### PR TITLE
Fix stale remote message image served from Glide cache

### DIFF
--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/MessageCta.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/MessageCta.kt
@@ -34,6 +34,7 @@ import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
+import com.bumptech.glide.signature.ObjectKey
 import com.duckduckgo.common.ui.view.MessageCta.MessageType.REMOTE_MESSAGE
 import com.duckduckgo.common.ui.view.MessageCta.MessageType.REMOTE_PROMO_MESSAGE
 import com.duckduckgo.common.ui.viewbinding.viewBinding
@@ -179,16 +180,16 @@ class MessageCta : FrameLayout {
         @DrawableRes drawableRes: Int?,
     ) {
         // Check if imageUrl is a local file path
-        val imageSource: Any = if (imageUrl.startsWith("/")) {
-            File(imageUrl)
-        } else {
-            imageUrl
-        }
+        val localFile = if (imageUrl.startsWith("/")) File(imageUrl) else null
+        val imageSource: Any = localFile ?: imageUrl
 
         Glide
             .with(imageView)
             .load(imageSource)
             .apply {
+                if (localFile != null) {
+                    signature(ObjectKey(localFile.lastModified()))
+                }
                 if (drawableRes != null) {
                     error(AppCompatResources.getDrawable(context, drawableRes))
                 }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/cardslist/CardsListAdapter.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/cardslist/CardsListAdapter.kt
@@ -30,6 +30,7 @@ import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
+import com.bumptech.glide.signature.ObjectKey
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.remote.messaging.api.CardItem
@@ -263,12 +264,18 @@ class CardsListAdapter @Inject constructor() : ListAdapter<ModalListItem, CardsL
             listener: RequestListener<Drawable>? = null,
         ) {
             if (!imageUrl.isNullOrEmpty()) {
-                val imageSource: Any = imageFilePath?.let { File(it) } ?: imageUrl
+                val localFile = imageFilePath?.let { File(it) }
+                val imageSource: Any = localFile ?: imageUrl
                 Glide.with(imageView)
                     .load(imageSource)
                     .centerCrop()
                     .error(placeholder.drawable(true))
-                    .apply { if (listener != null) addListener(listener) }
+                    .apply {
+                        if (localFile != null) {
+                            signature(ObjectKey(localFile.lastModified()))
+                        }
+                        if (listener != null) addListener(listener)
+                    }
                     .transition(withCrossFade())
                     .into(imageView)
             } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1217012422339641
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

`RemoteMessageImageStore` caches a remote message's image locally under a file name that is stable per surface (`active_message_remote_image_<surface>.png`), so every new active message overwrites the previous image at that same path.

Glide keys its caches on the model alone, and for a `File` model that means the path. When the active message changed, the new tab page and the cards-list modal header rendered the **previous** message's image.

Fix: derive a Glide `signature()` from the file's last modified time at the two sites that load these local files, so rewriting the file yields a new cache key. 

### Steps to test this PR


Apply the following patch:

```
Index: remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/evaluator/RemoteMessageModalSurfaceEvaluator.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/evaluator/RemoteMessageModalSurfaceEvaluator.kt b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/evaluator/RemoteMessageModalSurfaceEvaluator.kt
--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/evaluator/RemoteMessageModalSurfaceEvaluator.kt	(revision 59bfb705a366967e904a4fafd44619052af3259f)
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/evaluator/RemoteMessageModalSurfaceEvaluator.kt	(date 1785398656052)
@@ -76,9 +76,9 @@
                 return@withContext ModalEvaluator.EvaluationResult.Skipped
             }
 
-            if (!hasMetBackgroundTimeThreshold()) {
-                return@withContext ModalEvaluator.EvaluationResult.Skipped
-            }
+            // if (!hasMetBackgroundTimeThreshold()) {
+            //     return@withContext ModalEvaluator.EvaluationResult.Skipped
+            // }
 
             val message = remoteMessagingRepository.message()
                 ?: return@withContext ModalEvaluator.EvaluationResult.Skipped
Index: remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingFeatureToggles.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingFeatureToggles.kt b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingFeatureToggles.kt
--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingFeatureToggles.kt	(revision 59bfb705a366967e904a4fafd44619052af3259f)
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingFeatureToggles.kt	(date 1785399532780)
@@ -48,5 +48,6 @@
      * If the remote feature is not present defaults to `false`
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.InternalAlwaysEnabled
     fun remoteMessageModalSurface(): Toggle
 }
Index: modal-coordinator/modal-coordinator-impl/src/main/java/com/duckduckgo/modalcoordinator/impl/ModalEvaluatorCoordinator.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/modal-coordinator/modal-coordinator-impl/src/main/java/com/duckduckgo/modalcoordinator/impl/ModalEvaluatorCoordinator.kt b/modal-coordinator/modal-coordinator-impl/src/main/java/com/duckduckgo/modalcoordinator/impl/ModalEvaluatorCoordinator.kt
--- a/modal-coordinator/modal-coordinator-impl/src/main/java/com/duckduckgo/modalcoordinator/impl/ModalEvaluatorCoordinator.kt	(revision 59bfb705a366967e904a4fafd44619052af3259f)
+++ b/modal-coordinator/modal-coordinator-impl/src/main/java/com/duckduckgo/modalcoordinator/impl/ModalEvaluatorCoordinator.kt	(date 1785398656058)
@@ -67,10 +67,10 @@
         logcat { "ModalEvaluatorCoordinator: Starting coordinated evaluation" }
 
         // Check 24-hour blocking first
-        if (completionStore.isBlockedBy24HourWindow()) {
-            logcat { "ModalEvaluatorCoordinator: Evaluation is blocked by 24-hour window" }
-            return@withLock
-        }
+        // if (completionStore.isBlockedBy24HourWindow()) {
+        //     logcat { "ModalEvaluatorCoordinator: Evaluation is blocked by 24-hour window" }
+        //     return@withLock
+        // }
 
         val evaluators = modalEvaluatorPluginPoint.getPlugins().sortedBy { it.priority }
         logcat { "ModalEvaluatorCoordinator: Found ${evaluators.size} evaluators" }
```


- [x] Go to Settings -> Remote messaging service 
- [x] Override the RMF config URL with https://api.jsonblob.com/019fb1ee-b86b-7e84-95e4-cb948f3d5d80/json
- [x] Download the config 
- [x] Go to NTP and check the message displayed 
- [x] Go back to settings and download the config again
- [x] Check the message displayed on NTP and make sure the image is different 
- [x] Go back to settings and download the config again
- [x] Background/ foregorund the app
- [x] A what’s new message should be displayed
- [x] Go back to settings and download the config again
- [x] Background/ foregorund the app
- [ ] A what’s new message should be displayed, with different images 

### UI changes
| Before  | After |
| ------ | ----- |
Previous message's image shown for the new message|Current message's image shown|
