### PR TITLE
Handle sync logic on the displayed QR code page

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ShareAction.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ShareAction.kt
@@ -36,6 +36,20 @@ class ShareAction @Inject constructor(private val appBuildConfig: AppBuildConfig
         return if (intent != null) startActivity(applicationContext, intent) else false
     }
 
+    fun shareText(applicationContext: Context, text: String): Boolean {
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, text)
+        }
+        val chooser = Intent.createChooser(
+            intent,
+            applicationContext.getString(R.string.sync_share_title),
+        ).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+        return startActivity(applicationContext, chooser)
+    }
+
     private fun createShareIntent(applicationContext: Context, file: File): Intent? {
         val fileUri = getFilePathUri(applicationContext, file)
         val intent =

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/CodeExchangeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/CodeExchangeActivity.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.sync.impl.ui.v2
 
+import android.content.Context
 import android.content.Intent
 import android.graphics.Outline
 import android.os.Bundle
@@ -46,6 +47,16 @@ class CodeExchangeActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
+    private val launchSource get() = intent.getStringExtra(LAUNCH_SOURCE_EXTRA_KEY)
+
+    private val qrCodeLauncher = registerForActivityResult(QrCodeContract()) { result ->
+        when (result) {
+            is QrCodeContract.Output.Success -> finish()
+            is QrCodeContract.Output.Failure -> finish()
+            is QrCodeContract.Output.NoOp -> Unit
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -74,7 +85,7 @@ class CodeExchangeActivity : DuckDuckGoActivity() {
             finish()
         }
         binding.showQrCodeButton.setOnClickListener {
-            startActivity(Intent(this, QrCodeActivity::class.java))
+            qrCodeLauncher.launch(QrCodeContract.Input(launchSource))
         }
     }
 
@@ -118,5 +129,15 @@ class CodeExchangeActivity : DuckDuckGoActivity() {
     companion object {
         private const val SCANNER_POSITION = 0
         private const val MANUAL_CODE_ENTRY_POSITION = 1
+        private const val LAUNCH_SOURCE_EXTRA_KEY = "launch_source"
+
+        fun intent(
+            context: Context,
+            source: String?,
+        ): Intent {
+            return Intent(context, CodeExchangeActivity::class.java).apply {
+                putExtra(LAUNCH_SOURCE_EXTRA_KEY, source)
+            }
+        }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/CodeExchangeContract.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/CodeExchangeContract.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui.v2
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+import com.duckduckgo.sync.impl.ui.v2.CodeExchangeContract.Input
+
+class CodeExchangeContract : ActivityResultContract<Input, Unit>() {
+    override fun createIntent(
+        context: Context,
+        input: Input,
+    ): Intent {
+        return CodeExchangeActivity.intent(context, input.source)
+    }
+
+    override fun parseResult(
+        resultCode: Int,
+        intent: Intent?,
+    ) = Unit
+
+    data class Input(
+        val source: String?,
+    )
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/QrCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/QrCodeActivity.kt
@@ -17,6 +17,8 @@
 package com.duckduckgo.sync.impl.ui.v2
 
 import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.annotation.StringRes
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
@@ -31,14 +33,25 @@ import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.ShareAction
 import com.duckduckgo.sync.impl.databinding.ActivitySyncV2QrCodeBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.showV2PairingError
+import com.duckduckgo.sync.impl.ui.syncV2ConfirmationMessage
 import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.AskHostConfirmation
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.AskJoinerConfirmation
 import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.Close
 import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.SetFailureResult
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.SetSuccessResult
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.ShareCode
 import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.ShowMessage
 import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.ShowV2Error
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Factory
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Factory.Provider
 import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.ViewState
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import logcat.logcat
@@ -49,13 +62,21 @@ import com.duckduckgo.mobile.android.R as CommonR
 class QrCodeActivity : DuckDuckGoActivity() {
     private val binding by viewBinding<ActivitySyncV2QrCodeBinding>()
 
-    private val viewModel by bindViewModel<SyncExchangeViewModel>()
+    @Inject
+    lateinit var vmFactory: Factory
 
     @Inject
     lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
 
     @Inject
     lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
+    @Inject
+    lateinit var shareAction: ShareAction
+
+    private val viewModel by viewModels<SyncExchangeViewModel> {
+        Provider(vmFactory, null)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -70,8 +91,14 @@ class QrCodeActivity : DuckDuckGoActivity() {
         }
 
         configureToolbar()
+        configureCodeButtons()
 
         observeViewModel()
+    }
+
+    private fun configureCodeButtons() {
+        binding.copyCodeButton.setOnClickListener { viewModel.onCopyCodeClicked() }
+        binding.shareButton.setOnClickListener { viewModel.onShareCodeClicked() }
     }
 
     private fun observeViewModel() {
@@ -100,11 +127,64 @@ class QrCodeActivity : DuckDuckGoActivity() {
 
     private fun processCommand(command: Command) {
         when (command) {
+            is AskHostConfirmation -> showHostConfirmationDialog(command.peerName, command.peerKind)
+            is AskJoinerConfirmation -> showJoinerConfirmationDialog(command.peerName, command.peerKind)
+            is ShowMessage -> showMessage(command.message)
+            is ShareCode -> shareText(command.code)
+            is SetSuccessResult -> logcat { "TODO" }
+            is SetFailureResult -> logcat { "TODO" }
             is ShowError -> showError(command)
             is ShowV2Error -> showV2Error(command)
-            is SetFailureResult -> logcat { "TODO" }
             is Close -> finish()
         }
+    }
+
+    private fun showHostConfirmationDialog(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_host_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onHostConfirmed()
+                    }
+
+                    override fun onNegativeButtonClicked() {
+                        viewModel.onHostDenied()
+                    }
+                },
+            )
+            .show()
+    }
+
+    private fun showJoinerConfirmationDialog(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_joiner_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onJoinerConfirmed()
+                    }
+
+                    override fun onNegativeButtonClicked() {
+                        viewModel.onJoinerDenied()
+                    }
+                },
+            )
+            .show()
+    }
+
+    private fun showMessage(@StringRes message: Int) {
+        Snackbar.make(binding.root, message, Snackbar.LENGTH_LONG).show()
+    }
+
+    private fun shareText(text: String) {
+        shareAction.shareText(this, text)
     }
 
     private fun showError(error: ShowError) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/QrCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/QrCodeActivity.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.sync.impl.ui.v2
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.annotation.StringRes
@@ -54,7 +56,6 @@ import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.ViewState
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import logcat.logcat
 import javax.inject.Inject
 import com.duckduckgo.mobile.android.R as CommonR
 
@@ -74,8 +75,10 @@ class QrCodeActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var shareAction: ShareAction
 
+    private val launchSource get() = intent.getStringExtra(LAUNCH_SOURCE_EXTRA_KEY)
+
     private val viewModel by viewModels<SyncExchangeViewModel> {
-        Provider(vmFactory, null)
+        Provider(vmFactory, launchSource)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -131,8 +134,8 @@ class QrCodeActivity : DuckDuckGoActivity() {
             is AskJoinerConfirmation -> showJoinerConfirmationDialog(command.peerName, command.peerKind)
             is ShowMessage -> showMessage(command.message)
             is ShareCode -> shareText(command.code)
-            is SetSuccessResult -> logcat { "TODO" }
-            is SetFailureResult -> logcat { "TODO" }
+            is SetSuccessResult -> setResult(QrCodeContract.RESULT_SYNC_SUCCESS)
+            is SetFailureResult -> setResult(QrCodeContract.RESULT_SYNC_FAILURE)
             is ShowError -> showError(command)
             is ShowV2Error -> showV2Error(command)
             is Close -> finish()
@@ -218,5 +221,18 @@ class QrCodeActivity : DuckDuckGoActivity() {
         edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
         edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
         edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
+    }
+
+    companion object {
+        private const val LAUNCH_SOURCE_EXTRA_KEY = "launch_source"
+
+        fun intent(
+            context: Context,
+            source: String?,
+        ): Intent {
+            return Intent(context, QrCodeActivity::class.java).apply {
+                putExtra(LAUNCH_SOURCE_EXTRA_KEY, source)
+            }
+        }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/QrCodeContract.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/QrCodeContract.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui.v2
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+import com.duckduckgo.sync.impl.ui.v2.QrCodeContract.Input
+import com.duckduckgo.sync.impl.ui.v2.QrCodeContract.Output
+import com.duckduckgo.sync.impl.ui.v2.QrCodeContract.Output.Failure
+import com.duckduckgo.sync.impl.ui.v2.QrCodeContract.Output.NoOp
+import com.duckduckgo.sync.impl.ui.v2.QrCodeContract.Output.Success
+
+class QrCodeContract : ActivityResultContract<Input, Output>() {
+    override fun createIntent(
+        context: Context,
+        input: Input,
+    ): Intent {
+        return QrCodeActivity.intent(context, input.source)
+    }
+
+    override fun parseResult(
+        resultCode: Int,
+        intent: Intent?,
+    ): Output {
+        return when (resultCode) {
+            RESULT_SYNC_SUCCESS -> Success
+            RESULT_SYNC_FAILURE -> Failure
+            else -> NoOp
+        }
+    }
+
+    data class Input(
+        val source: String?,
+    )
+
+    sealed interface Output {
+        data object Success : Output
+
+        data object Failure : Output
+
+        data object NoOp : Output
+    }
+
+    companion object {
+        const val RESULT_SYNC_SUCCESS = 200
+        const val RESULT_SYNC_FAILURE = 201
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.sync.impl.ui.v2
 
 import android.Manifest
-import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.View
@@ -187,6 +186,10 @@ class SyncActivity : DuckDuckGoActivity() {
             viewModel.onConnectionCancelled()
         }
     }
+
+    private val codeExchangeLauncher = registerForActivityResult(
+        CodeExchangeContract(),
+    ) { /* No-op, auto-refresh will update the device list */ }
 
     private val downloadPdfPermissionLauncher = registerForActivityResult(RequestPermission()) { isGranted ->
         if (isGranted) {
@@ -421,7 +424,7 @@ class SyncActivity : DuckDuckGoActivity() {
 
             is SyncWithAnotherDevice -> {
                 authenticate {
-                    startActivity(Intent(this, CodeExchangeActivity::class.java))
+                    codeExchangeLauncher.launch(CodeExchangeContract.Input(launchSource))
                 }
             }
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncExchangeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncExchangeViewModel.kt
@@ -134,6 +134,7 @@ class SyncExchangeViewModel @AssistedInject constructor(
 
         var isPolling = qrCodeResult is Result.Success
         while (isPolling) {
+            delay(POLLING_INTERVAL_CONNECT_FLOW)
             accountRepository.pollConnectionKeys()
                 .onSuccess { isSynced ->
                     if (isSynced) {
@@ -152,7 +153,6 @@ class SyncExchangeViewModel @AssistedInject constructor(
                         }
                     }
                 }
-            delay(POLLING_INTERVAL_CONNECT_FLOW)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncExchangeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncExchangeViewModel.kt
@@ -85,7 +85,6 @@ class SyncExchangeViewModel @AssistedInject constructor(
     }
 
     fun onHostConfirmed() {
-        _viewState.update { it.copy(isConnecting = true) }
         codeDispatcher.confirmHost()
     }
 
@@ -94,7 +93,6 @@ class SyncExchangeViewModel @AssistedInject constructor(
     }
 
     fun onJoinerConfirmed() {
-        _viewState.update { it.copy(isConnecting = true) }
         codeDispatcher.confirmJoiner()
     }
 
@@ -177,23 +175,19 @@ class SyncExchangeViewModel @AssistedInject constructor(
                 is DispatchOutcome.LoggedIn -> {
                     pixels.fireLoginPixel()
                     pixels.fireSyncSetupFinishedSuccessfully(SYNC_CONNECT, outcome.path, outcome.myRole, outcome.peerKind)
-                    _viewState.update { it.copy(isConnecting = false) }
                     _commands.send(Command.SetSuccessResult)
                     _commands.send(Command.Close)
                 }
 
                 is DispatchOutcome.AlreadyConnected -> {
-                    _viewState.update { it.copy(isConnecting = false) }
                     _commands.send(Command.ShowV2Error(v2AlreadyPairedError))
                 }
 
                 is DispatchOutcome.UpgradeRequired -> {
-                    _viewState.update { it.copy(isConnecting = false) }
                     _commands.send(Command.ShowV2Error(v2UpgradeRequiredError))
                 }
 
                 is DispatchOutcome.Failed -> {
-                    _viewState.update { it.copy(isConnecting = false) }
                     _commands.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
                 }
             }
@@ -219,7 +213,6 @@ class SyncExchangeViewModel @AssistedInject constructor(
 
     data class ViewState(
         val bitmap: BitmapWithCode? = null,
-        val isConnecting: Boolean = false,
     )
 
     data class BitmapWithCode(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncExchangeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncExchangeViewModel.kt
@@ -19,19 +19,23 @@ package com.duckduckgo.sync.impl.ui.v2
 import android.graphics.Bitmap
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.clipboard.ClipboardInteractor
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.QREncoder
 import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
 import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
 import com.duckduckgo.sync.impl.pixels.fireSetupFailed
@@ -41,23 +45,28 @@ import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl.ProtocolVersion
 import com.duckduckgo.sync.impl.ui.toV2PairingError
 import com.duckduckgo.sync.impl.ui.v2AlreadyPairedError
 import com.duckduckgo.sync.impl.ui.v2UpgradeRequiredError
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import logcat.logcat
-import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
-@ContributesViewModel(ActivityScope::class)
-class SyncExchangeViewModel @Inject constructor(
+class SyncExchangeViewModel @AssistedInject constructor(
+    @Assisted private val source: String?,
     private val accountRepository: SyncAccountRepository,
     private val codeDispatcher: SyncCodeDispatcher,
     private val pixels: SyncPixels,
     private val syncFeature: SyncFeature,
     private val qrEncoder: QREncoder,
+    private val clipboard: ClipboardInteractor,
     private val dispatchers: DispatcherProvider,
 ) : ViewModel() {
     private val _commands = Channel<Command>(Channel.BUFFERED)
@@ -75,6 +84,24 @@ class SyncExchangeViewModel @Inject constructor(
         }
     }
 
+    fun onHostConfirmed() {
+        _viewState.update { it.copy(isConnecting = true) }
+        codeDispatcher.confirmHost()
+    }
+
+    fun onHostDenied() {
+        codeDispatcher.denyHost()
+    }
+
+    fun onJoinerConfirmed() {
+        _viewState.update { it.copy(isConnecting = true) }
+        codeDispatcher.confirmJoiner()
+    }
+
+    fun onJoinerDenied() {
+        codeDispatcher.denyJoiner()
+    }
+
     fun onErrorDialogDismissed() {
         viewModelScope.launch {
             _commands.send(Command.SetFailureResult)
@@ -82,10 +109,51 @@ class SyncExchangeViewModel @Inject constructor(
         }
     }
 
-    private suspend fun startV1Presentation() {
-        accountRepository.getConnectQR()
+    fun onCopyCodeClicked() {
+        viewModelScope.launch {
+            val code = viewState.value.bitmap?.url ?: return@launch
+            val isNotificationShown = clipboard.copyToClipboard(code, isSensitive = true)
+            if (!isNotificationShown) {
+                _commands.send(Command.ShowMessage(R.string.sync_code_copied_message))
+            }
+            pixels.fireSyncSetupCodeCopiedToClipboard(SYNC_CONNECT)
+        }
+    }
+
+    fun onShareCodeClicked() {
+        viewModelScope.launch {
+            val code = viewState.value.bitmap?.url ?: return@launch
+            _commands.send(Command.ShareCode(code))
+        }
+    }
+
+    private suspend fun startV1Presentation() = coroutineScope {
+        val qrCodeResult = accountRepository.getConnectQR()
             .onSuccess { showQrCode(it.qrCode) }
             .onFailure { _commands.send(Command.ShowError(R.string.sync_connect_generic_error, it.reason)) }
+
+        var isPolling = qrCodeResult is Result.Success
+        while (isPolling) {
+            accountRepository.pollConnectionKeys()
+                .onSuccess { isSynced ->
+                    if (isSynced) {
+                        pixels.fireSignupConnectPixel(source)
+                        pixels.fireSyncSetupFinishedSuccessfully(SYNC_CONNECT)
+                        _commands.send(Command.SetSuccessResult)
+                        _commands.send(Command.Close)
+                        isPolling = false
+                    }
+                }
+                .onFailure { failure ->
+                    when (failure.code) {
+                        CONNECT_FAILED.code, LOGIN_FAILED.code -> {
+                            _commands.send(Command.ShowError(R.string.sync_connect_login_error, failure.reason))
+                            isPolling = false
+                        }
+                    }
+                }
+            delay(POLLING_INTERVAL_CONNECT_FLOW)
+        }
     }
 
     private suspend fun startV2Presentation() {
@@ -99,26 +167,33 @@ class SyncExchangeViewModel @Inject constructor(
                 }
 
                 is DispatchOutcome.HostConfirmationRequested -> {
-                    logcat { "TODO" }
+                    _commands.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
                 }
 
                 is DispatchOutcome.JoinerConfirmationRequested -> {
-                    logcat { "TODO" }
+                    _commands.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
                 }
 
                 is DispatchOutcome.LoggedIn -> {
-                    logcat { "TODO" }
+                    pixels.fireLoginPixel()
+                    pixels.fireSyncSetupFinishedSuccessfully(SYNC_CONNECT, outcome.path, outcome.myRole, outcome.peerKind)
+                    _viewState.update { it.copy(isConnecting = false) }
+                    _commands.send(Command.SetSuccessResult)
+                    _commands.send(Command.Close)
                 }
 
                 is DispatchOutcome.AlreadyConnected -> {
+                    _viewState.update { it.copy(isConnecting = false) }
                     _commands.send(Command.ShowV2Error(v2AlreadyPairedError))
                 }
 
                 is DispatchOutcome.UpgradeRequired -> {
+                    _viewState.update { it.copy(isConnecting = false) }
                     _commands.send(Command.ShowV2Error(v2UpgradeRequiredError))
                 }
 
                 is DispatchOutcome.Failed -> {
+                    _viewState.update { it.copy(isConnecting = false) }
                     _commands.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
                 }
             }
@@ -144,6 +219,7 @@ class SyncExchangeViewModel @Inject constructor(
 
     data class ViewState(
         val bitmap: BitmapWithCode? = null,
+        val isConnecting: Boolean = false,
     )
 
     data class BitmapWithCode(
@@ -153,6 +229,16 @@ class SyncExchangeViewModel @Inject constructor(
     )
 
     internal sealed interface Command {
+        data class AskJoinerConfirmation(
+            val peerName: String?,
+            val peerKind: PeerKind? = null,
+        ) : Command
+
+        data class AskHostConfirmation(
+            val peerName: String?,
+            val peerKind: PeerKind? = null,
+        ) : Command
+
         data class ShowError(
             @StringRes val message: Int,
             val reason: String = "",
@@ -162,8 +248,38 @@ class SyncExchangeViewModel @Inject constructor(
             val content: V2PairingErrorContent,
         ) : Command
 
+        data class ShowMessage(
+            @StringRes val message: Int,
+        ) : Command
+
+        data class ShareCode(
+            val code: String,
+        ) : Command
+
         data object SetFailureResult : Command
 
+        data object SetSuccessResult : Command
+
         data object Close : Command
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(source: String?): SyncExchangeViewModel
+
+        class Provider(
+            private val assistedFactory: Factory,
+            private val source: String?,
+        ) : ViewModelProvider.Factory {
+
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return assistedFactory.create(source) as T
+            }
+        }
+    }
+
+    companion object {
+        private val POLLING_INTERVAL_CONNECT_FLOW = 5.seconds
     }
 }

--- a/sync/sync-impl/src/main/res/layout/activity_sync_v2_qr_code.xml
+++ b/sync/sync-impl/src/main/res/layout/activity_sync_v2_qr_code.xml
@@ -55,6 +55,7 @@
                 android:theme="@style/Theme.DuckDuckGo.Light">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/barcodeContainer"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent">
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/SyncExchangeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/SyncExchangeViewModelTest.kt
@@ -18,10 +18,12 @@ package com.duckduckgo.sync.impl.ui.v2
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
+import com.duckduckgo.app.clipboard.ClipboardInteractor
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.TestSyncFixtures
+import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
 import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.QREncoder
@@ -39,9 +41,14 @@ import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl
 import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl.ProtocolVersion.V2
 import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.BitmapWithCode
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.AskHostConfirmation
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.AskJoinerConfirmation
 import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.Close
 import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.SetFailureResult
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.SetSuccessResult
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.ShareCode
 import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.ShowMessage
 import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.ShowV2Error
 import com.duckduckgo.sync.impl.ui.v2AlreadyPairedError
 import com.duckduckgo.sync.impl.ui.v2UpgradeRequiredError
@@ -82,19 +89,23 @@ class SyncExchangeViewModelTest {
     private val pixels = mock<SyncPixels>()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
     private val qrEncoder = mock<QREncoder>()
+    private val clipboard = mock<ClipboardInteractor>()
 
     @Before
     fun setup() {
         whenever(codeDispatcher.presentV2()).thenReturn(emptyFlow())
         whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(bitmap)
+        whenever(accountRepository.pollConnectionKeys()).thenReturn(Result.Success(true))
     }
 
-    private fun createTestee() = SyncExchangeViewModel(
+    private fun createTestee(source: String? = null) = SyncExchangeViewModel(
+        source = source,
         accountRepository = accountRepository,
         codeDispatcher = codeDispatcher,
         pixels = pixels,
         syncFeature = syncFeature,
         qrEncoder = qrEncoder,
+        clipboard = clipboard,
         dispatchers = coroutineTestRule.testDispatcherProvider,
     )
 
@@ -129,6 +140,43 @@ class SyncExchangeViewModelTest {
 
             cancel()
         }
+        verify(accountRepository, never()).pollConnectionKeys()
+    }
+
+    @Test
+    fun `when v2 is disabled and the connection keys are synced then the success result is set and the screen closes`() = runTest {
+        givenV2Disabled()
+        whenever(accountRepository.getConnectQR()).thenReturn(Result.Success(AuthCode(qrCode = "raw-code", rawCode = "b64-code")))
+        whenever(accountRepository.pollConnectionKeys()).thenReturn(Result.Success(true))
+
+        val testee = createTestee(source = "foo")
+
+        testee.commands.test {
+            assertIs<SetSuccessResult>(awaitItem())
+            assertIs<Close>(awaitItem())
+
+            cancel()
+        }
+        verify(pixels).fireSignupConnectPixel("foo")
+        verify(pixels).fireSyncSetupFinishedSuccessfully(SYNC_CONNECT, null, null, null)
+    }
+
+    @Test
+    fun `when v2 is disabled and polling fails with a login error then an error is shown`() = runTest {
+        givenV2Disabled()
+        whenever(accountRepository.getConnectQR()).thenReturn(Result.Success(AuthCode(qrCode = "raw-code", rawCode = "b64-code")))
+        whenever(accountRepository.pollConnectionKeys()).thenReturn(Result.Error(code = LOGIN_FAILED.code, reason = "boom"))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            val command = awaitItem()
+            assertIs<ShowError>(command)
+            assertEquals(R.string.sync_connect_login_error, command.message)
+            assertEquals("boom", command.reason)
+
+            cancel()
+        }
     }
 
     @Test
@@ -157,6 +205,93 @@ class SyncExchangeViewModelTest {
 
             cancel()
         }
+    }
+
+    @Test
+    fun `when the host confirmation is requested then the user is asked to confirm the host`() = runTest {
+        givenV2Enabled()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.HostConfirmationRequested(peerName = "Other Device")))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            assertEquals(AskHostConfirmation(peerName = "Other Device"), awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the joiner confirmation is requested then the user is asked to confirm the joiner`() = runTest {
+        givenV2Enabled()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device")))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            assertEquals(AskJoinerConfirmation(peerName = "Other Device"), awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the host is confirmed then the dispatcher is notified and the connection is in progress`() = runTest {
+        givenV2Enabled()
+
+        val testee = createTestee()
+        testee.onHostConfirmed()
+
+        verify(codeDispatcher).confirmHost()
+        assertTrue(testee.viewState.value.isConnecting)
+    }
+
+    @Test
+    fun `when the host is denied then the dispatcher is notified`() = runTest {
+        givenV2Enabled()
+
+        val testee = createTestee()
+        testee.onHostDenied()
+
+        verify(codeDispatcher).denyHost()
+    }
+
+    @Test
+    fun `when the joiner is confirmed then the dispatcher is notified and the connection is in progress`() = runTest {
+        givenV2Enabled()
+
+        val testee = createTestee()
+        testee.onJoinerConfirmed()
+
+        verify(codeDispatcher).confirmJoiner()
+        assertTrue(testee.viewState.value.isConnecting)
+    }
+
+    @Test
+    fun `when the joiner is denied then the dispatcher is notified`() = runTest {
+        givenV2Enabled()
+
+        val testee = createTestee()
+        testee.onJoinerDenied()
+
+        verify(codeDispatcher).denyJoiner()
+    }
+
+    @Test
+    fun `when the login completes then the success result is set and the screen closes`() = runTest {
+        givenV2Enabled()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.LoggedIn(path = SetupPath.PAIRING)))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            assertIs<SetSuccessResult>(awaitItem())
+            assertIs<Close>(awaitItem())
+
+            cancel()
+        }
+        verify(pixels).fireLoginPixel()
+        verify(pixels).fireSyncSetupFinishedSuccessfully(SYNC_CONNECT, SetupPath.PAIRING, null, null)
     }
 
     @Test
@@ -246,6 +381,90 @@ class SyncExchangeViewModelTest {
         createTestee()
 
         verifyNoInteractions(pixels)
+    }
+
+    @Test
+    fun `when the copy button is clicked then the linking code is copied to the clipboard`() = runTest {
+        givenV2Enabled()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.LinkingCodeReady(linkingUrl)))
+
+        val testee = createTestee()
+        testee.onCopyCodeClicked()
+
+        verify(clipboard).copyToClipboard(linkingUrl, isSensitive = true)
+        verify(pixels).fireSyncSetupCodeCopiedToClipboard(SYNC_CONNECT)
+    }
+
+    @Test
+    fun `when the copied code notification is not shown by the system then a message is shown`() = runTest {
+        givenV2Enabled()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.LinkingCodeReady(linkingUrl)))
+        whenever(clipboard.copyToClipboard(any(), any())).thenReturn(false)
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            testee.onCopyCodeClicked()
+            assertEquals(ShowMessage(R.string.sync_code_copied_message), awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the copied code notification is shown by the system then no message is shown`() = runTest {
+        givenV2Enabled()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.LinkingCodeReady(linkingUrl)))
+        whenever(clipboard.copyToClipboard(any(), any())).thenReturn(true)
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            testee.onCopyCodeClicked()
+            expectNoEvents()
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the copy button is clicked before the code is ready then nothing is copied`() = runTest {
+        givenV2Enabled()
+
+        val testee = createTestee()
+        testee.onCopyCodeClicked()
+
+        verifyNoInteractions(clipboard)
+        verifyNoInteractions(pixels)
+    }
+
+    @Test
+    fun `when the share button is clicked then the share code command is sent`() = runTest {
+        givenV2Enabled()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.LinkingCodeReady(linkingUrl)))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            testee.onShareCodeClicked()
+            assertEquals(ShareCode(linkingUrl), awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the share button is clicked before the code is ready then no command is sent`() = runTest {
+        givenV2Enabled()
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            testee.onShareCodeClicked()
+            expectNoEvents()
+
+            cancel()
+        }
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/SyncExchangeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/SyncExchangeViewModelTest.kt
@@ -236,14 +236,13 @@ class SyncExchangeViewModelTest {
     }
 
     @Test
-    fun `when the host is confirmed then the dispatcher is notified and the connection is in progress`() = runTest {
+    fun `when the host is confirmed then the dispatcher is notified`() = runTest {
         givenV2Enabled()
 
         val testee = createTestee()
         testee.onHostConfirmed()
 
         verify(codeDispatcher).confirmHost()
-        assertTrue(testee.viewState.value.isConnecting)
     }
 
     @Test
@@ -257,14 +256,13 @@ class SyncExchangeViewModelTest {
     }
 
     @Test
-    fun `when the joiner is confirmed then the dispatcher is notified and the connection is in progress`() = runTest {
+    fun `when the joiner is confirmed then the dispatcher is notified`() = runTest {
         givenV2Enabled()
 
         val testee = createTestee()
         testee.onJoinerConfirmed()
 
         verify(codeDispatcher).confirmJoiner()
-        assertTrue(testee.viewState.value.isConnecting)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1215321458176118/task/1216422585541214?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1215321458176118/task/1216509582049467?focus=true
API Proposals URL(s) (if applicable): N/A

### Description

Wires up the connection logic behind the QR code screen in the simplified Sync With Another Device flow. 

Completing the connection:
- When another device scans the code, a "Sync your data?" confirmation dialog is shown, naming the other device when it is known. The dialog covers both roles this device can be elected into, host or joiner.
- Tapping "Sync Now" continues the connection. Tapping "Cancel" denies it, which ends the session with a "Sync canceled." dialog.
- Once the devices are connected, the QR code screen and the "Sync With Another Device" screen behind it close, returning the user to Sync Settings, where the new device appears in the device list.
- When the v2 connect flow is disabled (`canUseV2ConnectFlow`, `canShowV2ConnectCode`), the legacy flow is used instead. After showing the code, the screen polls for the connection every 5 seconds and closes the flow in the same way once the other device connects. If polling fails with a connect or login error, an error dialog is shown.

Copying and sharing the code:
- "Copy Text Code" copies the code to the clipboard as sensitive content. A "Recovery Code Copied" snackbar confirms the action, unless the system already shows its own clipboard confirmation.
- "Share" opens the system share sheet with the code as plain text.
- Both buttons do nothing while the code is still loading.

Failure handling:
- Dismissing any error dialog on the QR code screen reports a failure result and closes both the QR code screen and the "Sync With Another Device" screen.

The screens now communicate through activity result contracts (`QrCodeContract` and `CodeExchangeContract`) instead of plain intents, so the sync result can propagate back to Sync Settings.

### Steps to test this PR

_Connect two devices via the QR code_
- [ ] Open Sync Dev Settings.
- [ ] Tap "Launch Sync Settings V2".
- [ ] Tap "Sync With Another Device".
- [ ] Complete the device authentication prompt.
- [ ] Tap "Show QR Code".
- [ ] On a second device, go to "Sync With Another Device" in Sync & Backup.
- [ ] Scan the code shown on the first device.
- [ ] When the "Sync your data?" dialog appears, tap "Sync Now".
- [ ] Verify the QR code screen and the "Sync With Another Device" screen close.
- [ ] Verify the second device appears in the device list in Sync Settings.

_Cancel the connection_
- [ ] Tap "Show QR Code" again on the first device.
- [ ] Scan the code with the second device.
- [ ] When the "Sync your data?" dialog appears, tap "Cancel".
- [ ] Verify a "Sync canceled." dialog is shown.
- [ ] Dismiss the dialog.
- [ ] Verify the setup screens close without the devices being connected.

_Copy the code_
- [ ] On the QR code screen, tap "Copy Text Code".
- [ ] Verify the code is in the clipboard.
- [ ] Verify a confirmation is shown, either the system clipboard notification or a snackbar.

_Share the code_
- [ ] On the QR code screen, tap "Share".
- [ ] Verify the system share sheet opens with the code as text.

_Legacy connect flow_
- [ ] Disable the `canUseV2ConnectFlow` and `canShowV2ConnectCode` feature flags.
- [ ] Tap "Sync With Another Device".
- [ ] Tap "Show QR Code".
- [ ] Scan the code with the second device.
- [ ] Verify the devices connect and the setup screens close within a few seconds, without a confirmation dialog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes device pairing confirmation, legacy polling, and multi-activity result propagation in the sync connect path—important user data flow but built on existing dispatcher/repository APIs.
> 
> **Overview**
> Completes the **Sync With Another Device** QR screen by driving real connect/pairing behavior in `SyncExchangeViewModel` and `QrCodeActivity`, instead of TODO stubs.
> 
> **V2 pairing:** When another device uses the code, the QR screen shows host/joiner **“Sync your data?”** dialogs and forwards confirm/deny to `SyncCodeDispatcher`. Successful login fires pixels, sets a success activity result, and closes the screen.
> 
> **Legacy (V1) path:** If v2 connect flags are off, the screen still shows the QR code but **polls** `pollConnectionKeys` every 5 seconds until sync completes or connect/login errors surface.
> 
> **Copy & share:** Copy uses sensitive clipboard handling with optional snackbar; share uses new `ShareAction.shareText` for the plain-text linking URL. Both are no-ops until the code is loaded.
> 
> **Navigation:** `QrCodeContract` and `CodeExchangeContract` replace raw intents so `CodeExchangeActivity` and `SyncActivity` can close the stack on success/failure from the QR screen. Launch **source** is passed through assisted-injection on the exchange ViewModel for analytics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb053241a3eefbcdf0d8692f896b2724e3daabc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->