### PR TITLE
[Config-driven linear onboarding dialogs] Unify title handling

### DIFF
--- a/.maestro/onboarding/preonboarding_returning_user_quick_setup_customize.yaml
+++ b/.maestro/onboarding/preonboarding_returning_user_quick_setup_customize.yaml
@@ -26,7 +26,7 @@ tags:
           timeout: 30000
       - tapOn: "I've been here before"
       - assertVisible:
-          text: ".*Want to customize anything?.*"
+          text: ".*Want to customize.anything?.*"
 
       - tapOn: "Address bar position"
       - assertVisible:

--- a/.maestro/onboarding/preonboarding_returning_user_quick_setup_start_browsing.yaml
+++ b/.maestro/onboarding/preonboarding_returning_user_quick_setup_start_browsing.yaml
@@ -26,7 +26,7 @@ tags:
           timeout: 30000
       - tapOn: "I've been here before"
       - assertVisible:
-          text: ".*Want to customize anything?.*"
+          text: ".*Want to customize.anything?.*"
       - assertVisible:
           text: "Set DuckDuckGo as default"
       - assertVisible:

--- a/.maestro/shared/pre_onboarding.yaml
+++ b/.maestro/shared/pre_onboarding.yaml
@@ -27,7 +27,7 @@ appId: com.duckduckgo.mobile.android
     commands:
       - tapOn: "cancel"
 - assertVisible:
-    text: ".*where should I put your address bar?.*"
+    text: ".*where should I put your address.bar?.*"
 - tapOn: "next"
 - assertVisible:
     text: ".*want easy access to private AI chat?.*"

--- a/app/src/main/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarPickerBottomSheetDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarPickerBottomSheetDialog.kt
@@ -37,7 +37,6 @@ import com.duckduckgo.app.browser.databinding.BottomSheetNewAddressBarPickerBind
 import com.duckduckgo.app.onboardingquicksetup.ui.BrandDesignInputScreenPicker.Transition
 import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
 import com.duckduckgo.common.ui.setRoundCorners
-import com.duckduckgo.common.ui.view.TypeAnimationTextView
 import com.duckduckgo.common.utils.extensions.html
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -131,9 +130,8 @@ class NewAddressBarPickerBottomSheetDialog(
 
     private fun revealContent() {
         binding.inputScreen.root.isVisible = true
-        binding.inputScreen.inputScreenTitle.startOnboardingTypingAnimation(
-            getString(context, R.string.preOnboardingInputScreenTitleUpdated),
-        ) {
+        binding.inputScreen.inputScreenTitle.setTitle(getString(context, R.string.preOnboardingInputScreenTitleUpdated))
+        binding.inputScreen.inputScreenTitle.typeTitle {
             contentFadeInAnimatorSet = AnimatorSet().apply {
                 playTogether(
                     ObjectAnimator.ofFloat(
@@ -195,15 +193,6 @@ class NewAddressBarPickerBottomSheetDialog(
         restoreOrientation()
     }
 
-    private fun TypeAnimationTextView.startOnboardingTypingAnimation(
-        text: String,
-        afterAnimation: () -> Unit = {},
-    ) {
-        typingDelayInMs = TYPING_DELAY_MS
-        delayAfterAnimationInMs = TYPING_POST_DELAY_MS
-        startTypingAnimation(text, isCancellable = true, afterAnimation = afterAnimation)
-    }
-
     private fun isWindowValid(): Boolean = (context as? Activity)?.let { activity ->
         !activity.isFinishing && !activity.isDestroyed && activity.window?.decorView?.isAttachedToWindow == true
     } ?: false
@@ -212,8 +201,6 @@ class NewAddressBarPickerBottomSheetDialog(
         private const val WING_STOP_PROGRESS = 0.5f
         private const val WING_START_DELAY = 300L
         private const val WING_FADE_IN_DURATION = 150L
-        private const val TYPING_DELAY_MS = 20L
-        private const val TYPING_POST_DELAY_MS = 20L
         private const val CONTENT_FADE_IN_DURATION = 200L
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -100,7 +100,6 @@ import com.duckduckgo.app.onboardingquicksetup.ui.RemoveWidgetInstructionsBottom
 import com.duckduckgo.app.widget.AddWidgetLauncher
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.store.AppTheme
-import com.duckduckgo.common.ui.view.TypeAnimationTextView
 import com.duckduckgo.common.ui.view.addBottomShadow
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.ui.view.toPx
@@ -903,9 +902,9 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     binding.daxDialogCta.secondaryCta.visibility = if (showSecondaryCta) View.INVISIBLE else View.GONE
 
                     val titleRes = if (isSyncRestore) R.string.syncRestoreDialogBrandDesignTitle else R.string.preOnboardingWelcomeDialogTitle
+                    binding.daxDialogCta.welcomeContent.titleText.setTitle(getString(titleRes))
                     if (isSyncRestore) {
                         // SYNC_RESTORE reuses welcomeContent with its own copy and the sync-restore CTAs.
-                        binding.daxDialogCta.welcomeContent.hiddenTitleText.text = getString(titleRes)
                         binding.daxDialogCta.welcomeContent.bodyText1.text =
                             getString(R.string.syncRestoreDialogBrandDesignBody1).preventWidows().html(requireContext())
                         binding.daxDialogCta.primaryCta.text = getString(R.string.syncRestoreDialogPrimaryCta)
@@ -933,9 +932,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                         },
                         onAnimationEnd = {
                             fadeInDialog {
-                                binding.daxDialogCta.welcomeContent.titleText.startOnboardingTypingAnimation(
-                                    getString(titleRes),
-                                ) {
+                                binding.daxDialogCta.welcomeContent.titleText.typeTitle {
                                     val animators = mutableListOf<Animator>(
                                         ObjectAnimator.ofFloat(binding.daxDialogCta.welcomeContent.bodyText1, View.ALPHA, 1f)
                                             .setDuration(DIALOG_CONTENT_FADE_IN_DURATION),
@@ -983,8 +980,9 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
 
                     binding.daxDialogCta.reinstallerQuickSetupContent.root.isVisible = true
                     updateQuickSetupRowsVisibility()
-                    binding.daxDialogCta.reinstallerQuickSetupContent.quickSetupTitleHidden.text =
-                        getString(R.string.preOnboardingReinstallQuickSetupTitle).html(requireContext())
+                    binding.daxDialogCta.reinstallerQuickSetupContent.quickSetupTitle.setTitle(
+                        getString(R.string.preOnboardingReinstallQuickSetupTitle),
+                    )
 
                     val showBottomWingAnimation = applyDecorationLayout(
                         binding.bottomWingAnimation,
@@ -1005,9 +1003,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                             // end event was already in flight; unlike Animator.cancel(), this is
                             // not a synchronous stop.
                             if (view == null) return
-                            binding.daxDialogCta.reinstallerQuickSetupContent.quickSetupTitle.startOnboardingTypingAnimation(
-                                getString(R.string.preOnboardingReinstallQuickSetupTitle),
-                            ) {
+                            binding.daxDialogCta.reinstallerQuickSetupContent.quickSetupTitle.typeTitle {
                                 quickSetupFadeInAnimatorSet = AnimatorSet().apply {
                                     playTogether(
                                         ObjectAnimator.ofFloat(
@@ -1121,8 +1117,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingAddToDockPrimaryCta)
                     binding.daxDialogCta.primaryCta.alpha = 0f
 
-                    titleView.cancelAnimation()
-                    titleView.text = ""
+                    titleView.setTitle(getString(R.string.preOnboardingDockStepTitle))
                     titleView.alpha = 1f
 
                     binding.daxDialogCta.cardView.setArrowDepthFraction(0f)
@@ -1138,7 +1133,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     val listener = object : TransitionListenerAdapter() {
                         override fun onTransitionEnd(transition: androidx.transition.Transition) {
                             if (view == null) return
-                            titleView.startOnboardingTypingAnimation(getString(R.string.preOnboardingDockStepTitle).preventWidows()) {
+                            titleView.typeTitle {
                                 homeScreenPromptFadeInAnimatorSet = AnimatorSet().apply {
                                     playTogether(
                                         ObjectAnimator.ofFloat(bodyView, View.ALPHA, 1f)
@@ -1201,8 +1196,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     binding.daxDialogCta.secondaryCta.text = getString(R.string.experimentHomeScreenWidgetBottomSheetDialogGhostButton)
                     binding.daxDialogCta.secondaryCta.alpha = 0f
 
-                    titleView.cancelAnimation()
-                    titleView.text = ""
+                    titleView.setTitle(getString(R.string.experimentHomeScreenWidgetBottomSheetDialogTitle))
                     titleView.alpha = 1f
 
                     binding.daxDialogCta.cardView.setArrowAnimationTarget(ARROW_TARGET_OFFSET_END_DP.toPx().toFloat())
@@ -1220,9 +1214,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     val listener = object : TransitionListenerAdapter() {
                         override fun onTransitionEnd(transition: androidx.transition.Transition) {
                             if (view == null) return
-                            titleView.startOnboardingTypingAnimation(
-                                getString(R.string.experimentHomeScreenWidgetBottomSheetDialogTitle).preventWidows(),
-                            ) {
+                            titleView.typeTitle {
                                 binding.daxDialogCta.secondaryCta.isVisible = true
                                 homeScreenPromptFadeInAnimatorSet = AnimatorSet().apply {
                                     playTogether(
@@ -1314,6 +1306,8 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
 
                     binding.daxDialogCta.stepIndicator.animateToStep(stepIndicator)
 
+                    binding.daxDialogCta.addressBarContent.addressBarTitle.setTitle(getString(R.string.preOnboardingAddressBarTitle))
+
                     val transition = ChangeBounds().apply {
                         duration = DIALOG_TRANSITION_DURATION
                     }
@@ -1321,9 +1315,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     val listener = object : TransitionListenerAdapter() {
                         override fun onTransitionEnd(transition: androidx.transition.Transition) {
                             if (view == null) return
-                            binding.daxDialogCta.addressBarContent.addressBarTitle.startOnboardingTypingAnimation(
-                                getString(R.string.preOnboardingAddressBarTitle),
-                            ) {
+                            binding.daxDialogCta.addressBarContent.addressBarTitle.typeTitle {
                                 addressBarFadeInAnimatorSet = AnimatorSet().apply {
                                     playTogether(
                                         ObjectAnimator.ofFloat(
@@ -1384,6 +1376,8 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                         playLeftWingAnimation()
                     }
 
+                    binding.daxDialogCta.inputScreenContent.inputScreenTitle.setTitle(getString(R.string.preOnboardingInputScreenTitleUpdated))
+
                     val transition = ChangeBounds().apply {
                         duration = DIALOG_TRANSITION_DURATION
                     }
@@ -1391,9 +1385,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     val listener = object : TransitionListenerAdapter() {
                         override fun onTransitionEnd(transition: androidx.transition.Transition) {
                             if (view == null) return
-                            binding.daxDialogCta.inputScreenContent.inputScreenTitle.startOnboardingTypingAnimation(
-                                getString(R.string.preOnboardingInputScreenTitleUpdated),
-                            ) {
+                            binding.daxDialogCta.inputScreenContent.inputScreenTitle.typeTitle {
                                 inputScreenFadeInAnimatorSet = AnimatorSet().apply {
                                     playTogether(
                                         ObjectAnimator.ofFloat(
@@ -1459,7 +1451,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     } else {
                         getString(R.string.preOnboardingInputModeDemoTitle)
                     }
-                    binding.daxDialogCta.inputScreenPreviewContent.inputScreenPreviewTitleHidden.text = title
+                    binding.daxDialogCta.inputScreenPreviewContent.inputScreenPreviewTitle.setTitle(title)
 
                     if (stepIndicator != null) {
                         binding.daxDialogCta.stepIndicator.animateToStep(stepIndicator)
@@ -1497,7 +1489,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                         override fun onTransitionEnd(transition: androidx.transition.Transition) {
                             if (view == null) return
                             val previewContent = binding.daxDialogCta.inputScreenPreviewContent
-                            previewContent.inputScreenPreviewTitle.startOnboardingTypingAnimation(title) {
+                            previewContent.inputScreenPreviewTitle.typeTitle {
                                 inputScreenPreviewFadeInAnimatorSet = AnimatorSet().apply {
                                     playTogether(
                                         ObjectAnimator.ofFloat(previewContent.inputModeToggle, View.ALPHA, 1f)
@@ -1643,7 +1635,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
             binding.daxDialogCta.comparisonChartContent.comparisonTable.alpha = 0f
             binding.daxDialogCta.daxCtaContainer.alpha = 0f
             fadeInDialog {
-                playComparisonChartContentIntro(comparisonChartConfig)
+                playComparisonChartContentIntro()
             }
         } else {
             val transition = ChangeBounds().apply {
@@ -1656,7 +1648,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     // end event was already in flight; unlike Animator.cancel(), this is
                     // not a synchronous stop.
                     if (view == null) return
-                    playComparisonChartContentIntro(comparisonChartConfig)
+                    playComparisonChartContentIntro()
                 }
             }
             changeBoundsTransitionListener = listener
@@ -1732,15 +1724,14 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 binding.daxDialogCta.root.isVisible = true
                 binding.daxDialogCta.daxCtaContainer.alpha = 1f
                 binding.daxDialogCta.welcomeContent.root.alpha = 1f
-                binding.daxDialogCta.welcomeContent.titleText.cancelAnimation()
                 val titleString = if (isSyncRestore) {
                     getString(R.string.syncRestoreDialogBrandDesignTitle)
                 } else {
                     getString(R.string.preOnboardingWelcomeDialogTitle)
                 }
-                binding.daxDialogCta.welcomeContent.titleText.text = titleString
+                binding.daxDialogCta.welcomeContent.titleText.setTitle(titleString)
+                binding.daxDialogCta.welcomeContent.titleText.snapTitle()
                 if (isSyncRestore) {
-                    binding.daxDialogCta.welcomeContent.hiddenTitleText.text = titleString
                     binding.daxDialogCta.welcomeContent.bodyText1.text =
                         getString(R.string.syncRestoreDialogBrandDesignBody1).preventWidows().html(requireContext())
                     binding.daxDialogCta.primaryCta.text = getString(R.string.syncRestoreDialogPrimaryCta)
@@ -1809,9 +1800,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     }
                 }
                 binding.daxDialogCta.cardView.setArrowDepthFraction(if (showWing) 1f else 0f)
-                binding.daxDialogCta.comparisonChartContent.comparisonChartTitle.cancelAnimation()
-                binding.daxDialogCta.comparisonChartContent.comparisonChartTitle.text =
-                    getString(comparisonChartConfig.titleRes).preventWidows()
+                binding.daxDialogCta.comparisonChartContent.comparisonChartTitle.snapTitle()
                 binding.daxDialogCta.comparisonChartContent.comparisonTable.alpha = 1f
                 comparisonCheckViews().forEach { checkView ->
                     checkView.alpha = 1f
@@ -1858,8 +1847,8 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 }
 
                 val titleView = binding.daxDialogCta.addToDockContent.addToDockTitle
-                titleView.cancelAnimation()
-                titleView.text = getString(R.string.preOnboardingDockStepTitle).preventWidows()
+                titleView.setTitle(getString(R.string.preOnboardingDockStepTitle))
+                titleView.snapTitle()
                 titleView.alpha = 1f
                 binding.daxDialogCta.addToDockContent.addToDockBody.text =
                     getString(R.string.preOnboardingAddToDockBody).preventWidows()
@@ -1939,8 +1928,8 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 }
 
                 val titleView = binding.daxDialogCta.widgetPromptContent.widgetPromptTitle
-                titleView.cancelAnimation()
-                titleView.text = getString(R.string.experimentHomeScreenWidgetBottomSheetDialogTitle).preventWidows()
+                titleView.setTitle(getString(R.string.experimentHomeScreenWidgetBottomSheetDialogTitle))
+                titleView.snapTitle()
                 titleView.alpha = 1f
                 binding.daxDialogCta.widgetPromptContent.widgetPromptBody.alpha = 1f
                 binding.daxDialogCta.widgetPromptContent.widgetPromptMedia.alpha = 1f
@@ -2009,9 +1998,8 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 cardView.setArrowAnimationFraction(1f)
                 cardView.setArrowDepthFraction(if (showBobbingDax) 1f else 0f)
                 binding.daxDialogCta.addressBarContent.root.alpha = 1f
-                binding.daxDialogCta.addressBarContent.addressBarTitle.cancelAnimation()
-                binding.daxDialogCta.addressBarContent.addressBarTitle.text =
-                    getString(R.string.preOnboardingAddressBarTitle)
+                binding.daxDialogCta.addressBarContent.addressBarTitle.setTitle(getString(R.string.preOnboardingAddressBarTitle))
+                binding.daxDialogCta.addressBarContent.addressBarTitle.snapTitle()
                 binding.daxDialogCta.addressBarContent.addressBarPicker.alpha = 1f
 
                 binding.daxDialogCta.stepIndicator.alpha = 1f
@@ -2108,9 +2096,8 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 val descriptionText = getString(R.string.preOnboardingInputScreenDescription).preventWidows()
                 binding.daxDialogCta.inputScreenContent.inputScreenDescription.text = descriptionText.html(requireContext())
 
-                binding.daxDialogCta.inputScreenContent.inputScreenTitle.cancelAnimation()
-                binding.daxDialogCta.inputScreenContent.inputScreenTitle.text =
-                    getString(R.string.preOnboardingInputScreenTitleUpdated)
+                binding.daxDialogCta.inputScreenContent.inputScreenTitle.setTitle(getString(R.string.preOnboardingInputScreenTitleUpdated))
+                binding.daxDialogCta.inputScreenContent.inputScreenTitle.snapTitle()
                 binding.daxDialogCta.inputScreenContent.inputScreenPicker.alpha = 1f
                 binding.daxDialogCta.inputScreenContent.inputScreenDescription.alpha = 1f
 
@@ -2151,11 +2138,10 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 binding.daxDialogCta.reinstallerQuickSetupContent.root.isVisible = true
                 updateQuickSetupRowsVisibility()
                 binding.daxDialogCta.reinstallerQuickSetupContent.quickSetupOptionsContainer.alpha = 1f
-                binding.daxDialogCta.reinstallerQuickSetupContent.quickSetupTitleHidden.text =
-                    getString(R.string.preOnboardingReinstallQuickSetupTitle).html(requireContext())
-                binding.daxDialogCta.reinstallerQuickSetupContent.quickSetupTitle.cancelAnimation()
-                binding.daxDialogCta.reinstallerQuickSetupContent.quickSetupTitle.text =
-                    getString(R.string.preOnboardingReinstallQuickSetupTitle).html(requireContext())
+                binding.daxDialogCta.reinstallerQuickSetupContent.quickSetupTitle.setTitle(
+                    getString(R.string.preOnboardingReinstallQuickSetupTitle),
+                )
+                binding.daxDialogCta.reinstallerQuickSetupContent.quickSetupTitle.snapTitle()
 
                 binding.daxDialogCta.primaryCta.alpha = 1f
                 binding.daxDialogCta.primaryCta.text = if (isCustomAiOnboardingFlow) {
@@ -2239,14 +2225,13 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     binding.daxDialogCta.inputScreenPreviewContent.inputModeDemoCard.addBottomShadow()
                 }
 
-                binding.daxDialogCta.inputScreenPreviewContent.inputScreenPreviewTitle.cancelAnimation()
                 val title = if (isCustomAiOnboardingFlow) {
                     getString(R.string.preOnboardingInputModeDemoTitleCustomAi)
                 } else {
                     getString(R.string.preOnboardingInputModeDemoTitle)
-                }.html(requireContext())
-                binding.daxDialogCta.inputScreenPreviewContent.inputScreenPreviewTitleHidden.text = title
-                binding.daxDialogCta.inputScreenPreviewContent.inputScreenPreviewTitle.text = title
+                }
+                binding.daxDialogCta.inputScreenPreviewContent.inputScreenPreviewTitle.setTitle(title)
+                binding.daxDialogCta.inputScreenPreviewContent.inputScreenPreviewTitle.snapTitle()
                 binding.daxDialogCta.inputScreenPreviewContent.inputModeToggle.alpha = 1f
                 binding.daxDialogCta.inputScreenPreviewContent.inputModeToggle.isVisible = !isCustomAiOnboardingFlow
                 binding.daxDialogCta.inputScreenPreviewContent.inputModeDemoCard.alpha = 1f
@@ -2648,10 +2633,8 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         }
     }
 
-    private fun playComparisonChartContentIntro(comparisonChartConfig: ComparisonChartConfig) {
-        binding.daxDialogCta.comparisonChartContent.comparisonChartTitle.startOnboardingTypingAnimation(
-            getString(comparisonChartConfig.titleRes).preventWidows(),
-        ) {
+    private fun playComparisonChartContentIntro() {
+        binding.daxDialogCta.comparisonChartContent.comparisonChartTitle.typeTitle {
             comparisonChartFadeInAnimatorSet = AnimatorSet().apply {
                 playTogether(
                     ObjectAnimator.ofFloat(
@@ -2686,15 +2669,6 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
             .start()
     }
 
-    private fun TypeAnimationTextView.startOnboardingTypingAnimation(
-        text: String,
-        afterAnimation: () -> Unit = {},
-    ) {
-        typingDelayInMs = TYPING_DELAY_MS
-        delayAfterAnimationInMs = TYPING_POST_DELAY_MS
-        startTypingAnimation(text, isCancellable = true, afterAnimation = afterAnimation)
-    }
-
     private fun skipCurrentDialogAnimation() {
         if (!isAnimating) return
 
@@ -2709,7 +2683,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 reinstallerQuickSetupContent.quickSetupTitle,
                 addToDockContent.addToDockTitle,
                 widgetPromptContent.widgetPromptTitle,
-            ).filter { it.hasAnimationStarted() }.forEach { it.performClick() }
+            ).forEach { it.finishTyping() }
         }
 
         // End any running content fade-in animations (end() snaps to final values and triggers end listeners)
@@ -3008,7 +2982,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 comparisonChartHeaderLeftIconCard.addBottomShadow()
                 comparisonChartHeaderRightIconCard.addBottomShadow()
             }
-            comparisonChartTitleHidden.text = getString(config.titleRes).preventWidows()
+            comparisonChartTitle.setTitle(getString(config.titleRes))
             if (config.headerLeftLabelRes != null) {
                 comparisonChartHeaderLabel.text = getString(config.headerLeftLabelRes).preventWidows()
                 comparisonChartHeaderLabel.isVisible = true
@@ -3074,8 +3048,6 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         private const val CHECK_ICON_AVD_START_DELAY = 180L
 
         private const val DIALOG_TRANSITION_DURATION = 400L
-        private const val TYPING_DELAY_MS = 20L
-        private const val TYPING_POST_DELAY_MS = 20L
         private const val INPUT_SCREEN_PREVIEW_SUGGESTION_ANIMATION_DURATION = 500L
         private const val INPUT_SCREEN_PREVIEW_SUGGESTIONS_ANIMATION_DELAY = 500L
         private const val MIN_SCREEN_HEIGHT_FOR_KEYBOARD_DP = 600

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/view/OnboardingDialogTitleController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/view/OnboardingDialogTitleController.kt
@@ -22,9 +22,7 @@ import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.common.utils.extensions.preventWidows
 
 /**
- * The title machinery behind [OnboardingDialogTitleView], kept apart from the view so it can be exercised
- * without inflating anything: [animatedText] types the title in, while [sizingText] already holds the whole
- * title so the card reserves its final height instead of growing as the text types.
+ * The title machinery behind [OnboardingDialogTitleView].
  */
 internal class OnboardingDialogTitleController(
     private val animatedText: TypeAnimationTextView,
@@ -38,8 +36,6 @@ internal class OnboardingDialogTitleController(
      * height, while [animatedText] stays empty until [typeTitle] or [snapTitle].
      */
     fun setTitle(text: String) {
-        // Without this, a title set while a previous typing animation is still running would keep being
-        // overpainted by that animation's remaining frames.
         animatedText.cancelAnimation()
         title = text.preventWidows()
         sizingText.text = decodedTitle()
@@ -57,13 +53,9 @@ internal class OnboardingDialogTitleController(
         animatedText.text = decodedTitle()
     }
 
-    /**
-     * Tap-to-skip: completes a running typing animation, [typeTitle]'s `onFinished` included.
-     *
-     * [TypeAnimationTextView.finishAnimation] snaps the text but doesn't invoke that callback, so go through
-     * the click listener [TypeAnimationTextView.startTypingAnimation] installs, which does both in order.
-     */
     fun finishTyping() {
+        // TypeAnimationTextView.finishAnimation snaps the text but doesn't invoke that callback.
+        // Workaround by using the click listener, which does both in order.
         if (animatedText.hasAnimationStarted()) {
             animatedText.performClick()
         }
@@ -73,11 +65,6 @@ internal class OnboardingDialogTitleController(
         animatedText.cancelAnimation()
     }
 
-    /**
-     * [title] is kept as authored because [typeTitle] hands it to [TypeAnimationTextView.startTypingAnimation],
-     * which decodes it itself. The paths that assign text directly have to decode here instead, or a title
-     * carrying markup (`<br/>`) would render its tags literally and mis-measure [sizingText].
-     */
     private fun decodedTitle(): CharSequence = title.html(animatedText.context)
 
     private companion object {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/view/OnboardingDialogTitleController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/view/OnboardingDialogTitleController.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.view
+
+import android.widget.TextView
+import com.duckduckgo.common.ui.view.TypeAnimationTextView
+import com.duckduckgo.common.utils.extensions.html
+import com.duckduckgo.common.utils.extensions.preventWidows
+
+/**
+ * The title machinery behind [OnboardingDialogTitleView], kept apart from the view so it can be exercised
+ * without inflating anything: [animatedText] types the title in, while [sizingText] already holds the whole
+ * title so the card reserves its final height instead of growing as the text types.
+ */
+internal class OnboardingDialogTitleController(
+    private val animatedText: TypeAnimationTextView,
+    private val sizingText: TextView,
+) {
+
+    private var title: String = ""
+
+    /**
+     * Stages [text] as the title: [sizingText] takes it immediately so the card can reserve its final
+     * height, while [animatedText] stays empty until [typeTitle] or [snapTitle].
+     */
+    fun setTitle(text: String) {
+        // Without this, a title set while a previous typing animation is still running would keep being
+        // overpainted by that animation's remaining frames.
+        animatedText.cancelAnimation()
+        title = text.preventWidows()
+        sizingText.text = decodedTitle()
+        animatedText.text = ""
+    }
+
+    fun typeTitle(onFinished: () -> Unit = {}) {
+        animatedText.typingDelayInMs = TYPING_DELAY_MS
+        animatedText.delayAfterAnimationInMs = TYPING_POST_DELAY_MS
+        animatedText.startTypingAnimation(title, isCancellable = true, afterAnimation = onFinished)
+    }
+
+    fun snapTitle() {
+        animatedText.cancelAnimation()
+        animatedText.text = decodedTitle()
+    }
+
+    /**
+     * Tap-to-skip: completes a running typing animation, [typeTitle]'s `onFinished` included.
+     *
+     * [TypeAnimationTextView.finishAnimation] snaps the text but doesn't invoke that callback, so go through
+     * the click listener [TypeAnimationTextView.startTypingAnimation] installs, which does both in order.
+     */
+    fun finishTyping() {
+        if (animatedText.hasAnimationStarted()) {
+            animatedText.performClick()
+        }
+    }
+
+    fun cancelAnimation() {
+        animatedText.cancelAnimation()
+    }
+
+    /**
+     * [title] is kept as authored because [typeTitle] hands it to [TypeAnimationTextView.startTypingAnimation],
+     * which decodes it itself. The paths that assign text directly have to decode here instead, or a title
+     * carrying markup (`<br/>`) would render its tags literally and mis-measure [sizingText].
+     */
+    private fun decodedTitle(): CharSequence = title.html(animatedText.context)
+
+    private companion object {
+        const val TYPING_DELAY_MS = 20L
+        const val TYPING_POST_DELAY_MS = 20L
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/view/OnboardingDialogTitleView.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/view/OnboardingDialogTitleView.kt
@@ -28,8 +28,7 @@ import com.duckduckgo.app.browser.databinding.ViewOnboardingDialogTitleBinding
  * The title of an onboarding dialog card: it types the title in, and reserves the space the finished title
  * will take so the card doesn't resize while it types. See [OnboardingDialogTitleController].
  *
- * Accepts `android:text` for the initial title, and `android:includeFontPadding`, which it forwards to both
- * of its texts so they keep measuring identically.
+ * Accepts `android:text` for the initial title.
  */
 class OnboardingDialogTitleView @JvmOverloads constructor(
     context: Context,
@@ -47,9 +46,6 @@ class OnboardingDialogTitleView @JvmOverloads constructor(
 
     init {
         context.theme.obtainStyledAttributes(attrs, R.styleable.OnboardingDialogTitleView, 0, 0).use { attributes ->
-            val includeFontPadding = attributes.getBoolean(R.styleable.OnboardingDialogTitleView_android_includeFontPadding, true)
-            binding.onboardingDialogTitleSizingText.includeFontPadding = includeFontPadding
-            binding.onboardingDialogTitleAnimatedText.includeFontPadding = includeFontPadding
             attributes.getString(R.styleable.OnboardingDialogTitleView_android_text)?.let(::setTitle)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/view/OnboardingDialogTitleView.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/view/OnboardingDialogTitleView.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import androidx.core.content.res.use
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.ViewOnboardingDialogTitleBinding
+
+/**
+ * The title of an onboarding dialog card: it types the title in, and reserves the space the finished title
+ * will take so the card doesn't resize while it types. See [OnboardingDialogTitleController].
+ *
+ * Accepts `android:text` for the initial title, and `android:includeFontPadding`, which it forwards to both
+ * of its texts so they keep measuring identically.
+ */
+class OnboardingDialogTitleView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    private val binding: ViewOnboardingDialogTitleBinding =
+        ViewOnboardingDialogTitleBinding.inflate(LayoutInflater.from(context), this)
+
+    private val controller = OnboardingDialogTitleController(
+        animatedText = binding.onboardingDialogTitleAnimatedText,
+        sizingText = binding.onboardingDialogTitleSizingText,
+    )
+
+    init {
+        context.theme.obtainStyledAttributes(attrs, R.styleable.OnboardingDialogTitleView, 0, 0).use { attributes ->
+            val includeFontPadding = attributes.getBoolean(R.styleable.OnboardingDialogTitleView_android_includeFontPadding, true)
+            binding.onboardingDialogTitleSizingText.includeFontPadding = includeFontPadding
+            binding.onboardingDialogTitleAnimatedText.includeFontPadding = includeFontPadding
+            attributes.getString(R.styleable.OnboardingDialogTitleView_android_text)?.let(::setTitle)
+        }
+    }
+
+    fun setTitle(text: String) = controller.setTitle(text)
+
+    fun typeTitle(onFinished: () -> Unit = {}) = controller.typeTitle(onFinished)
+
+    fun snapTitle() = controller.snapTitle()
+
+    fun finishTyping() = controller.finishTyping()
+
+    fun cancelAnimation() = controller.cancelAnimation()
+}

--- a/app/src/main/res/layout/include_brand_design_add_to_dock.xml
+++ b/app/src/main/res/layout/include_brand_design_add_to_dock.xml
@@ -26,7 +26,6 @@
         android:id="@+id/addToDockTitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:includeFontPadding="false"
         android:paddingHorizontal="12dp"
         android:text="@string/preOnboardingDockStepTitle" />
 

--- a/app/src/main/res/layout/include_brand_design_add_to_dock.xml
+++ b/app/src/main/res/layout/include_brand_design_add_to_dock.xml
@@ -22,33 +22,13 @@
     android:clipToPadding="false"
     android:orientation="vertical">
 
-    <FrameLayout
+    <com.duckduckgo.app.onboarding.ui.view.OnboardingDialogTitleView
+        android:id="@+id/addToDockTitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingHorizontal="12dp">
-
-        <com.duckduckgo.common.ui.view.text.DaxTextView
-            android:id="@+id/addToDockTitleHidden"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:includeFontPadding="false"
-            android:text="@string/preOnboardingDockStepTitle"
-            android:visibility="invisible"
-            app:typography="onboarding_title" />
-
-        <com.duckduckgo.common.ui.view.TypeAnimationTextView
-            android:id="@+id/addToDockTitle"
-            style="@style/Typography.DuckDuckGo.Onboarding.Title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:clickable="true"
-            android:focusable="true"
-            android:gravity="center"
-            android:includeFontPadding="false"
-            android:textColor="?attr/daxColorPrimaryText" />
-
-    </FrameLayout>
+        android:includeFontPadding="false"
+        android:paddingHorizontal="12dp"
+        android:text="@string/preOnboardingDockStepTitle" />
 
     <com.duckduckgo.common.ui.view.text.DaxTextView
         android:id="@+id/addToDockBody"

--- a/app/src/main/res/layout/include_brand_design_comparison_chart.xml
+++ b/app/src/main/res/layout/include_brand_design_comparison_chart.xml
@@ -20,32 +20,13 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <FrameLayout
+    <com.duckduckgo.app.onboarding.ui.view.OnboardingDialogTitleView
+        android:id="@+id/comparisonChartTitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dp"
-        android:paddingHorizontal="12dp">
-
-        <com.duckduckgo.common.ui.view.text.DaxTextView
-            android:id="@+id/comparisonChartTitleHidden"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="@string/preOnboardingDaxDialog2Title"
-            android:visibility="invisible"
-            app:typography="onboarding_title" />
-
-        <com.duckduckgo.common.ui.view.TypeAnimationTextView
-            android:id="@+id/comparisonChartTitle"
-            style="@style/Typography.DuckDuckGo.Onboarding.Title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:clickable="true"
-            android:focusable="true"
-            android:gravity="center"
-            android:textColor="?attr/daxColorPrimaryText" />
-
-    </FrameLayout>
+        android:paddingHorizontal="12dp"
+        android:text="@string/preOnboardingDaxDialog2Title" />
 
     <LinearLayout
         android:id="@+id/comparisonTable"

--- a/app/src/main/res/layout/include_brand_design_dialog_welcome.xml
+++ b/app/src/main/res/layout/include_brand_design_dialog_welcome.xml
@@ -20,32 +20,12 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <FrameLayout
+    <com.duckduckgo.app.onboarding.ui.view.OnboardingDialogTitleView
+        android:id="@+id/titleText"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <com.duckduckgo.common.ui.view.text.DaxTextView
-            android:id="@+id/hiddenTitleText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:includeFontPadding="false"
-            android:text="@string/preOnboardingWelcomeDialogTitle"
-            android:visibility="invisible"
-            app:typography="onboarding_title" />
-
-        <com.duckduckgo.common.ui.view.TypeAnimationTextView
-            android:id="@+id/titleText"
-            style="@style/Typography.DuckDuckGo.Onboarding.Title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:clickable="true"
-            android:focusable="true"
-            android:gravity="center"
-            android:includeFontPadding="false"
-            android:textColor="?attr/daxColorPrimaryText" />
-
-    </FrameLayout>
+        android:layout_height="wrap_content"
+        android:includeFontPadding="false"
+        android:text="@string/preOnboardingWelcomeDialogTitle" />
 
     <com.duckduckgo.common.ui.view.text.DaxTextView
         android:id="@+id/bodyText1"

--- a/app/src/main/res/layout/include_brand_design_dialog_welcome.xml
+++ b/app/src/main/res/layout/include_brand_design_dialog_welcome.xml
@@ -24,7 +24,6 @@
         android:id="@+id/titleText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:includeFontPadding="false"
         android:text="@string/preOnboardingWelcomeDialogTitle" />
 
     <com.duckduckgo.common.ui.view.text.DaxTextView

--- a/app/src/main/res/layout/include_brand_design_input_screen.xml
+++ b/app/src/main/res/layout/include_brand_design_input_screen.xml
@@ -20,32 +20,13 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <FrameLayout
+    <com.duckduckgo.app.onboarding.ui.view.OnboardingDialogTitleView
+        android:id="@+id/inputScreenTitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="32dp"
-        android:paddingHorizontal="12dp">
-
-        <com.duckduckgo.common.ui.view.text.DaxTextView
-            android:id="@+id/inputScreenTitleHidden"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="@string/preOnboardingInputScreenTitleUpdated"
-            android:visibility="invisible"
-            app:typography="onboarding_title" />
-
-        <com.duckduckgo.common.ui.view.TypeAnimationTextView
-            android:id="@+id/inputScreenTitle"
-            style="@style/Typography.DuckDuckGo.Onboarding.Title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:clickable="true"
-            android:focusable="true"
-            android:gravity="center"
-            android:textColor="?attr/daxColorPrimaryText" />
-
-    </FrameLayout>
+        android:paddingHorizontal="12dp"
+        android:text="@string/preOnboardingInputScreenTitleUpdated" />
 
     <com.duckduckgo.app.onboardingquicksetup.ui.BrandDesignInputScreenPicker
         android:id="@+id/inputScreenPicker"

--- a/app/src/main/res/layout/include_brand_design_input_screen_preview.xml
+++ b/app/src/main/res/layout/include_brand_design_input_screen_preview.xml
@@ -23,32 +23,13 @@
     android:gravity="center_horizontal"
     android:orientation="vertical">
 
-    <FrameLayout
+    <com.duckduckgo.app.onboarding.ui.view.OnboardingDialogTitleView
+        android:id="@+id/inputScreenPreviewTitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
-        android:paddingHorizontal="12dp">
-
-        <com.duckduckgo.common.ui.view.text.DaxTextView
-            android:id="@+id/inputScreenPreviewTitleHidden"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="@string/preOnboardingInputModeDemoTitle"
-            android:visibility="invisible"
-            app:typography="onboarding_title" />
-
-        <com.duckduckgo.common.ui.view.TypeAnimationTextView
-            android:id="@+id/inputScreenPreviewTitle"
-            style="@style/Typography.DuckDuckGo.Onboarding.Title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:clickable="true"
-            android:focusable="true"
-            android:gravity="center"
-            android:textColor="?attr/daxColorPrimaryText" />
-
-    </FrameLayout>
+        android:paddingHorizontal="12dp"
+        android:text="@string/preOnboardingInputModeDemoTitle" />
 
     <com.duckduckgo.browser.ui.inputmode.InputModeTabLayout
         android:id="@+id/inputModeToggle"

--- a/app/src/main/res/layout/include_brand_design_reinstaller_quick_setup.xml
+++ b/app/src/main/res/layout/include_brand_design_reinstaller_quick_setup.xml
@@ -25,8 +25,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/keyline_6"
-        android:layout_marginEnd="@dimen/keyline_6"
-        android:includeFontPadding="false" />
+        android:layout_marginEnd="@dimen/keyline_6" />
 
     <LinearLayout
         android:id="@+id/quickSetupOptionsContainer"

--- a/app/src/main/res/layout/include_brand_design_reinstaller_quick_setup.xml
+++ b/app/src/main/res/layout/include_brand_design_reinstaller_quick_setup.xml
@@ -15,42 +15,18 @@
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/keyline_4"
     android:orientation="vertical">
 
-    <FrameLayout
-        android:id="@+id/quickSetupTitleContainer"
+    <com.duckduckgo.app.onboarding.ui.view.OnboardingDialogTitleView
+        android:id="@+id/quickSetupTitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/keyline_6"
-        android:layout_marginEnd="@dimen/keyline_6">
-
-        <com.duckduckgo.common.ui.view.text.DaxTextView
-            android:id="@+id/quickSetupTitleHidden"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:includeFontPadding="false"
-            android:visibility="invisible"
-            app:typography="onboarding_title"
-            tools:text="@string/preOnboardingReinstallQuickSetupTitle" />
-
-        <com.duckduckgo.common.ui.view.TypeAnimationTextView
-            android:id="@+id/quickSetupTitle"
-            style="@style/Typography.DuckDuckGo.Onboarding.Title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:clickable="true"
-            android:focusable="true"
-            android:gravity="center"
-            android:includeFontPadding="false"
-            android:textColor="?attr/daxColorPrimaryText"
-            tools:text="@string/preOnboardingReinstallQuickSetupTitle" />
-
-    </FrameLayout>
+        android:layout_marginEnd="@dimen/keyline_6"
+        android:includeFontPadding="false" />
 
     <LinearLayout
         android:id="@+id/quickSetupOptionsContainer"

--- a/app/src/main/res/layout/include_brand_design_widget_prompt.xml
+++ b/app/src/main/res/layout/include_brand_design_widget_prompt.xml
@@ -20,33 +20,13 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <FrameLayout
+    <com.duckduckgo.app.onboarding.ui.view.OnboardingDialogTitleView
+        android:id="@+id/widgetPromptTitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingHorizontal="@dimen/keyline_3">
-
-        <com.duckduckgo.common.ui.view.text.DaxTextView
-            android:id="@+id/widgetPromptTitleHidden"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:includeFontPadding="false"
-            android:text="@string/experimentHomeScreenWidgetBottomSheetDialogTitle"
-            android:visibility="invisible"
-            app:typography="onboarding_title" />
-
-        <com.duckduckgo.common.ui.view.TypeAnimationTextView
-            android:id="@+id/widgetPromptTitle"
-            style="@style/Typography.DuckDuckGo.Onboarding.Title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:clickable="true"
-            android:focusable="true"
-            android:gravity="center"
-            android:includeFontPadding="false"
-            android:textColor="?attr/daxColorPrimaryText" />
-
-    </FrameLayout>
+        android:includeFontPadding="false"
+        android:paddingHorizontal="@dimen/keyline_3"
+        android:text="@string/experimentHomeScreenWidgetBottomSheetDialogTitle" />
 
     <com.duckduckgo.common.ui.view.text.DaxTextView
         android:id="@+id/widgetPromptBody"

--- a/app/src/main/res/layout/include_brand_design_widget_prompt.xml
+++ b/app/src/main/res/layout/include_brand_design_widget_prompt.xml
@@ -24,7 +24,6 @@
         android:id="@+id/widgetPromptTitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:includeFontPadding="false"
         android:paddingHorizontal="@dimen/keyline_3"
         android:text="@string/experimentHomeScreenWidgetBottomSheetDialogTitle" />
 

--- a/app/src/main/res/layout/view_onboarding_dialog_title.xml
+++ b/app/src/main/res/layout/view_onboarding_dialog_title.xml
@@ -13,27 +13,28 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
+    tools:parentTag="android.widget.FrameLayout">
 
-    <com.duckduckgo.app.onboarding.ui.view.OnboardingDialogTitleView
-        android:id="@+id/addressBarTitle"
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/onboardingDialogTitleSizingText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:paddingHorizontal="12dp"
-        android:text="@string/preOnboardingAddressBarTitle" />
+        android:gravity="center"
+        android:visibility="invisible"
+        app:typography="onboarding_title" />
 
-    <com.duckduckgo.app.onboardingquicksetup.ui.BrandDesignAddressBarPositionPicker
-        android:id="@+id/addressBarPicker"
+    <com.duckduckgo.common.ui.view.TypeAnimationTextView
+        android:id="@+id/onboardingDialogTitleAnimatedText"
+        style="@style/Typography.DuckDuckGo.Onboarding.Title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_4"
-        android:layout_marginBottom="@dimen/keyline_2"
-        android:alpha="0"
-        tools:alpha="1" />
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center"
+        android:textColor="?attr/daxColorPrimaryText"
+        tools:text="Onboarding dialog title" />
 
-</LinearLayout>
+</merge>

--- a/app/src/main/res/layout/view_onboarding_dialog_title.xml
+++ b/app/src/main/res/layout/view_onboarding_dialog_title.xml
@@ -23,6 +23,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
+        android:includeFontPadding="false"
         android:visibility="invisible"
         app:typography="onboarding_title" />
 
@@ -34,6 +35,7 @@
         android:clickable="true"
         android:focusable="true"
         android:gravity="center"
+        android:includeFontPadding="false"
         android:textColor="?attr/daxColorPrimaryText"
         tools:text="Onboarding dialog title" />
 

--- a/app/src/main/res/values/attrs-onboarding-dialog-title.xml
+++ b/app/src/main/res/values/attrs-onboarding-dialog-title.xml
@@ -17,7 +17,6 @@
 
     <declare-styleable name="OnboardingDialogTitleView">
         <attr name="android:text" />
-        <attr name="android:includeFontPadding" />
     </declare-styleable>
 
 </resources>

--- a/app/src/main/res/values/attrs-onboarding-dialog-title.xml
+++ b/app/src/main/res/values/attrs-onboarding-dialog-title.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+
+    <declare-styleable name="OnboardingDialogTitleView">
+        <attr name="android:text" />
+        <attr name="android:includeFontPadding" />
+    </declare-styleable>
+
+</resources>

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/view/OnboardingDialogTitleControllerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/view/OnboardingDialogTitleControllerTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.view
+
+import android.os.Looper
+import android.widget.TextView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.common.ui.view.TypeAnimationTextView
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.time.Duration
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class OnboardingDialogTitleControllerTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val animatedText = TypeAnimationTextView(context)
+    private val sizingText = TextView(context)
+    private val controller = OnboardingDialogTitleController(animatedText, sizingText)
+
+    private fun letTypingRun() = shadowOf(Looper.getMainLooper()).idleFor(Duration.ofSeconds(5))
+
+    @Test
+    fun whenTitleSetThenSizingTextReservesSpaceForTheDecodedTitle() {
+        controller.setTitle("Ready to get started?<br/>Try a search or AI chat!")
+
+        assertEquals("Ready to get started?\nTry a search or AI${NBSP}chat!", sizingText.text.toString())
+    }
+
+    @Test
+    fun whenTitleSetThenTheLastSpaceBecomesNonBreaking() {
+        controller.setTitle("Where should I put your address bar?")
+
+        assertEquals("Where should I put your address${NBSP}bar?", sizingText.text.toString())
+    }
+
+    @Test
+    fun whenTitleHasASingleSpaceThenItIsLeftAlone() {
+        controller.setTitle("Hi there.")
+
+        assertEquals("Hi there.", sizingText.text.toString())
+    }
+
+    @Test
+    fun whenTitleSetThenAnimatedTextIsCleared() {
+        controller.setTitle("Protections activated!")
+        controller.snapTitle()
+
+        controller.setTitle("Where should I put your address bar?")
+
+        assertEquals("", animatedText.text.toString())
+    }
+
+    @Test
+    fun whenTitleSnappedThenAnimatedTextShowsTheWholeDecodedTitle() {
+        controller.setTitle("Welcome back!<br/>Want to customize anything?")
+
+        controller.snapTitle()
+
+        assertEquals("Welcome back!\nWant to customize${NBSP}anything?", animatedText.text.toString())
+    }
+
+    @Test
+    fun whenTypingFinishedEarlyThenAnimatedTextShowsTheWholeDecodedTitle() {
+        controller.setTitle("Welcome back!<br/>Want to customize anything?")
+
+        controller.typeTitle()
+        controller.finishTyping()
+
+        assertEquals("Welcome back!\nWant to customize${NBSP}anything?", animatedText.text.toString())
+    }
+
+    @Test
+    fun whenTypingFinishedEarlyThenOnFinishedIsInvoked() {
+        controller.setTitle("Protections activated!")
+        var finished = false
+
+        controller.typeTitle { finished = true }
+        controller.finishTyping()
+
+        assertEquals(true, finished)
+    }
+
+    @Test
+    fun whenTypingNeverStartedThenFinishTypingLeavesTheTitleAlone() {
+        controller.setTitle("Protections activated!")
+
+        controller.finishTyping()
+
+        assertEquals("", animatedText.text.toString())
+    }
+
+    @Test
+    fun whenTitleSetWhileTypingThenTheSupersededAnimationPaintsNothing() {
+        controller.setTitle("Protections activated!")
+        controller.typeTitle()
+
+        controller.setTitle("Where should I put your address bar?")
+        letTypingRun()
+
+        assertEquals("", animatedText.text.toString())
+    }
+
+    @Test
+    fun whenAnimationCancelledThenTypingPaintsNothingFurther() {
+        controller.setTitle("Protections activated!")
+        controller.typeTitle()
+
+        controller.cancelAnimation()
+        letTypingRun()
+
+        assertEquals("", animatedText.text.toString())
+    }
+
+    @Test
+    fun whenTypingRunsToCompletionThenAnimatedTextShowsTheWholeDecodedTitle() {
+        controller.setTitle("Welcome back!<br/>Want to customize anything?")
+
+        controller.typeTitle()
+        letTypingRun()
+
+        assertEquals("Welcome back!\nWant to customize${NBSP}anything?", animatedText.text.toString())
+    }
+
+    private companion object {
+        const val NBSP = '\u00A0'
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/view/OnboardingDialogTitleControllerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/view/OnboardingDialogTitleControllerTest.kt
@@ -40,28 +40,28 @@ class OnboardingDialogTitleControllerTest {
     private fun letTypingRun() = shadowOf(Looper.getMainLooper()).idleFor(Duration.ofSeconds(5))
 
     @Test
-    fun whenTitleSetThenSizingTextReservesSpaceForTheDecodedTitle() {
+    fun `when title set then sizing text reserves space for the decoded title`() {
         controller.setTitle("Ready to get started?<br/>Try a search or AI chat!")
 
         assertEquals("Ready to get started?\nTry a search or AI${NBSP}chat!", sizingText.text.toString())
     }
 
     @Test
-    fun whenTitleSetThenTheLastSpaceBecomesNonBreaking() {
+    fun `when title set then the last space becomes non-breaking`() {
         controller.setTitle("Where should I put your address bar?")
 
         assertEquals("Where should I put your address${NBSP}bar?", sizingText.text.toString())
     }
 
     @Test
-    fun whenTitleHasASingleSpaceThenItIsLeftAlone() {
+    fun `when title has a single space then it is left alone`() {
         controller.setTitle("Hi there.")
 
         assertEquals("Hi there.", sizingText.text.toString())
     }
 
     @Test
-    fun whenTitleSetThenAnimatedTextIsCleared() {
+    fun `when title set then animated text is cleared`() {
         controller.setTitle("Protections activated!")
         controller.snapTitle()
 
@@ -71,7 +71,7 @@ class OnboardingDialogTitleControllerTest {
     }
 
     @Test
-    fun whenTitleSnappedThenAnimatedTextShowsTheWholeDecodedTitle() {
+    fun `when title snapped then animated text shows the whole decoded title`() {
         controller.setTitle("Welcome back!<br/>Want to customize anything?")
 
         controller.snapTitle()
@@ -80,7 +80,7 @@ class OnboardingDialogTitleControllerTest {
     }
 
     @Test
-    fun whenTypingFinishedEarlyThenAnimatedTextShowsTheWholeDecodedTitle() {
+    fun `when typing finished early then animated text shows the whole decoded title`() {
         controller.setTitle("Welcome back!<br/>Want to customize anything?")
 
         controller.typeTitle()
@@ -90,7 +90,7 @@ class OnboardingDialogTitleControllerTest {
     }
 
     @Test
-    fun whenTypingFinishedEarlyThenOnFinishedIsInvoked() {
+    fun `when typing finished early then onFinished is invoked`() {
         controller.setTitle("Protections activated!")
         var finished = false
 
@@ -101,7 +101,7 @@ class OnboardingDialogTitleControllerTest {
     }
 
     @Test
-    fun whenTypingNeverStartedThenFinishTypingLeavesTheTitleAlone() {
+    fun `when typing never started then finishTyping leaves the title alone`() {
         controller.setTitle("Protections activated!")
 
         controller.finishTyping()
@@ -110,7 +110,7 @@ class OnboardingDialogTitleControllerTest {
     }
 
     @Test
-    fun whenTitleSetWhileTypingThenTheSupersededAnimationPaintsNothing() {
+    fun `when title set while typing then the superseded animation paints nothing`() {
         controller.setTitle("Protections activated!")
         controller.typeTitle()
 
@@ -121,7 +121,7 @@ class OnboardingDialogTitleControllerTest {
     }
 
     @Test
-    fun whenAnimationCancelledThenTypingPaintsNothingFurther() {
+    fun `when animation cancelled then typing paints nothing further`() {
         controller.setTitle("Protections activated!")
         controller.typeTitle()
 
@@ -132,7 +132,7 @@ class OnboardingDialogTitleControllerTest {
     }
 
     @Test
-    fun whenTypingRunsToCompletionThenAnimatedTextShowsTheWholeDecodedTitle() {
+    fun `when typing runs to completion then animated text shows the whole decoded title`() {
         controller.setTitle("Welcome back!<br/>Want to customize anything?")
 
         controller.typeTitle()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216978524863339?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/72649045549333/task/1216854264994244
API Proposals URL(s) (if applicable):

### Description
The title machinery each step layout copy-pasted — typing `TypeAnimationTextView`, invisible sizing twin, `preventWidows` at the call site — becomes one `OnboardingDialogTitleView`, dropped into all eight step includes plus the address bar picker bottom sheet, which shares the input screen layout.

Three behavior changes:

1. **`preventWidows` on every title**, not the three that happened to call it. Five titles gain a non-breaking space before their last word.
2. **`includeFontPadding="false"` on every title.** Four layouts set it, four left the platform default.
3. **Input screen preview sizing fix.** Its animated path sized the twin from the raw string, so a literal `<br/>` reserved one line instead of two and the card grew while the title typed. Now decoded uniformly, matching what the snap path already did.

@mikescamell, all of the above look to me like unintentional drift, so addressing here. Let me know if that's not the case though!

### Steps to test this PR

- [ ] Apply below patch:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
index df50491818..446dd61735 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
@@ -155,10 +155,10 @@ class NewUserOnboardingPlanProvider @Inject constructor(
                 add(initialStep(firstDialog))
                 add(comparisonChartStep())
                 add(defaultBrowserPromptStep())
-                if (showDock) {
+                if (true) {
                     add(addToDockStep())
                 }
-                if (showWidget) {
+                if (true) {
                     add(widgetPromptStep(ctx))
                     add(addWidgetStep(ctx))
                 }
```

- [x] Clean install.
- [x] Walk the linear flow end to end. Verify titles type in, the card does not resize while typing, content below fades in afterwards.
- [x] Tap the card mid-typing. Content snaps into place.
- [x] Rotate on each step. Title appears complete with no animation, card correctly sized.
- [x] Background and re-enter mid-step. No stale title from the previous step.

### UI changes
The only visual difference is caused by the application of universal font padding handling. On screens that previously didn't disable font padding, this results in a minor shift of the whole content up. A before -> after example below:

<img width="320" height="714" alt="onboarding_font_padding_before_after_small" src="https://github.com/user-attachments/assets/cb155199-8f8b-4f24-a5ce-cc726b617149" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-run and reinstaller onboarding UI across many steps; visual/timing changes are intentional but need end-to-end verification. Logic is centralized with tests, limiting regression risk outside onboarding.
> 
> **Overview**
> Introduces **`OnboardingDialogTitleView`** (with **`OnboardingDialogTitleController`**) so onboarding dialog titles share one pattern: invisible sizing text for stable card height, typed **`TypeAnimationTextView`**, and centralized **`preventWidows`** + HTML decoding via **`setTitle`**, **`typeTitle`**, **`snapTitle`**, and **`finishTyping`**.
> 
> **`BrandDesignUpdateWelcomePage`**, the address bar picker bottom sheet, and eight step includes swap duplicated FrameLayout twins and local **`startOnboardingTypingAnimation`** helpers for the new view. Skip-mid-animation now calls **`finishTyping()`** on each title instead of **`performClick()`** on views that were typing.
> 
> **Behavior alignment:** all titles get **`preventWidows`** (non-breaking space before the last word) and **`includeFontPadding="false"`**; the input-screen preview title sizes from decoded HTML so the card no longer grows when a `<br/>` splits the title.
> 
> Maestro flows update regex assertions for the new spacing (e.g. **`address.bar`**, **`customize.anything`**). Unit tests cover **`OnboardingDialogTitleController`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf7728e53e3bdbc6274e7c0228f3f74db0ebddad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->