### PR TITLE
Sample the data-clearing wide event at 5%

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/fire/wideevents/DataClearingWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/wideevents/DataClearingWideEvent.kt
@@ -110,6 +110,7 @@ class DataClearingWideEventImpl @Inject constructor(
             flowEntryPoint = entryPoint.value,
             metadata = metadata,
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
+            samplingProbability = SAMPLING_PROBABILITY,
         ).getOrNull()
 
         cachedFlowId?.let { flowId ->
@@ -230,6 +231,7 @@ class DataClearingWideEventImpl @Inject constructor(
 
     private companion object {
         const val FLOW_NAME = "data-clearing"
+        const val SAMPLING_PROBABILITY = 0.05f
         const val KEY_CLEAR_OPTIONS = "clear_options"
         const val KEY_TOTAL_DURATION_MS_BUCKETED = "total_duration_ms_bucketed"
         const val KEY_BROWSER_MODE = "browser_mode"

--- a/app/src/test/java/com/duckduckgo/app/fire/wideevents/DataClearingWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/wideevents/DataClearingWideEventTest.kt
@@ -70,6 +70,7 @@ class DataClearingWideEventTest {
             flowEntryPoint = "single_tab_fire_dialog",
             metadata = mapOf("clear_options" to "tabs,data", "browser_mode" to "regular"),
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
+            samplingProbability = 0.05f,
         )
         verify(wideEventClient).intervalStart(wideEventId = 123L, key = "total_duration_ms_bucketed")
     }
@@ -86,6 +87,7 @@ class DataClearingWideEventTest {
             flowEntryPoint = "app_shortcut",
             metadata = mapOf("clear_options" to "tabs", "browser_mode" to "fire"),
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
+            samplingProbability = 0.05f,
         )
     }
 
@@ -112,6 +114,7 @@ class DataClearingWideEventTest {
                 "tab_count" to "11-20",
             ),
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
+            samplingProbability = 0.05f,
         )
     }
 
@@ -133,6 +136,7 @@ class DataClearingWideEventTest {
                 flowEntryPoint = "single_tab_fire_dialog",
                 metadata = mapOf("clear_options" to "", "browser_mode" to "regular", "tab_count" to bucket),
                 cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
+                samplingProbability = 0.05f,
             )
         }
     }
@@ -149,6 +153,7 @@ class DataClearingWideEventTest {
             flowEntryPoint = "app_shortcut",
             metadata = mapOf("clear_options" to "", "browser_mode" to "regular"),
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
+            samplingProbability = 0.05f,
         )
     }
 
@@ -165,6 +170,7 @@ class DataClearingWideEventTest {
             flowEntryPoint = "single_tab_fire_dialog",
             metadata = mapOf("clear_options" to "duckai_chats", "browser_mode" to "regular"),
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
+            samplingProbability = 0.05f,
         )
     }
 
@@ -181,6 +187,7 @@ class DataClearingWideEventTest {
             flowEntryPoint = "single_tab_fire_dialog",
             metadata = mapOf("clear_options" to "tabs,data,duckai_chats", "browser_mode" to "regular"),
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
+            samplingProbability = 0.05f,
         )
         verify(wideEventClient).intervalStart(wideEventId = 124L, key = "total_duration_ms_bucketed")
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205648422731273/task/1217014953183500?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

The `data-clearing` wide event currently records every flow. Data clearing runs on every Fire button press and on every automatic foreground/background clear, so we send more volume than we need to spot regressions.

### Steps to test this PR

- [x] Use the fire button several times to perform data clear (doesn't matter if single tab or full).
- [x] Confirm the `wide_data-clearing_c` pixel is either not sent at all or sent with `global.sample_rate=0.05`  param.

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics sampling only; clearing behavior and event shape stay the same, with backend weighting via persisted sample rate.
> 
> **Overview**
> Reduces telemetry volume for the **`data-clearing`** wide event by passing **`samplingProbability = 0.05f`** into **`wideEventClient.flowStart`** in `DataClearingWideEventImpl`, so only about 5% of clears are recorded. Sampled-out flows get a sentinel flow ID from **`flowStart`**; existing step/finish/interval handling already no-ops when there is no real ID, so callers were not changed.
> 
> Unit tests that assert **`flowStart`** arguments were updated to expect **`samplingProbability = 0.05f`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0400117f78539db581780f1216b75ddda8d13ed8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->