### PR TITLE
Send meta.type and meta.version with wide events

### DIFF
--- a/.claude/rules/wide-events.md
+++ b/.claude/rules/wide-events.md
@@ -76,6 +76,23 @@ FlowStatus.Unknown   // unexpected termination; always pair with a last_step in 
 
 When a flow is sampled out, `flowStart` returns a sentinel ID. All subsequent calls (`flowStep`, `flowFinish`, etc.) with that ID are silent no-ops with zero disk I/O — no special handling needed at the call site. The probability is persisted with the event and sent to the backend so it can weight the data correctly.
 
+### Meta parameters
+
+Every event is sent with `meta.type` and `meta.version`, which together identify the event definition it validates against. Both come from the optional `definition` parameter of `flowStart`, and the defaults are what almost every event wants:
+
+```kotlin
+wideEventClient.flowStart(
+    name = "my-feature-action",
+    definition = WideEventDefinition(
+        version = Version(minor = 1, patch = 0),   // defaults to Version.INITIAL (0.0)
+        type = "android-my-feature-action",        // defaults to android-{name}
+    ),
+)
+```
+
+- `meta.type` defaults to `android-{name}` with underscores normalized to hyphens (`page-load` becomes `android-page-load`), which matches the `ios-*` / `macos-*` / `win-*` identifiers of the other platforms. Keep flow names kebab-case and you never need to set it — an explicit type is an override, not the norm.
+- `meta.version` is a composed semver `<base_major>.<minor>.<patch>`. You declare only MINOR and PATCH, in step with the event's definition; MAJOR tracks the base template shared by every wide event and is added by the client. **Bump PATCH when you add an optional parameter to an event, MINOR when you rename, remove, or retype one** — a new event starts at `Version.INITIAL` (`0.0`), and the client prepends whichever base template major is current.
+
 ### CleanupPolicy
 
 Defines what happens to flows abandoned due to app termination or timeout:

--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -2232,6 +2232,8 @@
             "widePixelAppName",
             "widePixelFormFactor",
             "widePixelDevMode",
+            "widePixelMetaType",
+            "widePixelMetaVersion",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide event",
@@ -2554,6 +2556,8 @@
             "widePixelAppName",
             "widePixelFormFactor",
             "widePixelDevMode",
+            "widePixelMetaType",
+            "widePixelMetaVersion",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide event",
@@ -2876,6 +2880,8 @@
             "widePixelAppName",
             "widePixelFormFactor",
             "widePixelDevMode",
+            "widePixelMetaType",
+            "widePixelMetaVersion",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide event",

--- a/PixelDefinitions/pixels/definitions/wide_data_clearing.json5
+++ b/PixelDefinitions/pixels/definitions/wide_data_clearing.json5
@@ -14,6 +14,8 @@
             "widePixelAppName",
             "widePixelFormFactor",
             "widePixelDevMode",
+            "widePixelMetaType",
+            "widePixelMetaVersion",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide event",

--- a/PixelDefinitions/pixels/definitions/wide_free_trial_conversion.json5
+++ b/PixelDefinitions/pixels/definitions/wide_free_trial_conversion.json5
@@ -15,6 +15,8 @@
             "widePixelAppName",
             "widePixelFormFactor",
             "widePixelDevMode",
+            "widePixelMetaType",
+            "widePixelMetaVersion",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide pixel",

--- a/PixelDefinitions/pixels/definitions/wide_input_screen_onboarding.json5
+++ b/PixelDefinitions/pixels/definitions/wide_input_screen_onboarding.json5
@@ -15,6 +15,8 @@
             "widePixelAppName",
             "widePixelFormFactor",
             "widePixelDevMode",
+            "widePixelMetaType",
+            "widePixelMetaVersion",
             {
                 "key": "context.name",
                 "description": "Entry point to the Input Screen onboarding flow.",

--- a/PixelDefinitions/pixels/definitions/wide_page_load.json5
+++ b/PixelDefinitions/pixels/definitions/wide_page_load.json5
@@ -15,6 +15,8 @@
             "widePixelAppName",
             "widePixelFormFactor",
             "widePixelDevMode",
+            "widePixelMetaType",
+            "widePixelMetaVersion",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide event",

--- a/PixelDefinitions/pixels/definitions/wide_post_idle_session.json5
+++ b/PixelDefinitions/pixels/definitions/wide_post_idle_session.json5
@@ -16,17 +16,8 @@
             "widePixelAppName",
             "widePixelFormFactor",
             "widePixelDevMode",
-            {
-                "key": "meta.type",
-                "type": "string",
-                "description": "Wide event type identifier (platform-prefixed)",
-                "enum": ["android-post-idle-session"]
-            },
-            {
-                "key": "meta.version",
-                "type": "string",
-                "description": "Composed semver: <base_major>.<event_minor>.<event_patch>"
-            },
+            "widePixelMetaType",
+            "widePixelMetaVersion",
             {
                 "key": "global.is_first_daily_occurrence",
                 "type": "boolean",

--- a/PixelDefinitions/pixels/definitions/wide_subscription-purchase.json5
+++ b/PixelDefinitions/pixels/definitions/wide_subscription-purchase.json5
@@ -14,6 +14,8 @@
             "widePixelAppName",
             "widePixelFormFactor",
             "widePixelDevMode",
+            "widePixelMetaType",
+            "widePixelMetaVersion",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide pixel",

--- a/PixelDefinitions/pixels/definitions/wide_subscription_restore.json5
+++ b/PixelDefinitions/pixels/definitions/wide_subscription_restore.json5
@@ -14,6 +14,8 @@
             "widePixelAppName",
             "widePixelFormFactor",
             "widePixelDevMode",
+            "widePixelMetaType",
+            "widePixelMetaVersion",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide pixel",

--- a/PixelDefinitions/pixels/definitions/wide_sync_setup.json5
+++ b/PixelDefinitions/pixels/definitions/wide_sync_setup.json5
@@ -14,6 +14,8 @@
             "widePixelAppName",
             "widePixelFormFactor",
             "widePixelDevMode",
+            "widePixelMetaType",
+            "widePixelMetaVersion",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide pixel",

--- a/PixelDefinitions/pixels/definitions/wide_vpn_enable.json5
+++ b/PixelDefinitions/pixels/definitions/wide_vpn_enable.json5
@@ -15,6 +15,8 @@
             "widePixelAppName",
             "widePixelFormFactor",
             "widePixelDevMode",
+            "widePixelMetaType",
+            "widePixelMetaVersion",
             {
                 "key": "context.name",
                 "description": "Entry point to the VPN enable flow.",

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -77,6 +77,16 @@
         "type": "number",
         "description": "Sample rate for this pixel, between 0 and 1"
     },
+    "widePixelMetaType": {
+        "key": "meta.type",
+        "type": "string",
+        "description": "Company unique wide event type identifier"
+    },
+    "widePixelMetaVersion": {
+        "key": "meta.version",
+        "type": "string",
+        "description": "Composed semver of the wide event schema: <base_major>.<event_minor>.<event_patch>"
+    },
     "widePixelFeatureStatus": {
         "key": "feature.status",
         "type": "string",

--- a/app/src/test/java/com/duckduckgo/app/browser/pageload/PageLoadWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pageload/PageLoadWideEventTest.kt
@@ -66,7 +66,7 @@ class PageLoadWideEventTest {
         androidBrowserConfigFeature.sendPageLoadWideEvent().setRawStoredState(Toggle.State(true))
 
         // Mock all WideEventClient methods to return successful Results
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any())).thenReturn(Result.success(123L))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any())).thenReturn(Result.success(123L))
         whenever(wideEventClient.flowStep(any(), any(), any(), any())).thenReturn(Result.success(Unit))
         whenever(wideEventClient.intervalStart(any(), any(), any(), any())).thenReturn(Result.success(Unit))
         whenever(wideEventClient.intervalEnd(any(), any())).thenReturn(Result.success(100.milliseconds))
@@ -86,7 +86,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when onPageStarted called then starts flow records step and starts interval timers`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(123L))
 
         pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com")
@@ -111,7 +111,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when onPageVisible called then ends time_to_visible interval and records step`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(456L))
 
         pageLoadWideEvent.onPageStarted("tab_2", "https://twitter.com")
@@ -139,7 +139,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when onProgressChanged called then ends time_to_escaped_fixed_progress interval and records step`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(789L))
 
         pageLoadWideEvent.onPageStarted("tab_3", "https://reddit.com")
@@ -165,7 +165,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when onPageLoadFinished called with success then ends interval and records step`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(999L))
 
         pageLoadWideEvent.onPageStarted("tab_4", "https://espn.com")
@@ -203,7 +203,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when onPageLoadFinished called with error then includes error code in step metadata`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(888L))
 
         pageLoadWideEvent.onPageStarted("tab_5", "https://wikipedia.org")
@@ -283,7 +283,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when multiple tabs load then have independent flows`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(100L))
             .thenReturn(Result.success(200L))
 
@@ -313,7 +313,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when flowStart fails then handled gracefully`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.failure(Exception("Flow start failed")))
 
         pageLoadWideEvent.onPageStarted("tab_fail", "https://reddit.com")
@@ -326,7 +326,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when complete page load lifecycle then tracks all phases`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(500L))
 
         // Start page load
@@ -377,7 +377,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when onPageStarted called with different url then aborts previous flow`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(800L))
             .thenReturn(Result.success(900L))
 
@@ -393,12 +393,12 @@ class PageLoadWideEventTest {
         verify(wideEventClient).flowAbort(800L)
 
         // Verify second flow was started
-        verify(wideEventClient, times(2)).flowStart(any(), anyOrNull(), any(), any(), any())
+        verify(wideEventClient, times(2)).flowStart(any(), anyOrNull(), any(), any(), any(), any())
     }
 
     @Test
     fun `when onPageStarted called with same url then does not start duplicate flow`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(1000L))
 
         // Start page load twice with same URL
@@ -408,7 +408,7 @@ class PageLoadWideEventTest {
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Verify flowStart was only called once and flowAbort was never called
-        verify(wideEventClient, times(1)).flowStart(any(), anyOrNull(), any(), any(), any())
+        verify(wideEventClient, times(1)).flowStart(any(), anyOrNull(), any(), any(), any(), any())
         verify(wideEventClient, never()).flowAbort(any())
     }
 
@@ -418,7 +418,7 @@ class PageLoadWideEventTest {
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Verify flowStart was never called
-        verify(wideEventClient, never()).flowStart(any(), anyOrNull(), any(), any(), any())
+        verify(wideEventClient, never()).flowStart(any(), anyOrNull(), any(), any(), any(), any())
     }
 
     @Test
@@ -428,13 +428,13 @@ class PageLoadWideEventTest {
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Verify flowStart was never called
-        verify(wideEventClient, never()).flowStart(any(), anyOrNull(), any(), any(), any())
+        verify(wideEventClient, never()).flowStart(any(), anyOrNull(), any(), any(), any(), any())
     }
 
     @Test
     fun `when onPageStarted called with subdomain of tracked site then starts flow`() = runTest {
         // mobile.twitter.com should be tracked since twitter.com is in perfSites
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(123L))
 
         pageLoadWideEvent.onPageStarted("tab_1", "https://mobile.twitter.com/duckduckgo")
@@ -452,7 +452,7 @@ class PageLoadWideEventTest {
     @Test
     fun `when onPageVisible called with untracked url then does nothing`() = runTest {
         // Start with a tracked URL
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(123L))
         pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com")
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
@@ -472,7 +472,7 @@ class PageLoadWideEventTest {
     @Test
     fun `when onProgressChanged called with untracked url then does nothing`() = runTest {
         // Start with a tracked URL
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(123L))
         pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com")
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
@@ -492,7 +492,7 @@ class PageLoadWideEventTest {
     @Test
     fun `when onPageLoadFinished called with success and untracked url then does nothing`() = runTest {
         // Start with a tracked URL
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(123L))
         pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com")
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
@@ -520,7 +520,7 @@ class PageLoadWideEventTest {
     @Test
     fun `when onPageLoadFinished called with error and untracked url then does nothing`() = runTest {
         // Start with a tracked URL
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(123L))
         pageLoadWideEvent.onPageStarted("tab_1", "https://espn.com")
         coroutineRule.testScope.testScheduler.advanceUntilIdle()

--- a/app/src/test/java/com/duckduckgo/app/browser/postidle/RealPostIdleSessionWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/postidle/RealPostIdleSessionWideEventTest.kt
@@ -65,7 +65,7 @@ class RealPostIdleSessionWideEventTest {
         whenever(duckChatInputModeState.displayedMode).thenReturn(displayedModeFlow)
         androidBrowserConfigFeature.sendPostIdleSessionWideEvent().setRawStoredState(Toggle.State(true))
 
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any())).thenReturn(Result.success(123L))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any())).thenReturn(Result.success(123L))
         whenever(wideEventClient.flowStep(any(), any(), any(), any())).thenReturn(Result.success(Unit))
         whenever(wideEventClient.intervalStart(any(), any(), anyOrNull(), anyOrNull())).thenReturn(Result.success(Unit))
         whenever(wideEventClient.intervalEnd(any(), any())).thenReturn(Result.success(100.milliseconds))
@@ -97,6 +97,7 @@ class RealPostIdleSessionWideEventTest {
                 ),
             ),
             samplingProbability = any(),
+            definition = any(),
         )
         verify(wideEventClient).intervalStart(eq(123L), eq("session_duration_ms_bucketed"), anyOrNull(), anyOrNull())
         verify(wideEventClient).intervalStart(eq(123L), eq("time_to_first_interaction_ms_bucketed"), anyOrNull(), anyOrNull())
@@ -105,7 +106,7 @@ class RealPostIdleSessionWideEventTest {
 
     @Test
     fun `when onSurfaceShown called twice then prior flow is aborted before new flowStart`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(1L))
             .thenReturn(Result.success(2L))
 
@@ -121,6 +122,7 @@ class RealPostIdleSessionWideEventTest {
             metadata = eq(mapOf("surface" to "lut")),
             cleanupPolicy = any(),
             samplingProbability = any(),
+            definition = any(),
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/fire/wideevents/DataClearingWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/wideevents/DataClearingWideEventTest.kt
@@ -59,7 +59,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `start starts a new flow with entry point and clear options`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(123L))
 
         val clearOptions = setOf(FireClearOption.TABS, FireClearOption.DATA)
@@ -77,7 +77,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `start with browserMode includes browser_mode in metadata`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(125L))
 
         dataClearingWideEvent.start(EntryPoint.APP_SHORTCUT, setOf(FireClearOption.TABS), browserMode = BrowserMode.FIRE)
@@ -93,7 +93,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `start with tabType and tabCount includes bucketed values in metadata`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(127L))
 
         dataClearingWideEvent.start(
@@ -120,7 +120,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `start buckets tab counts using the shared tab_count boundaries`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(128L))
 
         listOf(0 to "1", 1 to "1", 2 to "2-5", 10 to "6-10", 81 to "81+", 200 to "81+").forEach { (count, bucket) ->
@@ -143,7 +143,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `start with empty clear options sets empty metadata value`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(456L))
 
         dataClearingWideEvent.start(EntryPoint.APP_SHORTCUT, emptySet(), browserMode = BrowserMode.REGULAR)
@@ -159,7 +159,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `start with duckai chats option includes duckai_chats in metadata`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(789L))
 
         val clearOptions = setOf(FireClearOption.DUCKAI_CHATS)
@@ -176,7 +176,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `start with single tab fire dialog entry point sends correct flow entry point`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(124L))
 
         val clearOptions = setOf(FireClearOption.TABS, FireClearOption.DATA, FireClearOption.DUCKAI_CHATS)
@@ -194,7 +194,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `start resets existing flow before starting new one`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(1L))
             .thenReturn(Result.success(2L))
 
@@ -206,7 +206,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `stepSuccess sends successful step`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(500L))
 
         dataClearingWideEvent.start(EntryPoint.SINGLE_TAB_FIRE_DIALOG, setOf(FireClearOption.TABS), browserMode = BrowserMode.REGULAR)
@@ -221,7 +221,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `stepSuccess with different steps sends correct step names`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(501L))
 
         dataClearingWideEvent.start(EntryPoint.SINGLE_TAB_FIRE_DIALOG, setOf(FireClearOption.TABS), browserMode = BrowserMode.REGULAR)
@@ -236,7 +236,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `stepFailure sends failed step with error class`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(600L))
 
         dataClearingWideEvent.start(EntryPoint.SINGLE_TAB_FIRE_DIALOG, setOf(FireClearOption.DATA), browserMode = BrowserMode.REGULAR)
@@ -252,7 +252,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `finishSuccess ends interval and finishes flow with success`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(700L))
 
         dataClearingWideEvent.start(EntryPoint.SINGLE_TAB_FIRE_DIALOG, setOf(FireClearOption.TABS), browserMode = BrowserMode.REGULAR)
@@ -264,7 +264,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `finishSuccess clears cached flow id`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(701L))
 
         dataClearingWideEvent.start(EntryPoint.SINGLE_TAB_FIRE_DIALOG, setOf(FireClearOption.TABS), browserMode = BrowserMode.REGULAR)
@@ -282,7 +282,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `finishFailure ends interval and finishes flow with failure`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(800L))
 
         dataClearingWideEvent.start(EntryPoint.SINGLE_TAB_FIRE_DIALOG, setOf(FireClearOption.TABS), browserMode = BrowserMode.REGULAR)
@@ -297,7 +297,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `finishFailure clears cached flow id`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(801L))
 
         dataClearingWideEvent.start(EntryPoint.SINGLE_TAB_FIRE_DIALOG, setOf(FireClearOption.TABS), browserMode = BrowserMode.REGULAR)
@@ -315,7 +315,7 @@ class DataClearingWideEventTest {
 
     @Test
     fun `getCurrentFlowId returns cached flow id`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(900L))
 
         dataClearingWideEvent.start(EntryPoint.SINGLE_TAB_FIRE_DIALOG, setOf(FireClearOption.TABS), browserMode = BrowserMode.REGULAR)

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/pixels/VpnEnableWideEventTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/pixels/VpnEnableWideEventTest.kt
@@ -60,7 +60,7 @@ class VpnEnableWideEventTest {
 
     @Test
     fun `onUserRequestedVpnStart starts a new flow`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(123L))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
         whenever(networkProtectionState.isOnboarded()).thenReturn(true)
@@ -81,7 +81,7 @@ class VpnEnableWideEventTest {
 
     @Test
     fun `onUserRequestedVpnStart with SYSTEM_TILE entry point`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(456L))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
         whenever(networkProtectionState.isOnboarded()).thenReturn(false)
@@ -102,7 +102,7 @@ class VpnEnableWideEventTest {
 
     @Test
     fun `onUserRequestedVpnStart with NOTIFICATION entry point`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(789L))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.WAITING)
         whenever(networkProtectionState.isOnboarded()).thenReturn(true)
@@ -123,7 +123,7 @@ class VpnEnableWideEventTest {
 
     @Test
     fun `onUserRequestedVpnStart ends previous flow if one is active`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(1L))
             .thenReturn(Result.success(2L))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
@@ -138,7 +138,7 @@ class VpnEnableWideEventTest {
 
     @Test
     fun `onVpnConflictDialogShown sends flowStep`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(100L))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
         whenever(networkProtectionState.isOnboarded()).thenReturn(false)
@@ -155,7 +155,7 @@ class VpnEnableWideEventTest {
 
     @Test
     fun `onVpnConflictDialogCancel finishes flow with Cancelled`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(200L))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
         whenever(networkProtectionState.isOnboarded()).thenReturn(false)
@@ -173,7 +173,7 @@ class VpnEnableWideEventTest {
 
     @Test
     fun `onVpnConflictDialogCancel clears wideEventId`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(300L))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
         whenever(networkProtectionState.isOnboarded()).thenReturn(false)
@@ -190,7 +190,7 @@ class VpnEnableWideEventTest {
 
     @Test
     fun `onAskForVpnPermission sends flowStep`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(400L))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
         whenever(networkProtectionState.isOnboarded()).thenReturn(false)
@@ -207,7 +207,7 @@ class VpnEnableWideEventTest {
 
     @Test
     fun `onVpnPermissionRejected finishes flow with Cancelled`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(500L))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
         whenever(networkProtectionState.isOnboarded()).thenReturn(false)
@@ -225,7 +225,7 @@ class VpnEnableWideEventTest {
 
     @Test
     fun `onVpnPermissionRejected clears wideEventId`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(600L))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
         whenever(networkProtectionState.isOnboarded()).thenReturn(false)
@@ -242,7 +242,7 @@ class VpnEnableWideEventTest {
 
     @Test
     fun `onStartVpn sends flowStep and starts interval`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(700L))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
         whenever(networkProtectionState.isOnboarded()).thenReturn(false)
@@ -275,7 +275,7 @@ class VpnEnableWideEventTest {
 
     @Test
     fun `subscription status exception is handled gracefully`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(800L))
         whenever(subscriptions.getSubscriptionStatus()).thenThrow(RuntimeException("Error"))
         whenever(networkProtectionState.isOnboarded()).thenReturn(false)
@@ -296,7 +296,7 @@ class VpnEnableWideEventTest {
 
     @Test
     fun `onboarded check exception is handled gracefully`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(900L))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
         whenever(networkProtectionState.isOnboarded()).thenThrow(RuntimeException("Error"))

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEventTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEventTest.kt
@@ -172,7 +172,7 @@ class PirInitialScanCompletionWideEventTest {
 
     @Test
     fun whenManualInitialRunStartedAndFlagFalseThenFlowStartedWithExpectedMetadata() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(42L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(42L))
 
         testee.onRunStarted(
             executionType = PirExecutionType.MANUAL_INITIAL,
@@ -244,14 +244,14 @@ class PirInitialScanCompletionWideEventTest {
 
     @Test
     fun whenScheduledRunStartedWhileFlowOpenThenScheduledCountIncrementedAndNoNewFlow() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(1L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(1L))
         runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
         // foreground=1 after the manual initial run
 
         runStarted(executionType = PirExecutionType.SCHEDULED)
         runStarted(executionType = PirExecutionType.SCHEDULED)
 
-        verify(wideEventClient).flowStart(any(), any(), any(), any(), any())
+        verify(wideEventClient).flowStart(any(), any(), any(), any(), any(), any())
         assertEquals(1L, dataStore.initialScanCompletionFlowId)
         assertEquals(1, dataStore.initialScanCompletionForegroundRunCount)
         assertEquals(2, dataStore.initialScanCompletionScheduledRunCount)
@@ -259,12 +259,12 @@ class PirInitialScanCompletionWideEventTest {
 
     @Test
     fun whenManualEditProfileRunStartedWhileFlowOpenThenForegroundCountIncremented() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(1L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(1L))
         runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
 
         runStarted(executionType = PirExecutionType.MANUAL_EDIT_PROFILE)
 
-        verify(wideEventClient).flowStart(any(), any(), any(), any(), any())
+        verify(wideEventClient).flowStart(any(), any(), any(), any(), any(), any())
         assertEquals(2, dataStore.initialScanCompletionForegroundRunCount)
         assertEquals(0, dataStore.initialScanCompletionScheduledRunCount)
     }
@@ -279,20 +279,20 @@ class PirInitialScanCompletionWideEventTest {
 
     @Test
     fun whenManualInitialResumeRunStartedWhileFlowOpenThenForegroundCountIncremented() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(1L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(1L))
         runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
 
         runStarted(executionType = PirExecutionType.MANUAL_INITIAL_RESUME)
 
         // The resume continues the open journey flow (no second flowStart) and counts as a foreground run.
-        verify(wideEventClient).flowStart(any(), any(), any(), any(), any())
+        verify(wideEventClient).flowStart(any(), any(), any(), any(), any(), any())
         assertEquals(2, dataStore.initialScanCompletionForegroundRunCount)
         assertEquals(0, dataStore.initialScanCompletionScheduledRunCount)
     }
 
     @Test
     fun whenScanCompletedAndAllJobsDoneThenFlowFinishedWithSuccess() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(99L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(99L))
         runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
         runStarted(executionType = PirExecutionType.SCHEDULED)
         whenever(pirSchedulingRepository.getAllValidScanJobRecords()).thenReturn(
@@ -324,7 +324,7 @@ class PirInitialScanCompletionWideEventTest {
 
     @Test
     fun whenUnscannedJobBelongsToInactiveBrokerThenFlowStillFinishesSuccess() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(99L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(99L))
         runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
         // b3 was never scanned, but its broker is no longer active so the scanner will never run it.
         // It must not block the journey from completing.
@@ -354,7 +354,7 @@ class PirInitialScanCompletionWideEventTest {
 
     @Test
     fun whenUnscannedJobBelongsToUnparseableBrokerThenFlowStillFinishesSuccess() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(99L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(99L))
         runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
         // b3 is active but its scan steps don't parse, so the scanner silently skips it and its job
         // stays unscanned forever. It must not block the journey from completing.
@@ -391,7 +391,7 @@ class PirInitialScanCompletionWideEventTest {
 
     @Test
     fun whenScanCompletedAndSomeJobsNotDoneThenFlowRemainsOpen() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(99L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(99L))
         runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
         whenever(pirSchedulingRepository.getAllValidScanJobRecords()).thenReturn(
             listOf(
@@ -423,7 +423,7 @@ class PirInitialScanCompletionWideEventTest {
 
     @Test
     fun whenOnUserResetCalledAndFlowOpenThenFlowAborted() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(55L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(55L))
         whenever(wideEventClient.flowAbort(any())).thenReturn(Result.success(Unit))
         runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
 
@@ -444,7 +444,7 @@ class PirInitialScanCompletionWideEventTest {
     fun whenOnUserResetCalledAndFeatureFlagDisabledMidFlightThenInFlightFlowStillAborted() = runTest {
         // Flow opens while flag is ON, then flag flips OFF before user reset. We must still abort
         // the in-flight flow so it doesn't get auto-finished as Unknown by the cleanup timeout.
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(55L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(55L))
         whenever(wideEventClient.flowAbort(any())).thenReturn(Result.success(Unit))
         runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
         pirRemoteFeatures.sendScanWideEvent().setRawStoredState(Toggle.State(false))
@@ -456,7 +456,7 @@ class PirInitialScanCompletionWideEventTest {
 
     @Test
     fun whenJourneySpansMultipleRunsThenSuccessReportsTotalCounts() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(7L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(7L))
 
         // Initial foreground run starts the flow.
         runStarted(executionType = PirExecutionType.MANUAL_INITIAL)

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
@@ -157,7 +157,7 @@ class PirScanWideEventTest {
     @Test
     fun whenScheduledRunStartedAndSampledInThenFlowStartedWithScheduledName() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(50L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(50L))
 
         // When
         runStarted(PirExecutionType.SCHEDULED, 2, 5, 10)
@@ -204,7 +204,7 @@ class PirScanWideEventTest {
             hookInvocations++
             true
         }
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(1L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(1L))
 
         // When
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 1)
@@ -216,7 +216,7 @@ class PirScanWideEventTest {
     @Test
     fun whenManualInitialRunStartedThenFlowStartedWithExpectedParameters() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(123L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(123L))
 
         // When
         testee.onRunStarted(
@@ -276,7 +276,7 @@ class PirScanWideEventTest {
     @Test
     fun whenManualEditProfileRunStartedThenEntryPointAndExecutionTypeReflectThat() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(456L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(456L))
 
         // When
         runStarted(PirExecutionType.MANUAL_EDIT_PROFILE, 1, 3, 6)
@@ -304,7 +304,7 @@ class PirScanWideEventTest {
     @Test
     fun whenManualInitialResumeRunStartedThenEntryPointAndExecutionTypeReflectThat() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(789L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(789L))
 
         // When
         runStarted(PirExecutionType.MANUAL_INITIAL_RESUME, 1, 3, 6)
@@ -332,7 +332,7 @@ class PirScanWideEventTest {
     @Test
     fun whenManualAndScheduledFlowsBothActiveThenTheyDoNotInterfere() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(11L)) // manual flow id
             .thenReturn(Result.success(22L)) // scheduled flow id
 
@@ -376,7 +376,7 @@ class PirScanWideEventTest {
     @Test
     fun whenScanJobsResolvedToLowerCountThenDecileMathUsesActualCount() = runTest {
         // Given - PirJobsRunner says 100 eligible jobs, but PirScan filters down to 5.
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(42L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(42L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 100)
 
         // When - PirScan reports the resolved count, then runs only 5 jobs.
@@ -398,7 +398,7 @@ class PirScanWideEventTest {
     fun whenScanJobsResolvedToZeroThenOpenDecileIntervalIsClosed() = runTest {
         // Given - PirJobsRunner says 10 eligible jobs (so onRunStarted opened decile_0_10),
         // but PirScan filters all of them out.
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(43L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(43L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 10)
 
         // When
@@ -412,7 +412,7 @@ class PirScanWideEventTest {
     @Test
     fun whenScanJobsResolvedToSameCountThenNoStateChange() = runTest {
         // Given - resolved count matches the pre-filter estimate (the common case).
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(44L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(44L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 10)
 
         // When
@@ -434,7 +434,7 @@ class PirScanWideEventTest {
     @Test
     fun whenRunStartedWithZeroTotalScanJobsThenTotalIntervalsStartButNoDecileInterval() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(789L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(789L))
 
         // When
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 0, 0)
@@ -468,7 +468,7 @@ class PirScanWideEventTest {
     @Test
     fun whenSecondRunStartedWhileFlowOpenThenStaleFlowFinishedWithCancelled() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(100L))
             .thenReturn(Result.success(200L))
 
@@ -493,7 +493,7 @@ class PirScanWideEventTest {
     @Test
     fun whenManualFlowOpenAndProfileEditRunStartsThenStaleFlowFinishedWithSupersededByProfileEdit() = runTest {
         // Given an open manual flow (the initial scan)
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(101L))
             .thenReturn(Result.success(201L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 1)
@@ -516,7 +516,7 @@ class PirScanWideEventTest {
     @Test
     fun whenManualFlowOpenAndInitialResumeRunStartsThenStaleFlowFinishedWithSupersededByNewRun() = runTest {
         // Given an open manual flow (the interrupted initial scan)
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(102L))
             .thenReturn(Result.success(202L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 1)
@@ -542,7 +542,7 @@ class PirScanWideEventTest {
         // 8h cleanup-on-timeout policy, which never calls flowFinish. Attaching last_step as metadata on
         // every step persists it incrementally (flowStep metadata is merged + stored immediately), so an
         // Unknown event still reports how far the scan got.
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(70L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(70L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 10)
 
         // When - complete 5 of 10 jobs (crosses 50%)
@@ -566,7 +566,7 @@ class PirScanWideEventTest {
     @Test
     fun whenTenJobsCompleteOneAtATimeThenAllNineProgressStepsFire() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(1L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(1L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 10)
 
         // When
@@ -586,7 +586,7 @@ class PirScanWideEventTest {
     @Test
     fun whenFiveJobsCompleteThenDecilesAreJumpedAndOnlyHighestCrossedFires() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(1L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(1L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 5)
 
         // When
@@ -633,7 +633,7 @@ class PirScanWideEventTest {
     @Test
     fun whenSingleJobScanThenOnlyProgress90FiresAndIntervalsClose() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(7L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(7L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 1)
 
         // When
@@ -662,7 +662,7 @@ class PirScanWideEventTest {
     @Test
     fun whenTenJobsCompleteThenDecileIntervalsOpenAndCloseInOrder() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(11L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(11L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 10)
 
         // When
@@ -696,7 +696,7 @@ class PirScanWideEventTest {
     @Test
     fun whenScanCompletedThenScanCompletedStepEmitted() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(2L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(2L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 0) // zero scan jobs path
 
         // When
@@ -714,7 +714,7 @@ class PirScanWideEventTest {
     @Test
     fun whenOptOutStartedThenStepAndIntervalEmitted() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(3L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(3L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 0)
 
         // When
@@ -737,7 +737,7 @@ class PirScanWideEventTest {
     @Test
     fun whenOptOutCompletedThenIntervalClosedAndFlowFinishedWithSuccess() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(4L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(4L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 0)
         testee.onOptOutStarted(PirExecutionType.MANUAL_INITIAL)
 
@@ -762,7 +762,7 @@ class PirScanWideEventTest {
     @Test
     fun whenOptOutSkippedThenStepEmittedAndFlowFinishedWithSuccess() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(5L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(5L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 0)
 
         // When
@@ -789,7 +789,7 @@ class PirScanWideEventTest {
     @Test
     fun whenScanCompletedThenOptOutCompletedThenTotalScanEndsAtScanAndTotalFlowEndsAtFinish() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(70L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(70L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 0) // zero scan jobs, no decile interval
 
         // When
@@ -813,7 +813,7 @@ class PirScanWideEventTest {
     @Test
     fun whenOptOutSkippedThenTotalFlowIntervalEndedBeforeFlowFinish() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(71L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(71L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 0)
         testee.onScanCompleted(PirExecutionType.MANUAL_INITIAL) // ends the scan-phase total
 
@@ -834,7 +834,7 @@ class PirScanWideEventTest {
     @Test
     fun whenRunFailedMidScanThenBothTotalIntervalsEndedBeforeFlowFinish() = runTest {
         // Given - failure fires before scan_completed, so the scan-phase total is still open.
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(72L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(72L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 10) // decile_0_10 + both totals open
 
         // When
@@ -855,7 +855,7 @@ class PirScanWideEventTest {
     @Test
     fun whenRunFailedThenFlowFinishedWithFailure() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(6L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(6L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 0, 0)
 
         // When
@@ -871,7 +871,7 @@ class PirScanWideEventTest {
     @Test
     fun whenRunCancelledThenFlowFinishedWithCancelled() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(8L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(8L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 1)
         testee.onScanJobCompleted(PirExecutionType.MANUAL_INITIAL) // emits progress_90 (which persists last_step = progress_90)
 
@@ -889,7 +889,7 @@ class PirScanWideEventTest {
     @Test
     fun whenRunFailedDuringScanThenOpenDecileIntervalIsClosedBeforeFlowFinish() = runTest {
         // Given - 10 jobs total, only 2 completed -> still inside decile_20_30 when failure fires.
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(60L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(60L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 10)
         repeat(2) { testee.onScanJobCompleted(PirExecutionType.MANUAL_INITIAL) } // progress_20 fires, decile_20_30 opens
 
@@ -908,7 +908,7 @@ class PirScanWideEventTest {
     @Test
     fun whenRunFailedDuringOptOutThenOpenOptOutIntervalIsClosedBeforeFlowFinish() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(61L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(61L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 0) // zero scan jobs, no decile interval
         testee.onScanCompleted(PirExecutionType.MANUAL_INITIAL)
         testee.onOptOutStarted(PirExecutionType.MANUAL_INITIAL) // opens INTERVAL_OPT_OUT_DURATION
@@ -928,7 +928,7 @@ class PirScanWideEventTest {
     @Test
     fun whenRunCancelledDuringScanThenOpenDecileIntervalIsClosedBeforeFlowFinish() = runTest {
         // Given - cancellation fires while scan is in progress (decile_0_10 still open).
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(62L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(62L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 10)
 
         // When
@@ -947,7 +947,7 @@ class PirScanWideEventTest {
     @Test
     fun whenRunCancelledDuringOptOutThenOpenOptOutIntervalIsClosedBeforeFlowFinish() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(63L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(63L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 0)
         testee.onScanCompleted(PirExecutionType.MANUAL_INITIAL)
         testee.onOptOutStarted(PirExecutionType.MANUAL_INITIAL)
@@ -968,7 +968,7 @@ class PirScanWideEventTest {
     @Test
     fun whenOnWorkCancelledThenOpenFlowFinishedWithCancelledAndReason() = runTest {
         // Given an open manual flow with no scan jobs (so no decile interval is opened)
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(80L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(80L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 0)
 
         // When work is cancelled externally (e.g. via PirWorkHandler.cancelWork)
@@ -1010,7 +1010,7 @@ class PirScanWideEventTest {
 
     @Test
     fun whenRunCancelledBeforeStartThenOneShotFlowEmittedWithZeroedCountsAndReason() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(90L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(90L))
 
         testee.onRunCancelledBeforeStart(PirExecutionType.MANUAL_INITIAL, CancellationReason.FOREGROUND_START_FAILED)
 
@@ -1047,7 +1047,7 @@ class PirScanWideEventTest {
         // (-> onWorkCancelled). The before-start hook must reuse the already-open flow instead of
         // synthesizing a second one, otherwise the follow-on onWorkCancelled produces a duplicate
         // cancelled wide event for a single user action.
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(300L)) // onRunStarted
             .thenReturn(Result.success(301L)) // any (unwanted) synthetic one-shot would get this id
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 0) // opens manual flow 300L
@@ -1056,7 +1056,7 @@ class PirScanWideEventTest {
         testee.onWorkCancelled(CancellationReason.SUBSCRIPTION_EXPIRED)
 
         // No synthetic one-shot was started (only the original onRunStarted flowStart)...
-        verify(wideEventClient, times(1)).flowStart(any(), any(), any(), any(), any())
+        verify(wideEventClient, times(1)).flowStart(any(), any(), any(), any(), any(), any())
         // ...and the run is finished as Cancelled exactly once, reusing the open flow.
         verify(wideEventClient, times(1)).flowFinish(any(), eq(FlowStatus.Cancelled), any())
         verify(wideEventClient).flowFinish(
@@ -1122,7 +1122,7 @@ class PirScanWideEventTest {
     @Test
     fun whenRunFailedWithMappedExceptionThenFlowFinishedWithMappedReasonValue() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(99L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(99L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 1)
 
         // When - simulating PirJobsRunner mapping an IOException via fromException.
@@ -1158,7 +1158,7 @@ class PirScanWideEventTest {
 
     @Test
     fun whenOnUserResetCalledAndManualFlowOpenThenManualFlowAborted() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(11L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(11L))
         whenever(wideEventClient.flowAbort(any())).thenReturn(Result.success(Unit))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 1)
 
@@ -1169,7 +1169,7 @@ class PirScanWideEventTest {
 
     @Test
     fun whenOnUserResetCalledAndScheduledFlowOpenThenScheduledFlowAborted() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(22L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(22L))
         whenever(wideEventClient.flowAbort(any())).thenReturn(Result.success(Unit))
         runStarted(PirExecutionType.SCHEDULED, 1, 1, 1)
 
@@ -1180,9 +1180,9 @@ class PirScanWideEventTest {
 
     @Test
     fun whenOnUserResetCalledAndBothFlowsOpenThenBothAreAborted() = runTest {
-        whenever(wideEventClient.flowStart(any(), eq(ENTRY_POINT_MANUAL_INITIAL), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), eq(ENTRY_POINT_MANUAL_INITIAL), any(), any(), any(), any()))
             .thenReturn(Result.success(11L))
-        whenever(wideEventClient.flowStart(any(), eq(ENTRY_POINT_SCHEDULED), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), eq(ENTRY_POINT_SCHEDULED), any(), any(), any(), any()))
             .thenReturn(Result.success(22L))
         whenever(wideEventClient.flowAbort(any())).thenReturn(Result.success(Unit))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 1)
@@ -1196,7 +1196,7 @@ class PirScanWideEventTest {
 
     @Test
     fun whenOnUserResetCalledAndManualFlowOpenThenStateClearedSoNextRunStartsFresh() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(11L), Result.success(33L))
         whenever(wideEventClient.flowAbort(any())).thenReturn(Result.success(Unit))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 1)
@@ -1214,7 +1214,7 @@ class PirScanWideEventTest {
     fun whenOnUserResetCalledAndFeatureFlagDisabledMidFlightThenInFlightFlowStillAborted() = runTest {
         // Flow opens while flag is ON, then flag flips OFF before user reset. We must still abort
         // the in-flight flow so it doesn't get auto-finished as Unknown by the cleanup timeout.
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(11L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(11L))
         whenever(wideEventClient.flowAbort(any())).thenReturn(Result.success(Unit))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 1)
         pirRemoteFeatures.sendScanWideEvent().setRawStoredState(Toggle.State(false))
@@ -1227,7 +1227,7 @@ class PirScanWideEventTest {
     @Test
     fun whenStepReachedAfterTimeElapsedThenLastStepElapsedIsBucketedSinceRunStart() = runTest {
         // Given - the run starts at t=1s; a 10-job scan.
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(73L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(73L))
         timeProvider.elapsed = 1_000
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 10)
 
@@ -1255,7 +1255,7 @@ class PirScanWideEventTest {
     @Test
     fun whenRunFailedWithRendererGoneAndSystemKillThenFlowFinishedAsFailureWithDidCrashFalse() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(50L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(50L))
         runStarted(PirExecutionType.MANUAL_INITIAL, profileQueriesCount = 1, brokerCount = 1, totalScanJobs = 1)
 
         // When
@@ -1276,7 +1276,7 @@ class PirScanWideEventTest {
     @Test
     fun whenRunFailedWithoutDidCrashThenFlowFinishedWithEmptyMetadata() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(51L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(51L))
         runStarted(PirExecutionType.MANUAL_INITIAL, profileQueriesCount = 1, brokerCount = 1, totalScanJobs = 1)
 
         // When (existing callers pass no didCrash)

--- a/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/wideevents/WideEventClient.kt
+++ b/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/wideevents/WideEventClient.kt
@@ -34,6 +34,7 @@ interface WideEventClient {
      *   E.g., 0.1 means ~10 % of events are kept and the rest are silently dropped.
      *   When an event is sampled out, [SAMPLED_OUT_FLOW_ID] is returned and all subsequent
      *   operations on that ID become no-ops.
+     * @param definition Definition that this event conforms to, see [WideEventDefinition].
      * @return Wide event ID used for subsequent calls.
      */
     suspend fun flowStart(
@@ -42,6 +43,7 @@ interface WideEventClient {
         metadata: Map<String, String> = emptyMap(),
         cleanupPolicy: CleanupPolicy = OnTimeout(duration = 7.days),
         samplingProbability: Float = 1.0f,
+        definition: WideEventDefinition = WideEventDefinition(),
     ): Result<Long>
 
     /**
@@ -143,6 +145,31 @@ interface WideEventClient {
          * All subsequent operations on this ID are silent no-ops with zero disk I/O.
          */
         const val SAMPLED_OUT_FLOW_ID = -1L
+    }
+}
+
+/**
+ * Identifies the wide event definition that a flow conforms to.
+ *
+ * @param version Version of the event definition. Bump it whenever the set of parameters the event sends changes.
+ * @param type Globally unique identifier of the event definition. Defaults to the flow name prefixed with
+ *   the platform, e.g. "android-subscription-purchase".
+ */
+data class WideEventDefinition(
+    val version: Version = Version.INITIAL,
+    val type: String? = null,
+) {
+    /**
+     * MINOR and PATCH components of the definition version, as declared in the definition itself.
+     * MAJOR is shared by all wide events and set automatically.
+     */
+    data class Version(
+        val minor: Int,
+        val patch: Int,
+    ) {
+        companion object {
+            val INITIAL = Version(minor = 0, patch = 0)
+        }
     }
 }
 

--- a/statistics/statistics-impl/schemas/com.duckduckgo.app.statistics.wideevents.db.WideEventDatabase/4.json
+++ b/statistics/statistics-impl/schemas/com.duckduckgo.app.statistics.wideevents.db.WideEventDatabase/4.json
@@ -1,0 +1,96 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "00c17c485dcd88950c2d3f421f2737ba",
+    "entities": [
+      {
+        "tableName": "wide_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `flow_entry_point` TEXT, `metadata` TEXT NOT NULL, `steps` TEXT NOT NULL, `status` TEXT, `cleanup_policy` TEXT NOT NULL, `active_intervals` TEXT NOT NULL, `sampling_probability` REAL NOT NULL DEFAULT 1.0, `meta_type` TEXT NOT NULL, `meta_version` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "flowEntryPoint",
+            "columnName": "flow_entry_point",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "steps",
+            "columnName": "steps",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cleanupPolicy",
+            "columnName": "cleanup_policy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeIntervals",
+            "columnName": "active_intervals",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "samplingProbability",
+            "columnName": "sampling_probability",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "1.0"
+          },
+          {
+            "fieldPath": "metaType",
+            "columnName": "meta_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metaVersion",
+            "columnName": "meta_version",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '00c17c485dcd88950c2d3f421f2737ba')"
+    ]
+  }
+}

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/ApiWideEventSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/ApiWideEventSender.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.statistics.wideevents.api.ContextSection
 import com.duckduckgo.app.statistics.wideevents.api.FeatureData
 import com.duckduckgo.app.statistics.wideevents.api.FeatureSection
 import com.duckduckgo.app.statistics.wideevents.api.GlobalSection
+import com.duckduckgo.app.statistics.wideevents.api.MetaSection
 import com.duckduckgo.app.statistics.wideevents.api.WideEventRequest
 import com.duckduckgo.app.statistics.wideevents.api.WideEventService
 import com.duckduckgo.app.statistics.wideevents.db.WideEventRepository
@@ -49,6 +50,10 @@ class ApiWideEventSender @Inject constructor(
         requireNotNull(event.status) { "Attempting to send wide event with null status" }
 
         val request = WideEventRequest(
+            meta = MetaSection(
+                type = event.metaType,
+                version = event.metaVersion,
+            ),
             global = GlobalSection(
                 platform = PLATFORM,
                 type = TYPE,

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSender.kt
@@ -48,6 +48,8 @@ class PixelWideEventSender @Inject constructor(
         val parameters =
             mutableMapOf<String, String>().apply {
                 putAll(getCommonPixelParameters())
+                put(PARAM_META_TYPE, event.metaType)
+                put(PARAM_META_VERSION, event.metaVersion)
                 put(PARAM_SAMPLE_RATE, event.samplingProbability.toString())
                 put(PARAM_STATUS, event.status.toParamValue())
 
@@ -119,6 +121,8 @@ class PixelWideEventSender @Inject constructor(
         const val COUNT_PIXEL_SUFFIX = "_c"
         const val DAILY_PIXEL_SUFFIX = "_d"
 
+        const val PARAM_META_TYPE = "meta.type"
+        const val PARAM_META_VERSION = "meta.version"
         const val PARAM_PLATFORM = "global.platform"
         const val PARAM_TYPE = "global.type"
         const val PARAM_SAMPLE_RATE = "global.sample_rate"

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/WideEventClientImpl.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/WideEventClientImpl.kt
@@ -58,6 +58,8 @@ class WideEventClientImpl @Inject constructor(
                 metadata = metadata,
                 cleanupPolicy = cleanupPolicy.mapToRepositoryCleanupPolicy(),
                 samplingProbability = samplingProbability,
+                metaType = WideEventMeta.typeFor(name),
+                metaVersion = WideEventMeta.DEFAULT_VERSION,
             )
         }
     }

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/WideEventClientImpl.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/WideEventClientImpl.kt
@@ -43,6 +43,7 @@ class WideEventClientImpl @Inject constructor(
         metadata: Map<String, String>,
         cleanupPolicy: CleanupPolicy,
         samplingProbability: Float,
+        definition: WideEventDefinition,
     ): Result<Long> {
         if (!isFeatureEnabled()) return Result.failure(Exception("Wide events feature disabled"))
         if (samplingProbability !in 0.0f..1.0f) {
@@ -58,8 +59,8 @@ class WideEventClientImpl @Inject constructor(
                 metadata = metadata,
                 cleanupPolicy = cleanupPolicy.mapToRepositoryCleanupPolicy(),
                 samplingProbability = samplingProbability,
-                metaType = WideEventMeta.typeFor(name),
-                metaVersion = WideEventMeta.DEFAULT_VERSION,
+                metaType = definition.type ?: WideEventMeta.typeFor(name),
+                metaVersion = WideEventMeta.versionFor(definition.version),
             )
         }
     }

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/WideEventMeta.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/WideEventMeta.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.statistics.wideevents
+
+object WideEventMeta {
+    const val DEFAULT_VERSION = "1.0.0"
+
+    /** `meta.type` is kebab-case across all platforms, hence the separator normalization. */
+    fun typeFor(eventName: String): String = TYPE_PREFIX + eventName.replace('_', '-')
+
+    private const val TYPE_PREFIX = "android-"
+}

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/api/WideEventRequest.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/api/WideEventRequest.kt
@@ -19,10 +19,16 @@ package com.duckduckgo.app.statistics.wideevents.api
 import com.squareup.moshi.Json
 
 data class WideEventRequest(
+    @field:Json(name = "meta") val meta: MetaSection,
     @field:Json(name = "global") val global: GlobalSection,
     @field:Json(name = "app") val app: AppSection,
     @field:Json(name = "feature") val feature: FeatureSection,
     @field:Json(name = "context") val context: ContextSection?,
+)
+
+data class MetaSection(
+    @field:Json(name = "type") val type: String,
+    @field:Json(name = "version") val version: String,
 )
 
 data class GlobalSection(

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/Mappers.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/Mappers.kt
@@ -28,6 +28,8 @@ fun WideEventEntity.mapToRepositoryWideEvent(): WideEventRepository.WideEvent =
         activeIntervals = activeIntervals.map { it.mapToRepositoryWideEventInterval() },
         createdAt = createdAt,
         samplingProbability = samplingProbability,
+        metaType = metaType,
+        metaVersion = metaVersion,
     )
 
 fun WideEventRepository.WideEventStatus.mapToDbWideEventStatus(): WideEventEntity.WideEventStatus =

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventDatabase.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventDatabase.kt
@@ -24,7 +24,7 @@ import java.time.Instant
 
 @Database(
     exportSchema = true,
-    version = 3,
+    version = 4,
     entities = [
         WideEventEntity::class,
     ],

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventDatabaseModule.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventDatabaseModule.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.room.Room
 import com.duckduckgo.app.statistics.wideevents.db.migration.WideEventsMigration1To2
 import com.duckduckgo.app.statistics.wideevents.db.migration.WideEventsMigration2To3
+import com.duckduckgo.app.statistics.wideevents.db.migration.WideEventsMigration3To4
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
@@ -41,7 +42,7 @@ class WideEventDatabaseModule {
                 klass = WideEventDatabase::class.java,
                 name = "wide_events.db",
             )
-            .addMigrations(WideEventsMigration1To2, WideEventsMigration2To3)
+            .addMigrations(WideEventsMigration1To2, WideEventsMigration2To3, WideEventsMigration3To4)
             .fallbackToDestructiveMigration()
             .enableMultiInstanceInvalidation()
             .addTypeConverter(wideEventEntityTypeConverters)

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventEntity.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventEntity.kt
@@ -54,6 +54,10 @@ data class WideEventEntity(
     val activeIntervals: List<WideEventInterval>,
     @ColumnInfo(name = "sampling_probability", defaultValue = "1.0")
     val samplingProbability: Float = 1.0f,
+    @ColumnInfo(name = "meta_type")
+    val metaType: String,
+    @ColumnInfo(name = "meta_version")
+    val metaVersion: String,
 ) {
     data class MetadataEntry(
         @Json(name = "key")

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventRepository.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventRepository.kt
@@ -27,6 +27,8 @@ interface WideEventRepository {
         metadata: Map<String, String?>,
         cleanupPolicy: CleanupPolicy,
         samplingProbability: Float = 1.0f,
+        metaType: String,
+        metaVersion: String,
     ): Long
 
     suspend fun addWideEventStep(
@@ -76,6 +78,8 @@ interface WideEventRepository {
         val activeIntervals: List<WideEventInterval>,
         val createdAt: Instant,
         val samplingProbability: Float = 1.0f,
+        val metaType: String,
+        val metaVersion: String,
     )
 
     data class WideEventStep(

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventRepositoryImpl.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventRepositoryImpl.kt
@@ -38,6 +38,8 @@ class WideEventRepositoryImpl @Inject constructor(
         metadata: Map<String, String?>,
         cleanupPolicy: CleanupPolicy,
         samplingProbability: Float,
+        metaType: String,
+        metaVersion: String,
     ): Long {
         val entity =
             WideEventEntity(
@@ -50,6 +52,8 @@ class WideEventRepositoryImpl @Inject constructor(
                 cleanupPolicy = cleanupPolicy.mapToDbCleanupPolicy(),
                 activeIntervals = emptyList(),
                 samplingProbability = samplingProbability,
+                metaType = metaType,
+                metaVersion = metaVersion,
             )
 
         return wideEventDao.insertWideEvent(entity)

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/migration/WideEventsMigration3To4.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/migration/WideEventsMigration3To4.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.statistics.wideevents.db.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * v4 adds the non-null `meta_type` and `meta_version` columns. The old table is renamed aside and a
+ * new one created from the current schema, because SQLite can only add a non-null column with a
+ * default, and these columns have none.
+ *
+ * Values for rows that predate the columns are backfilled here, and stay frozen at what the naming
+ * convention and the initial schema version were at the time of this migration.
+ */
+internal val WideEventsMigration3To4 = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE wide_events RENAME TO wide_events_old")
+
+        db.execSQL(
+            """
+            CREATE TABLE wide_events (
+                `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                `name` TEXT NOT NULL,
+                `created_at` INTEGER NOT NULL,
+                `flow_entry_point` TEXT,
+                `metadata` TEXT NOT NULL,
+                `steps` TEXT NOT NULL,
+                `status` TEXT,
+                `cleanup_policy` TEXT NOT NULL,
+                `active_intervals` TEXT NOT NULL,
+                `sampling_probability` REAL NOT NULL DEFAULT 1.0,
+                `meta_type` TEXT NOT NULL,
+                `meta_version` TEXT NOT NULL
+            )
+            """.trimIndent(),
+        )
+
+        db.execSQL(
+            """
+            INSERT INTO wide_events (
+                id, name, created_at, flow_entry_point, metadata, steps, status, cleanup_policy,
+                active_intervals, sampling_probability, meta_type, meta_version
+            )
+            SELECT
+                id, name, created_at, flow_entry_point, metadata, steps, status, cleanup_policy,
+                active_intervals, sampling_probability,
+                'android-' || replace(name, '_', '-'), '1.0.0'
+            FROM wide_events_old
+            """.trimIndent(),
+        )
+
+        db.execSQL("DROP TABLE wide_events_old")
+    }
+}

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/ApiWideEventSenderTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/ApiWideEventSenderTest.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.statistics.wideevents.api.ContextSection
 import com.duckduckgo.app.statistics.wideevents.api.FeatureData
 import com.duckduckgo.app.statistics.wideevents.api.FeatureSection
 import com.duckduckgo.app.statistics.wideevents.api.GlobalSection
+import com.duckduckgo.app.statistics.wideevents.api.MetaSection
 import com.duckduckgo.app.statistics.wideevents.api.WideEventRequest
 import com.duckduckgo.app.statistics.wideevents.api.WideEventService
 import com.duckduckgo.app.statistics.wideevents.db.WideEventRepository
@@ -85,6 +86,10 @@ class ApiWideEventSenderTest {
         apiWideEventSender.sendWideEvent(event)
 
         val expectedRequest = WideEventRequest(
+            meta = MetaSection(
+                type = "android-subscription-purchase",
+                version = "1.0.0",
+            ),
             global = GlobalSection(
                 platform = "Android",
                 type = "app",
@@ -125,6 +130,10 @@ class ApiWideEventSenderTest {
         apiWideEventSender.sendWideEvent(event)
 
         val expectedRequest = WideEventRequest(
+            meta = MetaSection(
+                type = "android-feature-event",
+                version = "1.0.0",
+            ),
             global = GlobalSection(
                 platform = "Android",
                 type = "app",
@@ -160,6 +169,10 @@ class ApiWideEventSenderTest {
         apiWideEventSender.sendWideEvent(event)
 
         val expectedRequest = WideEventRequest(
+            meta = MetaSection(
+                type = "android-simple-event",
+                version = "1.0.0",
+            ),
             global = GlobalSection(
                 platform = "Android",
                 type = "app",
@@ -195,6 +208,10 @@ class ApiWideEventSenderTest {
         apiWideEventSender.sendWideEvent(event)
 
         val expectedRequest = WideEventRequest(
+            meta = MetaSection(
+                type = "android-debug-event",
+                version = "1.0.0",
+            ),
             global = GlobalSection(
                 platform = "Android",
                 type = "app",
@@ -230,6 +247,10 @@ class ApiWideEventSenderTest {
         apiWideEventSender.sendWideEvent(event)
 
         val expectedRequest = WideEventRequest(
+            meta = MetaSection(
+                type = "android-tablet-event",
+                version = "1.0.0",
+            ),
             global = GlobalSection(
                 platform = "Android",
                 type = "app",
@@ -263,6 +284,10 @@ class ApiWideEventSenderTest {
         apiWideEventSender.sendWideEvent(event)
 
         val expectedRequest = WideEventRequest(
+            meta = MetaSection(
+                type = "android-unknown-event",
+                version = "1.0.0",
+            ),
             global = GlobalSection(
                 platform = "Android",
                 type = "app",
@@ -301,6 +326,10 @@ class ApiWideEventSenderTest {
         apiWideEventSender.sendWideEvent(event)
 
         val expectedRequest = WideEventRequest(
+            meta = MetaSection(
+                type = "android-filtered-event",
+                version = "1.0.0",
+            ),
             global = GlobalSection(
                 platform = "Android",
                 type = "app",
@@ -368,6 +397,10 @@ class ApiWideEventSenderTest {
         apiWideEventSender.sendWideEvent(event)
 
         val expectedRequest = WideEventRequest(
+            meta = MetaSection(
+                type = "android-sampled-event",
+                version = "1.0.0",
+            ),
             global = GlobalSection(
                 platform = "Android",
                 type = "app",
@@ -381,6 +414,45 @@ class ApiWideEventSenderTest {
             ),
             feature = FeatureSection(
                 name = "sampled-event",
+                status = "SUCCESS",
+                data = null,
+            ),
+            context = null,
+        )
+
+        verify(wideEventService).sendWideEvent(eq(expectedRequest))
+    }
+
+    @Test
+    fun `when event has stored meta type and version then stored values are sent`() = runTest {
+        val event = createWideEvent(
+            id = 700L,
+            name = "some-event",
+            status = WideEventRepository.WideEventStatus.SUCCESS,
+            metaType = "android-some-other-event",
+            metaVersion = "2.1.3",
+        )
+
+        apiWideEventSender.sendWideEvent(event)
+
+        val expectedRequest = WideEventRequest(
+            meta = MetaSection(
+                type = "android-some-other-event",
+                version = "2.1.3",
+            ),
+            global = GlobalSection(
+                platform = "Android",
+                type = "app",
+                sampleRate = 1.0f,
+            ),
+            app = AppSection(
+                name = "DuckDuckGo Android",
+                version = "5.123.0",
+                formFactor = "phone",
+                devMode = false,
+            ),
+            feature = FeatureSection(
+                name = "some-event",
                 status = "SUCCESS",
                 data = null,
             ),
@@ -414,6 +486,8 @@ class ApiWideEventSenderTest {
         metadata: Map<String, String?> = emptyMap(),
         flowEntryPoint: String? = null,
         samplingProbability: Float = 1.0f,
+        metaType: String = "android-$name",
+        metaVersion: String = "1.0.0",
     ) = WideEventRepository.WideEvent(
         id = id,
         name = name,
@@ -429,5 +503,7 @@ class ApiWideEventSenderTest {
         ),
         createdAt = Instant.parse("2025-12-03T10:15:30.00Z"),
         samplingProbability = samplingProbability,
+        metaType = metaType,
+        metaVersion = metaVersion,
     )
 }

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/CompletedWideEventsProcessorTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/CompletedWideEventsProcessorTest.kt
@@ -205,5 +205,7 @@ class CompletedWideEventsProcessorTest {
             ),
             activeIntervals = emptyList(),
             createdAt = Instant.parse("2025-12-03T10:15:30.00Z"),
+            metaType = "android-test-event",
+            metaVersion = "1.0.0",
         )
 }

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSenderTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSenderTest.kt
@@ -32,6 +32,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -90,6 +91,8 @@ class PixelWideEventSenderTest {
 
             val expectedParameters =
                 mapOf(
+                    "meta.type" to "android-subscription-purchase",
+                    "meta.version" to "1.0.0",
                     "global.platform" to "Android",
                     "global.type" to "app",
                     "global.sample_rate" to "1.0",
@@ -119,6 +122,30 @@ class PixelWideEventSenderTest {
             )
         }
 
+    @Test
+    fun `when event has stored meta type and version then stored values are sent`() =
+        runTest {
+            val event =
+                createWideEvent(
+                    id = 789L,
+                    name = "some-event",
+                    status = WideEventRepository.WideEventStatus.SUCCESS,
+                    metaType = "android-some-other-event",
+                    metaVersion = "2.1.3",
+                )
+
+            pixelWideEventSender.sendWideEvent(event)
+
+            verify(pixel).enqueueFire(
+                pixelName = eq("wide_some-event_c"),
+                parameters = argThat {
+                    get("meta.type") == "android-some-other-event" && get("meta.version") == "2.1.3"
+                },
+                encodedParameters = any(),
+                type = any(),
+            )
+        }
+
     private fun createWideEvent(
         id: Long,
         name: String,
@@ -127,6 +154,8 @@ class PixelWideEventSenderTest {
         metadata: Map<String, String?> = emptyMap(),
         flowEntryPoint: String? = null,
         samplingProbability: Float = 1.0f,
+        metaType: String = "android-$name",
+        metaVersion: String = "1.0.0",
     ) = WideEventRepository.WideEvent(
         id = id,
         name = name,
@@ -143,5 +172,7 @@ class PixelWideEventSenderTest {
         ),
         createdAt = Instant.parse("2025-12-03T10:15:30.00Z"),
         samplingProbability = samplingProbability,
+        metaType = metaType,
+        metaVersion = metaVersion,
     )
 }

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/WideEventCleanerTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/WideEventCleanerTest.kt
@@ -89,6 +89,8 @@ class WideEventCleanerTest {
                     ),
                     activeIntervals = emptyList(),
                     createdAt = timeProvider.currentTime,
+                    metaType = "android-test",
+                    metaVersion = "1.0.0",
                 )
             whenever(wideEventRepository.getActiveWideEventIds()).thenReturn(listOf(1L))
             whenever(wideEventRepository.getWideEvents(setOf(1L))).thenReturn(listOf(event))
@@ -131,6 +133,8 @@ class WideEventCleanerTest {
                         ),
                     ),
                     createdAt = start,
+                    metaType = "android-test",
+                    metaVersion = "1.0.0",
                 )
             whenever(wideEventRepository.getActiveWideEventIds()).thenReturn(listOf(6L))
             whenever(wideEventRepository.getWideEvents(setOf(6L))).thenReturn(listOf(event))
@@ -170,6 +174,8 @@ class WideEventCleanerTest {
                         ),
                     ),
                     createdAt = start,
+                    metaType = "android-test",
+                    metaVersion = "1.0.0",
                 )
             whenever(wideEventRepository.getActiveWideEventIds()).thenReturn(listOf(7L))
             whenever(wideEventRepository.getWideEvents(setOf(7L))).thenReturn(listOf(event))
@@ -206,6 +212,8 @@ class WideEventCleanerTest {
                     ),
                     activeIntervals = emptyList(),
                     createdAt = createdAt,
+                    metaType = "android-test",
+                    metaVersion = "1.0.0",
                 )
             whenever(wideEventRepository.getActiveWideEventIds()).thenReturn(listOf(3L))
             whenever(wideEventRepository.getWideEvents(setOf(3L))).thenReturn(listOf(event))
@@ -248,6 +256,8 @@ class WideEventCleanerTest {
                         ),
                     ),
                     createdAt = start,
+                    metaType = "android-test",
+                    metaVersion = "1.0.0",
                 )
             whenever(wideEventRepository.getActiveWideEventIds()).thenReturn(listOf(4L))
             whenever(wideEventRepository.getWideEvents(setOf(4L))).thenReturn(listOf(event))
@@ -281,6 +291,8 @@ class WideEventCleanerTest {
                     ),
                     activeIntervals = emptyList(),
                     createdAt = timeProvider.currentTime,
+                    metaType = "android-test",
+                    metaVersion = "1.0.0",
                 )
             whenever(wideEventRepository.getActiveWideEventIds()).thenReturn(listOf(5L))
             whenever(wideEventRepository.getWideEvents(setOf(5L))).thenReturn(listOf(event))

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/WideEventClientTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/WideEventClientTest.kt
@@ -73,7 +73,7 @@ class WideEventClientTest {
             val metadata = mapOf("free_trial_eligible" to "true", "user_type" to "premium")
             val cleanupPolicy = CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = true)
 
-            whenever(wideEventRepository.insertWideEvent(any(), any(), any(), anyOrNull(), any()))
+            whenever(wideEventRepository.insertWideEvent(any(), any(), any(), anyOrNull(), any(), anyOrNull(), any()))
                 .thenReturn(expectedEventId)
 
             val result = wideEventClient.flowStart(name, flowEntryPoint, metadata, cleanupPolicy)
@@ -91,6 +91,8 @@ class WideEventClientTest {
                     metadata = emptyMap(),
                 ),
                 samplingProbability = 1.0f,
+                metaType = "android-subscription-purchase",
+                metaVersion = "1.0.0",
             )
         }
 
@@ -100,7 +102,7 @@ class WideEventClientTest {
             val expectedEventId = 456L
             val name = "login_flow"
 
-            whenever(wideEventRepository.insertWideEvent(any(), anyOrNull(), any(), anyOrNull(), any()))
+            whenever(wideEventRepository.insertWideEvent(any(), anyOrNull(), any(), anyOrNull(), any(), anyOrNull(), any()))
                 .thenReturn(expectedEventId)
 
             val result = wideEventClient.flowStart(name)
@@ -118,6 +120,8 @@ class WideEventClientTest {
                     metadata = emptyMap(),
                 ),
                 samplingProbability = 1.0f,
+                metaType = "android-login-flow",
+                metaVersion = "1.0.0",
             )
         }
 
@@ -125,7 +129,7 @@ class WideEventClientTest {
     fun `when flowStart encounters repository exception then returns failure`() =
         runTest {
             val exception = RuntimeException("Database error")
-            whenever(wideEventRepository.insertWideEvent(any(), anyOrNull(), any(), anyOrNull(), any()))
+            whenever(wideEventRepository.insertWideEvent(any(), anyOrNull(), any(), anyOrNull(), any(), anyOrNull(), any()))
                 .thenThrow(exception)
 
             val result = wideEventClient.flowStart("test_flow")
@@ -440,7 +444,7 @@ class WideEventClientTest {
                     flowStatus = FlowStatus.Failure("timeout"),
                 )
 
-            whenever(wideEventRepository.insertWideEvent(any(), anyOrNull(), any(), anyOrNull(), any()))
+            whenever(wideEventRepository.insertWideEvent(any(), anyOrNull(), any(), anyOrNull(), any(), anyOrNull(), any()))
                 .thenReturn(wideEventId)
 
             val result =
@@ -462,6 +466,8 @@ class WideEventClientTest {
                     metadata = mapOf("failure_reason" to "timeout"),
                 ),
                 samplingProbability = 1.0f,
+                metaType = "android-timeout-flow",
+                metaVersion = "1.0.0",
             )
         }
 
@@ -478,21 +484,21 @@ class WideEventClientTest {
     @Test
     fun `when flowStart called with samplingProbability 1 then always creates event`() =
         runTest {
-            whenever(wideEventRepository.insertWideEvent(any(), anyOrNull(), any(), anyOrNull(), any()))
+            whenever(wideEventRepository.insertWideEvent(any(), anyOrNull(), any(), anyOrNull(), any(), anyOrNull(), any()))
                 .thenReturn(42L)
 
             val result = wideEventClient.flowStart("sampled_flow", samplingProbability = 1.0f)
 
             assertTrue(result.isSuccess)
             assertEquals(42L, result.getOrNull())
-            verify(wideEventRepository).insertWideEvent(any(), anyOrNull(), any(), anyOrNull(), any())
+            verify(wideEventRepository).insertWideEvent(any(), anyOrNull(), any(), anyOrNull(), any(), anyOrNull(), any())
         }
 
     @Test
     fun `when flowStart called with custom samplingProbability then passes it to repository`() =
         runTest {
             fakeRandom.nextFloatValue = 0.1f // below 0.5 threshold, so sampled in
-            whenever(wideEventRepository.insertWideEvent(any(), anyOrNull(), any(), anyOrNull(), any()))
+            whenever(wideEventRepository.insertWideEvent(any(), anyOrNull(), any(), anyOrNull(), any(), anyOrNull(), any()))
                 .thenReturn(99L)
 
             val result = wideEventClient.flowStart("sampled_flow", samplingProbability = 0.5f)
@@ -509,6 +515,8 @@ class WideEventClientTest {
                     metadata = emptyMap(),
                 ),
                 samplingProbability = 0.5f,
+                metaType = "android-sampled-flow",
+                metaVersion = "1.0.0",
             )
         }
 

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/WideEventClientTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/WideEventClientTest.kt
@@ -126,6 +126,37 @@ class WideEventClientTest {
         }
 
     @Test
+    fun `when flowStart called with definition then meta parameters are stored`() =
+        runTest {
+            whenever(wideEventRepository.insertWideEvent(any(), anyOrNull(), any(), anyOrNull(), any(), anyOrNull(), any()))
+                .thenReturn(789L)
+
+            val result = wideEventClient.flowStart(
+                name = "test_flow",
+                definition = WideEventDefinition(
+                    version = WideEventDefinition.Version(minor = 2, patch = 3),
+                    type = "android-custom-definition",
+                ),
+            )
+
+            assertTrue(result.isSuccess)
+
+            verify(wideEventRepository).insertWideEvent(
+                name = "test_flow",
+                flowEntryPoint = null,
+                metadata = emptyMap(),
+                cleanupPolicy = WideEventRepository.CleanupPolicy.OnTimeout(
+                    duration = Duration.ofDays(7),
+                    status = WideEventRepository.WideEventStatus.UNKNOWN,
+                    metadata = emptyMap(),
+                ),
+                samplingProbability = 1.0f,
+                metaType = "android-custom-definition",
+                metaVersion = "1.2.3",
+            )
+        }
+
+    @Test
     fun `when flowStart encounters repository exception then returns failure`() =
         runTest {
             val exception = RuntimeException("Database error")

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/WideEventMetaTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/WideEventMetaTest.kt
@@ -16,13 +16,18 @@
 
 package com.duckduckgo.app.statistics.wideevents
 
-object WideEventMeta {
-    /** `meta.type` is kebab-case across all platforms, hence the separator normalization. */
-    fun typeFor(eventName: String): String = TYPE_PREFIX + eventName.replace('_', '-')
+import org.junit.Assert.assertEquals
+import org.junit.Test
 
-    /** MAJOR tracks the base template shared by every wide event, so callers only declare MINOR and PATCH. */
-    fun versionFor(version: WideEventDefinition.Version): String = "$BASE_TEMPLATE_MAJOR.${version.minor}.${version.patch}"
+class WideEventMetaTest {
+    @Test
+    fun `version is composed of the base template major and the definition version`() {
+        assertEquals("1.2.3", WideEventMeta.versionFor(WideEventDefinition.Version(minor = 2, patch = 3)))
+    }
 
-    private const val TYPE_PREFIX = "android-"
-    private const val BASE_TEMPLATE_MAJOR = 1
+    @Test
+    fun `type is derived from the event name and normalized to kebab case`() {
+        assertEquals("android-page-load", WideEventMeta.typeFor("page-load"))
+        assertEquals("android-some-event-name", WideEventMeta.typeFor("some_event_name"))
+    }
 }

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/db/WideEventRepositoryTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/db/WideEventRepositoryTest.kt
@@ -87,6 +87,8 @@ class WideEventRepositoryTest {
                     flowEntryPoint = null,
                     metadata = emptyMap(),
                     cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+                    metaType = "android-test-event",
+                    metaVersion = "1.0.0",
                 )
 
             assertTrue(eventId > 0)
@@ -105,6 +107,8 @@ class WideEventRepositoryTest {
                         "key2" to null,
                     ),
                     cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+                    metaType = "android-test-event",
+                    metaVersion = "1.0.0",
                 )
 
             assertTrue(eventId > 0)
@@ -124,6 +128,8 @@ class WideEventRepositoryTest {
                     flowEntryPoint = null,
                     metadata = emptyMap(),
                     cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+                    metaType = "android-test-event",
+                    metaVersion = "1.0.0",
                 )
 
             val activeEventId =
@@ -132,6 +138,8 @@ class WideEventRepositoryTest {
                     flowEntryPoint = null,
                     metadata = emptyMap(),
                     cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+                    metaType = "android-test-event",
+                    metaVersion = "1.0.0",
                 )
 
             // complete wide event
@@ -156,6 +164,8 @@ class WideEventRepositoryTest {
                     flowEntryPoint = null,
                     metadata = emptyMap(),
                     cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+                    metaType = "android-test-event",
+                    metaVersion = "1.0.0",
                 )
 
             val eventId2 =
@@ -164,6 +174,8 @@ class WideEventRepositoryTest {
                     flowEntryPoint = null,
                     metadata = emptyMap(),
                     cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+                    metaType = "android-test-event",
+                    metaVersion = "1.0.0",
                 )
 
             val eventId3 =
@@ -172,6 +184,8 @@ class WideEventRepositoryTest {
                     flowEntryPoint = null,
                     metadata = emptyMap(),
                     cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+                    metaType = "android-test-event",
+                    metaVersion = "1.0.0",
                 )
 
             val eventId4 =
@@ -180,6 +194,8 @@ class WideEventRepositoryTest {
                     flowEntryPoint = null,
                     metadata = emptyMap(),
                     cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+                    metaType = "android-test-event",
+                    metaVersion = "1.0.0",
                 )
 
             wideEventRepository.setWideEventStatus(
@@ -211,6 +227,8 @@ class WideEventRepositoryTest {
                         "key2" to null,
                     ),
                     cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+                    metaType = "android-test-event",
+                    metaVersion = "1.0.0",
                 )
 
             wideEventRepository.addWideEventStep(
@@ -259,6 +277,25 @@ class WideEventRepositoryTest {
         }
 
     @Test
+    fun `when meta parameters are stored, then they are returned with the event`() =
+        runTest {
+            val eventId =
+                wideEventRepository.insertWideEvent(
+                    name = "test_event",
+                    flowEntryPoint = null,
+                    metadata = emptyMap(),
+                    cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+                    metaType = "android-test-event",
+                    metaVersion = "2.1.3",
+                )
+
+            with(wideEventRepository.getWideEvents(setOf(eventId)).single()) {
+                assertTrue(metaType == "android-test-event")
+                assertTrue(metaVersion == "2.1.3")
+            }
+        }
+
+    @Test
     fun `when delete event then it is no longer accessible`() =
         runTest {
             val completedEventId =
@@ -267,6 +304,8 @@ class WideEventRepositoryTest {
                     flowEntryPoint = null,
                     metadata = emptyMap(),
                     cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+                    metaType = "android-test-event",
+                    metaVersion = "1.0.0",
                 )
 
             val activeEventId =
@@ -275,6 +314,8 @@ class WideEventRepositoryTest {
                     flowEntryPoint = null,
                     metadata = emptyMap(),
                     cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+                    metaType = "android-test-event",
+                    metaVersion = "1.0.0",
                 )
 
             // complete wide event
@@ -306,6 +347,8 @@ class WideEventRepositoryTest {
                         "key2" to null,
                     ),
                     cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+                    metaType = "android-test-event",
+                    metaVersion = "1.0.0",
                 )
 
             assertTrue(eventId > 0)
@@ -331,6 +374,8 @@ class WideEventRepositoryTest {
                     flowEntryPoint = null,
                     metadata = emptyMap(),
                     cleanupPolicy = policy,
+                    metaType = "android-test-event",
+                    metaVersion = "1.0.0",
                 )
 
             val event = wideEventRepository.getWideEvents(setOf(eventId)).single()
@@ -346,6 +391,8 @@ class WideEventRepositoryTest {
                     flowEntryPoint = null,
                     metadata = emptyMap(),
                     cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+                    metaType = "android-test-event",
+                    metaVersion = "1.0.0",
                 )
 
             wideEventRepository.startInterval(
@@ -368,6 +415,8 @@ class WideEventRepositoryTest {
                     flowEntryPoint = null,
                     metadata = emptyMap(),
                     cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+                    metaType = "android-test-event",
+                    metaVersion = "1.0.0",
                 )
 
             wideEventRepository.startInterval(
@@ -394,6 +443,8 @@ class WideEventRepositoryTest {
             flowEntryPoint = null,
             metadata = emptyMap(),
             cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+            metaType = "android-test-event",
+            metaVersion = "1.0.0",
         )
 
         wideEventRepository.startInterval(
@@ -417,6 +468,8 @@ class WideEventRepositoryTest {
             flowEntryPoint = null,
             metadata = emptyMap(),
             cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+            metaType = "android-test-event",
+            metaVersion = "1.0.0",
         )
 
         wideEventRepository.startInterval(
@@ -440,6 +493,8 @@ class WideEventRepositoryTest {
             flowEntryPoint = null,
             metadata = emptyMap(),
             cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+            metaType = "android-test-event",
+            metaVersion = "1.0.0",
         )
 
         wideEventRepository.startInterval(
@@ -464,6 +519,8 @@ class WideEventRepositoryTest {
             flowEntryPoint = null,
             metadata = emptyMap(),
             cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+            metaType = "android-test-event",
+            metaVersion = "1.0.0",
         )
 
         wideEventRepository.startInterval(
@@ -488,6 +545,8 @@ class WideEventRepositoryTest {
             flowEntryPoint = null,
             metadata = emptyMap(),
             cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+            metaType = "android-test-event",
+            metaVersion = "1.0.0",
         )
 
         wideEventRepository.startInterval(
@@ -511,6 +570,8 @@ class WideEventRepositoryTest {
             flowEntryPoint = null,
             metadata = emptyMap(),
             cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+            metaType = "android-test-event",
+            metaVersion = "1.0.0",
         )
 
         wideEventRepository.startInterval(
@@ -534,6 +595,8 @@ class WideEventRepositoryTest {
             flowEntryPoint = null,
             metadata = emptyMap(),
             cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+            metaType = "android-test-event",
+            metaVersion = "1.0.0",
         )
 
         wideEventRepository.startInterval(
@@ -557,6 +620,8 @@ class WideEventRepositoryTest {
             flowEntryPoint = null,
             metadata = emptyMap(),
             cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+            metaType = "android-test-event",
+            metaVersion = "1.0.0",
         )
 
         wideEventRepository.startInterval(
@@ -580,6 +645,8 @@ class WideEventRepositoryTest {
             flowEntryPoint = null,
             metadata = emptyMap(),
             cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+            metaType = "android-test-event",
+            metaVersion = "1.0.0",
         )
         val customBuckets = listOf(Duration.ofMillis(100), Duration.ofMillis(500), Duration.ofSeconds(2))
 
@@ -602,6 +669,8 @@ class WideEventRepositoryTest {
             flowEntryPoint = null,
             metadata = emptyMap(),
             cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+            metaType = "android-test-event",
+            metaVersion = "1.0.0",
         )
         val unorderedBuckets = listOf(Duration.ofSeconds(2), Duration.ofMillis(100), Duration.ofMillis(500))
 
@@ -627,6 +696,8 @@ class WideEventRepositoryTest {
             flowEntryPoint = null,
             metadata = emptyMap(),
             cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+            metaType = "android-test-event",
+            metaVersion = "1.0.0",
         )
 
         assertThrows(IllegalArgumentException::class.java) {
@@ -648,6 +719,8 @@ class WideEventRepositoryTest {
             flowEntryPoint = null,
             metadata = emptyMap(),
             cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+            metaType = "android-test-event",
+            metaVersion = "1.0.0",
         )
 
         wideEventRepository.startInterval(

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/db/migration/WideEventsMigration3To4Test.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/db/migration/WideEventsMigration3To4Test.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.statistics.wideevents.db.migration
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.statistics.wideevents.db.WideEventDatabase
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WideEventsMigration3To4Test {
+    @get:Rule
+    val testHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        WideEventDatabase::class.java,
+        emptyList(),
+    )
+
+    @Test
+    fun `migration backfills existing events with a derived meta type and the initial meta version`() {
+        testHelper.createDatabase(TEST_DB_NAME, 3).use { db ->
+            db.insertWideEvent(id = 1, name = "some_event_name")
+        }
+
+        testHelper.runMigrationsAndValidate(TEST_DB_NAME, 4, true, WideEventsMigration3To4).use { db ->
+            assertEquals("android-some-event-name", db.readString(id = 1, column = "meta_type"))
+            assertEquals("1.0.0", db.readString(id = 1, column = "meta_version"))
+        }
+    }
+
+    @Test
+    fun `migration preserves existing event data`() {
+        testHelper.createDatabase(TEST_DB_NAME, 3).use { db ->
+            db.insertWideEvent(id = 1, name = "event-1", flowEntryPoint = "settings", samplingProbability = 0.5f)
+        }
+
+        testHelper.runMigrationsAndValidate(TEST_DB_NAME, 4, true, WideEventsMigration3To4).use { db ->
+            assertEquals("event-1", db.readString(id = 1, column = "name"))
+            assertEquals("settings", db.readString(id = 1, column = "flow_entry_point"))
+            assertEquals(0.5f, db.readSamplingProbability(id = 1), DELTA)
+        }
+    }
+
+    private companion object {
+        const val TEST_DB_NAME = "wide_events_migration_test"
+        const val DELTA = 0.0001f
+    }
+}
+
+private fun SupportSQLiteDatabase.insertWideEvent(
+    id: Long,
+    name: String = "flow",
+    flowEntryPoint: String? = null,
+    samplingProbability: Float = 1.0f,
+) {
+    execSQL(
+        """
+        INSERT INTO wide_events (
+            id, name, created_at, flow_entry_point, metadata, steps, status, cleanup_policy, active_intervals,
+            sampling_probability
+        ) VALUES (
+            ?, ?, 0, ?, '[]', '[]', NULL,
+            '{"type":"OnTimeout","duration":600000,"status":"unknown","metadata":{}}',
+            '[]', ?
+        )
+        """.trimIndent(),
+        arrayOf<Any?>(id, name, flowEntryPoint, samplingProbability),
+    )
+}
+
+private fun SupportSQLiteDatabase.readSamplingProbability(id: Long): Float =
+    query("SELECT sampling_probability FROM wide_events WHERE id = ?", arrayOf(id)).use { cursor ->
+        cursor.moveToFirst()
+        cursor.getFloat(0)
+    }
+
+private fun SupportSQLiteDatabase.readString(
+    id: Long,
+    column: String,
+): String? =
+    query("SELECT $column FROM wide_events WHERE id = ?", arrayOf(id)).use { cursor ->
+        if (cursor.moveToFirst() && !cursor.isNull(0)) cursor.getString(0) else null
+    }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEventTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEventTest.kt
@@ -64,7 +64,7 @@ class AuthTokenRefreshWideEventTest {
 
     @Test
     fun `onStart starts a new flow and total interval`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(123L))
 
         authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
@@ -86,12 +86,12 @@ class AuthTokenRefreshWideEventTest {
 
     @Test
     fun `onStart ends previous flow if one is active`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(1L))
 
         authWideEvent.onStart(SubscriptionStatus.WAITING)
 
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(2L))
 
         authWideEvent.onStart(SubscriptionStatus.AUTO_RENEWABLE)
@@ -102,7 +102,7 @@ class AuthTokenRefreshWideEventTest {
 
     @Test
     fun `onTokenRead sends step and starts jwks interval`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(10L))
         authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
 
@@ -114,7 +114,7 @@ class AuthTokenRefreshWideEventTest {
 
     @Test
     fun `onJwksFetched ends jwks interval and starts tokens interval`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(11L))
         authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
 
@@ -127,7 +127,7 @@ class AuthTokenRefreshWideEventTest {
 
     @Test
     fun `onTokensFetched ends tokens interval and sends step`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(12L))
         authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
 
@@ -139,7 +139,7 @@ class AuthTokenRefreshWideEventTest {
 
     @Test
     fun `onTokensValidated sends validation step`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(13L))
         authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
 
@@ -150,7 +150,7 @@ class AuthTokenRefreshWideEventTest {
 
     @Test
     fun `onBackendErrorResponse sends token_request failure with metadata`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(14L))
         authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
 
@@ -166,7 +166,7 @@ class AuthTokenRefreshWideEventTest {
 
     @Test
     fun `onPlayLoginSuccess sends step`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(15L))
         authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
 
@@ -177,7 +177,7 @@ class AuthTokenRefreshWideEventTest {
 
     @Test
     fun `onPlayLoginFailure sends failure step, finishes flow and clears id`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(16L))
         authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
 
@@ -202,7 +202,7 @@ class AuthTokenRefreshWideEventTest {
 
     @Test
     fun `onUnknownAccountError cancels flow and clears id`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(17L))
         authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
 
@@ -218,7 +218,7 @@ class AuthTokenRefreshWideEventTest {
 
     @Test
     fun `onSuccess finishes with Success and clears id`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(18L))
         authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
 
@@ -234,7 +234,7 @@ class AuthTokenRefreshWideEventTest {
 
     @Test
     fun `onFailure finishes with Failure and clears id`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(19L))
         authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/FreeTrialConversionWideEventTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/FreeTrialConversionWideEventTest.kt
@@ -78,7 +78,7 @@ class FreeTrialConversionWideEventTest {
 
     @Test
     fun `onFreeTrialStarted starts flow with correct metadata and fires pixel`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any())).thenReturn(Result.success(123L))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any())).thenReturn(Result.success(123L))
         whenever(wideEventClient.getFlowIds(any())).thenReturn(Result.success(emptyList()))
 
         freeTrialConversionWideEvent.onFreeTrialStarted("ddg.privacy.pro.yearly.renews.us")
@@ -102,7 +102,7 @@ class FreeTrialConversionWideEventTest {
         freeTrialConversionWideEvent.onFreeTrialStarted("ddg.privacy.pro.yearly.renews.us")
 
         verify(pixelSender).reportFreeTrialStart()
-        verify(wideEventClient, never()).flowStart(any(), any(), any(), any(), any())
+        verify(wideEventClient, never()).flowStart(any(), any(), any(), any(), any(), any())
     }
 
     @Test
@@ -367,14 +367,14 @@ class FreeTrialConversionWideEventTest {
         verify(pixelSender).reportFreeTrialVpnActivation("vpn_activated_d1", "google")
 
         // Wide events do not fire when feature is disabled
-        verify(wideEventClient, never()).flowStart(any(), any(), any(), any(), any())
+        verify(wideEventClient, never()).flowStart(any(), any(), any(), any(), any(), any())
         verify(wideEventClient, never()).flowStep(any(), any(), any(), any())
         verify(wideEventClient, never()).flowFinish(any(), any(), any())
     }
 
     @Test
     fun `flow resets after conversion and pixel fires for new trial`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any())).thenReturn(Result.success(456L))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any())).thenReturn(Result.success(456L))
         whenever(wideEventClient.getFlowIds(any()))
             .thenReturn(Result.success(listOf(123L)))
             .thenReturn(Result.success(emptyList()))
@@ -402,6 +402,7 @@ class FreeTrialConversionWideEventTest {
             metadata = eq(mapOf("free_trial_plan" to "ddg.privacy.pro.monthly.renews.us")),
             cleanupPolicy = any(),
             samplingProbability = any(),
+            definition = any(),
         )
     }
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionPurchaseWideEventTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionPurchaseWideEventTest.kt
@@ -59,7 +59,7 @@ class SubscriptionPurchaseWideEventTest {
     @Test
     fun `onPurchaseFlowStarted starts a new flow`() =
         runTest {
-            whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+            whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
                 .thenReturn(Result.success(123L))
 
             subscriptionPurchaseWideEvent.onPurchaseFlowStarted("sub_id", true, "app_settings")
@@ -181,7 +181,7 @@ class SubscriptionPurchaseWideEventTest {
     @Test
     fun `onBillingFlowInitFailure without failureContext sends empty-metadata flowStep`() =
         runTest {
-            whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+            whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
                 .thenReturn(Result.success(123L))
             subscriptionPurchaseWideEvent.onPurchaseFlowStarted("sub_id", true, "app_settings")
 
@@ -206,7 +206,7 @@ class SubscriptionPurchaseWideEventTest {
     @Test
     fun `onBillingFlowInitFailure with failureContext and empty loadedProductIds emits no_products_loaded reason`() =
         runTest {
-            whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+            whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
                 .thenReturn(Result.success(123L))
             subscriptionPurchaseWideEvent.onPurchaseFlowStarted("sub_id", true, "app_settings")
 
@@ -247,7 +247,7 @@ class SubscriptionPurchaseWideEventTest {
     @Test
     fun `onBillingFlowInitFailure with failureContext where requestedProductId not in loadedProductIds emits product_id_not_found reason`() =
         runTest {
-            whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+            whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
                 .thenReturn(Result.success(123L))
             subscriptionPurchaseWideEvent.onPurchaseFlowStarted("sub_id", true, "app_settings")
 
@@ -283,7 +283,7 @@ class SubscriptionPurchaseWideEventTest {
     @Test
     fun `onBillingFlowInitFailure with failureContext where requestedProductId is in loadedProductIds emits offer_not_found reason`() =
         runTest {
-            whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+            whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
                 .thenReturn(Result.success(123L))
             subscriptionPurchaseWideEvent.onPurchaseFlowStarted("sub_id", true, "app_settings")
 
@@ -319,7 +319,7 @@ class SubscriptionPurchaseWideEventTest {
     @Test
     fun `onBillingFlowInitFailure serializes lastLoadProductsOutcome Failure to failure_BILLING_UNAVAILABLE`() =
         runTest {
-            whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+            whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
                 .thenReturn(Result.success(123L))
             subscriptionPurchaseWideEvent.onPurchaseFlowStarted("sub_id", true, "app_settings")
 
@@ -355,7 +355,7 @@ class SubscriptionPurchaseWideEventTest {
     @Test
     fun `onBillingFlowInitFailure forwards non-null offerId verbatim`() =
         runTest {
-            whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+            whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
                 .thenReturn(Result.success(123L))
             subscriptionPurchaseWideEvent.onPurchaseFlowStarted("sub_id", true, "app_settings")
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionRestoreWideEventTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionRestoreWideEventTest.kt
@@ -63,7 +63,7 @@ class SubscriptionRestoreWideEventTest {
 
     @Test
     fun `onEmailRestoreFlowStarted starts a new flow with email platform`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(123L))
 
         subscriptionRestoreWideEvent.onEmailRestoreFlowStarted(isOriginWeb = false)
@@ -82,7 +82,7 @@ class SubscriptionRestoreWideEventTest {
 
     @Test
     fun `onGooglePlayRestoreFlowStarted starts a new flow with google account platform`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(456L))
 
         subscriptionRestoreWideEvent.onGooglePlayRestoreFlowStarted(isOriginWeb = false)
@@ -101,7 +101,7 @@ class SubscriptionRestoreWideEventTest {
 
     @Test
     fun `onGooglePlayRestoreFlowStartedOnPurchaseAttempt starts a new flow with purchase attempt flag`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(789L))
 
         subscriptionRestoreWideEvent.onGooglePlayRestoreFlowStartedOnPurchaseAttempt()
@@ -119,7 +119,7 @@ class SubscriptionRestoreWideEventTest {
 
     @Test
     fun `onEmailRestoreSuccess ends interval and finishes flow with success`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(100L))
 
         subscriptionRestoreWideEvent.onEmailRestoreFlowStarted(isOriginWeb = false)
@@ -131,7 +131,7 @@ class SubscriptionRestoreWideEventTest {
 
     @Test
     fun `onGooglePlayRestoreSuccess ends interval and finishes flow with success`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(200L))
 
         subscriptionRestoreWideEvent.onGooglePlayRestoreFlowStarted(isOriginWeb = false)
@@ -143,7 +143,7 @@ class SubscriptionRestoreWideEventTest {
 
     @Test
     fun `onGooglePlayRestoreFailure finishes flow with failure`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(300L))
 
         subscriptionRestoreWideEvent.onGooglePlayRestoreFlowStarted(isOriginWeb = false)
@@ -157,7 +157,7 @@ class SubscriptionRestoreWideEventTest {
 
     @Test
     fun `starting a new flow when one is active finishes the previous flow with Unknown status`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(1L))
             .thenReturn(Result.success(2L))
 
@@ -207,18 +207,18 @@ class SubscriptionRestoreWideEventTest {
 
     @Test
     fun `flowStart failure does not call intervalStart`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.failure(RuntimeException("error")))
 
         subscriptionRestoreWideEvent.onEmailRestoreFlowStarted(isOriginWeb = false)
 
-        verify(wideEventClient).flowStart(any(), anyOrNull(), any(), any(), any())
+        verify(wideEventClient).flowStart(any(), anyOrNull(), any(), any(), any(), any())
         verify(wideEventClient, never()).intervalStart(any(), any(), any(), any())
     }
 
     @Test
     fun `onSubscriptionWebViewUrlChanged records activation flow started step`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(100L))
 
         subscriptionRestoreWideEvent.onEmailRestoreFlowStarted(isOriginWeb = false)
@@ -230,7 +230,7 @@ class SubscriptionRestoreWideEventTest {
 
     @Test
     fun `onSubscriptionWebViewUrlChanged records email input step`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(100L))
 
         subscriptionRestoreWideEvent.onEmailRestoreFlowStarted(isOriginWeb = false)
@@ -244,7 +244,7 @@ class SubscriptionRestoreWideEventTest {
 
     @Test
     fun `onSubscriptionWebViewUrlChanged records one time password input step`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(100L))
 
         subscriptionRestoreWideEvent.onEmailRestoreFlowStarted(isOriginWeb = false)
@@ -258,7 +258,7 @@ class SubscriptionRestoreWideEventTest {
 
     @Test
     fun `onSubscriptionWebViewUrlChanged ignores query parameters when matching path`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(100L))
 
         subscriptionRestoreWideEvent.onEmailRestoreFlowStarted(isOriginWeb = false)
@@ -270,7 +270,7 @@ class SubscriptionRestoreWideEventTest {
 
     @Test
     fun `onSubscriptionWebViewUrlChanged does not record step for unmatched URL`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(100L))
 
         subscriptionRestoreWideEvent.onEmailRestoreFlowStarted(isOriginWeb = false)

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionSwitchWideEventTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionSwitchWideEventTest.kt
@@ -65,7 +65,7 @@ class SubscriptionSwitchWideEventTest {
 
     @Test
     fun `onSwitchFlowStarted starts flow with correct metadata`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(123L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(123L))
 
         subscriptionSwitchWideEvent.onSwitchFlowStarted(
             context = "subscription_settings",
@@ -91,7 +91,7 @@ class SubscriptionSwitchWideEventTest {
 
     @Test
     fun `onSwitchFlowStarted with Plus yearly to Plus monthly has tier_change_type crossgrade and downgrade billing cycle`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(123L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(123L))
 
         subscriptionSwitchWideEvent.onSwitchFlowStarted(
             context = "subscription_settings",
@@ -116,7 +116,7 @@ class SubscriptionSwitchWideEventTest {
 
     @Test
     fun `onSwitchFlowStarted with Pro monthly to Pro yearly has tier_change_type crossgrade and upgrade billing cycle`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(123L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(123L))
 
         subscriptionSwitchWideEvent.onSwitchFlowStarted(
             context = "subscription_settings",
@@ -141,7 +141,7 @@ class SubscriptionSwitchWideEventTest {
 
     @Test
     fun `onSwitchFlowStarted with Plus to Pro has tier_change_type upgrade and none as billing cycle switch type`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(123L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(123L))
 
         subscriptionSwitchWideEvent.onSwitchFlowStarted(
             context = "subscription_settings",
@@ -166,7 +166,7 @@ class SubscriptionSwitchWideEventTest {
 
     @Test
     fun `onSwitchFlowStarted with Pro to Plus has tier_change_type downgrade`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(123L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any())).thenReturn(Result.success(123L))
 
         subscriptionSwitchWideEvent.onSwitchFlowStarted(
             context = "subscription_settings",
@@ -439,7 +439,7 @@ class SubscriptionSwitchWideEventTest {
         subscriptionSwitchWideEvent.onPlayBillingSwitchSuccess()
         subscriptionSwitchWideEvent.onSwitchConfirmationSuccess()
 
-        verify(wideEventClient, never()).flowStart(any(), any(), any(), any(), any())
+        verify(wideEventClient, never()).flowStart(any(), any(), any(), any(), any(), any())
         verify(wideEventClient, never()).flowStep(any(), any(), any(), any())
         verify(wideEventClient, never()).flowFinish(any(), any(), any())
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/wideevents/SyncSetupWideEventImplTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/wideevents/SyncSetupWideEventImplTest.kt
@@ -62,7 +62,7 @@ class SyncSetupWideEventImplTest {
 
     @Test
     fun `onFlowStarted starts a new flow with correct parameters`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(1L))
 
         wideEvent.onFlowStarted()
@@ -76,7 +76,7 @@ class SyncSetupWideEventImplTest {
 
     @Test
     fun `onFlowStarted passes source as flowEntryPoint`() = runTest {
-        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(1L))
 
         wideEvent.onFlowStarted(source = "settings")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213817723602340
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): https://app.asana.com/1/137249556945/task/1217024679030254

### Description

Wide events now send the two required common parameters that identify the event definition they validate against: `meta.type` (derived from the flow name as `android-<name>`) and `meta.version` (initially `1.0.0`). Both are persisted per event, sent by both transports, declared in the pixel definitions, and settable per event through a new optional `definition` parameter on `flowStart`.

Reviewable in three commits: the wire format and storage, the pixel definitions, then the public API.

### Steps to test this PR

_Wide events carry the meta parameters_
- [x] Install an internal build and tap the fire button to complete a `data-clearing` flow 
      - This wide event uses 5% sample rate now, so may be easier to change it for testing, by removing following line from WideEventClientImpl:
        `if (random.nextFloat() >= samplingProbability) return Result.success(SAMPLED_OUT_FLOW_ID)`
      - Alternatively, perform any operation that sends a wide event
- [x] Confirm the `wide_data-clearing_c` pixel carries `meta.type=android-data-clearing` and `meta.version=1.0.0`, and that the POST body has a top-level `meta` object

_Events in flight survive the DB migration_
- [x] Install a build from `develop`, start a flow (e.g. begin a subscription purchase) and background the app without finishing it
- [x] Install this build over it, finish the flow, and confirm the event is sent with the derived type and `1.0.0`

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes|No UI changes|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches analytics wire format, DB migration for in-flight events, and pixel schema across many features; behavior is well-tested but rollout affects all wide-event consumers.
> 
> **Overview**
> Wide events now identify their schema with **`meta.type`** and **`meta.version`**, persisted when a flow starts and included on both the API POST body and wide pixels.
> 
> **`flowStart`** accepts an optional **`WideEventDefinition`** (minor/patch version and optional type override). Defaults derive **`android-{name}`** (underscores → hyphens) and **`1.{minor}.{patch}`** via **`WideEventMeta`**. The Room DB moves to v4 with **`meta_type`** / **`meta_version`**; existing rows are backfilled in migration 3→4.
> 
> Pixel definitions use shared **`widePixelMetaType`** / **`widePixelMetaVersion`** (replacing inline **`meta.*`** on post-idle-session). Tests mock the new **`flowStart`** arity. Docs in **`wide-events.md`** cover meta parameters and version bump rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e37046dc69c40e3bf4ea1ffd26e998421e3e41f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217269281689923
  - https://app.asana.com/0/0/1213817723602340