### PR TITLE
Add suggested prompts to contextual sheet

### DIFF
--- a/duckchat/duckchat-impl/build.gradle
+++ b/duckchat/duckchat-impl/build.gradle
@@ -73,6 +73,7 @@ dependencies {
 
     implementation Square.retrofit2.retrofit
     implementation Square.moshi
+    implementation "com.squareup.moshi:moshi-kotlin:_"
 
     testImplementation Testing.junit4
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"

--- a/duckchat/duckchat-impl/src/main/assets/PageSuggestionsCatalog.json
+++ b/duckchat/duckchat-impl/src/main/assets/PageSuggestionsCatalog.json
@@ -1,0 +1,117 @@
+{
+  "maxSuggestedPrompts": 4,
+  "defaults": ["summarize-page", "translate-page"],
+
+  "catalog": {
+    "summarize-page":      { "label": "Summarize this page", "icon": "summary", "prompt": "Summarize this page." },
+    "translate-page":      { "label": "Translate this page", "icon": "translate", "prompt": "Translate this page into {language}.", "condition": "differentLanguage" },
+
+    "key-takeaways":       { "label": "What are the key takeaways?", "icon": "summary", "prompt": "What are the key takeaways from this article?" },
+    "explain-simply":      { "label": "Explain this simply", "prompt": "Explain this in simple, plain language." },
+    "counterarguments":    { "label": "What are the counterarguments?", "prompt": "What are the main counterarguments or criticisms of this?" },
+    "related-articles":    { "label": "Suggest related articles to explore", "prompt": "Suggest related articles or topics worth exploring next." },
+
+    "shopping-list":       { "label": "Generate a shopping list", "prompt": "Create a shopping list with quantities from this recipe." },
+    "recipe-nutrition":    { "label": "Estimate the nutrition", "prompt": "Estimate the nutritional information for this recipe." },
+    "scale-recipe":        { "label": "Adjust the servings", "prompt": "Rewrite this recipe scaled for a different number of servings." },
+
+    "product-pros-cons":   { "label": "What are the pros and cons?", "prompt": "What are the pros and cons of this product?" },
+    "find-alternatives":   { "label": "Find me alternatives", "prompt": "Suggest some alternatives to this product." },
+
+    "summarize-video":     { "label": "Summarize this video", "icon": "summary", "prompt": "Summarize this video." },
+    "video-key-points":    { "label": "What are the key points?", "prompt": "What are the key points covered in this video?" },
+
+    "tailor-resume":       { "label": "Tailor my resume", "prompt": "Help me tailor my resume for this job." },
+    "interview-prep":      { "label": "Help me prep for the interview", "prompt": "What interview questions might come up for this role?" },
+    "cover-letter":        { "label": "Draft a cover letter", "prompt": "Draft a cover letter for this job." },
+
+    "event-details":       { "label": "What are the key details?", "icon": "summary", "prompt": "Summarize the key details of this event." },
+
+    "worth-watching":      { "label": "Is this worth watching?", "prompt": "Is this worth watching? Give me a spoiler-free take." },
+    "similar-titles":      { "label": "Recommend similar titles", "prompt": "Recommend similar movies or shows." },
+    "cast-crew":           { "label": "Cast & Crew", "prompt": "Who are the main cast and crew, and what else are they known for?" },
+
+    "summarize-book":      { "label": "Summarize this book", "icon": "summary", "prompt": "Summarize this book." },
+    "similar-books":       { "label": "Recommend similar books", "prompt": "Recommend similar books." },
+
+    "explain-paper":       { "label": "Explain this paper", "prompt": "Explain this research paper in plain language." },
+    "paper-contributions": { "label": "What are the key contributions?", "prompt": "What are the key contributions of this paper?" },
+
+    "menu-highlights":     { "label": "What should I order?", "prompt": "What are the must-try dishes here?" },
+    "place-hours":         { "label": "What are the hours & location?", "prompt": "What are the opening hours, location, and contact details for this place?" },
+    "place-reviews":       { "label": "Is this place any good?", "prompt": "Is this place any good? Summarize its reputation based on reviews and ratings." },
+
+    "summarize-thread":    { "label": "Summarize this discussion", "icon": "summary", "prompt": "Summarize this discussion thread." },
+
+    "explain-repo":        { "label": "Explain this repo", "prompt": "Explain what this repository does and how to use it." },
+
+    "explain-answer":      { "label": "Explain the top answer", "prompt": "Explain the accepted answer in simple terms." },
+
+    "howto-steps":         { "label": "Walk me through the steps", "prompt": "Break this down into clear, numbered steps." },
+    "howto-materials":     { "label": "What will I need?", "prompt": "List the tools, materials, or prerequisites I need for this." },
+
+    "course-learn":        { "label": "What will I learn?", "prompt": "What are the key things I will learn from this course?" },
+    "course-worth":        { "label": "Is it worth taking?", "prompt": "Based on this page, is this course worth taking?" },
+
+    "faq-answer":          { "label": "What does this answer?", "prompt": "What are the main questions this page answers?" },
+    "faq-summary":         { "label": "Summarize the Q&As", "icon": "summary", "prompt": "Summarize the questions and answers on this page." },
+
+    "review-verdict":      { "label": "What's the verdict?", "prompt": "What is the overall verdict and rating for this?" },
+    "review-summary":      { "label": "Sum up the reviews", "icon": "summary", "prompt": "Summarize what the reviews say." },
+
+    "who-is-this":         { "label": "Who is this person?", "prompt": "Give me a quick background on this person." },
+    "person-background":   { "label": "Summarize their background", "icon": "summary", "prompt": "Summarize the background and notable work of this person." }
+  },
+
+  "byJsonLdType": [
+    { "type": "Recipe",                 "ids": ["shopping-list", "recipe-nutrition", "scale-recipe"] },
+    { "type": "HowTo",                  "ids": ["howto-steps", "howto-materials"] },
+    { "type": "JobPosting",             "ids": ["tailor-resume", "interview-prep", "cover-letter"] },
+    { "type": "Product",                "ids": ["product-pros-cons", "find-alternatives"] },
+    { "type": "Movie",                  "ids": ["worth-watching", "similar-titles", "cast-crew"] },
+    { "type": "TVSeries",               "ids": ["worth-watching", "similar-titles", "cast-crew"] },
+    { "type": "Book",                   "ids": ["summarize-book", "similar-books"] },
+    { "type": "Course",                 "ids": ["course-learn", "course-worth"] },
+    { "type": "Event",                  "ids": ["event-details"] },
+    { "type": "ScholarlyArticle",       "ids": ["explain-paper", "paper-contributions"] },
+    { "type": "Restaurant",             "ids": ["menu-highlights"] },
+    { "type": "FoodEstablishment",      "ids": ["menu-highlights"] },
+    { "type": "LocalBusiness",          "ids": ["place-hours", "place-reviews"] },
+    { "type": "Article",                "ids": ["key-takeaways", "explain-simply", "counterarguments", "related-articles"] },
+    { "type": "NewsArticle",            "ids": ["key-takeaways", "explain-simply", "counterarguments", "related-articles"] },
+    { "type": "ReportageNewsArticle",   "ids": ["key-takeaways", "explain-simply", "counterarguments", "related-articles"] },
+    { "type": "LiveBlogPosting",        "ids": ["key-takeaways", "explain-simply", "counterarguments", "related-articles"] },
+    { "type": "BlogPosting",            "ids": ["key-takeaways", "explain-simply", "counterarguments", "related-articles"] },
+    { "type": "FAQPage",                "ids": ["faq-answer", "faq-summary"] },
+    { "type": "DiscussionForumPosting", "ids": ["summarize-thread"] },
+    { "type": "QAPage",                 "ids": ["summarize-thread"] },
+    { "type": "SoftwareSourceCode",     "ids": ["explain-repo"] },
+    { "type": "Review",                 "ids": ["review-verdict", "review-summary"] },
+    { "type": "AggregateRating",        "ids": ["review-verdict", "review-summary"] },
+    { "type": "Person",                 "ids": ["who-is-this", "person-background"] },
+    { "type": "VideoObject",            "ids": ["summarize-video", "video-key-points"] }
+  ],
+
+  "byOgType": {
+    "article":      ["key-takeaways", "explain-simply", "counterarguments", "related-articles"],
+    "product":      ["product-pros-cons", "find-alternatives"],
+    "product.item": ["product-pros-cons", "find-alternatives"],
+    "video":        ["summarize-video", "video-key-points"],
+    "video.other":  ["summarize-video", "video-key-points"],
+    "video.movie":  ["worth-watching", "similar-titles", "cast-crew"],
+    "video.episode":["worth-watching", "similar-titles", "cast-crew"],
+    "video.tv_show":["worth-watching", "similar-titles", "cast-crew"],
+    "book":         ["summarize-book", "similar-books"],
+    "profile":      ["who-is-this", "person-background"]
+  },
+
+  "byDomain": {
+    "youtube.com":       ["summarize-video", "video-key-points"],
+    "imdb.com":          ["worth-watching", "similar-titles", "cast-crew"],
+    "github.com":        ["explain-repo"],
+    "arxiv.org":         ["explain-paper", "paper-contributions"],
+    "reddit.com":        ["summarize-thread"],
+    "stackoverflow.com": ["explain-answer"],
+    "amazon.com":        ["product-pros-cons", "find-alternatives"]
+  }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -871,7 +871,7 @@ class DuckChatContextualFragment :
                 binding.contextualWebviewContainer.gone()
                 binding.contextualModePrompts.show()
                 binding.contextualInputContainer.setBackgroundColor(
-                    requireContext().getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorSurface),
+                    requireContext().getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorBackground),
                 )
                 contextualNativeInputManager.onInputMode()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -915,6 +915,10 @@ class DuckChatContextualFragment :
             viewState.quickActionState == DuckChatContextualViewModel.QuickActionState.LEGACY_SUMMARIZE ||
                 viewState.quickActionState == DuckChatContextualViewModel.QuickActionState.SUBMIT_SUMMARIZE
 
+        binding.contextualSuggestionsView.setReservedQuickActionSlots(
+            if (viewState.quickActionState == DuckChatContextualViewModel.QuickActionState.ASK_ABOUT_PAGE) 1 else 0,
+        )
+
         if (isSummarizeQuickAction && binding.contextualSuggestionsView.hasContent()) {
             binding.contextualPromptQuickAction.gone()
         } else {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -47,6 +47,7 @@ import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.AnyThread
 import androidx.core.content.ContextCompat
+import androidx.core.view.doOnNextLayout
 import androidx.core.view.isInvisible
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.setFragmentResult
@@ -125,6 +126,7 @@ import org.json.JSONObject
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Named
+import com.duckduckgo.mobile.android.R as CommonR
 
 @InjectWith(FragmentScope::class)
 class DuckChatContextualFragment :
@@ -245,6 +247,9 @@ class DuckChatContextualFragment :
                 val imeVisible = heightDiff > threshold
                 if (imeVisible != isKeyboardVisible) {
                     isKeyboardVisible = imeVisible
+                    if (!imeVisible) {
+                        reserveSpaceForSuggestions()
+                    }
                     val composerHasFocus = if (viewModel.viewState.value.contextualNativeInputEnabled) {
                         binding.contextualNativeInputWidget.hasFocus()
                     } else {
@@ -264,6 +269,9 @@ class DuckChatContextualFragment :
             ) {
                 if (newState == BottomSheetBehavior.STATE_HIDDEN) {
                     viewModel.onSheetClosed()
+                }
+                if (newState == BottomSheetBehavior.STATE_HALF_EXPANDED) {
+                    bottomSheet.requestLayout()
                 }
                 backPressedCallback.isEnabled = newState != BottomSheetBehavior.STATE_HIDDEN
                 updateContentAreaHeight()
@@ -538,6 +546,28 @@ class DuckChatContextualFragment :
         configureBehaviour(bottomSheetBehavior)
         configureButtons()
         configureSuggestions()
+        binding.contextualModeRoot.doOnNextLayout { reserveSpaceForSuggestions() }
+        binding.contextualInputContainer.addOnLayoutChangeListener { _, _, top, _, bottom, _, oldTop, _, oldBottom ->
+            if (bottom - top != oldBottom - oldTop) reserveSpaceForSuggestions()
+        }
+    }
+
+    private fun reserveSpaceForSuggestions() {
+        if (!viewModel.viewState.value.contextualSuggestionsEnabled) return
+        if (isKeyboardVisible) return
+        val sheet = binding.contextualModeRoot.parent as? View ?: return
+        val coordinatorHeight = (sheet.parent as? View)?.height?.takeIf { it > 0 } ?: return
+        val prompts = binding.contextualModePrompts.getChildAt(0) ?: return
+        val cardHeight = binding.contextualPromptQuickAction.height + resources.getDimensionPixelSize(CommonR.dimen.keyline_2)
+        val reservedSpace = binding.contextualModeButtons.height + binding.contextualInputContainer.height +
+            prompts.paddingTop + prompts.paddingBottom + MAX_PROMPT_CARDS * cardHeight
+        val ratio = (reservedSpace.toFloat() / coordinatorHeight).coerceIn(HALF_EXPANDED_RATIO, MAX_HALF_EXPANDED_RATIO)
+        if (bottomSheetBehavior.halfExpandedRatio != ratio) {
+            bottomSheetBehavior.halfExpandedRatio = ratio
+            if (bottomSheetBehavior.state == BottomSheetBehavior.STATE_HALF_EXPANDED) {
+                sheet.requestLayout()
+            }
+        }
     }
 
     private fun configureBehaviour(bottomSheetBehavior: BottomSheetBehavior<View>) {
@@ -573,7 +603,8 @@ class DuckChatContextualFragment :
         val sheet = binding.contextualModeRoot.parent as? View ?: return
         val coordinatorHeight = (sheet.parent as? View)?.height ?: return
         if (coordinatorHeight <= 0) return
-        val visibleSheetHeight = (coordinatorHeight - sheet.top).coerceAtLeast(0)
+        val halfExpandedHeight = (coordinatorHeight * bottomSheetBehavior.halfExpandedRatio).toInt()
+        val visibleSheetHeight = (coordinatorHeight - sheet.top).coerceAtLeast(halfExpandedHeight)
         val chromeHeight = binding.contextualModeButtons.height + binding.contextualInputContainer.height
         val contentHeight = (visibleSheetHeight - chromeHeight).coerceAtLeast(0)
         // Size the middle to the visible sheet minus header + input, so the input sits on the visible edge.
@@ -1300,6 +1331,8 @@ class DuckChatContextualFragment :
 
     companion object {
         private const val HALF_EXPANDED_RATIO = 0.5f
+        private const val MAX_HALF_EXPANDED_RATIO = 0.9f
+        private const val MAX_PROMPT_CARDS = 4
         private const val MAX_CHAT_TITLE_LINES = 1
         private const val PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE = 200
         private const val CUSTOM_UA =

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -113,7 +113,9 @@ import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.cancellable
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -535,6 +537,7 @@ class DuckChatContextualFragment :
 
         configureBehaviour(bottomSheetBehavior)
         configureButtons()
+        configureSuggestions()
     }
 
     private fun configureBehaviour(bottomSheetBehavior: BottomSheetBehavior<View>) {
@@ -770,6 +773,7 @@ class DuckChatContextualFragment :
                 when (command) {
                     is DuckChatContextualSharedViewModel.Command.PageContextAttached -> {
                         viewModel.onPageContextReceived(command.tabId, command.pageContext, command.isStorePageContextEnabled)
+                        binding.contextualSuggestionsView.onPageContextUpdated(command.pageContext)
                     }
 
                     is DuckChatContextualSharedViewModel.Command.MainBrowserPageFinished -> {
@@ -780,6 +784,9 @@ class DuckChatContextualFragment :
                         logcat { "Duck.ai Contextual: OpenSheet" }
                         setupKeyboardVisibilityListener()
                         viewModel.onSheetReopened()
+                        if (viewModel.viewState.value.sheetMode == DuckChatContextualViewModel.SheetMode.INPUT) {
+                            binding.contextualSuggestionsView.load()
+                        }
                     }
 
                     is DuckChatContextualSharedViewModel.Command.OnContextualFireConfirmed -> {
@@ -793,6 +800,16 @@ class DuckChatContextualFragment :
         viewModel.viewState
             .onEach { viewState ->
                 renderViewState(viewState)
+            }.launchIn(lifecycleScope)
+
+        viewModel.viewState
+            .map { it.sheetMode }
+            .distinctUntilChanged()
+            .onEach { sheetMode ->
+                when (sheetMode) {
+                    DuckChatContextualViewModel.SheetMode.INPUT -> binding.contextualSuggestionsView.load()
+                    DuckChatContextualViewModel.SheetMode.WEBVIEW -> binding.contextualSuggestionsView.clear()
+                }
             }.launchIn(lifecycleScope)
 
         observeSubscriptionEventDataChannel()
@@ -811,8 +828,7 @@ class DuckChatContextualFragment :
             binding.contextualFullScreen.gone()
         }
 
-        binding.contextualPromptQuickAction.setText(viewState.quickActionState.labelResId)
-        binding.contextualPromptQuickAction.setCompoundDrawablesRelativeWithIntrinsicBounds(viewState.quickActionState.iconResId, 0, 0, 0)
+        applyQuickActionVisibility(viewState)
         binding.legacyInputField.setHint(viewState.chatHintResId)
 
         if (viewState.showChatsIcon) {
@@ -892,6 +908,34 @@ class DuckChatContextualFragment :
 
     private fun showFireConfirmationDialog() {
         duckChatSharedViewModel.onContextualFireButtonClicked()
+    }
+
+    private fun applyQuickActionVisibility(viewState: DuckChatContextualViewModel.ViewState) {
+        val isSummarizeQuickAction =
+            viewState.quickActionState == DuckChatContextualViewModel.QuickActionState.LEGACY_SUMMARIZE ||
+                viewState.quickActionState == DuckChatContextualViewModel.QuickActionState.SUBMIT_SUMMARIZE
+
+        if (isSummarizeQuickAction && binding.contextualSuggestionsView.hasContent()) {
+            binding.contextualPromptQuickAction.gone()
+        } else {
+            binding.contextualPromptQuickAction.show()
+            binding.contextualPromptQuickAction.setText(viewState.quickActionState.labelResId)
+            binding.contextualPromptQuickAction.setCompoundDrawablesRelativeWithIntrinsicBounds(viewState.quickActionState.iconResId, 0, 0, 0)
+        }
+    }
+
+    private fun configureSuggestions() {
+        binding.contextualSuggestionsView.onSuggestionSelected = { suggestion ->
+            val currentInput = if (viewModel.viewState.value.contextualNativeInputEnabled) {
+                binding.contextualNativeInputWidget.text
+            } else {
+                binding.legacyInputField.text.toString()
+            }
+            viewModel.onSuggestionSelected(suggestion, currentInput)
+        }
+        binding.contextualSuggestionsView.onContentChanged = {
+            applyQuickActionVisibility(viewModel.viewState.value)
+        }
     }
 
     private fun showChatsPopup(showNewChatHeader: Boolean, recentChats: List<ChatHistoryItem>) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -202,6 +202,7 @@ class DuckChatContextualViewModel @Inject constructor(
                     quickActionState = initialQuickActionState,
                     chatHintResId = chatHintResId,
                     showChatsIcon = isContextualSheetImprovementsEnabled,
+                    contextualSuggestionsEnabled = duckChatFeature.contextualSuggestedPrompts().isEnabled(),
                 )
             }
             if (isContextualSheetImprovementsEnabled) {
@@ -252,6 +253,7 @@ class DuckChatContextualViewModel @Inject constructor(
         val recentChats: List<ChatHistoryItem> = emptyList(),
         val nativeChatInputEnabled: Boolean = false,
         val contextualNativeInputEnabled: Boolean = false,
+        val contextualSuggestionsEnabled: Boolean = false,
     )
 
     fun onSheetReopened() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -1011,6 +1011,12 @@ class DuckChatContextualViewModel @Inject constructor(
     // loaded chat is deleted elsewhere, so we don't pop a dismissed sheet back open).
     private fun renderNewChatState(sheetState: Int? = BottomSheetBehavior.STATE_HALF_EXPANDED) {
         viewModelScope.launch(dispatchers.io()) {
+            if (sheetState == BottomSheetBehavior.STATE_HALF_EXPANDED) {
+                withContext(dispatchers.main()) {
+                    isPageContextRequested = true
+                    commandChannel.trySend(Command.RequestPageContext)
+                }
+            }
             val currentTabId = _viewState.value.tabId
             if (currentTabId.isNotBlank()) {
                 contextualDataStore.clearTabChatUrl(currentTabId)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.toChatIdOrNull
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.contextual.suggestions.ContextualSuggestedPrompt
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.helper.NativeAction
@@ -780,6 +781,16 @@ class DuckChatContextualViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    fun onSuggestionSelected(
+        suggestion: ContextualSuggestedPrompt,
+        currentInput: String,
+    ) {
+        onPromptSent(
+            prompt = suggestion.prompt,
+            followUpPrefill = currentInput.takeIf { it.isNotEmpty() },
+        )
     }
 
     fun onAskAboutPageClicked() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -670,21 +670,24 @@ class DuckChatContextualViewModel @Inject constructor(
             duckChatPixels.reportContextualPlaceholderContextTapped()
         }
         viewModelScope.launch {
-            val isContextValid = isContextValid(currentPageContext, reportInvalidPixels = true)
-            if (isContextValid) {
-                pageContextState = pageContextState.copy(attachedPage = pageContextState.currentPage)
-                val json = JSONObject(currentPageContext)
+            if (isContextValid(currentPageContext, reportInvalidPixels = true)) {
                 duckChatPixels.reportContextualPageContextManuallyAttachedNative()
-                _viewState.update { current ->
-                    logcat { "Duck.ai Contextual: addPageContext $current context $currentPageContext" }
-                    current.copy(
-                        showContext = true,
-                        userRemovedContext = false,
-                        contextTitle = json.optString("title"),
-                        contextUrl = json.optString("url"),
-                    )
-                }
+                attachCurrentPageContext()
             }
+        }
+    }
+
+    private fun attachCurrentPageContext() {
+        pageContextState = pageContextState.copy(attachedPage = pageContextState.currentPage)
+        val json = JSONObject(currentPageContext)
+        _viewState.update { current ->
+            logcat { "Duck.ai Contextual: attachCurrentPageContext $current context $currentPageContext" }
+            current.copy(
+                showContext = true,
+                userRemovedContext = false,
+                contextTitle = json.optString("title"),
+                contextUrl = json.optString("url"),
+            )
         }
     }
 
@@ -787,10 +790,17 @@ class DuckChatContextualViewModel @Inject constructor(
         suggestion: ContextualSuggestedPrompt,
         currentInput: String,
     ) {
+        attachPageContextForSuggestion()
         onPromptSent(
             prompt = suggestion.prompt,
             followUpPrefill = currentInput.takeIf { it.isNotEmpty() },
         )
+    }
+
+    private fun attachPageContextForSuggestion() {
+        if (_viewState.value.showContext) return
+        if (!isContextValid(currentPageContext)) return
+        attachCurrentPageContext()
     }
 
     fun onAskAboutPageClicked() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -1011,14 +1011,14 @@ class DuckChatContextualViewModel @Inject constructor(
     // loaded chat is deleted elsewhere, so we don't pop a dismissed sheet back open).
     private fun renderNewChatState(sheetState: Int? = BottomSheetBehavior.STATE_HALF_EXPANDED) {
         viewModelScope.launch(dispatchers.io()) {
-            if (sheetState == BottomSheetBehavior.STATE_HALF_EXPANDED) {
-                withContext(dispatchers.main()) {
-                    isPageContextRequested = true
-                    commandChannel.trySend(Command.RequestPageContext)
-                }
-            }
             val currentTabId = _viewState.value.tabId
             if (currentTabId.isNotBlank()) {
+                if (sheetState == BottomSheetBehavior.STATE_HALF_EXPANDED) {
+                    withContext(dispatchers.main()) {
+                        isPageContextRequested = true
+                        commandChannel.trySend(Command.RequestPageContext)
+                    }
+                }
                 contextualDataStore.clearTabChatUrl(currentTabId)
 
                 withContext(dispatchers.main()) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestedPromptsProvider.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestedPromptsProvider.kt
@@ -50,13 +50,13 @@ class RealContextualSuggestedPromptsProvider @Inject constructor(
     override suspend fun resolveSuggestions(
         input: ResolvePageSuggestionsInput,
     ): List<ContextualSuggestedPrompt> = withContext(dispatcherProvider.io()) {
-        val catalog = bundledCatalog ?: return@withContext DECODE_FAILURE_FALLBACK
+        val catalog = bundledCatalog ?: return@withContext emptyList()
         ContextualSuggestionsMatcher.resolve(input, catalog)
             .filterNot { it.id == SUGGESTION_ID_SUMMARIZE_PAGE }
     }
 
     override suspend fun maxSuggestedPrompts(): Int = withContext(dispatcherProvider.io()) {
-        bundledCatalog?.maxSuggestedPrompts ?: DECODE_FAILURE_FALLBACK.size
+        bundledCatalog?.maxSuggestedPrompts ?: 1
     }
 
     override suspend fun prioritySuggestionIds(): Set<String> = withContext(dispatcherProvider.io()) {
@@ -76,13 +76,5 @@ class RealContextualSuggestedPromptsProvider @Inject constructor(
     companion object {
         private const val CATALOG_ASSET_PATH = "PageSuggestionsCatalog.json"
         private const val SUGGESTION_ID_SUMMARIZE_PAGE = "summarize-page"
-        private val DECODE_FAILURE_FALLBACK = listOf(
-            ContextualSuggestedPrompt(
-                id = SUGGESTION_ID_SUMMARIZE_PAGE,
-                label = "Summarize this page",
-                prompt = "Summarize this page.",
-                icon = "summary",
-            ),
-        )
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestedPromptsProvider.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestedPromptsProvider.kt
@@ -50,6 +50,7 @@ class RealContextualSuggestedPromptsProvider @Inject constructor(
     ): List<ContextualSuggestedPrompt> = withContext(dispatcherProvider.io()) {
         val catalog = bundledCatalog ?: return@withContext DECODE_FAILURE_FALLBACK
         ContextualSuggestionsMatcher.resolve(input, catalog)
+            .filterNot { it.id == SUGGESTION_ID_SUMMARIZE_PAGE }
     }
 
     private fun loadBundledCatalog(): SuggestionCatalog? {
@@ -63,9 +64,10 @@ class RealContextualSuggestedPromptsProvider @Inject constructor(
 
     companion object {
         private const val CATALOG_ASSET_PATH = "PageSuggestionsCatalog.json"
+        private const val SUGGESTION_ID_SUMMARIZE_PAGE = "summarize-page"
         private val DECODE_FAILURE_FALLBACK = listOf(
             ContextualSuggestedPrompt(
-                id = "summarize-page",
+                id = SUGGESTION_ID_SUMMARIZE_PAGE,
                 label = "Summarize this page",
                 prompt = "Summarize this page.",
                 icon = "summary",

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestedPromptsProvider.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestedPromptsProvider.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual.suggestions
+
+import android.content.Context
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.withContext
+import logcat.LogPriority.ERROR
+import logcat.logcat
+import javax.inject.Inject
+
+interface ContextualSuggestedPromptsProvider {
+    suspend fun resolveSuggestions(input: ResolvePageSuggestionsInput): List<ContextualSuggestedPrompt>
+}
+
+@ContributesBinding(AppScope::class)
+class RealContextualSuggestedPromptsProvider @Inject constructor(
+    private val context: Context,
+    private val dispatcherProvider: DispatcherProvider,
+) : ContextualSuggestedPromptsProvider {
+
+    internal var catalogAssetPath: String = CATALOG_ASSET_PATH
+
+    private val moshi by lazy {
+        Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    }
+
+    private val bundledCatalog: SuggestionCatalog? by lazy { loadBundledCatalog() }
+
+    override suspend fun resolveSuggestions(
+        input: ResolvePageSuggestionsInput,
+    ): List<ContextualSuggestedPrompt> = withContext(dispatcherProvider.io()) {
+        val catalog = bundledCatalog ?: return@withContext DECODE_FAILURE_FALLBACK
+        ContextualSuggestionsMatcher.resolve(input, catalog)
+    }
+
+    private fun loadBundledCatalog(): SuggestionCatalog? {
+        return runCatching {
+            val json = context.assets.open(catalogAssetPath).bufferedReader().use { it.readText() }
+            moshi.adapter(SuggestionCatalog::class.java).fromJson(json)
+        }.onFailure {
+            logcat(ERROR) { "[Suggestions] Failed to load $catalogAssetPath: $it" }
+        }.getOrNull()
+    }
+
+    companion object {
+        private const val CATALOG_ASSET_PATH = "PageSuggestionsCatalog.json"
+        private val DECODE_FAILURE_FALLBACK = listOf(
+            ContextualSuggestedPrompt(
+                id = "summarize-page",
+                label = "Summarize this page",
+                prompt = "Summarize this page.",
+                icon = "summary",
+            ),
+        )
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestedPromptsProvider.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestedPromptsProvider.kt
@@ -29,6 +29,8 @@ import javax.inject.Inject
 
 interface ContextualSuggestedPromptsProvider {
     suspend fun resolveSuggestions(input: ResolvePageSuggestionsInput): List<ContextualSuggestedPrompt>
+    suspend fun maxSuggestedPrompts(): Int
+    suspend fun prioritySuggestionIds(): Set<String>
 }
 
 @ContributesBinding(AppScope::class)
@@ -51,6 +53,15 @@ class RealContextualSuggestedPromptsProvider @Inject constructor(
         val catalog = bundledCatalog ?: return@withContext DECODE_FAILURE_FALLBACK
         ContextualSuggestionsMatcher.resolve(input, catalog)
             .filterNot { it.id == SUGGESTION_ID_SUMMARIZE_PAGE }
+    }
+
+    override suspend fun maxSuggestedPrompts(): Int = withContext(dispatcherProvider.io()) {
+        bundledCatalog?.maxSuggestedPrompts ?: DECODE_FAILURE_FALLBACK.size
+    }
+
+    override suspend fun prioritySuggestionIds(): Set<String> = withContext(dispatcherProvider.io()) {
+        val catalog = bundledCatalog ?: return@withContext emptySet()
+        catalog.defaults.filter { catalog.catalog[it]?.condition != null }.toSet()
     }
 
     private fun loadBundledCatalog(): SuggestionCatalog? {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsLoadingView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsLoadingView.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual.suggestions
+
+import android.animation.Animator
+import android.animation.ObjectAnimator
+import android.animation.PropertyValuesHolder
+import android.content.Context
+import android.graphics.drawable.GradientDrawable
+import android.provider.Settings
+import android.util.AttributeSet
+import android.view.Gravity
+import android.view.View
+import android.widget.LinearLayout
+import androidx.core.content.ContextCompat
+import com.duckduckgo.common.ui.view.getColorFromAttr
+import com.duckduckgo.common.ui.view.toPx
+import com.duckduckgo.mobile.android.R as CommonR
+
+class ContextualSuggestionsLoadingView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : LinearLayout(context, attrs, defStyleAttr) {
+
+    private val dots: List<View>
+    private val animators = mutableListOf<Animator>()
+
+    init {
+        orientation = HORIZONTAL
+        gravity = Gravity.CENTER_VERTICAL
+        background = ContextCompat.getDrawable(context, CommonR.drawable.duck_ai_prompt_background)
+        minimumHeight = HEIGHT_DP.toPx()
+        setPadding(HORIZONTAL_PADDING_DP.toPx(), 0, HORIZONTAL_PADDING_DP.toPx(), 0)
+
+        val dotColor = context.getColorFromAttr(CommonR.attr.daxColorSecondaryText)
+        dots = (0 until DOT_COUNT).map { index ->
+            View(context).apply {
+                background = GradientDrawable().apply {
+                    shape = GradientDrawable.OVAL
+                    setColor(dotColor)
+                }
+                alpha = RESTING_ALPHA
+                scaleX = RESTING_SCALE
+                scaleY = RESTING_SCALE
+                layoutParams = LayoutParams(DOT_SIZE_DP.toPx(), DOT_SIZE_DP.toPx()).apply {
+                    if (index < DOT_COUNT - 1) marginEnd = DOT_SPACING_DP.toPx()
+                }
+            }
+        }
+        dots.forEach { addView(it) }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        startAnimating()
+    }
+
+    override fun onDetachedFromWindow() {
+        stopAnimating()
+        super.onDetachedFromWindow()
+    }
+
+    private fun startAnimating() {
+        stopAnimating()
+        if (isReduceMotionEnabled()) {
+            dots.forEach {
+                it.alpha = 1f
+                it.scaleX = 1f
+                it.scaleY = 1f
+            }
+            return
+        }
+        dots.forEachIndexed { index, dot ->
+            val animator = ObjectAnimator.ofPropertyValuesHolder(
+                dot,
+                PropertyValuesHolder.ofFloat(ALPHA, RESTING_ALPHA, 1f),
+                PropertyValuesHolder.ofFloat(SCALE_X, RESTING_SCALE, 1f),
+                PropertyValuesHolder.ofFloat(SCALE_Y, RESTING_SCALE, 1f),
+            ).apply {
+                duration = HALF_CYCLE_MS
+                startDelay = index * STAGGER_MS
+                repeatCount = ObjectAnimator.INFINITE
+                repeatMode = ObjectAnimator.REVERSE
+            }
+            animators.add(animator)
+            animator.start()
+        }
+    }
+
+    private fun stopAnimating() {
+        animators.forEach { it.cancel() }
+        animators.clear()
+    }
+
+    private fun isReduceMotionEnabled(): Boolean =
+        Settings.Global.getFloat(context.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f) == 0f
+
+    private companion object {
+        const val DOT_COUNT = 3
+        const val DOT_SIZE_DP = 7
+        const val DOT_SPACING_DP = 5
+        const val HORIZONTAL_PADDING_DP = 14
+        const val HEIGHT_DP = 36
+        const val RESTING_ALPHA = 0.3f
+        const val RESTING_SCALE = 0.7f
+        const val HALF_CYCLE_MS = 500L
+        const val STAGGER_MS = 200L
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsMatcher.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsMatcher.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual.suggestions
+
+import java.net.URI
+import java.util.Locale
+
+data class ContextualSuggestedPrompt(
+    val id: String,
+    val label: String,
+    val prompt: String,
+    val icon: String?,
+)
+
+data class PageTypeSignals(
+    val jsonLdType: List<String> = emptyList(),
+    val ogType: String? = null,
+    val lang: String = "",
+)
+
+data class ResolvePageSuggestionsInput(
+    val pageTypeSignals: PageTypeSignals?,
+    val url: String?,
+    val uiLocale: String,
+)
+
+data class SuggestionCatalog(
+    val maxSuggestedPrompts: Int,
+    val defaults: List<String>,
+    val catalog: Map<String, Entry>,
+    val byJsonLdType: List<JsonLdMapping>,
+    val byOgType: Map<String, List<String>>,
+    val byDomain: Map<String, List<String>>,
+) {
+    data class Entry(
+        val label: String,
+        val icon: String? = null,
+        val prompt: String,
+        val condition: String? = null,
+    )
+
+    data class JsonLdMapping(
+        val type: String,
+        val ids: List<String>,
+    )
+}
+
+object ContextualSuggestionsMatcher {
+
+    private const val LANGUAGE_TEMPLATE = "{language}"
+    private const val CONDITION_DIFFERENT_LANGUAGE = "differentLanguage"
+
+    fun resolve(
+        input: ResolvePageSuggestionsInput,
+        catalog: SuggestionCatalog,
+    ): List<ContextualSuggestedPrompt> {
+        val cap = maxOf(1, catalog.maxSuggestedPrompts)
+        val candidateIds = collectCandidateIds(input, catalog, cap)
+        val seen = mutableSetOf<String>()
+        val resolved = mutableListOf<ContextualSuggestedPrompt>()
+
+        for (id in candidateIds) {
+            if (resolved.size >= cap) break
+            if (!seen.add(id)) continue
+
+            val entry = catalog.catalog[id] ?: continue
+            if (!conditionPasses(entry.condition, input)) continue
+
+            resolved.add(
+                ContextualSuggestedPrompt(
+                    id = id,
+                    label = entry.label,
+                    prompt = applyTemplate(entry.prompt, input),
+                    icon = entry.icon,
+                ),
+            )
+        }
+        return resolved
+    }
+
+    private fun collectCandidateIds(
+        input: ResolvePageSuggestionsInput,
+        catalog: SuggestionCatalog,
+        cap: Int,
+    ): List<String> {
+        var contextual: List<String>? = null
+
+        input.pageTypeSignals?.let { signals ->
+            contextual = matchByJsonLdType(signals.jsonLdType, catalog.byJsonLdType)
+            if (contextual == null) {
+                val ogType = signals.ogType
+                if (!ogType.isNullOrEmpty()) {
+                    contextual = catalog.byOgType[ogType.trim().lowercase()]
+                }
+            }
+        }
+        if (contextual == null) {
+            hostname(input.url)?.let { host ->
+                contextual = matchByDomain(host, catalog.byDomain)
+            }
+        }
+
+        val priorityDefaults = catalog.defaults.filter { id ->
+            val condition = catalog.catalog[id]?.condition ?: return@filter false
+            conditionPasses(condition, input)
+        }
+        val floorDefaults = catalog.defaults.filter { catalog.catalog[it]?.condition == null }
+
+        val body = contextual ?: floorDefaults
+        val bodyBudget = (cap - priorityDefaults.size).coerceAtLeast(0)
+        return body.take(bodyBudget) + priorityDefaults
+    }
+
+    private fun matchByJsonLdType(
+        types: List<String>,
+        mappings: List<SuggestionCatalog.JsonLdMapping>,
+    ): List<String>? {
+        if (types.isEmpty()) return null
+        val present = types.map { it.trim().lowercase() }.toSet()
+        return mappings.firstOrNull { present.contains(it.type.lowercase()) }?.ids
+    }
+
+    private fun matchByDomain(
+        hostname: String,
+        table: Map<String, List<String>>,
+    ): List<String>? {
+        return table.entries.firstOrNull { domainMatches(hostname, it.key) }?.value
+    }
+
+    private fun conditionPasses(
+        condition: String?,
+        input: ResolvePageSuggestionsInput,
+    ): Boolean {
+        if (condition == null) return true
+        return when (condition) {
+            CONDITION_DIFFERENT_LANGUAGE -> {
+                val pageLang = pageLanguageSubtag(input.pageTypeSignals?.lang ?: "")
+                val uiLang = uiLanguageSubtag(input.uiLocale)
+                pageLang.isNotEmpty() && uiLang.isNotEmpty() && pageLang != uiLang
+            }
+            else -> false
+        }
+    }
+
+    private fun applyTemplate(
+        prompt: String,
+        input: ResolvePageSuggestionsInput,
+    ): String {
+        if (!prompt.contains(LANGUAGE_TEMPLATE)) return prompt
+        return prompt.replace(LANGUAGE_TEMPLATE, languageDisplayName(input.uiLocale))
+    }
+
+    private fun pageLanguageSubtag(tag: String): String {
+        return tag.trim().lowercase().split("-").firstOrNull().orEmpty()
+    }
+
+    private fun uiLanguageSubtag(uiLocale: String): String {
+        return localeFrom(uiLocale).language.lowercase()
+    }
+
+    private fun languageDisplayName(uiLocale: String): String {
+        val subtag = uiLanguageSubtag(uiLocale)
+        if (subtag.isEmpty()) return subtag
+        val name = Locale(subtag).getDisplayLanguage(localeFrom(uiLocale))
+        return if (name.isNotEmpty() && name.lowercase() != subtag) name else subtag
+    }
+
+    private fun localeFrom(uiLocale: String): Locale {
+        val tag = uiLocale.substringBefore("@").replace("_", "-")
+        return Locale.forLanguageTag(tag)
+    }
+
+    private fun hostname(url: String?): String? {
+        if (url.isNullOrBlank()) return null
+        val host = runCatching { URI(url).host }.getOrNull() ?: return null
+        return host.lowercase()
+    }
+
+    private fun domainMatches(
+        hostname: String,
+        domain: String,
+    ): Boolean {
+        val normalized = domain.trim().lowercase()
+        return hostname == normalized || hostname.endsWith(".$normalized")
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual.suggestions
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.LinearLayout
+import androidx.annotation.DrawableRes
+import androidx.core.view.isNotEmpty
+import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.common.ui.view.toPx
+import com.duckduckgo.common.utils.ViewViewModelFactory
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.databinding.ItemContextualSuggestionBinding
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+@InjectWith(ViewScope::class)
+class ContextualSuggestionsView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : LinearLayout(context, attrs, defStyle) {
+
+    @Inject
+    lateinit var viewModelFactory: ViewViewModelFactory
+
+    private val viewModel: ContextualSuggestionsViewModel by lazy {
+        ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[ContextualSuggestionsViewModel::class.java]
+    }
+
+    var onSuggestionSelected: ((ContextualSuggestedPrompt) -> Unit)? = null
+
+    var onContentChanged: (() -> Unit)? = null
+
+    private val loadingView = ContextualSuggestionsLoadingView(context)
+    private val cardsContainer = LinearLayout(context).apply { orientation = VERTICAL }
+
+    init {
+        orientation = VERTICAL
+        addView(
+            loadingView,
+            LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT).apply { bottomMargin = LOADING_MARGIN_BOTTOM_DP.toPx() },
+        )
+        addView(cardsContainer, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT))
+        loadingView.gone()
+    }
+
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+        val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        viewModel.viewState
+            .onEach { render(it) }
+            .launchIn(scope)
+    }
+
+    fun load() = viewModel.load()
+
+    fun onPageContextUpdated(serializedPageContext: String) = viewModel.onPageContextUpdated(serializedPageContext)
+
+    fun clear() = viewModel.clear()
+
+    fun hasContent(): Boolean = loadingView.isVisible || cardsContainer.isNotEmpty()
+
+    private fun render(viewState: ContextualSuggestionsViewModel.ViewState) {
+        if (viewState.loading) loadingView.show() else loadingView.gone()
+
+        cardsContainer.removeAllViews()
+        if (!viewState.loading && viewState.suggestions.isNotEmpty()) {
+            val inflater = LayoutInflater.from(context)
+            viewState.suggestions.forEach { suggestion ->
+                val itemBinding = ItemContextualSuggestionBinding.inflate(inflater, cardsContainer, false)
+                itemBinding.suggestionLabel.text = suggestion.label
+                itemBinding.suggestionLabel.setCompoundDrawablesRelativeWithIntrinsicBounds(iconResFor(suggestion.icon), 0, 0, 0)
+                itemBinding.root.setOnClickListener { onSuggestionSelected?.invoke(suggestion) }
+                cardsContainer.addView(itemBinding.root)
+            }
+        }
+        onContentChanged?.invoke()
+    }
+
+    @DrawableRes
+    private fun iconResFor(icon: String?): Int = when (icon) {
+        "summary" -> R.drawable.ic_summarize_16
+        "translate" -> R.drawable.ic_translate_16
+        else -> R.drawable.ic_idea_16
+    }
+
+    private companion object {
+        const val LOADING_MARGIN_BOTTOM_DP = 8
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
@@ -99,6 +99,12 @@ class ContextualSuggestionsView @JvmOverloads constructor(
         }
     }
 
+    fun setReservedQuickActionSlots(count: Int) {
+        doOnAttach {
+            viewModel.onReservedQuickActionSlotsChanged(count)
+        }
+    }
+
     fun hasContent(): Boolean = loadingView.isVisible || cardsContainer.isNotEmpty()
 
     private fun render(viewState: ContextualSuggestionsViewModel.ViewState) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
@@ -21,6 +21,7 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.LinearLayout
 import androidx.annotation.DrawableRes
+import androidx.core.view.doOnAttach
 import androidx.core.view.isNotEmpty
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
@@ -80,11 +81,23 @@ class ContextualSuggestionsView @JvmOverloads constructor(
             .launchIn(scope)
     }
 
-    fun load() = viewModel.load()
+    fun load() {
+        doOnAttach {
+            viewModel.load()
+        }
+    }
 
-    fun onPageContextUpdated(serializedPageContext: String) = viewModel.onPageContextUpdated(serializedPageContext)
+    fun onPageContextUpdated(serializedPageContext: String) {
+        doOnAttach {
+            viewModel.onPageContextUpdated(serializedPageContext)
+        }
+    }
 
-    fun clear() = viewModel.clear()
+    fun clear() {
+        doOnAttach {
+            viewModel.clear()
+        }
+    }
 
     fun hasContent(): Boolean = loadingView.isVisible || cardsContainer.isNotEmpty()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.toPx
+import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.impl.R
@@ -62,6 +63,8 @@ class ContextualSuggestionsView @JvmOverloads constructor(
     private val loadingView = ContextualSuggestionsLoadingView(context)
     private val cardsContainer = LinearLayout(context).apply { orientation = VERTICAL }
 
+    private val viewStateJob = ConflatedJob()
+
     init {
         orientation = VERTICAL
         addView(
@@ -76,9 +79,14 @@ class ContextualSuggestionsView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
         val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
-        viewModel.viewState
+        viewStateJob += viewModel.viewState
             .onEach { render(it) }
             .launchIn(scope)
+    }
+
+    override fun onDetachedFromWindow() {
+        viewStateJob.cancel()
+        super.onDetachedFromWindow()
     }
 
     fun load() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
@@ -54,7 +54,10 @@ class ContextualSuggestionsViewModel @Inject constructor(
         loadJob?.cancel()
         loadJob = viewModelScope.launch {
             val enabled = withContext(dispatchers.io()) { duckChatFeature.contextualSuggestedPrompts().isEnabled() }
-            if (!enabled) return@launch
+            if (!enabled) {
+                _viewState.value = ViewState(suggestions = emptyList(), loading = false)
+                return@launch
+            }
             _viewState.value = ViewState(suggestions = emptyList(), loading = true)
             delay(TIMEOUT_MS)
             if (_viewState.value.loading) {
@@ -82,7 +85,10 @@ class ContextualSuggestionsViewModel @Inject constructor(
         url: String?,
         pageTypeSignals: PageTypeSignals?,
     ) = withContext(dispatchers.io()) {
-        if (!duckChatFeature.contextualSuggestedPrompts().isEnabled()) return@withContext
+        if (!duckChatFeature.contextualSuggestedPrompts().isEnabled()) {
+            _viewState.value = ViewState(suggestions = emptyList(), loading = false)
+            return@withContext
+        }
         val input = ResolvePageSuggestionsInput(
             pageTypeSignals = pageTypeSignals,
             url = url,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
@@ -49,6 +50,10 @@ class ContextualSuggestionsViewModel @Inject constructor(
     val viewState: StateFlow<ViewState> = _viewState.asStateFlow()
 
     private var loadJob: Job? = null
+    private var resolvedSuggestions: List<ContextualSuggestedPrompt> = emptyList()
+    private var maxSuggestedPrompts: Int = 1
+    private var prioritySuggestionIds: Set<String> = emptySet()
+    private var reservedQuickActionSlots: Int = 0
 
     fun load() {
         loadJob?.cancel()
@@ -78,7 +83,23 @@ class ContextualSuggestionsViewModel @Inject constructor(
 
     fun clear() {
         loadJob?.cancel()
+        resolvedSuggestions = emptyList()
         _viewState.value = ViewState(suggestions = emptyList(), loading = false)
+    }
+
+    fun onReservedQuickActionSlotsChanged(count: Int) {
+        if (reservedQuickActionSlots == count) return
+        reservedQuickActionSlots = count
+        _viewState.update { it.copy(suggestions = visibleSuggestions()) }
+    }
+
+    private fun visibleSuggestions(): List<ContextualSuggestedPrompt> {
+        val capacity = (maxSuggestedPrompts - reservedQuickActionSlots).coerceAtLeast(0)
+        if (resolvedSuggestions.size <= capacity) return resolvedSuggestions
+        val prioritySuggestions = resolvedSuggestions.filter { it.id in prioritySuggestionIds }
+        val regularSuggestions = resolvedSuggestions.filterNot { it.id in prioritySuggestionIds }
+        val priorityCount = minOf(prioritySuggestions.size, capacity)
+        return regularSuggestions.take(capacity - priorityCount) + prioritySuggestions.take(priorityCount)
     }
 
     private suspend fun resolve(
@@ -95,7 +116,10 @@ class ContextualSuggestionsViewModel @Inject constructor(
             uiLocale = Locale.getDefault().toLanguageTag(),
         )
         val resolved = suggestedPromptsProvider.resolveSuggestions(input)
-        _viewState.value = ViewState(suggestions = resolved, loading = false)
+        maxSuggestedPrompts = suggestedPromptsProvider.maxSuggestedPrompts()
+        prioritySuggestionIds = suggestedPromptsProvider.prioritySuggestionIds()
+        resolvedSuggestions = resolved
+        _viewState.value = ViewState(suggestions = visibleSuggestions(), loading = false)
     }
 
     private fun parsePageTypeSignals(pageContextJson: JSONObject): PageTypeSignals? {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
@@ -89,7 +89,6 @@ class ContextualSuggestionsViewModel @Inject constructor(
             uiLocale = Locale.getDefault().toLanguageTag(),
         )
         val resolved = suggestedPromptsProvider.resolveSuggestions(input)
-            .filterNot { it.id == SUGGESTION_ID_SUMMARIZE_PAGE }
         _viewState.value = ViewState(suggestions = resolved, loading = false)
     }
 
@@ -112,6 +111,5 @@ class ContextualSuggestionsViewModel @Inject constructor(
 
     companion object {
         private const val TIMEOUT_MS = 5_000L
-        private const val SUGGESTION_ID_SUMMARIZE_PAGE = "summarize-page"
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
@@ -73,6 +73,7 @@ class ContextualSuggestionsViewModel @Inject constructor(
 
     fun onPageContextUpdated(serializedPageContext: String) {
         val json = runCatching { JSONObject(serializedPageContext) }.getOrNull() ?: return
+        if (json.optString("title").isBlank() || json.optString("content").isBlank()) return
         viewModelScope.launch {
             resolve(
                 url = json.optString("url").takeIf { it.isNotBlank() },

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual.suggestions
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.util.Locale
+import javax.inject.Inject
+
+@ContributesViewModel(ViewScope::class)
+class ContextualSuggestionsViewModel @Inject constructor(
+    private val suggestedPromptsProvider: ContextualSuggestedPromptsProvider,
+    private val duckChatFeature: DuckChatFeature,
+    private val dispatchers: DispatcherProvider,
+) : ViewModel() {
+
+    data class ViewState(
+        val suggestions: List<ContextualSuggestedPrompt> = emptyList(),
+        val loading: Boolean = false,
+    )
+
+    private val _viewState = MutableStateFlow(ViewState())
+    val viewState: StateFlow<ViewState> = _viewState.asStateFlow()
+
+    fun load() {
+        viewModelScope.launch {
+            val enabled = withContext(dispatchers.io()) { duckChatFeature.contextualSuggestedPrompts().isEnabled() }
+            if (!enabled) return@launch
+            _viewState.value = ViewState(suggestions = emptyList(), loading = true)
+            delay(TIMEOUT_MS)
+            if (_viewState.value.loading) {
+                resolve(url = null, pageTypeSignals = null)
+            }
+        }
+    }
+
+    fun onPageContextUpdated(serializedPageContext: String) {
+        val json = runCatching { JSONObject(serializedPageContext) }.getOrNull() ?: return
+        viewModelScope.launch {
+            resolve(
+                url = json.optString("url").takeIf { it.isNotBlank() },
+                pageTypeSignals = parsePageTypeSignals(json),
+            )
+        }
+    }
+
+    fun clear() {
+        _viewState.value = ViewState(suggestions = emptyList(), loading = false)
+    }
+
+    private suspend fun resolve(
+        url: String?,
+        pageTypeSignals: PageTypeSignals?,
+    ) = withContext(dispatchers.io()) {
+        if (!duckChatFeature.contextualSuggestedPrompts().isEnabled()) return@withContext
+        val input = ResolvePageSuggestionsInput(
+            pageTypeSignals = pageTypeSignals,
+            url = url,
+            uiLocale = Locale.getDefault().toLanguageTag(),
+        )
+        val resolved = suggestedPromptsProvider.resolveSuggestions(input)
+            .filterNot { it.id == SUGGESTION_ID_SUMMARIZE_PAGE }
+        _viewState.value = ViewState(suggestions = resolved, loading = false)
+    }
+
+    private fun parsePageTypeSignals(pageContextJson: JSONObject): PageTypeSignals? {
+        val signals = pageContextJson.optJSONObject("pageTypeSignals") ?: return null
+        val jsonLdArray = signals.optJSONArray("jsonLdType")
+        val jsonLdType = buildList {
+            if (jsonLdArray != null) {
+                for (i in 0 until jsonLdArray.length()) {
+                    add(jsonLdArray.optString(i))
+                }
+            }
+        }
+        return PageTypeSignals(
+            jsonLdType = jsonLdType,
+            ogType = signals.optString("ogType").takeIf { it.isNotBlank() },
+            lang = signals.optString("lang"),
+        )
+    }
+
+    companion object {
+        private const val TIMEOUT_MS = 5_000L
+        private const val SUGGESTION_ID_SUMMARIZE_PAGE = "summarize-page"
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -47,8 +48,11 @@ class ContextualSuggestionsViewModel @Inject constructor(
     private val _viewState = MutableStateFlow(ViewState())
     val viewState: StateFlow<ViewState> = _viewState.asStateFlow()
 
+    private var loadJob: Job? = null
+
     fun load() {
-        viewModelScope.launch {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
             val enabled = withContext(dispatchers.io()) { duckChatFeature.contextualSuggestedPrompts().isEnabled() }
             if (!enabled) return@launch
             _viewState.value = ViewState(suggestions = emptyList(), loading = true)
@@ -70,6 +74,7 @@ class ContextualSuggestionsViewModel @Inject constructor(
     }
 
     fun clear() {
+        loadJob?.cancel()
         _viewState.value = ViewState(suggestions = emptyList(), loading = false)
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
@@ -105,10 +105,11 @@ class ContextualSuggestionsViewModel @Inject constructor(
     private suspend fun resolve(
         url: String?,
         pageTypeSignals: PageTypeSignals?,
-    ) = withContext(dispatchers.io()) {
-        if (!duckChatFeature.contextualSuggestedPrompts().isEnabled()) {
+    ) {
+        val enabled = withContext(dispatchers.io()) { duckChatFeature.contextualSuggestedPrompts().isEnabled() }
+        if (!enabled) {
             _viewState.value = ViewState(suggestions = emptyList(), loading = false)
-            return@withContext
+            return
         }
         val input = ResolvePageSuggestionsInput(
             pageTypeSignals = pageTypeSignals,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -286,6 +286,13 @@ interface DuckChatFeature {
     fun contextualSheetImprovements(): Toggle
 
     /**
+     * @return `true` when context-aware suggested prompts are shown on the contextual Duck.ai start surface.
+     * If the remote feature is not present defaults to `internal`.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun contextualSuggestedPrompts(): Toggle
+
+    /**
      * @return `true` when the native controls for AI Features are enabled in the app.
      * If the remote feature is not present defaults to `internal`
      */

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -412,6 +412,11 @@ class RealDuckChatJSHelper @Inject constructor(
                 false
             }
         }
+        val supportsSuggestions = withContext(dispatcherProvider.io()) {
+            duckChat.isDuckChatContextualModeEnabled() &&
+                mode == Mode.CONTEXTUAL &&
+                duckChatFeature.contextualSuggestedPrompts().isEnabled()
+        }
         val jsonPayload =
             JSONObject().apply {
                 put(PLATFORM, ANDROID)
@@ -433,6 +438,7 @@ class RealDuckChatJSHelper @Inject constructor(
                     duckChat.isDuckChatContextualModeEnabled() &&
                         duckChat.areMultipleContentAttachmentsEnabled(),
                 )
+                put(SUPPORTS_SUGGESTIONS, supportsSuggestions)
                 put(SUPPORTS_SUBSCRIPTION, supportsSubscription)
                 put(INSTALL_TYPE, if (appBuildConfig.isAppReinstall()) INSTALL_TYPE_RETURNING else INSTALL_TYPE_NEW)
                 getInstallAgeBucket()?.let { put(INSTALL_AGE, it) }
@@ -618,6 +624,7 @@ class RealDuckChatJSHelper @Inject constructor(
         private const val SUPPORTS_CHAT_CONTEXTUAL_MODE = "supportsAIChatContextualMode"
         private const val SUPPORTS_CHAT_SYNC = "supportsAIChatSync"
         private const val SUPPORTS_PAGE_CONTEXT = "supportsPageContext"
+        private const val SUPPORTS_SUGGESTIONS = "supportsSuggestions"
         private const val SUPPORTS_MULTIPLE_PAGE_CONTEXT = "supportsMultipleContexts"
         private const val SUPPORTS_NATIVE_STORAGE = "supportsNativeStorage"
         private const val SUPPORTS_SUBSCRIPTION = "supportsSubscription"

--- a/duckchat/duckchat-impl/src/main/res/drawable/contextual_sheet_background.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/contextual_sheet_background.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners
+        android:topLeftRadius="@dimen/dialogBorderRadius"
+        android:topRightRadius="@dimen/dialogBorderRadius" />
+    <solid android:color="?attr/daxColorBackground" />
+</shape>

--- a/duckchat/duckchat-impl/src/main/res/drawable/ic_idea_16.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/ic_idea_16.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M10,13.995C10.345,13.995 10.625,14.274 10.625,14.619V14.75C10.625,15.441 10.064,16.001 9.373,16L6.623,15.995C5.934,15.994 5.376,15.435 5.375,14.747L5.375,14.62C5.375,14.275 5.654,13.995 5.999,13.995C6.345,13.994 6.625,14.274 6.625,14.619L6.625,14.745L9.375,14.75V14.619C9.375,14.274 9.655,13.995 10,13.995Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M8,0C11.314,0 14,2.685 14,5.998C14,7.927 13.087,9.644 11.673,10.74C11.443,10.918 11.333,11.142 11.333,11.336V11.412C11.333,12.47 10.475,13.328 9.417,13.328H6.583C5.525,13.328 4.667,12.47 4.667,11.412V11.336C4.667,11.142 4.557,10.918 4.327,10.74C2.913,9.644 2,7.927 2,5.998C2,2.685 4.686,0 8,0ZM8,1.333C5.423,1.333 3.333,3.421 3.333,5.998L3.334,6.068C3.356,7.539 4.058,8.846 5.144,9.687C5.619,10.055 6,10.638 6,11.336V11.412C6,11.734 6.261,11.995 6.583,11.995H9.417C9.739,11.995 10,11.734 10,11.412V11.336C10,10.638 10.381,10.055 10.856,9.687C11.959,8.833 12.667,7.498 12.667,5.998L12.665,5.877C12.602,3.397 10.602,1.397 8.121,1.334L8,1.333Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+</vector>

--- a/duckchat/duckchat-impl/src/main/res/drawable/ic_translate_16.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/ic_translate_16.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <group>
+    <clip-path
+        android:pathData="M0,0h16v16h-16z"/>
+    <path
+        android:pathData="M5.625,0C5.97,0 6.25,0.28 6.25,0.625V1.75H10.375L10.407,1.751C10.737,1.768 11,2.041 11,2.375C11,2.709 10.737,2.982 10.407,2.999L10.375,3H8.999C9.014,4.743 8.425,6.444 7.321,7.855C7.073,8.173 6.8,8.47 6.509,8.748C7.102,9.125 7.754,9.425 8.449,9.638L10.313,5.375L10.332,5.333C10.439,5.131 10.648,5.002 10.879,5C11.125,4.998 11.349,5.14 11.452,5.363L15.942,15.113C16.087,15.427 15.95,15.798 15.637,15.942C15.323,16.087 14.952,15.95 14.808,15.637L13.708,13.25H8.235L7.198,15.625C7.06,15.941 6.691,16.086 6.375,15.948C6.059,15.81 5.915,15.441 6.053,15.125L7.946,10.789C7.065,10.505 6.239,10.097 5.5,9.578C4.609,10.203 3.594,10.671 2.505,10.95C2.171,11.036 1.83,10.834 1.744,10.5C1.658,10.166 1.86,9.825 2.194,9.739C3.023,9.526 3.797,9.189 4.49,8.748C4.199,8.47 3.927,8.173 3.679,7.855C2.575,6.444 1.987,4.743 2.001,3H0.625C0.28,3 0,2.72 0,2.375C0,2.03 0.28,1.75 0.625,1.75H5V0.625C5,0.28 5.28,0 5.625,0ZM8.781,12H13.133L10.899,7.151L8.781,12ZM3.25,3C3.236,4.456 3.726,5.887 4.663,7.085C4.914,7.406 5.195,7.706 5.5,7.981C5.805,7.706 6.086,7.406 6.337,7.085C7.274,5.887 7.764,4.456 7.75,3H3.25Z"
+        android:fillColor="?attr/daxColorPrimaryIcon"/>
+  </group>
+</vector>

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
@@ -147,6 +147,7 @@
                     android:id="@+id/contextualPromptQuickAction"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/keyline_2"
                     android:background="@drawable/duck_ai_prompt_background"
                     android:drawableStart="@drawable/ic_arrow_down_right_16"
                     android:drawablePadding="@dimen/keyline_2"
@@ -185,7 +186,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
-            android:layout_margin="@dimen/keyline_2"
+            android:layout_marginHorizontal="@dimen/keyline_2"
+            android:layout_marginBottom="@dimen/keyline_2"
             app:cardBackgroundColor="?attr/daxColorWindow"
             app:cardElevation="4dp"
             app:cardUseCompatPadding="false">

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
@@ -133,6 +133,22 @@
             android:paddingTop="@dimen/keyline_4"
             android:paddingBottom="@dimen/keyline_1">
 
+            <com.duckduckgo.duckchat.impl.contextual.suggestions.ContextualSuggestionsLoadingView
+                android:id="@+id/contextualSuggestionsLoading"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/keyline_2"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
+            <LinearLayout
+                android:id="@+id/contextualSuggestionsContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
             <com.duckduckgo.common.ui.view.text.DaxTextView
                 android:id="@+id/contextualPromptQuickAction"
                 android:layout_width="wrap_content"

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
@@ -123,33 +123,39 @@
         android:layout_height="0dp"
         android:layout_weight="1">
 
-        <LinearLayout
+        <androidx.core.widget.NestedScrollView
             android:id="@+id/contextualModePrompts"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:paddingHorizontal="@dimen/keyline_4"
-            android:gravity="bottom"
-            android:paddingTop="@dimen/keyline_4"
-            android:paddingBottom="@dimen/keyline_1">
+            android:fillViewport="true">
 
-            <com.duckduckgo.duckchat.impl.contextual.suggestions.ContextualSuggestionsView
-                android:id="@+id/contextualSuggestionsView"
+            <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-            <com.duckduckgo.common.ui.view.text.DaxTextView
-                android:id="@+id/contextualPromptQuickAction"
-                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="@drawable/duck_ai_prompt_background"
-                android:drawableStart="@drawable/ic_arrow_down_right_16"
-                android:drawablePadding="@dimen/keyline_2"
-                android:padding="@dimen/keyline_2"
-                tools:text="@string/duckAIContextualPromptSummarize"
-                app:typography="body2_bold" />
+                android:orientation="vertical"
+                android:paddingHorizontal="@dimen/keyline_4"
+                android:gravity="bottom"
+                android:paddingTop="@dimen/keyline_4"
+                android:paddingBottom="@dimen/keyline_1">
 
-        </LinearLayout>
+                <com.duckduckgo.duckchat.impl.contextual.suggestions.ContextualSuggestionsView
+                    android:id="@+id/contextualSuggestionsView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+
+                <com.duckduckgo.common.ui.view.text.DaxTextView
+                    android:id="@+id/contextualPromptQuickAction"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/duck_ai_prompt_background"
+                    android:drawableStart="@drawable/ic_arrow_down_right_16"
+                    android:drawablePadding="@dimen/keyline_2"
+                    android:padding="@dimen/keyline_2"
+                    tools:text="@string/duckAIContextualPromptSummarize"
+                    app:typography="body2_bold" />
+
+            </LinearLayout>
+        </androidx.core.widget.NestedScrollView>
 
         <FrameLayout
             android:id="@+id/contextualWebviewContainer"

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
@@ -22,7 +22,7 @@
     android:id="@+id/contextualModeRoot"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@drawable/rounded_top_corners_bottom_sheet_drawable"
+    android:background="@drawable/contextual_sheet_background"
     tools:ignore="Overdraw"
     android:orientation="vertical">
 

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
@@ -133,21 +133,10 @@
             android:paddingTop="@dimen/keyline_4"
             android:paddingBottom="@dimen/keyline_1">
 
-            <com.duckduckgo.duckchat.impl.contextual.suggestions.ContextualSuggestionsLoadingView
-                android:id="@+id/contextualSuggestionsLoading"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/keyline_2"
-                android:visibility="gone"
-                tools:visibility="visible" />
-
-            <LinearLayout
-                android:id="@+id/contextualSuggestionsContainer"
+            <com.duckduckgo.duckchat.impl.contextual.suggestions.ContextualSuggestionsView
+                android:id="@+id/contextualSuggestionsView"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:visibility="gone"
-                tools:visibility="visible" />
+                android:layout_height="wrap_content" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextView
                 android:id="@+id/contextualPromptQuickAction"

--- a/duckchat/duckchat-impl/src/main/res/layout/item_contextual_suggestion.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/item_contextual_suggestion.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.duckduckgo.common.ui.view.text.DaxTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/suggestionLabel"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/keyline_2"
+    android:background="@drawable/duck_ai_prompt_background"
+    android:drawablePadding="@dimen/keyline_2"
+    android:padding="@dimen/keyline_2"
+    app:typography="body2_bold"
+    tools:drawableStart="@drawable/ic_summarize_16"
+    tools:text="Summarize this page" />

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -2759,6 +2759,43 @@ class DuckChatContextualViewModelTest {
         )
 
     @Test
+    fun `when suggestion selected with valid page context then context is attached and submitted`() = runTest {
+        testee = buildViewModel()
+        testee.currentPageContext = """{"title":"Recipe","url":"https://bbc.co.uk/food","content":"ingredients"}"""
+        val suggestion = ContextualSuggestedPrompt("shopping-list", "Generate a shopping list", "Create a shopping list.", null)
+
+        testee.onSuggestionSelected(suggestion, currentInput = "")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatPixels).reportContextualPromptSubmittedWithContextNative()
+    }
+
+    @Test
+    fun `when suggestion selected without valid page context then submitted without context`() = runTest {
+        testee = buildViewModel()
+        testee.currentPageContext = ""
+        val suggestion = ContextualSuggestedPrompt("id", "Label", "Do the thing.", null)
+
+        testee.onSuggestionSelected(suggestion, currentInput = "")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatPixels).reportContextualPromptSubmittedWithoutContextNative()
+    }
+
+    @Test
+    fun `when user removed context then suggestion tap re-attaches it`() = runTest {
+        testee = buildViewModel()
+        testee.currentPageContext = """{"title":"Recipe","url":"https://bbc.co.uk/food","content":"ingredients"}"""
+        testee.removePageContext()
+        val suggestion = ContextualSuggestedPrompt("shopping-list", "Generate a shopping list", "Create a shopping list.", null)
+
+        testee.onSuggestionSelected(suggestion, currentInput = "")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatPixels).reportContextualPromptSubmittedWithContextNative()
+    }
+
+    @Test
     fun `when suggestion selected then prompt submitted and chat opened`() = runTest {
         testee = buildViewModel()
         val suggestion = ContextualSuggestedPrompt("id", "Label", "Do the thing.", null)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -77,6 +77,7 @@ class DuckChatContextualViewModelTest {
     private val duckChatFeature: DuckChatFeature = mock()
     private val contextualFireButtonToggle: Toggle = mock()
     private val contextualSheetImprovementsToggle: Toggle = mock()
+    private val contextualSuggestedPromptsToggle: Toggle = mock()
     private val modelManager: com.duckduckgo.duckchat.impl.models.DuckAiModelManager = mock()
     private val contextualNativeInputManager: ContextualNativeInputManager = mock()
     private val chatHistoryRepository: ChatHistoryRepository = mock()
@@ -89,6 +90,8 @@ class DuckChatContextualViewModelTest {
         whenever(contextualFireButtonToggle.isEnabled()).thenReturn(false)
         whenever(duckChatFeature.contextualSheetImprovements()).thenReturn(contextualSheetImprovementsToggle)
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
+        whenever(duckChatFeature.contextualSuggestedPrompts()).thenReturn(contextualSuggestedPromptsToggle)
+        whenever(contextualSuggestedPromptsToggle.isEnabled()).thenReturn(true)
         whenever(chatHistoryRepository.observeChats()).thenReturn(recentChatsFlow)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
         whenever(

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -2826,6 +2826,24 @@ class DuckChatContextualViewModelTest {
         }
     }
 
+    @Test
+    fun `when new chat requested then page context is re-requested before the sheet state change`() = runTest {
+        testee = buildViewModel()
+        testee.onSheetOpened("tab")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.commands.test {
+            awaitItem()
+
+            testee.onNewChatRequested()
+            coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+            assertTrue(awaitItem() is DuckChatContextualViewModel.Command.RequestPageContext)
+            assertTrue(testee.isPageContextRequested)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     private fun buildViewModel() = DuckChatContextualViewModel(
         dispatchers = coroutineRule.testDispatcherProvider,
         duckChat = duckChat,

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -23,6 +23,7 @@ import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.contextual.suggestions.ContextualSuggestedPrompt
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.helper.NativeAction
@@ -2756,6 +2757,37 @@ class DuckChatContextualViewModelTest {
             pinned = false,
             lastEditMillis = lastEditMillis,
         )
+
+    @Test
+    fun `when suggestion selected then prompt submitted and chat opened`() = runTest {
+        testee = buildViewModel()
+        val suggestion = ContextualSuggestedPrompt("id", "Label", "Do the thing.", null)
+
+        testee.subscriptionEventDataFlow.test {
+            testee.onSuggestionSelected(suggestion, currentInput = "")
+            coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+            awaitItem()
+            assertEquals(DuckChatContextualViewModel.SheetMode.WEBVIEW, testee.viewState.value.sheetMode)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when suggestion selected with typed text then draft carried into new chat input`() = runTest {
+        testee = buildViewModel()
+        val suggestion = ContextualSuggestedPrompt("id", "Label", "Do the thing.", null)
+
+        testee.commands.test {
+            testee.onSuggestionSelected(suggestion, currentInput = "Hello")
+            coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+            val command = awaitItem()
+            assertTrue(command is DuckChatContextualViewModel.Command.ChangeSheetState)
+            assertEquals("Hello", (command as DuckChatContextualViewModel.Command.ChangeSheetState).prefillNativeInput)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
 
     private fun buildViewModel() = DuckChatContextualViewModel(
         dispatchers = coroutineRule.testDispatcherProvider,

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsMatcherTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsMatcherTest.kt
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual.suggestions
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ContextualSuggestionsMatcherTest {
+
+    private val catalog = SuggestionCatalog(
+        maxSuggestedPrompts = 4,
+        defaults = listOf("summarize-page", "translate-page"),
+        catalog = mapOf(
+            "summarize-page" to entry("Summarize this page", icon = "summary", prompt = "Summarize this page."),
+            "translate-page" to entry(
+                "Translate this page",
+                icon = "translate",
+                prompt = "Translate this page into {language}.",
+                condition = "differentLanguage",
+            ),
+            "shopping-list" to entry("Generate a shopping list", prompt = "Create a shopping list."),
+            "recipe-nutrition" to entry("Estimate the nutrition", prompt = "Estimate the nutrition."),
+            "scale-recipe" to entry("Adjust the servings", prompt = "Scale this recipe."),
+            "product-pros-cons" to entry("What are the pros and cons?", prompt = "Pros and cons?"),
+            "find-alternatives" to entry("Find me alternatives", prompt = "Alternatives?"),
+            "summarize-video" to entry("Summarize this video", icon = "summary", prompt = "Summarize this video."),
+            "video-key-points" to entry("What are the key points?", prompt = "Key points?"),
+            "explain-repo" to entry("Explain this repo", prompt = "Explain this repo."),
+        ),
+        byJsonLdType = listOf(
+            SuggestionCatalog.JsonLdMapping("Recipe", listOf("shopping-list", "recipe-nutrition", "scale-recipe")),
+            SuggestionCatalog.JsonLdMapping("Product", listOf("product-pros-cons", "find-alternatives")),
+            SuggestionCatalog.JsonLdMapping("VideoObject", listOf("summarize-video", "video-key-points")),
+        ),
+        byOgType = mapOf(
+            "product" to listOf("product-pros-cons", "find-alternatives"),
+            "video" to listOf("summarize-video", "video-key-points"),
+        ),
+        byDomain = mapOf(
+            "youtube.com" to listOf("summarize-video", "video-key-points"),
+            "github.com" to listOf("explain-repo"),
+        ),
+    )
+
+    private fun entry(
+        label: String,
+        icon: String? = null,
+        prompt: String,
+        condition: String? = null,
+    ) = SuggestionCatalog.Entry(label = label, icon = icon, prompt = prompt, condition = condition)
+
+    private fun input(
+        jsonLdType: List<String> = emptyList(),
+        ogType: String? = null,
+        lang: String = "en",
+        url: String? = null,
+        uiLocale: String = "en-US",
+        noSignals: Boolean = false,
+    ) = ResolvePageSuggestionsInput(
+        pageTypeSignals = if (noSignals) null else PageTypeSignals(jsonLdType, ogType, lang),
+        url = url,
+        uiLocale = uiLocale,
+    )
+
+    @Test
+    fun whenJsonLdTypeMatchesThenReturnsThoseSuggestionsFirst() {
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), catalog)
+
+        assertEquals(listOf("shopping-list", "recipe-nutrition", "scale-recipe"), result.map { it.id })
+    }
+
+    @Test
+    fun whenPageSpecificMatchThenSummarizePageDroppedFromDefaults() {
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Product")), catalog)
+
+        assertEquals(listOf("product-pros-cons", "find-alternatives"), result.map { it.id })
+        assertFalse(result.any { it.id == "summarize-page" })
+    }
+
+    @Test
+    fun whenJsonLdTypeMatchIsCaseInsensitiveThenMatches() {
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("  rEcIpE ")), catalog)
+
+        assertEquals(listOf("shopping-list", "recipe-nutrition", "scale-recipe"), result.map { it.id })
+    }
+
+    @Test
+    fun whenMultipleJsonLdTypesPresentThenFirstCatalogMappingWins() {
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Product", "Recipe")), catalog)
+
+        assertEquals(listOf("shopping-list", "recipe-nutrition", "scale-recipe"), result.map { it.id })
+    }
+
+    @Test
+    fun whenNoJsonLdMatchButOgTypeMatchesThenUsesOgType() {
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Unknown"), ogType = "product"), catalog)
+
+        assertEquals(listOf("product-pros-cons", "find-alternatives"), result.map { it.id })
+    }
+
+    @Test
+    fun whenOgTypeHasWhitespaceAndCaseThenNormalisedBeforeLookup() {
+        val result = ContextualSuggestionsMatcher.resolve(input(ogType = " VIDEO "), catalog)
+
+        assertEquals(listOf("summarize-video", "video-key-points"), result.map { it.id })
+    }
+
+    @Test
+    fun whenNoSignalsButUrlDomainMatchesThenUsesDomain() {
+        val result = ContextualSuggestionsMatcher.resolve(
+            input(noSignals = true, url = "https://www.youtube.com/watch?v=abc"),
+            catalog,
+        )
+
+        assertEquals(listOf("summarize-video", "video-key-points"), result.map { it.id })
+    }
+
+    @Test
+    fun whenDomainIsExactHostThenMatches() {
+        val result = ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = "https://github.com/duckduckgo"), catalog)
+
+        assertEquals(listOf("explain-repo"), result.map { it.id })
+    }
+
+    @Test
+    fun whenSignalsMatchThenDomainIsNotConsulted() {
+        val result = ContextualSuggestionsMatcher.resolve(
+            input(jsonLdType = listOf("Recipe"), url = "https://www.youtube.com/watch?v=abc"),
+            catalog,
+        )
+
+        assertEquals(listOf("shopping-list", "recipe-nutrition", "scale-recipe"), result.map { it.id })
+    }
+
+    @Test
+    fun whenNothingMatchesThenReturnsDefaultsIncludingSummarizePage() {
+        val result = ContextualSuggestionsMatcher.resolve(
+            input(jsonLdType = listOf("Unknown"), url = "https://example.com"),
+            catalog,
+        )
+
+        assertEquals(listOf("summarize-page"), result.map { it.id })
+    }
+
+    @Test
+    fun whenNoSignalsAndNoUrlThenReturnsDefaults() {
+        val result = ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = null), catalog)
+
+        assertEquals(listOf("summarize-page"), result.map { it.id })
+    }
+
+    @Test
+    fun whenCandidateAlsoInDefaultsThenDeduplicated() {
+        val recipeThenSummarizeCatalog = catalog.copy(defaults = listOf("shopping-list", "summarize-page"))
+
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), recipeThenSummarizeCatalog)
+
+        assertEquals(1, result.count { it.id == "shopping-list" })
+    }
+
+    @Test
+    fun whenMoreCandidatesThanMaxThenCappedAtMax() {
+        val cappedCatalog = catalog.copy(maxSuggestedPrompts = 2)
+
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), cappedCatalog)
+
+        assertEquals(2, result.size)
+        assertEquals(listOf("shopping-list", "recipe-nutrition"), result.map { it.id })
+    }
+
+    @Test
+    fun whenPageLanguageDiffersFromUiThenTranslateIncluded() {
+        val result = ContextualSuggestionsMatcher.resolve(
+            input(noSignals = false, jsonLdType = listOf("Unknown"), lang = "fr", uiLocale = "en-US"),
+            catalog,
+        )
+
+        assertTrue(result.any { it.id == "translate-page" })
+    }
+
+    @Test
+    fun whenPageLanguageMatchesUiThenTranslateExcluded() {
+        val result = ContextualSuggestionsMatcher.resolve(
+            input(jsonLdType = listOf("Unknown"), lang = "en", uiLocale = "en-US"),
+            catalog,
+        )
+
+        assertFalse(result.any { it.id == "translate-page" })
+    }
+
+    @Test
+    fun whenPageLanguageIsRegionalVariantOfUiThenTranslateExcluded() {
+        val result = ContextualSuggestionsMatcher.resolve(
+            input(jsonLdType = listOf("Unknown"), lang = "en-GB", uiLocale = "en_US"),
+            catalog,
+        )
+
+        assertFalse(result.any { it.id == "translate-page" })
+    }
+
+    @Test
+    fun whenPageLanguageMissingThenTranslateExcluded() {
+        val result = ContextualSuggestionsMatcher.resolve(
+            input(jsonLdType = listOf("Unknown"), lang = "", uiLocale = "en-US"),
+            catalog,
+        )
+
+        assertFalse(result.any { it.id == "translate-page" })
+    }
+
+    @Test
+    fun whenContextualMatchFillsCapAndTranslateApplicableThenTranslateDisplacesLastSuggestion() {
+        val articleCatalog = catalog.copy(
+            catalog = catalog.catalog +
+                mapOf(
+                    "a1" to entry("A1", prompt = "A1."),
+                    "a2" to entry("A2", prompt = "A2."),
+                    "a3" to entry("A3", prompt = "A3."),
+                    "a4" to entry("A4", prompt = "A4."),
+                ),
+            byJsonLdType = catalog.byJsonLdType + SuggestionCatalog.JsonLdMapping("Article", listOf("a1", "a2", "a3", "a4")),
+        )
+
+        val result = ContextualSuggestionsMatcher.resolve(
+            input(jsonLdType = listOf("Article"), lang = "fr", uiLocale = "en-US"),
+            articleCatalog,
+        )
+
+        assertEquals(listOf("a1", "a2", "a3", "translate-page"), result.map { it.id })
+    }
+
+    @Test
+    fun whenTranslateIncludedThenLanguagePlaceholderReplacedWithDisplayName() {
+        val result = ContextualSuggestionsMatcher.resolve(
+            input(jsonLdType = listOf("Unknown"), lang = "de", uiLocale = "en-US"),
+            catalog,
+        )
+
+        val translate = result.first { it.id == "translate-page" }
+        assertEquals("Translate this page into English.", translate.prompt)
+        assertFalse(translate.prompt.contains("{language}"))
+    }
+
+    @Test
+    fun whenPromptHasNoPlaceholderThenLeftUnchanged() {
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), catalog)
+
+        assertEquals("Create a shopping list.", result.first { it.id == "shopping-list" }.prompt)
+    }
+
+    @Test
+    fun whenEntryResolvedThenLabelAndIconCarriedThrough() {
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("VideoObject")), catalog)
+
+        val video = result.first { it.id == "summarize-video" }
+        assertEquals("Summarize this video", video.label)
+        assertEquals("summary", video.icon)
+    }
+
+    @Test
+    fun whenHostnameMerelyEndsWithDomainTextThenDoesNotMatch() {
+        val result = ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = "https://notgithub.com/duckduckgo"), catalog)
+
+        assertEquals(listOf("summarize-page"), result.map { it.id })
+    }
+
+    @Test
+    fun whenEntryHasUnknownConditionThenItIsExcluded() {
+        val futureCatalog = catalog.copy(
+            catalog = catalog.catalog + mapOf("future" to entry("Future", prompt = "Future.", condition = "notYetInvented")),
+            byJsonLdType = listOf(SuggestionCatalog.JsonLdMapping("Recipe", listOf("future", "shopping-list"))),
+        )
+
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), futureCatalog)
+
+        assertFalse(result.any { it.id == "future" })
+        assertTrue(result.any { it.id == "shopping-list" })
+    }
+
+    @Test
+    fun whenCandidateIdHasNoCatalogEntryThenItIsSkipped() {
+        val danglingCatalog = catalog.copy(
+            byJsonLdType = listOf(SuggestionCatalog.JsonLdMapping("Recipe", listOf("missing-id", "shopping-list"))),
+        )
+
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), danglingCatalog)
+
+        assertFalse(result.any { it.id == "missing-id" })
+        assertTrue(result.any { it.id == "shopping-list" })
+    }
+
+    @Test
+    fun whenUrlIsMalformedThenFallsBackToDefaults() {
+        val result = ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = "not a url ://"), catalog)
+
+        assertEquals(listOf("summarize-page"), result.map { it.id })
+    }
+
+    @Test
+    fun whenOgTypeIsBlankThenDomainTierIsStillConsulted() {
+        val result = ContextualSuggestionsMatcher.resolve(
+            input(jsonLdType = listOf("Unknown"), ogType = "", url = "https://github.com/duckduckgo"),
+            catalog,
+        )
+
+        assertEquals(listOf("explain-repo"), result.map { it.id })
+    }
+
+    @Test
+    fun whenMaxSuggestedPromptsIsZeroThenAtLeastOneSuggestionIsReturned() {
+        val zeroCapCatalog = catalog.copy(maxSuggestedPrompts = 0)
+
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), zeroCapCatalog)
+
+        assertEquals(listOf("shopping-list"), result.map { it.id })
+    }
+
+    @Test
+    fun whenNothingMatchesAndLanguageDiffersThenDefaultsKeepFloorThenPriorityOrder() {
+        val result = ContextualSuggestionsMatcher.resolve(
+            input(jsonLdType = listOf("Unknown"), lang = "fr", uiLocale = "en-US"),
+            catalog,
+        )
+
+        assertEquals(listOf("summarize-page", "translate-page"), result.map { it.id })
+    }
+
+    @Test
+    fun whenUiLocaleIsNotEnglishThenLanguageNameIsLocalizedInUiLanguage() {
+        val result = ContextualSuggestionsMatcher.resolve(
+            input(jsonLdType = listOf("Unknown"), lang = "en", uiLocale = "de-DE"),
+            catalog,
+        )
+
+        val translate = result.first { it.id == "translate-page" }
+        assertEquals("Translate this page into Deutsch.", translate.prompt)
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
@@ -56,7 +56,11 @@ class ContextualSuggestionsViewModelTest {
     fun setup() {
         whenever(duckChatFeature.contextualSuggestedPrompts()).thenReturn(suggestedPromptsToggle)
         whenever(suggestedPromptsToggle.isEnabled()).thenReturn(true)
-        runBlocking { stubProvider(emptyList()) }
+        runBlocking {
+            stubProvider(emptyList())
+            whenever(suggestedPromptsProvider.maxSuggestedPrompts()).thenReturn(4)
+            whenever(suggestedPromptsProvider.prioritySuggestionIds()).thenReturn(setOf("translate-page"))
+        }
     }
 
     private suspend fun stubProvider(result: List<ContextualSuggestedPrompt>) {
@@ -195,6 +199,53 @@ class ContextualSuggestionsViewModelTest {
         viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com/next","content":"c"}""")
 
         assertTrue(viewModel.viewState.value.suggestions.isEmpty())
+    }
+
+    @Test
+    fun `when quick action slot reserved then at most three suggestions shown with priority included`() = runTest {
+        val regular = (1..3).map { ContextualSuggestedPrompt("regular-$it", "Label $it", "Prompt $it.", null) }
+        val translate = ContextualSuggestedPrompt("translate-page", "Translate this page", "Translate.", "translate")
+        stubProvider(regular + translate)
+
+        viewModel.onReservedQuickActionSlotsChanged(1)
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+
+        assertEquals(listOf("regular-1", "regular-2", "translate-page"), viewModel.viewState.value.suggestions.map { it.id })
+    }
+
+    @Test
+    fun `when no quick action slot reserved then four suggestions shown`() = runTest {
+        val regular = (1..3).map { ContextualSuggestedPrompt("regular-$it", "Label $it", "Prompt $it.", null) }
+        val translate = ContextualSuggestedPrompt("translate-page", "Translate this page", "Translate.", "translate")
+        stubProvider(regular + translate)
+
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+
+        assertEquals(4, viewModel.viewState.value.suggestions.size)
+    }
+
+    @Test
+    fun `when reserved slot released then full suggestion list restored`() = runTest {
+        val regular = (1..3).map { ContextualSuggestedPrompt("regular-$it", "Label $it", "Prompt $it.", null) }
+        val translate = ContextualSuggestedPrompt("translate-page", "Translate this page", "Translate.", "translate")
+        stubProvider(regular + translate)
+        viewModel.onReservedQuickActionSlotsChanged(1)
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+
+        viewModel.onReservedQuickActionSlotsChanged(0)
+
+        assertEquals(4, viewModel.viewState.value.suggestions.size)
+    }
+
+    @Test
+    fun `when fewer suggestions than budget and slot reserved then list unchanged`() = runTest {
+        val suggestions = (1..2).map { ContextualSuggestedPrompt("regular-$it", "Label $it", "Prompt $it.", null) }
+        stubProvider(suggestions)
+
+        viewModel.onReservedQuickActionSlotsChanged(1)
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+
+        assertEquals(2, viewModel.viewState.value.suggestions.size)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
@@ -172,6 +172,32 @@ class ContextualSuggestionsViewModelTest {
     }
 
     @Test
+    fun `when feature disabled after suggestions rendered then next load clears them`() = runTest {
+        stubProvider(listOf(ContextualSuggestedPrompt("id", "Label", "Prompt.", null)))
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+        assertTrue(viewModel.viewState.value.suggestions.isNotEmpty())
+
+        whenever(suggestedPromptsToggle.isEnabled()).thenReturn(false)
+        viewModel.load()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(viewModel.viewState.value.suggestions.isEmpty())
+        assertFalse(viewModel.viewState.value.loading)
+    }
+
+    @Test
+    fun `when feature disabled after suggestions rendered then next page context clears them`() = runTest {
+        stubProvider(listOf(ContextualSuggestedPrompt("id", "Label", "Prompt.", null)))
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+        assertTrue(viewModel.viewState.value.suggestions.isNotEmpty())
+
+        whenever(suggestedPromptsToggle.isEnabled()).thenReturn(false)
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com/next","content":"c"}""")
+
+        assertTrue(viewModel.viewState.value.suggestions.isEmpty())
+    }
+
+    @Test
     fun `when cleared then suggestions and loading reset`() = runTest {
         val tailored = ContextualSuggestedPrompt("id", "Label", "Prompt.", null)
         stubProvider(listOf(tailored))

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual.suggestions
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class ContextualSuggestionsViewModelTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val suggestedPromptsProvider: ContextualSuggestedPromptsProvider = mock()
+    private val duckChatFeature: DuckChatFeature = mock()
+    private val suggestedPromptsToggle: Toggle = mock()
+
+    private val viewModel = ContextualSuggestionsViewModel(
+        suggestedPromptsProvider = suggestedPromptsProvider,
+        duckChatFeature = duckChatFeature,
+        dispatchers = coroutineRule.testDispatcherProvider,
+    )
+
+    @Before
+    fun setup() {
+        whenever(duckChatFeature.contextualSuggestedPrompts()).thenReturn(suggestedPromptsToggle)
+        whenever(suggestedPromptsToggle.isEnabled()).thenReturn(true)
+        runBlocking { stubProvider(emptyList()) }
+    }
+
+    private suspend fun stubProvider(result: List<ContextualSuggestedPrompt>) {
+        whenever(suggestedPromptsProvider.resolveSuggestions(any())).thenReturn(result)
+    }
+
+    @Test
+    fun `when feature disabled then load does nothing`() = runTest {
+        whenever(suggestedPromptsToggle.isEnabled()).thenReturn(false)
+
+        viewModel.load()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(viewModel.viewState.value.loading)
+        assertTrue(viewModel.viewState.value.suggestions.isEmpty())
+        verify(suggestedPromptsProvider, never()).resolveSuggestions(any())
+    }
+
+    @Test
+    fun `when load starts then loading state begins`() = runTest {
+        viewModel.load()
+        coroutineRule.testDispatcher.scheduler.runCurrent()
+
+        assertTrue(viewModel.viewState.value.loading)
+    }
+
+    @Test
+    fun `when timeout elapses without page context then defaults resolved with no url`() = runTest {
+        viewModel.load()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(viewModel.viewState.value.loading)
+        val captor = argumentCaptor<ResolvePageSuggestionsInput>()
+        verify(suggestedPromptsProvider).resolveSuggestions(captor.capture())
+        assertEquals(null, captor.lastValue.url)
+        assertEquals(null, captor.lastValue.pageTypeSignals)
+    }
+
+    @Test
+    fun `when page context arrives while loading then suggestions resolved and timeout tick is a no-op`() = runTest {
+        val tailored = ContextualSuggestedPrompt("summarize-video", "Summarize this video", "Summarize this video.", "summary")
+        stubProvider(listOf(tailored))
+
+        viewModel.load()
+        coroutineRule.testDispatcher.scheduler.runCurrent()
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf(tailored), viewModel.viewState.value.suggestions)
+        assertFalse(viewModel.viewState.value.loading)
+        verify(suggestedPromptsProvider, times(1)).resolveSuggestions(any())
+    }
+
+    @Test
+    fun `when page context has page-type signals then they are parsed and passed to the provider`() = runTest {
+        viewModel.onPageContextUpdated(
+            """
+            {"title":"T","url":"https://www.bbc.co.uk/food","content":"c",
+             "pageTypeSignals":{"jsonLdType":["Recipe"],"ogType":"article","lang":"en"}}
+            """.trimIndent(),
+        )
+
+        val captor = argumentCaptor<ResolvePageSuggestionsInput>()
+        verify(suggestedPromptsProvider, atLeastOnce()).resolveSuggestions(captor.capture())
+        val input = captor.lastValue
+        assertEquals(listOf("Recipe"), input.pageTypeSignals?.jsonLdType)
+        assertEquals("article", input.pageTypeSignals?.ogType)
+        assertEquals("en", input.pageTypeSignals?.lang)
+        assertEquals("https://www.bbc.co.uk/food", input.url)
+    }
+
+    @Test
+    fun `when resolved suggestions include summarize-page then it is filtered out`() = runTest {
+        val tailored = ContextualSuggestedPrompt("key-takeaways", "What are the key takeaways?", "Key takeaways?", "summary")
+        val summarize = ContextualSuggestedPrompt("summarize-page", "Summarize this page", "Summarize this page.", "summary")
+        stubProvider(listOf(summarize, tailored))
+
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+
+        assertEquals(listOf(tailored), viewModel.viewState.value.suggestions)
+    }
+
+    @Test
+    fun `when page context arrives after timeout then defaults upgraded to page-tailored suggestions`() = runTest {
+        viewModel.load()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        val tailored = ContextualSuggestedPrompt("explain-repo", "Explain this repo", "Explain this repo.", null)
+        stubProvider(listOf(tailored))
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://github.com/duckduckgo","content":"c"}""")
+
+        assertEquals(listOf(tailored), viewModel.viewState.value.suggestions)
+    }
+
+    @Test
+    fun `when page context is not valid json then it is ignored`() = runTest {
+        viewModel.load()
+        coroutineRule.testDispatcher.scheduler.runCurrent()
+
+        viewModel.onPageContextUpdated("not json")
+
+        assertTrue(viewModel.viewState.value.loading)
+        verify(suggestedPromptsProvider, never()).resolveSuggestions(any())
+    }
+
+    @Test
+    fun `when feature disabled then page context is ignored`() = runTest {
+        whenever(suggestedPromptsToggle.isEnabled()).thenReturn(false)
+
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+
+        assertTrue(viewModel.viewState.value.suggestions.isEmpty())
+        verify(suggestedPromptsProvider, never()).resolveSuggestions(any())
+    }
+
+    @Test
+    fun `when cleared then suggestions and loading reset`() = runTest {
+        val tailored = ContextualSuggestedPrompt("id", "Label", "Prompt.", null)
+        stubProvider(listOf(tailored))
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+
+        viewModel.clear()
+
+        assertTrue(viewModel.viewState.value.suggestions.isEmpty())
+        assertFalse(viewModel.viewState.value.loading)
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.contextual.suggestions
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -180,6 +181,26 @@ class ContextualSuggestionsViewModelTest {
         viewModel.clear()
 
         assertTrue(viewModel.viewState.value.suggestions.isEmpty())
+        assertFalse(viewModel.viewState.value.loading)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when start surface cycles then stale timeout from previous cycle cannot cut the new load short`() = runTest {
+        viewModel.load()
+        coroutineRule.testDispatcher.scheduler.advanceTimeBy(1_000)
+        viewModel.clear()
+
+        viewModel.load()
+        coroutineRule.testDispatcher.scheduler.runCurrent()
+        assertTrue(viewModel.viewState.value.loading)
+
+        coroutineRule.testDispatcher.scheduler.advanceTimeBy(4_500)
+
+        assertTrue(viewModel.viewState.value.loading)
+        verify(suggestedPromptsProvider, never()).resolveSuggestions(any())
+
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
         assertFalse(viewModel.viewState.value.loading)
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
@@ -133,7 +133,7 @@ class ContextualSuggestionsViewModelTest {
     }
 
     @Test
-    fun `when provider returns the summarize-page fallback then it is rendered`() = runTest {
+    fun `when provider returns a summarize-page suggestion then it is rendered`() = runTest {
         val fallback = ContextualSuggestedPrompt("summarize-page", "Summarize this page", "Summarize this page.", "summary")
         stubProvider(listOf(fallback))
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
@@ -155,6 +155,18 @@ class ContextualSuggestionsViewModelTest {
     }
 
     @Test
+    fun `when page context lacks content then suggestions are not re-targeted`() = runTest {
+        val tailored = ContextualSuggestedPrompt("key-takeaways", "What are the key takeaways?", "Key takeaways?", "summary")
+        stubProvider(listOf(tailored))
+        viewModel.onPageContextUpdated("""{"title":"Page A","url":"https://a.com","content":"a content"}""")
+
+        viewModel.onPageContextUpdated("""{"title":"Page B","url":"https://b.com"}""")
+
+        assertEquals(listOf(tailored), viewModel.viewState.value.suggestions)
+        verify(suggestedPromptsProvider, times(1)).resolveSuggestions(any())
+    }
+
+    @Test
     fun `when page context is not valid json then it is ignored`() = runTest {
         viewModel.load()
         coroutineRule.testDispatcher.scheduler.runCurrent()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
@@ -129,14 +129,13 @@ class ContextualSuggestionsViewModelTest {
     }
 
     @Test
-    fun `when resolved suggestions include summarize-page then it is filtered out`() = runTest {
-        val tailored = ContextualSuggestedPrompt("key-takeaways", "What are the key takeaways?", "Key takeaways?", "summary")
-        val summarize = ContextualSuggestedPrompt("summarize-page", "Summarize this page", "Summarize this page.", "summary")
-        stubProvider(listOf(summarize, tailored))
+    fun `when provider returns the summarize-page fallback then it is rendered`() = runTest {
+        val fallback = ContextualSuggestedPrompt("summarize-page", "Summarize this page", "Summarize this page.", "summary")
+        stubProvider(listOf(fallback))
 
         viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
 
-        assertEquals(listOf(tailored), viewModel.viewState.value.suggestions)
+        assertEquals(listOf(fallback), viewModel.viewState.value.suggestions)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/RealContextualSuggestedPromptsProviderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/RealContextualSuggestedPromptsProviderTest.kt
@@ -92,6 +92,20 @@ class RealContextualSuggestedPromptsProviderTest {
     }
 
     @Test
+    fun whenRealCatalogThenBudgetAndPriorityIdsComeFromCatalog() = runTest {
+        assertEquals(4, provider.maxSuggestedPrompts())
+        assertEquals(setOf("translate-page"), provider.prioritySuggestionIds())
+    }
+
+    @Test
+    fun whenCatalogAssetMissingThenBudgetMatchesFallbackAndNoPriorityIds() = runTest {
+        provider.catalogAssetPath = "DoesNotExist.json"
+
+        assertEquals(1, provider.maxSuggestedPrompts())
+        assertEquals(emptySet<String>(), provider.prioritySuggestionIds())
+    }
+
+    @Test
     fun whenCatalogAssetMissingThenReturnsSummarizePageFallback() = runTest {
         provider.catalogAssetPath = "DoesNotExist.json"
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/RealContextualSuggestedPromptsProviderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/RealContextualSuggestedPromptsProviderTest.kt
@@ -98,7 +98,7 @@ class RealContextualSuggestedPromptsProviderTest {
     }
 
     @Test
-    fun whenCatalogAssetMissingThenBudgetMatchesFallbackAndNoPriorityIds() = runTest {
+    fun whenCatalogAssetMissingThenMinimalBudgetAndNoPriorityIds() = runTest {
         provider.catalogAssetPath = "DoesNotExist.json"
 
         assertEquals(1, provider.maxSuggestedPrompts())
@@ -106,7 +106,7 @@ class RealContextualSuggestedPromptsProviderTest {
     }
 
     @Test
-    fun whenCatalogAssetMissingThenReturnsSummarizePageFallback() = runTest {
+    fun whenCatalogAssetMissingThenReturnsNoSuggestions() = runTest {
         provider.catalogAssetPath = "DoesNotExist.json"
 
         val result = provider.resolveSuggestions(
@@ -117,7 +117,6 @@ class RealContextualSuggestedPromptsProviderTest {
             ),
         )
 
-        assertEquals(1, result.size)
-        assertEquals("summarize-page", result.first().id)
+        assertTrue(result.isEmpty())
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/RealContextualSuggestedPromptsProviderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/RealContextualSuggestedPromptsProviderTest.kt
@@ -64,7 +64,7 @@ class RealContextualSuggestedPromptsProviderTest {
     }
 
     @Test
-    fun whenRealCatalogAndNothingMatchesThenReturnsNonEmptyFloor() = runTest {
+    fun whenRealCatalogResolvesThenSummarizePageIsExcluded() = runTest {
         val result = provider.resolveSuggestions(
             ResolvePageSuggestionsInput(
                 pageTypeSignals = null,
@@ -73,8 +73,7 @@ class RealContextualSuggestedPromptsProviderTest {
             ),
         )
 
-        assertTrue(result.isNotEmpty())
-        assertTrue(result.any { it.id == "summarize-page" })
+        assertTrue(result.none { it.id == "summarize-page" })
         assertTrue(result.size <= 4)
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/RealContextualSuggestedPromptsProviderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/RealContextualSuggestedPromptsProviderTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual.suggestions
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RealContextualSuggestedPromptsProviderTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val provider = RealContextualSuggestedPromptsProvider(context, coroutineRule.testDispatcherProvider)
+
+    @Test
+    fun whenRealCatalogAndDomainMatchesThenResolvesPageSpecificSuggestions() = runTest {
+        val result = provider.resolveSuggestions(
+            ResolvePageSuggestionsInput(
+                pageTypeSignals = null,
+                url = "https://www.youtube.com/watch?v=abc",
+                uiLocale = "en-US",
+            ),
+        )
+
+        assertEquals(listOf("summarize-video", "video-key-points"), result.map { it.id })
+    }
+
+    @Test
+    fun whenRealCatalogAndJsonLdTypeMatchesThenResolvesPageSpecificSuggestions() = runTest {
+        val result = provider.resolveSuggestions(
+            ResolvePageSuggestionsInput(
+                pageTypeSignals = PageTypeSignals(jsonLdType = listOf("Recipe"), ogType = null, lang = "en"),
+                url = "https://example.com/recipe",
+                uiLocale = "en-US",
+            ),
+        )
+
+        assertEquals(listOf("shopping-list", "recipe-nutrition", "scale-recipe"), result.map { it.id })
+    }
+
+    @Test
+    fun whenRealCatalogAndNothingMatchesThenReturnsNonEmptyFloor() = runTest {
+        val result = provider.resolveSuggestions(
+            ResolvePageSuggestionsInput(
+                pageTypeSignals = null,
+                url = "https://example.com",
+                uiLocale = "en-US",
+            ),
+        )
+
+        assertTrue(result.isNotEmpty())
+        assertTrue(result.any { it.id == "summarize-page" })
+        assertTrue(result.size <= 4)
+    }
+
+    @Test
+    fun whenRealCatalogAndDifferentLanguageThenTranslateIsTemplated() = runTest {
+        val result = provider.resolveSuggestions(
+            ResolvePageSuggestionsInput(
+                pageTypeSignals = PageTypeSignals(jsonLdType = emptyList(), ogType = null, lang = "fr"),
+                url = "https://example.com",
+                uiLocale = "en-US",
+            ),
+        )
+
+        val translate = result.first { it.id == "translate-page" }
+        assertEquals("Translate this page into English.", translate.prompt)
+    }
+
+    @Test
+    fun whenCatalogAssetMissingThenReturnsSummarizePageFallback() = runTest {
+        provider.catalogAssetPath = "DoesNotExist.json"
+
+        val result = provider.resolveSuggestions(
+            ResolvePageSuggestionsInput(
+                pageTypeSignals = null,
+                url = "https://www.youtube.com/watch?v=abc",
+                uiLocale = "en-US",
+            ),
+        )
+
+        assertEquals(1, result.size)
+        assertEquals("summarize-page", result.first().id)
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -312,6 +312,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSuggestions", false)
             put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
@@ -653,6 +654,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSuggestions", false)
             put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
@@ -750,6 +752,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSuggestions", false)
             put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
@@ -909,6 +912,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", true)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSuggestions", false)
             put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
@@ -920,6 +924,60 @@ class RealDuckChatJSHelperTest {
         assertEquals(expected.method, result.method)
         assertEquals(expected.featureName, result.featureName)
         assertEquals(expected.params.toString(), result.params.toString())
+    }
+
+    @Test
+    fun whenGetAIChatNativeConfigValuesAndSuggestedPromptsEnabledInContextualModeThenSupportsSuggestionsTrue() = runTest {
+        whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(true)
+        whenever(mockDuckChat.isDuckChatContextualModeEnabled()).thenReturn(true)
+        mockDuckChatFeature.contextualSuggestedPrompts().setRawStoredState(Toggle.State(enable = true))
+
+        val result = testee.processJsCallbackMessage(
+            "aiChat",
+            "getAIChatNativeConfigValues",
+            "123",
+            null,
+            Mode.CONTEXTUAL,
+            viewModel.updatedPageContext,
+        )
+
+        assertTrue(result!!.params.getBoolean("supportsSuggestions"))
+    }
+
+    @Test
+    fun whenGetAIChatNativeConfigValuesAndSuggestedPromptsEnabledButModeFullThenSupportsSuggestionsFalse() = runTest {
+        whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(true)
+        whenever(mockDuckChat.isDuckChatContextualModeEnabled()).thenReturn(true)
+        mockDuckChatFeature.contextualSuggestedPrompts().setRawStoredState(Toggle.State(enable = true))
+
+        val result = testee.processJsCallbackMessage(
+            "aiChat",
+            "getAIChatNativeConfigValues",
+            "123",
+            null,
+            Mode.FULL,
+            viewModel.updatedPageContext,
+        )
+
+        assertFalse(result!!.params.getBoolean("supportsSuggestions"))
+    }
+
+    @Test
+    fun whenGetAIChatNativeConfigValuesAndSuggestedPromptsEnabledButContextualModeDisabledThenSupportsSuggestionsFalse() = runTest {
+        whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(true)
+        whenever(mockDuckChat.isDuckChatContextualModeEnabled()).thenReturn(false)
+        mockDuckChatFeature.contextualSuggestedPrompts().setRawStoredState(Toggle.State(enable = true))
+
+        val result = testee.processJsCallbackMessage(
+            "aiChat",
+            "getAIChatNativeConfigValues",
+            "123",
+            null,
+            Mode.CONTEXTUAL,
+            viewModel.updatedPageContext,
+        )
+
+        assertFalse(result!!.params.getBoolean("supportsSuggestions"))
     }
 
     @Test
@@ -957,6 +1015,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", true)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", true)
+            put("supportsSuggestions", false)
             put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
@@ -1002,6 +1061,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSuggestions", false)
             put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
@@ -1047,6 +1107,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", true)
             put("supportsMultipleContexts", false)
+            put("supportsSuggestions", false)
             put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
@@ -1359,6 +1420,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSuggestions", false)
             put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
@@ -1401,6 +1463,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSuggestions", false)
             put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
@@ -1443,6 +1506,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSuggestions", false)
             put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
@@ -1486,6 +1550,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSuggestions", false)
             put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217024500235994?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1216117537545343?focus=true
API Proposals URL(s) (if applicable):

### Description

- Adds suggested prompts to the contextual sheet

### Steps to test this PR

_Fresh install from this branch_

_Movie_
- [x] Go to https://www.imdb.com/title/tt4971344/ and open contextual
- [x] Verify related suggestions displayed
- [x] Click a suggestion
- [x] Verify suggestion submitted with context

_E-commerce_
- [x] Go to https://www.amazon.com/Sonos-Five-High-Fidelity-Speaker-Superior/dp/B0876H4X8X and open contextual
- [x] Verify related suggestions displayed
- [x] Click a suggestion
- [x] Verify suggestion submitted with context

_Paper_
- [x] Go to https://arxiv.org/list/cs.AI/recent and open contextual
- [x] Verify related suggestions displayed
- [x] Click a suggestion
- [x] Verify suggestion submitted with context

_Recipe_
- [x] Go to https://www.bbc.co.uk/food/recipes/no-bake_strawberry_30276 and open contextual
- [x] Verify related suggestions displayed
- [x] Click a suggestion
- [x] Verify suggestion submitted with context

_New chat_
- [x] Submit a suggestion
- [x] Start a new chat from the overflow
- [x] Verify related suggestions displayed

_Navigation_
- [x] Navigate between two different sites (e.g. IMDB listing -> BBC recipe)
- [x] Verify that the suggestions are updated accordingly

_Loading indicator_
- [x] This one’s a bit hard to test but open contextual before a site has fully loaded
- [x] Verify that the loading indicator is visible before the suggestions are shown

_Automatically Send Page Context_
- [x] Enable "Automatically Send Page Context” in AI Features
- [x] Verify that only the suggestions are shown when context is attached

_Disable feature_
- [x] Disable feature
- [x] Open https://www.imdb.com/title/tt4971344/
- [x] Verify no suggestions displayed
(if the sheet is already open it requires a new page context or closing the sheet to clear)

### UI changes

Context unattached

| Before  | After |
| ------ | ----- |
<img width="1080" height="2400" alt="Screenshot_20260730_211139" src="https://github.com/user-attachments/assets/db3837b8-1675-4ee6-b422-465c2101f5b2" />|<img width="1080" height="2400" alt="Screenshot_20260730_211340" src="https://github.com/user-attachments/assets/a1754970-9a65-470a-9f2e-f961d8ae4f7e" />

Context attached

| Before  | After |
| ------ | ----- |
<img width="1080" height="2400" alt="Screenshot_20260730_211535" src="https://github.com/user-attachments/assets/b651255f-c16e-4fb4-a2b2-faa93ef06719" />|<img width="1080" height="2400" alt="Screenshot_20260730_211357" src="https://github.com/user-attachments/assets/54a1533f-c27b-4c81-af3c-f8ad1c4ce67e" />

No suggestions (context unattached)

| Before  | After |
| ------ | ----- |
<img width="1080" height="2400" alt="Screenshot_20260730_211938" src="https://github.com/user-attachments/assets/737ff17b-6117-4b42-aed8-20988da039d4" />|<img width="1080" height="2400" alt="Screenshot_20260730_211938" src="https://github.com/user-attachments/assets/812145fc-4453-4d85-ba74-560c6f673e6f" />

No suggestions (context attached)

| Before  | After |
| ------ | ----- |
<img width="1080" height="2400" alt="Screenshot_20260730_211930" src="https://github.com/user-attachments/assets/a7beac4a-b21c-4be9-9530-01b2fec1231d" />|<img width="1080" height="2400" alt="Screenshot_20260730_211930" src="https://github.com/user-attachments/assets/c58d6760-4d36-449e-85fb-45774216599c" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches contextual sheet layout, bottom-sheet sizing, and prompt submission with page context; feature is toggle-gated but user-facing chat behavior changes when enabled.
> 
> **Overview**
> Adds **context-aware suggested prompts** on the contextual Duck.ai input surface, gated by a new **`contextualSuggestedPrompts`** feature toggle (default internal).
> 
> Prompts come from a bundled **`PageSuggestionsCatalog.json`**, resolved via JSON-LD type, Open Graph type, and domain, with conditions (e.g. translate when page language differs from UI) and a cap of four cards. Tapping a suggestion attaches page context when valid and submits the prompt like the existing quick actions.
> 
> The sheet UI gains **`ContextualSuggestionsView`** (loading dots + chips), a scrollable prompt area, and logic that **hides the legacy Summarize quick action** when suggestions already cover summarize-style content. **Half-expanded sheet height** is recalculated so prompt cards fit above the composer.
> 
> **`supportsSuggestions`** is added to the Duck.ai native JS config when contextual mode and the toggle are on. New chat / sheet reopen paths refresh suggestions and re-request page context where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66c66667feec987598e861721ce37f231d19986d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->