### PR TITLE
Enhance emulator setup and ADB reliability guidance for Android site breakage automated repro runs

### DIFF
--- a/.claude/skills/prepare-sbt-repro/SKILL.md
+++ b/.claude/skills/prepare-sbt-repro/SKILL.md
@@ -28,10 +28,10 @@ If the emulator crashes, disappears from ADB, or fails to capture screenshots, r
 ```sh
 emulator -avd ddg_pixel9_api35 -no-window -no-snapshot-save -no-boot-anim -gpu lavapipe
 ```
-Record the GPU mode used in the reproduction summary. Keep the proxy, URL, app package, and screenshot workflow unchanged between attempts.
+Record the GPU mode used in the required output. Keep the proxy, URL, app package, and screenshot workflow unchanged between attempts.
 
 ### ADB reliability
-- Wrap long or failure-prone ADB calls with `timeout`, especially `screencap`, `dumpsys`, `uiautomator`, and cleanup `adb shell` commands.
+- Wrap long or failure-prone ADB calls with `timeout`, especially `screencap`, `dumpsys`, `uiautomator`, and clean up `adb shell` commands.
 - If a retry starts another AVD, use explicit serial targeting for all later commands:
 ```sh
 adb -s <serial> ...
@@ -62,7 +62,6 @@ If screenshots are blocked by `Application Not Responding: com.google.android.ap
 adb shell input keyevent BACK
 adb shell am force-stop com.google.android.apps.nexuslauncher
 ```
-
 Then relaunch the URL activity and report the cleanup in the required output.
 
 ## Runtime configuration cleanup

--- a/.claude/skills/prepare-sbt-repro/SKILL.md
+++ b/.claude/skills/prepare-sbt-repro/SKILL.md
@@ -17,10 +17,24 @@ adb install -r android/app/build/outputs/apk/internal/debug/<apk-name>
 ## Emulator
 
 - Default to `ddg_pixel9_api35` as a known-good AVD.
-- Start headlessly:
+- Start headlessly with explicit software GPU rendering:
 
 ```sh
-emulator -avd ddg_pixel9_api35 -no-window -no-snapshot-save -no-boot-anim
+emulator -avd ddg_pixel9_api35 -no-window -no-snapshot-save -no-boot-anim -gpu swiftshader
+```
+
+If the emulator crashes, disappears from ADB, or fails to capture screenshots, retry once with:
+
+```sh
+emulator -avd ddg_pixel9_api35 -no-window -no-snapshot-save -no-boot-anim -gpu lavapipe
+```
+Record the GPU mode used in the reproduction summary. Keep the proxy, URL, app package, and screenshot workflow unchanged between attempts.
+
+### ADB reliability
+- Wrap long or failure-prone ADB calls with `timeout`, especially `screencap`, `dumpsys`, `uiautomator`, and cleanup `adb shell` commands.
+- If a retry starts another AVD, use explicit serial targeting for all later commands:
+```sh
+adb -s <serial> ...
 ```
 
 ## Load URL
@@ -36,11 +50,11 @@ adb shell am start -W -a android.intent.action.VIEW -d '<url>' com.duckduckgo.mo
 Prefer device-file screenshots; avoid `adb exec-out screencap -p` because it may hang.
 
 ```sh
-adb shell screencap -p /sdcard/before.png
-adb pull /sdcard/before.png /opt/cursor/artifacts/<dir>/before.png
+adb shell screencap -p /sdcard/screenshot_initial.png
+adb pull /sdcard/screenshot_initial.png /opt/cursor/artifacts/<dir>/screenshot_intial.png
 ```
 
-## System UI cleanup
+## System UI recovery
 
 If screenshots are blocked by `Application Not Responding: com.google.android.apps.nexuslauncher`, verify DDG is foreground/responsive first.
 
@@ -50,3 +64,10 @@ adb shell am force-stop com.google.android.apps.nexuslauncher
 ```
 
 Then relaunch the URL activity and report the cleanup in the required output.
+
+## Runtime configuration cleanup
+
+- Remove `/data/local/tmp/webview-command-line` from every AVD touched
+- Force-stop DDG, then stop emulators
+
+  

--- a/.claude/skills/prepare-sbt-repro/SKILL.md
+++ b/.claude/skills/prepare-sbt-repro/SKILL.md
@@ -51,7 +51,7 @@ Prefer device-file screenshots; avoid `adb exec-out screencap -p` because it may
 
 ```sh
 adb shell screencap -p /sdcard/screenshot_initial.png
-adb pull /sdcard/screenshot_initial.png /opt/cursor/artifacts/<dir>/screenshot_intial.png
+adb pull /sdcard/screenshot_initial.png /opt/cursor/artifacts/<dir>/screenshot_initial.png
 ```
 
 ## System UI recovery


### PR DESCRIPTION
Updated emulator instructions for headless operation with GPU options and added ADB reliability tips.

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217072935358636?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Emulator turns out to need a software-rendering flag in order to not crash when loading heavier sites

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
