### PR TITLE
Handle v1 exchange sync codes

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeViewModel.kt
@@ -34,7 +34,9 @@ import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_EXCHANGE
 import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
 import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.OriginalFlow
@@ -77,8 +79,15 @@ class DisplayQrCodeViewModel @AssistedInject constructor(
     private val _viewState = MutableStateFlow(ViewState())
     val viewState = _viewState.asStateFlow()
 
+    @Volatile
+    private var isSignedIn = false
+
+    private val syncType: ScreenType
+        get() = if (isSignedIn) SYNC_EXCHANGE else SYNC_CONNECT
+
     init {
         viewModelScope.launch(dispatchers.io()) {
+            isSignedIn = accountRepository.getAccountInfo().isSignedIn
             when (protocolVersion()) {
                 ProtocolVersion.V1 -> startV1Presentation()
                 ProtocolVersion.V2 -> startV2Presentation()
@@ -116,7 +125,7 @@ class DisplayQrCodeViewModel @AssistedInject constructor(
             if (!isNotificationShown) {
                 _commands.send(Command.ShowMessage(R.string.sync_code_copied_message))
             }
-            pixels.fireSyncSetupCodeCopiedToClipboard(SYNC_CONNECT)
+            pixels.fireSyncSetupCodeCopiedToClipboard(syncType)
         }
     }
 
@@ -127,7 +136,15 @@ class DisplayQrCodeViewModel @AssistedInject constructor(
         }
     }
 
-    private suspend fun startV1Presentation() = coroutineScope {
+    private suspend fun startV1Presentation() {
+        if (isSignedIn) {
+            startV1ExchangePresentation()
+        } else {
+            startV1ConnectPresentation()
+        }
+    }
+
+    private suspend fun startV1ConnectPresentation() = coroutineScope {
         val qrCodeResult = accountRepository.getConnectQR()
             .onSuccess { showQrCode(it.qrCode) }
             .onFailure { failure ->
@@ -142,10 +159,48 @@ class DisplayQrCodeViewModel @AssistedInject constructor(
                 .onSuccess { isSynced ->
                     if (isSynced) {
                         pixels.fireSignupConnectPixel(source)
-                        pixels.fireSyncSetupFinishedSuccessfully(SYNC_CONNECT)
+                        pixels.fireSyncSetupFinishedSuccessfully(syncType)
 
-                        val result = pairingResult()
-                        _commands.send(Command.SetPairingResult(result))
+                        _commands.send(Command.SetPairingResult(pairingResult()))
+                        _commands.send(Command.Close)
+                        isPolling = false
+                    }
+                }
+                .onFailure { failure ->
+                    _commands.send(Command.ShowV1Error(failure.toV1PairingError()))
+                    isPolling = false
+                }
+        }
+    }
+
+    private suspend fun startV1ExchangePresentation() {
+        if (!syncFeature.exchangeKeysToSyncWithAnotherDevice().isEnabled()) {
+            accountRepository.getRecoveryCode()
+                .onSuccess { showQrCode(it.qrCode) }
+                .onFailure { failure ->
+                    val content = V1PairingErrorContent(R.string.sync_connect_generic_error, failure.reason)
+                    _commands.send(Command.ShowV1Error(content))
+                }
+            return
+        }
+
+        val invitationResult = accountRepository.generateExchangeInvitationCode()
+            .onSuccess { showQrCode(it.qrCode) }
+            .onFailure { failure ->
+                val content = V1PairingErrorContent(R.string.sync_connect_generic_error, failure.reason)
+                _commands.send(Command.ShowV1Error(content))
+            }
+
+        var isPolling = invitationResult is Result.Success
+        while (isPolling) {
+            delay(POLLING_INTERVAL_EXCHANGE_FLOW)
+            accountRepository.pollSecondDeviceExchangeAcknowledgement()
+                .onSuccess { isAcknowledged ->
+                    if (isAcknowledged) {
+                        // The peer joined this account; this device did not log in, so no login pixel.
+                        pixels.fireSyncSetupFinishedSuccessfully(syncType)
+
+                        _commands.send(Command.SetPairingResult(pairingResult()))
                         _commands.send(Command.Close)
                         isPolling = false
                     }
@@ -159,8 +214,8 @@ class DisplayQrCodeViewModel @AssistedInject constructor(
 
     private suspend fun startV2Presentation() {
         codeDispatcher.presentV2().collect { outcome ->
-            pixels.fireSetupFailed(SYNC_CONNECT, outcome)
-            pixels.fireSetupCancelledIfDenied(SYNC_CONNECT, outcome)
+            pixels.fireSetupFailed(syncType, outcome)
+            pixels.fireSetupCancelledIfDenied(syncType, outcome)
 
             when (outcome) {
                 is DispatchOutcome.LinkingCodeReady -> {
@@ -177,7 +232,7 @@ class DisplayQrCodeViewModel @AssistedInject constructor(
 
                 is DispatchOutcome.LoggedIn -> {
                     pixels.fireLoginPixel()
-                    pixels.fireSyncSetupFinishedSuccessfully(SYNC_CONNECT, outcome.path, outcome.myRole, outcome.peerKind)
+                    pixels.fireSyncSetupFinishedSuccessfully(syncType, outcome.path, outcome.myRole, outcome.peerKind)
                     _commands.send(Command.SetPairingResult(pairingResult()))
                     _commands.send(Command.Close)
                 }
@@ -288,5 +343,6 @@ class DisplayQrCodeViewModel @AssistedInject constructor(
 
     companion object {
         private val POLLING_INTERVAL_CONNECT_FLOW = 5.seconds
+        private val POLLING_INTERVAL_EXCHANGE_FLOW = 2.seconds
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ExchangeSyncCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ExchangeSyncCodeActivity.kt
@@ -46,6 +46,7 @@ import com.duckduckgo.sync.impl.ui.syncV2ConfirmationMessage
 import com.duckduckgo.sync.impl.ui.v2.ExchangeSyncCodeViewModel.Command
 import com.duckduckgo.sync.impl.ui.v2.ExchangeSyncCodeViewModel.Command.AskHostConfirmation
 import com.duckduckgo.sync.impl.ui.v2.ExchangeSyncCodeViewModel.Command.AskJoinerConfirmation
+import com.duckduckgo.sync.impl.ui.v2.ExchangeSyncCodeViewModel.Command.AskSwitchAccount
 import com.duckduckgo.sync.impl.ui.v2.ExchangeSyncCodeViewModel.Command.Close
 import com.duckduckgo.sync.impl.ui.v2.ExchangeSyncCodeViewModel.Command.RunAcknowledgmentAnimation
 import com.duckduckgo.sync.impl.ui.v2.ExchangeSyncCodeViewModel.Command.SetPairingResult
@@ -141,6 +142,7 @@ class ExchangeSyncCodeActivity : DuckDuckGoActivity() {
         when (command) {
             is AskHostConfirmation -> showHostConfirmationDialog(command.peerName, command.peerKind)
             is AskJoinerConfirmation -> showJoinerConfirmationDialog(command.peerName, command.peerKind)
+            is AskSwitchAccount -> showSwitchAccountDialog(command.encodedStringCode)
             is ShowPairingAcknowledgement -> showPairingAcknowledgmentDialog()
             is RunAcknowledgmentAnimation -> runAcknowledgementAnimation()
             is SetPairingResult -> setResult(SyncPairingResult.RESULT_SYNC_COMPLETED, SyncPairingResult.resultIntent(command.result))
@@ -190,6 +192,26 @@ class ExchangeSyncCodeActivity : DuckDuckGoActivity() {
 
                     override fun onNegativeButtonClicked() {
                         viewModel.onJoinerDenied()
+                    }
+                },
+            )
+            .show()
+    }
+
+    private fun showSwitchAccountDialog(encodedStringCode: String) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_dialog_switch_account_header)
+            .setMessage(R.string.sync_dialog_switch_account_description)
+            .setPositiveButton(R.string.sync_dialog_switch_account_primary_button)
+            .setNegativeButton(R.string.sync_dialog_switch_account_secondary_button)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onUserAcceptedSwitchingAccount(encodedStringCode)
+                    }
+
+                    override fun onNegativeButtonClicked() {
+                        viewModel.onUserCancelledSwitchingAccount()
                     }
                 },
             )

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ExchangeSyncCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ExchangeSyncCodeViewModel.kt
@@ -20,11 +20,17 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.DispatchOutcome
+import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
+import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
+import com.duckduckgo.sync.impl.ExchangeResult.Pending
+import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode.Exchange
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
@@ -41,19 +47,21 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import logcat.logcat
+import kotlin.time.Duration.Companion.seconds
 
 class ExchangeSyncCodeViewModel @AssistedInject constructor(
     @Assisted private val syncUrl: String,
     @Assisted private val originalFlow: OriginalFlow,
     private val accountRepository: SyncAccountRepository,
     private val codeDispatcher: SyncCodeDispatcher,
+    private val syncFeature: SyncFeature,
     private val dispatchers: DispatcherProvider,
 ) : ViewModel() {
     private val _commands = Channel<Command>(Channel.BUFFERED)
@@ -112,6 +120,27 @@ class ExchangeSyncCodeViewModel @AssistedInject constructor(
         }
     }
 
+    fun onUserAcceptedSwitchingAccount(encodedStringCode: String) {
+        viewModelScope.launch(dispatchers.io()) {
+            accountRepository.logoutAndJoinNewAccount(encodedStringCode)
+                .onSuccess {
+                    animationCompletionSignal.await()
+                    _commands.send(Command.SetPairingResult(pairingResult()))
+                    _commands.send(Command.Close)
+                }
+                .onFailure { failure ->
+                    _commands.send(Command.ShowV1Error(failure.toV1PairingError()))
+                }
+        }
+    }
+
+    fun onUserCancelledSwitchingAccount() {
+        viewModelScope.launch {
+            _commands.send(Command.SetPairingResult(SyncPairingResult.Failure))
+            _commands.send(Command.Close)
+        }
+    }
+
     private suspend fun handleV1CodeDecision(decision: RouteDecision.Legacy) {
         _commands.send(Command.RunAcknowledgmentAnimation)
         val authCode = decision.authCode
@@ -120,7 +149,7 @@ class ExchangeSyncCodeViewModel @AssistedInject constructor(
                 .onSuccess {
                     when (authCode) {
                         is Exchange -> {
-                            logcat { "TODO: Poll for recovery key" }
+                            pollForV1RecoveryKey()
                         }
 
                         else -> {
@@ -131,8 +160,45 @@ class ExchangeSyncCodeViewModel @AssistedInject constructor(
                     }
                 }
                 .onFailure { failure ->
-                    _commands.send(Command.ShowV1Error(failure.toV1PairingError()))
+                    emitV1Error(failure)
                 }
+        }
+    }
+
+    private suspend fun pollForV1RecoveryKey() {
+        var isPolling = true
+        while (isPolling) {
+            delay(POLLING_INTERVAL_EXCHANGE_FLOW)
+            withContext(dispatchers.io()) { accountRepository.pollForRecoveryCodeAndLogin() }
+                .onSuccess { result ->
+                    when (result) {
+                        is AccountSwitchingRequired -> {
+                            _commands.send(Command.AskSwitchAccount(result.recoveryCode))
+                            isPolling = false
+                        }
+
+                        is LoggedIn -> {
+                            animationCompletionSignal.await()
+                            _commands.send(Command.SetPairingResult(pairingResult()))
+                            _commands.send(Command.Close)
+                            isPolling = false
+                        }
+
+                        is Pending -> Unit
+                    }
+                }
+                .onFailure { failure ->
+                    emitV1Error(failure)
+                    isPolling = false
+                }
+        }
+    }
+
+    private suspend fun emitV1Error(failure: Error) {
+        if (failure.code == ALREADY_SIGNED_IN.code && syncFeature.seamlessAccountSwitching().isEnabled()) {
+            _commands.send(Command.AskSwitchAccount(syncUrl))
+        } else {
+            _commands.send(Command.ShowV1Error(failure.toV1PairingError()))
         }
     }
 
@@ -182,6 +248,14 @@ class ExchangeSyncCodeViewModel @AssistedInject constructor(
         val isLoggedIn: Boolean = false,
     )
 
+    private suspend fun pairingResult(): SyncPairingResult = withContext(dispatchers.io()) {
+        accountRepository
+            .getThisConnectedDevice()
+            ?.let(ParcelableDevice::fromConnectedDevice)
+            ?.let { device -> SyncPairingResult.Success(device, originalFlow) }
+            ?: SyncPairingResult.Failure
+    }
+
     internal sealed interface Command {
         data class AskJoinerConfirmation(
             val peerName: String?,
@@ -191,6 +265,10 @@ class ExchangeSyncCodeViewModel @AssistedInject constructor(
         data class AskHostConfirmation(
             val peerName: String?,
             val peerKind: PeerKind? = null,
+        ) : Command
+
+        data class AskSwitchAccount(
+            val encodedStringCode: String,
         ) : Command
 
         data object ShowPairingAcknowledgement : Command
@@ -212,14 +290,6 @@ class ExchangeSyncCodeViewModel @AssistedInject constructor(
         data object Close : Command
     }
 
-    private suspend fun pairingResult(): SyncPairingResult = withContext(dispatchers.io()) {
-        accountRepository
-            .getThisConnectedDevice()
-            ?.let(ParcelableDevice::fromConnectedDevice)
-            ?.let { device -> SyncPairingResult.Success(device, originalFlow) }
-            ?: SyncPairingResult.Failure
-    }
-
     @AssistedFactory
     interface Factory {
         fun create(
@@ -238,5 +308,9 @@ class ExchangeSyncCodeViewModel @AssistedInject constructor(
                 return assistedFactory.create(syncUrl, originalFlow) as T
             }
         }
+    }
+
+    companion object {
+        private val POLLING_INTERVAL_EXCHANGE_FLOW = 2.seconds
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeViewModelTest.kt
@@ -23,8 +23,10 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.TestSyncFixtures
+import com.duckduckgo.sync.impl.AccountErrorCodes.EXCHANGE_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountInfo
 import com.duckduckgo.sync.impl.ConnectedDevice
 import com.duckduckgo.sync.impl.DeviceType
 import com.duckduckgo.sync.impl.DispatchOutcome
@@ -38,6 +40,7 @@ import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_EXCHANGE
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
@@ -107,6 +110,7 @@ class DisplayQrCodeViewModelTest {
         whenever(codeDispatcher.presentV2()).thenReturn(emptyFlow())
         whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(bitmap)
         whenever(accountRepository.pollConnectionKeys()).thenReturn(Result.Success(true))
+        whenever(accountRepository.getAccountInfo()).thenReturn(AccountInfo(isSignedIn = false))
     }
 
     private fun createTestee(source: String? = null) = DisplayQrCodeViewModel(
@@ -207,6 +211,129 @@ class DisplayQrCodeViewModelTest {
 
         verify(accountRepository).getConnectQR()
         verify(codeDispatcher, never()).presentV2()
+    }
+
+    @Test
+    fun `when v2 is disabled and this device is signed in then the exchange invitation code is shown as a QR code`() = runTest {
+        givenV2Disabled()
+        givenSignedIn()
+        givenExchangeKeysEnabled()
+        whenever(accountRepository.generateExchangeInvitationCode())
+            .thenReturn(Result.Success(AuthCode(qrCode = "invitation-code", rawCode = "b64-code")))
+        whenever(accountRepository.pollSecondDeviceExchangeAcknowledgement()).thenReturn(Result.Success(true))
+
+        val testee = createTestee()
+
+        testee.viewState.test {
+            assertEquals(BitmapWithCode(bitmap, "invitation-code", "invitation-code"), awaitItem().bitmap)
+            verify(qrEncoder).encodeAsBitmap(eq("invitation-code"), any(), any())
+            verify(accountRepository, never()).getConnectQR()
+            verify(codeDispatcher, never()).presentV2()
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when v2 is disabled and this device is signed in and the peer acknowledges then a success result is set and the screen closes`() = runTest {
+        givenV2Disabled()
+        givenSignedIn()
+        givenExchangeKeysEnabled()
+        givenThisConnectedDevice()
+        whenever(accountRepository.generateExchangeInvitationCode())
+            .thenReturn(Result.Success(AuthCode(qrCode = "invitation-code", rawCode = "b64-code")))
+        whenever(accountRepository.pollSecondDeviceExchangeAcknowledgement()).thenReturn(Result.Success(true))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            val command = awaitItem()
+            assertIs<SetPairingResult>(command)
+            assertEquals(
+                SyncPairingResult.Success(thisParcelableDevice, OriginalFlow.SYNC_THIS_DEVICE),
+                command.result,
+            )
+            assertIs<Close>(awaitItem())
+
+            cancel()
+        }
+        verify(pixels).fireSyncSetupFinishedSuccessfully(SYNC_EXCHANGE, null, null, null)
+        verify(pixels, never()).fireLoginPixel()
+        verify(pixels, never()).fireSignupConnectPixel(anyOrNull())
+    }
+
+    @Test
+    fun `when v2 is disabled and this device is signed in and the invitation code cannot be generated then an error is shown`() = runTest {
+        givenV2Disabled()
+        givenSignedIn()
+        givenExchangeKeysEnabled()
+        whenever(accountRepository.generateExchangeInvitationCode()).thenReturn(Result.Error(reason = "boom"))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            val command = awaitItem()
+            assertIs<ShowV1Error>(command)
+            assertEquals(R.string.sync_connect_generic_error, command.content.message)
+            assertEquals("boom", command.content.reason)
+
+            cancel()
+        }
+        verify(accountRepository, never()).pollSecondDeviceExchangeAcknowledgement()
+    }
+
+    @Test
+    fun `when v2 is disabled and this device is signed in and polling fails then an error is shown`() = runTest {
+        givenV2Disabled()
+        givenSignedIn()
+        givenExchangeKeysEnabled()
+        whenever(accountRepository.generateExchangeInvitationCode())
+            .thenReturn(Result.Success(AuthCode(qrCode = "invitation-code", rawCode = "b64-code")))
+        whenever(accountRepository.pollSecondDeviceExchangeAcknowledgement())
+            .thenReturn(Result.Error(code = EXCHANGE_FAILED.code, reason = "boom"))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            val command = awaitItem()
+            assertIs<ShowV1Error>(command)
+            assertEquals(R.string.sync_pairing_failed_generic_message, command.content.message)
+            assertEquals("boom", command.content.reason)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when v2 and exchange keys are disabled and this device is signed in then the recovery code is shown without polling`() = runTest {
+        givenV2Disabled()
+        givenSignedIn()
+        syncFeature.exchangeKeysToSyncWithAnotherDevice().setRawStoredState(State(false))
+        whenever(accountRepository.getRecoveryCode())
+            .thenReturn(Result.Success(AuthCode(qrCode = "recovery-code", rawCode = "recovery-code")))
+
+        val testee = createTestee()
+
+        testee.viewState.test {
+            assertEquals(BitmapWithCode(bitmap, "recovery-code", "recovery-code"), awaitItem().bitmap)
+
+            cancel()
+        }
+        verify(accountRepository, never()).pollSecondDeviceExchangeAcknowledgement()
+        verify(accountRepository, never()).generateExchangeInvitationCode()
+        verify(accountRepository, never()).getConnectQR()
+    }
+
+    @Test
+    fun `when this device is signed in then v2 pixels report the exchange screen`() = runTest {
+        givenV2Enabled()
+        givenSignedIn()
+        givenThisConnectedDevice()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.LoggedIn(path = SetupPath.PAIRING)))
+
+        createTestee()
+
+        verify(pixels).fireSyncSetupFinishedSuccessfully(SYNC_EXCHANGE, SetupPath.PAIRING, null, null)
     }
 
     @Test
@@ -543,6 +670,14 @@ class DisplayQrCodeViewModelTest {
 
     private fun givenThisConnectedDevice() {
         whenever(accountRepository.getThisConnectedDevice()).thenReturn(thisDevice)
+    }
+
+    private fun givenSignedIn() {
+        whenever(accountRepository.getAccountInfo()).thenReturn(AccountInfo(isSignedIn = true))
+    }
+
+    private fun givenExchangeKeysEnabled() {
+        syncFeature.exchangeKeysToSyncWithAnotherDevice().setRawStoredState(State(true))
     }
 
     private fun givenV2Enabled() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/ExchangeSyncCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/ExchangeSyncCodeViewModelTest.kt
@@ -18,11 +18,16 @@ package com.duckduckgo.sync.impl.ui.v2
 
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.ConnectCode
 import com.duckduckgo.sync.impl.ConnectedDevice
 import com.duckduckgo.sync.impl.DeviceType
 import com.duckduckgo.sync.impl.DispatchOutcome
+import com.duckduckgo.sync.impl.ExchangeResult
+import com.duckduckgo.sync.impl.InvitationCode
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result
@@ -31,11 +36,13 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.OriginalFlow
 import com.duckduckgo.sync.impl.ui.v2.ExchangeSyncCodeViewModel.Command.AskHostConfirmation
 import com.duckduckgo.sync.impl.ui.v2.ExchangeSyncCodeViewModel.Command.AskJoinerConfirmation
+import com.duckduckgo.sync.impl.ui.v2.ExchangeSyncCodeViewModel.Command.AskSwitchAccount
 import com.duckduckgo.sync.impl.ui.v2.ExchangeSyncCodeViewModel.Command.Close
 import com.duckduckgo.sync.impl.ui.v2.ExchangeSyncCodeViewModel.Command.RunAcknowledgmentAnimation
 import com.duckduckgo.sync.impl.ui.v2.ExchangeSyncCodeViewModel.Command.SetPairingResult
@@ -65,6 +72,7 @@ class ExchangeSyncCodeViewModelTest {
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private val recoveryAuthCode = SyncAuthCode.Recovery(RecoveryCode(primaryKey = "primary-key", userId = "user-id"))
+    private val exchangeAuthCode = SyncAuthCode.Exchange(InvitationCode(keyId = "key-id", publicKey = "public-key"))
 
     private val thisDevice = ConnectedDevice(
         thisDevice = true,
@@ -76,12 +84,14 @@ class ExchangeSyncCodeViewModelTest {
 
     private val accountRepository = mock<SyncAccountRepository>()
     private val codeDispatcher = mock<SyncCodeDispatcher>()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
 
     private fun createTestee() = ExchangeSyncCodeViewModel(
         syncUrl = "sync-url",
         originalFlow = OriginalFlow.SYNC_THIS_DEVICE,
         accountRepository = accountRepository,
         codeDispatcher = codeDispatcher,
+        syncFeature = syncFeature,
         dispatchers = coroutineTestRule.testDispatcherProvider,
     )
 
@@ -174,6 +184,219 @@ class ExchangeSyncCodeViewModelTest {
             assertIs<ShowV1Error>(command)
             assertEquals(R.string.sync_connect_login_error, command.content.message)
             assertEquals("boom", command.content.reason)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when processing a legacy exchange code succeeds then the recovery key is polled until login completes`() = runTest {
+        givenLegacyCode(exchangeAuthCode)
+        givenProcessCodeSucceeds()
+        givenThisConnectedDevice()
+        whenever(accountRepository.pollForRecoveryCodeAndLogin())
+            .thenReturn(Result.Success(ExchangeResult.Pending), Result.Success(ExchangeResult.LoggedIn))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+
+            testee.onAnimationComplete()
+            val command = awaitItem()
+            assertIs<SetPairingResult>(command)
+            assertEquals(
+                SyncPairingResult.Success(thisParcelableDevice, OriginalFlow.SYNC_THIS_DEVICE),
+                command.result,
+            )
+            assertIs<Close>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the exchange login completes then the screen does not close until the animation completes`() = runTest {
+        givenLegacyCode(exchangeAuthCode)
+        givenProcessCodeSucceeds()
+        givenThisConnectedDevice()
+        whenever(accountRepository.pollForRecoveryCodeAndLogin()).thenReturn(Result.Success(ExchangeResult.LoggedIn))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            expectNoEvents()
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when polling for the recovery key fails then a v1 error is shown`() = runTest {
+        givenLegacyCode(exchangeAuthCode)
+        givenProcessCodeSucceeds()
+        whenever(accountRepository.pollForRecoveryCodeAndLogin()).thenReturn(Result.Error(code = LOGIN_FAILED.code, reason = "boom"))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+
+            val command = awaitItem()
+            assertIs<ShowV1Error>(command)
+            assertEquals(R.string.sync_connect_login_error, command.content.message)
+            assertEquals("boom", command.content.reason)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when processing fails on an already signed in device and seamless switching is enabled then the user is asked to switch`() = runTest {
+        givenSeamlessAccountSwitching(enabled = true)
+        givenLegacyCode(recoveryAuthCode)
+        whenever(accountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code, reason = "boom"))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            assertEquals(AskSwitchAccount("sync-url"), awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when processing fails on an already signed in device and seamless switching is disabled then an error is shown`() = runTest {
+        givenSeamlessAccountSwitching(enabled = false)
+        givenLegacyCode(recoveryAuthCode)
+        whenever(accountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code, reason = "boom"))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+
+            val command = awaitItem()
+            assertIs<ShowV1Error>(command)
+            assertEquals(R.string.sync_login_authenticated_device_error, command.content.message)
+            assertEquals("boom", command.content.reason)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when polling fails on an already signed in device and seamless switching is enabled then the user is asked to switch`() = runTest {
+        givenSeamlessAccountSwitching(enabled = true)
+        givenLegacyCode(exchangeAuthCode)
+        givenProcessCodeSucceeds()
+        whenever(accountRepository.pollForRecoveryCodeAndLogin())
+            .thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code, reason = "boom"))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            assertEquals(AskSwitchAccount("sync-url"), awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when polling requires account switching then the user is asked to switch accounts`() = runTest {
+        givenLegacyCode(exchangeAuthCode)
+        givenProcessCodeSucceeds()
+        whenever(accountRepository.pollForRecoveryCodeAndLogin())
+            .thenReturn(Result.Success(ExchangeResult.AccountSwitchingRequired("encoded-code")))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            assertEquals(AskSwitchAccount("encoded-code"), awaitItem())
+            expectNoEvents()
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the user accepts switching accounts then the account is switched and a success result is set`() = runTest {
+        givenLegacyCode(exchangeAuthCode)
+        givenProcessCodeSucceeds()
+        givenThisConnectedDevice()
+        whenever(accountRepository.pollForRecoveryCodeAndLogin())
+            .thenReturn(Result.Success(ExchangeResult.AccountSwitchingRequired("encoded-code")))
+        whenever(accountRepository.logoutAndJoinNewAccount("encoded-code")).thenReturn(Result.Success(true))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            assertIs<AskSwitchAccount>(awaitItem())
+
+            testee.onAnimationComplete()
+            testee.onUserAcceptedSwitchingAccount("encoded-code")
+            val command = awaitItem()
+            assertIs<SetPairingResult>(command)
+            assertEquals(
+                SyncPairingResult.Success(thisParcelableDevice, OriginalFlow.SYNC_THIS_DEVICE),
+                command.result,
+            )
+            assertIs<Close>(awaitItem())
+
+            cancel()
+        }
+        verify(accountRepository).logoutAndJoinNewAccount("encoded-code")
+    }
+
+    @Test
+    fun `when switching accounts fails then a v1 error is shown`() = runTest {
+        givenLegacyCode(exchangeAuthCode)
+        givenProcessCodeSucceeds()
+        whenever(accountRepository.pollForRecoveryCodeAndLogin())
+            .thenReturn(Result.Success(ExchangeResult.AccountSwitchingRequired("encoded-code")))
+        whenever(accountRepository.logoutAndJoinNewAccount("encoded-code"))
+            .thenReturn(Result.Error(code = LOGIN_FAILED.code, reason = "boom"))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            assertIs<AskSwitchAccount>(awaitItem())
+
+            testee.onUserAcceptedSwitchingAccount("encoded-code")
+            val command = awaitItem()
+            assertIs<ShowV1Error>(command)
+            assertEquals(R.string.sync_connect_login_error, command.content.message)
+            assertEquals("boom", command.content.reason)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the user cancels switching accounts then the failure result is set and the screen closes`() = runTest {
+        givenLegacyCode(exchangeAuthCode)
+        givenProcessCodeSucceeds()
+        whenever(accountRepository.pollForRecoveryCodeAndLogin())
+            .thenReturn(Result.Success(ExchangeResult.AccountSwitchingRequired("encoded-code")))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            assertIs<AskSwitchAccount>(awaitItem())
+
+            testee.onUserCancelledSwitchingAccount()
+            val command = awaitItem()
+            assertIs<SetPairingResult>(command)
+            assertEquals(SyncPairingResult.Failure, command.result)
+            assertIs<Close>(awaitItem())
 
             cancel()
         }
@@ -467,6 +690,10 @@ class ExchangeSyncCodeViewModelTest {
 
     private fun givenLegacyCode(authCode: SyncAuthCode) {
         whenever(codeDispatcher.route(any())).thenReturn(RouteDecision.Legacy(authCode))
+    }
+
+    private fun givenSeamlessAccountSwitching(enabled: Boolean) {
+        syncFeature.seamlessAccountSwitching().setRawStoredState(State(enabled))
     }
 
     private fun givenV2Outcomes(vararg outcomes: DispatchOutcome) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1217053565470408
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1216509582049467
API Proposals URL(s) (if applicable): N/A

### Description

Completes v1 (legacy protocol) support for syncing with another device in the simplified sync flow. A signed-in device now displays the correct v1 code type for inviting another device, and a device that scans a v1 exchange invitation completes the sign-in instead of stalling. The legacy account switching behavior is also ported.

Displaying the code:
- When this device is already signed in to sync, the QR code screen now presents a v1 exchange invitation code and waits for the other device to join. Once it joins, the screen closes and reports a successful pairing. Previously the screen always presented a connect code, which is only valid for signed-out devices because it invites the peer's account onto this device and generating it overwrites the local account keys.
- If the `exchangeKeysToSyncWithAnotherDevice` feature flag is disabled, the recovery code is shown instead. Scanning it signs the other device in directly, and the displaying screen has no completion signal, matching the legacy screen.
- Signed-out devices keep showing the connect code as before, and the v2 protocol path is unchanged.

Scanning the code:
- Scanning a v1 exchange invitation now completes the sign-in. After the code is processed, the device polls for the recovery key sent back by the inviting device and.
- If the scanning device is already synced to a different account, a "Switch to a different Sync?" dialog is shown. "Switch Sync" leaves the current account and joins the inviting device's account. "Cancel" closes the screen without pairing.
- The same dialog replaces the error dialog whenever processing or polling a v1 code fails because the device is already signed in, as long as the `seamlessAccountSwitching` feature flag is enabled. Other failures show the existing v1 error dialog.

> [!WARNING]
> I could not verify the account switching path manually. I could not trigger the path at all. Even using the legacy Sync With Another Device screen following the steps from https://github.com/duckduckgo/Android/pull/5271. The behavior in this PR is a direct port of the legacy implementation, triggered under the same conditions, but there are no manual testing steps for it below.

### Steps to test this PR

> [!NOTE]
> All scenarios use the v1 protocol. Before testing, disable the `canUseV2ConnectFlow` and `canShowV2ConnectCode` feature flags on both devices so v1 codes are used.

_Sync with another device using a v1 exchange code_
- [ ] On device A, enable the `exchangeKeysToSyncWithAnotherDevice` feature flag.
- [ ] On device A, enable sync.
- [ ] On device A, open Sync Dev Settings.
- [ ] Tap "Launch Sync Settings V2".
- [ ] Tap "Sync With Another Device".
- [ ] Tap the QR code icon in the top bar.
- [ ] Verify a QR code is shown.
- [ ] On device B, with sync disabled, open Sync Dev Settings.
- [ ] Tap "Launch Sync Settings V2".
- [ ] Tap "Sync With Another Device".
- [ ] Scan device A's QR code.
- [ ] Verify device B plays the confirmation animation and joins device A's sync acc
- [ ] Verify the QR code screen on device A closes once device B has joined.

_Recovery code fallback_
- [ ] On device A, disable the `exchangeKeysToSyncWithAnotherDevice` feature flag.
- [ ] Open the QR code screen on device A again.
- [ ] Scan the code with device B.
- [ ] Verify device B signs in to device A's account.
- [ ] Verify the QR code screen on device A stays open until dismissed manually.

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync account pairing, login polling, and logout/switch-account paths in legacy v1 flows; mistakes could strand users on the wrong account or break multi-device pairing, though behavior mirrors the existing legacy implementation.
> 
> **Overview**
> Completes **v1 (legacy) protocol** support for “sync with another device” in the simplified sync UI.
> 
> **Showing a QR code (`DisplayQrCodeViewModel`):** Signed-in devices no longer always show a connect QR (which is wrong for signed-in state and can overwrite keys). They branch to **exchange invitation** polling when `exchangeKeysToSyncWithAnotherDevice` is on, or show a **recovery code** with no auto-close when that flag is off. Analytics use **`SYNC_EXCHANGE` vs `SYNC_CONNECT`** based on sign-in state.
> 
> **Scanning an exchange code (`ExchangeSyncCodeViewModel` + activity):** After processing a v1 **exchange** code, the app **polls for the recovery key** and finishes pairing instead of stalling. **Account switching** is ported: dialog on `AccountSwitchingRequired` or `ALREADY_SIGNED_IN` when `seamlessAccountSwitching` is enabled, with `logoutAndJoinNewAccount` on confirm.
> 
> Tests cover signed-in QR paths, exchange polling, switch-account flows, and pixel screen types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f0f581f04bf0aab9b318373c1ffe78132e7e3d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->