### PR TITLE
PIR: Forward extras on extracted profiles

### DIFF
--- a/pir/pir-impl/build.gradle
+++ b/pir/pir-impl/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     implementation AndroidX.security.crypto
 
     testImplementation Testing.junit4
+    testImplementation AndroidX.room.testing
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation project(path: ':common-test')
     testImplementation project(path: ':feature-toggles-test')
@@ -98,6 +99,9 @@ dependencies {
 
 android {
     namespace "com.duckduckgo.pir.impl"
+    sourceSets {
+        test.assets.srcDirs += files("$projectDir/schemas")
+    }
     anvil {
         generateDaggerFactories = true // default is false
     }

--- a/pir/pir-impl/schemas/com.duckduckgo.pir.impl.store.PirDatabase/17.json
+++ b/pir/pir-impl/schemas/com.duckduckgo.pir.impl.store.PirDatabase/17.json
@@ -1,0 +1,946 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 17,
+    "identityHash": "642943f91e5ef7438c568716d5a05864",
+    "entities": [
+      {
+        "tableName": "pir_broker_json_etag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fileName` TEXT NOT NULL, `etag` TEXT NOT NULL, PRIMARY KEY(`fileName`))",
+        "fields": [
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "etag",
+            "columnName": "etag",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fileName"
+          ]
+        }
+      },
+      {
+        "tableName": "pir_broker_details",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `fileName` TEXT NOT NULL, `url` TEXT NOT NULL, `version` TEXT NOT NULL, `parent` TEXT, `addedDatetime` INTEGER NOT NULL, `removedAt` INTEGER NOT NULL, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parent",
+            "columnName": "parent",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedDatetime",
+            "columnName": "addedDatetime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "removedAt",
+            "columnName": "removedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name"
+          ]
+        }
+      },
+      {
+        "tableName": "pir_broker_opt_out",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`brokerName` TEXT NOT NULL, `stepsJson` TEXT NOT NULL, `optOutUrl` TEXT, PRIMARY KEY(`brokerName`), FOREIGN KEY(`brokerName`) REFERENCES `pir_broker_details`(`name`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stepsJson",
+            "columnName": "stepsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optOutUrl",
+            "columnName": "optOutUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "brokerName"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "pir_broker_details",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "brokerName"
+            ],
+            "referencedColumns": [
+              "name"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "pir_broker_scan",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`brokerName` TEXT NOT NULL, `stepsJson` TEXT, PRIMARY KEY(`brokerName`), FOREIGN KEY(`brokerName`) REFERENCES `pir_broker_details`(`name`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stepsJson",
+            "columnName": "stepsJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "brokerName"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "pir_broker_details",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "brokerName"
+            ],
+            "referencedColumns": [
+              "name"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "pir_broker_scheduling_config",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`brokerName` TEXT NOT NULL, `retryError` INTEGER NOT NULL, `confirmOptOutScan` INTEGER NOT NULL, `maintenanceScan` INTEGER NOT NULL, `maxAttempts` INTEGER, PRIMARY KEY(`brokerName`), FOREIGN KEY(`brokerName`) REFERENCES `pir_broker_details`(`name`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retryError",
+            "columnName": "retryError",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmOptOutScan",
+            "columnName": "confirmOptOutScan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maintenanceScan",
+            "columnName": "maintenanceScan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxAttempts",
+            "columnName": "maxAttempts",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "brokerName"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "pir_broker_details",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "brokerName"
+            ],
+            "referencedColumns": [
+              "name"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "pir_user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `birthYear` INTEGER NOT NULL, `phone` TEXT, `deprecated` INTEGER NOT NULL, `user_firstName` TEXT NOT NULL, `user_lastName` TEXT NOT NULL, `user_middleName` TEXT, `user_suffix` TEXT, `address_city` TEXT NOT NULL, `address_state` TEXT NOT NULL, `address_street` TEXT, `address_zip` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "birthYear",
+            "columnName": "birthYear",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phone",
+            "columnName": "phone",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deprecated",
+            "columnName": "deprecated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName.firstName",
+            "columnName": "user_firstName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName.lastName",
+            "columnName": "user_lastName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName.middleName",
+            "columnName": "user_middleName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userName.suffix",
+            "columnName": "user_suffix",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addresses.city",
+            "columnName": "address_city",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addresses.state",
+            "columnName": "address_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addresses.street",
+            "columnName": "address_street",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addresses.zip",
+            "columnName": "address_zip",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "pir_events_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventTimeInMillis` INTEGER NOT NULL, `eventType` TEXT NOT NULL, PRIMARY KEY(`eventTimeInMillis`))",
+        "fields": [
+          {
+            "fieldPath": "eventTimeInMillis",
+            "columnName": "eventTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventTimeInMillis"
+          ]
+        }
+      },
+      {
+        "tableName": "pir_broker_scan_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventTimeInMillis` INTEGER NOT NULL, `brokerName` TEXT NOT NULL, `eventType` TEXT NOT NULL, PRIMARY KEY(`eventTimeInMillis`))",
+        "fields": [
+          {
+            "fieldPath": "eventTimeInMillis",
+            "columnName": "eventTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventTimeInMillis"
+          ]
+        }
+      },
+      {
+        "tableName": "pir_scan_complete_brokers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`brokerName` TEXT NOT NULL, `profileQueryId` INTEGER NOT NULL, `startTimeInMillis` INTEGER NOT NULL, `endTimeInMillis` INTEGER NOT NULL, `isSuccess` INTEGER NOT NULL, PRIMARY KEY(`brokerName`, `profileQueryId`))",
+        "fields": [
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileQueryId",
+            "columnName": "profileQueryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTimeInMillis",
+            "columnName": "startTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTimeInMillis",
+            "columnName": "endTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "brokerName",
+            "profileQueryId"
+          ]
+        }
+      },
+      {
+        "tableName": "pir_opt_out_complete_brokers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `brokerName` TEXT NOT NULL, `extractedProfile` TEXT NOT NULL, `startTimeInMillis` INTEGER NOT NULL, `endTimeInMillis` INTEGER NOT NULL, `isSubmitSuccess` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extractedProfile",
+            "columnName": "extractedProfile",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTimeInMillis",
+            "columnName": "startTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTimeInMillis",
+            "columnName": "endTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSubmitSuccess",
+            "columnName": "isSubmitSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "pir_opt_out_action_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `brokerName` TEXT NOT NULL, `extractedProfile` TEXT NOT NULL, `completionTimeInMillis` INTEGER NOT NULL, `actionType` TEXT NOT NULL, `isError` INTEGER NOT NULL, `result` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extractedProfile",
+            "columnName": "extractedProfile",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completionTimeInMillis",
+            "columnName": "completionTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionType",
+            "columnName": "actionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isError",
+            "columnName": "isError",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "result",
+            "columnName": "result",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "pir_extracted_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileQueryId` INTEGER NOT NULL, `brokerName` TEXT NOT NULL, `name` TEXT NOT NULL, `alternativeNames` TEXT NOT NULL, `age` TEXT NOT NULL, `addresses` TEXT NOT NULL, `phoneNumbers` TEXT NOT NULL, `relatives` TEXT NOT NULL, `profileUrl` TEXT NOT NULL, `identifier` TEXT NOT NULL, `reportId` TEXT NOT NULL, `email` TEXT NOT NULL, `fullName` TEXT NOT NULL, `dateAddedInMillis` INTEGER NOT NULL, `deprecated` INTEGER NOT NULL, `extras` TEXT NOT NULL DEFAULT '{}')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileQueryId",
+            "columnName": "profileQueryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alternativeNames",
+            "columnName": "alternativeNames",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "age",
+            "columnName": "age",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addresses",
+            "columnName": "addresses",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumbers",
+            "columnName": "phoneNumbers",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relatives",
+            "columnName": "relatives",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileUrl",
+            "columnName": "profileUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identifier",
+            "columnName": "identifier",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reportId",
+            "columnName": "reportId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAddedInMillis",
+            "columnName": "dateAddedInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deprecated",
+            "columnName": "deprecated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extras",
+            "columnName": "extras",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'{}'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pir_extracted_profiles_profileQueryId_brokerName_name_profileUrl_identifier",
+            "unique": true,
+            "columnNames": [
+              "profileQueryId",
+              "brokerName",
+              "name",
+              "profileUrl",
+              "identifier"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_pir_extracted_profiles_profileQueryId_brokerName_name_profileUrl_identifier` ON `${TABLE_NAME}` (`profileQueryId`, `brokerName`, `name`, `profileUrl`, `identifier`)"
+          }
+        ]
+      },
+      {
+        "tableName": "pir_scan_job_record",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`brokerName` TEXT NOT NULL, `userProfileId` INTEGER NOT NULL, `status` TEXT NOT NULL, `lastScanDateInMillis` INTEGER, `deprecated` INTEGER NOT NULL, `dateCreatedInMillis` INTEGER NOT NULL, PRIMARY KEY(`brokerName`, `userProfileId`))",
+        "fields": [
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userProfileId",
+            "columnName": "userProfileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastScanDateInMillis",
+            "columnName": "lastScanDateInMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "deprecated",
+            "columnName": "deprecated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateCreatedInMillis",
+            "columnName": "dateCreatedInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "brokerName",
+            "userProfileId"
+          ]
+        }
+      },
+      {
+        "tableName": "pir_optout_job_record",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`extractedProfileId` INTEGER NOT NULL, `brokerName` TEXT NOT NULL, `userProfileId` INTEGER NOT NULL, `status` TEXT NOT NULL, `attemptCount` INTEGER NOT NULL, `lastOptOutAttemptDate` INTEGER, `optOutRequestedDate` INTEGER NOT NULL, `optOutFormSubmittedDate` INTEGER, `optOutRemovedDate` INTEGER NOT NULL, `deprecated` INTEGER NOT NULL, `dateCreatedInMillis` INTEGER NOT NULL, `reporting_sevenDayConfirmationReportSentDateMs` INTEGER NOT NULL, `reporting_fourteenDayConfirmationReportSentDateMs` INTEGER NOT NULL, `reporting_twentyOneDayConfirmationReportSentDateMs` INTEGER NOT NULL, `reporting_fortyTwoDayConfirmationReportSentDateMs` INTEGER NOT NULL, PRIMARY KEY(`extractedProfileId`))",
+        "fields": [
+          {
+            "fieldPath": "extractedProfileId",
+            "columnName": "extractedProfileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userProfileId",
+            "columnName": "userProfileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOptOutAttemptDate",
+            "columnName": "lastOptOutAttemptDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "optOutRequestedDate",
+            "columnName": "optOutRequestedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optOutFormSubmittedDate",
+            "columnName": "optOutFormSubmittedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "optOutRemovedDate",
+            "columnName": "optOutRemovedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deprecated",
+            "columnName": "deprecated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateCreatedInMillis",
+            "columnName": "dateCreatedInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reporting.sevenDayConfirmationReportSentDateMs",
+            "columnName": "reporting_sevenDayConfirmationReportSentDateMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reporting.fourteenDayConfirmationReportSentDateMs",
+            "columnName": "reporting_fourteenDayConfirmationReportSentDateMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reporting.twentyOneDayConfirmationReportSentDateMs",
+            "columnName": "reporting_twentyOneDayConfirmationReportSentDateMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reporting.fortyTwoDayConfirmationReportSentDateMs",
+            "columnName": "reporting_fortyTwoDayConfirmationReportSentDateMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "extractedProfileId"
+          ]
+        }
+      },
+      {
+        "tableName": "pir_broker_mirror_sites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `url` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `removedAt` INTEGER NOT NULL, `optOutUrl` TEXT NOT NULL, `parentSite` TEXT NOT NULL, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "removedAt",
+            "columnName": "removedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optOutUrl",
+            "columnName": "optOutUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentSite",
+            "columnName": "parentSite",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name"
+          ]
+        }
+      },
+      {
+        "tableName": "pir_email_confirmation_job_record",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`extractedProfileId` INTEGER NOT NULL, `brokerName` TEXT NOT NULL, `userProfileId` INTEGER NOT NULL, `email` TEXT NOT NULL, `attemptId` TEXT NOT NULL, `dateCreatedInMillis` INTEGER NOT NULL, `emailConfirmationLink` TEXT NOT NULL, `linkFetchAttemptCount` INTEGER NOT NULL, `lastLinkFetchDateInMillis` INTEGER NOT NULL, `jobAttemptCount` INTEGER NOT NULL, `lastJobAttemptDateInMillis` INTEGER NOT NULL, `lastJobAttemptActionId` TEXT NOT NULL, `deprecated` INTEGER NOT NULL, PRIMARY KEY(`extractedProfileId`))",
+        "fields": [
+          {
+            "fieldPath": "extractedProfileId",
+            "columnName": "extractedProfileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userProfileId",
+            "columnName": "userProfileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptId",
+            "columnName": "attemptId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateCreatedInMillis",
+            "columnName": "dateCreatedInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emailConfirmationLink",
+            "columnName": "emailConfirmationLink",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkFetchAttemptCount",
+            "columnName": "linkFetchAttemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastLinkFetchDateInMillis",
+            "columnName": "lastLinkFetchDateInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobAttemptCount",
+            "columnName": "jobAttemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastJobAttemptDateInMillis",
+            "columnName": "lastJobAttemptDateInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastJobAttemptActionId",
+            "columnName": "lastJobAttemptActionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deprecated",
+            "columnName": "deprecated",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "extractedProfileId"
+          ]
+        }
+      },
+      {
+        "tableName": "pir_email_confirmation_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventTimeInMillis` INTEGER NOT NULL, `eventType` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`eventTimeInMillis`))",
+        "fields": [
+          {
+            "fieldPath": "eventTimeInMillis",
+            "columnName": "eventTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventTimeInMillis"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '642943f91e5ef7438c568716d5a05864')"
+    ]
+  }
+}

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirRunStateHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirRunStateHandler.kt
@@ -668,6 +668,7 @@ class RealPirRunStateHandler @Inject constructor(
                                     city = item.city,
                                     state = item.state,
                                     fullAddress = item.fullAddress,
+                                    extras = item.extras.orEmpty(),
                                 )
                             },
                             phoneNumbers = it.phoneNumbers,
@@ -676,13 +677,14 @@ class RealPirRunStateHandler @Inject constructor(
                             reportId = it.reportId.orEmpty(),
                             email = it.email.orEmpty(),
                             fullName = it.fullName.orEmpty(),
+                            extras = it.extras.orEmpty(),
                         )
                     }.also {
                         /**
                          * For every locally stored extractedProfile for the broker x profile that is not part of the newly received
                          * extracted Profiles, or no extracted Profiles were found on the broker:
                          * - We update the optOut status to REMOVED
-                         * - We store the new extracted profiles (if profile query is not deprecated). We ignore the ones that already exist.
+                         * - We store the new extracted profiles (if profile query is not deprecated) and refresh the ones we already have.
                          * - Update the corresponding ScanJobRecord
                          * For every stored extractedProfile that reappears in the results and whose opt-out was previously
                          * REMOVED, we revert it back to REQUESTED and report a reappearance pixel.
@@ -695,7 +697,7 @@ class RealPirRunStateHandler @Inject constructor(
                                     pixelSender.reportBrokerOptOutProfileReappeared(state.broker.url)
                                 }
                             jobRecordUpdater.updateScanMatchesFound(it, brokerName, state.profileQueryId)
-                            repository.saveNewExtractedProfiles(it)
+                            repository.saveExtractedProfiles(it)
                         } else {
                             jobRecordUpdater.updateScanNoMatchFound(brokerName, state.profileQueryId)
                         }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirUtils.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirUtils.kt
@@ -46,6 +46,7 @@ internal fun <T> List<T>.splitIntoParts(parts: Int): List<List<T>> {
 internal fun ExtractedProfile.toParams(fullName: String): ExtractedProfileParams {
     return ExtractedProfileParams(
         name = this.name.ifEmpty { null },
+        alternativeNames = this.alternativeNames,
         profileUrl = this.profileUrl.ifEmpty { null },
         fullName = fullName.ifEmpty { null },
         email = this.email.ifEmpty { null },

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirUtils.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirUtils.kt
@@ -16,8 +16,10 @@
 
 package com.duckduckgo.pir.impl.common
 
+import com.duckduckgo.pir.impl.models.AddressCityState
 import com.duckduckgo.pir.impl.models.ExtractedProfile
 import com.duckduckgo.pir.impl.scripts.models.ExtractedProfileParams
+import com.duckduckgo.pir.impl.scripts.models.ExtractedProfileParams.AddressParams
 
 internal fun <T> List<T>.splitIntoParts(parts: Int): List<List<T>> {
     if (this.isEmpty()) {
@@ -47,8 +49,54 @@ internal fun ExtractedProfile.toParams(fullName: String): ExtractedProfileParams
         profileUrl = this.profileUrl.ifEmpty { null },
         fullName = fullName.ifEmpty { null },
         email = this.email.ifEmpty { null },
+        age = this.age.ifEmpty { null },
+        addresses = this.addresses.map {
+            AddressParams(
+                city = it.city,
+                state = it.state,
+                extras = it.extras,
+            )
+        },
+        phoneNumbers = this.phoneNumbers,
+        relatives = this.relatives,
+        identifier = this.identifier.ifEmpty { null },
+        extras = this.extras,
     )
 }
+
+/**
+ * Two addresses describe the same place when their city and state match. Everything else on an
+ * address is detail scraped alongside it. Mirrors `sameCityState` in C-S-S.
+ */
+internal fun AddressCityState.sameCityState(other: AddressCityState): Boolean =
+    this.city == other.city && this.state == other.state
+
+/**
+ * Returns [scraped] with the attributes we own locally carried over from the stored record.
+ *
+ * Extras are merged rather than replaced: a key absent from the new scrape keeps the value we
+ * already hold, so a broker changing its page layout doesn't strip fields that a pending opt-out
+ * still needs. Address extras are merged onto the address with the same city and state.
+ */
+internal fun ExtractedProfile.refreshedWith(scraped: ExtractedProfile): ExtractedProfile {
+    val storedAddresses = this.addresses
+    return scraped.copy(
+        dbId = this.dbId,
+        dateAddedInMillis = this.dateAddedInMillis,
+        deprecated = this.deprecated,
+        extras = this.extras + scraped.extras,
+        addresses = scraped.addresses.map { address ->
+            val stored = storedAddresses.firstOrNull { it.sameCityState(address) }
+            address.copy(extras = stored?.extras.orEmpty() + address.extras)
+        },
+    )
+}
+
+/**
+ * Extras are excluded wherever we compare profiles for identity: a broker config that starts
+ * scraping a new field must not make a record we already hold look like a different one.
+ */
+internal fun List<AddressCityState>.withoutExtras(): List<AddressCityState> = this.map { it.copy(extras = emptyMap()) }
 
 internal fun ExtractedProfile.hasMatchingProfileOnParent(extractedProfiles: List<ExtractedProfile>): Boolean {
     return extractedProfiles.any {
@@ -60,7 +108,7 @@ internal fun ExtractedProfile.matches(extractedProfile: ExtractedProfile): Boole
     return this.name == extractedProfile.name && this.age == extractedProfile.age &&
         this.alternativeNames.isASubSetOrSuperSetOf(extractedProfile.alternativeNames) &&
         this.relatives.isASubSetOrSuperSetOf(extractedProfile.relatives) &&
-        this.addresses.isASubSetOrSuperSetOf(extractedProfile.addresses)
+        this.addresses.withoutExtras().isASubSetOrSuperSetOf(extractedProfile.addresses.withoutExtras())
 }
 
 private fun <T> List<T>.isASubSetOrSuperSetOf(other: List<T>): Boolean {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirUtils.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirUtils.kt
@@ -98,6 +98,23 @@ internal fun ExtractedProfile.refreshedWith(scraped: ExtractedProfile): Extracte
  */
 internal fun List<AddressCityState>.withoutExtras(): List<AddressCityState> = this.map { it.copy(extras = emptyMap()) }
 
+internal data class ExtractedProfileKey(
+    val profileQueryId: Long,
+    val brokerName: String,
+    val name: String,
+    val profileUrl: String,
+    val identifier: String,
+)
+
+internal fun ExtractedProfile.toKey(): ExtractedProfileKey =
+    ExtractedProfileKey(
+        profileQueryId = this.profileQueryId,
+        brokerName = this.brokerName,
+        name = this.name,
+        profileUrl = this.profileUrl,
+        identifier = this.identifier,
+    )
+
 internal fun ExtractedProfile.hasMatchingProfileOnParent(extractedProfiles: List<ExtractedProfile>): Boolean {
     return extractedProfiles.any {
         it.brokerName == this.brokerName && this.matches(it)
@@ -106,9 +123,9 @@ internal fun ExtractedProfile.hasMatchingProfileOnParent(extractedProfiles: List
 
 internal fun ExtractedProfile.matches(extractedProfile: ExtractedProfile): Boolean {
     return this.name == extractedProfile.name && this.age == extractedProfile.age &&
-        this.alternativeNames.isASubSetOrSuperSetOf(extractedProfile.alternativeNames) &&
-        this.relatives.isASubSetOrSuperSetOf(extractedProfile.relatives) &&
-        this.addresses.withoutExtras().isASubSetOrSuperSetOf(extractedProfile.addresses.withoutExtras())
+            this.alternativeNames.isASubSetOrSuperSetOf(extractedProfile.alternativeNames) &&
+            this.relatives.isASubSetOrSuperSetOf(extractedProfile.relatives) &&
+            this.addresses.withoutExtras().isASubSetOrSuperSetOf(extractedProfile.addresses.withoutExtras())
 }
 
 private fun <T> List<T>.isASubSetOrSuperSetOf(other: List<T>): Boolean {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirUtils.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirUtils.kt
@@ -123,9 +123,9 @@ internal fun ExtractedProfile.hasMatchingProfileOnParent(extractedProfiles: List
 
 internal fun ExtractedProfile.matches(extractedProfile: ExtractedProfile): Boolean {
     return this.name == extractedProfile.name && this.age == extractedProfile.age &&
-            this.alternativeNames.isASubSetOrSuperSetOf(extractedProfile.alternativeNames) &&
-            this.relatives.isASubSetOrSuperSetOf(extractedProfile.relatives) &&
-            this.addresses.withoutExtras().isASubSetOrSuperSetOf(extractedProfile.addresses.withoutExtras())
+        this.alternativeNames.isASubSetOrSuperSetOf(extractedProfile.alternativeNames) &&
+        this.relatives.isASubSetOrSuperSetOf(extractedProfile.relatives) &&
+        this.addresses.withoutExtras().isASubSetOrSuperSetOf(extractedProfile.addresses.withoutExtras())
 }
 
 private fun <T> List<T>.isASubSetOrSuperSetOf(other: List<T>): Boolean {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/models/ExtractedProfile.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/models/ExtractedProfile.kt
@@ -24,6 +24,10 @@ package com.duckduckgo.pir.impl.models
  * Majority of the attributes here came from the [PirSuccessResponse.ExtractedResponse]'s
  * [ScriptExtractedProfile]. Note that all attributes from the script can be null so we don't use
  * any as the local db id.
+ *
+ * [extras] holds fields the broker config asked the script to scrape that we have no schema for.
+ * We store and forward them verbatim so that a new field can be added in the broker config alone,
+ * without a native release.
  */
 data class ExtractedProfile(
     val dbId: Long = 0L,
@@ -42,10 +46,12 @@ data class ExtractedProfile(
     val identifier: String = "",
     val dateAddedInMillis: Long = 0L,
     val deprecated: Boolean = false,
+    val extras: Map<String, String> = emptyMap(),
 )
 
 data class AddressCityState(
     val city: String,
     val state: String,
     val fullAddress: String? = null,
+    val extras: Map<String, String> = emptyMap(),
 )

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/JobRecordUpdater.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/JobRecordUpdater.kt
@@ -19,8 +19,7 @@ package com.duckduckgo.pir.impl.scheduling
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.pir.impl.common.withoutExtras
-import com.duckduckgo.pir.impl.models.AddressCityState
+import com.duckduckgo.pir.impl.common.toKey
 import com.duckduckgo.pir.impl.models.ExtractedProfile
 import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord
@@ -592,39 +591,6 @@ class RealJobRecordUpdater @Inject constructor(
             }
         }
     }
-
-    private data class ExtractedProfileComparisonKey(
-        val profileQueryId: Long,
-        val brokerName: String,
-        val name: String,
-        val alternativeNames: List<String>,
-        val age: String,
-        val addresses: List<AddressCityState>,
-        val phoneNumbers: List<String>,
-        val relatives: List<String>,
-        val reportId: String,
-        val email: String,
-        val fullName: String,
-        val profileUrl: String,
-        val identifier: String,
-    )
-
-    private fun ExtractedProfile.toKey(): ExtractedProfileComparisonKey =
-        ExtractedProfileComparisonKey(
-            profileQueryId = profileQueryId,
-            brokerName = brokerName,
-            name = name,
-            alternativeNames = alternativeNames,
-            age = age,
-            addresses = addresses.withoutExtras(),
-            phoneNumbers = phoneNumbers,
-            relatives = relatives,
-            reportId = reportId,
-            email = email,
-            fullName = fullName,
-            profileUrl = profileUrl,
-            identifier = identifier,
-        )
 
     override suspend fun markEmailConfirmationLinkFetchFailed(extractedProfileId: Long) {
         schedulingRepository.deleteEmailConfirmationJobRecord(extractedProfileId)

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/JobRecordUpdater.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/JobRecordUpdater.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.pir.impl.scheduling
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.pir.impl.common.withoutExtras
 import com.duckduckgo.pir.impl.models.AddressCityState
 import com.duckduckgo.pir.impl.models.ExtractedProfile
 import com.duckduckgo.pir.impl.models.ProfileQuery
@@ -615,7 +616,7 @@ class RealJobRecordUpdater @Inject constructor(
             name = name,
             alternativeNames = alternativeNames,
             age = age,
-            addresses = addresses,
+            addresses = addresses.withoutExtras(),
             phoneNumbers = phoneNumbers,
             relatives = relatives,
             reportId = reportId,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
@@ -127,30 +127,12 @@ sealed class BrokerAction(
     ) : BrokerAction(id)
 }
 
-data class ExtractProfileSelectors(
-    val name: ProfileSelector?,
-    val alternativeNamesList: ProfileSelector?,
-    val age: ProfileSelector?,
-    val addressFull: ProfileSelector?,
-    val addressFullList: ProfileSelector?,
-    val addressCityState: ProfileSelector?,
-    val addressCityStateList: ProfileSelector?,
-    val phone: ProfileSelector?,
-    val phoneList: ProfileSelector?,
-    val relativesList: ProfileSelector?,
-    val profileUrl: ProfileSelector?,
-    val reportedId: ProfileSelector?,
-)
-
-data class ProfileSelector(
-    val selector: String?,
-    val findElements: Boolean?,
-    val beforeText: String?,
-    val afterText: String?,
-    val separator: String?,
-    val identifierType: String?,
-    val identifier: String?,
-)
+/**
+ * The `profile` block of an extract action, forwarded to C-S-S untouched. Modelling its shape would drop
+ * whatever a broker config uses that we haven't declared, and C-S-S scrapes fields we don't recognise
+ * into the extracted profile's `extras`.
+ */
+typealias ExtractProfileSelectors = Map<String, Any?>
 
 data class ElementSelector(
     val type: String,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
@@ -160,6 +160,7 @@ data class ElementSelector(
     val min: String?,
     val max: String?,
     val failSilently: Boolean?,
+    val format: String? = null,
 )
 
 data class ParentElement(

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/PirScriptRequestParams.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/PirScriptRequestParams.kt
@@ -43,6 +43,7 @@ sealed class PirScriptRequestData {
 data class ExtractedProfileParams(
     val id: Int? = null,
     val name: String? = null,
+    val alternativeNames: List<String> = emptyList(),
     val profileUrl: String? = null,
     val email: String? = null,
     val fullName: String? = null,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/PirScriptRequestParams.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/PirScriptRequestParams.kt
@@ -46,7 +46,19 @@ data class ExtractedProfileParams(
     val profileUrl: String? = null,
     val email: String? = null,
     val fullName: String? = null,
-)
+    val age: String? = null,
+    val addresses: List<AddressParams> = emptyList(),
+    val phoneNumbers: List<String> = emptyList(),
+    val relatives: List<String> = emptyList(),
+    val identifier: String? = null,
+    val extras: Map<String, String> = emptyMap(),
+) {
+    data class AddressParams(
+        val city: String,
+        val state: String,
+        val extras: Map<String, String> = emptyMap(),
+    )
+}
 
 // Wraps the generated email as { "email": "..." } so C-S-S can resolve it via data[dataSource].email.
 data class FetchedEmail(

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/PirScriptResponseParams.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/PirScriptResponseParams.kt
@@ -69,12 +69,14 @@ sealed class PirSuccessResponse(
             val email: String? = null,
             val removedDate: String? = null,
             val fullName: String? = null,
+            val extras: Map<String, String>? = null,
         )
 
         data class ScriptAddressCityState(
             val city: String,
             val state: String,
             val fullAddress: String? = null,
+            val extras: Map<String, String>? = null,
         )
     }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirDatabase.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirDatabase.kt
@@ -54,7 +54,7 @@ import com.squareup.moshi.Types
 
 @Database(
     exportSchema = true,
-    version = 16,
+    version = 17,
     entities = [
         BrokerJsonEtag::class,
         BrokerEntity::class,
@@ -77,6 +77,8 @@ import com.squareup.moshi.Types
     autoMigrations = [
         // v16: adds nullable optOutFormSubmittedDate column to OptOutJobRecordEntity
         AutoMigration(from = 15, to = 16),
+        // v17: adds extras column to StoredExtractedProfile
+        AutoMigration(from = 16, to = 17),
     ],
 )
 @TypeConverters(PirDatabaseConverters::class)
@@ -107,6 +109,8 @@ abstract class PirDatabase : RoomDatabase() {
 object PirDatabaseConverters {
     private val stringListType = Types.newParameterizedType(List::class.java, String::class.java)
     private val stringListAdapter: JsonAdapter<List<String>> = Moshi.Builder().build().adapter(stringListType)
+    private val stringMapType = Types.newParameterizedType(Map::class.java, String::class.java, String::class.java)
+    private val stringMapAdapter: JsonAdapter<Map<String, String>> = Moshi.Builder().build().adapter(stringMapType)
 
     @TypeConverter
     @JvmStatic
@@ -115,4 +119,12 @@ object PirDatabaseConverters {
     @TypeConverter
     @JvmStatic
     fun fromStringList(value: List<String>): String = stringListAdapter.toJson(value)
+
+    @TypeConverter
+    @JvmStatic
+    fun toStringMap(value: String): Map<String, String> = stringMapAdapter.fromJson(value)!!
+
+    @TypeConverter
+    @JvmStatic
+    fun fromStringMap(value: Map<String, String>): String = stringMapAdapter.toJson(value)
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirRepository.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirRepository.kt
@@ -556,28 +556,34 @@ class RealPirRepository(
                 return@withContext
             }
 
+            val db = database.await() ?: return@withContext
+            val userProfileDao = db.userProfileDao()
+            val dao = db.extractedProfileDao()
             val profileQueryId = extractedProfiles.first().profileQueryId
-            val profileQuery = userProfileDao()?.getUserProfile(profileQueryId)
-            if (profileQuery?.deprecated == true) {
-                // we should not store any new extracted profiles for a deprecated user profile
-                // also don't mark them as deprecated as we still want to show them on the UI
-                return@withContext
-            }
 
-            val dao = extractedProfileDao() ?: return@withContext
-            val storedProfiles = extractedProfiles
-                .map { it.brokerName }
-                .distinct()
-                .flatMap { dao.getExtractedProfilesForBrokerAndProfile(it, profileQueryId) }
-                .map { it.toExtractedProfile() }
-                .associateBy { it.storageKey() }
+            db.runInTransaction(
+                Runnable {
+                    if (userProfileDao.getUserProfile(profileQueryId)?.deprecated == true) {
+                        // we should not store any new extracted profiles for a deprecated user profile
+                        // also don't mark them as deprecated as we still want to show them on the UI
+                        return@Runnable
+                    }
 
-            val (alreadyStored, newlyFound) = extractedProfiles.partition { it.storageKey() in storedProfiles }
+                    val storedProfiles = extractedProfiles
+                        .map { it.brokerName }
+                        .distinct()
+                        .flatMap { dao.getExtractedProfilesForBrokerAndProfile(it, profileQueryId) }
+                        .map { it.toExtractedProfile() }
+                        .associateBy { it.storageKey() }
 
-            dao.insertNewExtractedProfiles(newlyFound.map { it.toStoredExtractedProfile() })
-            dao.updateExtractedProfiles(
-                alreadyStored.map { scraped ->
-                    storedProfiles.getValue(scraped.storageKey()).refreshedWith(scraped).toStoredExtractedProfile()
+                    val (alreadyStored, newlyFound) = extractedProfiles.partition { it.storageKey() in storedProfiles }
+
+                    dao.insertNewExtractedProfiles(newlyFound.map { it.toStoredExtractedProfile() })
+                    dao.updateExtractedProfiles(
+                        alreadyStored.map { scraped ->
+                            storedProfiles.getValue(scraped.storageKey()).refreshedWith(scraped).toStoredExtractedProfile()
+                        },
+                    )
                 },
             )
         }
@@ -887,17 +893,6 @@ class RealPirRepository(
             },
         )
 
-    /**
-     * Identifies a record within the unique index on the extracted profiles table.
-     */
-    private data class ExtractedProfileStorageKey(
-        val profileQueryId: Long,
-        val brokerName: String,
-        val name: String,
-        val profileUrl: String,
-        val identifier: String,
-    )
-
     private fun ExtractedProfile.storageKey(): ExtractedProfileStorageKey =
         ExtractedProfileStorageKey(
             profileQueryId = this.profileQueryId,
@@ -1017,6 +1012,17 @@ class RealPirRepository(
     private suspend fun extractedProfileDao(): ExtractedProfileDao? = database.await()?.extractedProfileDao()
 
     private suspend fun userProfileDao(): UserProfileDao? = database.await()?.userProfileDao()
+
+    /**
+     * Identifies a record within the unique index on the extracted profiles table.
+     */
+    private data class ExtractedProfileStorageKey(
+        val profileQueryId: Long,
+        val brokerName: String,
+        val name: String,
+        val profileUrl: String,
+        val identifier: String,
+    )
 
     companion object {
         private const val EMAIL_DATA_BATCH_SIZE = 100

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirRepository.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirRepository.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.pir.impl.store
 
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.pir.impl.common.refreshedWith
 import com.duckduckgo.pir.impl.models.Address
 import com.duckduckgo.pir.impl.models.AddressCityState
 import com.duckduckgo.pir.impl.models.Broker
@@ -48,6 +49,7 @@ import com.duckduckgo.pir.impl.store.db.UserProfile
 import com.duckduckgo.pir.impl.store.db.UserProfileDao
 import com.duckduckgo.pir.impl.store.secure.PirSecureStorageDatabaseFactory
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
@@ -137,10 +139,13 @@ interface PirRepository {
     suspend fun getBrokersForOptOut(formOptOutOnly: Boolean): List<String>
 
     /**
-     * This method saves the new extracted profiles to the database.
-     * Any existing profiles (see indices of the table), we ignore them
+     * This method saves the extracted profiles to the database.
+     *
+     * Profiles we already store (see indices of the table) are refreshed with the newly scraped
+     * attributes, keeping their local id, date added and deprecated flag. Extras are merged into
+     * the stored extras so that a key missing from this scrape keeps the value we already hold.
      */
-    suspend fun saveNewExtractedProfiles(extractedProfiles: List<ExtractedProfile>)
+    suspend fun saveExtractedProfiles(extractedProfiles: List<ExtractedProfile>)
 
     /**
      * Returns a list of all [ExtractedProfile] found for this particular broker.
@@ -318,7 +323,10 @@ class RealPirRepository(
         prepareDatabase()
     }
 
-    private val addressCityStateAdapter by lazy { Moshi.Builder().build().adapter(AddressCityState::class.java) }
+    // Kotlin defaults are needed here so that addresses stored before a field was introduced still parse.
+    private val addressCityStateAdapter by lazy {
+        Moshi.Builder().add(KotlinJsonAdapterFactory()).build().adapter(AddressCityState::class.java)
+    }
 
     override suspend fun isRepositoryAvailable(): Boolean = database.await() != null
 
@@ -542,7 +550,7 @@ class RealPirRepository(
                 }.orEmpty()
         }
 
-    override suspend fun saveNewExtractedProfiles(extractedProfiles: List<ExtractedProfile>) {
+    override suspend fun saveExtractedProfiles(extractedProfiles: List<ExtractedProfile>) {
         withContext(dispatcherProvider.io()) {
             if (extractedProfiles.isEmpty()) {
                 return@withContext
@@ -556,12 +564,22 @@ class RealPirRepository(
                 return@withContext
             }
 
-            extractedProfiles
-                .map {
-                    it.toStoredExtractedProfile()
-                }.also {
-                    extractedProfileDao()?.insertNewExtractedProfiles(it)
-                }
+            val dao = extractedProfileDao() ?: return@withContext
+            val storedProfiles = extractedProfiles
+                .map { it.brokerName }
+                .distinct()
+                .flatMap { dao.getExtractedProfilesForBrokerAndProfile(it, profileQueryId) }
+                .map { it.toExtractedProfile() }
+                .associateBy { it.storageKey() }
+
+            val (alreadyStored, newlyFound) = extractedProfiles.partition { it.storageKey() in storedProfiles }
+
+            dao.insertNewExtractedProfiles(newlyFound.map { it.toStoredExtractedProfile() })
+            dao.updateExtractedProfiles(
+                alreadyStored.map { scraped ->
+                    storedProfiles.getValue(scraped.storageKey()).refreshedWith(scraped).toStoredExtractedProfile()
+                },
+            )
         }
     }
 
@@ -869,6 +887,26 @@ class RealPirRepository(
             },
         )
 
+    /**
+     * Identifies a record within the unique index on the extracted profiles table.
+     */
+    private data class ExtractedProfileStorageKey(
+        val profileQueryId: Long,
+        val brokerName: String,
+        val name: String,
+        val profileUrl: String,
+        val identifier: String,
+    )
+
+    private fun ExtractedProfile.storageKey(): ExtractedProfileStorageKey =
+        ExtractedProfileStorageKey(
+            profileQueryId = this.profileQueryId,
+            brokerName = this.brokerName,
+            name = this.name,
+            profileUrl = this.profileUrl,
+            identifier = this.identifier,
+        )
+
     private fun StoredExtractedProfile.toExtractedProfile(): ExtractedProfile =
         ExtractedProfile(
             dbId = this.id,
@@ -890,6 +928,7 @@ class RealPirRepository(
             fullName = this.fullName,
             dateAddedInMillis = this.dateAddedInMillis,
             deprecated = this.deprecated,
+            extras = this.extras,
         )
 
     private fun ExtractedProfile.toStoredExtractedProfile(): StoredExtractedProfile =
@@ -918,6 +957,7 @@ class RealPirRepository(
                 this.dateAddedInMillis
             },
             deprecated = this.deprecated,
+            extras = this.extras,
         )
 
     private fun ProfileQuery.toUserProfile(): UserProfile =

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirRepository.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirRepository.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.pir.impl.store
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.pir.impl.common.refreshedWith
+import com.duckduckgo.pir.impl.common.toKey
 import com.duckduckgo.pir.impl.models.Address
 import com.duckduckgo.pir.impl.models.AddressCityState
 import com.duckduckgo.pir.impl.models.Broker
@@ -561,31 +562,29 @@ class RealPirRepository(
             val dao = db.extractedProfileDao()
             val profileQueryId = extractedProfiles.first().profileQueryId
 
-            db.runInTransaction(
-                Runnable {
-                    if (userProfileDao.getUserProfile(profileQueryId)?.deprecated == true) {
-                        // we should not store any new extracted profiles for a deprecated user profile
-                        // also don't mark them as deprecated as we still want to show them on the UI
-                        return@Runnable
-                    }
+            db.runInTransaction {
+                if (userProfileDao.getUserProfile(profileQueryId)?.deprecated == true) {
+                    // we should not store any new extracted profiles for a deprecated user profile
+                    // also don't mark them as deprecated as we still want to show them on the UI
+                    return@runInTransaction
+                }
 
-                    val storedProfiles = extractedProfiles
-                        .map { it.brokerName }
-                        .distinct()
-                        .flatMap { dao.getExtractedProfilesForBrokerAndProfile(it, profileQueryId) }
-                        .map { it.toExtractedProfile() }
-                        .associateBy { it.storageKey() }
+                val storedProfiles = extractedProfiles
+                    .map { it.brokerName }
+                    .distinct()
+                    .flatMap { dao.getExtractedProfilesForBrokerAndProfile(it, profileQueryId) }
+                    .map { it.toExtractedProfile() }
+                    .associateBy { it.toKey() }
 
-                    val (alreadyStored, newlyFound) = extractedProfiles.partition { it.storageKey() in storedProfiles }
+                val (alreadyStored, newlyFound) = extractedProfiles.partition { it.toKey() in storedProfiles }
 
-                    dao.insertNewExtractedProfiles(newlyFound.map { it.toStoredExtractedProfile() })
-                    dao.updateExtractedProfiles(
-                        alreadyStored.map { scraped ->
-                            storedProfiles.getValue(scraped.storageKey()).refreshedWith(scraped).toStoredExtractedProfile()
-                        },
-                    )
-                },
-            )
+                dao.insertNewExtractedProfiles(newlyFound.map { it.toStoredExtractedProfile() })
+                dao.updateExtractedProfiles(
+                    alreadyStored.map { scraped ->
+                        storedProfiles.getValue(scraped.toKey()).refreshedWith(scraped).toStoredExtractedProfile()
+                    },
+                )
+            }
         }
     }
 
@@ -893,15 +892,6 @@ class RealPirRepository(
             },
         )
 
-    private fun ExtractedProfile.storageKey(): ExtractedProfileStorageKey =
-        ExtractedProfileStorageKey(
-            profileQueryId = this.profileQueryId,
-            brokerName = this.brokerName,
-            name = this.name,
-            profileUrl = this.profileUrl,
-            identifier = this.identifier,
-        )
-
     private fun StoredExtractedProfile.toExtractedProfile(): ExtractedProfile =
         ExtractedProfile(
             dbId = this.id,
@@ -1012,17 +1002,6 @@ class RealPirRepository(
     private suspend fun extractedProfileDao(): ExtractedProfileDao? = database.await()?.extractedProfileDao()
 
     private suspend fun userProfileDao(): UserProfileDao? = database.await()?.userProfileDao()
-
-    /**
-     * Identifies a record within the unique index on the extracted profiles table.
-     */
-    private data class ExtractedProfileStorageKey(
-        val profileQueryId: Long,
-        val brokerName: String,
-        val name: String,
-        val profileUrl: String,
-        val identifier: String,
-    )
 
     companion object {
         private const val EMAIL_DATA_BATCH_SIZE = 100

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/db/ExtractedProfileDao.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/db/ExtractedProfileDao.kt
@@ -20,6 +20,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -50,6 +51,9 @@ interface ExtractedProfileDao {
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun insertNewExtractedProfiles(extractedProfiles: List<StoredExtractedProfile>)
+
+    @Update
+    fun updateExtractedProfiles(extractedProfiles: List<StoredExtractedProfile>)
 
     @Query("DELETE from pir_extracted_profiles")
     fun deleteAllExtractedProfiles()

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/db/ExtractedProfileEntities.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/db/ExtractedProfileEntities.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.pir.impl.store.db
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
@@ -52,4 +53,5 @@ data class StoredExtractedProfile(
     val fullName: String = "",
     val dateAddedInMillis: Long = 0L, // Tells us when the extracted profile has been found
     val deprecated: Boolean = false, // This should tell us if the profile is irrelevant for PIR (this is not me, profile edits)
+    @ColumnInfo(defaultValue = "{}") val extras: Map<String, String> = emptyMap(), // Scraped fields we have no schema for
 )

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/PirUtilsTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/PirUtilsTest.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.pir.impl.models.AddressCityState
 import com.duckduckgo.pir.impl.models.ExtractedProfile
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -670,5 +671,49 @@ class PirUtilsTest {
         val result = stored.refreshedWith(scraped)
 
         assertEquals(listOf(AddressCityState(city = "Boston", state = "MA", extras = mapOf("zip" to "02101"))), result.addresses)
+    }
+
+    @Test
+    fun whenToKeyAndOnlyScrapedDetailDiffersThenKeysAreEqual() {
+        val stored = ExtractedProfile(
+            profileQueryId = 123L,
+            brokerName = "test-broker",
+            name = "John Doe",
+            profileUrl = "https://example.com/profile/100",
+            identifier = "id100",
+            age = "35",
+            addresses = listOf(AddressCityState(city = "Springfield", state = "IL")),
+            alternativeNames = listOf("Johnny Doe"),
+            relatives = listOf("Jane Doe"),
+            extras = mapOf("county" to "Sangamon"),
+        )
+
+        val scraped = stored.copy(
+            dbId = 0L,
+            age = "36",
+            addresses = listOf(AddressCityState(city = "Boston", state = "MA")),
+            alternativeNames = emptyList(),
+            relatives = emptyList(),
+            extras = emptyMap(),
+        )
+
+        assertEquals(stored.toKey(), scraped.toKey())
+    }
+
+    @Test
+    fun whenToKeyAndAnIndexedFieldDiffersThenKeysAreNotEqual() {
+        val profile = ExtractedProfile(
+            profileQueryId = 123L,
+            brokerName = "test-broker",
+            name = "John Doe",
+            profileUrl = "https://example.com/profile/100",
+            identifier = "id100",
+        )
+
+        assertNotEquals(profile.toKey(), profile.copy(profileQueryId = 456L).toKey())
+        assertNotEquals(profile.toKey(), profile.copy(brokerName = "other-broker").toKey())
+        assertNotEquals(profile.toKey(), profile.copy(name = "Jane Doe").toKey())
+        assertNotEquals(profile.toKey(), profile.copy(profileUrl = "https://example.com/profile/200").toKey())
+        assertNotEquals(profile.toKey(), profile.copy(identifier = "id200").toKey())
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/PirUtilsTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/PirUtilsTest.kt
@@ -502,4 +502,173 @@ class PirUtilsTest {
 
         assertTrue(result)
     }
+
+    @Test
+    fun whenMatchesWithAddressesDifferingOnlyByExtrasThenReturnsTrue() {
+        val profile1 = ExtractedProfile(
+            profileQueryId = 123L,
+            brokerName = "test-broker",
+            name = "John Doe",
+            addresses = listOf(AddressCityState(city = "City", state = "State")),
+        )
+
+        val profile2 = ExtractedProfile(
+            profileQueryId = 456L,
+            brokerName = "test-broker",
+            name = "John Doe",
+            addresses = listOf(AddressCityState(city = "City", state = "State", extras = mapOf("zip" to "12345"))),
+        )
+
+        val result = profile1.matches(profile2)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenToParamsWithExtrasThenForwardsProfileAndAddressExtras() {
+        val profile = ExtractedProfile(
+            profileQueryId = 123L,
+            brokerName = "test-broker",
+            name = "John Doe",
+            age = "35",
+            addresses = listOf(
+                AddressCityState(
+                    city = "Springfield",
+                    state = "IL",
+                    fullAddress = "100 Sample Dr, Springfield, IL 62701",
+                    extras = mapOf("street" to "100 Sample Dr", "zip" to "62701"),
+                ),
+            ),
+            phoneNumbers = listOf("555-1234"),
+            relatives = listOf("Jane Doe"),
+            identifier = "id123",
+            extras = mapOf("county" to "Sangamon"),
+        )
+
+        val result = profile.toParams("John Doe")
+
+        assertEquals("35", result.age)
+        assertEquals(listOf("555-1234"), result.phoneNumbers)
+        assertEquals(listOf("Jane Doe"), result.relatives)
+        assertEquals("id123", result.identifier)
+        assertEquals(mapOf("county" to "Sangamon"), result.extras)
+        assertEquals(1, result.addresses.size)
+        assertEquals("Springfield", result.addresses[0].city)
+        assertEquals("IL", result.addresses[0].state)
+        assertEquals(mapOf("street" to "100 Sample Dr", "zip" to "62701"), result.addresses[0].extras)
+    }
+
+    @Test
+    fun whenToParamsWithoutExtrasThenSendsEmptyMaps() {
+        val profile = ExtractedProfile(
+            profileQueryId = 123L,
+            brokerName = "test-broker",
+            name = "John Doe",
+        )
+
+        val result = profile.toParams("John Doe")
+
+        assertNull(result.age)
+        assertNull(result.identifier)
+        assertTrue(result.extras.isEmpty())
+        assertTrue(result.addresses.isEmpty())
+        assertTrue(result.phoneNumbers.isEmpty())
+        assertTrue(result.relatives.isEmpty())
+    }
+
+    @Test
+    fun whenRefreshedWithThenKeepsLocallyOwnedAttributesAndTakesScrapedOnes() {
+        val stored = ExtractedProfile(
+            dbId = 42L,
+            profileQueryId = 123L,
+            brokerName = "test-broker",
+            name = "John Doe",
+            age = "35",
+            relatives = listOf("Jane Doe"),
+            dateAddedInMillis = 1000L,
+            deprecated = true,
+        )
+
+        val scraped = ExtractedProfile(
+            dbId = 0L,
+            profileQueryId = 123L,
+            brokerName = "test-broker",
+            name = "John Doe",
+            age = "36",
+            relatives = listOf("Jane Doe", "Jack Doe"),
+            dateAddedInMillis = 0L,
+            deprecated = false,
+        )
+
+        val result = stored.refreshedWith(scraped)
+
+        assertEquals(42L, result.dbId)
+        assertEquals(1000L, result.dateAddedInMillis)
+        assertTrue(result.deprecated)
+        assertEquals("36", result.age)
+        assertEquals(listOf("Jane Doe", "Jack Doe"), result.relatives)
+    }
+
+    @Test
+    fun whenRefreshedWithThenMergesProfileExtrasKeepingKeysMissingFromTheScrape() {
+        val stored = ExtractedProfile(
+            profileQueryId = 123L,
+            brokerName = "test-broker",
+            extras = mapOf("county" to "Sangamon", "middleName" to "Michael"),
+        )
+
+        val scraped = ExtractedProfile(
+            profileQueryId = 123L,
+            brokerName = "test-broker",
+            extras = mapOf("county" to "Cook"),
+        )
+
+        val result = stored.refreshedWith(scraped)
+
+        assertEquals(mapOf("county" to "Cook", "middleName" to "Michael"), result.extras)
+    }
+
+    @Test
+    fun whenRefreshedWithThenMergesExtrasOfTheAddressWithTheSameCityAndState() {
+        val stored = ExtractedProfile(
+            profileQueryId = 123L,
+            brokerName = "test-broker",
+            addresses = listOf(
+                AddressCityState(city = "Springfield", state = "IL", extras = mapOf("street" to "100 Sample Dr", "zip" to "62701")),
+                AddressCityState(city = "Boston", state = "MA", extras = mapOf("zip" to "02101")),
+            ),
+        )
+
+        val scraped = ExtractedProfile(
+            profileQueryId = 123L,
+            brokerName = "test-broker",
+            addresses = listOf(
+                AddressCityState(city = "Springfield", state = "IL", extras = mapOf("zip" to "62702")),
+            ),
+        )
+
+        val result = stored.refreshedWith(scraped)
+
+        assertEquals(1, result.addresses.size)
+        assertEquals(mapOf("street" to "100 Sample Dr", "zip" to "62702"), result.addresses[0].extras)
+    }
+
+    @Test
+    fun whenRefreshedWithNewAddressThenKeepsOnlyItsOwnExtras() {
+        val stored = ExtractedProfile(
+            profileQueryId = 123L,
+            brokerName = "test-broker",
+            addresses = listOf(AddressCityState(city = "Springfield", state = "IL", extras = mapOf("street" to "100 Sample Dr"))),
+        )
+
+        val scraped = ExtractedProfile(
+            profileQueryId = 123L,
+            brokerName = "test-broker",
+            addresses = listOf(AddressCityState(city = "Boston", state = "MA", extras = mapOf("zip" to "02101"))),
+        )
+
+        val result = stored.refreshedWith(scraped)
+
+        assertEquals(listOf(AddressCityState(city = "Boston", state = "MA", extras = mapOf("zip" to "02101"))), result.addresses)
+    }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/PirUtilsTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/PirUtilsTest.kt
@@ -102,6 +102,7 @@ class PirUtilsTest {
             profileQueryId = 123L,
             brokerName = "test-broker",
             name = "John Doe",
+            alternativeNames = listOf("Johnny Doe", "J Doe"),
             profileUrl = "https://example.com/profile",
             email = "john@example.com",
         )
@@ -109,6 +110,7 @@ class PirUtilsTest {
         val result = profile.toParams("John Doe")
 
         assertEquals("John Doe", result.name)
+        assertEquals(listOf("Johnny Doe", "J Doe"), result.alternativeNames)
         assertEquals("https://example.com/profile", result.profileUrl)
         assertEquals("John Doe", result.fullName)
         assertEquals("john@example.com", result.email)

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealBrokerStepsParserTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealBrokerStepsParserTest.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobR
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.EmailData
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.LinkFetchData
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction
+import com.duckduckgo.pir.impl.scripts.models.ElementSelector
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
@@ -153,7 +154,17 @@ class RealBrokerStepsParserTest {
                         "actionType": "fillForm",
                         "id": "fill-1",
                         "selector": "#optout-form",
-                        "elements": []
+                        "elements": [
+                            {
+                                "type": "elementType",
+                                "selector": "#element",
+                                "multiple": true,
+                                "min": "1",
+                                "max": "10",
+                                "failSilently": true,
+                                "format": "elementFormat"
+                            }
+                        ]
                     }
                 ]
             }
@@ -175,6 +186,23 @@ class RealBrokerStepsParserTest {
         assertEquals("optOut", optOutStep1.step.stepType)
         assertEquals("form", optOutStep1.step.optOutType)
         assertEquals(2, optOutStep1.step.actions.size)
+
+        val fillForm = optOutStep1.step.actions[1] as BrokerAction.FillForm
+        assertEquals(
+            listOf(
+                ElementSelector(
+                    type = "elementType",
+                    selector = "#element",
+                    parent = null,
+                    multiple = true,
+                    min = "1",
+                    max = "10",
+                    failSilently = true,
+                    format = "elementFormat",
+                ),
+            ),
+            fillForm.elements,
+        )
 
         val optOutStep2 = result[1] as OptOutStep
         assertEquals(testProfile2, optOutStep2.profileToOptOut)

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealPirRunStateHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealPirRunStateHandlerTest.kt
@@ -59,10 +59,12 @@ import com.duckduckgo.pir.impl.store.db.EmailConfirmationEventType.EMAIL_CONFIRM
 import com.duckduckgo.pir.impl.store.db.PirBrokerScanLog
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -401,7 +403,46 @@ class RealPirRunStateHandlerTest {
                 testBrokerName,
                 testProfileQueryId,
             )
-            inOrder.verify(mockRepository).saveNewExtractedProfiles(listOf(expectedExtractedProfile))
+            inOrder.verify(mockRepository).saveExtractedProfiles(listOf(expectedExtractedProfile))
+        }
+
+    @Test
+    fun whenHandleBrokerScanActionSucceededWithExtrasThenSavesProfileAndAddressExtras() =
+        runTest {
+            val extractedResponse =
+                ExtractedResponse(
+                    actionID = "extract123",
+                    actionType = "extract",
+                    response = listOf(
+                        testScriptExtractedProfile.copy(
+                            addresses = listOf(
+                                ScriptAddressCityState(
+                                    city = "New York",
+                                    state = "NY",
+                                    fullAddress = "123 Main St",
+                                    extras = mapOf("street" to "123 Main St", "zip" to "10001"),
+                                ),
+                            ),
+                            extras = mapOf("county" to "New York County"),
+                        ),
+                    ),
+                )
+            val state =
+                BrokerScanActionSucceeded(
+                    broker = testBroker,
+                    profileQueryId = testProfileQueryId,
+                    pirSuccessResponse = extractedResponse,
+                )
+            whenever(mockJobRecordUpdater.markReappearedOptOutJobRecords(any(), any(), any()))
+                .thenReturn(emptyList())
+
+            testee.handleState(state)
+
+            val captor = argumentCaptor<List<ExtractedProfile>>()
+            verify(mockRepository).saveExtractedProfiles(captor.capture())
+            val savedProfile = captor.firstValue.single()
+            assertEquals(mapOf("county" to "New York County"), savedProfile.extras)
+            assertEquals(mapOf("street" to "123 Main St", "zip" to "10001"), savedProfile.addresses.single().extras)
         }
 
     @Test

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealJobRecordUpdaterTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealJobRecordUpdaterTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.pir.impl.scheduling
 
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.pir.impl.models.AddressCityState
 import com.duckduckgo.pir.impl.models.ExtractedProfile
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.EmailData
@@ -456,6 +457,42 @@ class RealJobRecordUpdaterTest {
 
             verify(mockRepository).getExtractedProfiles(testBrokerName, testProfileQueryId)
             // Should not call getValidOptOutJobRecord or saveOptOutJobRecord since no profiles were removed
+            verify(mockSchedulingRepository, never()).getValidOptOutJobRecord(any(), any())
+            verify(mockSchedulingRepository, never()).saveOptOutJobRecord(any())
+        }
+
+    @Test
+    fun whenMarkRemovedProfilesWithOnlyScrapedDetailChangedThenDoesNotMarkAsRemoved() =
+        runTest {
+            // The broker re-lists the same record with a bumped age and an extra address. This is the
+            // same profile as far as storage is concerned, so it must not count as a removal.
+            val storedProfiles =
+                listOf(
+                    testExtractedProfile1.copy(
+                        age = "35",
+                        addresses = listOf(AddressCityState(city = "Springfield", state = "IL")),
+                        relatives = listOf("Jane Doe"),
+                    ),
+                )
+
+            val newProfiles =
+                listOf(
+                    testExtractedProfile1.copy(
+                        dbId = 0L,
+                        age = "36",
+                        addresses = listOf(
+                            AddressCityState(city = "Springfield", state = "IL"),
+                            AddressCityState(city = "Boston", state = "MA"),
+                        ),
+                        relatives = emptyList(),
+                    ),
+                )
+
+            whenever(mockRepository.getExtractedProfiles(testBrokerName, testProfileQueryId))
+                .thenReturn(storedProfiles)
+
+            toTest.markRemovedOptOutJobRecords(newProfiles, testBrokerName, testProfileQueryId)
+
             verify(mockSchedulingRepository, never()).getValidOptOutJobRecord(any(), any())
             verify(mockSchedulingRepository, never()).saveOptOutJobRecord(any())
         }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scripts/RealBrokerActionProcessorTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scripts/RealBrokerActionProcessorTest.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -143,6 +144,59 @@ class RealBrokerActionProcessorTest {
         assertEquals(PIRScriptConstants.SCRIPT_FEATURE_NAME, eventCaptor.firstValue.featureName)
         assertEquals(PIRScriptConstants.SUBSCRIBED_METHOD_NAME_RECEIVED, eventCaptor.firstValue.subscriptionName)
         assertNotNull(eventCaptor.firstValue.params)
+    }
+
+    @Test
+    fun whenPushExtractActionThenProfileSelectorsAreForwardedVerbatim() = runTest {
+        val actionJson = """
+            {
+                "actionType": "extract",
+                "id": "extract-1",
+                "selector": ".search-item",
+                "profile": {
+                    "name": {
+                        "selector": ".title"
+                    },
+                    "addressCityStateList": {
+                        "selector": ".//li",
+                        "findElements": true,
+                        "city": {
+                            "selector": ".city"
+                        },
+                        "state": {
+                            "selector": ".state"
+                        }
+                    },
+                    "profileUrl": {
+                        "selector": "a",
+                        "attribute": "href"
+                    },
+                    "shoeSize": {
+                        "selector": ".shoe"
+                    }
+                }
+            }
+        """.trimIndent()
+        val action = moshi.adapter(BrokerAction::class.java).fromJson(actionJson)!!
+
+        testee.pushAction(action, UserProfile())
+
+        val eventCaptor = argumentCaptor<SubscriptionEventData>()
+        verify(mockJsMessaging).sendSubscriptionEvent(eventCaptor.capture())
+
+        val pushedProfile = eventCaptor.firstValue.params
+            .getJSONObject("state")
+            .getJSONObject("action")
+            .getJSONObject("profile")
+        assertEquals(".title", pushedProfile.getJSONObject("name").getString("selector"))
+        assertEquals(".shoe", pushedProfile.getJSONObject("shoeSize").getString("selector"))
+        assertEquals("href", pushedProfile.getJSONObject("profileUrl").getString("attribute"))
+        pushedProfile.getJSONObject("addressCityStateList").also {
+            assertEquals(".//li", it.getString("selector"))
+            assertTrue(it.getBoolean("findElements"))
+            assertEquals(".city", it.getJSONObject("city").getString("selector"))
+            assertEquals(".state", it.getJSONObject("state").getString("selector"))
+        }
     }
 
     @Test

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/store/PirDatabaseMigration16To17Test.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/store/PirDatabaseMigration16To17Test.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.store
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PirDatabaseMigration16To17Test {
+
+    @get:Rule
+    val testHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        PirDatabase::class.java,
+        emptyList(),
+    )
+
+    @Test
+    fun whenMigratingFrom16To17ThenProfileStoredBeforeExtrasExistedGetsAnEmptyMap() {
+        testHelper.createDatabase(TEST_DB_NAME, 16).use { db ->
+            db.execSQL(
+                """
+                INSERT INTO pir_extracted_profiles
+                    (id, profileQueryId, brokerName, name, alternativeNames, age, addresses, phoneNumbers,
+                     relatives, profileUrl, identifier, reportId, email, fullName, dateAddedInMillis, deprecated)
+                VALUES
+                    (1, 1, 'broker.example', 'Jane Smith', '[]', '38', '$STORED_ADDRESSES', '[]', '[]',
+                     'https://broker.example/jane', 'jane-1', '', '', 'Jane Smith', 1000, 0)
+                """.trimIndent(),
+            )
+        }
+
+        testHelper.runMigrationsAndValidate(TEST_DB_NAME, 17, true).use { db ->
+            db.query("SELECT extras, addresses, identifier FROM pir_extracted_profiles WHERE id = 1").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals("{}", cursor.getString(0))
+                assertEquals(STORED_ADDRESSES, cursor.getString(1))
+                assertEquals("jane-1", cursor.getString(2))
+            }
+        }
+    }
+
+    private companion object {
+        const val TEST_DB_NAME = "pir_migration_test"
+
+        // An address as it was serialised before extras existed, which the repository must still parse.
+        const val STORED_ADDRESSES = """["{\"city\":\"Springfield\",\"state\":\"IL\"}"]"""
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/store/RealPirRepositoryTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/store/RealPirRepositoryTest.kt
@@ -46,6 +46,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -82,6 +83,9 @@ class RealPirRepositoryTest {
         whenever(mockDatabase.userProfileDao()).thenReturn(mockUserProfileDao)
         whenever(mockDatabase.extractedProfileDao()).thenReturn(mockExtractedProfileDao)
         whenever(mockBrokerJsonDao.getAllBrokersCount()).thenReturn(0)
+        doAnswer { it.getArgument<Runnable>(0).run() }
+            .whenever(mockDatabase)
+            .runInTransaction(any<Runnable>())
 
         testee = RealPirRepository(
             dispatcherProvider = coroutineRule.testDispatcherProvider,

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/store/RealPirRepositoryTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/store/RealPirRepositoryTest.kt
@@ -29,10 +29,13 @@ import com.duckduckgo.pir.impl.store.PirRepository.EmailConfirmationLinkFetchSta
 import com.duckduckgo.pir.impl.store.db.BrokerDao
 import com.duckduckgo.pir.impl.store.db.BrokerJsonDao
 import com.duckduckgo.pir.impl.store.db.ExtractedProfileDao
+import com.duckduckgo.pir.impl.store.db.StoredExtractedProfile
 import com.duckduckgo.pir.impl.store.db.UserName
 import com.duckduckgo.pir.impl.store.db.UserProfile
 import com.duckduckgo.pir.impl.store.db.UserProfileDao
 import com.duckduckgo.pir.impl.store.secure.PirSecureStorageDatabaseFactory
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -42,6 +45,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -65,6 +69,8 @@ class RealPirRepositoryTest {
     private val mockDatabaseFactory: PirSecureStorageDatabaseFactory = mock()
     private val mockDatabase: PirDatabase = mock()
     private val mockPixelSender: PirPixelSender = mock()
+
+    private val addressAdapter = Moshi.Builder().add(KotlinJsonAdapterFactory()).build().adapter(AddressCityState::class.java)
 
     @Before
     fun setUp() {
@@ -632,9 +638,9 @@ class RealPirRepositoryTest {
         assertEquals(false, result[0].deprecated)
     }
 
-    // Tests for saveNewExtractedProfiles
+    // Tests for saveExtractedProfiles
     @Test
-    fun whenSaveNewExtractedProfilesWithValidProfilesThenInsertThem() = runTest {
+    fun whenSaveExtractedProfilesWithValidProfilesThenInsertThem() = runTest {
         // Given
         val currentTime = 1000000L
         val profileQueryId = 1L
@@ -669,7 +675,7 @@ class RealPirRepositoryTest {
         whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(currentTime)
 
         // When
-        testee.saveNewExtractedProfiles(extractedProfiles)
+        testee.saveExtractedProfiles(extractedProfiles)
 
         // Then
         verify(mockUserProfileDao).getUserProfile(profileQueryId)
@@ -677,7 +683,7 @@ class RealPirRepositoryTest {
     }
 
     @Test
-    fun whenSaveNewExtractedProfilesWithDeprecatedProfileThenDoNotInsert() = runTest {
+    fun whenSaveExtractedProfilesWithDeprecatedProfileThenDoNotInsert() = runTest {
         // Given
         val profileQueryId = 1L
         val extractedProfiles = listOf(
@@ -698,7 +704,7 @@ class RealPirRepositoryTest {
         whenever(mockUserProfileDao.getUserProfile(profileQueryId)).thenReturn(deprecatedUserProfile)
 
         // When
-        testee.saveNewExtractedProfiles(extractedProfiles)
+        testee.saveExtractedProfiles(extractedProfiles)
 
         // Then
         verify(mockUserProfileDao).getUserProfile(profileQueryId)
@@ -706,12 +712,12 @@ class RealPirRepositoryTest {
     }
 
     @Test
-    fun whenSaveNewExtractedProfilesWithEmptyListThenDoNothing() = runTest {
+    fun whenSaveExtractedProfilesWithEmptyListThenDoNothing() = runTest {
         // Given
         val extractedProfiles = emptyList<ExtractedProfile>()
 
         // When
-        testee.saveNewExtractedProfiles(extractedProfiles)
+        testee.saveExtractedProfiles(extractedProfiles)
 
         // Then
         verifyNoInteractions(mockUserProfileDao)
@@ -719,7 +725,7 @@ class RealPirRepositoryTest {
     }
 
     @Test
-    fun whenSaveNewExtractedProfilesWithNonExistentProfileThenStillInsertsProfiles() = runTest {
+    fun whenSaveExtractedProfilesWithNonExistentProfileThenStillInsertsProfiles() = runTest {
         // Given - When profile doesn't exist, the deprecated check (profileQuery?.deprecated == true)
         // evaluates to false, so profiles still get inserted
         val currentTime = 1000000L
@@ -736,7 +742,7 @@ class RealPirRepositoryTest {
         whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(currentTime)
 
         // When
-        testee.saveNewExtractedProfiles(extractedProfiles)
+        testee.saveExtractedProfiles(extractedProfiles)
 
         // Then
         verify(mockUserProfileDao).getUserProfile(profileQueryId)
@@ -744,7 +750,7 @@ class RealPirRepositoryTest {
     }
 
     @Test
-    fun whenSaveNewExtractedProfilesWithZeroDateThenUseCurrentTime() = runTest {
+    fun whenSaveExtractedProfilesWithZeroDateThenUseCurrentTime() = runTest {
         // Given
         val currentTime = 5000000L
         val profileQueryId = 1L
@@ -768,7 +774,7 @@ class RealPirRepositoryTest {
         whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(currentTime)
 
         // When
-        testee.saveNewExtractedProfiles(extractedProfiles)
+        testee.saveExtractedProfiles(extractedProfiles)
 
         // Then
         verify(mockCurrentTimeProvider).currentTimeMillis()
@@ -776,7 +782,7 @@ class RealPirRepositoryTest {
     }
 
     @Test
-    fun whenSaveNewExtractedProfilesWithExistingDateThenKeepOriginalDate() = runTest {
+    fun whenSaveExtractedProfilesWithExistingDateThenKeepOriginalDate() = runTest {
         // Given
         val existingDate = 2000000L
         val currentTime = 5000000L
@@ -801,14 +807,14 @@ class RealPirRepositoryTest {
         whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(currentTime)
 
         // When
-        testee.saveNewExtractedProfiles(extractedProfiles)
+        testee.saveExtractedProfiles(extractedProfiles)
 
         // Then
         verify(mockExtractedProfileDao).insertNewExtractedProfiles(any())
     }
 
     @Test
-    fun whenSaveNewExtractedProfilesWithCompleteDataThenMapAllFields() = runTest {
+    fun whenSaveExtractedProfilesWithCompleteDataThenMapAllFields() = runTest {
         // Given
         val currentTime = 1000000L
         val profileQueryId = 1L
@@ -846,11 +852,127 @@ class RealPirRepositoryTest {
         whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(currentTime)
 
         // When
-        testee.saveNewExtractedProfiles(extractedProfiles)
+        testee.saveExtractedProfiles(extractedProfiles)
 
         // Then
         verify(mockUserProfileDao).getUserProfile(profileQueryId)
         verify(mockExtractedProfileDao).insertNewExtractedProfiles(any())
+    }
+
+    @Test
+    fun whenSaveExtractedProfilesWithExtrasThenPersistsProfileAndAddressExtras() = runTest {
+        // Given
+        val profileQueryId = 1L
+        val extractedProfiles = listOf(
+            ExtractedProfile(
+                profileQueryId = profileQueryId,
+                brokerName = "TestBroker",
+                name = "John Doe",
+                addresses = listOf(
+                    AddressCityState(city = "Springfield", state = "IL", extras = mapOf("street" to "100 Sample Dr", "zip" to "62701")),
+                ),
+                dateAddedInMillis = 999999L,
+                extras = mapOf("county" to "Sangamon"),
+            ),
+        )
+        whenever(mockUserProfileDao.getUserProfile(profileQueryId)).thenReturn(null)
+
+        // When
+        testee.saveExtractedProfiles(extractedProfiles)
+
+        // Then
+        val captor = argumentCaptor<List<StoredExtractedProfile>>()
+        verify(mockExtractedProfileDao).insertNewExtractedProfiles(captor.capture())
+        val inserted = captor.firstValue.single()
+        assertEquals(mapOf("county" to "Sangamon"), inserted.extras)
+        assertEquals(
+            AddressCityState(city = "Springfield", state = "IL", extras = mapOf("street" to "100 Sample Dr", "zip" to "62701")),
+            addressAdapter.fromJson(inserted.addresses.single()),
+        )
+    }
+
+    @Test
+    fun whenSaveExtractedProfilesWithAlreadyStoredProfileThenRefreshesItInsteadOfInserting() = runTest {
+        // Given
+        val profileQueryId = 1L
+        val stored = StoredExtractedProfile(
+            id = 7L,
+            profileQueryId = profileQueryId,
+            brokerName = "TestBroker",
+            name = "John Doe",
+            age = "35",
+            addresses = listOf(
+                addressAdapter.toJson(AddressCityState(city = "Springfield", state = "IL", extras = mapOf("street" to "100 Sample Dr"))),
+            ),
+            profileUrl = "https://example.com/profile",
+            identifier = "identifier-123",
+            dateAddedInMillis = 111L,
+            extras = mapOf("county" to "Sangamon", "middleName" to "Michael"),
+        )
+        val scraped = ExtractedProfile(
+            profileQueryId = profileQueryId,
+            brokerName = "TestBroker",
+            name = "John Doe",
+            age = "36",
+            addresses = listOf(AddressCityState(city = "Springfield", state = "IL", extras = mapOf("zip" to "62701"))),
+            profileUrl = "https://example.com/profile",
+            identifier = "identifier-123",
+            extras = mapOf("county" to "Cook"),
+        )
+        whenever(mockUserProfileDao.getUserProfile(profileQueryId)).thenReturn(null)
+        whenever(mockExtractedProfileDao.getExtractedProfilesForBrokerAndProfile("TestBroker", profileQueryId)).thenReturn(listOf(stored))
+
+        // When
+        testee.saveExtractedProfiles(listOf(scraped))
+
+        // Then
+        verify(mockExtractedProfileDao).insertNewExtractedProfiles(emptyList())
+        val captor = argumentCaptor<List<StoredExtractedProfile>>()
+        verify(mockExtractedProfileDao).updateExtractedProfiles(captor.capture())
+        val updated = captor.firstValue.single()
+        assertEquals(7L, updated.id)
+        assertEquals(111L, updated.dateAddedInMillis)
+        assertEquals("36", updated.age)
+        assertEquals(mapOf("county" to "Cook", "middleName" to "Michael"), updated.extras)
+        assertEquals(
+            AddressCityState(city = "Springfield", state = "IL", extras = mapOf("street" to "100 Sample Dr", "zip" to "62701")),
+            addressAdapter.fromJson(updated.addresses.single()),
+        )
+    }
+
+    @Test
+    fun whenSaveExtractedProfilesWithAddressStoredBeforeExtrasExistedThenParsesItAsEmptyExtras() = runTest {
+        // Given
+        val profileQueryId = 1L
+        val stored = StoredExtractedProfile(
+            id = 7L,
+            profileQueryId = profileQueryId,
+            brokerName = "TestBroker",
+            name = "John Doe",
+            addresses = listOf("""{"city":"Springfield","state":"IL"}"""),
+            identifier = "identifier-123",
+            dateAddedInMillis = 111L,
+        )
+        val scraped = ExtractedProfile(
+            profileQueryId = profileQueryId,
+            brokerName = "TestBroker",
+            name = "John Doe",
+            addresses = listOf(AddressCityState(city = "Springfield", state = "IL", extras = mapOf("zip" to "62701"))),
+            identifier = "identifier-123",
+        )
+        whenever(mockUserProfileDao.getUserProfile(profileQueryId)).thenReturn(null)
+        whenever(mockExtractedProfileDao.getExtractedProfilesForBrokerAndProfile("TestBroker", profileQueryId)).thenReturn(listOf(stored))
+
+        // When
+        testee.saveExtractedProfiles(listOf(scraped))
+
+        // Then
+        val captor = argumentCaptor<List<StoredExtractedProfile>>()
+        verify(mockExtractedProfileDao).updateExtractedProfiles(captor.capture())
+        assertEquals(
+            AddressCityState(city = "Springfield", state = "IL", extras = mapOf("zip" to "62701")),
+            addressAdapter.fromJson(captor.firstValue.single().addresses.single()),
+        )
     }
 
     @Test

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirResultsActivity.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirResultsActivity.kt
@@ -146,10 +146,11 @@ class PirResultsActivity : DuckDuckGoActivity() {
                     stringBuilder.append("NAME: ${profile.name}\n")
                     stringBuilder.append("FULL NAME: ${profile.fullName}\n")
                     stringBuilder.append("AGE: ${profile.age}\n")
-                    stringBuilder.append("ADDRESSES: ${profile.addresses.joinToString { "${it.city}, ${it.state}" }}\n")
+                    stringBuilder.append("ADDRESSES: ${profile.addresses.joinToString(" | ") { "${it.city}, ${it.state} ${it.extras}" }}\n")
                     stringBuilder.append("RELATIVES: ${profile.relatives.joinToString()}\n")
                     stringBuilder.append("PROFILE URL: ${profile.profileUrl}\n")
                     stringBuilder.append("IDENTIFIER: ${profile.identifier}\n")
+                    stringBuilder.append("PROFILE EXTRAS: ${profile.extras}\n")
                     stringBuilder.append("DEPRECATED: ${profile.deprecated}\n")
                     stringBuilder.toString()
                 }.also {


### PR DESCRIPTION
Task/Issue URL:
https://app.asana.com/1/137249556945/task/1216773212741753
Tech Design URL (if applicable):
https://app.asana.com/1/137249556945/project/481882893211075/task/1216773212741757
API Proposals URL(s) (if applicable):

### Description

Support `extras` in extracted profiles and addresses, pass them along to `fillForm`, and update stored profiles with the freshly scraped profile. This lessens the need for an app release when an opt out form requires a new field we don't have.

### Steps to test this PR

1. Point C-S-S to [Support extracting extras from profiles and addresses content-scope-scripts#2907](https://github.com/duckduckgo/content-scope-scripts/pull/2907):

```
npm install @duckduckgo/content-scope-scripts@github:duckduckgo/content-scope-scripts#pr-releases/randerson/pir-extras-open-field
```

2. Build and run.
4. Open Settings → Pir Dev Settings → Broker Config.
5. Select `cyberbackgroundchecks.com` and replace the JSON with: https://dub.duckduckgo.com/duckduckgo/dbp-api/blob/2fb2bb29f5d3f67bc6c70098ca36db7ca4a100b9/dbp-json/data/json/cyberbackgroundchecks.com.json
6. Complete a scan and opt out: Debug Scan → Run opt out → PIR Email → Debug opt out. 
7. The street and zip fields in the post-confirmation opt out form should be filled from data that was extracted during the scan.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PIR local storage, scan refresh semantics, and opt-out identity matching; changes are well-tested but incorrect merge or key logic could affect pending opt-outs or removal detection.
> 
> **Overview**
> Adds **`extras`** on extracted profiles and addresses so broker configs can scrape arbitrary fields without a native release, and passes the fuller profile through to C-S-S for **`fillForm`**.
> 
> On repeat scans, **`saveExtractedProfiles`** refreshes rows that already match the DB unique key (profile query, broker, name, URL, identifier) instead of ignoring them, merging extras so keys missing from a new scrape keep stored values. Profile identity for removals/reappearances uses a narrower key and **`matches`** ignores address extras so new scraped fields don’t look like a different person.
> 
> **`ExtractProfileSelectors`** becomes a passthrough map so extract profile config isn’t dropped at parse time. Room bumps to **v17** with an **`extras`** column, Moshi map converters, and migration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71d26d75b1cfb1de6e6c01f9ed8005f44fc8a619. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


