### PR TITLE
Update content scope scripts to version 15.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^16.9.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.22.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.23.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "16.18.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.18.0.tgz",
-      "integrity": "sha512-ZDDMbVLJXp3zhTmD1Lz5YHp+X23tFkBcLdmuD4KMGaDILNzVybfIHY8N+7RSX5VU7RHN0PKPWPzjWj6hGfpoDg==",
+      "version": "16.18.1",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.18.1.tgz",
+      "integrity": "sha512-lbxdl9iW4wGwlpW2fOBPZA8XNdz2cteGOB2Li7mgWyD9mWHbC+lD/uiWXqCBxlw0tBu69hn9Igi0SfvYm7SDgQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "tldts-experimental": "^7.4.3"
@@ -61,7 +61,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4d54ee90d73707c2cef21b1e5231e876409f2ab1",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#2b57f4b72186080efade861494eef5ad6f3853a1",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -594,18 +594,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.9",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
-      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.4.9",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.9.tgz",
-      "integrity": "sha512-zxh7G+3XL+Rg8CqSzjsqz9GODJY7ZhlwD9azD1ihVpueayTWAyQU5yyf7s34yZ5yDESCo6rr4TL8bHxykdy5hQ==",
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.10.tgz",
+      "integrity": "sha512-l+FUGTqw3cYLnM6uL45IhdIG1ue9N7ZnMe9ZFC0S3/ROTL6xkJrUFQvsjfqSD9YzywDvgWj9uRZTXib3v3bnHw==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.9"
+        "tldts-core": "^7.4.10"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
     "@duckduckgo/autoconsent": "^16.9.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.22.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.23.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217045173932281

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine dependency pin update with no application code changes in this diff; risk depends on upstream 15.23.0 behavior in injected privacy scripts.
> 
> **Overview**
> Bumps **`@duckduckgo/content-scope-scripts`** from **15.22.0** to **15.23.0** in `package.json` and `package-lock.json` (new git ref on the DuckDuckGo repo).
> 
> The lockfile also picks up minor transitive updates: **`@duckduckgo/autoconsent`** 16.18.0 → 16.18.1 and **`tldts-core` / `tldts-experimental`** 7.4.9 → 7.4.10.
> 
> This diff does not include copied assets under `node_modules/@duckduckgo/content-scope-scripts`; per the PR notes, full privacy/e2e workflows tied to that folder may not be required when only the pinned version changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8206e7770e756087e6fb06e2dc47038c028fafbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->