### PR TITLE
[Drift Audit] Correct interval API and Duration type in the wide-events rule doc

### DIFF
--- a/.cursor/rules/wide-events.mdc
+++ b/.cursor/rules/wide-events.mdc
@@ -32,8 +32,13 @@ wideEventClient.flowStep(
     metadata = mapOf("platform" to "google"),
 )
 
-// Measure latency between two points (always use bucketed values, not raw ms)
-wideEventClient.intervalStart(wideEventId = flowId, key = "creation_latency_ms_bucketed")
+// Measure latency between two points — the client buckets the duration for you
+wideEventClient.intervalStart(
+    wideEventId = flowId,
+    key = "creation_latency_ms_bucketed",
+    timeout = 10.minutes,                 // optional: auto-finish the flow with Unknown if it elapses
+    buckets = DEFAULT_INTERVAL_BUCKETS,   // optional: null records the raw duration
+)
 // ... operation ...
 wideEventClient.intervalEnd(wideEventId = flowId, key = "creation_latency_ms_bucketed")
 
@@ -67,6 +72,15 @@ FlowStatus.Unknown   // unexpected termination; always pair with a last_step in 
 
 When a flow is sampled out, `flowStart` returns a sentinel ID. All subsequent calls (`flowStep`, `flowFinish`, etc.) with that ID are silent no-ops with zero disk I/O — no special handling needed at the call site. The probability is persisted with the event and sent to the backend so it can weight the data correctly.
 
+### Intervals
+
+`intervalStart` / `intervalEnd` measure the time between two points and record it under `key`.
+
+- **The client buckets the duration for you.** The measured duration is rounded *down* to the nearest boundary in `buckets`, and durations below the smallest boundary are recorded as `0`. `buckets` defaults to `WideEventClient.DEFAULT_INTERVAL_BUCKETS` (1s, 5s, 10s, 30s, 1m, 5m, 10m). Pass a custom `Set<Duration>` when the flow runs on a different time scale (see `PageLoadWideEvent` and `PirScanWideEvent`), or `null` to record the raw duration.
+- **`timeout` is optional.** If it elapses before `intervalEnd`, `flowFinish`, or `flowAbort`, the flow auto-finishes with `FlowStatus.Unknown` and is sent; an explicit finish or abort cancels it. This is the "interval timeout" that `CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = true)` defers to.
+
+Durations across the API are `kotlin.time.Duration` (`10.minutes`, `7.days`), not `java.time.Duration`.
+
 ### CleanupPolicy
 
 Defines what happens to flows abandoned due to app termination or timeout:
@@ -80,7 +94,7 @@ CleanupPolicy.OnProcessStart(
 
 // Complete the flow with Unknown status after a duration
 CleanupPolicy.OnTimeout(
-    duration = Duration.ofDays(7),
+    duration = 7.days,
     flowStatus = FlowStatus.Unknown,
 )
 ```


### PR DESCRIPTION
Task/Issue URL: (app.asana.com/redacted)

### Description
`.cursor/rules/wide-events.mdc` — the interval section and the `CleanupPolicy.OnTimeout` example.

The wide-events area changed in this window via [`#7965` — Add support for wide event sampling](https://github.com/duckduckgo/Android/pull/7965) (`2ac7b09149`). That PR updated the doc for sampling itself, and I verified the new *Sampling* section against `WideEventClientImpl` — `SAMPLED_OUT_FLOW_ID = -1L`, the `if (wideEventId == SAMPLED_OUT_FLOW_ID) return Result.success(...)` short-circuit in every method, and the persisted probability — it is accurate and I left it alone. Re-reading the rest of the doc against the API surfaced two claims that no longer hold.

**1. `intervalStart` — described as a two-argument call with hand-bucketed keys.**

What the doc described: `intervalStart(wideEventId, key)` under the comment *"always use bucketed values, not raw ms"*, which reads as an instruction to bucket at the call site via the `_ms_bucketed` naming convention.

The code change that invalidated it: [`#8381` — Configurable interval buckets on WideEventClient.intervalStart](https://github.com/duckduckgo/Android/pull/8381) (`a8076fbe81`). `intervalStart` now takes `timeout: Duration? = null` and `buckets: Set<Duration>? = DEFAULT_INTERVAL_BUCKETS`, and the client does the bucketing — rounding down to the nearest boundary, recording `0` below the smallest, and recording the raw duration when `buckets` is null. Real callers pass custom bucket sets (`PageLoadWideEvent`, `PirScanWideEvent`) and timeouts (`SubscriptionSwitchWideEvent` at `10.minutes`, `SubscriptionPurchaseWideEvent` at `4.hours`) — none of which the doc mentioned.

The `timeout` gap also left a dangling concept: the *CleanupPolicy* section documents `ignoreIfIntervalTimeoutPresent` as *"keep alive if an interval timeout is set"*, but nothing in the doc explained what sets one.

How it now reads: the API example shows `intervalStart` with `timeout` and `buckets`, and a new *Intervals* subsection states the rounding-down behaviour, the default bucket set, what `null` does, and ties the `timeout` parameter back to `ignoreIfIntervalTimeoutPresent`.

**2. `CleanupPolicy.OnTimeout(duration = Duration.ofDays(7))` no longer compiles.**

The same PR migrated the API from `java.time.Duration` to `kotlin.time.Duration` — `flowStart`'s default is now `OnTimeout(duration = 7.days)` and `intervalEnd` returns `Result<kotlin.time.Duration>`. The doc's `Duration.ofDays(7)` is a `java.time` call against a `kotlin.time` parameter. Now reads `7.days`, with a line naming the type so the `10.minutes` / `7.days` literals aren't guesswork.

I also checked, and did **not** treat as drift:
- **`.cursor/rules/pixels.mdc` / `pixel-definitions.mdc`** vs [`#9306`](https://github.com/duckduckgo/Android/pull/9306) (`unified_input_surface` added to unified-input action pixels, plus a `params_dictionary` entry) and the PIR pixel additions in `PirPixel`/`PirPixelSender`/`PirPixelInterceptor` — routine additions that follow the documented shape; no documented claim became false.
- **`.cursor/rules/android-design-system.mdc`** — `Theming.kt` and `MessageCta.kt` saw small edits, but nothing the doc describes. Note this doc already has two open Drift Audit PRs against it ([`#9300`](https://github.com/duckduckgo/Android/pull/9300), [`#9315`](https://github.com/duckduckgo/Android/pull/9315)); I stayed out of it to avoid conflicting edits.
- **`.cursor/rules/maestro-ui-tests.mdc`** — three `.maestro/**` files changed by one line each (onboarding test content), not the tags/config/run mechanics the doc describes.
- **`.cursor/rules/architecture.mdc`** — the remaining merged PRs in the window (simplified sync UI, native input, onboarding dialogs, content-scope-scripts bumps, PIR renderer-crash handling, Glide cache fix, Develocity plugin bump) are all inside `-impl` code or build config the rule docs don't describe.

One thing for a human to weigh: the interval drift dates from `#8381` (30 Apr), not from this window's `#7965`. I fixed it because re-checking the wide-events doc is exactly what a change in that area calls for and the mismatch is unambiguous — the example doesn't compile — but if the preference is to keep each Drift Audit PR strictly to its window, that is a fair reason to trim this one.

`.cursor/rules/wide-events.mdc` is the only file changed — no code, and the `.claude/rules` symlink is untouched.

🤖 AI-docs Drift Auditor

### Steps to test this PR
- [ ] Read the updated *Intervals* section against `WideEventClient.intervalStart`'s KDoc and `DEFAULT_INTERVAL_BUCKETS` in `statistics/statistics-api/.../wideevents/WideEventClient.kt`, and confirm the rounding-down / zero-below-smallest / null-disables-bucketing description matches.
- [ ] Confirm the `Duration` type claim: `WideEventClient.kt` imports `kotlin.time.Duration` and defaults `flowStart`'s cleanup policy to `OnTimeout(duration = 7.days)`, so the corrected `7.days` example compiles and `Duration.ofDays(7)` would not.
- [ ] Spot-check the named callers — `PageLoadWideEvent` / `PirScanWideEvent` pass custom `buckets`, `SubscriptionSwitchWideEvent` passes `timeout = 10.minutes` — and confirm the doc's `timeout` / `buckets` guidance reflects real usage.

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |




> [!NOTE]
> <details>
> <summary><b>🔒 Integrity filter blocked 4 items</b></summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#8891](https://github.com/duckduckgo/Android/pull/8891) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8809](https://github.com/duckduckgo/Android/pull/8809) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8811](https://github.com/duckduckgo/Android/pull/8811) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#9341](https://github.com/duckduckgo/Android/pull/9341) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [AI-docs Semantic Drift Audit](https://github.com/duckduckgo/Android/actions/runs/30608506825/agentic_workflow) · [◷](https://github.com/search?q=repo%3Aduckduckgo%2FAndroid+%22gh-aw-workflow-id%3A+drift-audit%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: AI-docs Semantic Drift Audit, engine: claude, model: auto, id: 30608506825, workflow_id: drift-audit, run: https://github.com/duckduckgo/Android/actions/runs/30608506825 -->

<!-- gh-aw-workflow-id: drift-audit -->