### PR TITLE
Sync: Extract shared crypto/transport helpers

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceFieldDecryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceFieldDecryptor.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.sync.impl
 
+import androidx.annotation.WorkerThread
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.crypto.SyncLib
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
@@ -25,9 +26,10 @@ import dagger.SingleInstanceIn
 import javax.inject.Inject
 
 /**
- * Decrypts `name` + `type` for a single `entries_v2` entry. 3party uses the scoped MEK; ddg/null
- * uses the local primary key. Stateless — caller handles refresh/retry on [Result.Error].
+ * Decrypts `name` + `type` for a single `entries_v2` entry.
+ * 3party uses the main encryption key derived from the scoped password; ddg/null uses the local primary key.
  */
+@WorkerThread
 interface DeviceFieldDecryptor {
     fun decrypt(entry: DeviceV2): Result<DecryptedDevice>
 }
@@ -64,7 +66,12 @@ class RealDeviceFieldDecryptor @Inject constructor(
         val userId = syncStore.userId ?: return Result.Error(reason = "DeviceFieldDecryptor: userId missing")
 
         val thirdPartyMainKey = runCatching {
-            syncJweCrypto.hkdfDeriveBytes(scopedPassword, userId.toByteArray(Charsets.UTF_8), "Main Key", 32)
+            syncJweCrypto.hkdfDeriveBytes(
+                base64Key = scopedPassword,
+                salt = userId.toByteArray(Charsets.UTF_8),
+                info = HKDF_INFO_MAIN_ENCRYPTION_KEY,
+                outBytes = MAIN_ENCRYPTION_KEY_LENGTH_BYTES,
+            )
         }.getOrElse {
             return Result.Error(reason = "DeviceFieldDecryptor: 3p key derivation failed: ${it.message}")
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyUnwrapper.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyUnwrapper.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import android.util.Base64
+import androidx.annotation.WorkerThread
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.store.SyncStore
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+/**
+ * Recovers the raw private key from a [ProtectedKeyEntry] — the inverse of the two wrapping paths, [mintDdgWrappedProtectedKey] and [ThirdPartyKeyWrapper].
+ */
+@WorkerThread
+interface ProtectedKeyUnwrapper {
+    /**
+     * Decrypt [entry]'s private key using the credential it was wrapped with:
+     *   ddg entries are libsodium secretboxes under the account secret key,
+     *   3party entries are JWEs under the key derived from the scoped password.
+     */
+    fun unwrap(entry: ProtectedKeyEntry): Result<ByteArray>
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealProtectedKeyUnwrapper @Inject constructor(
+    private val syncStore: SyncStore,
+    private val syncJweCrypto: SyncJweCrypto,
+    private val nativeLib: SyncLib,
+) : ProtectedKeyUnwrapper {
+
+    override fun unwrap(entry: ProtectedKeyEntry): Result<ByteArray> {
+        return when (entry.encryptedWith) {
+            CREDENTIAL_ID_3PARTY -> unwrapThirdParty(entry)
+            CREDENTIAL_ID_DDG -> unwrapDdg(entry)
+            else -> Error(reason = "UnwrapProtectedKey: unknown credential encrypted_with=${entry.encryptedWith}")
+        }
+    }
+
+    private fun unwrapDdg(entry: ProtectedKeyEntry): Result<ByteArray> {
+        val accountSecretKey = syncStore.secretKey?.takeUnless { it.isEmpty() }
+            ?: return Error(reason = "UnwrapProtectedKey: no account secret key")
+
+        return runCatching {
+            // ddg keys are base64url on the wire; libsodium wants standard base64 bytes.
+            val encryptedBytes = Base64.decode(entry.encryptedPrivateKey.removeUrlSafetyToRestoreB64(), Base64.NO_WRAP)
+            val rawKeyBytes = nativeLib.decryptData(encryptedBytes, accountSecretKey).also {
+                it.checkResult("UnwrapProtectedKey: libsodium decrypt of ddg-wrapped key ${entry.kid} failed")
+            }.decryptedData
+            Success(rawKeyBytes)
+        }.getOrElse { it.asLoggedError("UnwrapProtectedKey: failed to unwrap ddg key ${entry.kid}") }
+    }
+
+    private fun unwrapThirdParty(entry: ProtectedKeyEntry): Result<ByteArray> {
+        val scopedPassword = syncStore.scopedPassword?.raw ?: return Error(reason = "UnwrapProtectedKey: scopedPassword missing")
+        val userId = syncStore.userId ?: return Error(reason = "UnwrapProtectedKey: userId missing")
+        return runCatching {
+            val mainEncryptionKey = syncJweCrypto.hkdfDeriveBytes(
+                base64Key = scopedPassword,
+                salt = userId.toByteArray(Charsets.UTF_8),
+                info = HKDF_INFO_MAIN_ENCRYPTION_KEY,
+                outBytes = MAIN_ENCRYPTION_KEY_LENGTH_BYTES,
+            )
+            Success(syncJweCrypto.jweDecryptSymmetric(entry.encryptedPrivateKey, mainEncryptionKey))
+        }.getOrElse { it.asLoggedError("UnwrapProtectedKey: failed to unwrap 3party key ${entry.kid}") }
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ScopedCredentialsEncoding.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ScopedCredentialsEncoding.kt
@@ -23,9 +23,14 @@ import logcat.LogPriority.ERROR
 import logcat.asLog
 import logcat.logcat
 
+/** HKDF `info` label for deriving the credential main encryption key */
+internal const val HKDF_INFO_MAIN_ENCRYPTION_KEY = "Main Key"
+
+/** Length in bytes of the derived main encryption key (an AES-256 key). */
+internal const val MAIN_ENCRYPTION_KEY_LENGTH_BYTES = 32
+
 /**
  * HKDF-SHA-256 over the decoded `base64Key` bytes, returning raw bytes for direct use as an AES key.
- * Used to derive the credential MEK (info="Main Key") per Encryption Algorithms TD (Asana 1214802412121967).
  */
 internal fun SyncJweCrypto.hkdfDeriveBytes(
     base64Key: String,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SetKeysIfAbsentCall.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SetKeysIfAbsentCall.kt
@@ -22,7 +22,6 @@ import com.squareup.anvil.annotations.ContributesBinding
 import logcat.LogPriority.INFO
 import logcat.logcat
 import retrofit2.HttpException
-import retrofit2.Response
 import javax.inject.Inject
 
 /** Runs the POST /sync/keys/purpose/{purpose}/set-if-absent request and maps its outcome. */
@@ -68,7 +67,7 @@ class RealSetKeysIfAbsentCall @Inject constructor(
                 logcat { "Sync-UnifiedDevices: set-if-absent 409 — a different key already exists; will fetch" }
                 Result.Success(SetKeysIfAbsentResult.ExistsFetchRequired)
             } else {
-                mapError(response)
+                response.toUnparsedError()
             }
         }.getOrElse { throwable ->
             logcat(INFO) { "Sync-UnifiedDevices: setKeysIfAbsent error ${throwable.localizedMessage}" }
@@ -77,18 +76,6 @@ class RealSetKeysIfAbsentCall @Inject constructor(
             } else {
                 Result.Error(reason = "internal error")
             }
-        }
-    }
-
-    private fun mapError(response: Response<SetKeyIfAbsentResponse?>): Result<SetKeysIfAbsentResult> {
-        val errorBody = response.errorBody()
-        val hasErrorBody = runCatching {
-            errorBody != null && errorBody.string().isNotEmpty()
-        }.getOrDefault(false)
-        return if (hasErrorBody) {
-            Result.Error(code = response.code(), reason = "unexpected status code")
-        } else {
-            Result.Error(code = response.code(), reason = "empty response")
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -150,6 +150,20 @@ interface SyncApi {
     fun deleteExchangeChannel(channelId: String): Result<Unit>
 }
 
+/**
+ * Turn a failed response into a [Result.Error] for endpoints whose error body we don't parse,
+ * distinguishing "the server said something we don't understand" from "the server said nothing".
+ * Reading the body consumes the stream, so it happens exactly once here.
+ */
+internal fun Response<*>.toUnparsedError(): Result.Error {
+    val hasErrorBody = runCatching { !errorBody()?.string().isNullOrEmpty() }.getOrDefault(false)
+    return if (hasErrorBody) {
+        Result.Error(code = code(), reason = "unexpected status code")
+    } else {
+        Result.Error(code = code(), reason = "empty response")
+    }
+}
+
 sealed class SetKeysIfAbsentResult {
     /** Our posted keys won (server returned 201). */
     data object Created : SetKeysIfAbsentResult()
@@ -521,15 +535,7 @@ class SyncServiceRemote @Inject constructor(
     }
 
     private fun mapRescopeTokenError(response: Response<TokenRescopeResponse?>): Result<String> {
-        val errorBody = response.errorBody()
-        val hasErrorBody = runCatching {
-            errorBody != null && errorBody.string().isNotEmpty()
-        }.getOrDefault(false)
-        val error = if (hasErrorBody) {
-            Result.Error(code = response.code(), reason = "unexpected status code")
-        } else {
-            Result.Error(code = response.code(), reason = "empty response")
-        }
+        val error = response.toUnparsedError()
         error.removeKeysIfInvalid()
         return error
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManager.kt
@@ -73,6 +73,7 @@ class RealThirdPartyCredentialManager @Inject constructor(
     private val syncJweCrypto: SyncJweCrypto,
     private val nativeLib: SyncLib,
     private val syncFeature: SyncFeature,
+    private val protectedKeyUnwrapper: ProtectedKeyUnwrapper,
 ) : ThirdPartyCredentialManager {
 
     /** Base linear-backoff between rate-limit retries. Overridable in tests to keep them fast. */
@@ -223,7 +224,7 @@ class RealThirdPartyCredentialManager @Inject constructor(
         val spMek = kotlin.runCatching { syncJweCrypto.hkdfDeriveBytes(newSpBase64, hkdfSalt, "Main Key", 32) }
             .getOrElse { return it.asLoggedError("CreateThirdPartyCredential: failed to derive 3party MEK") }
         val accountSecretKey = syncStore.secretKey
-            ?: return Error(reason = "CreateThirdPartyCredential: no account secret key for ddg-side decrypt")
+            ?: return Error(reason = "CreateThirdPartyCredential: no account secret key to mint against")
 
         val ddgKeys = when (val r = retryingOnRateLimit { syncApi.getProtectedKeys(token) }) {
             is Success -> r.data.filter { it.encryptedWith == CREDENTIAL_ID_DDG }
@@ -253,11 +254,10 @@ class RealThirdPartyCredentialManager @Inject constructor(
         logcat { "Sync-ScopedToken: ${ddgKeys.size} existing ddg key(s) to re-encrypt for 3party" }
         val reWrapResults = ddgKeys.map { key ->
             kotlin.runCatching {
-                // ddg key arrives base64url-encoded; convert to standard base64 then libsodium-decrypt.
-                val encryptedBytes = Base64.decode(key.encryptedPrivateKey.removeUrlSafetyToRestoreB64(), Base64.NO_WRAP)
-                val rawKeyBytes = nativeLib.decryptData(encryptedBytes, accountSecretKey).also {
-                    it.checkResult("CreateThirdPartyCredential: failed to libsodium-decrypt ddg key ${key.kid}")
-                }.decryptedData
+                val rawKeyBytes = when (val unwrapped = protectedKeyUnwrapper.unwrap(key)) {
+                    is Success -> unwrapped.data
+                    is Error -> error(unwrapped.reason)
+                }
                 val reEncryptedJwe = syncJweCrypto.jweEncryptSymmetric(rawKeyBytes, spMek, kid = CREDENTIAL_ID_3PARTY)
                 ProtectedKeyEntry(
                     kid = key.kid,

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ProtectedKeyUnwrapperTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ProtectedKeyUnwrapperTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.sync.crypto.DecryptBytesResult
+import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.store.ScopedPassword
+import com.duckduckgo.sync.store.SyncStore
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class ProtectedKeyUnwrapperTest {
+
+    private val syncStore: SyncStore = mock()
+    private val syncJweCrypto: SyncJweCrypto = mock()
+    private val nativeLib: SyncLib = mock()
+    private val unwrapper = RealProtectedKeyUnwrapper(syncStore, syncJweCrypto, nativeLib)
+
+    private val scopedPasswordBase64 = "AAECAwQFBgcICQoLDA0ODw=="
+
+    private val ddgKey = ProtectedKeyEntry(
+        kid = "kid-1",
+        purpose = "account_info",
+        encryptedWith = "ddg",
+        encryptedPrivateKey = "AAAA",
+        publicKey = RsaJwk(n = "n", e = "AQAB"),
+    )
+
+    private val thirdPartyKey = ddgKey.copy(encryptedWith = "3party")
+
+    @Test
+    fun whenDdgKeyThenLibsodiumDecryptWithAccountSecretKey() {
+        whenever(syncStore.secretKey).thenReturn("secretKey")
+        whenever(nativeLib.decryptData(any<ByteArray>(), eq("secretKey"))).thenReturn(DecryptBytesResult(0, byteArrayOf(1, 2, 3)))
+
+        val result = unwrapper.unwrap(ddgKey)
+
+        assertArrayEquals(byteArrayOf(1, 2, 3), (result as Result.Success).data)
+    }
+
+    @Test
+    fun whenDdgKeyAndNoAccountSecretKeyThenError() {
+        whenever(syncStore.secretKey).thenReturn(null)
+
+        assertTrue(unwrapper.unwrap(ddgKey) is Result.Error)
+    }
+
+    @Test
+    fun whenDdgDecryptFailsThenError() {
+        whenever(syncStore.secretKey).thenReturn("secretKey")
+        whenever(nativeLib.decryptData(any<ByteArray>(), eq("secretKey"))).thenReturn(DecryptBytesResult(1, ByteArray(0)))
+
+        assertTrue(unwrapper.unwrap(ddgKey) is Result.Error)
+    }
+
+    @Test
+    fun whenThirdPartyKeyThenJweDecryptWithDerivedMainKey() {
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword(scopedPasswordBase64))
+        whenever(syncStore.userId).thenReturn("user-42")
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), eq("Main Key"), eq(32))).thenReturn(ByteArray(32))
+        whenever(syncJweCrypto.jweDecryptSymmetric(eq("AAAA"), any())).thenReturn(byteArrayOf(4, 5, 6))
+
+        val result = unwrapper.unwrap(thirdPartyKey)
+
+        assertArrayEquals(byteArrayOf(4, 5, 6), (result as Result.Success).data)
+    }
+
+    @Test
+    fun whenThirdPartyKeyAndNoScopedPasswordThenError() {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncStore.userId).thenReturn("user-42")
+
+        assertTrue(unwrapper.unwrap(thirdPartyKey) is Result.Error)
+    }
+
+    @Test
+    fun whenCredentialIsUnknownThenError() {
+        assertTrue(unwrapper.unwrap(ddgKey.copy(encryptedWith = "magic")) is Result.Error)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManagerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManagerTest.kt
@@ -62,6 +62,7 @@ class ThirdPartyCredentialManagerTest {
     private val syncApi: SyncApi = mock()
     private val syncJweCrypto: SyncJweCrypto = mock()
     private val nativeLib: SyncLib = mock()
+    private val protectedKeyUnwrapper: ProtectedKeyUnwrapper = mock()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
 
     // A ddg-wrapped key already on the account; used by the happy-path tests.
@@ -77,7 +78,7 @@ class ThirdPartyCredentialManagerTest {
 
     @Before
     fun before() {
-        manager = RealThirdPartyCredentialManager(syncStore, syncApi, syncJweCrypto, nativeLib, syncFeature)
+        manager = RealThirdPartyCredentialManager(syncStore, syncApi, syncJweCrypto, nativeLib, syncFeature, protectedKeyUnwrapper)
     }
 
     // ---- create() ----
@@ -532,5 +533,6 @@ class ThirdPartyCredentialManagerTest {
         whenever(syncApi.getAccessCredentials(token)).thenReturn(Success(emptyList()))
         whenever(syncApi.createAccessCredential(anyString(), anyString(), any())).thenReturn(Success(true))
         whenever(nativeLib.decryptData(any<ByteArray>(), eq(secretKey))).thenReturn(DecryptBytesResult(0, "raw_key".toByteArray()))
+        whenever(protectedKeyUnwrapper.unwrap(any())).thenReturn(Success("raw_key".toByteArray()))
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1217068100697968?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Refactor to make future work easier / cleaner to land.

Extracts reusable helpers from existing `account_info` code for
- `ProtectedKeyUnwrapper`
- a shared `toUnparsedError()` function
- some crypto constants that were starting to get repeated in a lot of places

### Steps to test this PR
> [!NOTE]
> QA optional

- [ ] Fresh install `internal` build
- [ ] Visit `Sync Dev Settings`
- [ ] Scroll down and tap on `Create account` (one-tap enabling of sync on a new account)
- [ ] Scroll up and tap `Create & Register account_info Key` (ensures there is an existing ddg-wrapped protected key)
- [ ] Then tap on `Create 3party credential` and verify that succeeds 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches protected-key decryption and 3party credential key re-wrap logic; behavior is intended to be equivalent but errors in shared crypto paths could break credential creation or key adoption.
> 
> **Overview**
> Refactors sync crypto and HTTP error handling so upcoming unified-device work can reuse the same paths instead of duplicating them.
> 
> **Protected key unwrapping** is centralized in a new `ProtectedKeyUnwrapper` that recovers raw private bytes from `ProtectedKeyEntry` for **ddg** (libsodium secretbox under the account secret key) and **3party** (HKDF + symmetric JWE under the scoped password). `RealThirdPartyCredentialManager` now calls `protectedKeyUnwrapper.unwrap` when re-encrypting existing ddg keys for a new 3party credential, replacing inline Base64 decode + `nativeLib.decryptData`.
> 
> **HKDF main-key derivation** is aligned via shared constants `HKDF_INFO_MAIN_ENCRYPTION_KEY` and `MAIN_ENCRYPTION_KEY_LENGTH_BYTES` in `ScopedCredentialsEncoding`; `DeviceFieldDecryptor` and the unwrapper use them instead of scattered `"Main Key"` / `32` literals.
> 
> **Failed Retrofit responses** that do not parse error JSON share `Response.toUnparsedError()` on `SyncServiceRemote`, used from `SetKeysIfAbsentCall` and token rescope error mapping (replacing duplicate `mapError` / `mapRescopeTokenError` body reads).
> 
> `@WorkerThread` is added on `DeviceFieldDecryptor` and `ProtectedKeyUnwrapper`. New `ProtectedKeyUnwrapperTest` and updated credential manager tests cover the unwrapper injection path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9169deafa7deefa30120585f3ab84c2bcc873c0b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->