### PR TITLE
Drop defensive CopyOnWriteArrayList from the optimized RealContentScopeScripts

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/privacy/db/RealUserAllowListRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/db/RealUserAllowListRepository.kt
@@ -42,9 +42,6 @@ class RealUserAllowListRepository @Inject constructor(
     @IsMainProcess isMainProcess: Boolean,
 ) : UserAllowListRepository {
 
-    // Replaced on a worker thread while readers are on the main thread, so it is published in a single
-    // assignment rather than refilled in place. That also lets a caller hold the reference returned by
-    // domainsInUserAllowList() and detect a change by comparing it, instead of copying and deep-comparing.
     @Volatile
     private var userAllowList: List<String> = emptyList()
 

--- a/app/src/main/java/com/duckduckgo/app/privacy/db/RealUserAllowListRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/db/RealUserAllowListRepository.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.util.concurrent.CopyOnWriteArrayList
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
@@ -43,7 +42,12 @@ class RealUserAllowListRepository @Inject constructor(
     @IsMainProcess isMainProcess: Boolean,
 ) : UserAllowListRepository {
 
-    private val userAllowList = CopyOnWriteArrayList<String>()
+    // Replaced on a worker thread while readers are on the main thread, so it is published in a single
+    // assignment rather than refilled in place. That also lets a caller hold the reference returned by
+    // domainsInUserAllowList() and detect a change by comparing it, instead of copying and deep-comparing.
+    @Volatile
+    private var userAllowList: List<String> = emptyList()
+
     override fun isUrlInUserAllowList(url: String): Boolean {
         return isUriInUserAllowList(url.toUri())
     }
@@ -62,7 +66,7 @@ class RealUserAllowListRepository @Inject constructor(
 
     override fun domainsInUserAllowListFlow(): Flow<List<String>> {
         return all()
-            .onStart { emit(userAllowList.toList()) }
+            .onStart { emit(userAllowList) }
             .distinctUntilChanged()
     }
 
@@ -81,10 +85,7 @@ class RealUserAllowListRepository @Inject constructor(
     init {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             if (isMainProcess) {
-                all().collect { list ->
-                    userAllowList.clear()
-                    userAllowList.addAll(list)
-                }
+                all().collect { list -> userAllowList = list }
             }
         }
     }

--- a/app/src/test/java/com/duckduckgo/app/privacy/db/UserAllowListRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/privacy/db/UserAllowListRepositoryTest.kt
@@ -101,6 +101,20 @@ class UserAllowListRepositoryTest {
     }
 
     @Test
+    fun whenAllowListChangesThenAPreviouslyReturnedListIsUnaffected() {
+        dao.insert("example.com")
+        val held = repository.domainsInUserAllowList()
+        assertEquals(listOf("example.com"), held)
+
+        dao.insert("foo.com")
+
+        // Callers may cache the reference and detect a change by comparing it, so a published list must never
+        // be mutated afterwards.
+        assertEquals(listOf("example.com"), held)
+        assertEquals(2, repository.domainsInUserAllowList().size)
+    }
+
+    @Test
     fun whenAllowlistIsModifiedThenFlowEmitsEvent() = runTest {
         repository.domainsInUserAllowListFlow()
             .test {

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -75,13 +75,19 @@ class RealContentScopeScripts @Inject constructor(
 
     private var cachedContentScopeJson: String = getContentScopeJson("", emptyList(), optimized = true)
 
+    // Legacy-path baselines. Defensive copies, because the flag-off path is frozen as it shipped.
     private var cachedUserUnprotectedDomains = CopyOnWriteArrayList<String>()
+    private var cachedUnprotectTemporaryExceptions = CopyOnWriteArrayList<FeatureException>()
+
+    // Optimized-path baselines. Both repositories publish their list as an immutable snapshot in a single
+    // assignment, so holding the reference is enough and no copy is needed.
+    private var lastUserUnprotectedDomains: List<String> = emptyList()
+    private var lastUnprotectedTemporaryExceptions: List<FeatureException> = emptyList()
+
     private var cachedUserUnprotectedDomainsJson: String = EMPTY_JSON_LIST
+    private var cachedUnprotectTemporaryExceptionsJson: String = EMPTY_JSON_LIST
 
     private var cachedUserPreferencesJson: String = EMPTY_JSON
-
-    private var cachedUnprotectTemporaryExceptions = CopyOnWriteArrayList<FeatureException>()
-    private var cachedUnprotectTemporaryExceptionsJson: String = EMPTY_JSON_LIST
 
     private lateinit var cachedContentScopeJS: String
 
@@ -117,10 +123,18 @@ class RealContentScopeScripts @Inject constructor(
     ): String {
         var updateJS = false
 
+        // This path rewrites the shared JSON fields but keeps its own baselines, so the optimized baselines are
+        // dropped here. Without this, a mid-session flag flip followed by an input returning to its pre-flip
+        // value would leave the optimized path seeing no change while the shared JSON still holds what this
+        // path last wrote. Writes only: nothing below reads them, so legacy behaviour is unaffected.
+        cachedPluginConfig = ""
+        lastUserUnprotectedDomains = emptyList()
+        lastUnprotectedTemporaryExceptions = emptyList()
+
         val pluginParameters = getLegacyPluginParameters()
 
         if (cachedUnprotectTemporaryExceptions != unprotectedTemporary.unprotectedTemporaryExceptions) {
-            cacheUserUnprotectedTemporaryExceptions(unprotectedTemporary.unprotectedTemporaryExceptions, optimized = false)
+            cacheUserUnprotectedTemporaryExceptions(unprotectedTemporary.unprotectedTemporaryExceptions)
             updateJS = true
         }
 
@@ -131,7 +145,7 @@ class RealContentScopeScripts @Inject constructor(
         }
 
         if (cachedUserUnprotectedDomains != userAllowListRepository.domainsInUserAllowList()) {
-            cacheUserUnprotectedDomains(userAllowListRepository.domainsInUserAllowList(), optimized = false)
+            cacheUserUnprotectedDomains(userAllowListRepository.domainsInUserAllowList())
             updateJS = true
         }
 
@@ -165,8 +179,8 @@ class RealContentScopeScripts @Inject constructor(
         }
 
         val unprotectedTemporaryExceptions = unprotectedTemporary.unprotectedTemporaryExceptions
-        if (cachedUnprotectTemporaryExceptions != unprotectedTemporaryExceptions) {
-            cacheUserUnprotectedTemporaryExceptions(unprotectedTemporaryExceptions, optimized = true)
+        if (lastUnprotectedTemporaryExceptions.differsFrom(unprotectedTemporaryExceptions)) {
+            cacheOptimizedUnprotectedTemporaryExceptions(unprotectedTemporaryExceptions)
             contentScopeChanged = true
         }
 
@@ -176,8 +190,8 @@ class RealContentScopeScripts @Inject constructor(
         }
 
         val userUnprotectedDomains = userAllowListRepository.domainsInUserAllowList()
-        if (cachedUserUnprotectedDomains != userUnprotectedDomains) {
-            cacheUserUnprotectedDomains(userUnprotectedDomains, optimized = true)
+        if (lastUserUnprotectedDomains.differsFrom(userUnprotectedDomains)) {
+            cacheOptimizedUserUnprotectedDomains(userUnprotectedDomains)
             updateJS = true
         }
 
@@ -248,28 +262,44 @@ class RealContentScopeScripts @Inject constructor(
         append(value)
     }
 
-    private fun cacheUserUnprotectedDomains(
-        userUnprotectedDomains: List<String>,
-        optimized: Boolean,
-    ) {
+    private fun <T> List<T>.differsFrom(other: List<T>): Boolean = this !== other && this != other
+
+    private fun cacheOptimizedUserUnprotectedDomains(userUnprotectedDomains: List<String>) {
+        lastUserUnprotectedDomains = userUnprotectedDomains
+        cachedUserUnprotectedDomainsJson = if (userUnprotectedDomains.isEmpty()) {
+            EMPTY_JSON_LIST
+        } else {
+            getUserUnprotectedDomainsJson(userUnprotectedDomains, optimized = true)
+        }
+    }
+
+    private fun cacheOptimizedUnprotectedTemporaryExceptions(unprotectedTemporaryExceptions: List<FeatureException>) {
+        lastUnprotectedTemporaryExceptions = unprotectedTemporaryExceptions
+        cachedUnprotectTemporaryExceptionsJson = if (unprotectedTemporaryExceptions.isEmpty()) {
+            EMPTY_JSON_LIST
+        } else {
+            getUnprotectedTemporaryJson(unprotectedTemporaryExceptions, optimized = true)
+        }
+    }
+
+    // Frozen twins of the cacheOptimized* pair above: they copy the incoming list into a
+    // CopyOnWriteArrayList, which is what the flag-off path shipped with. Deleted with the flag.
+    private fun cacheUserUnprotectedDomains(userUnprotectedDomains: List<String>) {
         cachedUserUnprotectedDomains.clear()
         if (userUnprotectedDomains.isEmpty()) {
             cachedUserUnprotectedDomainsJson = EMPTY_JSON_LIST
         } else {
-            cachedUserUnprotectedDomainsJson = getUserUnprotectedDomainsJson(userUnprotectedDomains, optimized)
+            cachedUserUnprotectedDomainsJson = getUserUnprotectedDomainsJson(userUnprotectedDomains, optimized = false)
             cachedUserUnprotectedDomains.addAll(userUnprotectedDomains)
         }
     }
 
-    private fun cacheUserUnprotectedTemporaryExceptions(
-        unprotectedTemporaryExceptions: List<FeatureException>,
-        optimized: Boolean,
-    ) {
+    private fun cacheUserUnprotectedTemporaryExceptions(unprotectedTemporaryExceptions: List<FeatureException>) {
         cachedUnprotectTemporaryExceptions.clear()
         if (unprotectedTemporaryExceptions.isEmpty()) {
             cachedUnprotectTemporaryExceptionsJson = EMPTY_JSON_LIST
         } else {
-            cachedUnprotectTemporaryExceptionsJson = getUnprotectedTemporaryJson(unprotectedTemporaryExceptions, optimized)
+            cachedUnprotectTemporaryExceptionsJson = getUnprotectedTemporaryJson(unprotectedTemporaryExceptions, optimized = false)
             cachedUnprotectTemporaryExceptions.addAll(unprotectedTemporaryExceptions)
         }
     }

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -75,12 +75,11 @@ class RealContentScopeScripts @Inject constructor(
 
     private var cachedContentScopeJson: String = getContentScopeJson("", emptyList(), optimized = true)
 
-    // Legacy-path baselines. Defensive copies, because the flag-off path is frozen as it shipped.
+    // Legacy-path baselines.
     private var cachedUserUnprotectedDomains = CopyOnWriteArrayList<String>()
     private var cachedUnprotectTemporaryExceptions = CopyOnWriteArrayList<FeatureException>()
 
-    // Optimized-path baselines. Both repositories publish their list as an immutable snapshot in a single
-    // assignment, so holding the reference is enough and no copy is needed.
+    // Optimized-path baselines.
     private var lastUserUnprotectedDomains: List<String> = emptyList()
     private var lastUnprotectedTemporaryExceptions: List<FeatureException> = emptyList()
 
@@ -123,10 +122,8 @@ class RealContentScopeScripts @Inject constructor(
     ): String {
         var updateJS = false
 
-        // This path rewrites the shared JSON fields but keeps its own baselines, so the optimized baselines are
-        // dropped here. Without this, a mid-session flag flip followed by an input returning to its pre-flip
-        // value would leave the optimized path seeing no change while the shared JSON still holds what this
-        // path last wrote. Writes only: nothing below reads them, so legacy behaviour is unaffected.
+        // A mid-session flag flip followed by an input returning to its pre-flip value would leave the optimized path
+        // seeing no change. Writes only: nothing below reads them, so legacy behaviour is unaffected.
         cachedPluginConfig = ""
         lastUserUnprotectedDomains = emptyList()
         lastUnprotectedTemporaryExceptions = emptyList()
@@ -282,8 +279,6 @@ class RealContentScopeScripts @Inject constructor(
         }
     }
 
-    // Frozen twins of the cacheOptimized* pair above: they copy the incoming list into a
-    // CopyOnWriteArrayList, which is what the flag-off path shipped with. Deleted with the flag.
     private fun cacheUserUnprotectedDomains(userUnprotectedDomains: List<String>) {
         cachedUserUnprotectedDomains.clear()
         if (userUnprotectedDomains.isEmpty()) {

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -103,15 +103,39 @@ class RealContentScopeScripts @Inject constructor(
         "${getVersionNumberKeyValuePair()},${getPlatformKeyValuePair()}"
     }
 
+    private var lastCallWasOptimized: Boolean? = null
+
     override fun getScript(
         isDesktopMode: Boolean?,
         activeExperiments: List<Toggle>,
     ): String {
-        return if (optimizeInjectionEnabled()) {
+        val optimized = optimizeInjectionEnabled()
+        // The paths keep their own change-detection baselines but write the same JSON caches, so after a
+        // mid-session flag flip a baseline no longer describes what the cache holds. Dropping both together
+        // is the only state either path can safely resume from.
+        if (lastCallWasOptimized != null && lastCallWasOptimized != optimized) {
+            resetCaches()
+        }
+        lastCallWasOptimized = optimized
+
+        return if (optimized) {
             getOptimizedScript(isDesktopMode, activeExperiments)
         } else {
             getLegacyScript(isDesktopMode, activeExperiments)
         }
+    }
+
+    private fun resetCaches() {
+        cachedPluginConfig = ""
+        cachedUserUnprotectedDomains.clear()
+        cachedUnprotectTemporaryExceptions.clear()
+        lastUserUnprotectedDomains = emptyList()
+        lastUnprotectedTemporaryExceptions = emptyList()
+        cachedUserUnprotectedDomainsJson = EMPTY_JSON_LIST
+        cachedUnprotectTemporaryExceptionsJson = EMPTY_JSON_LIST
+        cachedContentScopeJson = buildContentScopeJson("", EMPTY_JSON_LIST)
+        // Never equal to a built preferences string, so the next call also reassembles the script.
+        cachedUserPreferencesJson = EMPTY_JSON
     }
 
     // Original implementation, left intact. Used when optimizeContentScopeInjection is disabled, and
@@ -121,12 +145,6 @@ class RealContentScopeScripts @Inject constructor(
         activeExperiments: List<Toggle>,
     ): String {
         var updateJS = false
-
-        // A mid-session flag flip followed by an input returning to its pre-flip value would leave the optimized path
-        // seeing no change. Writes only: nothing below reads them, so legacy behaviour is unaffected.
-        cachedPluginConfig = ""
-        lastUserUnprotectedDomains = emptyList()
-        lastUnprotectedTemporaryExceptions = emptyList()
 
         val pluginParameters = getLegacyPluginParameters()
 

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
@@ -334,6 +334,95 @@ class RealContentScopeScriptsTest {
     }
 
     @Test
+    fun whenFlagFlipsToOptimizedAndTheAllowListEmptiedWhileOnLegacyThenTheEmptyListIsReflected() {
+        val optimizeFlag = contentScopeScriptsFeature.optimizeContentScopeInjection()
+
+        optimizeFlag.setRawStoredState(State(enable = false))
+        assertTrue(testee.getScript(null, listOf()).contains("[\"$exampleUrl\"]"))
+
+        // Emptying is the one value a baseline reset cannot be told apart from, so the JSON legacy wrote
+        // must not survive on the strength of the baseline alone.
+        optimizeFlag.setRawStoredState(State(enable = true))
+        whenever(mockUserAllowListRepository.domainsInUserAllowList()).thenReturn(emptyList())
+        val js = testee.getScript(null, listOf())
+
+        assertTrue("the emptied allow list must be reflected", js.contains(", [], "))
+    }
+
+    @Test
+    fun whenFlagFlipsToOptimizedAndExceptionsEmptiedWhileOnLegacyThenTheEmptyListIsReflected() {
+        val optimizeFlag = contentScopeScriptsFeature.optimizeContentScopeInjection()
+
+        optimizeFlag.setRawStoredState(State(enable = false))
+        assertTrue(testee.getScript(null, listOf()).contains("\"domain\":\"example.com\""))
+
+        optimizeFlag.setRawStoredState(State(enable = true))
+        whenever(mockUnprotectedTemporary.unprotectedTemporaryExceptions).thenReturn(emptyList())
+        val js = testee.getScript(null, listOf())
+
+        assertTrue("the emptied exception list must be reflected", js.contains("\"unprotectedTemporary\":[]"))
+    }
+
+    @Test
+    fun whenFlagFlipsOnOffOnWithUnchangedInputsThenEveryScriptIsIdentical() {
+        val optimizeFlag = contentScopeScriptsFeature.optimizeContentScopeInjection()
+
+        optimizeFlag.setRawStoredState(State(enable = true))
+        val optimizedJs = testee.getScript(null, listOf())
+
+        optimizeFlag.setRawStoredState(State(enable = false))
+        val legacyJs = testee.getScript(null, listOf())
+
+        optimizeFlag.setRawStoredState(State(enable = true))
+        val optimizedAgainJs = testee.getScript(null, listOf())
+
+        verifyJsScript(optimizedJs)
+        verifyJsScript(legacyJs)
+        verifyJsScript(optimizedAgainJs)
+        assertEquals(optimizedJs, legacyJs)
+        assertEquals(optimizedJs, optimizedAgainJs)
+    }
+
+    @Test
+    fun whenFlagFlipsAndEveryInputIsEmptiedThenTheEmptyStateIsReflected() {
+        val optimizeFlag = contentScopeScriptsFeature.optimizeContentScopeInjection()
+
+        optimizeFlag.setRawStoredState(State(enable = false))
+        assertTrue(testee.getScript(null, listOf()).contains("\"features\":{$config1,$config2}"))
+
+        // Every input now coincides with the value the caches are dropped to, so nothing downstream is
+        // recomputed and the dropped state has to be coherent on its own.
+        optimizeFlag.setRawStoredState(State(enable = true))
+        whenever(mockPluginPoint.getPlugins()).thenReturn(emptyList())
+        whenever(mockUnprotectedTemporary.unprotectedTemporaryExceptions).thenReturn(emptyList())
+        whenever(mockUserAllowListRepository.domainsInUserAllowList()).thenReturn(emptyList())
+        val js = testee.getScript(null, listOf())
+
+        assertTrue("the emptied content scope must be reflected", js.contains("{\"features\":{},\"unprotectedTemporary\":[]}"))
+        assertTrue("the emptied allow list must be reflected", js.contains(", [], "))
+    }
+
+    @Test
+    fun whenFlagFlipsBackToLegacyThenAnAllowListRestoredToItsPreFlipValueIsStillReflected() {
+        val optimizeFlag = contentScopeScriptsFeature.optimizeContentScopeInjection()
+
+        optimizeFlag.setRawStoredState(State(enable = false))
+        assertTrue(testee.getScript(null, listOf()).contains("[\"$exampleUrl\"]"))
+
+        // The optimized path rewrites the shared allow list JSON, so legacy cannot rely on a baseline
+        // recorded before the flip either.
+        optimizeFlag.setRawStoredState(State(enable = true))
+        whenever(mockUserAllowListRepository.domainsInUserAllowList()).thenReturn(listOf(exampleUrl2))
+        assertTrue(testee.getScript(null, listOf()).contains("[\"$exampleUrl2\"]"))
+
+        optimizeFlag.setRawStoredState(State(enable = false))
+        whenever(mockUserAllowListRepository.domainsInUserAllowList()).thenReturn(listOf(exampleUrl))
+        val js = testee.getScript(null, listOf())
+
+        assertTrue("the restored allow list must be reflected", js.contains("[\"$exampleUrl\"]"))
+    }
+
+    @Test
     fun whenOptimizeEnabledThenEachToggleCohortIsReadOnce() = runTest {
         contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
         val mockToggle = mock<Toggle>()

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
@@ -212,6 +212,31 @@ class RealContentScopeScriptsTest {
     }
 
     @Test
+    fun whenOptimizeEnabledAndUnprotectedTemporaryIsANewInstanceWithEqualContentsThenScriptIsNotReassembled() {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+        testee.getScript(null, listOf())
+
+        // The repository publishes a new list instance on every reload, even when the contents are unchanged,
+        // so the identity fast path misses and the equals fallback has to stop a pointless reassembly.
+        whenever(mockUnprotectedTemporary.unprotectedTemporaryExceptions)
+            .thenReturn(listOf(unprotectedTemporaryException, unprotectedTemporaryException2))
+        testee.getScript(null, listOf())
+
+        verify(mockContentScopeJsReader).getContentScopeJS()
+    }
+
+    @Test
+    fun whenOptimizeEnabledAndAllowListIsANewInstanceWithEqualContentsThenScriptIsNotReassembled() {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+        testee.getScript(null, listOf())
+
+        whenever(mockUserAllowListRepository.domainsInUserAllowList()).thenReturn(listOf(exampleUrl))
+        testee.getScript(null, listOf())
+
+        verify(mockContentScopeJsReader).getContentScopeJS()
+    }
+
+    @Test
     fun whenOptimizeEnabledThenPluginConfigIsSweptOnEveryCall() {
         contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
 
@@ -259,6 +284,53 @@ class RealContentScopeScriptsTest {
 
         assertFalse("config dropped while on the legacy path must not be resurrected", js.contains(config2))
         assertTrue(js.contains("\"features\":{$config1}"))
+    }
+
+    @Test
+    fun whenFlagFlipsBackToOptimizedThenExceptionsRestoredToTheirPreFlipValueAreStillReflected() {
+        val optimizeFlag = contentScopeScriptsFeature.optimizeContentScopeInjection()
+
+        // Record the full exception list on the optimized path.
+        optimizeFlag.setRawStoredState(State(enable = true))
+        testee.getScript(null, listOf())
+
+        // The legacy path takes over, the list shrinks, and legacy rewrites the shared exceptions JSON.
+        optimizeFlag.setRawStoredState(State(enable = false))
+        whenever(mockUnprotectedTemporary.unprotectedTemporaryExceptions).thenReturn(listOf(unprotectedTemporaryException))
+        assertTrue(testee.getScript(null, listOf()).contains("\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"}]"))
+
+        // Back on the optimized path with the list restored to its pre-flip value. Comparing against a baseline
+        // captured before the flip would find no change and keep serving the JSON legacy wrote.
+        optimizeFlag.setRawStoredState(State(enable = true))
+        whenever(mockUnprotectedTemporary.unprotectedTemporaryExceptions)
+            .thenReturn(listOf(unprotectedTemporaryException, unprotectedTemporaryException2))
+        val js = testee.getScript(null, listOf())
+
+        assertTrue(
+            "the restored exception list must be reflected",
+            js.contains(
+                "\"unprotectedTemporary\":[{\"domain\":\"example.com\",\"reason\":\"reason\"}," +
+                    "{\"domain\":\"foo.com\",\"reason\":\"reason2\"}]",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFlagFlipsBackToOptimizedThenAnAllowListRestoredToItsPreFlipValueIsStillReflected() {
+        val optimizeFlag = contentScopeScriptsFeature.optimizeContentScopeInjection()
+
+        optimizeFlag.setRawStoredState(State(enable = true))
+        testee.getScript(null, listOf())
+
+        optimizeFlag.setRawStoredState(State(enable = false))
+        whenever(mockUserAllowListRepository.domainsInUserAllowList()).thenReturn(listOf(exampleUrl2))
+        assertTrue(testee.getScript(null, listOf()).contains("[\"$exampleUrl2\"]"))
+
+        optimizeFlag.setRawStoredState(State(enable = true))
+        whenever(mockUserAllowListRepository.domainsInUserAllowList()).thenReturn(listOf(exampleUrl))
+        val js = testee.getScript(null, listOf())
+
+        assertTrue("the restored allow list must be reflected", js.contains("[\"$exampleUrl\"]"))
     }
 
     @Test

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.launch
 interface UnprotectedTemporaryRepository {
     fun updateAll(exceptions: List<UnprotectedTemporaryEntity>)
 
-    /** Immutable snapshot. A caller may hold the reference: it is replaced, never mutated. */
     val exceptions: List<FeatureException>
 }
 
@@ -41,9 +40,6 @@ class RealUnprotectedTemporaryRepository(
     private val unprotectedTemporaryDao: UnprotectedTemporaryDao =
         database.unprotectedTemporaryDao()
 
-    // Reloaded on a worker thread while readers are on the main thread, so it is published in a single
-    // assignment: a reader sees either the previous list or the complete new one. Refilling in place would
-    // let a reader observe any prefix of the list mid-reload.
     @Volatile
     private var snapshot: List<FeatureException> = emptyList()
 

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
@@ -23,11 +23,12 @@ import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
 import com.duckduckgo.privacy.config.store.toFeatureException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import java.util.concurrent.CopyOnWriteArrayList
 
 interface UnprotectedTemporaryRepository {
     fun updateAll(exceptions: List<UnprotectedTemporaryEntity>)
-    val exceptions: CopyOnWriteArrayList<FeatureException>
+
+    /** Immutable snapshot. A caller may hold the reference: it is replaced, never mutated. */
+    val exceptions: List<FeatureException>
 }
 
 class RealUnprotectedTemporaryRepository(
@@ -39,7 +40,14 @@ class RealUnprotectedTemporaryRepository(
 
     private val unprotectedTemporaryDao: UnprotectedTemporaryDao =
         database.unprotectedTemporaryDao()
-    override val exceptions = CopyOnWriteArrayList<FeatureException>()
+
+    // Reloaded on a worker thread while readers are on the main thread, so it is published in a single
+    // assignment: a reader sees either the previous list or the complete new one. Refilling in place would
+    // let a reader observe any prefix of the list mid-reload.
+    @Volatile
+    private var snapshot: List<FeatureException> = emptyList()
+
+    override val exceptions get() = snapshot
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
@@ -55,7 +63,6 @@ class RealUnprotectedTemporaryRepository(
     }
 
     private fun loadToMemory() {
-        exceptions.clear()
-        unprotectedTemporaryDao.getAll().map { exceptions.add(it.toFeatureException()) }
+        snapshot = unprotectedTemporaryDao.getAll().map { it.toFeatureException() }
     }
 }

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/RealUnprotectedTemporaryRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/RealUnprotectedTemporaryRepositoryTest.kt
@@ -103,6 +103,68 @@ class RealUnprotectedTemporaryRepositoryTest {
             assertEquals(0, testee.exceptions.size)
         }
 
+    @Test
+    fun whenReloadingThenAReaderNeverObservesAPartialList() {
+        whenever(mockUnprotectedTemporaryDao.getAll())
+            .thenReturn(listOf(unprotectedTemporaryException, unprotectedTemporaryException2))
+        testee = createTestee()
+        assertEquals(2, testee.exceptions.size)
+
+        // Read `exceptions` from inside the reload, at the point where a refill-in-place implementation has
+        // already dropped the previous entries and not yet added the new ones.
+        val sizesObservedMidReload = mutableListOf<Int>()
+        whenever(mockUnprotectedTemporaryDao.getAll()).thenAnswer {
+            sizesObservedMidReload.add(testee.exceptions.size)
+            listOf(unprotectedTemporaryException)
+        }
+
+        testee.updateAll(listOf())
+
+        assertEquals(listOf(2), sizesObservedMidReload)
+        assertEquals(1, testee.exceptions.size)
+    }
+
+    @Test
+    fun whenReloadingThenAPreviouslyReturnedListIsUnaffected() {
+        whenever(mockUnprotectedTemporaryDao.getAll()).thenReturn(listOf(unprotectedTemporaryException))
+        testee = createTestee()
+        val held = testee.exceptions
+
+        whenever(mockUnprotectedTemporaryDao.getAll())
+            .thenReturn(listOf(unprotectedTemporaryException, unprotectedTemporaryException2))
+        testee.updateAll(listOf())
+
+        // Callers may cache the reference and detect a change by comparing it, so a published list must never
+        // be mutated afterwards.
+        assertEquals(1, held.size)
+        assertEquals(2, testee.exceptions.size)
+        assertNotSame(held, testee.exceptions)
+    }
+
+    @Test
+    fun whenReloadFailsThenThePreviouslyLoadedExceptionsAreRetained() {
+        whenever(mockUnprotectedTemporaryDao.getAll()).thenReturn(listOf(unprotectedTemporaryException))
+        testee = createTestee()
+        assertEquals(1, testee.exceptions.size)
+
+        whenever(mockUnprotectedTemporaryDao.getAll()).thenThrow(RuntimeException("database unavailable"))
+
+        // The new list is only published once the read succeeds, so a failed reload keeps serving the previous
+        // exceptions rather than dropping every exemption until the next successful one.
+        assertThrows(RuntimeException::class.java) { testee.updateAll(listOf()) }
+
+        assertEquals(1, testee.exceptions.size)
+        assertEquals(unprotectedTemporaryException.toFeatureException(), testee.exceptions.first())
+    }
+
+    private fun createTestee() =
+        RealUnprotectedTemporaryRepository(
+            mockDatabase,
+            TestScope(),
+            coroutineRule.testDispatcherProvider,
+            isMainProcess = true,
+        )
+
     private fun givenUnprotectedTemporaryDaoContainsExceptions() {
         whenever(mockUnprotectedTemporaryDao.getAll())
             .thenReturn(listOf(unprotectedTemporaryException))
@@ -110,5 +172,6 @@ class RealUnprotectedTemporaryRepositoryTest {
 
     companion object {
         val unprotectedTemporaryException = UnprotectedTemporaryEntity("example.com", "reason")
+        val unprotectedTemporaryException2 = UnprotectedTemporaryEntity("foo.com", "reason2")
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200905986587319/task/1217019532582642?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

Two privacy-config lists were rebuilt in place on a worker thread while readers read them on the main thread, and both repositories handed out the live instance.

`RealUnprotectedTemporaryRepository` did `clear()` then one `add()` per row, so a reader could observe any prefix — a millisecond-wide window on every config persist, with ~300 exception domains.
`RealContentScopeScripts` reads that list on every navigation and serializes it into the injected script, so a truncated read meant content-scope features running on sites meant to be exempt.

Both repositories now build the list aside and publish it in a single assignment to a `@Volatile` field, following `RealTrackerAllowlistRepository` in the same module. `UnprotectedTemporaryRepository.exceptions`widens from `CopyOnWriteArrayList<FeatureException>` to `List<FeatureException>`; no `-api` change, and existing test stubs are unaffected. `RealUserAllowListRepository` used a single `addAll()` so it could never tear, and is included for the second reason below.

Because a published list is now immutable, the optimized path in `RealContentScopeScripts` drops its two defensive `CopyOnWriteArrayList` copies and holds the references instead, comparing `!==` then `!=`: identity settles the unchanged case in O(1), and equals still stops a reload that changed nothing from reassembling the script. The legacy path keeps its copies and now clears the optimized baselines, so a mid-session flag flip followed by an input returning to its pre-flip value cannot leave the shared JSON stale.

### Steps to test this PR

- [x] Tests are passing.

With `optimizeContentScopeInjection` ON (default on internal)

- [x] Browse several pages in a row, confirm protections stay applied.
- [ ] Override the privacy config from dev settings, confirm an `unprotectedTemporary` change takes effect.
- [x] Tap the shield to allowlist a site, confirm protections drop, then re-protect it.
- [x] Toggle GPC and Accessibility → force zoom, reload, confirm both take effect. (i.e. YouTube)
- [x] Turn the flag OFF, restart, repeat the above. Behaviour must be identical to develop.
- [x] Flip it back ON without restarting, load a page, confirm protections are still correct.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes threading and caching for privacy exemptions and injected content-scope JS; incorrect behavior would mis-apply protections, but the change is well-tested around flag flips and list immutability.
> 
> **Overview**
> Fixes a **race** where `RealUnprotectedTemporaryRepository` and `RealUserAllowListRepository` rebuilt `CopyOnWriteArrayList` in place while readers (including content-scope script injection on every navigation) could see **truncated** exception or allowlist data.
> 
> Both repositories now **build aside and assign** a new `List` to a `@Volatile` field. `UnprotectedTemporaryRepository.exceptions` is typed as `List<FeatureException>` instead of the live `CopyOnWriteArrayList`. Failed reloads keep the previous snapshot; returned lists are not mutated after publish.
> 
> In **`RealContentScopeScripts`**, the optimized path drops defensive `CopyOnWriteArrayList` copies and uses **reference + equality** change detection (`differsFrom`) so equal content on a new list instance does not reassemble the script. **`resetCaches()`** runs when `optimizeContentScopeInjection` flips mid-session so legacy and optimized baselines cannot leave shared JSON stale after flag toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 605346c575be42582856b122ae0ca50c4adc5f47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->