### PR TITLE
Duck.Ai/NativeinputBar: Hide input when forward arrow pressed

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1979,6 +1979,7 @@ class BrowserTabFragment :
 
     private fun onForwardArrowClicked() {
         pixel.fire(AppPixelName.MENU_ACTION_NAVIGATE_FORWARD_PRESSED)
+        nativeInputManager.hideNativeInput(animate = false, isNavigation = true)
         viewModel.onUserPressedForward()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217025197182511?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Fixed the native input bar staying expanded when the browser menu's Forward button is pressed. It now collapses on Forward, matching the behavior of Back and other menu navigation actions.
  - The Forward handler now calls hideNativeInput(animate = false, isNavigation = true) before navigating, consistent with how other in-menu navigation collapses the input bar.

### Steps to test this PR
- [ ] Open a website in a new tab
- [ ] Open menu and press the back arrow
- [ ] Focus the native input
- [ ] Open menu and press the forward arrow
- [ ] Verify that native input is collapsed and the browser UX look as expeted
- [ ] Open a duck.ai chat in a new tab
- [ ] Open menu and press the back arrow
- [ ] Focus the native input
- [ ] Open menu and press the forward arrow
- [ ] Verify that native input is collapsed and the browser UX look as expeted

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line UI behavior change in browser navigation; no auth, data, or architectural impact.
> 
> **Overview**
> When users tap **Forward** in the browser menu, the Duck.AI **native input bar** is now dismissed before history navigation runs, so the overlay does not stay visible over the new page.
> 
> This mirrors existing navigation paths (e.g. `submitQuery`, voice search) that call `nativeInputManager.hideNativeInput(animate = false, isNavigation = true)` in `onForwardArrowClicked()` in `BrowserTabFragment`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67dfb5b2494de3baa998a59e3b594ae8b513912b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->