### PR TITLE
Detect scanned QR sync codes

### DIFF
--- a/sync/sync-impl/src/main/AndroidManifest.xml
+++ b/sync/sync-impl/src/main/AndroidManifest.xml
@@ -129,7 +129,7 @@
         <activity
             android:name=".ui.v2.ExchangeSyncCodeActivity"
             android:exported="false"
-            android:label="@string/sync_scanner_v2_qr_code_screen_title"
+            android:label="@string/sync_screen_title"
             android:parentActivityName=".ui.v2.ReadSyncCodeActivity"
             android:screenOrientation="portrait" />
     </application>

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeActivity.kt
@@ -38,7 +38,9 @@ import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivitySyncV2ReadSyncCodeBinding
 import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeViewModel.Command
+import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeViewModel.Command.ShowMessage
 import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeViewModel.Command.StartSyncProcess
+import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayoutMediator
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -105,6 +107,10 @@ class ReadSyncCodeActivity : DuckDuckGoActivity() {
                     launchSource = launchSource,
                 )
                 exchangeSyncCodeLauncher.launch(input)
+            }
+
+            is ShowMessage -> {
+                Snackbar.make(binding.root, command.message, Snackbar.LENGTH_LONG).show()
             }
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeCameraFragment.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeCameraFragment.kt
@@ -39,11 +39,14 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoFragment
 import com.duckduckgo.common.ui.view.toPx
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.databinding.FragmentSyncV2ReadSyncCodeCameraBinding
 import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeCameraIntroViewModel.Command
 import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeCameraIntroViewModel.Command.ExpandScannerCutout
@@ -52,8 +55,13 @@ import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeCameraIntroViewModel.Command.R
 import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeCameraIntroViewModel.Command.ResumeCamera
 import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeCameraIntroViewModel.ViewMode
 import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeCameraIntroViewModel.ViewState
+import com.google.zxing.BarcodeFormat.QR_CODE
+import com.journeyapps.barcodescanner.DefaultDecoderFactory
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @InjectWith(FragmentScope::class)
@@ -66,6 +74,12 @@ class ReadSyncCodeCameraFragment : DuckDuckGoFragment() {
 
     @Inject
     lateinit var viewModelFactory: FragmentViewModelFactory
+
+    @Inject
+    lateinit var syncFeature: SyncFeature
+
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
 
     private val animationViewModel by viewModels<ReadSyncCodeCameraIntroViewModel> { viewModelFactory }
 
@@ -238,8 +252,24 @@ class ReadSyncCodeCameraFragment : DuckDuckGoFragment() {
     }
 
     private fun configureScanner() {
-        binding.includeCamera.barcodeView.decodeContinuous { barcode ->
-            syncCodeViewModel.processScannedCode(barcode.text)
+        viewLifecycleOwner.lifecycleScope.launch {
+            val restrictToQr = withContext(dispatchers.io()) {
+                syncFeature.restrictScannedBarcodesToQrTypes().isEnabled()
+            }
+            if (restrictToQr) {
+                binding.includeCamera.barcodeView.decoderFactory = DefaultDecoderFactory(listOf(QR_CODE))
+            }
+
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                binding.includeCamera.barcodeView.decodeSingle { barcode ->
+                    syncCodeViewModel.processScannedCode(barcode.text)
+                }
+                try {
+                    awaitCancellation()
+                } finally {
+                    binding.includeCamera.barcodeView.stopDecoding()
+                }
+            }
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeCameraFragment.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeCameraFragment.kt
@@ -34,6 +34,7 @@ import androidx.core.view.doOnLayout
 import androidx.core.view.doOnPreDraw
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -68,6 +69,8 @@ class ReadSyncCodeCameraFragment : DuckDuckGoFragment() {
 
     private val animationViewModel by viewModels<ReadSyncCodeCameraIntroViewModel> { viewModelFactory }
 
+    private val syncCodeViewModel by activityViewModels<ReadSyncCodeViewModel> { viewModelFactory }
+
     private val cameraPermissionLauncher = registerForActivityResult(RequestPermission()) {
         animationViewModel.onCameraPermissionResult()
     }
@@ -93,6 +96,7 @@ class ReadSyncCodeCameraFragment : DuckDuckGoFragment() {
         configureIntroAnimation()
         configureReadyToScanButtons()
         configureGoToSettingsButton()
+        configureScanner()
         configureCutout()
 
         observeUiEvents()
@@ -230,6 +234,12 @@ class ReadSyncCodeCameraFragment : DuckDuckGoFragment() {
                 Uri.fromParts("package", requireContext().packageName, null),
             )
             startActivity(intent)
+        }
+    }
+
+    private fun configureScanner() {
+        binding.includeCamera.barcodeView.decodeContinuous { barcode ->
+            syncCodeViewModel.processScannedCode(barcode.text)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeViewModel.kt
@@ -23,9 +23,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.R
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -38,32 +36,19 @@ class ReadSyncCodeViewModel @Inject constructor(
     private val _commands = Channel<Command>(Channel.BUFFERED)
     val commands = _commands.receiveAsFlow()
 
-    private var scanCodeJob: Job? = null
-
     fun pasteSyncCode() {
         val code = clipboard.pasteFromClipboard()
         viewModelScope.launch {
-            processCode(code, invalidCodeMessage = R.string.sync_scanner_v2_manual_entry_invalid_code_pasted)
+            if (code.isBlank()) {
+                _commands.send(Command.ShowMessage(R.string.sync_scanner_v2_manual_entry_invalid_code_pasted))
+            } else {
+                _commands.send(Command.StartSyncProcess(code))
+            }
         }
     }
 
     fun processScannedCode(code: String) {
-        // The camera decodes continuously, emitting the same barcode for every frame it stays in
-        // view, so without debouncing a single scan would repeatedly start the sync flow.
-        if (scanCodeJob?.isActive == true) return
-        scanCodeJob = viewModelScope.launch {
-            processCode(code, invalidCodeMessage = R.string.sync_scanner_v2_scan_qr_code_invalid_code_scanned)
-            delay(SCAN_CODE_DEBOUNCE_DURATION)
-        }
-    }
-
-    private suspend fun processCode(
-        code: String,
-        @StringRes invalidCodeMessage: Int,
-    ) {
-        if (code.isBlank()) {
-            _commands.send(Command.ShowMessage(invalidCodeMessage))
-        } else {
+        viewModelScope.launch {
             _commands.send(Command.StartSyncProcess(code))
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeViewModel.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.time.Duration.Companion.seconds
 
 @ContributesViewModel(ActivityScope::class)
 class ReadSyncCodeViewModel @Inject constructor(
@@ -61,9 +60,5 @@ class ReadSyncCodeViewModel @Inject constructor(
         data class StartSyncProcess(
             val syncCode: String,
         ) : Command
-    }
-
-    companion object {
-        private val SCAN_CODE_DEBOUNCE_DURATION = 5.seconds
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeViewModel.kt
@@ -16,15 +16,20 @@
 
 package com.duckduckgo.sync.impl.ui.v2
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.R
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 @ContributesViewModel(ActivityScope::class)
 class ReadSyncCodeViewModel @Inject constructor(
@@ -33,16 +38,47 @@ class ReadSyncCodeViewModel @Inject constructor(
     private val _commands = Channel<Command>(Channel.BUFFERED)
     val commands = _commands.receiveAsFlow()
 
+    private var scanCodeJob: Job? = null
+
     fun pasteSyncCode() {
         val code = clipboard.pasteFromClipboard()
         viewModelScope.launch {
+            processCode(code, invalidCodeMessage = R.string.sync_scanner_v2_manual_entry_invalid_code_pasted)
+        }
+    }
+
+    fun processScannedCode(code: String) {
+        // The camera decodes continuously, emitting the same barcode for every frame it stays in
+        // view, so without debouncing a single scan would repeatedly start the sync flow.
+        if (scanCodeJob?.isActive == true) return
+        scanCodeJob = viewModelScope.launch {
+            processCode(code, invalidCodeMessage = R.string.sync_scanner_v2_scan_qr_code_invalid_code_scanned)
+            delay(SCAN_CODE_DEBOUNCE_DURATION)
+        }
+    }
+
+    private suspend fun processCode(
+        code: String,
+        @StringRes invalidCodeMessage: Int,
+    ) {
+        if (code.isBlank()) {
+            _commands.send(Command.ShowMessage(invalidCodeMessage))
+        } else {
             _commands.send(Command.StartSyncProcess(code))
         }
     }
 
     sealed interface Command {
+        data class ShowMessage(
+            @StringRes val message: Int,
+        ) : Command
+
         data class StartSyncProcess(
             val syncCode: String,
         ) : Command
+    }
+
+    companion object {
+        private val SCAN_CODE_DEBOUNCE_DURATION = 5.seconds
     }
 }

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -60,6 +60,7 @@
     <string name="sync_scanner_v2_scan_qr_code_headline">Scan QR Code</string>
     <string name="sync_scanner_v2_scan_qr_code_body">Open <annotation type="icon">&#65532;</annotation> <b><annotation type="highlight">DuckDuckGo for Desktop</annotation></b>\n<annotation type="gap">\n</annotation>and go to <annotation type="highlight">Sync &amp; Backup</annotation> › <annotation type="highlight">Sync With Another Device</annotation></string>
     <string name="sync_scanner_v2_scan_button_cta">I’m Ready to Scan</string>
+    <string name="sync_scanner_v2_scan_qr_code_invalid_code_scanned">Sorry, the scanned code is invalid.</string>
     <string name="sync_scanner_v2_enter_code_manually_tab_item_label">Enter Code</string>
     <string name="sync_scanner_v2_qr_code_screen_title">QR Code</string>
     <string name="sync_scanner_v2_qr_code_screen_headline">Scan from another device</string>

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeViewModelTest.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeViewModel.Command.ShowMessage
 import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeViewModel.Command.StartSyncProcess
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -88,47 +87,6 @@ class ReadSyncCodeViewModelTest {
             assertEquals(R.string.sync_scanner_v2_manual_entry_invalid_code_pasted, command.message)
 
             expectNoEvents()
-            cancel()
-        }
-    }
-
-    @Test
-    fun `when a blank code is scanned then an invalid scanned code message is shown instead of starting the sync process`() = runTest {
-        testee.commands.test {
-            testee.processScannedCode("")
-
-            val command = awaitItem()
-            assertIs<ShowMessage>(command)
-            assertEquals(R.string.sync_scanner_v2_scan_qr_code_invalid_code_scanned, command.message)
-
-            expectNoEvents()
-            cancel()
-        }
-    }
-
-    @Test
-    fun `when a code is scanned again within the debounce window then it is ignored`() = runTest {
-        testee.commands.test {
-            testee.processScannedCode("sync-code")
-            assertIs<StartSyncProcess>(awaitItem())
-
-            testee.processScannedCode("sync-code")
-
-            expectNoEvents()
-            cancel()
-        }
-    }
-
-    @Test
-    fun `when a code is scanned after the debounce window has elapsed then it is processed again`() = runTest {
-        testee.commands.test {
-            testee.processScannedCode("sync-code")
-            assertIs<StartSyncProcess>(awaitItem())
-            advanceUntilIdle()
-
-            testee.processScannedCode("sync-code")
-
-            assertIs<StartSyncProcess>(awaitItem())
             cancel()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeViewModelTest.kt
@@ -20,7 +20,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeViewModel.Command.ShowMessage
 import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeViewModel.Command.StartSyncProcess
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -32,6 +36,7 @@ import org.mockito.kotlin.whenever
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class ReadSyncCodeViewModelTest {
     @get:Rule
@@ -54,6 +59,76 @@ class ReadSyncCodeViewModelTest {
             assertIs<StartSyncProcess>(command)
             assertEquals("sync-code", command.syncCode)
 
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when a sync code is scanned then the sync process starts with the scanned url`() = runTest {
+        testee.commands.test {
+            testee.processScannedCode("sync-code")
+
+            val command = awaitItem()
+            assertIs<StartSyncProcess>(command)
+            assertEquals("sync-code", command.syncCode)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when a blank code is pasted then an invalid pasted code message is shown instead of starting the sync process`() = runTest {
+        whenever(clipboard.pasteFromClipboard()).thenReturn("")
+
+        testee.commands.test {
+            testee.pasteSyncCode()
+
+            val command = awaitItem()
+            assertIs<ShowMessage>(command)
+            assertEquals(R.string.sync_scanner_v2_manual_entry_invalid_code_pasted, command.message)
+
+            expectNoEvents()
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when a blank code is scanned then an invalid scanned code message is shown instead of starting the sync process`() = runTest {
+        testee.commands.test {
+            testee.processScannedCode("")
+
+            val command = awaitItem()
+            assertIs<ShowMessage>(command)
+            assertEquals(R.string.sync_scanner_v2_scan_qr_code_invalid_code_scanned, command.message)
+
+            expectNoEvents()
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when a code is scanned again within the debounce window then it is ignored`() = runTest {
+        testee.commands.test {
+            testee.processScannedCode("sync-code")
+            assertIs<StartSyncProcess>(awaitItem())
+
+            testee.processScannedCode("sync-code")
+
+            expectNoEvents()
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when a code is scanned after the debounce window has elapsed then it is processed again`() = runTest {
+        testee.commands.test {
+            testee.processScannedCode("sync-code")
+            assertIs<StartSyncProcess>(awaitItem())
+            advanceUntilIdle()
+
+            testee.processScannedCode("sync-code")
+
+            assertIs<StartSyncProcess>(awaitItem())
             cancel()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216422585541213?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/72649045549333/task/1216509582049467?focus=true
API Proposals URL(s) (if applicable): N/A

### Description

Detects and handles QR codes scanned with the camera on the "Scan QR" tab of the simplified Sync With Another Device screen, and adds basic validation of scanned and pasted codes.

- Scanning a sync code starts the sync process with the scanned URL. For now this opens the placeholder Sync With Another Device screen, which displays the URL.
- Scanned codes are debounced for 5 seconds. The camera decodes continuously and emits the same code for every frame it stays in view, so without the debounce a valid code would restart the sync flow.
- Scanning a blank code shows a "Sorry, the scanned code is invalid." snackbar instead of starting the sync process. Blank scans are debounced the same way as valid ones.
- Pasting a blank code with the "Paste Sync Code" button on the "Enter Code" tab shows a "Sorry, the pasted code is invalid." snackbar instead of starting the sync process.

### Steps to test this PR

_Scan a valid sync code_
- [ ] Open Sync Dev Settings.
- [ ] Tap "Launch Sync Settings V2".
- [ ] Tap "Sync With Another Device".
- [ ] Complete the device authentication prompt.
- [ ] Tap "I’m Ready to Scan" on the "Scan QR" tab.
- [ ] Grant the camera permission when prompted.
- [ ] Point the camera at a sync QR code from another device.
- [ ] Verify the placeholder Sync With Another Device screen opens and displays the scanned sync URL.

_Scan an invalid code_
- [ ] On the "Scan QR" tab, point the camera at a QR code that contains only blank text (for example one generated from a single space).
- [ ] Verify a "Sorry, the scanned code is invalid." snackbar is shown.
- [ ] Verify the sync process does not start.

_Paste an invalid code_
- [ ] Copy blank text (for example a single space) to the clipboard.
- [ ] Open the "Enter Code" tab.
- [ ] Tap "Paste Sync Code".
- [ ] Verify a "Sorry, the pasted code is invalid." snackbar is shown.

### UI changes
N/A



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync pairing entry points (camera scan and paste) in v2 UI; incorrect handling could start sync with bad data or spam launches, though scope is limited to the read-sync-code screen.
> 
> **Overview**
> Wires the **Scan QR** camera tab so decoded barcodes flow through `ReadSyncCodeViewModel` and launch the existing `ExchangeSyncCode` flow with the scanned text. Decoding runs while the fragment is resumed (with optional QR-only decoding when `restrictScannedBarcodesToQrTypes` is enabled) and stops when the lifecycle pauses.
> 
> **Paste** validation is tightened: blank clipboard content shows a snackbar via a new `ShowMessage` command instead of starting sync. The activity handles that command with a `Snackbar`.
> 
> Adds user-facing strings for invalid scanned/pasted codes (scanned invalid message is in resources; paste path uses it). `ExchangeSyncCodeActivity` uses the generic sync screen title. ViewModel tests cover scan, paste, and blank paste.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cccd6394186ae51dfec63b9ab5197b6c54325a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->