### PR TITLE
Fix missing product surface usage pixels for autocomplete and data clearing and update website loaded pixel usage

### DIFF
--- a/PixelDefinitions/pixels/definitions/mobile_surfaces_telemetry.json5
+++ b/PixelDefinitions/pixels/definitions/mobile_surfaces_telemetry.json5
@@ -42,14 +42,14 @@
         "parameters": ["appVersion"]
     },
     "m_product_telemetry_surface_usage_website": {
-        "description": "Fires when a website is loaded (total impressions)",
+        "description": "Fires when a non-SERP page is loaded, excluding Duck.ai which has its own surface pixel (total impressions)",
         "owners": ["catalinradoiu"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
     },
     "m_product_telemetry_surface_usage_website_daily": {
-        "description": "Fires when a website is loaded (daily unique)",
+        "description": "Fires when a non-SERP page is loaded, excluding Duck.ai which has its own surface pixel (daily unique)",
         "owners": ["catalinradoiu"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],

--- a/PixelDefinitions/pixels/definitions/mobile_surfaces_telemetry.json5
+++ b/PixelDefinitions/pixels/definitions/mobile_surfaces_telemetry.json5
@@ -70,14 +70,14 @@
         "parameters": ["appVersion"]
     },
     "m_product_telemetry_surface_usage_data_clearing": {
-        "description": "Fires when Clear Tabs and Data is clicked in the Fire Dialog (total impressions)",
+        "description": "Fires when a clearing action is confirmed in the Fire Dialog — clear all tabs and data, clear this tab, or delete Duck.ai chats (total impressions)",
         "owners": ["catalinradoiu"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
     },
     "m_product_telemetry_surface_usage_data_clearing_daily": {
-        "description": "Fires when Clear Tabs and Data is clicked in the Fire Dialog (daily unique)",
+        "description": "Fires when a clearing action is confirmed in the Fire Dialog — clear all tabs and data, clear this tab, or delete Duck.ai chats (daily unique)",
         "owners": ["catalinradoiu"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1299,8 +1299,21 @@ class BrowserTabViewModel @Inject constructor(
         currentViewState.copy(searchResults = AutoCompleteResult(result.query, result.suggestions)).also {
             lastAutoCompleteState = it
             autoCompleteViewState.value = it
+            fireAutoCompleteDisplayedPixels(previous = currentViewState, updated = it)
         }
     }
+
+    private fun fireAutoCompleteDisplayedPixels(
+        previous: AutoCompleteViewState,
+        updated: AutoCompleteViewState,
+    ) {
+        if (updated.suggestionsDisplayed() && !previous.suggestionsDisplayed()) {
+            pixel.fire(DuckChatPixelName.PRODUCT_TELEMETRY_SURFACE_AUTOCOMPLETE_DISPLAYED)
+            pixel.fire(DuckChatPixelName.PRODUCT_TELEMETRY_SURFACE_AUTOCOMPLETE_DISPLAYED_DAILY, type = Daily())
+        }
+    }
+
+    private fun AutoCompleteViewState.suggestionsDisplayed(): Boolean = showSuggestions && searchResults.suggestions.isNotEmpty()
 
     @VisibleForTesting
     public override fun onCleared() {
@@ -5467,10 +5480,6 @@ class BrowserTabViewModel @Inject constructor(
     fun autoCompleteSuggestionsGone() {
         viewModelScope.launch(dispatchers.io()) {
             lastAutoCompleteState?.searchResults?.suggestions?.let { suggestions ->
-                if (suggestions.isNotEmpty()) {
-                    pixel.fire(DuckChatPixelName.PRODUCT_TELEMETRY_SURFACE_AUTOCOMPLETE_DISPLAYED)
-                    pixel.fire(DuckChatPixelName.PRODUCT_TELEMETRY_SURFACE_AUTOCOMPLETE_DISPLAYED_DAILY, type = Daily())
-                }
                 if (suggestions.any { it is AutoCompleteBookmarkSuggestion && it.isFavorite }) {
                     pixel.fire(AppPixelName.AUTOCOMPLETE_DISPLAYED_LOCAL_FAVORITE)
                 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -690,7 +690,11 @@ class BrowserWebViewClient @Inject constructor(
                             duckPlayer.duckPlayerNavigatedToYoutube()
                         }
                     }
-                    uriLoadedManager.sendUriLoadedPixels(duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url))
+                    uriLoadedManager.sendUriLoadedPixels()
+                    // Duck.ai loads in this WebView too, and its own surface pixel already counts it.
+                    if (!duckChat.isDuckChatUrl(url.toUri())) {
+                        uriLoadedManager.sendSurfaceUsagePixels(duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url))
+                    }
 
                     webViewClientListener?.onSiteVisited(url, navigationList.currentItem?.title)
 

--- a/app/src/main/java/com/duckduckgo/app/browser/uriloaded/DuckDuckGoUriLoadedManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/uriloaded/DuckDuckGoUriLoadedManager.kt
@@ -31,7 +31,9 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 interface UriLoadedManager {
-    fun sendUriLoadedPixels(isDuckDuckGoUrl: Boolean)
+    fun sendUriLoadedPixels()
+
+    fun sendSurfaceUsagePixels(isDuckDuckGoUrl: Boolean)
 }
 
 @ContributesBinding(
@@ -61,11 +63,13 @@ class DuckDuckGoUriLoadedManager @Inject constructor(
         }
     }
 
-    override fun sendUriLoadedPixels(isDuckDuckGoUrl: Boolean) {
+    override fun sendUriLoadedPixels() {
         if (shouldSendUriLoadedPixel) {
             pixel.fire(AppPixelName.URI_LOADED)
         }
+    }
 
+    override fun sendSurfaceUsagePixels(isDuckDuckGoUrl: Boolean) {
         if (isDuckDuckGoUrl) {
             pixel.fire(AppPixelName.PRODUCT_TELEMETRY_SURFACE_SERP_LOADED)
             pixel.fire(AppPixelName.PRODUCT_TELEMETRY_SURFACE_SERP_LOADED_DAILY, type = Pixel.PixelType.Daily())

--- a/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModel.kt
@@ -43,7 +43,6 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FIRE_ANIMATION
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browsermode.api.BrowserMode
-import com.duckduckgo.common.utils.DateProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.dataclearing.api.fire.FireDialogProvider.FireDialogOrigin
 import com.duckduckgo.dataclearing.api.fire.FireDialogProvider.FireDialogOrigin.Browser
@@ -83,7 +82,6 @@ class SingleTabFireDialogViewModel @Inject constructor(
     private val userEventsStore: UserEventsStore,
     private val fireButtonStore: FireButtonStore,
     private val dispatcherProvider: DispatcherProvider,
-    private val dateProvider: DateProvider,
     private val tabRepository: TabRepository,
     private val webViewCapabilityChecker: WebViewCapabilityChecker,
     private val downloadsRepository: DownloadsRepository,
@@ -138,14 +136,13 @@ class SingleTabFireDialogViewModel @Inject constructor(
     private fun onDeleteAllClickedInRegularMode() {
         viewModelScope.launch {
             command.send(Command.OnClearStarted)
-            trySendDailyDeleteClicked()
+            fireDataClearingSurfacePixels()
             pixel.enqueueFire(FIRE_DIALOG_CLEAR_PRESSED)
             pixel.enqueueFire(
                 AppPixelName.FIRE_DIALOG_CLEAR_PRESSED_DAILY,
                 mapOf(Pixel.PixelParameter.BROWSER_MODE to browserMode.name.lowercase()),
                 type = Daily(),
             )
-            pixel.enqueueFire(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING)
 
             val (selectedFireAnimation, fireAnimationEnabled) = withContext(dispatcherProvider.io()) {
                 settingsDataStore.selectedFireAnimation to settingsDataStore.fireAnimationEnabled
@@ -191,6 +188,7 @@ class SingleTabFireDialogViewModel @Inject constructor(
             // empty tab switcher in Fire mode (see EVENT_ON_FIRE_TABS_CLEARED)
             shouldRestartAfterClearing = false
             command.send(Command.OnClearStarted)
+            fireDataClearingSurfacePixels()
 
             val fireAnimationEnabled = withContext(dispatcherProvider.io()) {
                 settingsDataStore.fireAnimationEnabled
@@ -221,6 +219,7 @@ class SingleTabFireDialogViewModel @Inject constructor(
         viewModelScope.launch {
             shouldRestartAfterClearing = false
             command.send(Command.OnClearStarted)
+            fireDataClearingSurfacePixels()
 
             val fireAnimationEnabled = withContext(dispatcherProvider.io()) {
                 settingsDataStore.fireAnimationEnabled
@@ -247,6 +246,7 @@ class SingleTabFireDialogViewModel @Inject constructor(
             val browserModeParams = mapOf(Pixel.PixelParameter.BROWSER_MODE to browserMode.name.lowercase())
             pixel.enqueueFire(AppPixelName.FIRE_DIALOG_CLEAR_SINGLE_TAB_PRESSED, browserModeParams)
             pixel.enqueueFire(AppPixelName.FIRE_DIALOG_CLEAR_SINGLE_TAB_PRESSED_DAILY, browserModeParams, type = Daily())
+            fireDataClearingSurfacePixels()
 
             command.send(Command.OnClearStarted)
 
@@ -380,16 +380,9 @@ class SingleTabFireDialogViewModel @Inject constructor(
         delay(500)
     }
 
-    private suspend fun trySendDailyDeleteClicked() {
-        withContext(dispatcherProvider.io()) {
-            val now = dateProvider.getUtcIsoLocalDate()
-            val timestamp = fireButtonStore.lastEventSendTime
-
-            if (timestamp == null || now > timestamp) {
-                fireButtonStore.storeLastFireButtonClearEventTime(now)
-                pixel.enqueueFire(AppPixelName.PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING_DAILY)
-            }
-        }
+    private fun fireDataClearingSurfacePixels() {
+        pixel.enqueueFire(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING)
+        pixel.enqueueFire(AppPixelName.PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING_DAILY, type = Daily())
     }
 
     sealed class ViewState {

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2153,24 +2153,33 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun wheneverAutoCompleteIsGoneAndSuggestionsIsNotEmptyFireAutocompleteDisplayed() = runTest {
-        whenever(mockAutoCompleteService.autoComplete("query")).thenReturn(emptyList())
-        whenever(mockSavedSitesRepository.getBookmarks()).thenReturn(
-            flowOf(listOf(Bookmark("abc", "query", "https://example.com", lastModified = null))),
-        )
-        whenever(mockSavedSitesRepository.getFavorites()).thenReturn(
-            flowOf(listOf(Favorite("abc", "query", "https://example.com", position = 1, lastModified = null))),
-        )
-        whenever(mockNavigationHistory.getHistory()).thenReturn(
-            flowOf(listOf(VisitedPage("https://foo.com".toUri(), "query", listOf(LocalDateTime.now())))),
-        )
-        whenever(mockTabRepository.flowTabs).thenReturn(
-            flowOf(listOf(TabEntity(tabId = "1", position = 1, url = "https://example.com", title = "query"))),
-        )
-        doReturn(true).whenever(mockAutoCompleteSettings).autoCompleteSuggestionsEnabled
+    fun whenAutoCompleteSuggestionsShownThenFireAutocompleteDisplayed() = runTest {
+        stubAutoCompleteSourcesForQuery()
 
-        whenever(mockAutoCompleteScorer.score("query", "https://foo.com".toUri(), 1, "query")).thenReturn(1)
-        whenever(mockUserStageStore.getUserAppStage()).thenReturn(ESTABLISHED)
+        testee.triggerAutocomplete("query", hasFocus = true, hasQueryChanged = true)
+        delay(500)
+
+        verify(mockPixel).fire(DuckChatPixelName.PRODUCT_TELEMETRY_SURFACE_AUTOCOMPLETE_DISPLAYED)
+        verify(mockPixel).fire(DuckChatPixelName.PRODUCT_TELEMETRY_SURFACE_AUTOCOMPLETE_DISPLAYED_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenAutoCompleteSuggestionsShownAndThenSelectedThenAutocompleteDisplayedFiredOnce() = runTest {
+        stubAutoCompleteSourcesForQuery()
+        whenever(mockOmnibarConverter.convertQueryToUrl("query", null)).thenReturn("https://example.com")
+
+        testee.triggerAutocomplete("query", hasFocus = true, hasQueryChanged = true)
+        delay(500)
+        testee.userSelectedAutocomplete(AutoCompleteDefaultSuggestion("query"))
+        delay(500)
+
+        verify(mockPixel).fire(DuckChatPixelName.PRODUCT_TELEMETRY_SURFACE_AUTOCOMPLETE_DISPLAYED)
+        verify(mockPixel).fire(DuckChatPixelName.PRODUCT_TELEMETRY_SURFACE_AUTOCOMPLETE_DISPLAYED_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenAutoCompleteSuggestionsShownAndThenGoneThenAutocompleteDisplayedFiredOnce() = runTest {
+        stubAutoCompleteSourcesForQuery()
 
         testee.triggerAutocomplete("query", hasFocus = true, hasQueryChanged = true)
         delay(500)
@@ -2181,12 +2190,26 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun wheneverAutoCompleteIsGoneAndSuggestionsIsEmptyDoNotFireAutocompleteDisplayed() = runTest {
+    fun whenAutoCompleteSuggestionsShownAgainForNewQueryThenFireAutocompleteDisplayedAgain() = runTest {
+        stubAutoCompleteSourcesForQuery()
+
+        testee.triggerAutocomplete("query", hasFocus = true, hasQueryChanged = true)
+        delay(500)
+        testee.triggerAutocomplete("", hasFocus = true, hasQueryChanged = true)
+        testee.triggerAutocomplete("query", hasFocus = true, hasQueryChanged = true)
+        delay(500)
+
+        verify(mockPixel, times(2)).fire(DuckChatPixelName.PRODUCT_TELEMETRY_SURFACE_AUTOCOMPLETE_DISPLAYED)
+        verify(mockPixel, times(2)).fire(DuckChatPixelName.PRODUCT_TELEMETRY_SURFACE_AUTOCOMPLETE_DISPLAYED_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenAutoCompleteSuggestionsAreEmptyThenDoNotFireAutocompleteDisplayed() = runTest {
         doReturn(true).whenever(mockAutoCompleteSettings).autoCompleteSuggestionsEnabled
         whenever(mockAutoCompleteService.autoComplete("query")).thenReturn(emptyList())
 
-        testee.autoCompleteStateFlow.value = "query"
-        testee.autoCompleteSuggestionsGone()
+        testee.triggerAutocomplete("query", hasFocus = true, hasQueryChanged = true)
+        delay(500)
 
         verify(mockPixel, never()).fire(DuckChatPixelName.PRODUCT_TELEMETRY_SURFACE_AUTOCOMPLETE_DISPLAYED)
         verify(mockPixel, never()).fire(
@@ -2247,8 +2270,7 @@ class BrowserTabViewModelTest {
 
         testee.autoCompleteSuggestionsGone()
 
-        verify(mockPixel).fire(DuckChatPixelName.PRODUCT_TELEMETRY_SURFACE_AUTOCOMPLETE_DISPLAYED)
-        verify(mockPixel).fire(DuckChatPixelName.PRODUCT_TELEMETRY_SURFACE_AUTOCOMPLETE_DISPLAYED_DAILY, type = Daily())
+        verify(mockPixel).fire(AppPixelName.AUTOCOMPLETE_DISPLAYED_LOCAL_HISTORY)
     }
 
     @Test
@@ -2287,13 +2309,8 @@ class BrowserTabViewModelTest {
         assertTrue(testee.omnibarAutocompleteCache.value.suggestions.isEmpty())
     }
 
-    /**
-     * Common setup mirroring [wheneverAutoCompleteIsGoneAndSuggestionsIsNotEmptyFireAutocompleteDisplayed]'s
-     * sources so the AutoCompleteApi produces a non-empty result for "query", then triggers the cache pipeline.
-     * Caller still needs to wait for the debounce.
-     */
-    private suspend fun primeOmnibarAutocompleteCacheForQuery() {
-        nativeInputUserSettingFlow.value = true
+    /** Stubs every autocomplete source so the AutoCompleteApi produces a non-empty result for "query". */
+    private suspend fun stubAutoCompleteSourcesForQuery() {
         doReturn(true).whenever(mockAutoCompleteSettings).autoCompleteSuggestionsEnabled
         whenever(mockAutoCompleteService.autoComplete("query")).thenReturn(emptyList())
         whenever(mockSavedSitesRepository.getBookmarks()).thenReturn(
@@ -2310,6 +2327,15 @@ class BrowserTabViewModelTest {
         )
         whenever(mockAutoCompleteScorer.score("query", "https://foo.com".toUri(), 1, "query")).thenReturn(1)
         whenever(mockUserStageStore.getUserAppStage()).thenReturn(ESTABLISHED)
+    }
+
+    /**
+     * Stubs the autocomplete sources for "query" and triggers the omnibar cache pipeline.
+     * Caller still needs to wait for the debounce.
+     */
+    private suspend fun primeOmnibarAutocompleteCacheForQuery() {
+        nativeInputUserSettingFlow.value = true
+        stubAutoCompleteSourcesForQuery()
 
         testee.onOmnibarTextRendered("query")
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -1743,7 +1743,8 @@ class BrowserWebViewClientTest {
         testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
         testee.onPageFinished(mockWebView, EXAMPLE_URL)
 
-        verify(mockUriLoadedManager).sendUriLoadedPixels(false)
+        verify(mockUriLoadedManager).sendUriLoadedPixels()
+        verify(mockUriLoadedManager).sendSurfaceUsagePixels(false)
     }
 
     @Test
@@ -1757,7 +1758,8 @@ class BrowserWebViewClientTest {
         testee.onPageStarted(mockWebView, DDG_URL, null)
         testee.onPageFinished(mockWebView, DDG_URL)
 
-        verify(mockUriLoadedManager).sendUriLoadedPixels(false)
+        verify(mockUriLoadedManager).sendUriLoadedPixels()
+        verify(mockUriLoadedManager).sendSurfaceUsagePixels(false)
     }
 
     @Test
@@ -1768,10 +1770,29 @@ class BrowserWebViewClientTest {
         whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
         whenever(mockWebView.progress).thenReturn(100)
 
+        whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoQueryUrl(EXAMPLE_SERP_URL)).thenReturn(true)
+
         testee.onPageStarted(mockWebView, EXAMPLE_SERP_URL, null)
         testee.onPageFinished(mockWebView, EXAMPLE_SERP_URL)
 
-        verify(mockUriLoadedManager).sendUriLoadedPixels(false)
+        verify(mockUriLoadedManager).sendUriLoadedPixels()
+        verify(mockUriLoadedManager).sendSurfaceUsagePixels(true)
+    }
+
+    @Test
+    fun whenDuckAiPageLoadsThenSurfaceUsagePixelsAreNotFired() {
+        val mockWebView = getImmediatelyInvokedMockWebView()
+
+        whenever(mockWebView.settings).thenReturn(mock())
+        whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
+        whenever(mockWebView.progress).thenReturn(100)
+        whenever(mockDuckChat.isDuckChatUrl(DUCK_AI_URL.toUri())).thenReturn(true)
+
+        testee.onPageStarted(mockWebView, DUCK_AI_URL, null)
+        testee.onPageFinished(mockWebView, DUCK_AI_URL)
+
+        verify(mockUriLoadedManager).sendUriLoadedPixels()
+        verify(mockUriLoadedManager, never()).sendSurfaceUsagePixels(any())
     }
 
     @Test
@@ -1999,5 +2020,6 @@ class BrowserWebViewClientTest {
         const val EXAMPLE_URL = "https://example.com"
         const val DDG_URL = "https://duckduckgo.com"
         const val EXAMPLE_SERP_URL = "https://duckduckgo.com/?q=test"
+        const val DUCK_AI_URL = "https://duck.ai/?q=test"
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/uriloaded/DuckDuckGoUriLoadedManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/uriloaded/DuckDuckGoUriLoadedManagerTest.kt
@@ -53,7 +53,7 @@ class DuckDuckGoUriLoadedManagerTest {
         whenever(mockUriLoadedKillSwitch.isEnabled()).thenReturn(true)
 
         initialize()
-        testee.sendUriLoadedPixels(isDuckDuckGoUrl = false)
+        testee.sendUriLoadedPixels()
 
         verify(mockPixel).fire(AppPixelName.URI_LOADED)
     }
@@ -63,7 +63,7 @@ class DuckDuckGoUriLoadedManagerTest {
         whenever(mockUriLoadedKillSwitch.isEnabled()).thenReturn(false)
 
         initialize()
-        testee.sendUriLoadedPixels(isDuckDuckGoUrl = false)
+        testee.sendUriLoadedPixels()
 
         verify(mockPixel, never()).fire(AppPixelName.URI_LOADED)
     }
@@ -74,7 +74,7 @@ class DuckDuckGoUriLoadedManagerTest {
 
         whenever(mockUriLoadedKillSwitch.isEnabled()).thenReturn(true)
         testee.onPrivacyConfigDownloaded()
-        testee.sendUriLoadedPixels(isDuckDuckGoUrl = false)
+        testee.sendUriLoadedPixels()
 
         verify(mockPixel).fire(AppPixelName.URI_LOADED)
 
@@ -82,17 +82,17 @@ class DuckDuckGoUriLoadedManagerTest {
 
         whenever(mockUriLoadedKillSwitch.isEnabled()).thenReturn(false)
         testee.onPrivacyConfigDownloaded()
-        testee.sendUriLoadedPixels(isDuckDuckGoUrl = false)
+        testee.sendUriLoadedPixels()
 
         verify(mockPixel, never()).fire(AppPixelName.URI_LOADED)
     }
 
     @Test
-    fun whenSendUriLoadedPixelsWithDuckDuckGoUrlThenSerpPixelsAreFired() {
+    fun whenSendSurfaceUsagePixelsWithDuckDuckGoUrlThenSerpPixelsAreFired() {
         whenever(mockUriLoadedKillSwitch.isEnabled()).thenReturn(true)
 
         initialize()
-        testee.sendUriLoadedPixels(isDuckDuckGoUrl = true)
+        testee.sendSurfaceUsagePixels(isDuckDuckGoUrl = true)
 
         verify(mockPixel).fire(AppPixelName.PRODUCT_TELEMETRY_SURFACE_SERP_LOADED)
         verify(mockPixel).fire(AppPixelName.PRODUCT_TELEMETRY_SURFACE_SERP_LOADED_DAILY, type = Pixel.PixelType.Daily())
@@ -106,11 +106,11 @@ class DuckDuckGoUriLoadedManagerTest {
     }
 
     @Test
-    fun whenSendUriLoadedPixelsWithNonDuckDuckGoUrlThenWebsitePixelsAreFired() {
+    fun whenSendSurfaceUsagePixelsWithNonDuckDuckGoUrlThenWebsitePixelsAreFired() {
         whenever(mockUriLoadedKillSwitch.isEnabled()).thenReturn(true)
 
         initialize()
-        testee.sendUriLoadedPixels(isDuckDuckGoUrl = false)
+        testee.sendSurfaceUsagePixels(isDuckDuckGoUrl = false)
 
         verify(mockPixel).fire(AppPixelName.PRODUCT_TELEMETRY_SURFACE_WEBSITE_LOADED)
         verify(mockPixel).fire(AppPixelName.PRODUCT_TELEMETRY_SURFACE_WEBSITE_LOADED_DAILY, type = Pixel.PixelType.Daily())

--- a/app/src/test/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModelTest.kt
@@ -47,7 +47,6 @@ import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.common.utils.DateProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.dataclearing.api.fire.FireDialogProvider.FireDialogOrigin
 import com.duckduckgo.downloads.api.DownloadsRepository
@@ -90,7 +89,6 @@ class SingleTabFireDialogViewModelTest {
     private val mockUserEventsStore: UserEventsStore = mock()
     private val mockFireButtonStore: FireButtonStore = mock()
     private val mockDispatcherProvider: DispatcherProvider = mock()
-    private val mockDateProvider: DateProvider = mock()
     private val mockTabRepository: TabRepository = mock()
     private val mockWebViewCapabilityChecker: WebViewCapabilityChecker = mock()
     private val mockDownloadsRepository: DownloadsRepository = mock()
@@ -107,7 +105,6 @@ class SingleTabFireDialogViewModelTest {
         whenever(mockDispatcherProvider.io()).thenReturn(coroutineTestRule.testDispatcherProvider.io())
         whenever(mockSettingsDataStore.selectedFireAnimation).thenReturn(FireAnimation.HeroFire)
         whenever(mockSettingsDataStore.fireAnimationEnabled).thenReturn(true)
-        whenever(mockDateProvider.getUtcIsoLocalDate()).thenReturn("2025-12-15")
 
         whenever(mockSettingsDataStore.singleTabFireDialogShownCount).thenReturn(0)
 
@@ -132,7 +129,6 @@ class SingleTabFireDialogViewModelTest {
         userEventsStore = mockUserEventsStore,
         fireButtonStore = mockFireButtonStore,
         dispatcherProvider = mockDispatcherProvider,
-        dateProvider = mockDateProvider,
         tabRepository = mockTabRepository,
         webViewCapabilityChecker = mockWebViewCapabilityChecker,
         downloadsRepository = mockDownloadsRepository,
@@ -966,50 +962,15 @@ class SingleTabFireDialogViewModelTest {
     }
 
     @Test
-    fun `when delete all clicked for first time then daily pixel is fired and timestamp is stored`() = runTest {
-        val today = "2025-12-15"
-        whenever(mockFireButtonStore.lastEventSendTime).thenReturn(null)
-        whenever(mockDateProvider.getUtcIsoLocalDate()).thenReturn(today)
+    fun `when delete all clicked then data clearing surface pixels are fired`() = runTest {
         testee = createViewModel()
 
         testee.onDeleteAllClicked()
 
         coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
 
-        verify(mockFireButtonStore).storeLastFireButtonClearEventTime(any())
-        verify(mockPixel).enqueueFire(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING_DAILY)
-    }
-
-    @Test
-    fun `when delete all clicked on same day then daily pixel is not fired again`() = runTest {
-        val today = "2025-12-15"
-        whenever(mockFireButtonStore.lastEventSendTime).thenReturn(today)
-        whenever(mockDateProvider.getUtcIsoLocalDate()).thenReturn(today)
-        testee = createViewModel()
-
-        testee.onDeleteAllClicked()
-
-        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
-
-        verify(mockPixel).enqueueFire(FIRE_DIALOG_CLEAR_PRESSED)
         verify(mockPixel).enqueueFire(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING)
-        verify(mockPixel, never()).enqueueFire(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING_DAILY)
-    }
-
-    @Test
-    fun `when delete all clicked on different day then daily pixel is fired and timestamp is updated`() = runTest {
-        val yesterday = "2025-12-14"
-        val today = "2025-12-15"
-        whenever(mockFireButtonStore.lastEventSendTime).thenReturn(yesterday)
-        whenever(mockDateProvider.getUtcIsoLocalDate()).thenReturn(today)
-        testee = createViewModel()
-
-        testee.onDeleteAllClicked()
-
-        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
-
-        verify(mockFireButtonStore).storeLastFireButtonClearEventTime(any())
-        verify(mockPixel).enqueueFire(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING_DAILY)
+        verify(mockPixel).enqueueFire(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING_DAILY, type = Daily())
     }
 
     @Test
@@ -1221,6 +1182,18 @@ class SingleTabFireDialogViewModelTest {
     }
 
     @Test
+    fun `when in fire mode delete all clicked then data clearing surface pixels are fired`() = runTest {
+        testee = createViewModel(browserMode = BrowserMode.FIRE)
+
+        testee.onDeleteAllClicked()
+
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(mockPixel).enqueueFire(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING)
+        verify(mockPixel).enqueueFire(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING_DAILY, type = Daily())
+    }
+
+    @Test
     fun `when in fire mode delete all clicked with animation enabled then dialog still completes`() = runTest {
         whenever(mockSettingsDataStore.fireAnimationEnabled).thenReturn(true)
         testee = createViewModel(browserMode = BrowserMode.FIRE)
@@ -1278,8 +1251,20 @@ class SingleTabFireDialogViewModelTest {
 
         verify(mockPixel, never()).enqueueFire(eq(FIRE_DIALOG_CLEAR_PRESSED), any(), any(), any())
         verify(mockPixel, never()).enqueueFire(eq(FIRE_DIALOG_CLEAR_PRESSED_DAILY), any(), any(), any())
-        verify(mockPixel, never()).enqueueFire(eq(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING), any(), any(), any())
         verify(mockPixel, never()).enqueueFire(eq(FIRE_DIALOG_ANIMATION), any(), any(), any())
+    }
+
+    @Test
+    fun `when delete selected chats clicked then data clearing surface pixels are fired`() = runTest {
+        testee = createViewModel()
+        testee.setOrigin(FireDialogOrigin.ChatHistory(selectedChatUrls = setOf("https://duck.ai?chatID=a")))
+
+        testee.onDeleteSelectedChatsClicked()
+
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(mockPixel).enqueueFire(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING)
+        verify(mockPixel).enqueueFire(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING_DAILY, type = Daily())
     }
 
     @Test
@@ -1397,8 +1382,20 @@ class SingleTabFireDialogViewModelTest {
 
         verify(mockPixel, never()).enqueueFire(eq(FIRE_DIALOG_CLEAR_PRESSED), any(), any(), any())
         verify(mockPixel, never()).enqueueFire(eq(FIRE_DIALOG_CLEAR_PRESSED_DAILY), any(), any(), any())
-        verify(mockPixel, never()).enqueueFire(eq(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING), any(), any(), any())
         verify(mockPixel, never()).enqueueFire(eq(FIRE_DIALOG_ANIMATION), any(), any(), any())
+    }
+
+    @Test
+    fun `when delete single chat clicked then data clearing surface pixels are fired`() = runTest {
+        testee = createViewModel()
+        testee.setOrigin(FireDialogOrigin.ChatAutocomplete("https://duck.ai?chatID=a"))
+
+        testee.onDeleteSingleChatClicked()
+
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(mockPixel).enqueueFire(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING)
+        verify(mockPixel).enqueueFire(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING_DAILY, type = Daily())
     }
 
     @Test
@@ -1485,6 +1482,21 @@ class SingleTabFireDialogViewModelTest {
         val params = mapOf(Pixel.PixelParameter.BROWSER_MODE to "regular")
         verify(mockPixel).enqueueFire(FIRE_DIALOG_CLEAR_SINGLE_TAB_PRESSED, params)
         verify(mockPixel).enqueueFire(FIRE_DIALOG_CLEAR_SINGLE_TAB_PRESSED_DAILY, params, type = Daily())
+    }
+
+    @Test
+    fun `when delete this tab clicked then data clearing surface pixels are fired`() = runTest {
+        whenever(mockTabRepository.getSelectedTab()).thenReturn(
+            TabEntity(tabId = "tab1", url = "https://example.com", title = "Example"),
+        )
+        testee = createViewModel()
+
+        testee.onDeleteThisTabClicked()
+
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(mockPixel).enqueueFire(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING)
+        verify(mockPixel).enqueueFire(PRODUCT_TELEMETRY_SURFACE_DATA_CLEARING_DAILY, type = Daily())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1216240606378290?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

Two product surface usage pixels were under-reporting because they were wired to the wrong moment.

**`m_product_telemetry_surface_usage_autocomplete`**: It was fired from `BrowserTabViewModel.autoCompleteSuggestionsGone()`, on dismissal. Tapping a suggestion never reaches that method. It now fires on the transition into "suggestions on screen", inside `onAutoCompleteResultReceived`.

**`m_product_telemetry_surface_usage_data_clearing`**: It was fired from only one of the four clearing actions the fire dialog offers (regular-mode "clear all tabs and data"). Clearing a single tab, burning all Fire tabs, using the fire button inside a Duck.ai chat — cleared data without counting anything. 

**`m_product_telemetry_surface_usage_website`**: Duck.ai loads in the browser WebView and isn't a DuckDuckGo query URL, but was counted as a website visit. Since Duck.ai already has its own surface pixel (m_product_telemetry_surface_usage_duck_ai), the same surface was being counted twice — once correctly, once as a website.  

### Steps to test this PR

_Autocomplete surface pixel fires when suggestions are shown_
- [x] Install and open the browser, focus the omnibar and type a query until suggestions appear
- [x] Verify `m_product_telemetry_surface_usage_autocomplete` (and `..._daily` once per day) fires as soon as the list appears, without dismissing it
- [x] Keep typing to refine the query while the list stays up; verify no extra impressions are counted
- [x] Tap a suggestion to navigate; no new pixel should be sent for autocomplete
- [x] Clear the omnibar, type again so the list re-appears; verify a new impression is counted

_Data clearing surface pixel fires for every clearing action_
- [x] Fire button → Delete all tabs: verify `m_product_telemetry_surface_usage_data_clearing` fires (as before)
- [x] Fire button → Delete a single tab: verify it fires
- [x] In Fire mode, fire button →  Delete all tabs/ single tab: verify it fires
- [x] Fire button inside a Duck.ai chat → delete the chat: verify it fires
- [x] Repeat any two actions on the same day: verify `..._data_clearing` fires each time and `..._data_clearing_daily` only once

_Duck.ai loads no longer counted as website surface usage_
- [x] Open a Duck.ai chat (omnibar Duck.ai mode, or navigate to duck.ai) and send a prompt
- [x] Verify m_product_telemetry_surface_usage_website / ..._website_daily do not fire for the chat load
- [x] Load a regular website; verify ..._website still fires as before
- [x] Run a search on DuckDuckGo; verify ..._serp still fires and ..._website does not 

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes to pixel timing and coverage; no auth, data handling, or user-facing behavior changes beyond analytics accuracy.
> 
> **Overview**
> Fixes under-reporting and double-counting in **product surface usage** telemetry by changing when pixels fire and which navigation paths count.
> 
> **Autocomplete** — `m_product_telemetry_surface_usage_autocomplete` no longer fires on dismissal (`autoCompleteSuggestionsGone`). It fires when suggestions **first appear** in `onAutoCompleteResultReceived`, using a transition check so repeated updates while the list stays visible do not add extra impressions.
> 
> **Data clearing** — `m_product_telemetry_surface_usage_data_clearing` is emitted from a shared `fireDataClearingSurfacePixels()` for every confirmed Fire Dialog action: clear all (regular and Fire mode), clear this tab, and delete Duck.ai chats. The daily pixel uses the standard `Daily()` pixel type instead of custom date/store logic (`DateProvider` / `fireButtonStore` removed from this path).
> 
> **Website vs SERP vs Duck.ai** — `UriLoadedManager` splits URI-loaded pixels from surface SERP/website pixels (`sendUriLoadedPixels()` vs `sendSurfaceUsagePixels(isDuckDuckGoUrl)`). On page finish, Duck.ai URLs skip website/SERP surface pixels because Duck.ai has its own surface pixel.
> 
> Pixel definition text in `mobile_surfaces_telemetry.json5` is updated to match these semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e77a342b45f0637874d328b6b2e4592ab3d579f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->