### PR TITLE
Add contextual header

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -64,6 +64,7 @@ import com.duckduckgo.browsermode.api.WebViewModeInitializer
 import com.duckduckgo.common.ui.DuckDuckGoFragment
 import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.ui.view.PopupMenuItemView
+import com.duckduckgo.common.ui.view.appendIconToText
 import com.duckduckgo.common.ui.view.dialog.ActionBottomSheetDialog
 import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.view.gone
@@ -125,6 +126,7 @@ import org.json.JSONObject
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Named
+import com.duckduckgo.mobile.android.R as CommonR
 
 @InjectWith(FragmentScope::class)
 class DuckChatContextualFragment :
@@ -538,6 +540,22 @@ class DuckChatContextualFragment :
         configureBehaviour(bottomSheetBehavior)
         configureButtons()
         configureSuggestions()
+        configureHeader()
+    }
+
+    private fun configureHeader() {
+        val header = getString(R.string.duckAIContextualHeader)
+        val placeholder = "%1\$s"
+        val placeholderIndex = header.indexOf(placeholder)
+        if (placeholderIndex < 0) {
+            binding.contextualHeader.text = header
+            return
+        }
+        val textBeforeIcon = header.substring(0, placeholderIndex).trimEnd()
+        val textAfterIcon = header.substring(placeholderIndex + placeholder.length)
+        binding.contextualHeader.text = requireContext()
+            .appendIconToText(textBeforeIcon, CommonR.drawable.ic_shield_color_24_rebrand)
+            .append(textAfterIcon)
     }
 
     private fun configureBehaviour(bottomSheetBehavior: BottomSheetBehavior<View>) {

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
@@ -79,8 +79,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/keyline_4"
-            android:drawableStart="@drawable/ic_duck_ai_color_24"
-            android:drawablePadding="@dimen/keyline_2"
             android:gravity="center"
             android:text="@string/duck_chat_title"
             app:layout_constraintEnd_toEndOf="parent"
@@ -129,9 +127,21 @@
             android:layout_height="match_parent"
             android:orientation="vertical"
             android:paddingHorizontal="@dimen/keyline_4"
-            android:gravity="bottom"
-            android:paddingTop="@dimen/keyline_4"
             android:paddingBottom="@dimen/keyline_1">
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/contextualHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/keyline_5"
+                android:gravity="center"
+                tools:text="@string/duckAIContextualHeader"
+                app:typography="h1" />
+
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
 
             <com.duckduckgo.duckchat.impl.contextual.suggestions.ContextualSuggestionsView
                 android:id="@+id/contextualSuggestionsView"

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -27,4 +27,7 @@
     <!-- Page context attachment -->
     <string name="duckChatPageContextRemoveContentDescription">Remove page context</string>
 
+    <!-- Contextual sheet header -->
+    <string name="duckAIContextualHeader" instruction="%1$s is replaced by a shield icon">All chats are %1$s private</string>
+
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216783690854379?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
- Adds a "All chats are private" header to the contextual sheet.
- Also removes the logo next to Duck.ai.

### Steps to test this PR

- [ ] Open the contextual sheet
- [ ] Verify the header is present
- [ ] Verify that the Duck.ai logo is no longer present
- [ ] Verify that suggestions are accommodated correctly
- [ ] Maximize the sheet
- [ ] Verify the header reacts accordingly

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1080" height="2400" alt="Screenshot_20260730_235009" src="https://github.com/user-attachments/assets/027586ce-af70-44a3-89f1-0e3fa27ca8a5" />|<img width="1080" height="2400" alt="Screenshot_20260730_230018" src="https://github.com/user-attachments/assets/cdcc4930-344d-4c75-9c55-824dc1af8130" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and layout-only changes in the contextual Duck.ai UI; no auth, networking, or data-handling logic.
> 
> **Overview**
> The contextual Duck.ai bottom sheet **INPUT** state now shows a centered **h1** header above the suggestions area: *“All chats are [shield] private”*, with the shield inserted via `appendIconToText` and a `%1$s` placeholder in `duckAIContextualHeader`.
> 
> **Layout:** The sheet title no longer uses a start drawable; a weighted `Space` keeps suggestions and the quick-action chip toward the bottom while the new header sits at the top. `configureHeader()` runs when the bottom sheet is set up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a287cf7041b1a40c018b8f21323a820581af8976. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->