### PR TITLE
Move ContentScopeScripts inbound JS messages off the JavaBridge thread

### DIFF
--- a/PixelDefinitions/pixels/definitions/content_scope_scripts.json5
+++ b/PixelDefinitions/pixels/definitions/content_scope_scripts.json5
@@ -1,0 +1,8 @@
+{
+    "m_content_scope_scripts_inbound_queue_full": {
+        "description": "The bounded queue of inbound contentScopeScripts JS messages was full, so a message was dropped without being routed to a handler. Reported once per overflow episode, at most once per day, and indicates the optimizeContentScopeMessaging kill-switch may need to be pulled.",
+        "owners": ["anikiki"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count"]
+    }
+}

--- a/content-scope-scripts/content-scope-scripts-impl/build.gradle
+++ b/content-scope-scripts/content-scope-scripts-impl/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation project(':browser-api')
     implementation project(':feature-toggles-api')
     implementation project(':js-messaging-api')
+    implementation project(':statistics-api')
     implementation project(':ad-blocking-api')
     implementation project(':data-store-api')
     implementation AndroidX.webkit

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
@@ -44,4 +44,15 @@ interface ContentScopeScriptsFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun optimizeContentScopeInjection(): Toggle
+
+    /**
+     * Kill-switch for the ContentScopeScripts inbound messaging performance work. Separate from
+     * [optimizeContentScopeInjection] so that either can be rolled back on its own.
+     * When enabled, inbound JS messages are queued and routed off the WebView JavaBridge thread.
+     * @return `true` when the remote config has the global "optimizeContentScopeMessaging" clientContentFeatures
+     * sub-feature flag enabled.
+     * If the remote feature is not present defaults to `internal`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun optimizeContentScopeMessaging(): Toggle
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
@@ -46,8 +46,7 @@ interface ContentScopeScriptsFeature {
     fun optimizeContentScopeInjection(): Toggle
 
     /**
-     * Kill-switch for the ContentScopeScripts inbound messaging performance work. Separate from
-     * [optimizeContentScopeInjection] so that either can be rolled back on its own.
+     * Kill-switch for the ContentScopeScripts inbound messaging performance work.
      * When enabled, inbound JS messages are queued and routed off the WebView JavaBridge thread.
      * @return `true` when the remote config has the global "optimizeContentScopeMessaging" clientContentFeatures
      * sub-feature flag enabled.

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
@@ -19,11 +19,16 @@ package com.duckduckgo.contentscopescripts.impl.messaging
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import androidx.core.net.toUri
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.toTldPlusOne
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.contentscopescripts.api.ContentScopeJsMessageHandlersPlugin
+import com.duckduckgo.contentscopescripts.impl.ContentScopeScriptsFeature
 import com.duckduckgo.contentscopescripts.impl.CoreContentScopeScripts
+import com.duckduckgo.contentscopescripts.impl.messaging.ContentScopeScriptsMessagingPixelName.INBOUND_QUEUE_FULL
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.js.messaging.api.JsErrorDetails
@@ -36,13 +41,25 @@ import com.duckduckgo.js.messaging.api.SubscriptionEvent
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.Moshi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import logcat.LogPriority.ERROR
+import logcat.LogPriority.WARN
 import logcat.asLog
 import logcat.logcat
 import org.json.JSONObject
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Named
+
+// Backstop against unbounded growth, not a tuning parameter: observed depth on real pages is 0-1.
+internal const val MAX_QUEUED_MESSAGES = 512
 
 @ContributesBinding(ActivityScope::class)
 @Named("ContentScopeScripts")
@@ -51,11 +68,94 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val coreContentScopeScripts: CoreContentScopeScripts,
     private val handlers: PluginPoint<ContentScopeJsMessageHandlersPlugin>,
+    private val contentScopeScriptsFeature: ContentScopeScriptsFeature,
+    private val pixel: Pixel,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : JsMessaging {
     private val moshi = Moshi.Builder().add(JSONObjectAdapter()).build()
 
-    private lateinit var webView: WebView
-    private lateinit var jsMessageCallback: JsMessageCallback
+    /**
+     * The WebView and callback a message must be routed against, published as one object so a reader gets a consistent
+     * pair rather than the WebView of one registration and the callback of the next. Queued messages carry the instance
+     * they arrived under, which is what lets [handle] recognise a message belonging to a WebView that is already gone —
+     * draining the queue in [register] cannot do that on its own, because the consumer may already have taken a message
+     * out of it.
+     */
+    private class Registration(
+        val webView: WebView,
+        val jsMessageCallback: JsMessageCallback,
+    )
+
+    @Volatile
+    private var registration: Registration? = null
+
+    /**
+     * The producer/consumer handoff for inbound messages. [process] is the producer: it runs on the WebView JavaBridge
+     * thread and only enqueues. [ensureQueueConsumerRunning] starts the consumer, of which there is at most one, so that
+     * handlers keep seeing messages one at a time and in the order the page sent them. The consumer stops once the queue
+     * drains, which keeps it from outliving the WebView.
+     *
+     * Bounded because enqueueing removed the backpressure the synchronous JavaBridge call used to provide: the page's JS
+     * thread no longer waits for a message to be handled, so nothing else limits how many can pile up behind a slow
+     * handler.
+     */
+    private val inboundQueue = LinkedBlockingQueue<QueuedMessage>(MAX_QUEUED_MESSAGES)
+    private val queueConsumerActive = AtomicBoolean(false)
+
+    /**
+     * One overflow episode reports once, rather than every message that arrives while the queue stays full. Reset when the
+     * consumer drains, so a later episode is still visible.
+     */
+    private val overflowReported = AtomicBoolean(false)
+
+    /**
+     * A message, the registration it arrived under, and — for domain restricted features only — the url of the document
+     * that sent it. The url read is scheduled when the message arrives rather than when it is handled, so it is not
+     * ordered behind everything else already queued: it decides whether a privileged feature may act on the message, and
+     * a page can navigate while its message is still waiting.
+     */
+    private class QueuedMessage(
+        val registration: Registration,
+        val jsMessage: JsMessage,
+        val url: Deferred<String?>?,
+    )
+
+    /**
+     * Handler lookup by feature name and method, so routing a message doesn't have to build every registered handler.
+     * The plugins are a fixed multibinding and their `featureName`/`methods` are constants, so the index is built once;
+     * the matched handler is still rebuilt per message because `allowedDomains` isn't constant — internal builds can
+     * change the Duck.ai host at runtime.
+     */
+    private val handlersByFeatureAndMethod: Map<String, Map<String, List<ContentScopeJsMessageHandlersPlugin>>> by lazy {
+        val index = mutableMapOf<String, MutableMap<String, MutableList<ContentScopeJsMessageHandlersPlugin>>>()
+        handlers.getPlugins().forEach { plugin ->
+            val handler = plugin.getJsMessageHandler()
+            handler.methods.forEach { method ->
+                index
+                    .getOrPut(handler.featureName) { mutableMapOf() }
+                    .getOrPut(method) { mutableListOf() }
+                    .add(plugin)
+            }
+        }
+        index
+    }
+
+    /**
+     * Features with at least one domain restricted handler, so we know whether a message needs its sending document's url
+     * without scanning handlers on the JavaBridge thread. Whether `allowedDomains` is empty is fixed per handler even
+     * though its contents are not, so this can be cached.
+     */
+    private val domainRestrictedFeatures: Set<String> by lazy {
+        handlersByFeatureAndMethod
+            .filterValues { methods ->
+                methods.values.flatten().any { it.getJsMessageHandler().allowedDomains.isNotEmpty() }
+            }.keys
+    }
+
+    // Sampled when the interface is attached rather than per message: the JavaBridge thread should not be reading
+    // feature state on every inbound message, and a flag change takes effect on the next WebView anyway.
+    @Volatile
+    private var optimizedProcessing: Boolean = false
 
     override val context: String = "contentScopeScripts"
     override val callbackName: String = coreContentScopeScripts.callbackName
@@ -67,7 +167,164 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
         message: String,
         secret: String,
     ) {
+        if (optimizedProcessing) {
+            processOptimized(message, secret)
+        } else {
+            processLegacy(message, secret)
+        }
+    }
+
+    private fun processOptimized(
+        message: String,
+        secret: String,
+    ) {
+        if (this.secret != secret) return
+        val jsMessage = parseJsMessage(message) ?: return
+        if (context != jsMessage.context) return
+        val registration = this.registration ?: return
+
+        // Produce and return: reading the url here would block the page's JS, since JavaBridge calls are synchronous from
+        // the page's point of view. Domain restricted features still have it read now, just without waiting for it.
+        val url =
+            if (allowedDomains.isNotEmpty() || jsMessage.featureName in domainRestrictedFeatures) {
+                appCoroutineScope.async(dispatcherProvider.main()) {
+                    runCatching { registration.webView.url }.getOrNull()
+                }
+            } else {
+                null
+            }
+        if (!inboundQueue.offer(QueuedMessage(registration, jsMessage, url))) {
+            // Nothing will await it, and cancelling before the main thread reaches it spares the dispatch entirely.
+            url?.cancel()
+            logcat(WARN) { "Inbound queue full, dropping ${jsMessage.featureName}.${jsMessage.method}" }
+            reportOverflow()
+            return
+        }
+        ensureQueueConsumerRunning()
+    }
+
+    /**
+     * A drop leaves any page waiting on a reply to this message waiting forever, which the synchronous JavaBridge call
+     * could not do. Reported so the kill-switch decision doesn't depend on a logcat nobody is reading on a release build.
+     */
+    private fun reportOverflow() {
+        if (!overflowReported.compareAndSet(false, true)) return
+        pixel.fire(INBOUND_QUEUE_FULL, type = Daily())
+    }
+
+    /**
+     * Parsed here rather than with Moshi because [JsMessage] has no generated adapter, so Moshi falls back to reflection:
+     * that measured as roughly 40% of the work this does on the JavaBridge thread, which is time the page's JS spends
+     * blocked. Returns null for anything we could not route, and the caller drops it. [processLegacy] keeps using Moshi so
+     * that the flag-off path stays exactly as it shipped.
+     */
+    private fun parseJsMessage(message: String): JsMessage? =
+        runCatching {
+            val json = JSONObject(message)
+            val featureName = json.optString("featureName")
+            val method = json.optString("method")
+            when {
+                featureName.isEmpty() || method.isEmpty() -> null
+                else ->
+                    JsMessage(
+                        context = json.optString("context"),
+                        featureName = featureName,
+                        method = method,
+                        params = json.optJSONObject("params") ?: JSONObject(),
+                        // isNull() covers both an absent id and an explicit JSON null, which optString() would otherwise
+                        // hand back as the string "null".
+                        id = if (json.isNull("id")) null else json.optString("id").takeUnless { it.isEmpty() },
+                    )
+            }
+        }.onFailure { logcat(ERROR) { "Exception is ${it.asLog()}" } }
+            .getOrNull()
+
+    private fun ensureQueueConsumerRunning() {
+        if (!queueConsumerActive.compareAndSet(false, true)) return
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            while (true) {
+                try {
+                    while (true) {
+                        ensureActive()
+                        val jsMessage = inboundQueue.poll() ?: break
+                        try {
+                            handle(jsMessage)
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            logcat(ERROR) { "Exception is ${e.asLog()}" }
+                        }
+                    }
+                } finally {
+                    // Released in a finally, and only while we still own it: anything escaping the loop (cancellation,
+                    // an Error) would otherwise leave the flag set with no consumer running, and no later message could
+                    // ever start one again.
+                    queueConsumerActive.set(false)
+                }
+                if (inboundQueue.isEmpty()) {
+                    overflowReported.set(false)
+                    return@launch
+                }
+                // A message queued while we were stopping found the consumer still active and started none of its own,
+                // so re-acquire rather than leave it unhandled. Losing the race means someone else took over.
+                if (!queueConsumerActive.compareAndSet(false, true)) return@launch
+            }
+        }
+    }
+
+    private suspend fun handle(queued: QueuedMessage) {
+        // Identity, not equality: a message belonging to a WebView that has since been replaced must not be routed
+        // against the one that took its place.
+        if (queued.registration !== this.registration) {
+            queued.url?.cancel()
+            return
+        }
+        val jsMessage = queued.jsMessage
+        val webView = queued.registration.webView
+        val jsMessageCallback = queued.registration.jsMessageCallback
+        val host = queued.url?.await()?.toUri()?.host
+
+        if (allowedDomains.isNotEmpty() && !isUrlAllowed(allowedDomains, host)) return
+
+        if (jsMessage.featureName == "webEvents" && jsMessage.method == "webEvent") {
+            val nativeData = JSONObject()
+            nativeData.put("webViewId", System.identityHashCode(webView).toString())
+            jsMessage.params.put("nativeData", nativeData)
+        }
+        if (jsMessage.method == "addDebugFlag") {
+            // If method is addDebugFlag, we want to handle it for all features
+            jsMessageCallback.process(
+                featureName = jsMessage.featureName,
+                method = jsMessage.method,
+                id = jsMessage.id,
+                data = jsMessage.params,
+            )
+            return
+        }
+
+        val handler =
+            handlersByFeatureAndMethod[jsMessage.featureName]
+                ?.get(jsMessage.method)
+                ?.firstNotNullOfOrNull { plugin ->
+                    plugin.getJsMessageHandler().takeIf { isUrlAllowed(it.allowedDomains, host) }
+                }
+
+        if (handler == null) {
+            jsMessage.id?.let { id -> sendMethodNotFoundError(jsMessage, id, webView) }
+            return
+        }
+        handler.process(jsMessage, this, jsMessageCallback)
+    }
+
+    // Used when optimizeContentScopeMessaging is disabled; delete with the flag.
+    private fun processLegacy(
+        message: String,
+        secret: String,
+    ) {
         try {
+            val registration = this.registration ?: return
+            val webView = registration.webView
+            val jsMessageCallback = registration.jsMessageCallback
             val adapter = moshi.adapter(JsMessage::class.java)
             val jsMessage = adapter.fromJson(message)
             val domain =
@@ -97,7 +354,7 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
                                 it.methods.contains(jsMessage.method) && it.featureName == jsMessage.featureName &&
                                     isUrlAllowed(it.allowedDomains, domain)
                             }?.process(jsMessage, this, jsMessageCallback) ?: run {
-                            jsMessage.id?.let { id -> sendMethodNotFoundError(jsMessage, id) }
+                            jsMessage.id?.let { id -> sendMethodNotFoundError(jsMessage, id, webView) }
                         }
                     }
                 }
@@ -112,9 +369,27 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
         jsMessageCallback: JsMessageCallback?,
     ) {
         if (jsMessageCallback == null) throw Exception("Callback cannot be null")
-        this.webView = webView
-        this.jsMessageCallback = jsMessageCallback
-        this.webView.addJavascriptInterface(this, coreContentScopeScripts.javascriptInterface)
+        // Registering again (the WebView is recreated, see BrowserTabFragment.resetWebView) leaves anything still queued
+        // belonging to a document that is gone: handling it would route it against the new WebView, and if the flag
+        // sampled below has since been disabled nothing would ever consume it. Swapped before the drain so a message
+        // offered during it still carries the previous registration.
+        this.registration = Registration(webView, jsMessageCallback)
+        drainQueue()
+        this.optimizedProcessing = contentScopeScriptsFeature.optimizeContentScopeMessaging().isEnabled()
+        webView.addJavascriptInterface(this, coreContentScopeScripts.javascriptInterface)
+
+        // The handler indexes are built on first use, which is otherwise the JavaBridge thread handling the first message
+        // of the page — time the page's JS spends blocked. Registration happens well before page scripts run.
+        appCoroutineScope.launch(dispatcherProvider.io()) { domainRestrictedFeatures }
+    }
+
+    // Drains rather than clears so the url reads of discarded messages can be cancelled: nothing will await them.
+    private fun drainQueue() {
+        val discarded = mutableListOf<QueuedMessage>()
+        inboundQueue.drainTo(discarded)
+        discarded.forEach { it.url?.cancel() }
+        // The queue is empty again, so the next overflow is a new episode even if no consumer got to observe this one.
+        overflowReported.set(false)
     }
 
     override fun sendSubscriptionEvent(subscriptionEventData: SubscriptionEventData) {
@@ -125,8 +400,8 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
                 subscriptionEventData.subscriptionName,
                 subscriptionEventData.params,
             )
-        if (::webView.isInitialized) {
-            jsMessageHelper.sendSubscriptionEvent(subscriptionEvent, callbackName, secret, webView)
+        registration?.webView?.let {
+            jsMessageHelper.sendSubscriptionEvent(subscriptionEvent, callbackName, secret, it)
         }
     }
 
@@ -139,7 +414,9 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
                 id = response.id,
                 result = response.params,
             )
-        jsMessageHelper.sendJsResponse(jsResponse, callbackName, secret, webView)
+        registration?.webView?.let {
+            jsMessageHelper.sendJsResponse(jsResponse, callbackName, secret, it)
+        }
     }
 
     private fun isUrlAllowed(
@@ -155,6 +432,7 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
     private fun sendMethodNotFoundError(
         jsMessage: JsMessage,
         id: String,
+        webView: WebView,
     ) {
         jsMessageHelper.sendJsResponse(
             JsRequestResponse.Error(

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
@@ -123,8 +123,7 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
     /**
      * Handler lookup by feature name and method, so routing a message doesn't have to build every registered handler.
      * The plugins are a fixed multibinding and their `featureName`/`methods` are constants, so the index is built once;
-     * the matched handler is still rebuilt per message because `allowedDomains` isn't constant — internal builds can
-     * change the Duck.ai host at runtime.
+     * the matched handler is still rebuilt per message because `allowedDomains` isn't constant.
      */
     private val handlersByFeatureAndMethod: Map<String, Map<String, List<ContentScopeJsMessageHandlersPlugin>>> by lazy {
         val index = mutableMapOf<String, MutableMap<String, MutableList<ContentScopeJsMessageHandlersPlugin>>>()
@@ -183,8 +182,6 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
         if (context != jsMessage.context) return
         val registration = this.registration ?: return
 
-        // Produce and return: reading the url here would block the page's JS, since JavaBridge calls are synchronous from
-        // the page's point of view. Domain restricted features still have it read now, just without waiting for it.
         val url =
             if (allowedDomains.isNotEmpty() || jsMessage.featureName in domainRestrictedFeatures) {
                 appCoroutineScope.async(dispatcherProvider.main()) {
@@ -194,7 +191,6 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
                 null
             }
         if (!inboundQueue.offer(QueuedMessage(registration, jsMessage, url))) {
-            // Nothing will await it, and cancelling before the main thread reaches it spares the dispatch entirely.
             url?.cancel()
             logcat(WARN) { "Inbound queue full, dropping ${jsMessage.featureName}.${jsMessage.method}" }
             reportOverflow()
@@ -212,12 +208,6 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
         pixel.fire(INBOUND_QUEUE_FULL, type = Daily())
     }
 
-    /**
-     * Parsed here rather than with Moshi because [JsMessage] has no generated adapter, so Moshi falls back to reflection:
-     * that measured as roughly 40% of the work this does on the JavaBridge thread, which is time the page's JS spends
-     * blocked. Returns null for anything we could not route, and the caller drops it. [processLegacy] keeps using Moshi so
-     * that the flag-off path stays exactly as it shipped.
-     */
     private fun parseJsMessage(message: String): JsMessage? =
         runCatching {
             val json = JSONObject(message)
@@ -231,8 +221,6 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
                         featureName = featureName,
                         method = method,
                         params = json.optJSONObject("params") ?: JSONObject(),
-                        // isNull() covers both an absent id and an explicit JSON null, which optString() would otherwise
-                        // hand back as the string "null".
                         id = if (json.isNull("id")) null else json.optString("id").takeUnless { it.isEmpty() },
                     )
             }
@@ -256,25 +244,18 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
                         }
                     }
                 } finally {
-                    // Released in a finally, and only while we still own it: anything escaping the loop (cancellation,
-                    // an Error) would otherwise leave the flag set with no consumer running, and no later message could
-                    // ever start one again.
                     queueConsumerActive.set(false)
                 }
                 if (inboundQueue.isEmpty()) {
                     overflowReported.set(false)
                     return@launch
                 }
-                // A message queued while we were stopping found the consumer still active and started none of its own,
-                // so re-acquire rather than leave it unhandled. Losing the race means someone else took over.
                 if (!queueConsumerActive.compareAndSet(false, true)) return@launch
             }
         }
     }
 
     private suspend fun handle(queued: QueuedMessage) {
-        // Identity, not equality: a message belonging to a WebView that has since been replaced must not be routed
-        // against the one that took its place.
         if (queued.registration !== this.registration) {
             queued.url?.cancel()
             return
@@ -369,26 +350,18 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
         jsMessageCallback: JsMessageCallback?,
     ) {
         if (jsMessageCallback == null) throw Exception("Callback cannot be null")
-        // Registering again (the WebView is recreated, see BrowserTabFragment.resetWebView) leaves anything still queued
-        // belonging to a document that is gone: handling it would route it against the new WebView, and if the flag
-        // sampled below has since been disabled nothing would ever consume it. Swapped before the drain so a message
-        // offered during it still carries the previous registration.
         this.registration = Registration(webView, jsMessageCallback)
         drainQueue()
         this.optimizedProcessing = contentScopeScriptsFeature.optimizeContentScopeMessaging().isEnabled()
         webView.addJavascriptInterface(this, coreContentScopeScripts.javascriptInterface)
 
-        // The handler indexes are built on first use, which is otherwise the JavaBridge thread handling the first message
-        // of the page — time the page's JS spends blocked. Registration happens well before page scripts run.
         appCoroutineScope.launch(dispatcherProvider.io()) { domainRestrictedFeatures }
     }
 
-    // Drains rather than clears so the url reads of discarded messages can be cancelled: nothing will await them.
     private fun drainQueue() {
         val discarded = mutableListOf<QueuedMessage>()
         inboundQueue.drainTo(discarded)
         discarded.forEach { it.url?.cancel() }
-        // The queue is empty again, so the next overflow is a new episode even if no consumer got to observe this one.
         overflowReported.set(false)
     }
 

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsMessagingPixelName.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsMessagingPixelName.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.contentscopescripts.impl.messaging
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+
+enum class ContentScopeScriptsMessagingPixelName(
+    override val pixelName: String,
+) : Pixel.PixelName {
+    INBOUND_QUEUE_FULL("m_content_scope_scripts_inbound_queue_full"),
+}

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessagingTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessagingTest.kt
@@ -18,10 +18,17 @@ package com.duckduckgo.contentscopescripts.impl.messaging
 
 import android.webkit.WebView
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.contentscopescripts.api.ContentScopeJsMessageHandlersPlugin
+import com.duckduckgo.contentscopescripts.impl.ContentScopeScriptsFeature
 import com.duckduckgo.contentscopescripts.impl.CoreContentScopeScripts
+import com.duckduckgo.contentscopescripts.impl.messaging.ContentScopeScriptsMessagingPixelName.INBOUND_QUEUE_FULL
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.js.messaging.api.JsErrorDetails
 import com.duckduckgo.js.messaging.api.JsMessage
 import com.duckduckgo.js.messaging.api.JsMessageCallback
@@ -31,6 +38,14 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.js.messaging.api.JsRequestResponse
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Before
@@ -39,11 +54,14 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class ContentScopeScriptsJsMessagingTest {
     @get:Rule var coroutineRule = CoroutineTestRule()
@@ -52,6 +70,8 @@ class ContentScopeScriptsJsMessagingTest {
     private val jsMessageHelper: JsMessageHelper = mock()
     private val coreContentScopeScripts: CoreContentScopeScripts = mock()
     private val handlers: PluginPoint<ContentScopeJsMessageHandlersPlugin> = FakePluginPoint()
+    private val contentScopeScriptsFeature = FakeFeatureToggleFactory.create(ContentScopeScriptsFeature::class.java)
+    private val pixel: Pixel = mock()
     private lateinit var contentScopeScriptsJsMessaging: ContentScopeScriptsJsMessaging
 
     private class FakePluginPoint : PluginPoint<ContentScopeJsMessageHandlersPlugin> {
@@ -80,14 +100,20 @@ class ContentScopeScriptsJsMessagingTest {
         whenever(coreContentScopeScripts.secret).thenReturn("secret")
         whenever(coreContentScopeScripts.javascriptInterface).thenReturn("javascriptInterface")
         whenever(coreContentScopeScripts.callbackName).thenReturn("callbackName")
-        contentScopeScriptsJsMessaging =
-            ContentScopeScriptsJsMessaging(
-                jsMessageHelper,
-                coroutineRule.testDispatcherProvider,
-                coreContentScopeScripts,
-                handlers,
-            )
+        contentScopeScriptsFeature.optimizeContentScopeMessaging().setRawStoredState(State(enable = true))
+        contentScopeScriptsJsMessaging = givenMessaging(handlers)
     }
+
+    private fun givenMessaging(handlers: PluginPoint<ContentScopeJsMessageHandlersPlugin>) =
+        ContentScopeScriptsJsMessaging(
+            jsMessageHelper,
+            coroutineRule.testDispatcherProvider,
+            coreContentScopeScripts,
+            handlers,
+            contentScopeScriptsFeature,
+            pixel,
+            coroutineRule.testScope,
+        )
 
     @Test
     fun `when process and message can be handled then execute callback`() =
@@ -241,7 +267,7 @@ class ContentScopeScriptsJsMessagingTest {
         }
 
     @Test
-    fun `when processing addDebugFlag message with valid secret and domain then process message`() =
+    fun `when processing addDebugFlag message with valid secret then process message`() =
         runTest {
             givenInterfaceIsRegistered()
 
@@ -253,6 +279,23 @@ class ContentScopeScriptsJsMessagingTest {
             contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
 
             assertEquals(1, callback.counter)
+        }
+
+    @Test
+    fun `when processing addDebugFlag message then do not send method not found error`() =
+        runTest {
+            givenInterfaceIsRegistered()
+
+            val message =
+                """
+                {"context":"contentScopeScripts","featureName":"debugFeature","id":"debugId","method":"addDebugFlag","params":{}}
+                """.trimIndent()
+
+            contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+            // addDebugFlag is answered by the callback alone, so it must not also be treated as an unrouted method.
+            assertEquals(1, callback.counter)
+            verify(jsMessageHelper, never()).sendJsResponse(any(), any(), any(), any())
         }
 
     @Test
@@ -305,13 +348,7 @@ class ContentScopeScriptsJsMessagingTest {
     @Test
     fun `when processing webEvents webEvent message then nativeData with webViewId is injected`() =
         runTest {
-            val webEventsHandlers = WebEventsPluginPoint()
-            val messaging = ContentScopeScriptsJsMessaging(
-                jsMessageHelper,
-                coroutineRule.testDispatcherProvider,
-                coreContentScopeScripts,
-                webEventsHandlers,
-            )
+            val messaging = givenMessaging(WebEventsPluginPoint())
             messaging.register(mockWebView, webEventsCallback)
             whenever(mockWebView.url).thenReturn("https://example.com")
 
@@ -345,10 +382,418 @@ class ContentScopeScriptsJsMessagingTest {
             assertFalse(params?.has("nativeData") ?: false)
         }
 
+    @Test
+    fun `when handler has no allowed domains then webView url is not read`() =
+        runTest {
+            val messaging = givenMessaging(WebEventsPluginPoint())
+            messaging.register(mockWebView, webEventsCallback)
+
+            val message =
+                """
+                {"context":"contentScopeScripts","featureName":"webEvents","id":"e1","method":"webEvent","params":{"type":"adwall.detected"}}
+                """.trimIndent()
+
+            messaging.process(message, messaging.secret)
+
+            assertEquals(1, webEventsCallback.counter)
+            verify(mockWebView, never()).url
+        }
+
+    @Test
+    fun `when multiple messages are received then all are handled in arrival order`() =
+        runTest {
+            givenInterfaceIsRegistered()
+
+            listOf("first", "second", "third").forEach { id ->
+                contentScopeScriptsJsMessaging.process(
+                    """
+                    {"context":"contentScopeScripts","featureName":"webCompat","id":"$id","method":"webShare","params":{}}
+                    """.trimIndent(),
+                    contentScopeScriptsJsMessaging.secret,
+                )
+            }
+
+            assertEquals(3, callback.counter)
+            assertEquals(listOf("first", "second", "third"), callback.ids)
+        }
+
+    @Test
+    fun `when message has no method then do nothing`() =
+        runTest {
+            givenInterfaceIsRegistered()
+
+            val message =
+                """
+                {"context":"contentScopeScripts","featureName":"webCompat","id":"myId","params":{}}
+                """.trimIndent()
+
+            contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+            assertEquals(0, callback.counter)
+        }
+
+    @Test
+    fun `when message has no params then it is handled with empty params`() =
+        runTest {
+            givenInterfaceIsRegistered()
+
+            val message =
+                """
+                {"context":"contentScopeScripts","featureName":"webCompat","id":"myId","method":"webShare"}
+                """.trimIndent()
+
+            contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+            assertEquals(1, callback.counter)
+            assertEquals(0, callback.lastData?.length())
+        }
+
+    @Test
+    fun `when message id is null then it is handled without an id`() =
+        runTest {
+            givenInterfaceIsRegistered()
+
+            val message =
+                """
+                {"context":"contentScopeScripts","featureName":"webCompat","id":null,"method":"webShare","params":{}}
+                """.trimIndent()
+
+            contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+            assertEquals(1, callback.counter)
+            assertEquals(emptyList<String>(), callback.ids)
+        }
+
+    @Test
+    fun `when first handler for a method is not allowed on this domain then a later one still handles it`() =
+        runTest {
+            val messaging = givenMessaging(TwoHandlersPluginPoint())
+            messaging.register(mockWebView, callback)
+            whenever(mockWebView.url).thenReturn("https://example.com")
+
+            val message =
+                """
+                {"context":"contentScopeScripts","featureName":"webCompat","id":"myId","method":"webShare","params":{}}
+                """.trimIndent()
+
+            messaging.process(message, messaging.secret)
+
+            assertEquals(1, callback.counter)
+            assertEquals(listOf("open"), callback.handledBy)
+        }
+
+    @Test
+    fun `when optimization is disabled and message can be handled then execute callback`() =
+        runTest {
+            contentScopeScriptsFeature.optimizeContentScopeMessaging().setRawStoredState(State(enable = false))
+            val messaging = givenMessaging(handlers)
+            messaging.register(mockWebView, callback)
+            whenever(mockWebView.url).thenReturn("https://example.com")
+
+            val message =
+                """
+                {"context":"contentScopeScripts","featureName":"webCompat","id":"myId","method":"webShare","params":{}}
+                """.trimIndent()
+
+            messaging.process(message, messaging.secret)
+
+            assertEquals(1, callback.counter)
+        }
+
+    @Test
+    fun `when optimization is disabled and url is not allowed do nothing`() =
+        runTest {
+            contentScopeScriptsFeature.optimizeContentScopeMessaging().setRawStoredState(State(enable = false))
+            val messaging = givenMessaging(handlers)
+            messaging.register(mockWebView, callback)
+            whenever(mockWebView.url).thenReturn("https://notAllowed.com")
+
+            val message =
+                """
+                {"context":"contentScopeScripts","featureName":"webCompat","id":"myId","method":"webShare","params":{}}
+                """.trimIndent()
+
+            messaging.process(message, messaging.secret)
+
+            assertEquals(0, callback.counter)
+        }
+
+    @Test
+    fun `when optimization is disabled and no handler matches and message has id then send method not found error`() =
+        runTest {
+            contentScopeScriptsFeature.optimizeContentScopeMessaging().setRawStoredState(State(enable = false))
+            val messaging = givenMessaging(handlers)
+            messaging.register(mockWebView, callback)
+            whenever(mockWebView.url).thenReturn("https://example.com")
+
+            val message =
+                """
+                {"context":"contentScopeScripts","featureName":"webCompat","id":"myId","method":"unknownMethod","params":{}}
+                """.trimIndent()
+
+            messaging.process(message, messaging.secret)
+
+            assertEquals(0, callback.counter)
+            verify(jsMessageHelper).sendJsResponse(
+                JsRequestResponse.Error(
+                    context = "contentScopeScripts",
+                    featureName = "webCompat",
+                    method = "unknownMethod",
+                    id = "myId",
+                    error = JsErrorDetails(code = -32601, message = "Method not found"),
+                ),
+                "callbackName",
+                "secret",
+                mockWebView,
+            )
+        }
+
+    @Test
+    fun `when optimization is disabled and no handler matches and message has no id then do not send error response`() =
+        runTest {
+            contentScopeScriptsFeature.optimizeContentScopeMessaging().setRawStoredState(State(enable = false))
+            val messaging = givenMessaging(handlers)
+            messaging.register(mockWebView, callback)
+            whenever(mockWebView.url).thenReturn("https://example.com")
+
+            val message =
+                """
+                {"context":"contentScopeScripts","featureName":"webCompat","method":"unknownMethod","params":{}}
+                """.trimIndent()
+
+            messaging.process(message, messaging.secret)
+
+            assertEquals(0, callback.counter)
+            verify(jsMessageHelper, never()).sendJsResponse(any(), any(), any(), any())
+        }
+
+    @Test
+    fun `when optimization is disabled and processing addDebugFlag message then do not send method not found error`() =
+        runTest {
+            contentScopeScriptsFeature.optimizeContentScopeMessaging().setRawStoredState(State(enable = false))
+            val messaging = givenMessaging(handlers)
+            messaging.register(mockWebView, callback)
+            whenever(mockWebView.url).thenReturn("https://example.com")
+
+            val message =
+                """
+                {"context":"contentScopeScripts","featureName":"debugFeature","id":"debugId","method":"addDebugFlag","params":{}}
+                """.trimIndent()
+
+            messaging.process(message, messaging.secret)
+
+            // addDebugFlag is answered by the callback alone, so it must not also be treated as an unrouted method.
+            assertEquals(1, callback.counter)
+            verify(jsMessageHelper, never()).sendJsResponse(any(), any(), any(), any())
+        }
+
+    @Test
+    fun `when optimization is disabled then the url is read for every message`() =
+        runTest {
+            contentScopeScriptsFeature.optimizeContentScopeMessaging().setRawStoredState(State(enable = false))
+            val messaging = givenMessaging(WebEventsPluginPoint())
+            messaging.register(mockWebView, webEventsCallback)
+            whenever(mockWebView.url).thenReturn("https://example.com")
+
+            val message =
+                """
+                {"context":"contentScopeScripts","featureName":"webEvents","id":"e1","method":"webEvent","params":{"type":"adwall.detected"}}
+                """.trimIndent()
+
+            messaging.process(message, messaging.secret)
+
+            assertEquals(1, webEventsCallback.counter)
+            // The legacy path reads the url regardless of the handler's allowed domains.
+            verify(mockWebView, atLeastOnce()).url
+        }
+
+    @Test
+    fun `when the flag is disabled after registering then the value sampled at registration is still used`() =
+        runTest {
+            val messaging = givenMessaging(WebEventsPluginPoint())
+            messaging.register(mockWebView, webEventsCallback)
+            contentScopeScriptsFeature.optimizeContentScopeMessaging().setRawStoredState(State(enable = false))
+
+            messaging.process(webEventMessage("e1"), messaging.secret)
+
+            assertEquals(1, webEventsCallback.counter)
+            // Still the optimized path: the legacy one would have read the url even for a handler with no allowed domains.
+            verify(mockWebView, never()).url
+        }
+
+    // The tests above run on an UnconfinedTestDispatcher, where the consumer drains each message before the next one is
+    // offered, so the queue never holds more than one. These use a StandardTestDispatcher instead: nothing runs until
+    // advanceUntilIdle(), so messages genuinely queue and the consumer's ordering and recovery paths are exercised.
+    @Test
+    fun `when messages queue up behind the consumer then they are handled in arrival order`() =
+        runTest {
+            val messaging = givenQueuedMessaging(handlers)
+            messaging.register(mockWebView, callback)
+            whenever(mockWebView.url).thenReturn("https://example.com")
+
+            listOf("first", "second", "third").forEach { messaging.process(webShareMessage(it), messaging.secret) }
+            advanceUntilIdle()
+
+            assertEquals(listOf("first", "second", "third"), callback.ids)
+        }
+
+    @Test
+    fun `when registering again then messages queued for the previous webView are dropped`() =
+        runTest {
+            val messaging = givenQueuedMessaging(handlers)
+            messaging.register(mockWebView, callback)
+            whenever(mockWebView.url).thenReturn("https://example.com")
+            messaging.process(webShareMessage("stale"), messaging.secret)
+
+            messaging.register(mockWebView, callback)
+            advanceUntilIdle()
+
+            assertEquals(0, callback.counter)
+        }
+
+    @Test
+    fun `when the inbound queue is full then further messages are dropped`() =
+        runTest {
+            val messaging = givenQueuedMessaging(WebEventsPluginPoint())
+            messaging.register(mockWebView, webEventsCallback)
+
+            repeat(MAX_QUEUED_MESSAGES + 8) { messaging.process(webEventMessage("e$it"), messaging.secret) }
+            advanceUntilIdle()
+
+            assertEquals(MAX_QUEUED_MESSAGES, webEventsCallback.counter)
+        }
+
+    @Test
+    fun `when the inbound queue overflows then one pixel is fired for the episode`() =
+        runTest {
+            val messaging = givenQueuedMessaging(WebEventsPluginPoint())
+            messaging.register(mockWebView, webEventsCallback)
+
+            repeat(MAX_QUEUED_MESSAGES + 8) { messaging.process(webEventMessage("e$it"), messaging.secret) }
+
+            verify(pixel, times(1)).fire(INBOUND_QUEUE_FULL, type = Daily())
+        }
+
+    @Test
+    fun `when the queue drains then a later overflow is reported again`() =
+        runTest {
+            val messaging = givenQueuedMessaging(WebEventsPluginPoint())
+            messaging.register(mockWebView, webEventsCallback)
+
+            repeat(MAX_QUEUED_MESSAGES + 1) { messaging.process(webEventMessage("first$it"), messaging.secret) }
+            advanceUntilIdle()
+            repeat(MAX_QUEUED_MESSAGES + 1) { messaging.process(webEventMessage("second$it"), messaging.secret) }
+
+            verify(pixel, times(2)).fire(INBOUND_QUEUE_FULL, type = Daily())
+        }
+
+    @Test
+    fun `when the queue never overflows then no pixel is fired`() =
+        runTest {
+            val messaging = givenQueuedMessaging(WebEventsPluginPoint())
+            messaging.register(mockWebView, webEventsCallback)
+
+            repeat(MAX_QUEUED_MESSAGES) { messaging.process(webEventMessage("e$it"), messaging.secret) }
+            advanceUntilIdle()
+
+            verify(pixel, never()).fire(INBOUND_QUEUE_FULL, type = Daily())
+        }
+
+    @Test
+    fun `when registering again then a message queued for the previous registration reaches neither callback`() =
+        runTest {
+            val messaging = givenQueuedMessaging(handlers)
+            messaging.register(mockWebView, callback)
+            whenever(mockWebView.url).thenReturn("https://example.com")
+            messaging.process(webShareMessage("stale"), messaging.secret)
+
+            messaging.register(mock(), webEventsCallback)
+            advanceUntilIdle()
+
+            assertEquals(0, callback.counter)
+            assertEquals(0, webEventsCallback.counter)
+        }
+
+    @Test
+    fun `when a handler throws an error then later messages are still handled`() =
+        runTest {
+            val messaging = givenQueuedMessaging(ThrowingPluginPoint())
+            messaging.register(mockWebView, callback)
+
+            messaging.process(webShareMessage("boom"), messaging.secret)
+            advanceUntilIdle()
+            messaging.process(webShareMessage("after"), messaging.secret)
+            advanceUntilIdle()
+
+            assertEquals(listOf("after"), callback.ids)
+        }
+
+    private fun webShareMessage(id: String) =
+        """
+        {"context":"contentScopeScripts","featureName":"webCompat","id":"$id","method":"webShare","params":{}}
+        """.trimIndent()
+
+    private fun webEventMessage(id: String) =
+        """
+        {"context":"contentScopeScripts","featureName":"webEvents","id":"$id","method":"webEvent","params":{"type":"t"}}
+        """.trimIndent()
+
+    private fun TestScope.givenQueuedMessaging(
+        handlers: PluginPoint<ContentScopeJsMessageHandlersPlugin>,
+    ): ContentScopeScriptsJsMessaging {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val dispatcherProvider =
+            object : DispatcherProvider {
+                override fun io(): CoroutineDispatcher = dispatcher
+
+                override fun main(): CoroutineDispatcher = dispatcher
+
+                override fun computation(): CoroutineDispatcher = dispatcher
+
+                override fun unconfined(): CoroutineDispatcher = dispatcher
+            }
+        // Deliberately not the TestScope: one of these tests has a handler throw an Error, and an uncaught throwable in a
+        // child of the TestScope fails the test before the consumer's own recovery can be observed.
+        val scope = CoroutineScope(SupervisorJob() + dispatcher + CoroutineExceptionHandler { _, _ -> })
+        return ContentScopeScriptsJsMessaging(
+            jsMessageHelper,
+            dispatcherProvider,
+            coreContentScopeScripts,
+            handlers,
+            contentScopeScriptsFeature,
+            pixel,
+            scope,
+        )
+    }
+
+    private class ThrowingPluginPoint : PluginPoint<ContentScopeJsMessageHandlersPlugin> {
+        override fun getPlugins(): Collection<ContentScopeJsMessageHandlersPlugin> = listOf(Plugin())
+
+        class Plugin : ContentScopeJsMessageHandlersPlugin {
+            override fun getJsMessageHandler(): JsMessageHandler =
+                object : JsMessageHandler {
+                    override fun process(
+                        jsMessage: JsMessage,
+                        jsMessaging: JsMessaging,
+                        jsMessageCallback: JsMessageCallback?,
+                    ) {
+                        if (jsMessage.id == "boom") throw AssertionError("boom")
+                        jsMessageCallback?.process(featureName, jsMessage.method, jsMessage.id, jsMessage.params)
+                    }
+
+                    override val allowedDomains: List<String> = emptyList()
+                    override val featureName: String = "webCompat"
+                    override val methods: List<String> = listOf("webShare")
+                }
+        }
+    }
+
     private val callback =
         object : JsMessageCallback() {
             var counter = 0
             var lastData: JSONObject? = null
+            val ids = mutableListOf<String>()
+            val handledBy = mutableListOf<String>()
 
             override fun process(
                 featureName: String,
@@ -358,6 +803,8 @@ class ContentScopeScriptsJsMessagingTest {
             ) {
                 counter++
                 lastData = data
+                id?.let { ids.add(it) }
+                handledBy.add(featureName)
             }
         }
 
@@ -376,6 +823,31 @@ class ContentScopeScriptsJsMessagingTest {
                 lastData = data
             }
         }
+
+    private class TwoHandlersPluginPoint : PluginPoint<ContentScopeJsMessageHandlersPlugin> {
+        override fun getPlugins(): Collection<ContentScopeJsMessageHandlersPlugin> =
+            listOf(Plugin(listOf("other.com"), "restricted"), Plugin(emptyList(), "open"))
+
+        class Plugin(
+            private val domains: List<String>,
+            private val name: String,
+        ) : ContentScopeJsMessageHandlersPlugin {
+            override fun getJsMessageHandler(): JsMessageHandler =
+                object : JsMessageHandler {
+                    override fun process(
+                        jsMessage: JsMessage,
+                        jsMessaging: JsMessaging,
+                        jsMessageCallback: JsMessageCallback?,
+                    ) {
+                        jsMessageCallback?.process(name, jsMessage.method, jsMessage.id, jsMessage.params)
+                    }
+
+                    override val allowedDomains: List<String> = domains
+                    override val featureName: String = "webCompat"
+                    override val methods: List<String> = listOf("webShare")
+                }
+        }
+    }
 
     private class WebEventsPluginPoint : PluginPoint<ContentScopeJsMessageHandlersPlugin> {
         override fun getPlugins(): Collection<ContentScopeJsMessageHandlersPlugin> = listOf(WebEventsPlugin())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216755882810224?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

Inbound contentScopeScripts JS messages were routed to their handlers on the WebView JavaBridge thread. Because JavaBridge calls are synchronous from the page's point of view, the page's JS thread was blocked for the whole round trip — including a runBlocking hop to the main thread just to read the document url, and reflective Moshi parsing of every message.

process() now only parses and enqueues; a single consumer drains the queue off the JavaBridge thread, so handlers still see messages one at a time in the order the page sent them. The sending document's url is sampled on arrival rather than at handling time, so domain-restricted features are still checked against the document that actually sent the message. Handler lookup is indexed by feature name and method, and parsing uses JSONObject instead of Moshi.

Enqueueing removes the backpressure the synchronous call provided, so the queue is bounded (512) and overflow fires a daily m_content_scope_scripts_inbound_queue_full pixel.

All of it sits behind optimizeContentScopeMessaging, sampled when the JS interface is attached. With the flag off, process() runs exactly as it shipped.

### Steps to test this PR

The flag defaults to enabled on internal builds, and is sampled at WebView attach — so after flipping it, open a new tab or restart the app.

- [x] Browse normally across a few sites and confirm no behaviour change: pages load, no missing protections, no crashes.
- [x] Trigger a message that expects a native response — tap a site's share button (navigator.share) and confirm the Android share sheet opens with the right URL. (i.e. https://mdn.github.io/dom-examples/web-share/)
- [x] Trigger a message that needs the document's origin — visit a site that requests camera/mic and confirm the permission state shown matches what the site sees. (i.e https://permission.site/)
- [x] Submit a broken site report from the privacy dashboard and confirm it completes (exercises breakageReportResult).
- [x] Flip optimizeContentScopeMessaging off in the internal feature-toggle inventory, restart, and repeat steps 2–4 — behaviour should be identical.

Queue overflow isn't reachable by hand (observed depth on real pages is 0–1); it's covered by unit tests in ContentScopeScriptsJsMessagingTest.

### NO UI changes



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core WebView JS bridge routing for privacy/content-scope features with async ordering and queue drops on overflow, but behavior is gated behind an internal-default kill-switch and legacy path remains unchanged when disabled.
> 
> **Overview**
> Inbound **contentScopeScripts** messages no longer run handlers on the WebView **JavaBridge** thread. With **`optimizeContentScopeMessaging`** enabled (sampled at JS interface attach), `process()` only parses and enqueues; a single consumer on **IO** drains a bounded queue (512) so handlers still run **in order**, one at a time.
> 
> The optimized path uses **JSONObject** parsing instead of Moshi, indexes handlers by feature/method, and snapshots the sending document URL on enqueue (not at handle time) for domain checks. Overflow drops messages and fires daily **`m_content_scope_scripts_inbound_queue_full`**. **`Registration`** pairs WebView + callback so stale queued work is dropped on re-register. The flag off path keeps the previous synchronous **`processLegacy`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79118fdbc7618afb5513440130fdc3c30b89d1a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->