### PR TITLE
Bundle onboardingPrompts experiment in local privacy config

### DIFF
--- a/.maestro/shared/pre_onboarding.yaml
+++ b/.maestro/shared/pre_onboarding.yaml
@@ -26,6 +26,19 @@ appId: com.duckduckgo.mobile.android
       true: ${SET_AS_DEFAULT != 'true'}
     commands:
       - tapOn: "cancel"
+# The "Add to Dock" / "Widget prompt" onboarding pages only show for some cohorts of the
+# addToDockAndWidgetExperimentJul25 experiment (see OnboardingPromptsToggles); both are optional so
+# this flow stays deterministic regardless of which cohort a run gets enrolled into.
+- runFlow:
+    when:
+      visible: "Add me to your favorites row."
+    commands:
+      - tapOn: "Got it!"
+- runFlow:
+    when:
+      visible: "Try our Home screen widget!"
+    commands:
+      - tapOn: "Not Now"
 - assertVisible:
     text: ".*where should I put your address.bar?.*"
 - tapOn: "next"

--- a/.maestro/shared/pre_onboarding.yaml
+++ b/.maestro/shared/pre_onboarding.yaml
@@ -29,14 +29,26 @@ appId: com.duckduckgo.mobile.android
 # The "Add to Dock" / "Widget prompt" onboarding pages only show for some cohorts of the
 # addToDockAndWidgetExperimentJul25 experiment (see OnboardingPromptsToggles); both are optional so
 # this flow stays deterministic regardless of which cohort a run gets enrolled into.
+- extendedWaitUntil:
+    visible:
+      id: "addToDockTitle"
+    timeout: 3000
+    optional: true
 - runFlow:
     when:
-      visible: "Add me to your favorites row."
+      visible:
+        id: "addToDockTitle"
     commands:
       - tapOn: "Got it!"
+- extendedWaitUntil:
+    visible:
+      id: "widgetPromptTitle"
+    timeout: 3000
+    optional: true
 - runFlow:
     when:
-      visible: "Try our Home screen widget!"
+      visible:
+        id: "widgetPromptTitle"
     commands:
       - tapOn: "Not Now"
 - assertVisible:

--- a/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
+++ b/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
@@ -947,6 +947,32 @@
                     "reason": "Site breakage"
                 }
             ]
+        },
+        "onboardingPrompts": {
+            "state": "enabled",
+            "features": {
+                "addToDockAndWidgetExperimentJul25": {
+                    "state": "enabled",
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatmentDockOnly",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatmentWidgetOnly",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatmentDockAndWidget",
+                            "weight": 1
+                        }
+                    ]
+                }
+            }
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216232144477360
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

### Description

Bundles the `onboardingPrompts` remote feature (`OnboardingPromptsToggles`) into the local fallback `privacy_config.json`, mirroring the sub-feature `addToDockAndWidgetExperimentJul25` and its four cohorts (`control`, `treatmentDockOnly`, `treatmentWidgetOnly`, `treatmentDockAndWidget`), each weighted equally.

By the time we enroll the users into this experiment the remote privacy config is most likely not downloaded, so we need to rely on the local config. 

**Maestro fix:** bundling the experiment means a new/reinstalled user going through the full onboarding flow can now land on the new Add-to-Dock / Widget-prompt pages instead of going straight from "choose your browser" to the address-bar step. `.maestro/shared/pre_onboarding.yaml` is shared by several Maestro suites beyond the onboarding tests themselves (fire_button, custom_tabs, sync_flows), so it now conditionally taps through either new page if it appears (tapping "Not Now" on the widget prompt to avoid the system pin-widget dialog), keeping the flow deterministic regardless of which cohort a given run is enrolled into.

### Steps to test this PR

_Fallback enrollment_
- [ ] Remove DDG downloads folder
- [ ] Clean install the app
- [ ] Launch onboarding 
- [ ] Verify the user is enrolled into one of the four `addToDockAndWidgetExperimentJul25` cohorts and the corresponding onboarding prompt behavior is shown.
- [ ] Repeat this step and check that different cohorts are assigned 

_Maestro regression_
- [ ] Run `.maestro/onboarding/onboarding.yaml` (or any other suite that calls `../shared/pre_onboarding.yaml`) a few times locally; it should pass regardless of which cohort it lands in.

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are bundled remote-config defaults and optional Maestro steps; no production app logic or security paths are modified.
> 
> **Overview**
> Adds **`onboardingPrompts`** to the bundled **`privacy_config.json`**, enabling **`addToDockAndWidgetExperimentJul25`** with four equal-weight cohorts (`control`, `treatmentDockOnly`, `treatmentWidgetOnly`, `treatmentDockAndWidget`). Reinstallers and other users on the local fallback config before remote privacy config loads can be enrolled in the dock/widget onboarding experiment, consistent with prior bundled onboarding experiments.
> 
> **Maestro:** **`pre_onboarding.yaml`** now optionally waits for and dismisses the Add-to-Dock screen (`addToDockTitle` → “Got it!”) and the widget prompt (`widgetPromptTitle` → “Not Now”) so shared suites stay deterministic across cohorts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f064979eb90e7567c67d01ac68fea7c083cee22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->