### PR TITLE
Stop resolving contentScope experiments on every navigation

### DIFF
--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
@@ -56,9 +56,7 @@ interface ContentScopeScriptsFeature {
     fun optimizeContentScopeMessaging(): Toggle
 
     /**
-     * Kill-switch for holding the resolved contentScope experiments between privacy config updates. Separate from
-     * [optimizeContentScopeInjection] because it is the only part of that work that changes behaviour rather than
-     * just cost: enrolment is re-evaluated when a new config lands instead of on every navigation.
+     * Kill-switch for holding the resolved contentScope experiments between privacy config updates.
      * @return `true` when the remote config has the global "cacheContentScopeExperiments" clientContentFeatures
      * sub-feature flag enabled.
      * If the remote feature is not present defaults to `internal`

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
@@ -54,4 +54,15 @@ interface ContentScopeScriptsFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun optimizeContentScopeMessaging(): Toggle
+
+    /**
+     * Kill-switch for holding the resolved contentScope experiments between privacy config updates. Separate from
+     * [optimizeContentScopeInjection] because it is the only part of that work that changes behaviour rather than
+     * just cost: enrolment is re-evaluated when a new config lands instead of on every navigation.
+     * @return `true` when the remote config has the global "cacheContentScopeExperiments" clientContentFeatures
+     * sub-feature flag enabled.
+     * If the remote feature is not present defaults to `internal`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun cacheContentScopeExperiments(): Toggle
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperiments.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperiments.kt
@@ -55,14 +55,6 @@ class RealContentScopeExperiments @Inject constructor(
     @Volatile
     private var activeExperiments: List<Toggle>? = null
 
-    /**
-     * Sampled rather than read per call because the flag is itself a toggle: reading it on every navigation would put
-     * back a chunk of the cost this is here to remove. Cleared alongside the result so a remote change to the
-     * kill-switch takes effect at the next privacy config update rather than needing a restart.
-     */
-    @Volatile
-    private var cachingEnabled: Boolean? = null
-
     private val resolveMutex = Mutex()
 
     override suspend fun getActiveExperiments(): List<Toggle> {
@@ -85,13 +77,12 @@ class RealContentScopeExperiments @Inject constructor(
 
     private fun invalidate() {
         activeExperiments = null
-        cachingEnabled = null
     }
 
     private suspend fun cachingEnabled(): Boolean =
-        cachingEnabled ?: withContext(dispatcherProvider.io()) {
+        withContext(dispatcherProvider.io()) {
             contentScopeScriptsFeature.cacheContentScopeExperiments().isEnabled()
-        }.also { cachingEnabled = it }
+        }
 
     private suspend fun resolve(): List<Toggle> =
         withContext(dispatcherProvider.io()) {

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperiments.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperiments.kt
@@ -29,6 +29,7 @@ import dagger.SingleInstanceIn
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 
 @SingleInstanceIn(AppScope::class)
@@ -57,13 +58,22 @@ class RealContentScopeExperiments @Inject constructor(
 
     private val resolveMutex = Mutex()
 
+    private val invalidationCount = AtomicInteger(0)
+
     override suspend fun getActiveExperiments(): List<Toggle> {
         activeExperiments?.let { return it }
 
         if (!cachingEnabled()) return resolve()
 
         return resolveMutex.withLock {
-            activeExperiments ?: resolve().also { activeExperiments = it }
+            activeExperiments ?: run {
+                val count = invalidationCount.get()
+                resolve().also {
+                    if (invalidationCount.get() == count) {
+                        activeExperiments = it
+                    }
+                }
+            }
         }
     }
 
@@ -76,6 +86,7 @@ class RealContentScopeExperiments @Inject constructor(
     }
 
     private fun invalidate() {
+        invalidationCount.incrementAndGet()
         activeExperiments = null
     }
 

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperiments.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperiments.kt
@@ -18,20 +18,86 @@ package com.duckduckgo.contentscopescripts.impl.features.contentscopeexperiments
 
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.contentscopescripts.api.contentscopeExperiments.ContentScopeExperiments
+import com.duckduckgo.contentscopescripts.impl.ContentScopeScriptsFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(
+    scope = AppScope::class,
+    boundType = ContentScopeExperiments::class,
+)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PrivacyConfigCallbackPlugin::class,
+)
 class RealContentScopeExperiments @Inject constructor(
     private val contentScopeExperimentsFeature: ContentScopeExperimentsFeature,
+    private val contentScopeScriptsFeature: ContentScopeScriptsFeature,
     private val featureTogglesInventory: FeatureTogglesInventory,
     private val dispatcherProvider: DispatcherProvider,
-) : ContentScopeExperiments {
-    override suspend fun getActiveExperiments(): List<Toggle> =
+) : ContentScopeExperiments, PrivacyConfigCallbackPlugin {
+
+    /**
+     * Resolving the active experiments walks every feature toggle in the app and enrols each candidate, which is too
+     * expensive to repeat per navigation: page start awaits it before content scope scripts can be injected. The
+     * result only changes when a new privacy config lands, so it is held until then.
+     */
+    @Volatile
+    private var activeExperiments: List<Toggle>? = null
+
+    /**
+     * Sampled rather than read per call because the flag is itself a toggle: reading it on every navigation would put
+     * back a chunk of the cost this is here to remove. Cleared alongside the result so a remote change to the
+     * kill-switch takes effect at the next privacy config update rather than needing a restart.
+     */
+    @Volatile
+    private var cachingEnabled: Boolean? = null
+
+    private val resolveMutex = Mutex()
+
+    override suspend fun getActiveExperiments(): List<Toggle> {
+        // Returning without suspending matters as much as holding the result: the caller awaits this on the main
+        // thread before injecting, so dispatching to io() and back would cost a main looper turn even for a hit.
+        activeExperiments?.let { return it }
+
+        // Resolving straight through, rather than under the mutex, keeps the disabled path exactly as it shipped:
+        // concurrent navigations in different tabs resolve in parallel instead of queueing behind each other.
+        if (!cachingEnabled()) return resolve()
+
+        return resolveMutex.withLock {
+            activeExperiments ?: resolve().also { activeExperiments = it }
+        }
+    }
+
+    override fun onPrivacyConfigDownloaded() {
+        invalidate()
+    }
+
+    override fun onPrivacyConfigPersisted() {
+        invalidate()
+    }
+
+    private fun invalidate() {
+        activeExperiments = null
+        cachingEnabled = null
+    }
+
+    private suspend fun cachingEnabled(): Boolean =
+        cachingEnabled ?: withContext(dispatcherProvider.io()) {
+            contentScopeScriptsFeature.cacheContentScopeExperiments().isEnabled()
+        }.also { cachingEnabled = it }
+
+    private suspend fun resolve(): List<Toggle> =
         withContext(dispatcherProvider.io()) {
             val featureName = contentScopeExperimentsFeature.self().featureName().name
             val experiments =

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperiments.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperiments.kt
@@ -66,12 +66,8 @@ class RealContentScopeExperiments @Inject constructor(
     private val resolveMutex = Mutex()
 
     override suspend fun getActiveExperiments(): List<Toggle> {
-        // Returning without suspending matters as much as holding the result: the caller awaits this on the main
-        // thread before injecting, so dispatching to io() and back would cost a main looper turn even for a hit.
         activeExperiments?.let { return it }
 
-        // Resolving straight through, rather than under the mutex, keeps the disabled path exactly as it shipped:
-        // concurrent navigations in different tabs resolve in parallel instead of queueing behind each other.
         if (!cachingEnabled()) return resolve()
 
         return resolveMutex.withLock {

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperimentsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperimentsTest.kt
@@ -173,6 +173,19 @@ class RealContentScopeExperimentsTest {
 
         assertEquals(3, fakeFeatureTogglesInventory.togglesForParentCallCount)
     }
+
+    @Test
+    fun whenCachingFlagFlipsToEnabledThenNextCallStartsCachingWithoutInvalidation() = runTest {
+        fakeContentScopeScriptsFeature.cacheContentScopeExperiments().setRawStoredState(Toggle.State(false))
+        givenExperimentsFeatureEnabled()
+
+        testee.getActiveExperiments()
+        fakeContentScopeScriptsFeature.cacheContentScopeExperiments().setRawStoredState(Toggle.State(true))
+        testee.getActiveExperiments()
+        testee.getActiveExperiments()
+
+        assertEquals(2, fakeFeatureTogglesInventory.togglesForParentCallCount)
+    }
 }
 
 class FakeFeatureTogglesInventory(private val feature: ContentScopeExperimentsFeature) : FeatureTogglesInventory {

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperimentsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperimentsTest.kt
@@ -2,6 +2,7 @@ package com.duckduckgo.contentscopescripts.impl.features.contentscopeexperiments
 
 import android.annotation.SuppressLint
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.contentscopescripts.impl.ContentScopeScriptsFeature
 import com.duckduckgo.contentscopescripts.impl.features.contentscopeexperiments.ContentScopeExperimentsFeature.Cohorts.CONTROL
 import com.duckduckgo.contentscopescripts.impl.features.contentscopeexperiments.ContentScopeExperimentsFeature.Cohorts.TREATMENT
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
@@ -10,6 +11,7 @@ import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.State.Cohort
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.test.runTest
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -17,16 +19,35 @@ import org.junit.Test
 class RealContentScopeExperimentsTest {
 
     private val fakeContentScopeExperimentsFeature = FakeFeatureToggleFactory.create(ContentScopeExperimentsFeature::class.java)
-    private val mockFeatureTogglesInventory: FeatureTogglesInventory = FakeFeatureTogglesInventory(fakeContentScopeExperimentsFeature)
+    private val fakeContentScopeScriptsFeature = FakeFeatureToggleFactory.create(ContentScopeScriptsFeature::class.java)
+    private val fakeFeatureTogglesInventory = FakeFeatureTogglesInventory(fakeContentScopeExperimentsFeature)
+    private val mockFeatureTogglesInventory: FeatureTogglesInventory = fakeFeatureTogglesInventory
 
     @get:Rule
     val coroutineRule = CoroutineTestRule()
 
     private val testee = RealContentScopeExperiments(
         contentScopeExperimentsFeature = fakeContentScopeExperimentsFeature,
+        contentScopeScriptsFeature = fakeContentScopeScriptsFeature,
         featureTogglesInventory = mockFeatureTogglesInventory,
         dispatcherProvider = coroutineRule.testDispatcherProvider,
     )
+
+    @Before
+    fun setup() {
+        fakeContentScopeScriptsFeature.cacheContentScopeExperiments().setRawStoredState(Toggle.State(true))
+    }
+
+    private fun givenExperimentsFeatureEnabled() {
+        fakeContentScopeExperimentsFeature.self().setRawStoredState(Toggle.State(true))
+        fakeContentScopeExperimentsFeature.test().setRawStoredState(
+            Toggle.State(
+                remoteEnableState = true,
+                cohorts = listOf(Cohort(name = TREATMENT.cohortName, weight = 1)),
+                assignedCohort = Cohort(name = TREATMENT.cohortName, weight = 1),
+            ),
+        )
+    }
 
     @Test
     fun whenContentScopeExperimentsFeatureIsDisabledThenGetExperimentsReturnsEmptyList() = runTest {
@@ -105,14 +126,65 @@ class RealContentScopeExperimentsTest {
         assertEquals(TREATMENT.cohortName, experiments[0].getCohort()?.name)
         assertEquals("test", experiments[0].featureName().name)
     }
+
+    @Test
+    fun whenCachingEnabledThenRepeatedCallsResolveOnce() = runTest {
+        givenExperimentsFeatureEnabled()
+
+        val first = testee.getActiveExperiments()
+        val second = testee.getActiveExperiments()
+        val third = testee.getActiveExperiments()
+
+        assertEquals(1, fakeFeatureTogglesInventory.togglesForParentCallCount)
+        assertEquals(first, second)
+        assertEquals(first, third)
+    }
+
+    @Test
+    fun whenPrivacyConfigPersistedThenNextCallResolvesAgain() = runTest {
+        givenExperimentsFeatureEnabled()
+
+        testee.getActiveExperiments()
+        testee.onPrivacyConfigPersisted()
+        testee.getActiveExperiments()
+
+        assertEquals(2, fakeFeatureTogglesInventory.togglesForParentCallCount)
+    }
+
+    @Test
+    fun whenPrivacyConfigDownloadedThenNextCallResolvesAgain() = runTest {
+        givenExperimentsFeatureEnabled()
+
+        testee.getActiveExperiments()
+        testee.onPrivacyConfigDownloaded()
+        testee.getActiveExperiments()
+
+        assertEquals(2, fakeFeatureTogglesInventory.togglesForParentCallCount)
+    }
+
+    @Test
+    fun whenCachingDisabledThenEveryCallResolves() = runTest {
+        fakeContentScopeScriptsFeature.cacheContentScopeExperiments().setRawStoredState(Toggle.State(false))
+        givenExperimentsFeatureEnabled()
+
+        testee.getActiveExperiments()
+        testee.getActiveExperiments()
+        testee.getActiveExperiments()
+
+        assertEquals(3, fakeFeatureTogglesInventory.togglesForParentCallCount)
+    }
 }
 
 class FakeFeatureTogglesInventory(private val feature: ContentScopeExperimentsFeature) : FeatureTogglesInventory {
+    var togglesForParentCallCount = 0
+        private set
+
     override suspend fun getAll(): List<Toggle> {
         TODO("Not yet implemented")
     }
 
     override suspend fun getAllTogglesForParent(name: String): List<Toggle> {
+        togglesForParentCallCount++
         return listOf(feature.test(), feature.bloops())
     }
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperimentsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperimentsTest.kt
@@ -175,6 +175,32 @@ class RealContentScopeExperimentsTest {
     }
 
     @Test
+    fun whenPrivacyConfigPersistedWhileResolvingThenResultIsNotCached() = runTest {
+        givenExperimentsFeatureEnabled()
+
+        fakeFeatureTogglesInventory.onResolveStarted = { testee.onPrivacyConfigPersisted() }
+        testee.getActiveExperiments()
+        fakeFeatureTogglesInventory.onResolveStarted = null
+
+        testee.getActiveExperiments()
+
+        assertEquals(2, fakeFeatureTogglesInventory.togglesForParentCallCount)
+    }
+
+    @Test
+    fun whenPrivacyConfigDownloadedWhileResolvingThenResultIsNotCached() = runTest {
+        givenExperimentsFeatureEnabled()
+
+        fakeFeatureTogglesInventory.onResolveStarted = { testee.onPrivacyConfigDownloaded() }
+        testee.getActiveExperiments()
+        fakeFeatureTogglesInventory.onResolveStarted = null
+
+        testee.getActiveExperiments()
+
+        assertEquals(2, fakeFeatureTogglesInventory.togglesForParentCallCount)
+    }
+
+    @Test
     fun whenCachingFlagFlipsToEnabledThenNextCallStartsCachingWithoutInvalidation() = runTest {
         fakeContentScopeScriptsFeature.cacheContentScopeExperiments().setRawStoredState(Toggle.State(false))
         givenExperimentsFeatureEnabled()
@@ -192,12 +218,15 @@ class FakeFeatureTogglesInventory(private val feature: ContentScopeExperimentsFe
     var togglesForParentCallCount = 0
         private set
 
+    var onResolveStarted: (() -> Unit)? = null
+
     override suspend fun getAll(): List<Toggle> {
         TODO("Not yet implemented")
     }
 
     override suspend fun getAllTogglesForParent(name: String): List<Toggle> {
         togglesForParentCallCount++
+        onResolveStarted?.invoke()
         return listOf(feature.test(), feature.bloops())
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217017440666479?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

Content scope scripts are injected from onPageStarted, and that injection first awaits ContentScopeExperiments.getActiveExperiments(). Resolving it materialises every feature toggle in the app through a reflective proxy (~580), splits each toggle key twice (~1,140 string splits), then enrols and evaluates the 22 contentScopeExperiments sub-toggles.

Injection already races the page's own scripts, so this is protections coverage as well as page-load cost: it's time the page runs without our protections.

The result only changes when a new privacy config lands, so it's now resolved once and held until then, invalidated via PrivacyConfigCallbackPlugin. Cache hits return without suspending — the caller awaits this on the main thread, so dispatching to io() and back would cost a main looper turn even for a hit. Concurrent callers serialise on a mutex so tabs navigating together resolve once between them.

Behind cacheContentScopeExperiments. The flag is sampled rather than read per call (it's itself a toggle, so reading it per navigation would put back part of the cost). With the flag off, resolve runs straight through without taking the mutex, exactly as it behaves today.

Behaviour change: enrolment is re-evaluated when a config is persisted rather than on every navigation.

### Steps to test this PR

The flag defaults to enabled on internal builds. Both the cached result and the sampled flag are cleared on privacy config updates, so restart the app after changing either.

- [x] Browse normally across several sites and confirm no behaviour change: pages load, protections apply, no crashes.
- [x] Confirm enrolment still works: enable a contentScopeExperiment* sub-toggle under contentScopeExperiments in the internal feature-toggle inventory, restart the app, browse, then check that a cohort has been assigned (stored state in the inventory, or the experiment_enroll pixel).
- [x] Confirm invalidation: relaunch so a fresh privacy config is downloaded and persisted, and check experiments are re-resolved rather than serving a stale list.
- [x] Turn cacheContentScopeExperiments off, restart, and repeat 1–2 — behaviour should be identical, resolving on every navigation.
- [x] Unit tests are passing. `./gradlew :content-scope-scripts-impl:testDebugUnitTest` — `RealContentScopeExperimentsTest` covers resolve-once, re-resolve after persisted/downloaded, and resolve-per-call with the flag off.

Two notes for reviewers. With the cache on, flipping an experiment sub-toggle by hand in the toggle inventory won't take effect until the next config download or restart, because a manual toggle edit doesn't fire the config callback — that's expected, not a bug. And the latency win isn't observable in-app; the wide-event intervals that make it measurable in the field come in a follow-up PR.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when experiment cohorts are resolved relative to navigation and privacy config, which affects content-scope script injection timing and experiment assignment; mitigated by a kill-switch and invalidation on config updates.
> 
> **Overview**
> **Caches** the resolved active content-scope experiment toggles so `getActiveExperiments()` no longer walks and enrols every app toggle on each navigation—work that currently blocks document-start script injection on page start.
> 
> When the new **`cacheContentScopeExperiments`** kill-switch is on (default **internal**), `RealContentScopeExperiments` keeps the list in memory, returns cache hits without extra suspension, and uses a mutex so concurrent navigations resolve once. **`PrivacyConfigCallbackPlugin`** clears the cache on config download and persist; an invalidation counter avoids storing a result if config changes mid-resolve. With the flag off, behavior matches today (resolve every call, no mutex).
> 
> **Behavior change:** experiment enrolment is re-evaluated when privacy config is persisted/downloaded, not on every navigation—manual toggle edits in the inventory won’t refresh until the next config event or restart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e41d027d9a149aea55d6a2c31be67bbdd6affc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->