### PR TITLE
Set native input search-only mode hint to Search

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -771,6 +771,13 @@ class NativeInputModeWidget @JvmOverloads constructor(
         updateNewLineButtonVisibility()
         updateSendButtonIcon()
         applyOmnibarShape()
+        if (!isChatTabSelected()) {
+            val searchOnly = state.inputMode == NativeInputState.InputMode.SEARCH_ONLY &&
+                state.inputContext == NativeInputState.InputContext.BROWSER
+            // Search-only browser input uses the shorter "Search" placeholder.
+            val searchHint = if (searchOnly) R.string.input_screen_search_only_hint else R.string.input_screen_search_hint
+            inputField.hint = context.getString(searchHint)
+        }
         // Re-apply chat input type whenever the inputs to `applyChatInputType` (context, position,
         // chatId) change, or on the first emission. This corrects stale IME setup from a tab listener
         // that fired before the state-flow caught up.

--- a/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Търсене или въвеждане на адрес</string>
+    <string name="input_screen_search_only_hint">Търсене</string>
     <string name="input_screen_chat_hint">Задавайте въпроси поверително</string>
     <string name="input_screen_user_pref_without_ai">Само търсене</string>
     <string name="input_screen_user_pref_with_ai">Търсене и Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Vyhledejte nebo zadejte adresu</string>
+    <string name="input_screen_search_only_hint">Vyhledávání</string>
     <string name="input_screen_chat_hint">Zeptej se soukromě</string>
     <string name="input_screen_user_pref_without_ai">Jen vyhledávání</string>
     <string name="input_screen_user_pref_with_ai">Vyhledávání a Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Søg eller indtast adresse</string>
+    <string name="input_screen_search_only_hint">Søg</string>
     <string name="input_screen_chat_hint">Spørg privat</string>
     <string name="input_screen_user_pref_without_ai">Kun søgning</string>
     <string name="input_screen_user_pref_with_ai">Søg &amp; Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Adresse suchen oder eingeben</string>
+    <string name="input_screen_search_only_hint">Suche</string>
     <string name="input_screen_chat_hint">Privat fragen</string>
     <string name="input_screen_user_pref_without_ai">Nur Suchen</string>
     <string name="input_screen_user_pref_with_ai">Suche &amp; Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Αναζήτηση ή εισαγωγή διεύθυνσης</string>
+    <string name="input_screen_search_only_hint">Αναζήτηση</string>
     <string name="input_screen_chat_hint">Ρωτήστε ιδιωτικά</string>
     <string name="input_screen_user_pref_without_ai">Αναζήτηση μόνο</string>
     <string name="input_screen_user_pref_with_ai">Αναζήτηση και Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Buscar o introducir dirección</string>
+    <string name="input_screen_search_only_hint">Buscar</string>
     <string name="input_screen_chat_hint">Pregunta en privado</string>
     <string name="input_screen_user_pref_without_ai">Solo buscar</string>
     <string name="input_screen_user_pref_with_ai">Búsqueda y Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Otsi või sisesta aadress</string>
+    <string name="input_screen_search_only_hint">Otsing</string>
     <string name="input_screen_chat_hint">Küsi privaatselt</string>
     <string name="input_screen_user_pref_without_ai">Ainult otsi</string>
     <string name="input_screen_user_pref_with_ai">Otsi ja Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Hae tai anna osoite</string>
+    <string name="input_screen_search_only_hint">Hae</string>
     <string name="input_screen_chat_hint">Kysy yksityisesti</string>
     <string name="input_screen_user_pref_without_ai">Vain haku</string>
     <string name="input_screen_user_pref_with_ai">Haku ja Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Rechercher ou saisir une adresse</string>
+    <string name="input_screen_search_only_hint">Rechercher</string>
     <string name="input_screen_chat_hint">Demander en privé</string>
     <string name="input_screen_user_pref_without_ai">Recherche uniquement</string>
     <string name="input_screen_user_pref_with_ai">Recherche et Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Pretraži ili unesi adresu</string>
+    <string name="input_screen_search_only_hint">Pretraga</string>
     <string name="input_screen_chat_hint">Pitaj privatno</string>
     <string name="input_screen_user_pref_without_ai">Samo pretraživanje</string>
     <string name="input_screen_user_pref_with_ai">Pretraživanje i Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Keresés vagy cím megadása</string>
+    <string name="input_screen_search_only_hint">Keresés</string>
     <string name="input_screen_chat_hint">Kérdezz privátban</string>
     <string name="input_screen_user_pref_without_ai">Csak keresés</string>
     <string name="input_screen_user_pref_with_ai">Keresés és Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Cerca o digita l\'indirizzo</string>
+    <string name="input_screen_search_only_hint">Ricerca</string>
     <string name="input_screen_chat_hint">Chiedi in privato</string>
     <string name="input_screen_user_pref_without_ai">Solo ricerca</string>
     <string name="input_screen_user_pref_with_ai">Ricerca e Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Ieškoti arba įvesti adresą</string>
+    <string name="input_screen_search_only_hint">Paieška</string>
     <string name="input_screen_chat_hint">Klauskite privačiai</string>
     <string name="input_screen_user_pref_without_ai">Tik paieška</string>
     <string name="input_screen_user_pref_with_ai">Paieška ir „Duck.ai“</string>

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Meklē vai ievadi adresi</string>
+    <string name="input_screen_search_only_hint">Meklēt</string>
     <string name="input_screen_chat_hint">Pajautāt privāti</string>
     <string name="input_screen_user_pref_without_ai">Meklēt tikai</string>
     <string name="input_screen_user_pref_with_ai">Meklēšana &amp; Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Søk eller skriv inn adresse</string>
+    <string name="input_screen_search_only_hint">Søk</string>
     <string name="input_screen_chat_hint">Spør privat</string>
     <string name="input_screen_user_pref_without_ai">Bare søk</string>
     <string name="input_screen_user_pref_with_ai">Søk og Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Zoek of voer een adres in</string>
+    <string name="input_screen_search_only_hint">Zoeken</string>
     <string name="input_screen_chat_hint">Vraag privé</string>
     <string name="input_screen_user_pref_without_ai">Alleen zoeken</string>
     <string name="input_screen_user_pref_with_ai">Zoeken en Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Wyszukaj lub wprowadź adres</string>
+    <string name="input_screen_search_only_hint">Szukaj</string>
     <string name="input_screen_chat_hint">Zapytaj prywatnie</string>
     <string name="input_screen_user_pref_without_ai">Tylko wyszukiwanie</string>
     <string name="input_screen_user_pref_with_ai">Wyszukiwanie i Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Pesquisar ou inserir endereço</string>
+    <string name="input_screen_search_only_hint">Pesquisar</string>
     <string name="input_screen_chat_hint">Perguntar em privado</string>
     <string name="input_screen_user_pref_without_ai">Pesquisar apenas</string>
     <string name="input_screen_user_pref_with_ai">Pesquisa e Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Caută sau introdu adresa</string>
+    <string name="input_screen_search_only_hint">Căutare</string>
     <string name="input_screen_chat_hint">Întreabă în mod privat</string>
     <string name="input_screen_user_pref_without_ai">Doar căutare</string>
     <string name="input_screen_user_pref_with_ai">Caută pe Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Введите поисковый запрос или адрес сайта</string>
+    <string name="input_screen_search_only_hint">Поиск</string>
     <string name="input_screen_chat_hint">Задать вопрос (конфиденциально)</string>
     <string name="input_screen_user_pref_without_ai">Только поиск</string>
     <string name="input_screen_user_pref_with_ai">Поиск и Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Vyhľadajte alebo zadajte adresu</string>
+    <string name="input_screen_search_only_hint">Vyhľadávať</string>
     <string name="input_screen_chat_hint">Spýtaj sa súkromne</string>
     <string name="input_screen_user_pref_without_ai">Len vyhľadávanie</string>
     <string name="input_screen_user_pref_with_ai">Vyhľadávanie &amp; Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Poišči ali vnesi naslov</string>
+    <string name="input_screen_search_only_hint">Iskanje</string>
     <string name="input_screen_chat_hint">Vprašaj zasebno</string>
     <string name="input_screen_user_pref_without_ai">Samo iskanje</string>
     <string name="input_screen_user_pref_with_ai">Iskanje in Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Sök eller ange adress</string>
+    <string name="input_screen_search_only_hint">Sökning</string>
     <string name="input_screen_chat_hint">Fråga privat</string>
     <string name="input_screen_user_pref_without_ai">Sök endast</string>
     <string name="input_screen_user_pref_with_ai">Sök &amp; Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
@@ -59,6 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Adres ara veya gir</string>
+    <string name="input_screen_search_only_hint">Arama yap</string>
     <string name="input_screen_chat_hint">Özel olarak sor</string>
     <string name="input_screen_user_pref_without_ai">Yalnızca Arama</string>
     <string name="input_screen_user_pref_with_ai">Arama ve Duck.ai</string>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -58,6 +58,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Search or enter address</string>
+    <string name="input_screen_search_only_hint">Search</string>
     <string name="input_screen_chat_hint">Ask privately</string>
     <string name="input_screen_user_pref_without_ai">Search Only</string>
     <string name="input_screen_user_pref_with_ai">Search &amp; Duck.ai</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1216993873318563?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

Change the hint of the native input in search-only mode to “Search” making it more and consistent with the omnibar.

I used the existing translations for other “Search” strings. no need for new ones or copy review.
### Steps to test this PR
- [x] Enable `nativeInputSearchOnly` feature-flag
- [x] Enable Search only mode for the native input
- [x] Observe the Hint text (placeholder) being “Search” 


### UI changes
| Before  | After |
| ------ | ----- |
|<img width="540" height="1200" alt="Screenshot_20260728_100312" src="https://github.com/user-attachments/assets/091cfe17-2fa5-4671-b797-737d84fa6b38" />|<img width="1080" height="2269" alt="share_5723551064964830700" src="https://github.com/user-attachments/assets/29603cb5-b542-49db-8349-243a0db6b099" />|





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI placeholder change only; no behavior or data-handling changes.
> 
> **Overview**
> When the native address-bar input is in **search-only** mode on the **browser** tab (not Duck.ai), the field placeholder now shows the short **"Search"** text instead of **"Search or enter address"**, matching the omnibar.
> 
> `NativeInputModeWidget.applyState` picks `input_screen_search_only_hint` vs `input_screen_search_hint` when the search tab is active and `inputMode` is `SEARCH_ONLY` with `inputContext` `BROWSER`. Chat-tab hints are unchanged.
> 
> A new `input_screen_search_only_hint` string is added in the default and translated `strings-duckchat.xml` files (reusing existing "Search" wording where applicable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26e204fc9fad108c9c16af98fbd8b4ae09fbef75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->