### PR TITLE
Rename onboarding pixel params and bucket days since install

### DIFF
--- a/PixelDefinitions/pixels/definitions/onboarding.json5
+++ b/PixelDefinitions/pixels/definitions/onboarding.json5
@@ -56,21 +56,22 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
             {
-                "key": "it",
+                "key": "installType",
                 "type": "string",
                 "description": "Install type",
                 "enum": ["new", "reinstall"]
             },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             {
                 "key": "flow",
@@ -87,7 +88,7 @@
             {
                 "key": "value",
                 "type": "string",
-                "description": "Only set when e=clicked. Composite encoding of the user's Quick Setup selections, formatted as 'set_as_default:on|off,widget:on|off,address_bar:top|bottom|split,input_type:search|search_and_duckai'."
+                "description": "Only set when event=clicked. Composite encoding of the user's Quick Setup selections, formatted as 'set_as_default:on|off,widget:on|off,address_bar:top|bottom|split,input_type:search|search_and_duckai'."
             }
         ]
     },
@@ -127,20 +128,21 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            { "key": "value", "type": "string", "description": "Only set when e=clicked.", "enum": ["engage", "dismiss"] }
+            { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
     "onboarding_set-default": {
@@ -151,23 +153,24 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked", "confirmed"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
             {
                 "key": "value",
                 "type": "string",
-                "description": "Set to engage when e=clicked. When e=confirmed, the resulting default browser. Absent for shown.",
+                "description": "Set to engage when event=clicked. When event=confirmed, the resulting default browser. Absent for shown.",
                 "enum": ["engage", "ddg", "other"]
             }
         ]
@@ -180,16 +183,17 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] }
@@ -203,23 +207,24 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked", "confirmed"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
             {
                 "key": "value",
                 "type": "string",
-                "description": "For e=clicked: engage|dismiss. For e=confirmed: added|not_added.",
+                "description": "For event=clicked: engage|dismiss. For event=confirmed: added|not_added.",
                 "enum": ["engage", "dismiss", "added", "not_added"]
             }
         ]
@@ -232,23 +237,24 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
             {
                 "key": "value",
                 "type": "string",
-                "description": "Only set when e=clicked. Chosen address bar position.",
+                "description": "Only set when event=clicked. Chosen address bar position.",
                 "enum": ["top", "bottom", "split"]
             }
         ]
@@ -261,23 +267,24 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
             {
                 "key": "value",
                 "type": "string",
-                "description": "Only set when e=clicked. Chosen search experience.",
+                "description": "Only set when event=clicked. Chosen search experience.",
                 "enum": ["search_only", "search_plus_duckai"]
             }
         ]
@@ -290,20 +297,21 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            { "key": "value", "type": "string", "description": "Only set when e=clicked.", "enum": ["engage", "dismiss"] }
+            { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
     "onboarding_notifications": {
@@ -314,23 +322,24 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "confirmed"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
             {
                 "key": "value",
                 "type": "string",
-                "description": "Only set when e=confirmed. Permission result.",
+                "description": "Only set when event=confirmed. Permission result.",
                 "enum": ["granted", "denied"]
             }
         ]
@@ -343,16 +352,17 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
@@ -365,7 +375,7 @@
             {
                 "key": "value",
                 "type": "string",
-                "description": "Only set when e=clicked. The tried query's source (suggested/custom) and mode (search/chat).",
+                "description": "Only set when event=clicked. The tried query's source (suggested/custom) and mode (search/chat).",
                 "enum": ["suggested_search", "suggested_chat", "custom_search", "custom_chat"]
             }
         ]
@@ -378,20 +388,21 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            { "key": "value", "type": "string", "description": "Only set when e=clicked.", "enum": ["engage"] }
+            { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage"] }
         ]
     },
     "onboarding_fire-button": {
@@ -402,16 +413,17 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
@@ -421,7 +433,7 @@
                 "description": "Duck.ai search/chat branch. Set only in the custom Duck.ai flow.",
                 "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
             },
-            { "key": "value", "type": "string", "description": "Only set when e=clicked.", "enum": ["engage"] }
+            { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage"] }
         ]
     },
     "onboarding_search": {
@@ -432,23 +444,24 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
             {
                 "key": "value",
                 "type": "string",
-                "description": "Only set when e=clicked. Whether the query came from a suggestion or was typed, or dismiss if closed via the close button.",
+                "description": "Only set when event=clicked. Whether the query came from a suggestion or was typed, or dismiss if closed via the close button.",
                 "enum": ["suggested", "custom", "dismiss"]
             }
         ]
@@ -461,20 +474,21 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            { "key": "value", "type": "string", "description": "Only set when e=clicked.", "enum": ["engage", "dismiss"] }
+            { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
     "onboarding_visit-site": {
@@ -485,23 +499,24 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
             {
                 "key": "value",
                 "type": "string",
-                "description": "Only set when e=clicked. Whether the query came from a suggestion or was typed, or dismiss if closed via the close button.",
+                "description": "Only set when event=clicked. Whether the query came from a suggestion or was typed, or dismiss if closed via the close button.",
                 "enum": ["suggested", "custom", "dismiss"]
             }
         ]
@@ -514,20 +529,21 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            { "key": "value", "type": "string", "description": "Only set when e=clicked.", "enum": ["engage", "dismiss"] }
+            { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
     "onboarding_fire-button": {
@@ -538,20 +554,21 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            { "key": "value", "type": "string", "description": "Only set when e=clicked.", "enum": ["engage", "dismiss"] }
+            { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
     "onboarding_end": {
@@ -562,20 +579,21 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            { "key": "value", "type": "string", "description": "Only set when e=clicked.", "enum": ["engage", "dismiss"] }
+            { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
     "onboarding_subscription-promo": {
@@ -586,20 +604,21 @@
         "parameters": [
             "appVersion",
             {
-                "key": "e",
+                "key": "event",
                 "type": "string",
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "clicked"]
             },
-            { "key": "it", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
+            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
             {
-                "key": "d",
-                "type": "integer",
-                "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
+                "key": "daysSinceInstall",
+                "type": "string",
+                "description": "Days since install, bucketed.",
+                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            { "key": "value", "type": "string", "description": "Only set when e=clicked.", "enum": ["engage", "dismiss"] }
+            { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingPixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingPixelSender.kt
@@ -237,10 +237,16 @@ class RealOnboardingPixelSender @Inject constructor(
             PIXEL_PARAM_PIXEL_SOURCE to deviceInfo.formFactor().description,
         )
         variant?.let { params[PIXEL_PARAM_VARIANT] = it }
-        if (days in 0..MAX_DAYS_SINCE_INSTALL_REPORTED) {
-            params[PIXEL_PARAM_DAYS_SINCE_INSTALL] = days.toString()
-        }
+        params[PIXEL_PARAM_DAYS_SINCE_INSTALL] = daysSinceInstallBucket(days)
         return params
+    }
+
+    private fun daysSinceInstallBucket(days: Long): String = when {
+        days <= 0L -> DAYS_SINCE_INSTALL_0
+        days <= 3L -> DAYS_SINCE_INSTALL_1_3
+        days <= 10L -> DAYS_SINCE_INSTALL_4_10
+        days <= 28L -> DAYS_SINCE_INSTALL_11_28
+        else -> DAYS_SINCE_INSTALL_OVER_28
     }
 
     private fun engageOrDismiss(engaged: Boolean): String = if (engaged) VALUE_ENGAGE else VALUE_DISMISS
@@ -260,11 +266,10 @@ class RealOnboardingPixelSender @Inject constructor(
     private fun onOff(value: Boolean): String = if (value) "on" else "off"
 
     private companion object {
-        private const val PIXEL_PARAM_EVENT = "e"
+        private const val PIXEL_PARAM_EVENT = "event"
         private const val PIXEL_PARAM_VALUE = "value"
-        private const val PIXEL_PARAM_INSTALL_TYPE = "it"
-        private const val PIXEL_PARAM_DAYS_SINCE_INSTALL = "d"
-        private const val PIXEL_PARAM_SOURCE = "source"
+        private const val PIXEL_PARAM_INSTALL_TYPE = "installType"
+        private const val PIXEL_PARAM_DAYS_SINCE_INSTALL = "daysSinceInstall"
         private const val PIXEL_PARAM_FLOW = "flow"
         private const val PIXEL_PARAM_VARIANT = "variant"
         private const val PIXEL_PARAM_PIXEL_SOURCE = "pixelSource"
@@ -316,6 +321,10 @@ class RealOnboardingPixelSender @Inject constructor(
         private const val INPUT_TYPE_SEARCH = "search"
         private const val INPUT_TYPE_SEARCH_AND_DUCKAI = "search_and_duckai"
 
-        private const val MAX_DAYS_SINCE_INSTALL_REPORTED = 28L
+        private const val DAYS_SINCE_INSTALL_0 = "0"
+        private const val DAYS_SINCE_INSTALL_1_3 = "1-3"
+        private const val DAYS_SINCE_INSTALL_4_10 = "4-10"
+        private const val DAYS_SINCE_INSTALL_11_28 = "11-28"
+        private const val DAYS_SINCE_INSTALL_OVER_28 = "28+"
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/RealOnboardingPixelSenderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/RealOnboardingPixelSenderTest.kt
@@ -44,6 +44,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.concurrent.TimeUnit
@@ -91,7 +92,7 @@ class RealOnboardingPixelSenderTest {
 
         verify(mockPixel).fire(
             ONBOARDING_WELCOME,
-            mapOf("it" to "new", "flow" to "default", "pixelSource" to "phone", "d" to "0", "e" to "shown"),
+            mapOf("installType" to "new", "flow" to "default", "pixelSource" to "phone", "daysSinceInstall" to "0", "event" to "shown"),
             type = Unique(tag = "onboarding_welcome_shown"),
         )
     }
@@ -118,11 +119,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_WELCOME,
             mapOf(
-                "it" to "reinstall",
+                "installType" to "reinstall",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "3",
-                "e" to "clicked",
+                "daysSinceInstall" to "1-3",
+                "event" to "clicked",
                 "value" to "engage",
             ),
             type = Unique(tag = "onboarding_welcome_clicked_engage"),
@@ -138,11 +139,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_WELCOME,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "dismiss",
             ),
             type = Unique(tag = "onboarding_welcome_clicked_dismiss"),
@@ -158,11 +159,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_ADDRESS_BAR_POSITION,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "split",
             ),
             type = Unique(tag = "onboarding_address-bar-position_clicked_split"),
@@ -178,11 +179,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_SEARCH_EXPERIENCE,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "search_plus_duckai",
             ),
             type = Unique(tag = "onboarding_search-experience_clicked_search_plus_duckai"),
@@ -198,11 +199,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_SEARCH_EXPERIENCE,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "search_only",
             ),
             type = Unique(tag = "onboarding_search-experience_clicked_search_only"),
@@ -218,11 +219,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_SET_DEFAULT,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "confirmed",
+                "daysSinceInstall" to "0",
+                "event" to "confirmed",
                 "value" to "ddg",
             ),
             type = Unique(tag = "onboarding_set-default_confirmed_ddg"),
@@ -238,11 +239,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_SET_DEFAULT,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "confirmed",
+                "daysSinceInstall" to "0",
+                "event" to "confirmed",
                 "value" to "other",
             ),
             type = Unique(tag = "onboarding_set-default_confirmed_other"),
@@ -258,11 +259,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_SET_DEFAULT,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "engage",
             ),
             type = Unique(tag = "onboarding_set-default_clicked_engage"),
@@ -279,11 +280,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_NOTIFICATIONS,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "tablet",
-                "d" to "0",
-                "e" to "confirmed",
+                "daysSinceInstall" to "0",
+                "event" to "confirmed",
                 "value" to "denied",
             ),
             type = Unique(tag = "onboarding_notifications_confirmed_denied"),
@@ -311,7 +312,7 @@ class RealOnboardingPixelSenderTest {
 
         verify(mockPixel).fire(
             ONBOARDING_QUICK_SETUP,
-            mapOf("it" to "reinstall", "flow" to "default", "pixelSource" to "phone", "d" to "3", "e" to "shown"),
+            mapOf("installType" to "reinstall", "flow" to "default", "pixelSource" to "phone", "daysSinceInstall" to "1-3", "event" to "shown"),
             type = Unique(tag = "onboarding_quick-setup_shown"),
         )
     }
@@ -346,11 +347,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_QUICK_SETUP,
             mapOf(
-                "it" to "reinstall",
+                "installType" to "reinstall",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "set_as_default:off,widget:off,address_bar:top,input_type:search_and_duckai",
             ),
             type = Unique(
@@ -390,11 +391,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_QUICK_SETUP,
             mapOf(
-                "it" to "reinstall",
+                "installType" to "reinstall",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "set_as_default:on,widget:off,address_bar:bottom,input_type:search",
             ),
             type = Unique(
@@ -434,11 +435,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_QUICK_SETUP,
             mapOf(
-                "it" to "reinstall",
+                "installType" to "reinstall",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "set_as_default:off,widget:on,address_bar:split,input_type:search_and_duckai",
             ),
             type = Unique(
@@ -457,7 +458,7 @@ class RealOnboardingPixelSenderTest {
 
         verify(mockPixel).fire(
             ONBOARDING_WELCOME,
-            mapOf("it" to "new", "flow" to "duckai", "pixelSource" to "phone", "d" to "0", "e" to "shown"),
+            mapOf("installType" to "new", "flow" to "duckai", "pixelSource" to "phone", "daysSinceInstall" to "0", "event" to "shown"),
             type = Unique(tag = "onboarding_welcome_shown"),
         )
     }
@@ -486,12 +487,12 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_SET_DEFAULT,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "duckai",
                 "variant" to "search_plus_duckai-chat",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "shown",
+                "daysSinceInstall" to "0",
+                "event" to "shown",
             ),
             type = Unique(tag = "onboarding_set-default_shown"),
         )
@@ -520,12 +521,12 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_ADDRESS_BAR_POSITION,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "variant" to "search_plus_duckai-search",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "shown",
+                "daysSinceInstall" to "0",
+                "event" to "shown",
             ),
             type = Unique(tag = "onboarding_address-bar-position_shown"),
         )
@@ -539,7 +540,7 @@ class RealOnboardingPixelSenderTest {
 
         verify(mockPixel).fire(
             ONBOARDING_WELCOME,
-            mapOf("it" to "new", "flow" to "default", "pixelSource" to "phone", "d" to "0", "e" to "shown"),
+            mapOf("installType" to "new", "flow" to "default", "pixelSource" to "phone", "daysSinceInstall" to "0", "event" to "shown"),
             type = Unique(tag = "onboarding_welcome_shown"),
         )
     }
@@ -553,11 +554,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_WELCOME,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "engage",
             ),
             type = Unique(tag = "onboarding_welcome_clicked_engage"),
@@ -573,11 +574,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_WELCOME,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "dismiss",
             ),
             type = Unique(tag = "onboarding_welcome_clicked_dismiss"),
@@ -592,7 +593,7 @@ class RealOnboardingPixelSenderTest {
 
         verify(mockPixel).fire(
             ONBOARDING_SEARCH_CHAT_TOGGLE,
-            mapOf("it" to "new", "flow" to "default", "pixelSource" to "phone", "d" to "0", "e" to "shown"),
+            mapOf("installType" to "new", "flow" to "default", "pixelSource" to "phone", "daysSinceInstall" to "0", "event" to "shown"),
             type = Unique(tag = "onboarding_search-chat-toggle_shown"),
         )
     }
@@ -609,11 +610,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_SEARCH_CHAT_TOGGLE,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "suggested_search",
             ),
             type = Unique(tag = "onboarding_search-chat-toggle_clicked_suggested_search"),
@@ -632,11 +633,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_SEARCH_CHAT_TOGGLE,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "custom_chat",
             ),
             type = Unique(tag = "onboarding_search-chat-toggle_clicked_custom_chat"),
@@ -651,7 +652,7 @@ class RealOnboardingPixelSenderTest {
 
         verify(mockPixel).fire(
             ONBOARDING_AI_INTRO,
-            mapOf("it" to "new", "flow" to "default", "pixelSource" to "phone", "d" to "0", "e" to "shown"),
+            mapOf("installType" to "new", "flow" to "default", "pixelSource" to "phone", "daysSinceInstall" to "0", "event" to "shown"),
             type = Unique(tag = "onboarding_ai-intro_shown"),
         )
     }
@@ -665,11 +666,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_AI_INTRO,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "engage",
             ),
             type = Unique(tag = "onboarding_ai-intro_clicked_engage"),
@@ -685,11 +686,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_SEARCH,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "suggested",
             ),
             type = Unique(tag = "onboarding_search_clicked_suggested"),
@@ -705,11 +706,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_VISIT_SITE,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "custom",
             ),
             type = Unique(tag = "onboarding_visit-site_clicked_custom"),
@@ -724,7 +725,7 @@ class RealOnboardingPixelSenderTest {
 
         verify(mockPixel).fire(
             ONBOARDING_SEARCH,
-            mapOf("it" to "new", "flow" to "default", "pixelSource" to "phone", "d" to "0", "e" to "shown"),
+            mapOf("installType" to "new", "flow" to "default", "pixelSource" to "phone", "daysSinceInstall" to "0", "event" to "shown"),
             type = Unique(tag = "onboarding_search_shown"),
         )
     }
@@ -737,7 +738,14 @@ class RealOnboardingPixelSenderTest {
 
         verify(mockPixel).fire(
             ONBOARDING_SEARCH,
-            mapOf("it" to "new", "flow" to "default", "pixelSource" to "phone", "d" to "0", "e" to "clicked", "value" to "engage"),
+            mapOf(
+                "installType" to "new",
+                "flow" to "default",
+                "pixelSource" to "phone",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
+                "value" to "engage",
+            ),
             type = Unique(tag = "onboarding_search_clicked"),
         )
     }
@@ -751,12 +759,26 @@ class RealOnboardingPixelSenderTest {
 
         verify(mockPixel).fire(
             ONBOARDING_SEARCH,
-            mapOf("it" to "new", "flow" to "default", "pixelSource" to "phone", "d" to "0", "e" to "clicked", "value" to "engage"),
+            mapOf(
+                "installType" to "new",
+                "flow" to "default",
+                "pixelSource" to "phone",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
+                "value" to "engage",
+            ),
             type = Unique(tag = "onboarding_search_clicked"),
         )
         verify(mockPixel).fire(
             ONBOARDING_SEARCH,
-            mapOf("it" to "new", "flow" to "default", "pixelSource" to "phone", "d" to "0", "e" to "clicked", "value" to "dismiss"),
+            mapOf(
+                "installType" to "new",
+                "flow" to "default",
+                "pixelSource" to "phone",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
+                "value" to "dismiss",
+            ),
             type = Unique(tag = "onboarding_search_clicked"),
         )
     }
@@ -770,11 +792,11 @@ class RealOnboardingPixelSenderTest {
         verify(mockPixel).fire(
             ONBOARDING_VISIT_SITE,
             mapOf(
-                "it" to "new",
+                "installType" to "new",
                 "flow" to "default",
                 "pixelSource" to "phone",
-                "d" to "0",
-                "e" to "clicked",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
                 "value" to "suggested",
             ),
             type = Unique(tag = "onboarding_visit-site_clicked"),
@@ -784,5 +806,55 @@ class RealOnboardingPixelSenderTest {
     @Test(expected = IllegalStateException::class)
     fun whenFireContextualCalledWithUnsupportedActionThenThrows() = runTest {
         testee.fireContextual(ONBOARDING_SEARCH, OnboardingPixelAction.SetDefaultConfirmed(isDdgDefault = true))
+    }
+
+    @Test
+    fun whenInstalledTodayThenDaysSinceInstallBucketIsZero() = runTest {
+        fireWelcomeShownInstalledDaysAgo(0L)
+
+        verifyWelcomeShownWithDaysSinceInstall("0")
+    }
+
+    @Test
+    fun whenInstalledOneToThreeDaysAgoThenDaysSinceInstallBucketIsOneToThree() = runTest {
+        fireWelcomeShownInstalledDaysAgo(1L, 3L)
+
+        verifyWelcomeShownWithDaysSinceInstall("1-3", times = 2)
+    }
+
+    @Test
+    fun whenInstalledFourToTenDaysAgoThenDaysSinceInstallBucketIsFourToTen() = runTest {
+        fireWelcomeShownInstalledDaysAgo(4L, 10L)
+
+        verifyWelcomeShownWithDaysSinceInstall("4-10", times = 2)
+    }
+
+    @Test
+    fun whenInstalledElevenToTwentyEightDaysAgoThenDaysSinceInstallBucketIsElevenToTwentyEight() = runTest {
+        fireWelcomeShownInstalledDaysAgo(11L, 28L)
+
+        verifyWelcomeShownWithDaysSinceInstall("11-28", times = 2)
+    }
+
+    @Test
+    fun whenInstalledMoreThanTwentyEightDaysAgoThenDaysSinceInstallBucketIsOverTwentyEight() = runTest {
+        fireWelcomeShownInstalledDaysAgo(29L, 400L)
+
+        verifyWelcomeShownWithDaysSinceInstall("28+", times = 2)
+    }
+
+    private fun fireWelcomeShownInstalledDaysAgo(vararg daysAgo: Long) {
+        daysAgo.forEach {
+            whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(it))
+            testee.fire(ONBOARDING_WELCOME, OnboardingPixelAction.Shown)
+        }
+    }
+
+    private fun verifyWelcomeShownWithDaysSinceInstall(bucket: String, times: Int = 1) {
+        verify(mockPixel, times(times)).fire(
+            ONBOARDING_WELCOME,
+            mapOf("installType" to "new", "flow" to "default", "pixelSource" to "phone", "daysSinceInstall" to bucket, "event" to "shown"),
+            type = Unique(tag = "onboarding_welcome_shown"),
+        )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1216821799405151
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

### Description

Applies the revised onboarding instrumentation standard agreed in [New parameter names and buckets](https://app.asana.com/1/137249556945/task/1216821984327708).

**More transparent parameter names** — every onboarding pixel fired through `OnboardingPixelSender` now sends:

| Before | After |
| --- | --- |
| `e` | `event` |
| `it` | `installType` |
| `d` | `daysSinceInstall` |

**Bucketed days since install** — `daysSinceInstall` was an exact day count that was omitted entirely once more than 28 days had passed. It is now one of five buckets: `0`, `1-3`, `4-10`, `11-28`, `28+`. Installs older than 28 days are no longer dropped; they report `28+`.

### Steps to test this PR

_Renamed parameters_
- [x] Clean install the app
- [x] Filter logcat for "Pixel sent"` while stepping through onboarding (welcome → set default → address bar position → search experience → notifications → contextual dialogs).
- [x] Confirm each `onboarding_*` pixel carries `event=`, `installType=` and `daysSinceInstall=` — and that `e=`, `it=` and `d=` no longer appear.

_Days-since-install buckets_
- [x] On the fresh install above, confirm `daysSinceInstall=0`.
- [x] Filter in logcat for “onboarding_”. You should see the reuqest for sending the pixel. However it will fail because of SSL handshake error after changing the device time, but you can still see the pixel params. 
- [x] Move the device clock forward (e.g. +5 days), relaunch and trigger a contextual onboarding pixel, and confirm `daysSinceInstall=4-10`.
- [x] Move the clock forward past 28 days and confirm `daysSinceInstall=28+` is sent rather than the parameter being omitted.

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes|No UI changes|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes live onboarding pixel parameter names and the shape of days-since-install data, which can break downstream analytics until pipelines and dashboards are updated; app behavior is limited to telemetry.
> 
> **Overview**
> Aligns **onboarding instrumentation** with clearer parameter names and a bucketed **days since install** field across pixel definitions and `RealOnboardingPixelSender`.
> 
> **Parameter renames** on the shared onboarding standard: `e` → `event`, `it` → `installType`, `d` → `daysSinceInstall`. Descriptions that referenced `e=clicked` are updated to `event=clicked`.
> 
> **`daysSinceInstall`** is no longer a raw day count (0–28, omitted after 28). It is always sent as a string bucket: `0`, `1-3`, `4-10`, `11-28`, or `28+`, via `daysSinceInstallBucket()` in `OnboardingPixelSender.kt`. `PixelDefinitions/pixels/definitions/onboarding.json5` matches the new keys, types, and enums for all affected `onboarding_*` pixels.
> 
> **Tests** in `RealOnboardingPixelSenderTest` expect the new param names and buckets, with added coverage for each bucket boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90d214d7b0c8eec0c4bba07d0fc994fd0d54d2c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->