### PR TITLE
Add generic handling of v1 sync errors

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V1PairingError.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V1PairingError.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import android.content.Context
+import androidx.annotation.StringRes
+import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
+import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
+import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.Result.Error
+
+/** Dialog copy for a v1 pairing terminal outcome. */
+internal data class V1PairingErrorContent(
+    @StringRes val message: Int,
+    val reason: String,
+)
+
+/**
+ * Maps a v1 pairing error code to dialog copy.
+ */
+internal fun Error.toV1PairingError(): V1PairingErrorContent {
+    val message = when (code) {
+        ALREADY_SIGNED_IN.code -> R.string.sync_login_authenticated_device_error
+        LOGIN_FAILED.code -> R.string.sync_connect_login_error
+        CONNECT_FAILED.code -> R.string.sync_connect_generic_error
+        CREATE_ACCOUNT_FAILED.code -> R.string.sync_create_account_generic_error
+        INVALID_CODE.code -> R.string.sync_invalid_code_error
+        else -> R.string.sync_pairing_failed_generic_message
+    }
+    return V1PairingErrorContent(message, reason)
+}
+
+/**
+ * Renders a v1 pairing error dialog: hardcoded title, and a provided message with a reason.
+ */
+internal fun Context.showV1PairingError(
+    content: V1PairingErrorContent,
+    onDismissed: () -> Unit,
+) {
+    TextAlertDialogBuilder(this)
+        .setTitle(R.string.sync_dialog_error_title)
+        .setMessage(getString(content.message) + "\n" + content.reason)
+        .setPositiveButton(R.string.sync_dialog_error_ok)
+        .addEventListener(
+            object : TextAlertDialogBuilder.EventListener() {
+                override fun onPositiveButtonClicked() {
+                    onDismissed()
+                }
+            },
+        )
+        .show()
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeActivity.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.ShareAction
 import com.duckduckgo.sync.impl.databinding.ActivitySyncV2DisplayQrCodeBinding
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.ui.showV1PairingError
 import com.duckduckgo.sync.impl.ui.showV2PairingError
 import com.duckduckgo.sync.impl.ui.syncV2ConfirmationMessage
 import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command
@@ -47,8 +48,8 @@ import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.Close
 import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.SetFailureResult
 import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.SetSuccessResult
 import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.ShareCode
-import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.ShowMessage
+import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.ShowV1Error
 import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.ShowV2Error
 import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Factory
 import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Factory.Provider
@@ -136,7 +137,7 @@ class DisplayQrCodeActivity : DuckDuckGoActivity() {
             is ShareCode -> shareText(command.code)
             is SetSuccessResult -> setResult(DisplayQrCodeContract.RESULT_SYNC_SUCCESS)
             is SetFailureResult -> setResult(DisplayQrCodeContract.RESULT_SYNC_FAILURE)
-            is ShowError -> showError(command)
+            is ShowV1Error -> showV1Error(command)
             is ShowV2Error -> showV2Error(command)
             is Close -> finish()
         }
@@ -190,19 +191,10 @@ class DisplayQrCodeActivity : DuckDuckGoActivity() {
         shareAction.shareText(this, text)
     }
 
-    private fun showError(error: ShowError) {
-        TextAlertDialogBuilder(this)
-            .setTitle(R.string.sync_dialog_error_title)
-            .setMessage(getString(error.message) + "\n" + error.reason)
-            .setPositiveButton(R.string.sync_dialog_error_ok)
-            .addEventListener(
-                object : TextAlertDialogBuilder.EventListener() {
-                    override fun onPositiveButtonClicked() {
-                        viewModel.onErrorDialogDismissed()
-                    }
-                },
-            )
-            .show()
+    private fun showV1Error(error: ShowV1Error) {
+        showV1PairingError(error.content) {
+            viewModel.onErrorDialogDismissed()
+        }
     }
 
     private fun showV2Error(error: ShowV2Error) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeViewModel.kt
@@ -23,8 +23,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.app.clipboard.ClipboardInteractor
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
-import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.QREncoder
 import com.duckduckgo.sync.impl.R
@@ -39,9 +37,11 @@ import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
 import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
 import com.duckduckgo.sync.impl.pixels.fireSetupFailed
+import com.duckduckgo.sync.impl.ui.V1PairingErrorContent
 import com.duckduckgo.sync.impl.ui.V2PairingErrorContent
 import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl
 import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl.ProtocolVersion
+import com.duckduckgo.sync.impl.ui.toV1PairingError
 import com.duckduckgo.sync.impl.ui.toV2PairingError
 import com.duckduckgo.sync.impl.ui.v2AlreadyPairedError
 import com.duckduckgo.sync.impl.ui.v2UpgradeRequiredError
@@ -128,7 +128,10 @@ class DisplayQrCodeViewModel @AssistedInject constructor(
     private suspend fun startV1Presentation() = coroutineScope {
         val qrCodeResult = accountRepository.getConnectQR()
             .onSuccess { showQrCode(it.qrCode) }
-            .onFailure { _commands.send(Command.ShowError(R.string.sync_connect_generic_error, it.reason)) }
+            .onFailure { failure ->
+                val content = V1PairingErrorContent(R.string.sync_connect_generic_error, failure.reason)
+                _commands.send(Command.ShowV1Error(content))
+            }
 
         var isPolling = qrCodeResult is Result.Success
         while (isPolling) {
@@ -144,12 +147,8 @@ class DisplayQrCodeViewModel @AssistedInject constructor(
                     }
                 }
                 .onFailure { failure ->
-                    when (failure.code) {
-                        CONNECT_FAILED.code, LOGIN_FAILED.code -> {
-                            _commands.send(Command.ShowError(R.string.sync_connect_login_error, failure.reason))
-                            isPolling = false
-                        }
-                    }
+                    _commands.send(Command.ShowV1Error(failure.toV1PairingError()))
+                    isPolling = false
                 }
         }
     }
@@ -232,9 +231,8 @@ class DisplayQrCodeViewModel @AssistedInject constructor(
             val peerKind: PeerKind? = null,
         ) : Command
 
-        data class ShowError(
-            @StringRes val message: Int,
-            val reason: String = "",
+        data class ShowV1Error(
+            val content: V1PairingErrorContent,
         ) : Command
 
         data class ShowV2Error(

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -16,6 +16,7 @@
 
 <resources>
     <!-- Simplified Sync  -->
+    <string name="sync_pairing_failed_generic_message">Something went wrong.</string>
     <string name="sync_settings_v2_header_headline_disabled">Keep DuckDuckGo in sync!</string>
     <string name="sync_settings_v2_header_headline_enabled">DuckDuckGo is in sync.</string>
     <string name="sync_settings_v2_header_body_disabled">Sync your autofill data and bookmarks end-to-end encrypted across your DuckDuckGo apps.</string>

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V1PairingErrorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V1PairingErrorTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
+import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.GENERIC_ERROR
+import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.Result.Error
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class V1PairingErrorTest {
+
+    @Test
+    fun whenCodeIsAlreadySignedInThenAuthenticatedDeviceMessage() {
+        val content = Error(code = ALREADY_SIGNED_IN.code).toV1PairingError()
+        assertEquals(R.string.sync_login_authenticated_device_error, content.message)
+    }
+
+    @Test
+    fun whenCodeIsLoginFailedThenConnectLoginMessage() {
+        val content = Error(code = LOGIN_FAILED.code).toV1PairingError()
+        assertEquals(R.string.sync_connect_login_error, content.message)
+    }
+
+    @Test
+    fun whenCodeIsConnectFailedThenConnectGenericMessage() {
+        val content = Error(code = CONNECT_FAILED.code).toV1PairingError()
+        assertEquals(R.string.sync_connect_generic_error, content.message)
+    }
+
+    @Test
+    fun whenCodeIsCreateAccountFailedThenCreateAccountGenericMessage() {
+        val content = Error(code = CREATE_ACCOUNT_FAILED.code).toV1PairingError()
+        assertEquals(R.string.sync_create_account_generic_error, content.message)
+    }
+
+    @Test
+    fun whenCodeIsInvalidCodeThenInvalidCodeMessage() {
+        val content = Error(code = INVALID_CODE.code).toV1PairingError()
+        assertEquals(R.string.sync_invalid_code_error, content.message)
+    }
+
+    @Test
+    fun whenCodeIsGenericOrUnknownThenPairingFailedGenericMessage() {
+        listOf(GENERIC_ERROR.code, 9999).forEach { code ->
+            val content = Error(code = code).toV1PairingError()
+            assertEquals("code $code message", R.string.sync_pairing_failed_generic_message, content.message)
+        }
+    }
+
+    @Test
+    fun whenErrorHasReasonThenReasonIsCarriedOver() {
+        val content = Error(code = LOGIN_FAILED.code, reason = "connection dropped").toV1PairingError()
+        assertEquals("connection dropped", content.reason)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeViewModelTest.kt
@@ -47,8 +47,8 @@ import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.Close
 import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.SetFailureResult
 import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.SetSuccessResult
 import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.ShareCode
-import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.ShowMessage
+import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.ShowV1Error
 import com.duckduckgo.sync.impl.ui.v2.DisplayQrCodeViewModel.Command.ShowV2Error
 import com.duckduckgo.sync.impl.ui.v2AlreadyPairedError
 import com.duckduckgo.sync.impl.ui.v2UpgradeRequiredError
@@ -134,9 +134,9 @@ class DisplayQrCodeViewModelTest {
 
         testee.commands.test {
             val command = awaitItem()
-            assertIs<ShowError>(command)
-            assertEquals(R.string.sync_connect_generic_error, command.message)
-            assertEquals("boom", command.reason)
+            assertIs<ShowV1Error>(command)
+            assertEquals(R.string.sync_connect_generic_error, command.content.message)
+            assertEquals("boom", command.content.reason)
 
             cancel()
         }
@@ -171,9 +171,9 @@ class DisplayQrCodeViewModelTest {
 
         testee.commands.test {
             val command = awaitItem()
-            assertIs<ShowError>(command)
-            assertEquals(R.string.sync_connect_login_error, command.message)
-            assertEquals("boom", command.reason)
+            assertIs<ShowV1Error>(command)
+            assertEquals(R.string.sync_connect_login_error, command.content.message)
+            assertEquals("boom", command.content.reason)
 
             cancel()
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1216983525911047?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1216509582049467?focus=true
API Proposals URL(s) (if applicable): N/A

### Description

Reworks v1 pairing error handling on the QR code screen of the simplified to follow the same generic approach already used for v2 errors. Pairing will be spread across different view models, so the error code to message mapping (`toV1PairingError`) and the dialog rendering (`showV1PairingError`) now live outside the activity and can be reused wherever the v1 protocol is handled.

- All v1 failures are now handled. Previously only the connect failed and login failed codes were, and any other failure while waiting for another device was swallowed, potentially leaving the screen active indefinitely.
- Any polling failure now stops the flow and shows an error dialog. For example, losing the network connection while the QR code is displayed now surfaces an error instead of silently retrying forever.

> [!warning]
> I'm happy to close this PR without merging if you think that some errors were correctly swallowed (it is current behavior in the legacy flow). It can be a bit weird to open QR code and have a Sync & Backup error dialog displayed after 5 seconds if you have no internet connection. On the other hand the alternative is to leave the user hanging. On the other other hand it is for the v1 sync protocol. Assuming that the v2 feature flag is enabled and we use that protocol this is more about handling it more easily in the code.

### Steps to test this PR
QA optional

### UI changes
QA optional



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible v1 sync pairing behavior on the QR screen (more errors shown, polling stops on any failure). Limited to legacy v1 path when v2 flags are off; no auth/crypto changes.
> 
> **Overview**
> Introduces **shared v1 pairing error handling** aligned with the existing v2 pattern: `toV1PairingError()` maps `AccountErrorCodes` to user strings (with a new generic fallback), and `showV1PairingError()` renders the standard error dialog.
> 
> On the simplified sync **QR code screen**, v1 failures no longer use ad‑hoc `ShowError` in the activity. The view model emits `ShowV1Error` with `V1PairingErrorContent`, and polling errors are routed through the mapper instead of only treating login/connect failures.
> 
> **Behavior change:** any v1 polling failure now **stops polling** and shows a dialog (e.g. network loss while waiting), whereas previously only some error codes surfaced and others could leave the screen polling indefinitely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7771913dda92f8735be738e41b7888a32b1cce46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->