### PR TITLE
Enable unified input maestro tests

### DIFF
--- a/.maestro/unified_input_screen/unified_input_open_duckai_back_to_ntp.yaml
+++ b/.maestro/unified_input_screen/unified_input_open_duckai_back_to_ntp.yaml
@@ -1,7 +1,7 @@
 appId: com.duckduckgo.mobile.android
 name: "UnifiedInput: open duck.ai via icon (AI off) and back to NTP × omnibar positions"
-# DISABLED: untagged so it is excluded from the tagged (unifiedInputTest) CI suite.
-tags: []
+tags:
+  - unifiedInputTest
 ---
 # 1/3 — omnibar top
 - retry:

--- a/.maestro/unified_input_screen/unified_input_with_seeded_favorites.yaml
+++ b/.maestro/unified_input_screen/unified_input_with_seeded_favorites.yaml
@@ -51,52 +51,50 @@ tags:
       - runFlow: shared/launch_and_skip_onboarding.yaml
       - runFlow: shared/assert_seeded_favorites_visible.yaml
 
-# DISABLED: combos with nativeInputToggle=true, inputWithAiToggle=false (AI off) are commented out below.
-#
-# # 4/6 — AI off, omnibar top
-# - retry:
-#     maxRetries: 3
-#     commands:
-#       - launchApp:
-#           clearState: true
-#           stopApp: true
-#           arguments:
-#             isMaestro: "true"
-#             nativeInputToggle: "true"
-#             inputWithAiToggle: "false"
-#             omnibarPosition: "top"
-#             addFavorites: "example.com;duckduckgo.com;privacytest.com"
-#       - runFlow: shared/launch_and_skip_onboarding.yaml
-#       - runFlow: shared/assert_seeded_favorites_visible.yaml
-#
-# # 5/6 — AI off, omnibar bottom
-# - retry:
-#     maxRetries: 3
-#     commands:
-#       - launchApp:
-#           clearState: true
-#           stopApp: true
-#           arguments:
-#             isMaestro: "true"
-#             nativeInputToggle: "true"
-#             inputWithAiToggle: "false"
-#             omnibarPosition: "bottom"
-#             addFavorites: "example.com;duckduckgo.com;privacytest.com"
-#       - runFlow: shared/launch_and_skip_onboarding.yaml
-#       - runFlow: shared/assert_seeded_favorites_visible.yaml
-#
-# # 6/6 — AI off, omnibar split
-# - retry:
-#     maxRetries: 3
-#     commands:
-#       - launchApp:
-#           clearState: true
-#           stopApp: true
-#           arguments:
-#             isMaestro: "true"
-#             nativeInputToggle: "true"
-#             inputWithAiToggle: "false"
-#             omnibarPosition: "split"
-#             addFavorites: "example.com;duckduckgo.com;privacytest.com"
-#       - runFlow: shared/launch_and_skip_onboarding.yaml
-#       - runFlow: shared/assert_seeded_favorites_visible.yaml
+# 4/6 — AI off, omnibar top
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
+          arguments:
+            isMaestro: "true"
+            nativeInputToggle: "true"
+            inputWithAiToggle: "false"
+            omnibarPosition: "top"
+            addFavorites: "example.com;duckduckgo.com;privacytest.com"
+      - runFlow: shared/launch_and_skip_onboarding.yaml
+      - runFlow: shared/assert_seeded_favorites_visible.yaml
+
+# 5/6 — AI off, omnibar bottom
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
+          arguments:
+            isMaestro: "true"
+            nativeInputToggle: "true"
+            inputWithAiToggle: "false"
+            omnibarPosition: "bottom"
+            addFavorites: "example.com;duckduckgo.com;privacytest.com"
+      - runFlow: shared/launch_and_skip_onboarding.yaml
+      - runFlow: shared/assert_seeded_favorites_visible.yaml
+
+# 6/6 — AI off, omnibar split
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
+          arguments:
+            isMaestro: "true"
+            nativeInputToggle: "true"
+            inputWithAiToggle: "false"
+            omnibarPosition: "split"
+            addFavorites: "example.com;duckduckgo.com;privacytest.com"
+      - runFlow: shared/launch_and_skip_onboarding.yaml
+      - runFlow: shared/assert_seeded_favorites_visible.yaml

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputSearchOnlyFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputSearchOnlyFeature.kt
@@ -31,6 +31,6 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 )
 interface NativeInputSearchOnlyFeature {
 
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun self(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216642253022048?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

Re-enables the unified-input e2e tests around the search-only (AI-off) address bar that were disabled to unblock releases while the search-only native input was incomplete. That path is now in place, so they pass again; also turns the feature on for internal builds so the tests actually exercise it.

Re-enabled
- `unified_input_open_duckai_back_to_ntp.yaml`  restored the unifiedInputTest tag. Covers AI-off → open Duck.ai via the in-field icon → back to NTP, across top/bottom/split.
- `unified_input_with_seeded_favorites.yaml` restored the three AI-off combos (top/bottom/split, inputWithAiToggle=false) that were commented out. Confirms seeded favourites render on the NTP in search-only mode.

### Steps to test this PR
- Ran `maestro test .maestro/unified_input_screen --include-tags unifiedInputTest` locally and verified all tests pass

FOr a more focused test, you can run the updated tests only:

```
maestro test \
    .maestro/unified_input_screen/unified_input_open_duckai_back_to_ntp.yaml \
    .maestro/unified_input_screen/unified_input_with_seeded_favorites.yaml
```

### UI changes

Pure tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a remote feature default for omnibar behavior on internal builds; production default behavior for external users is unchanged if INTERNAL only applies to internal channels, but misconfiguration could affect search-only UX broadly.
> 
> **Overview**
> Re-enables unified input Maestro coverage in CI by tagging flows with **`unifiedInputTest`** (previously untagged and excluded) and restoring the **AI-off × omnibar** seeded-favorites scenarios that were commented out.
> 
> Changes **`NativeInputSearchOnlyFeature`** default from **`FALSE`** to **`INTERNAL`** so internal builds use the native omnibar in search-only mode (Duck.ai off)—matching what those Maestro launches assert with `inputWithAiToggle: "false"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab51f1736346f31e11faa1e5f3e2357dbc19f31f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->