### PR TITLE
Improve RealContentScopeScripts.getScript()

### DIFF
--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -71,10 +71,6 @@ class RealContentScopeScripts @Inject constructor(
     private val experimentsAdapter: JsonAdapter<List<Experiment>> =
         reusableMoshi.adapter(Types.newParameterizedType(List::class.java, Experiment::class.java))
 
-    // Compared against a freshly assembled config on every call, not used to skip assembling it: the
-    // feature repos load their persisted config into memory asynchronously and expose no completion
-    // signal, so any attempt to decide up front that the config cannot have changed risks serving
-    // default protections for the rest of the process.
     private var cachedPluginConfig: String = ""
 
     private var cachedContentScopeJson: String = getContentScopeJson("", emptyList(), optimized = true)
@@ -121,7 +117,7 @@ class RealContentScopeScripts @Inject constructor(
     ): String {
         var updateJS = false
 
-        val pluginParameters = getPluginParameters()
+        val pluginParameters = getLegacyPluginParameters()
 
         if (cachedUnprotectTemporaryExceptions != unprotectedTemporary.unprotectedTemporaryExceptions) {
             cacheUserUnprotectedTemporaryExceptions(unprotectedTemporary.unprotectedTemporaryExceptions, optimized = false)
@@ -161,7 +157,7 @@ class RealContentScopeScripts @Inject constructor(
         var updateJS = false
         var contentScopeChanged = false
 
-        val pluginParameters = getPluginParameters()
+        val pluginParameters = getOptimizedPluginParameters()
 
         if (cachedPluginConfig != pluginParameters.config) {
             cachedPluginConfig = pluginParameters.config
@@ -207,7 +203,7 @@ class RealContentScopeScripts @Inject constructor(
 
     private fun getInterfaceKeyValuePair() = "\"javascriptInterface\":\"$javascriptInterface\""
 
-    private fun getPluginParameters(): PluginParameters {
+    private fun getLegacyPluginParameters(): PluginParameters {
         var config = ""
         var preferences = ""
         val plugins = pluginPoint.getPlugins()
@@ -231,6 +227,25 @@ class RealContentScopeScripts @Inject constructor(
             }
         }
         return PluginParameters(config, preferences)
+    }
+
+    private fun getOptimizedPluginParameters(): PluginParameters {
+        val config = StringBuilder()
+        val preferences = StringBuilder()
+        pluginPoint.getPlugins().forEach { plugin ->
+            plugin.config().let { pluginConfig ->
+                if (pluginConfig.isNotEmpty()) config.appendCommaSeparated(pluginConfig)
+            }
+            plugin.preferences()?.let { pluginPreferences ->
+                if (pluginPreferences.isNotEmpty()) preferences.appendCommaSeparated(pluginPreferences)
+            }
+        }
+        return PluginParameters(config.toString(), preferences.toString())
+    }
+
+    private fun StringBuilder.appendCommaSeparated(value: String) {
+        if (isNotEmpty()) append(',')
+        append(value)
     }
 
     private fun cacheUserUnprotectedDomains(
@@ -387,12 +402,12 @@ class RealContentScopeScripts @Inject constructor(
 
     private fun getSessionKeyValuePair() = "\"sessionKey\":\"${fingerprintProtectionManager.getSeed()}\""
 
-    // Toggle.getCohort() is suspend but has no suspension points today, so runBlocking runs inline and
-    // never parks the caller. If it ever gains real IO this becomes a main-thread stall.
     private fun getExperimentsKeyValuePair(
         activeExperiments: List<Toggle>,
         optimized: Boolean,
     ): String {
+        if (optimized && activeExperiments.isEmpty()) return EMPTY_COHORTS
+
         return runBlocking {
             val jsonAdapter: JsonAdapter<List<Experiment>> = if (optimized) {
                 experimentsAdapter
@@ -441,6 +456,7 @@ class RealContentScopeScripts @Inject constructor(
     companion object {
         const val EMPTY_JSON_LIST = "[]"
         const val EMPTY_JSON = "{}"
+        const val EMPTY_COHORTS = "\"currentCohorts\":$EMPTY_JSON_LIST"
         const val CONTENT_SCOPE = "\$CONTENT_SCOPE$"
         const val USER_UNPROTECTED_DOMAINS = "\$USER_UNPROTECTED_DOMAINS$"
         const val USER_PREFERENCES = "\$USER_PREFERENCES$"

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -25,10 +25,8 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.fingerprintprotection.api.FingerprintProtectionManager
-import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.squareup.anvil.annotations.ContributesBinding
-import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Moshi.Builder
@@ -54,8 +52,7 @@ interface CoreContentScopeScripts {
 }
 
 @SingleInstanceIn(AppScope::class)
-@ContributesBinding(AppScope::class, boundType = CoreContentScopeScripts::class)
-@ContributesMultibinding(AppScope::class, boundType = PrivacyConfigCallbackPlugin::class)
+@ContributesBinding(AppScope::class)
 class RealContentScopeScripts @Inject constructor(
     private val pluginPoint: PluginPoint<ContentScopeConfigPlugin>,
     private val userAllowListRepository: UserAllowListRepository,
@@ -64,7 +61,7 @@ class RealContentScopeScripts @Inject constructor(
     private val unprotectedTemporary: UnprotectedTemporary,
     private val fingerprintProtectionManager: FingerprintProtectionManager,
     private val contentScopeScriptsFeature: ContentScopeScriptsFeature,
-) : CoreContentScopeScripts, PrivacyConfigCallbackPlugin {
+) : CoreContentScopeScripts {
     // These adapters must be declared before cachedContentScopeJson.
     private val reusableMoshi: Moshi = Builder().build()
     private val userUnprotectedDomainsAdapter: JsonAdapter<List<String>> =
@@ -74,21 +71,13 @@ class RealContentScopeScripts @Inject constructor(
     private val experimentsAdapter: JsonAdapter<List<Experiment>> =
         reusableMoshi.adapter(Types.newParameterizedType(List::class.java, Experiment::class.java))
 
-    // Plugin config() is driven only by privacy-config persistence, so we cache the assembled
-    // config string and refresh it only when a new config is persisted/downloaded, rather than
-    // iterating every plugin on every navigation. Set from onPrivacyConfigPersisted() (worker
-    // thread) and read in getScript() (main), hence @Volatile.
-    @Volatile private var pluginConfigNeedsRebuild: Boolean = true
-
-    // Startup latch: feature repos load their persisted config into memory asynchronously and
-    // expose no completion signal, so we keep refreshing the plugin config on every call until it
-    // stops changing (repos settled), then trust pluginConfigNeedsRebuild. Only touched from getScript().
-    // On a config download the repos reload synchronously inside PrivacyFeaturePlugin.store(), before
-    // onPrivacyConfigPersisted() is dispatched, so the latch only has to cover process startup.
-    private var pluginConfigSettled: Boolean = false
+    // Compared against a freshly assembled config on every call, not used to skip assembling it: the
+    // feature repos load their persisted config into memory asynchronously and expose no completion
+    // signal, so any attempt to decide up front that the config cannot have changed risks serving
+    // default protections for the rest of the process.
     private var cachedPluginConfig: String = ""
 
-    private var cachedContentScopeJson: String = getContentScopeJson("", emptyList(), optimizeInjectionEnabled())
+    private var cachedContentScopeJson: String = getContentScopeJson("", emptyList(), optimized = true)
 
     private var cachedUserUnprotectedDomains = CopyOnWriteArrayList<String>()
     private var cachedUserUnprotectedDomainsJson: String = EMPTY_JSON_LIST
@@ -132,11 +121,6 @@ class RealContentScopeScripts @Inject constructor(
     ): String {
         var updateJS = false
 
-        // This path maintains cachedContentScopeJson but not cachedPluginConfig, so the optimized path
-        // must re-derive it if the flag is ever flipped back mid-session. Write-only here: nothing below
-        // reads it, so legacy behaviour is unaffected.
-        pluginConfigNeedsRebuild = true
-
         val pluginParameters = getPluginParameters()
 
         if (cachedUnprotectTemporaryExceptions != unprotectedTemporary.unprotectedTemporaryExceptions) {
@@ -167,10 +151,9 @@ class RealContentScopeScripts @Inject constructor(
         return cachedContentScopeJS
     }
 
-    // Optimized path: the expensive plugin config() assembly is cached and refreshed only when the
-    // privacy config is persisted (plus a startup stabilisation latch, see field docs), and the
-    // content scope JSON is re-serialized only when one of its two inputs actually changed. The
-    // cheaper per-call inputs (allow list, preferences, cohorts) are unchanged.
+    // Optimized path: every input is still read on every call, so nothing here can go stale. What it
+    // avoids is the work downstream of an unchanged input — re-serializing the unprotected temporary
+    // exceptions, rebuilding the content scope JSON, and reassembling the script template.
     private fun getOptimizedScript(
         isDesktopMode: Boolean?,
         activeExperiments: List<Toggle>,
@@ -178,15 +161,11 @@ class RealContentScopeScripts @Inject constructor(
         var updateJS = false
         var contentScopeChanged = false
 
-        if (pluginConfigNeedsRebuild || !pluginConfigSettled) {
-            pluginConfigNeedsRebuild = false
-            val pluginConfig = getPluginConfig()
-            // An empty config means the repos have not finished loading yet, so never latch on it.
-            pluginConfigSettled = pluginConfig.isNotEmpty() && pluginConfig == cachedPluginConfig
-            if (pluginConfig != cachedPluginConfig) {
-                cachedPluginConfig = pluginConfig
-                contentScopeChanged = true
-            }
+        val pluginParameters = getPluginParameters()
+
+        if (cachedPluginConfig != pluginParameters.config) {
+            cachedPluginConfig = pluginParameters.config
+            contentScopeChanged = true
         }
 
         val unprotectedTemporaryExceptions = unprotectedTemporary.unprotectedTemporaryExceptions
@@ -206,7 +185,7 @@ class RealContentScopeScripts @Inject constructor(
             updateJS = true
         }
 
-        val userPreferencesJson = getUserPreferencesJson(getPluginPreferences(), isDesktopMode, activeExperiments, optimized = true)
+        val userPreferencesJson = getUserPreferencesJson(pluginParameters.preferences, isDesktopMode, activeExperiments, optimized = true)
         if (cachedUserPreferencesJson != userPreferencesJson) {
             cachedUserPreferencesJson = userPreferencesJson
             updateJS = true
@@ -227,18 +206,6 @@ class RealContentScopeScripts @Inject constructor(
     private fun getCallbackKeyValuePair() = "\"messageCallback\":\"$callbackName\""
 
     private fun getInterfaceKeyValuePair() = "\"javascriptInterface\":\"$javascriptInterface\""
-
-    override fun onPrivacyConfigDownloaded() {
-        // No-op: invalidation is handled in onPrivacyConfigPersisted(), which fires on every persist
-        // (both the startup local-config load and each remote download), whereas this fires on
-        // downloads only.
-    }
-
-    override fun onPrivacyConfigPersisted() {
-        // Invalidate the cached plugin config so the next getScript() rebuilds it. Fires on every
-        // config persist (startup local load and each remote download).
-        pluginConfigNeedsRebuild = true
-    }
 
     private fun getPluginParameters(): PluginParameters {
         var config = ""
@@ -265,16 +232,6 @@ class RealContentScopeScripts @Inject constructor(
         }
         return PluginParameters(config, preferences)
     }
-
-    private fun getPluginConfig(): String = joinNonEmpty { it.config() }
-
-    private fun getPluginPreferences(): String = joinNonEmpty { it.preferences() }
-
-    private inline fun joinNonEmpty(value: (ContentScopeConfigPlugin) -> String?): String =
-        pluginPoint.getPlugins()
-            .mapNotNull(value)
-            .filter { it.isNotEmpty() }
-            .joinToString(",")
 
     private fun cacheUserUnprotectedDomains(
         userUnprotectedDomains: List<String>,

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -25,8 +25,10 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.fingerprintprotection.api.FingerprintProtectionManager
+import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Moshi.Builder
@@ -52,7 +54,8 @@ interface CoreContentScopeScripts {
 }
 
 @SingleInstanceIn(AppScope::class)
-@ContributesBinding(AppScope::class)
+@ContributesBinding(AppScope::class, boundType = CoreContentScopeScripts::class)
+@ContributesMultibinding(AppScope::class, boundType = PrivacyConfigCallbackPlugin::class)
 class RealContentScopeScripts @Inject constructor(
     private val pluginPoint: PluginPoint<ContentScopeConfigPlugin>,
     private val userAllowListRepository: UserAllowListRepository,
@@ -61,7 +64,7 @@ class RealContentScopeScripts @Inject constructor(
     private val unprotectedTemporary: UnprotectedTemporary,
     private val fingerprintProtectionManager: FingerprintProtectionManager,
     private val contentScopeScriptsFeature: ContentScopeScriptsFeature,
-) : CoreContentScopeScripts {
+) : CoreContentScopeScripts, PrivacyConfigCallbackPlugin {
     // These adapters must be declared before cachedContentScopeJson.
     private val reusableMoshi: Moshi = Builder().build()
     private val userUnprotectedDomainsAdapter: JsonAdapter<List<String>> =
@@ -71,7 +74,21 @@ class RealContentScopeScripts @Inject constructor(
     private val experimentsAdapter: JsonAdapter<List<Experiment>> =
         reusableMoshi.adapter(Types.newParameterizedType(List::class.java, Experiment::class.java))
 
-    private var cachedContentScopeJson: String = getContentScopeJson("", emptyList())
+    // Plugin config() is driven only by privacy-config persistence, so we cache the assembled
+    // config string and refresh it only when a new config is persisted/downloaded, rather than
+    // iterating every plugin on every navigation. Set from onPrivacyConfigPersisted() (worker
+    // thread) and read in getScript() (main), hence @Volatile.
+    @Volatile private var pluginConfigNeedsRebuild: Boolean = true
+
+    // Startup latch: feature repos load their persisted config into memory asynchronously and
+    // expose no completion signal, so we keep refreshing the plugin config on every call until it
+    // stops changing (repos settled), then trust pluginConfigNeedsRebuild. Only touched from getScript().
+    // On a config download the repos reload synchronously inside PrivacyFeaturePlugin.store(), before
+    // onPrivacyConfigPersisted() is dispatched, so the latch only has to cover process startup.
+    private var pluginConfigSettled: Boolean = false
+    private var cachedPluginConfig: String = ""
+
+    private var cachedContentScopeJson: String = getContentScopeJson("", emptyList(), optimizeInjectionEnabled())
 
     private var cachedUserUnprotectedDomains = CopyOnWriteArrayList<String>()
     private var cachedUserUnprotectedDomainsJson: String = EMPTY_JSON_LIST
@@ -93,34 +110,98 @@ class RealContentScopeScripts @Inject constructor(
         isDesktopMode: Boolean?,
         activeExperiments: List<Toggle>,
     ): String {
+        return if (optimizeInjectionEnabled()) {
+            getOptimizedScript(isDesktopMode, activeExperiments)
+        } else {
+            getLegacyScript(isDesktopMode, activeExperiments)
+        }
+    }
+
+    // Original implementation, left intact. Used when optimizeContentScopeInjection is disabled, and
+    // deleted together with that flag once the optimized path is fully rolled out.
+    private fun getLegacyScript(
+        isDesktopMode: Boolean?,
+        activeExperiments: List<Toggle>,
+    ): String {
         var updateJS = false
 
         val pluginParameters = getPluginParameters()
 
         if (cachedUnprotectTemporaryExceptions != unprotectedTemporary.unprotectedTemporaryExceptions) {
-            cacheUserUnprotectedTemporaryExceptions(unprotectedTemporary.unprotectedTemporaryExceptions)
+            cacheUserUnprotectedTemporaryExceptions(unprotectedTemporary.unprotectedTemporaryExceptions, optimized = false)
             updateJS = true
         }
 
-        val contentScopeJson = getContentScopeJson(pluginParameters.config, cachedUnprotectTemporaryExceptions)
+        val contentScopeJson = getContentScopeJson(pluginParameters.config, cachedUnprotectTemporaryExceptions, optimized = false)
         if (cachedContentScopeJson != contentScopeJson) {
             cachedContentScopeJson = contentScopeJson
             updateJS = true
         }
 
         if (cachedUserUnprotectedDomains != userAllowListRepository.domainsInUserAllowList()) {
-            cacheUserUnprotectedDomains(userAllowListRepository.domainsInUserAllowList())
+            cacheUserUnprotectedDomains(userAllowListRepository.domainsInUserAllowList(), optimized = false)
             updateJS = true
         }
 
-        val userPreferencesJson = getUserPreferencesJson(pluginParameters.preferences, isDesktopMode, activeExperiments)
+        val userPreferencesJson = getUserPreferencesJson(pluginParameters.preferences, isDesktopMode, activeExperiments, optimized = false)
         if (cachedUserPreferencesJson != userPreferencesJson) {
             cachedUserPreferencesJson = userPreferencesJson
             updateJS = true
         }
 
         if (!this::cachedContentScopeJS.isInitialized || updateJS) {
-            cacheContentScopeJS()
+            cacheContentScopeJS(optimized = false)
+        }
+        return cachedContentScopeJS
+    }
+
+    // Optimized path: the expensive plugin config() assembly is cached and refreshed only when the
+    // privacy config is persisted (plus a startup stabilisation latch, see field docs), and the
+    // content scope JSON is re-serialized only when one of its two inputs actually changed. The
+    // cheaper per-call inputs (allow list, preferences, cohorts) are unchanged.
+    private fun getOptimizedScript(
+        isDesktopMode: Boolean?,
+        activeExperiments: List<Toggle>,
+    ): String {
+        var updateJS = false
+        var contentScopeChanged = false
+
+        if (pluginConfigNeedsRebuild || !pluginConfigSettled) {
+            pluginConfigNeedsRebuild = false
+            val pluginConfig = getPluginConfig()
+            // An empty config means the repos have not finished loading yet, so never latch on it.
+            pluginConfigSettled = pluginConfig.isNotEmpty() && pluginConfig == cachedPluginConfig
+            if (pluginConfig != cachedPluginConfig) {
+                cachedPluginConfig = pluginConfig
+                contentScopeChanged = true
+            }
+        }
+
+        val unprotectedTemporaryExceptions = unprotectedTemporary.unprotectedTemporaryExceptions
+        if (cachedUnprotectTemporaryExceptions != unprotectedTemporaryExceptions) {
+            cacheUserUnprotectedTemporaryExceptions(unprotectedTemporaryExceptions, optimized = true)
+            contentScopeChanged = true
+        }
+
+        if (contentScopeChanged) {
+            cachedContentScopeJson = buildContentScopeJson(cachedPluginConfig, cachedUnprotectTemporaryExceptionsJson)
+            updateJS = true
+        }
+
+        val userUnprotectedDomains = userAllowListRepository.domainsInUserAllowList()
+        if (cachedUserUnprotectedDomains != userUnprotectedDomains) {
+            cacheUserUnprotectedDomains(userUnprotectedDomains, optimized = true)
+            updateJS = true
+        }
+
+        val userPreferencesJson = getUserPreferencesJson(getPluginPreferences(), isDesktopMode, activeExperiments, optimized = true)
+        if (cachedUserPreferencesJson != userPreferencesJson) {
+            cachedUserPreferencesJson = userPreferencesJson
+            updateJS = true
+        }
+
+        if (!this::cachedContentScopeJS.isInitialized || updateJS) {
+            cacheContentScopeJS(optimized = true)
         }
         return cachedContentScopeJS
     }
@@ -134,6 +215,18 @@ class RealContentScopeScripts @Inject constructor(
     private fun getCallbackKeyValuePair() = "\"messageCallback\":\"$callbackName\""
 
     private fun getInterfaceKeyValuePair() = "\"javascriptInterface\":\"$javascriptInterface\""
+
+    override fun onPrivacyConfigDownloaded() {
+        // No-op: invalidation is handled in onPrivacyConfigPersisted(), which fires on every persist
+        // (both the startup local-config load and each remote download), whereas this fires on
+        // downloads only.
+    }
+
+    override fun onPrivacyConfigPersisted() {
+        // Invalidate the cached plugin config so the next getScript() rebuilds it. Fires on every
+        // config persist (startup local load and each remote download).
+        pluginConfigNeedsRebuild = true
+    }
 
     private fun getPluginParameters(): PluginParameters {
         var config = ""
@@ -161,31 +254,47 @@ class RealContentScopeScripts @Inject constructor(
         return PluginParameters(config, preferences)
     }
 
-    private fun cacheUserUnprotectedDomains(userUnprotectedDomains: List<String>) {
+    private fun getPluginConfig(): String = joinNonEmpty { it.config() }
+
+    private fun getPluginPreferences(): String = joinNonEmpty { it.preferences() }
+
+    private inline fun joinNonEmpty(value: (ContentScopeConfigPlugin) -> String?): String =
+        pluginPoint.getPlugins()
+            .mapNotNull(value)
+            .filter { it.isNotEmpty() }
+            .joinToString(",")
+
+    private fun cacheUserUnprotectedDomains(
+        userUnprotectedDomains: List<String>,
+        optimized: Boolean,
+    ) {
         cachedUserUnprotectedDomains.clear()
         if (userUnprotectedDomains.isEmpty()) {
             cachedUserUnprotectedDomainsJson = EMPTY_JSON_LIST
         } else {
-            cachedUserUnprotectedDomainsJson = getUserUnprotectedDomainsJson(userUnprotectedDomains)
+            cachedUserUnprotectedDomainsJson = getUserUnprotectedDomainsJson(userUnprotectedDomains, optimized)
             cachedUserUnprotectedDomains.addAll(userUnprotectedDomains)
         }
     }
 
-    private fun cacheUserUnprotectedTemporaryExceptions(unprotectedTemporaryExceptions: List<FeatureException>) {
+    private fun cacheUserUnprotectedTemporaryExceptions(
+        unprotectedTemporaryExceptions: List<FeatureException>,
+        optimized: Boolean,
+    ) {
         cachedUnprotectTemporaryExceptions.clear()
         if (unprotectedTemporaryExceptions.isEmpty()) {
             cachedUnprotectTemporaryExceptionsJson = EMPTY_JSON_LIST
         } else {
-            cachedUnprotectTemporaryExceptionsJson = getUnprotectedTemporaryJson(unprotectedTemporaryExceptions)
+            cachedUnprotectTemporaryExceptionsJson = getUnprotectedTemporaryJson(unprotectedTemporaryExceptions, optimized)
             cachedUnprotectTemporaryExceptions.addAll(unprotectedTemporaryExceptions)
         }
     }
 
-    private fun cacheContentScopeJS() {
+    private fun cacheContentScopeJS(optimized: Boolean) {
         val contentScopeJS = contentScopeJSReader.getContentScopeJS()
         val messagingParameters = "${getSecretKeyValuePair()},${getCallbackKeyValuePair()},${getInterfaceKeyValuePair()}"
 
-        cachedContentScopeJS = if (optimizeInjectionEnabled()) {
+        cachedContentScopeJS = if (optimized) {
             assembleContentScopeJS(contentScopeJS, messagingParameters)
         } else {
             contentScopeJS
@@ -253,8 +362,11 @@ class RealContentScopeScripts @Inject constructor(
         return segments
     }
 
-    private fun getUserUnprotectedDomainsJson(userUnprotectedDomains: List<String>): String {
-        if (optimizeInjectionEnabled()) {
+    private fun getUserUnprotectedDomainsJson(
+        userUnprotectedDomains: List<String>,
+        optimized: Boolean,
+    ): String {
+        if (optimized) {
             return userUnprotectedDomainsAdapter.toJson(userUnprotectedDomains)
         } else {
             val type = Types.newParameterizedType(MutableList::class.java, String::class.java)
@@ -264,8 +376,11 @@ class RealContentScopeScripts @Inject constructor(
         }
     }
 
-    private fun getUnprotectedTemporaryJson(unprotectedTemporaryExceptions: List<FeatureException>): String {
-        if (optimizeInjectionEnabled()) {
+    private fun getUnprotectedTemporaryJson(
+        unprotectedTemporaryExceptions: List<FeatureException>,
+        optimized: Boolean,
+    ): String {
+        if (optimized) {
             return unprotectedTemporaryAdapter.toJson(unprotectedTemporaryExceptions)
         } else {
             val type = Types.newParameterizedType(MutableList::class.java, FeatureException::class.java)
@@ -279,8 +394,9 @@ class RealContentScopeScripts @Inject constructor(
         userPreferences: String,
         isDesktopMode: Boolean?,
         activeExperiments: List<Toggle>,
+        optimized: Boolean,
     ): String {
-        val experiments = getExperimentsKeyValuePair(activeExperiments)
+        val experiments = getExperimentsKeyValuePair(activeExperiments, optimized)
         val defaultParameters =
             "${getVersionNumberKeyValuePair()},${getPlatformKeyValuePair()},${getLanguageKeyValuePair()}," +
                 "${getSessionKeyValuePair()},${getDesktopModeKeyValuePair(isDesktopMode ?: false)},$MESSAGING_PARAMETERS"
@@ -300,9 +416,14 @@ class RealContentScopeScripts @Inject constructor(
 
     private fun getSessionKeyValuePair() = "\"sessionKey\":\"${fingerprintProtectionManager.getSeed()}\""
 
-    private fun getExperimentsKeyValuePair(activeExperiments: List<Toggle>): String {
+    // Toggle.getCohort() is suspend but has no suspension points today, so runBlocking runs inline and
+    // never parks the caller. If it ever gains real IO this becomes a main-thread stall.
+    private fun getExperimentsKeyValuePair(
+        activeExperiments: List<Toggle>,
+        optimized: Boolean,
+    ): String {
         return runBlocking {
-            val jsonAdapter: JsonAdapter<List<Experiment>> = if (optimizeInjectionEnabled()) {
+            val jsonAdapter: JsonAdapter<List<Experiment>> = if (optimized) {
                 experimentsAdapter
             } else {
                 val type = Types.newParameterizedType(List::class.java, Experiment::class.java)
@@ -326,10 +447,13 @@ class RealContentScopeScripts @Inject constructor(
     private fun getContentScopeJson(
         config: String,
         unprotectedTemporaryExceptions: List<FeatureException>,
-    ): String =
-        (
-            "{\"features\":{$config},\"unprotectedTemporary\":${getUnprotectedTemporaryJson(unprotectedTemporaryExceptions)}}"
-            )
+        optimized: Boolean,
+    ): String = buildContentScopeJson(config, getUnprotectedTemporaryJson(unprotectedTemporaryExceptions, optimized))
+
+    private fun buildContentScopeJson(
+        config: String,
+        unprotectedTemporaryJson: String,
+    ): String = "{\"features\":{$config},\"unprotectedTemporary\":$unprotectedTemporaryJson}"
 
     companion object {
         const val EMPTY_JSON_LIST = "[]"

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -106,6 +106,13 @@ class RealContentScopeScripts @Inject constructor(
     override val javascriptInterface: String = getSecret()
     override val callbackName: String = getSecret()
 
+    private val cachedMessagingParameters: String =
+        "${getSecretKeyValuePair()},${getCallbackKeyValuePair()},${getInterfaceKeyValuePair()}"
+
+    private val cachedVersionAndPlatformParameters: String by lazy {
+        "${getVersionNumberKeyValuePair()},${getPlatformKeyValuePair()}"
+    }
+
     override fun getScript(
         isDesktopMode: Boolean?,
         activeExperiments: List<Toggle>,
@@ -124,6 +131,11 @@ class RealContentScopeScripts @Inject constructor(
         activeExperiments: List<Toggle>,
     ): String {
         var updateJS = false
+
+        // This path maintains cachedContentScopeJson but not cachedPluginConfig, so the optimized path
+        // must re-derive it if the flag is ever flipped back mid-session. Write-only here: nothing below
+        // reads it, so legacy behaviour is unaffected.
+        pluginConfigNeedsRebuild = true
 
         val pluginParameters = getPluginParameters()
 
@@ -292,11 +304,11 @@ class RealContentScopeScripts @Inject constructor(
 
     private fun cacheContentScopeJS(optimized: Boolean) {
         val contentScopeJS = contentScopeJSReader.getContentScopeJS()
-        val messagingParameters = "${getSecretKeyValuePair()},${getCallbackKeyValuePair()},${getInterfaceKeyValuePair()}"
 
         cachedContentScopeJS = if (optimized) {
-            assembleContentScopeJS(contentScopeJS, messagingParameters)
+            assembleContentScopeJS(contentScopeJS)
         } else {
+            val messagingParameters = "${getSecretKeyValuePair()},${getCallbackKeyValuePair()},${getInterfaceKeyValuePair()}"
             contentScopeJS
                 .replace(CONTENT_SCOPE, cachedContentScopeJson)
                 .replace(USER_UNPROTECTED_DOMAINS, cachedUserUnprotectedDomainsJson)
@@ -305,26 +317,22 @@ class RealContentScopeScripts @Inject constructor(
         }
     }
 
-    private fun assembleContentScopeJS(
-        template: String,
-        messagingParameters: String,
-    ): String {
+    private fun assembleContentScopeJS(template: String): String {
         val segments = cachedTemplateSegments ?: splitTemplate(template).also { cachedTemplateSegments = it }
         val builder = StringBuilder(
             template.length +
                 cachedContentScopeJson.length +
                 cachedUserUnprotectedDomainsJson.length +
                 cachedUserPreferencesJson.length +
-                messagingParameters.length,
+                cachedMessagingParameters.length,
         )
         segments.forEach { segment ->
             when (segment) {
                 is TemplateSegment.Literal -> builder.append(segment.text)
                 TemplateSegment.ContentScope -> builder.append(cachedContentScopeJson)
                 TemplateSegment.UserUnprotectedDomains -> builder.append(cachedUserUnprotectedDomainsJson)
-                TemplateSegment.UserPreferences ->
-                    builder.append(cachedUserPreferencesJson.replace(MESSAGING_PARAMETERS, messagingParameters))
-                TemplateSegment.MessagingParameters -> builder.append(messagingParameters)
+                TemplateSegment.UserPreferences -> builder.append(cachedUserPreferencesJson)
+                TemplateSegment.MessagingParameters -> builder.append(cachedMessagingParameters)
             }
         }
         return builder.toString()
@@ -397,9 +405,15 @@ class RealContentScopeScripts @Inject constructor(
         optimized: Boolean,
     ): String {
         val experiments = getExperimentsKeyValuePair(activeExperiments, optimized)
+        val messaging = if (optimized) cachedMessagingParameters else MESSAGING_PARAMETERS
+        val versionAndPlatform = if (optimized) {
+            cachedVersionAndPlatformParameters
+        } else {
+            "${getVersionNumberKeyValuePair()},${getPlatformKeyValuePair()}"
+        }
         val defaultParameters =
-            "${getVersionNumberKeyValuePair()},${getPlatformKeyValuePair()},${getLanguageKeyValuePair()}," +
-                "${getSessionKeyValuePair()},${getDesktopModeKeyValuePair(isDesktopMode ?: false)},$MESSAGING_PARAMETERS"
+            "$versionAndPlatform,${getLanguageKeyValuePair()}," +
+                "${getSessionKeyValuePair()},${getDesktopModeKeyValuePair(isDesktopMode ?: false)},$messaging"
         if (userPreferences.isEmpty()) {
             return "{$experiments,$defaultParameters}"
         }
@@ -430,17 +444,29 @@ class RealContentScopeScripts @Inject constructor(
                 val moshi = Builder().build()
                 moshi.adapter(type)
             }
-            activeExperiments
-                .filter { it.getCohort() != null && it.featureName().parentName != null }
-                .map {
+            val experiments = if (optimized) {
+                activeExperiments.mapNotNull { toggle ->
+                    val cohort = toggle.getCohort() ?: return@mapNotNull null
+                    val featureName = toggle.featureName()
+                    val parentName = featureName.parentName ?: return@mapNotNull null
                     Experiment(
-                        cohort = it.getCohort()!!.name,
-                        feature = it.featureName().parentName!!,
-                        subfeature = it.featureName().name,
+                        cohort = cohort.name,
+                        feature = parentName,
+                        subfeature = featureName.name,
                     )
-                }.let {
-                    return@runBlocking "\"currentCohorts\":${jsonAdapter.toJson(it)}"
                 }
+            } else {
+                activeExperiments
+                    .filter { it.getCohort() != null && it.featureName().parentName != null }
+                    .map {
+                        Experiment(
+                            cohort = it.getCohort()!!.name,
+                            feature = it.featureName().parentName!!,
+                            subfeature = it.featureName().name,
+                        )
+                    }
+            }
+            return@runBlocking "\"currentCohorts\":${jsonAdapter.toJson(experiments)}"
         }
     }
 

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
@@ -29,7 +29,6 @@ import com.duckduckgo.feature.toggles.api.Toggle.FeatureName
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.feature.toggles.api.Toggle.State.Cohort
 import com.duckduckgo.fingerprintprotection.api.FingerprintProtectionManager
-import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
@@ -170,61 +169,38 @@ class RealContentScopeScriptsTest {
     }
 
     @Test
-    fun whenOptimizeEnabledAndPluginConfigChangesAfterStabilisingThenNotReflectedUntilPrivacyConfigPersisted() {
+    fun whenOptimizeEnabledAndPluginConfigChangesThenReflectedImmediately() {
         contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
-        // Two calls to let the plugin config stabilise (repos "settled").
         testee.getScript(null, listOf())
-        testee.getScript(null, listOf())
-
-        // Plugin config changes with no persist signal: must keep serving the cached config.
-        whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(mockPlugin1))
-        val staleJs = testee.getScript(null, listOf())
-        assertTrue(staleJs.contains("\"features\":{$config1,$config2}"))
-
-        // Persist signal invalidates the cached plugin config; next call rebuilds it.
-        (testee as PrivacyConfigCallbackPlugin).onPrivacyConfigPersisted()
-        val freshJs = testee.getScript(null, listOf())
-        assertTrue(freshJs.contains("\"features\":{$config1}"))
-        assertFalse("stale config2 must be gone after invalidation", freshJs.contains(config2))
-    }
-
-    @Test
-    fun whenOptimizeEnabledAndPluginConfigChangesBeforeStabilisingThenReflectedWithoutPersistSignal() {
-        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
-
-        // First call: the config has not stabilised yet, so the next call must still rebuild it. This is the
-        // cold-start window where the feature repos are still loading their persisted config into memory.
         testee.getScript(null, listOf())
 
         whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(mockPlugin1))
         val js = testee.getScript(null, listOf())
 
         assertTrue(js.contains("\"features\":{$config1}"))
-        assertFalse("config2 must be gone while the plugin config is still unsettled", js.contains(config2))
+        assertFalse("config2 must be gone on the very next call", js.contains(config2))
     }
 
     @Test
-    fun whenOptimizeEnabledAndPluginConfigIsEmptyThenNeverLatchesAndPicksUpTheLoadedConfig() {
+    fun whenOptimizeEnabledAndPluginConfigLoadsAfterEarlyNavigationsThenItIsStillPickedUp() {
         contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
-        // The feature repos have not finished loading their persisted config yet, so every plugin
-        // reports an empty config for the first two sweeps and the real config on the third.
-        whenever(mockPlugin1.config()).thenReturn("", "", config1)
-        whenever(mockPlugin2.config()).thenReturn("")
+        // A feature repo that has not finished its async load reports the entity's default JSON, which is
+        // non-empty ("elementHiding":{} and friends). Repeated identical sweeps therefore say nothing about
+        // whether the repos are done, and must not be taken as a signal to stop sweeping.
+        val configDefault = "\"config1\":{}"
+        whenever(mockPlugin1.config()).thenReturn(configDefault, configDefault, config1)
 
-        assertTrue(testee.getScript(null, listOf()).contains("\"features\":{}"))
-        assertTrue(testee.getScript(null, listOf()).contains("\"features\":{}"))
+        assertTrue(testee.getScript(null, listOf()).contains("\"features\":{$configDefault,$config2}"))
+        assertTrue(testee.getScript(null, listOf()).contains("\"features\":{$configDefault,$config2}"))
 
-        // Two identical empty sweeps must not settle the latch, otherwise the loaded config would
-        // never be picked up. No persist signal is sent here on purpose.
         val js = testee.getScript(null, listOf())
-        assertTrue("the loaded config must be picked up without a persist signal", js.contains("\"features\":{$config1}"))
+        assertTrue("a late repo load must be picked up", js.contains("\"features\":{$config1,$config2}"))
+        assertFalse("the default config must not survive the load", js.contains(configDefault))
     }
 
     @Test
-    fun whenOptimizeEnabledAndOnlyUnprotectedTemporaryChangesAfterSettlingThenContentScopeJsonIsRebuilt() {
+    fun whenOptimizeEnabledAndOnlyUnprotectedTemporaryChangesThenContentScopeJsonIsRebuilt() {
         contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
-        // Two calls to settle the plugin config, so the rebuild below can only be driven by the
-        // unprotected temporary change and not by the plugin config branch.
         testee.getScript(null, listOf())
         testee.getScript(null, listOf())
 
@@ -232,37 +208,19 @@ class RealContentScopeScriptsTest {
         val js = testee.getScript(null, listOf())
 
         assertTrue(js.contains("\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"}]"))
-        assertTrue("the settled plugin config must survive the rebuild", js.contains("\"features\":{$config1,$config2}"))
+        assertTrue("the unchanged plugin config must survive the rebuild", js.contains("\"features\":{$config1,$config2}"))
     }
 
     @Test
-    fun whenOptimizeEnabledAndPrivacyConfigDownloadedThenCachedPluginConfigIsNotInvalidated() {
-        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
-        testee.getScript(null, listOf())
-        testee.getScript(null, listOf())
-
-        // Invalidation is deliberately driven by onPrivacyConfigPersisted(), which is a superset of
-        // this callback, so a download on its own must not rebuild the cached plugin config.
-        whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(mockPlugin1))
-        (testee as PrivacyConfigCallbackPlugin).onPrivacyConfigDownloaded()
-
-        val js = testee.getScript(null, listOf())
-        assertTrue(js.contains("\"features\":{$config1,$config2}"))
-    }
-
-    @Test
-    fun whenOptimizeEnabledThenPluginConfigIsOnlyRebuiltUntilSettledAndOnPersist() {
+    fun whenOptimizeEnabledThenPluginConfigIsSweptOnEveryCall() {
         contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
 
-        // Calls 1 and 2 both sweep the plugins (call 2 is what settles the latch); calls 3 and 4 must not.
         repeat(4) { testee.getScript(null, listOf()) }
-        verify(mockPlugin1, times(2)).config()
 
-        // A persist signal re-arms the rebuild for exactly one sweep: the config comes back unchanged, so
-        // the latch settles again immediately and the following calls skip the sweep.
-        (testee as PrivacyConfigCallbackPlugin).onPrivacyConfigPersisted()
-        repeat(3) { testee.getScript(null, listOf()) }
-        verify(mockPlugin1, times(3)).config()
+        // Deliberately not cached, see the cachedPluginConfig field comment. The saving is downstream: an
+        // unchanged config means no JSON rebuild and no template reassembly.
+        verify(mockPlugin1, times(4)).config()
+        verify(mockContentScopeJsReader).getContentScopeJS()
     }
 
     @Test
@@ -282,19 +240,19 @@ class RealContentScopeScriptsTest {
     fun whenFlagFlipsBackToOptimizedThenPluginConfigDroppedOnTheLegacyPathIsNotResurrected() {
         val optimizeFlag = contentScopeScriptsFeature.optimizeContentScopeInjection()
 
-        // Settle the cached plugin config on the full plugin set.
+        // Record the plugin config on the full plugin set.
         optimizeFlag.setRawStoredState(State(enable = true))
         testee.getScript(null, listOf())
         testee.getScript(null, listOf())
 
-        // The legacy path takes over and the plugin config shrinks. Legacy recomputes it per call, so it
-        // serves the new config, but it does not maintain the optimized path's cache of it.
+        // The legacy path takes over and the plugin config shrinks. Legacy serves the new config but does
+        // not maintain the comparison baseline the optimized path keeps.
         optimizeFlag.setRawStoredState(State(enable = false))
         whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(mockPlugin1))
         assertTrue(testee.getScript(null, listOf()).contains("\"features\":{$config1}"))
 
-        // Back to the optimized path with no persist signal, and something else forces a rebuild of the
-        // content scope JSON. It must not be rebuilt from the plugin config captured before the flip.
+        // Back on the optimized path, with something else also forcing a rebuild of the content scope
+        // JSON. It must not be rebuilt from the config recorded before the flip.
         optimizeFlag.setRawStoredState(State(enable = true))
         whenever(mockUnprotectedTemporary.unprotectedTemporaryExceptions).thenReturn(listOf(unprotectedTemporaryException))
         val js = testee.getScript(null, listOf())

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
@@ -489,6 +489,11 @@ class RealContentScopeScriptsTest {
     @Test
     fun whenOptimizeInjectionEnabledThenOutputIsByteIdenticalToFallbackPath() {
         // getScript memoizes cachedContentScopeJS, so each path uses its own fresh instance to force a real build.
+        // Two preferences contributors as well as two config ones, so the comparison covers both accumulators
+        // in getLegacyPluginParameters and its hand-maintained twin getOptimizedPluginParameters.
+        whenever(mockPlugin1.preferences()).thenReturn("\"pref1\":true")
+        whenever(mockPlugin2.preferences()).thenReturn("\"pref2\":false")
+
         // Fallback path (chained String.replace).
         contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = false))
         val fallbackTestee = createTestee()

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
@@ -279,6 +279,77 @@ class RealContentScopeScriptsTest {
     }
 
     @Test
+    fun whenFlagFlipsBackToOptimizedThenPluginConfigDroppedOnTheLegacyPathIsNotResurrected() {
+        val optimizeFlag = contentScopeScriptsFeature.optimizeContentScopeInjection()
+
+        // Settle the cached plugin config on the full plugin set.
+        optimizeFlag.setRawStoredState(State(enable = true))
+        testee.getScript(null, listOf())
+        testee.getScript(null, listOf())
+
+        // The legacy path takes over and the plugin config shrinks. Legacy recomputes it per call, so it
+        // serves the new config, but it does not maintain the optimized path's cache of it.
+        optimizeFlag.setRawStoredState(State(enable = false))
+        whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(mockPlugin1))
+        assertTrue(testee.getScript(null, listOf()).contains("\"features\":{$config1}"))
+
+        // Back to the optimized path with no persist signal, and something else forces a rebuild of the
+        // content scope JSON. It must not be rebuilt from the plugin config captured before the flip.
+        optimizeFlag.setRawStoredState(State(enable = true))
+        whenever(mockUnprotectedTemporary.unprotectedTemporaryExceptions).thenReturn(listOf(unprotectedTemporaryException))
+        val js = testee.getScript(null, listOf())
+
+        assertFalse("config dropped while on the legacy path must not be resurrected", js.contains(config2))
+        assertTrue(js.contains("\"features\":{$config1}"))
+    }
+
+    @Test
+    fun whenOptimizeEnabledThenEachToggleCohortIsReadOnce() = runTest {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+        val mockToggle = mock<Toggle>()
+        whenever(mockToggle.getCohort()).thenReturn(Cohort("control", weight = 1))
+        whenever(mockToggle.featureName()).thenReturn(FeatureName("contentScopeExperiments", "test"))
+
+        testee.getScript(null, listOf(mockToggle))
+
+        // getCohort() can enrol to self-heal a stale cohort, so the optimized path must not call it twice.
+        verify(mockToggle).getCohort()
+    }
+
+    @Test
+    fun whenOptimizeDisabledThenEachToggleCohortIsReadTwice() = runTest {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = false))
+        val mockToggle = mock<Toggle>()
+        whenever(mockToggle.getCohort()).thenReturn(Cohort("control", weight = 1))
+        whenever(mockToggle.featureName()).thenReturn(FeatureName("contentScopeExperiments", "test"))
+
+        testee.getScript(null, listOf(mockToggle))
+
+        // The legacy path filters then maps, so it reads each toggle twice. Frozen deliberately.
+        verify(mockToggle, times(2)).getCohort()
+    }
+
+    @Test
+    fun whenOptimizeEnabledThenBuildConstantsAreReadOnce() {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+
+        repeat(3) { testee.getScript(null, listOf()) }
+
+        // The version and platform parameters cannot change while the process is alive.
+        verify(mockAppBuildConfig).versionCode
+    }
+
+    @Test
+    fun whenOptimizeDisabledThenBuildConstantsAreReadOnEveryCall() {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = false))
+
+        repeat(3) { testee.getScript(null, listOf()) }
+
+        // The legacy path rebuilds them per call. Frozen deliberately.
+        verify(mockAppBuildConfig, times(3)).versionCode
+    }
+
+    @Test
     fun whenOptimizeDisabledThenPluginConfigChangesAreReflectedImmediately() {
         contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = false))
         testee.getScript(null, listOf())

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.feature.toggles.api.Toggle.FeatureName
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.feature.toggles.api.Toggle.State.Cohort
 import com.duckduckgo.fingerprintprotection.api.FingerprintProtectionManager
+import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
@@ -166,6 +167,128 @@ class RealContentScopeScriptsTest {
         verify(mockUnprotectedTemporary, times(3)).unprotectedTemporaryExceptions
         verify(mockUserAllowListRepository, times(3)).domainsInUserAllowList()
         verify(mockContentScopeJsReader, times(2)).getContentScopeJS()
+    }
+
+    @Test
+    fun whenOptimizeEnabledAndPluginConfigChangesAfterStabilisingThenNotReflectedUntilPrivacyConfigPersisted() {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+        // Two calls to let the plugin config stabilise (repos "settled").
+        testee.getScript(null, listOf())
+        testee.getScript(null, listOf())
+
+        // Plugin config changes with no persist signal: must keep serving the cached config.
+        whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(mockPlugin1))
+        val staleJs = testee.getScript(null, listOf())
+        assertTrue(staleJs.contains("\"features\":{$config1,$config2}"))
+
+        // Persist signal invalidates the cached plugin config; next call rebuilds it.
+        (testee as PrivacyConfigCallbackPlugin).onPrivacyConfigPersisted()
+        val freshJs = testee.getScript(null, listOf())
+        assertTrue(freshJs.contains("\"features\":{$config1}"))
+        assertFalse("stale config2 must be gone after invalidation", freshJs.contains(config2))
+    }
+
+    @Test
+    fun whenOptimizeEnabledAndPluginConfigChangesBeforeStabilisingThenReflectedWithoutPersistSignal() {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+
+        // First call: the config has not stabilised yet, so the next call must still rebuild it. This is the
+        // cold-start window where the feature repos are still loading their persisted config into memory.
+        testee.getScript(null, listOf())
+
+        whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(mockPlugin1))
+        val js = testee.getScript(null, listOf())
+
+        assertTrue(js.contains("\"features\":{$config1}"))
+        assertFalse("config2 must be gone while the plugin config is still unsettled", js.contains(config2))
+    }
+
+    @Test
+    fun whenOptimizeEnabledAndPluginConfigIsEmptyThenNeverLatchesAndPicksUpTheLoadedConfig() {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+        // The feature repos have not finished loading their persisted config yet, so every plugin
+        // reports an empty config for the first two sweeps and the real config on the third.
+        whenever(mockPlugin1.config()).thenReturn("", "", config1)
+        whenever(mockPlugin2.config()).thenReturn("")
+
+        assertTrue(testee.getScript(null, listOf()).contains("\"features\":{}"))
+        assertTrue(testee.getScript(null, listOf()).contains("\"features\":{}"))
+
+        // Two identical empty sweeps must not settle the latch, otherwise the loaded config would
+        // never be picked up. No persist signal is sent here on purpose.
+        val js = testee.getScript(null, listOf())
+        assertTrue("the loaded config must be picked up without a persist signal", js.contains("\"features\":{$config1}"))
+    }
+
+    @Test
+    fun whenOptimizeEnabledAndOnlyUnprotectedTemporaryChangesAfterSettlingThenContentScopeJsonIsRebuilt() {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+        // Two calls to settle the plugin config, so the rebuild below can only be driven by the
+        // unprotected temporary change and not by the plugin config branch.
+        testee.getScript(null, listOf())
+        testee.getScript(null, listOf())
+
+        whenever(mockUnprotectedTemporary.unprotectedTemporaryExceptions).thenReturn(listOf(unprotectedTemporaryException))
+        val js = testee.getScript(null, listOf())
+
+        assertTrue(js.contains("\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"}]"))
+        assertTrue("the settled plugin config must survive the rebuild", js.contains("\"features\":{$config1,$config2}"))
+    }
+
+    @Test
+    fun whenOptimizeEnabledAndPrivacyConfigDownloadedThenCachedPluginConfigIsNotInvalidated() {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+        testee.getScript(null, listOf())
+        testee.getScript(null, listOf())
+
+        // Invalidation is deliberately driven by onPrivacyConfigPersisted(), which is a superset of
+        // this callback, so a download on its own must not rebuild the cached plugin config.
+        whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(mockPlugin1))
+        (testee as PrivacyConfigCallbackPlugin).onPrivacyConfigDownloaded()
+
+        val js = testee.getScript(null, listOf())
+        assertTrue(js.contains("\"features\":{$config1,$config2}"))
+    }
+
+    @Test
+    fun whenOptimizeEnabledThenPluginConfigIsOnlyRebuiltUntilSettledAndOnPersist() {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+
+        // Calls 1 and 2 both sweep the plugins (call 2 is what settles the latch); calls 3 and 4 must not.
+        repeat(4) { testee.getScript(null, listOf()) }
+        verify(mockPlugin1, times(2)).config()
+
+        // A persist signal re-arms the rebuild for exactly one sweep: the config comes back unchanged, so
+        // the latch settles again immediately and the following calls skip the sweep.
+        (testee as PrivacyConfigCallbackPlugin).onPrivacyConfigPersisted()
+        repeat(3) { testee.getScript(null, listOf()) }
+        verify(mockPlugin1, times(3)).config()
+    }
+
+    @Test
+    fun whenOptimizeEnabledAndNothingChangesThenScriptIsAssembledOnceAndInputsReadOncePerCall() {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+
+        repeat(4) { verifyJsScript(testee.getScript(null, listOf())) }
+
+        // No input changed, so the script is assembled once and each input is read once per call
+        // (the legacy path reads these twice on the call that changes them).
+        verify(mockContentScopeJsReader).getContentScopeJS()
+        verify(mockUnprotectedTemporary, times(4)).unprotectedTemporaryExceptions
+        verify(mockUserAllowListRepository, times(4)).domainsInUserAllowList()
+    }
+
+    @Test
+    fun whenOptimizeDisabledThenPluginConfigChangesAreReflectedImmediately() {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = false))
+        testee.getScript(null, listOf())
+        testee.getScript(null, listOf())
+
+        // Legacy path recomputes config every call, so a change is picked up with no persist signal.
+        whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(mockPlugin1))
+        val js = testee.getScript(null, listOf())
+        assertTrue(js.contains("\"features\":{$config1}"))
+        assertFalse("config2 must be gone immediately on the legacy path", js.contains(config2))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1216821003646786?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

 ### Description

  Reduces the per-navigation cost of `getScript()` without changing its output, behind the `optimizeContentScopeInjection` kill-switch (`DefaultFeatureValue.INTERNAL`). Every input is still read on every call, so nothing can go stale — the savings are all downstream, in skipping work whose inputs didn't change and doing the rest more cheaply.

  Optimized path:

  - Plugin `config()` and `preferences()` accumulate into `StringBuilder`s instead of reassigning a `String` per plugin, which copied the whole accumulator each time — quadratic in the assembled config size, across ~22 plugins, on the main thread.
  - The contentScope JSON is rebuilt only when the assembled config or the exception list actually changed, reusing the already-serialized exceptions instead of re-serializing and re-comparing per call.
  - `runBlocking` is skipped entirely when no contentScope experiment is active — `getActiveExperiments()` returns only enabled toggles, so the result is then a constant.
  - `Toggle.getCohort()` is called once per toggle instead of twice; it can enrol to self-heal a stale cohort, so the second call wasn't a free read.
  - The feature flag is read once per call rather than at each use site, so a flag flip can't mix the two paths mid-call.
  - Messaging parameters and the version/platform constants are assembled once, and the messaging parameters are embedded when building the preferences JSON instead of being substituted from a placeholder during assembly.

  An earlier revision cached the assembled plugin config and invalidated it on privacy-config persistence.
  That was removed: a feature repo that hasn't finished its async load reports its default JSON rather than an
  empty string, so the startup stabilisation latch could settle on defaults and serve them for the rest of the
  process.

  Deliberately unchanged: allow list, unprotected temporary, plugin `config()` and `preferences()`, cohorts and
  desktop mode are evaluated on every call, so config-driven and user-facing settings (GPC, forced zoom,
  allowlisting) apply immediately.

  Rollback: with the flag off, every call runs `optimized = false` end to end through the original helpers —
  throwaway Moshi instances, the original quadratic parameter assembly, the original cohort filter/map, and the
  chained-replace assembly. The legacy path is byte-and-behaviour identical to before and is deleted with the
  flag once rollout completes. `whenOptimizeInjectionEnabledThenOutputIsByteIdenticalToFallbackPath` compares
  the two paths in full, and two further tests pin the freeze via the per-flag `getCohort()` and
  `appBuildConfig` read counts.

### Steps to test this PR
  
  - [x] Tests are passing.

  flag ON (default on internal)

  - [x] Fresh install, browse several pages in a row, confirm protections stay applied.
  - [x] Override the privacy config from dev settings, confirm a config-driven change takes effect.
  - [x] Toggle GPC in Settings, reload, confirm `globalPrivacyControlValue` takes effect (`sec-gpc: 1` is not
        sent when GPC is off).
  - [x] Toggle Accessibility → force zoom, reload, confirm behaviour changes.
  - [x] Tap the shield to allowlist a site, confirm protections drop, then re-protect it.
  - [x] Switch to desktop site and confirm the change is reflected.

  Rollback is clean
  
  - [x] Turn the flag OFF, restart, repeat the above. Behaviour must be identical to develop.
  - [x] Flip it back ON without restarting, load a page, confirm protections are still correct.


### NO UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how often privacy-config-driven script JSON is rebuilt and when plugin config updates apply (persist vs startup latch), which could affect protection behavior if invalidation or settling logic is wrong; legacy path preserved behind a kill-switch.
> 
> **Overview**
> Adds an **optimized** `getScript()` path behind `optimizeContentScopeInjection`, while keeping the prior logic as `getLegacyScript()` for rollback.
> 
> **Caching & invalidation:** Assembled plugin `config()` is cached and only rebuilt when `onPrivacyConfigPersisted()` sets `pluginConfigNeedsRebuild`, or during startup until the config stabilizes (empty configs never latch). `RealContentScopeScripts` now implements `PrivacyConfigCallbackPlugin`; `onPrivacyConfigDownloaded()` is intentionally a no-op.
> 
> **Per-call work:** Allow list, plugin `preferences()`, desktop mode, and cohorts still update every navigation. Content-scope JSON is rebuilt only when cached plugin config or unprotected-temporary exceptions change. Messaging secrets, version/platform strings, reusable Moshi adapters, and single-pass template assembly are reused on the optimized path; cohort reads go from two `getCohort()` calls to one per toggle.
> 
> **Flag behavior:** Mid-session flag flips route entirely through one path; legacy sets `pluginConfigNeedsRebuild` so switching back to optimized does not resurrect stale plugin config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d54e2870bc6d78529de2443f1bcfb9d681d77c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->