### PR TITLE
Sync: Write & verify device_info via dev settings

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoPrivateKeyProvider.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoPrivateKeyProvider.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import android.util.Base64
+import androidx.annotation.WorkerThread
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.store.SyncStore
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+/**
+ * Supplies the account's `account_info` private key, unwrapped for the current credential and
+ * encoded as base64url PKCS#8.
+ */
+@WorkerThread
+interface AccountInfoPrivateKeyProvider {
+    fun privateKey(): Result<String>
+}
+
+@ContributesBinding(AppScope::class)
+class RealAccountInfoPrivateKeyProvider @Inject constructor(
+    private val syncStore: SyncStore,
+    private val syncApi: SyncApi,
+    private val protectedKeyUnwrapper: ProtectedKeyUnwrapper,
+) : AccountInfoPrivateKeyProvider {
+
+    override fun privateKey(): Result<String> {
+        val token = syncStore.token.takeUnless { it.isNullOrEmpty() }
+            ?: return Error(reason = "AccountInfoPrivateKey: not signed in")
+        val credentialId = syncStore.credentialId ?: CREDENTIAL_ID_DDG
+
+        val entry = when (val result = syncApi.getProtectedKeys(token)) {
+            is Success -> result.data.firstOrNull { it.purpose == SYNC_PURPOSE_ACCOUNT_INFO && it.encryptedWith == credentialId }
+                ?: return Error(reason = "AccountInfoPrivateKey: no account_info key wrapped for credential=$credentialId")
+            is Error -> return result
+        }
+
+        val rawKeyBytes = when (val result = protectedKeyUnwrapper.unwrap(entry)) {
+            is Success -> result.data
+            is Error -> return result
+        }
+
+        return Success(Base64.encodeToString(rawKeyBytes, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP))
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceFieldDecryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceFieldDecryptor.kt
@@ -22,7 +22,6 @@ import com.duckduckgo.sync.crypto.SyncLib
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
-import dagger.SingleInstanceIn
 import javax.inject.Inject
 
 /**
@@ -40,7 +39,6 @@ data class DecryptedDevice(
     val type: String?,
 )
 
-@SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealDeviceFieldDecryptor @Inject constructor(
     private val syncStore: SyncStore,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceFieldEncryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceFieldEncryptor.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.annotation.WorkerThread
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.store.SyncStore
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+/**
+ * Encrypts the legacy `name`/`type` device fields for the current device's credential — the inverse
+ * of [DeviceFieldDecryptor], so the values stay readable by clients that don't understand
+ * `device_info` yet. 3party encrypts under a main encryption key derived from the scoped password;
+ * ddg/null encrypts with the local primary key.
+ */
+@WorkerThread
+interface DeviceFieldEncryptor {
+    fun encrypt(name: String, type: String): Result<EncryptedDeviceFields>
+}
+
+data class EncryptedDeviceFields(
+    val name: String,
+    val type: String,
+)
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealDeviceFieldEncryptor @Inject constructor(
+    private val syncStore: SyncStore,
+    private val syncJweCrypto: SyncJweCrypto,
+    private val nativeLib: SyncLib,
+) : DeviceFieldEncryptor {
+
+    override fun encrypt(name: String, type: String): Result<EncryptedDeviceFields> {
+        return when (syncStore.credentialId) {
+            CREDENTIAL_ID_3PARTY -> encryptThirdParty(name, type)
+            CREDENTIAL_ID_DDG, null -> encryptDdg(name, type)
+            else -> Error(reason = "DeviceFieldEncryptor: unknown credential_id=${syncStore.credentialId}")
+        }
+    }
+
+    private fun encryptDdg(name: String, type: String): Result<EncryptedDeviceFields> {
+        val primaryKey = syncStore.primaryKey?.takeUnless { it.isEmpty() }
+            ?: return Error(reason = "DeviceFieldEncryptor: primaryKey missing")
+        return runCatching {
+            val encryptedName = nativeLib.encryptData(name, primaryKey).also {
+                it.checkResult("DeviceFieldEncryptor: ddg name encrypt failed")
+            }.encryptedData
+            val encryptedType = nativeLib.encryptData(type, primaryKey).also {
+                it.checkResult("DeviceFieldEncryptor: ddg type encrypt failed")
+            }.encryptedData
+            Success(EncryptedDeviceFields(encryptedName, encryptedType))
+        }.getOrElse { it.asLoggedError("DeviceFieldEncryptor: ddg encrypt failed") }
+    }
+
+    private fun encryptThirdParty(name: String, type: String): Result<EncryptedDeviceFields> {
+        val scopedPassword = syncStore.scopedPassword?.raw ?: return Error(reason = "DeviceFieldEncryptor: scopedPassword missing")
+        val userId = syncStore.userId ?: return Error(reason = "DeviceFieldEncryptor: userId missing")
+        return runCatching {
+            val mainEncryptionKey = syncJweCrypto.hkdfDeriveBytes(
+                scopedPassword,
+                userId.toByteArray(Charsets.UTF_8),
+                HKDF_INFO_MAIN_ENCRYPTION_KEY,
+                MAIN_ENCRYPTION_KEY_LENGTH_BYTES,
+            )
+            val encryptedName = syncJweCrypto.jweEncryptSymmetric(name.toByteArray(Charsets.UTF_8), mainEncryptionKey)
+            val encryptedType = syncJweCrypto.jweEncryptSymmetric(type.toByteArray(Charsets.UTF_8), mainEncryptionKey)
+            Success(EncryptedDeviceFields(encryptedName, encryptedType))
+        }.getOrElse { it.asLoggedError("DeviceFieldEncryptor: 3party encrypt failed") }
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceFieldEncryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceFieldEncryptor.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
-import dagger.SingleInstanceIn
 import javax.inject.Inject
 
 /**
@@ -43,7 +42,6 @@ data class EncryptedDeviceFields(
     val type: String,
 )
 
-@SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealDeviceFieldEncryptor @Inject constructor(
     private val syncStore: SyncStore,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoDecryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoDecryptor.kt
@@ -35,6 +35,7 @@ interface DeviceInfoDecryptor {
     fun openSession(): Result<Session>
 
     /** Decrypts `device_info` blobs with a private key held only for this session's lifetime. */
+    @WorkerThread
     interface Session {
         fun decrypt(deviceInfoJwe: String): Result<DeviceInfoPayload>
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoDecryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoDecryptor.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.annotation.WorkerThread
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+/**
+ * Recovers [DeviceInfoPayload]s from `device_info` JWEs using the account's `account_info` private key.
+ *
+ * The private key is fetched and unwrapped once per [openSession];
+ * reuse the returned [Session] to decrypt every blob from a device list off that single fetch.
+ */
+@WorkerThread
+interface DeviceInfoDecryptor {
+    fun openSession(): Result<Session>
+
+    /** Decrypts `device_info` blobs with a private key held only for this session's lifetime. */
+    interface Session {
+        fun decrypt(deviceInfoJwe: String): Result<DeviceInfoPayload>
+    }
+}
+
+@ContributesBinding(AppScope::class)
+class RealDeviceInfoDecryptor @Inject constructor(
+    private val accountInfoPrivateKeyProvider: AccountInfoPrivateKeyProvider,
+    private val syncJweCrypto: SyncJweCrypto,
+) : DeviceInfoDecryptor {
+
+    override fun openSession(): Result<DeviceInfoDecryptor.Session> =
+        when (val result = accountInfoPrivateKeyProvider.privateKey()) {
+            is Success -> Success(RealSession(privateKeyBase64Url = result.data, syncJweCrypto = syncJweCrypto))
+            is Error -> result
+        }
+
+    private class RealSession(
+        private val privateKeyBase64Url: String,
+        private val syncJweCrypto: SyncJweCrypto,
+    ) : DeviceInfoDecryptor.Session {
+        override fun decrypt(deviceInfoJwe: String): Result<DeviceInfoPayload> = runCatching {
+            val plaintext = String(syncJweCrypto.jweDecryptRsaOaep(deviceInfoJwe, privateKeyBase64Url), Charsets.UTF_8)
+            val payload = DeviceInfoPayload.fromJson(plaintext)
+                ?: return Error(reason = "DeviceInfoDecryptor: device_info payload could not be parsed")
+            Success(payload.copy(type = payload.type?.takeUnless { it.isEmpty() }))
+        }.getOrElse { it.asLoggedError("DeviceInfoDecryptor: failed to decrypt device_info") }
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoEncryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoEncryptor.kt
@@ -26,7 +26,6 @@ import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.Json
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import dagger.SingleInstanceIn
 import logcat.logcat
 import javax.inject.Inject
 
@@ -57,7 +56,6 @@ data class DeviceInfoPayload(
     }
 }
 
-@SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealDeviceInfoEncryptor @Inject constructor(
     private val syncStore: SyncStore,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoEncryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoEncryptor.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.annotation.WorkerThread
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.store.SyncStore
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.Json
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dagger.SingleInstanceIn
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * Produces the cross-credential `device_info` blob:
+ * a JWE of a [DeviceInfoPayload] under the account's `account_info` public key (RSA-OAEP-256 + A256GCM)
+ */
+@WorkerThread
+interface DeviceInfoEncryptor {
+    fun encrypt(name: String, type: String): Result<String>
+}
+
+/**
+ * The plaintext `device_info` shape
+ */
+data class DeviceInfoPayload(
+    @field:Json(name = "name") val name: String,
+    @field:Json(name = "type") val type: String? = null,
+) {
+    companion object {
+        private val adapter by lazy {
+            Moshi.Builder().add(KotlinJsonAdapterFactory()).build().adapter(DeviceInfoPayload::class.java)
+        }
+
+        fun toJson(payload: DeviceInfoPayload): String = adapter.toJson(payload)
+
+        fun fromJson(json: String): DeviceInfoPayload? = adapter.fromJson(json)
+    }
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealDeviceInfoEncryptor @Inject constructor(
+    private val syncStore: SyncStore,
+    private val syncJweCrypto: SyncJweCrypto,
+) : DeviceInfoEncryptor {
+
+    override fun encrypt(name: String, type: String): Result<String> {
+        val publicKey = syncStore.accountInfoPublicKey
+            ?: return Error(reason = "DeviceInfoEncryptor: no cached account_info key")
+
+        return runCatching {
+            val plaintext = DeviceInfoPayload.toJson(DeviceInfoPayload(name = name, type = type)).toByteArray(Charsets.UTF_8)
+
+            // Cached keys are stored as JWK n/e; the encrypter wants SPKI
+            val recipientPublicKey = syncJweCrypto.rsaSpkiFromJwkComponents(publicKey.modulus, publicKey.exponent)
+            val jwe = syncJweCrypto.jweEncryptRsaOaep(plaintext, recipientPublicKey, kid = publicKey.keyId)
+            if (jwe.length > MAX_DEVICE_INFO_CHARS) {
+                return Error(reason = "DeviceInfoEncryptor: device_info is ${jwe.length} chars, over the $MAX_DEVICE_INFO_CHARS limit")
+            }
+            logcat { "Sync-UnifiedDevices: encrypted device_info (${jwe.length} chars, kid=${publicKey.keyId})" }
+            Success(jwe)
+        }.getOrElse { it.asLoggedError("DeviceInfoEncryptor: failed to encrypt device_info") }
+    }
+
+    companion object {
+        private const val MAX_DEVICE_INFO_CHARS = 2000
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoUpdater.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoUpdater.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.annotation.WorkerThread
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.store.SyncStore
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+/**
+ * Publishes this device's name to the server. Writes the cross-credential `device_info` blob and
+ * the per-credential `name`/`type` fields in the same request, so clients that don't read `device_info` yet still see the new name.
+ */
+@WorkerThread
+interface DeviceInfoUpdater {
+    /** Returns the server's device list as it stands after the update. */
+    fun updateThisDevice(name: String): Result<List<DeviceV2>>
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealDeviceInfoUpdater @Inject constructor(
+    private val syncStore: SyncStore,
+    private val syncApi: SyncApi,
+    private val syncDeviceIds: SyncDeviceIds,
+    private val deviceInfoEncryptor: DeviceInfoEncryptor,
+    private val deviceFieldEncryptor: DeviceFieldEncryptor,
+) : DeviceInfoUpdater {
+
+    override fun updateThisDevice(name: String): Result<List<DeviceV2>> {
+        val token = syncStore.token.takeUnless { it.isNullOrEmpty() }
+            ?: return Error(reason = "UpdateDeviceInfo: not signed in")
+        val type = syncDeviceIds.deviceType().deviceFactor
+
+        val deviceInfo = when (val result = deviceInfoEncryptor.encrypt(name, type)) {
+            is Success -> result.data
+            is Error -> return result
+        }
+        val legacyFields = when (val result = deviceFieldEncryptor.encrypt(name, type)) {
+            is Success -> result.data
+            is Error -> return result
+        }
+
+        return when (
+            val result = syncApi.patchThisDevice(
+                token = token,
+                encryptedName = legacyFields.name,
+                encryptedType = legacyFields.type,
+                deviceInfo = deviceInfo,
+            )
+        ) {
+            is Success -> Success(result.data.devicesV2)
+            is Error -> result
+        }
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
@@ -61,6 +61,12 @@ interface SyncService {
         @Header("Authorization") token: String,
     ): Call<DeviceResponse>
 
+    @PATCH("$SYNC_PROD_ENVIRONMENT_URL/sync/devices")
+    fun patchDevices(
+        @Header("Authorization") token: String,
+        @Body request: PatchDevicesRequest,
+    ): Call<PatchDevicesResponse>
+
     @POST("$SYNC_PROD_ENVIRONMENT_URL/sync/connect")
     fun connect(
         @Header("Authorization") token: String,
@@ -257,13 +263,38 @@ data class Device(
     @field:Json(name = "jw_iat") val jwIat: String,
 )
 
-// `name` and `type` are encrypted with the credential in `credentialId`.
+/**
+ * `name` and `type` are encrypted with the credential in `credentialId`
+ * `info` is the cross-credential `device_info` JWE (encrypted under the account_info key).
+ */
 data class DeviceV2(
     @field:Json(name = "id") val deviceId: String? = null,
     @field:Json(name = "name") val deviceName: String? = null,
     @field:Json(name = "type") val deviceType: String? = null,
+    @field:Json(name = "info") val deviceInfo: String? = null,
     @field:Json(name = "jw_iat") val jwIat: String? = null,
     @field:Json(name = "credential_id") val credentialId: String? = null,
+)
+
+/** Request body for PATCH /sync/devices. Exactly one [DeviceUpdate], targeting the current device. */
+data class PatchDevicesRequest(
+    val updates: List<DeviceUpdate>,
+)
+
+/**
+ * A single device update. [id] must be the current device id.
+ * A null field is left unchanged, except [info], which the server clears when it is omitted, so always send the current value.
+ */
+data class DeviceUpdate(
+    @field:Json(name = "id") val id: String,
+    @field:Json(name = "name") val name: String? = null,
+    @field:Json(name = "type") val type: String? = null,
+    @field:Json(name = "info") val info: String? = null,
+)
+
+data class PatchDevicesResponse(
+    val devices: List<Device> = emptyList(),
+    @field:Json(name = "devices_v2") val devicesV2: List<DeviceV2> = emptyList(),
 )
 
 data class ErrorResponse(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -76,6 +76,18 @@ interface SyncApi {
 
     fun getDevices(token: String): Result<DeviceEntries>
 
+    /**
+     * Update this device's `name`, `type` and `info`. All three fields are sent every time — the server clears `info` when it is omitted.
+     *
+     * Returns the server's post-update device list.
+     */
+    fun patchThisDevice(
+        token: String,
+        encryptedName: String,
+        encryptedType: String,
+        deviceInfo: String,
+    ): Result<PatchDevicesResponse>
+
     fun getBookmarks(
         token: String,
         since: String,
@@ -250,6 +262,29 @@ class SyncServiceRemote @Inject constructor(
         return onSuccess(response) {
             val devices = response.body()?.devices ?: return@onSuccess Result.Error(reason = "getDevices: empty body")
             Result.Success(devices)
+        }
+    }
+
+    override fun patchThisDevice(
+        token: String,
+        encryptedName: String,
+        encryptedType: String,
+        deviceInfo: String,
+    ): Result<PatchDevicesResponse> {
+        val deviceId = syncStore.deviceId.takeUnless { it.isNullOrEmpty() }
+            ?: return Result.Error(reason = "PatchDevices: no device id")
+
+        val response = runCatching {
+            val update = DeviceUpdate(id = deviceId, name = encryptedName, type = encryptedType, info = deviceInfo)
+            syncService.patchDevices("Bearer $token", PatchDevicesRequest(listOf(update))).execute()
+        }.getOrElse { throwable ->
+            return Result.Error(reason = throwable.message.toString())
+        }
+
+        return onSuccess(response) {
+            val body = response.body() ?: return@onSuccess Result.Error(reason = "PatchDevices: empty body")
+            logcat(INFO) { "Sync-UnifiedDevices: patchDevices ok — ${body.devicesV2.size} devices_v2 returned" }
+            Result.Success(body)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptor.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.sync.impl
 
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
-import dagger.SingleInstanceIn
 import logcat.LogPriority.WARN
 import logcat.logcat
 import javax.inject.Inject
@@ -46,7 +45,6 @@ data class DecryptAllResult(
     val undecryptable: List<String>,
 )
 
-@SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealThirdPartyDeviceListDecryptor @Inject constructor(
     private val deviceFieldDecryptor: DeviceFieldDecryptor,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/crypto/SyncJweCrypto.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/crypto/SyncJweCrypto.kt
@@ -21,6 +21,7 @@ import com.squareup.anvil.annotations.ContributesBinding
 import io.jsonwebtoken.Jwts
 import logcat.logcat
 import org.json.JSONObject
+import java.math.BigInteger
 import java.security.KeyFactory
 import java.security.KeyPair
 import java.security.KeyPairGenerator
@@ -30,6 +31,7 @@ import java.security.SecureRandom
 import java.security.interfaces.RSAPublicKey
 import java.security.spec.MGF1ParameterSpec
 import java.security.spec.PKCS8EncodedKeySpec
+import java.security.spec.RSAPublicKeySpec
 import java.security.spec.X509EncodedKeySpec
 import java.util.Base64
 import javax.crypto.Cipher
@@ -78,6 +80,13 @@ interface SyncJweCrypto {
      * Returns them as base64url strings ready for use in a JWK.
      */
     fun extractJwkComponents(publicKeyBase64: String): Pair<String, String>
+
+    /**
+     * Build a base64url SPKI-DER public key from RSA JWK components — modulus [n] and exponent [e],
+     * both base64url. The inverse of [extractJwkComponents], so a cached JWK public key can be fed
+     * straight into [jweEncryptRsaOaep].
+     */
+    fun rsaSpkiFromJwkComponents(n: String, e: String): String
 
     /**
      * HKDF-SHA-256 (RFC 5869), restricted to a single HKDF-Expand block ([outBytes] in 1..32).
@@ -208,6 +217,13 @@ class RealSyncJweCrypto @Inject constructor() : SyncJweCrypto {
         val nBytes = rsaPublicKey.modulus.toByteArray().dropLeadingZero()
         val eBytes = rsaPublicKey.publicExponent.toByteArray().dropLeadingZero()
         return b64UrlEncode(nBytes) to b64UrlEncode(eBytes)
+    }
+
+    override fun rsaSpkiFromJwkComponents(n: String, e: String): String {
+        val modulus = BigInteger(1, b64UrlDecode(n))
+        val exponent = BigInteger(1, b64UrlDecode(e))
+        val publicKey = KeyFactory.getInstance("RSA").generatePublic(RSAPublicKeySpec(modulus, exponent))
+        return b64UrlEncode(publicKey.encoded)
     }
 
     /**

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncGzipInterceptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncGzipInterceptor.kt
@@ -54,8 +54,11 @@ class SyncGzipInterceptor @Inject constructor(
             return chain.proceed(chain.request())
         }
 
+        // The /sync/devices endpoint rejects gzip bodies as invalid_json, so skip compression here until the backend supports it.
+        val isDevicesEndpoint = chain.request().url.encodedPath.endsWith("/sync/devices")
+
         // check if it's http operation is PATCH
-        if (chain.request().method == "PATCH" && syncFeature.gzipPatchRequests().isEnabled()) {
+        if (chain.request().method == "PATCH" && !isDevicesEndpoint && syncFeature.gzipPatchRequests().isEnabled()) {
             kotlin.runCatching {
                 val originalRequest = chain.request()
                 val body = originalRequest.body ?: return chain.proceed(originalRequest)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoPrivateKeyProviderTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoPrivateKeyProviderTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.sync.TestSyncFixtures.token
+import com.duckduckgo.sync.store.SyncStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class AccountInfoPrivateKeyProviderTest {
+
+    private val syncStore: SyncStore = mock()
+    private val syncApi: SyncApi = mock()
+    private val protectedKeyUnwrapper: ProtectedKeyUnwrapper = mock()
+    private val provider = RealAccountInfoPrivateKeyProvider(syncStore, syncApi, protectedKeyUnwrapper)
+
+    private val ddgKey = ProtectedKeyEntry(
+        kid = "kid-1",
+        purpose = "account_info",
+        encryptedWith = "ddg",
+        encryptedPrivateKey = "AAAA",
+        publicKey = RsaJwk(n = "n", e = "AQAB"),
+    )
+
+    @Test
+    fun whenKeyIsWrappedForCurrentCredentialThenReturnItBase64UrlEncoded() {
+        stubSignedIn()
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Result.Success(listOf(ddgKey)))
+        whenever(protectedKeyUnwrapper.unwrap(ddgKey)).thenReturn(Result.Success(byteArrayOf(-5, -16, 0)))
+
+        val result = provider.privateKey()
+
+        // base64url of {0xFB, 0xF0, 0x00}, unpadded — "+" and "/" would appear in standard base64.
+        assertEquals(Result.Success("-_AA"), result)
+    }
+
+    @Test
+    fun whenNotSignedInThenErrorWithoutFetching() {
+        whenever(syncStore.token).thenReturn(null)
+
+        assertTrue(provider.privateKey() is Result.Error)
+        verify(syncApi, never()).getProtectedKeys(any())
+    }
+
+    @Test
+    fun whenNoKeyWrappedForCurrentCredentialThenError() {
+        stubSignedIn()
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Result.Success(listOf(ddgKey.copy(encryptedWith = "3party"))))
+
+        assertTrue(provider.privateKey() is Result.Error)
+    }
+
+    @Test
+    fun whenUnwrapFailsThenError() {
+        stubSignedIn()
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Result.Success(listOf(ddgKey)))
+        whenever(protectedKeyUnwrapper.unwrap(ddgKey)).thenReturn(Result.Error(reason = "no account secret key"))
+
+        assertTrue(provider.privateKey() is Result.Error)
+    }
+
+    private fun stubSignedIn() {
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.credentialId).thenReturn("ddg")
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceFieldEncryptorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceFieldEncryptorTest.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.sync.crypto.EncryptResult
+import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.store.ScopedPassword
+import com.duckduckgo.sync.store.SyncStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class DeviceFieldEncryptorTest {
+
+    private val syncStore: SyncStore = mock()
+    private val syncJweCrypto: SyncJweCrypto = mock()
+    private val nativeLib: SyncLib = mock()
+
+    private lateinit var encryptor: DeviceFieldEncryptor
+
+    // Valid standard-base64 string so hkdfDeriveBytes' inner Base64.decode doesn't throw.
+    private val spBase64 = "AAECAwQFBgcICQoLDA0ODw=="
+    private val userId = "user-42"
+    private val primaryKey = "primaryKeyBase64"
+
+    @Before
+    fun before() {
+        encryptor = RealDeviceFieldEncryptor(syncStore, syncJweCrypto, nativeLib)
+    }
+
+    // ---------- 3party path ----------
+
+    @Test
+    fun whenThirdPartyWithValidSpAndUserIdThenEncryptsNameAndTypeUnderMek() {
+        whenever(syncStore.credentialId).thenReturn("3party")
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword(spBase64))
+        whenever(syncStore.userId).thenReturn(userId)
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), eq("Main Key"), eq(32))).thenReturn(ByteArray(32))
+        whenever(syncJweCrypto.jweEncryptSymmetric(any(), any(), anyOrNull())).thenAnswer {
+            "enc-" + String(it.getArgument(0), Charsets.UTF_8)
+        }
+
+        val result = encryptor.encrypt("My Phone", "phone")
+
+        assertEquals(Success(EncryptedDeviceFields(name = "enc-My Phone", type = "enc-phone")), result)
+    }
+
+    @Test
+    fun whenThirdPartyAndScopedPasswordMissingThenError() {
+        whenever(syncStore.credentialId).thenReturn("3party")
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncStore.userId).thenReturn(userId)
+
+        val result = encryptor.encrypt("My Phone", "phone")
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenThirdPartyAndUserIdMissingThenError() {
+        whenever(syncStore.credentialId).thenReturn("3party")
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword(spBase64))
+        whenever(syncStore.userId).thenReturn(null)
+
+        val result = encryptor.encrypt("My Phone", "phone")
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenThirdPartyEncryptThrowsThenError() {
+        whenever(syncStore.credentialId).thenReturn("3party")
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword(spBase64))
+        whenever(syncStore.userId).thenReturn(userId)
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), any(), any())).thenReturn(ByteArray(32))
+        whenever(syncJweCrypto.jweEncryptSymmetric(any(), any(), anyOrNull())).thenThrow(RuntimeException("boom"))
+
+        val result = encryptor.encrypt("My Phone", "phone")
+
+        assertTrue(result is Error)
+    }
+
+    // ---------- ddg path ----------
+
+    @Test
+    fun whenDdgWithValidPrimaryKeyThenEncryptsNameAndType() {
+        whenever(syncStore.credentialId).thenReturn("ddg")
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(nativeLib.encryptData(eq("My Phone"), eq(primaryKey))).thenReturn(EncryptResult(0, "enc-name"))
+        whenever(nativeLib.encryptData(eq("phone"), eq(primaryKey))).thenReturn(EncryptResult(0, "enc-type"))
+
+        val result = encryptor.encrypt("My Phone", "phone")
+
+        assertEquals(Success(EncryptedDeviceFields(name = "enc-name", type = "enc-type")), result)
+    }
+
+    @Test
+    fun whenCredentialIdIsNullThenRoutesToDdgPath() {
+        whenever(syncStore.credentialId).thenReturn(null)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(nativeLib.encryptData(eq("My Phone"), eq(primaryKey))).thenReturn(EncryptResult(0, "enc-name"))
+        whenever(nativeLib.encryptData(eq("phone"), eq(primaryKey))).thenReturn(EncryptResult(0, "enc-type"))
+
+        val result = encryptor.encrypt("My Phone", "phone")
+
+        assertEquals(Success(EncryptedDeviceFields(name = "enc-name", type = "enc-type")), result)
+    }
+
+    @Test
+    fun whenDdgAndPrimaryKeyMissingThenError() {
+        whenever(syncStore.credentialId).thenReturn("ddg")
+        whenever(syncStore.primaryKey).thenReturn(null)
+
+        val result = encryptor.encrypt("My Phone", "phone")
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenDdgAndPrimaryKeyIsEmptyThenError() {
+        whenever(syncStore.credentialId).thenReturn("ddg")
+        whenever(syncStore.primaryKey).thenReturn("")
+
+        val result = encryptor.encrypt("My Phone", "phone")
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenDdgEncryptReturnsNonZeroResultThenError() {
+        whenever(syncStore.credentialId).thenReturn("ddg")
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(nativeLib.encryptData(eq("My Phone"), eq(primaryKey))).thenReturn(EncryptResult(1, "not encrypted"))
+
+        val result = encryptor.encrypt("My Phone", "phone")
+
+        assertTrue(result is Error)
+    }
+
+    // ---------- generic ----------
+
+    @Test
+    fun whenCredentialIdIsUnknownThenError() {
+        whenever(syncStore.credentialId).thenReturn("magic")
+
+        val result = encryptor.encrypt("My Phone", "phone")
+
+        assertTrue(result is Error)
+        // Sanity: didn't try to encrypt with either path.
+        verify(nativeLib, never()).encryptData(any<String>(), any())
+        verify(syncJweCrypto, never()).jweEncryptSymmetric(any(), any(), anyOrNull())
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoDecryptorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoDecryptorTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class DeviceInfoDecryptorTest {
+
+    private val accountInfoPrivateKeyProvider: AccountInfoPrivateKeyProvider = mock()
+    private val syncJweCrypto: SyncJweCrypto = mock()
+    private val decryptor = RealDeviceInfoDecryptor(accountInfoPrivateKeyProvider, syncJweCrypto)
+
+    @Test
+    fun whenBlobDecryptsThenReturnNameAndType() {
+        whenever(accountInfoPrivateKeyProvider.privateKey()).thenReturn(Result.Success("private-key"))
+        whenever(syncJweCrypto.jweDecryptRsaOaep("device.info.jwe", "private-key"))
+            .thenReturn("""{"name":"My Phone","type":"phone"}""".toByteArray(Charsets.UTF_8))
+
+        val result = openSessionAndDecrypt("device.info.jwe")
+
+        assertEquals(Result.Success(DeviceInfoPayload(name = "My Phone", type = "phone")), result)
+    }
+
+    @Test
+    fun whenTypeIsEmptyThenReturnNullType() {
+        whenever(accountInfoPrivateKeyProvider.privateKey()).thenReturn(Result.Success("private-key"))
+        whenever(syncJweCrypto.jweDecryptRsaOaep(any(), any()))
+            .thenReturn("""{"name":"My Phone","type":""}""".toByteArray(Charsets.UTF_8))
+
+        val result = openSessionAndDecrypt("device.info.jwe")
+
+        assertEquals(Result.Success(DeviceInfoPayload(name = "My Phone", type = null)), result)
+    }
+
+    @Test
+    fun whenPrivateKeyUnavailableThenOpenSessionErrorsWithoutDecrypting() {
+        whenever(accountInfoPrivateKeyProvider.privateKey()).thenReturn(Result.Error(reason = "not signed in"))
+
+        assertTrue(decryptor.openSession() is Result.Error)
+        verify(syncJweCrypto, never()).jweDecryptRsaOaep(any(), any())
+    }
+
+    @Test
+    fun whenBlobCannotBeDecryptedThenReturnError() {
+        whenever(accountInfoPrivateKeyProvider.privateKey()).thenReturn(Result.Success("private-key"))
+        whenever(syncJweCrypto.jweDecryptRsaOaep(eq("device.info.jwe"), any())).thenThrow(RuntimeException("bad tag"))
+
+        assertTrue(openSessionAndDecrypt("device.info.jwe") is Result.Error)
+    }
+
+    @Test
+    fun whenPayloadIsNotValidJsonThenReturnError() {
+        whenever(accountInfoPrivateKeyProvider.privateKey()).thenReturn(Result.Success("private-key"))
+        whenever(syncJweCrypto.jweDecryptRsaOaep(any(), any())).thenReturn("{ malformed".toByteArray(Charsets.UTF_8))
+
+        assertTrue(openSessionAndDecrypt("device.info.jwe") is Result.Error)
+    }
+
+    @Test
+    fun whenSessionDecryptsManyBlobsThenPrivateKeyFetchedOnce() {
+        whenever(accountInfoPrivateKeyProvider.privateKey()).thenReturn(Result.Success("private-key"))
+        whenever(syncJweCrypto.jweDecryptRsaOaep(any(), any()))
+            .thenReturn("""{"name":"n","type":"phone"}""".toByteArray(Charsets.UTF_8))
+
+        val session = (decryptor.openSession() as Result.Success).data
+        session.decrypt("a")
+        session.decrypt("b")
+        session.decrypt("c")
+
+        verify(accountInfoPrivateKeyProvider, times(1)).privateKey()
+    }
+
+    private fun openSessionAndDecrypt(deviceInfoJwe: String): Result<DeviceInfoPayload> =
+        when (val session = decryptor.openSession()) {
+            is Result.Success -> session.data.decrypt(deviceInfoJwe)
+            is Result.Error -> session
+        }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoEncryptorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoEncryptorTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.store.AccountInfoPublicKey
+import com.duckduckgo.sync.store.SyncStore
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class DeviceInfoEncryptorTest {
+
+    private val syncStore: SyncStore = mock()
+    private val syncJweCrypto: SyncJweCrypto = mock()
+    private val encryptor = RealDeviceInfoEncryptor(syncStore, syncJweCrypto)
+
+    @Test
+    fun whenNoCachedAccountInfoKeyThenReturnError() {
+        whenever(syncStore.accountInfoPublicKey).thenReturn(null)
+
+        val result = encryptor.encrypt("My Phone", "phone")
+
+        assertTrue(result is Result.Error)
+    }
+
+    @Test
+    fun whenKeyPresentThenEncryptsNameTypeJsonWithKid() {
+        whenever(syncStore.accountInfoPublicKey).thenReturn(AccountInfoPublicKey(keyId = "kid-1", modulus = "n", exponent = "e"))
+        whenever(syncJweCrypto.rsaSpkiFromJwkComponents("n", "e")).thenReturn("spki")
+        whenever(syncJweCrypto.jweEncryptRsaOaep(any(), eq("spki"), eq("kid-1"))).thenReturn("header.enckey.iv.ct.tag")
+
+        val result = encryptor.encrypt("My Phone", "phone")
+
+        assertEquals(Result.Success("header.enckey.iv.ct.tag"), result)
+        argumentCaptor<ByteArray>().apply {
+            verify(syncJweCrypto).jweEncryptRsaOaep(capture(), eq("spki"), eq("kid-1"))
+            val json = JSONObject(String(firstValue, Charsets.UTF_8))
+            assertEquals("My Phone", json.getString("name"))
+            assertEquals("phone", json.getString("type"))
+        }
+    }
+
+    @Test
+    fun whenEncryptedBlobExceedsMaxLengthThenReturnError() {
+        whenever(syncStore.accountInfoPublicKey).thenReturn(AccountInfoPublicKey(keyId = "kid-1", modulus = "n", exponent = "e"))
+        whenever(syncJweCrypto.rsaSpkiFromJwkComponents("n", "e")).thenReturn("spki")
+        whenever(syncJweCrypto.jweEncryptRsaOaep(any(), eq("spki"), eq("kid-1"))).thenReturn("x".repeat(2001))
+
+        val result = encryptor.encrypt("My Phone", "phone")
+
+        assertTrue(result is Result.Error)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoUpdaterTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoUpdaterTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.sync.TestSyncFixtures.token
+import com.duckduckgo.sync.store.SyncStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class DeviceInfoUpdaterTest {
+
+    private val syncStore: SyncStore = mock()
+    private val syncApi: SyncApi = mock()
+    private val syncDeviceIds: SyncDeviceIds = mock()
+    private val deviceInfoEncryptor: DeviceInfoEncryptor = mock()
+    private val deviceFieldEncryptor: DeviceFieldEncryptor = mock()
+    private val updater = RealDeviceInfoUpdater(syncStore, syncApi, syncDeviceIds, deviceInfoEncryptor, deviceFieldEncryptor)
+
+    private val updatedDevices = listOf(DeviceV2(deviceId = "device-1", deviceInfo = "device.info.jwe", credentialId = "ddg"))
+
+    @Before
+    fun before() {
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncDeviceIds.deviceType()).thenReturn(DeviceType("phone"))
+    }
+
+    @Test
+    fun whenAllStepsSucceedThenSendBothEncryptedFormsAndReturnUpdatedDevices() {
+        whenever(deviceInfoEncryptor.encrypt("My Phone", "phone")).thenReturn(Result.Success("device.info.jwe"))
+        whenever(deviceFieldEncryptor.encrypt("My Phone", "phone"))
+            .thenReturn(Result.Success(EncryptedDeviceFields(name = "encName", type = "encType")))
+        whenever(syncApi.patchThisDevice(token, "encName", "encType", "device.info.jwe"))
+            .thenReturn(Result.Success(PatchDevicesResponse(devicesV2 = updatedDevices)))
+
+        val result = updater.updateThisDevice("My Phone")
+
+        assertEquals(Result.Success(updatedDevices), result)
+    }
+
+    @Test
+    fun whenNotSignedInThenErrorWithoutEncrypting() {
+        whenever(syncStore.token).thenReturn(null)
+
+        assertTrue(updater.updateThisDevice("My Phone") is Result.Error)
+        verify(deviceInfoEncryptor, never()).encrypt(any(), any())
+    }
+
+    @Test
+    fun whenDeviceInfoEncryptionFailsThenErrorWithoutPatching() {
+        whenever(deviceInfoEncryptor.encrypt(any(), any())).thenReturn(Result.Error(reason = "no cached account_info key"))
+
+        assertTrue(updater.updateThisDevice("My Phone") is Result.Error)
+        verify(syncApi, never()).patchThisDevice(any(), any(), any(), any())
+    }
+
+    @Test
+    fun whenLegacyFieldEncryptionFailsThenErrorWithoutPatching() {
+        whenever(deviceInfoEncryptor.encrypt(any(), any())).thenReturn(Result.Success("device.info.jwe"))
+        whenever(deviceFieldEncryptor.encrypt(any(), any())).thenReturn(Result.Error(reason = "primaryKey missing"))
+
+        assertTrue(updater.updateThisDevice("My Phone") is Result.Error)
+        verify(syncApi, never()).patchThisDevice(any(), any(), any(), any())
+    }
+
+    @Test
+    fun whenPatchFailsThenReturnItsError() {
+        whenever(deviceInfoEncryptor.encrypt(any(), any())).thenReturn(Result.Success("device.info.jwe"))
+        whenever(deviceFieldEncryptor.encrypt(any(), any()))
+            .thenReturn(Result.Success(EncryptedDeviceFields(name = "encName", type = "encType")))
+        whenever(syncApi.patchThisDevice(any(), any(), any(), any()))
+            .thenReturn(Result.Error(code = 500, reason = "unexpected status code"))
+
+        assertEquals(Result.Error(code = 500, reason = "unexpected status code"), updater.updateThisDevice("My Phone"))
+    }
+
+    @Test
+    fun whenDeviceTypeIsTakenFromThisDeviceThenCallerCannotOverrideIt() {
+        whenever(syncDeviceIds.deviceType()).thenReturn(DeviceType("desktop"))
+        whenever(deviceInfoEncryptor.encrypt(any(), any())).thenReturn(Result.Success("device.info.jwe"))
+        whenever(deviceFieldEncryptor.encrypt(any(), any()))
+            .thenReturn(Result.Success(EncryptedDeviceFields(name = "encName", type = "encType")))
+        whenever(syncApi.patchThisDevice(any(), any(), any(), any()))
+            .thenReturn(Result.Success(PatchDevicesResponse(devicesV2 = updatedDevices)))
+
+        updater.updateThisDevice("My Laptop")
+
+        verify(deviceInfoEncryptor).encrypt(eq("My Laptop"), eq("desktop"))
+        verify(deviceFieldEncryptor).encrypt(eq("My Laptop"), eq("desktop"))
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
@@ -72,13 +72,17 @@ import com.duckduckgo.sync.TestSyncFixtures.token
 import com.duckduckgo.sync.TestSyncFixtures.untilTimestamp
 import com.duckduckgo.sync.TestSyncFixtures.userId
 import com.duckduckgo.sync.store.*
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.*
 import retrofit2.Call
 import retrofit2.HttpException
+import retrofit2.Response
 
 @RunWith(AndroidJUnit4::class)
 class SyncServiceRemoteTest {
@@ -416,6 +420,54 @@ class SyncServiceRemoteTest {
             .thenReturn(Result.Error(code = API_CODE.INVALID_LOGIN_CREDENTIALS.code, reason = "unexpected status code"))
 
         syncRemote.setKeysIfAbsent(token, "account_info", emptyList())
+
+        verify(syncStore).clearAll()
+    }
+
+    @Test
+    fun whenPatchThisDeviceSucceedsThenSendCurrentDeviceIdAndReturnUpdatedDevices() {
+        val body = PatchDevicesResponse(
+            devicesV2 = listOf(DeviceV2(deviceId = deviceId, deviceInfo = "device.info.jwe", credentialId = "ddg")),
+        )
+        val call: Call<PatchDevicesResponse> = mock()
+        whenever(syncStore.deviceId).thenReturn(deviceId)
+        whenever(syncService.patchDevices(anyString(), any())).thenReturn(call)
+        whenever(call.execute()).thenReturn(Response.success(body))
+
+        val result = syncRemote.patchThisDevice(token, "encName", "encType", "device.info.jwe")
+
+        assertEquals(Result.Success(body), result)
+        argumentCaptor<PatchDevicesRequest>().apply {
+            verify(syncService).patchDevices(eq("Bearer $token"), capture())
+            assertEquals(listOf(DeviceUpdate(id = deviceId, name = "encName", type = "encType", info = "device.info.jwe")), firstValue.updates)
+        }
+        verify(syncStore, never()).clearAll()
+    }
+
+    @Test
+    fun whenPatchThisDeviceAndNoDeviceIdThenReturnErrorWithoutCallingService() {
+        whenever(syncStore.deviceId).thenReturn(null)
+
+        val result = syncRemote.patchThisDevice(token, "encName", "encType", "device.info.jwe")
+
+        assertTrue(result is Result.Error)
+        verify(syncService, never()).patchDevices(anyString(), any())
+    }
+
+    @Test
+    fun whenPatchThisDeviceReturnsInvalidCredentialsThenClearStore() {
+        val call: Call<PatchDevicesResponse> = mock()
+        whenever(syncStore.deviceId).thenReturn(deviceId)
+        whenever(syncService.patchDevices(anyString(), any())).thenReturn(call)
+        whenever(call.execute()).thenReturn(
+            Response.error(
+                API_CODE.INVALID_LOGIN_CREDENTIALS.code,
+                """{"code":${API_CODE.INVALID_LOGIN_CREDENTIALS.code},"error":"invalid_login_credentials"}"""
+                    .toResponseBody("application/json".toMediaTypeOrNull()),
+            ),
+        )
+
+        syncRemote.patchThisDevice(token, "encName", "encType", "device.info.jwe")
 
         verify(syncStore).clearAll()
     }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -32,6 +32,7 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.dialog.CustomAlertDialogBuilder
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
@@ -41,6 +42,7 @@ import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.ui.SyncActivity
 import com.duckduckgo.sync.impl.ui.setup.SetupAccountActivity
 import com.duckduckgo.sync.internal.databinding.ActivityInternalSyncSettingsBinding
+import com.duckduckgo.sync.internal.databinding.DialogRenameDeviceBinding
 import com.duckduckgo.sync.internal.databinding.ItemConnectedDeviceBinding
 import com.duckduckgo.sync.internal.ui.SyncInternalSettingsViewModel.Command
 import com.duckduckgo.sync.internal.ui.SyncInternalSettingsViewModel.Command.LoginSuccess
@@ -187,6 +189,8 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.createAccountInfoKeyButton.setOnClickListener { viewModel.onCreateAccountInfoKeyClicked() }
         binding.showCachedAccountInfoKeyButton.setOnClickListener { viewModel.onShowCachedAccountInfoKeyClicked() }
         binding.deleteCachedAccountInfoKeyButton.setOnClickListener { viewModel.onDeleteCachedAccountInfoKeyClicked() }
+        binding.renameDeviceButton.setOnClickListener { viewModel.onRenameDeviceClicked() }
+        binding.fetchDecryptDevicesButton.setOnClickListener { viewModel.onFetchAndDecryptDevicesClicked() }
         binding.createThirdPartyCredentialButton.setOnClickListener { viewModel.onCreateThirdPartyCredentialClicked() }
         binding.refreshThirdPartyCredentialButton.setOnClickListener { viewModel.onRefreshThirdPartyCredentialClicked() }
         binding.showThirdPartyRecoveryQrButton.setOnClickListener { viewModel.onShowThirdPartyRecoveryQrClicked() }
@@ -257,7 +261,31 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
                     },
                 )
             }
+
+            is Command.ShowRenameDeviceDialog -> showRenameDeviceDialog(command)
         }
+    }
+
+    private fun showRenameDeviceDialog(command: Command.ShowRenameDeviceDialog) {
+        val inputBinding = DialogRenameDeviceBinding.inflate(layoutInflater).apply {
+            renameDeviceInput.text = command.currentName
+        }
+        CustomAlertDialogBuilder(this)
+            .setTitle("Rename device (type: ${command.currentType})")
+            .setPositiveButton(android.R.string.ok)
+            .setNegativeButton(android.R.string.cancel)
+            .setView(inputBinding)
+            .addEventListener(
+                object : CustomAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        val newName = inputBinding.renameDeviceInput.text.trim()
+                        if (newName.isNotEmpty()) {
+                            viewModel.onRenameDeviceConfirmed(newName)
+                        }
+                    }
+                },
+            )
+            .show()
     }
 
     private fun copyToClipboard(label: String, value: String) {
@@ -344,6 +372,8 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.keysTextView.text = viewState.keysText
         binding.accountInfoKeyResultTextView.text = viewState.accountInfoKeyResult
         binding.cachedAccountInfoKeyTextView.text = viewState.cachedAccountInfoKeyResult
+        binding.renameDeviceResultTextView.text = viewState.renameDeviceResult
+        binding.fetchDecryptDevicesResultTextView.text = viewState.fetchDecryptDevicesResult
         if (viewState.isSignedIn) {
             viewState.connectedDevices.forEach { device ->
                 val connectedBinding = ItemConnectedDeviceBinding.inflate(layoutInflater, binding.connectedDevicesList, true)

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -31,12 +31,17 @@ import com.duckduckgo.persistentstorage.api.PersistentStorageAvailability
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingStore
 import com.duckduckgo.sync.impl.AccountInfoKeyManager
 import com.duckduckgo.sync.impl.ConnectedDevice
+import com.duckduckgo.sync.impl.DeviceFieldDecryptor
+import com.duckduckgo.sync.impl.DeviceInfoDecryptor
+import com.duckduckgo.sync.impl.DeviceInfoUpdater
+import com.duckduckgo.sync.impl.DeviceV2
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncApi
 import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncDeviceIds
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
 import com.duckduckgo.sync.impl.autorestore.SyncRecoveryPersistentStorageKey
@@ -83,6 +88,10 @@ constructor(
     private val syncApi: SyncApi,
     private val testSyncWarningState: TestSyncWarningPlugin.StateHolder,
     private val accountInfoKeyManager: AccountInfoKeyManager,
+    private val deviceInfoUpdater: DeviceInfoUpdater,
+    private val deviceInfoDecryptor: DeviceInfoDecryptor,
+    private val deviceFieldDecryptor: DeviceFieldDecryptor,
+    private val syncDeviceIds: SyncDeviceIds,
     @field:SuppressLint("StaticFieldLeak") private val context: Context,
 ) : ViewModel() {
 
@@ -127,6 +136,8 @@ constructor(
         val isTestSyncWarningEnabled: Boolean = false,
         val accountInfoKeyResult: String = "",
         val cachedAccountInfoKeyResult: String = "",
+        val renameDeviceResult: String = "",
+        val fetchDecryptDevicesResult: String = "",
     )
 
     sealed class BlockStoreValue {
@@ -143,6 +154,7 @@ constructor(
         data class ShowThirdPartyRecoveryQR(val string: String) : Command()
         data object LoginSuccess : Command()
         data object LaunchRecoverDataScreen : Command()
+        data class ShowRenameDeviceDialog(val currentName: String, val currentType: String) : Command()
     }
 
     init {
@@ -314,6 +326,8 @@ constructor(
                 keysText = if (accountInfo.isSignedIn) viewState.value.keysText else "",
                 accountInfoKeyResult = if (accountInfo.isSignedIn) viewState.value.accountInfoKeyResult else "",
                 cachedAccountInfoKeyResult = if (accountInfo.isSignedIn) viewState.value.cachedAccountInfoKeyResult else "",
+                renameDeviceResult = if (accountInfo.isSignedIn) viewState.value.renameDeviceResult else "",
+                fetchDecryptDevicesResult = if (accountInfo.isSignedIn) viewState.value.fetchDecryptDevicesResult else "",
             ),
         )
     }
@@ -656,6 +670,96 @@ constructor(
             logcat { "Sync-UnifiedDevices: cached account_info key: $text" }
             viewState.update { it.copy(cachedAccountInfoKeyResult = text) }
         }
+    }
+
+    fun onRenameDeviceClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            if (syncStore.token.isNullOrEmpty()) {
+                command.send(ShowMessage("Not signed in"))
+                return@launch
+            }
+            if (syncStore.accountInfoPublicKey == null) {
+                command.send(ShowMessage("No cached account_info key — tap 'Create & Register account_info Key' first"))
+                return@launch
+            }
+            command.send(
+                Command.ShowRenameDeviceDialog(
+                    currentName = syncDeviceIds.deviceName(),
+                    currentType = syncDeviceIds.deviceType().deviceFactor,
+                ),
+            )
+        }
+    }
+
+    fun onRenameDeviceConfirmed(newName: String) {
+        viewModelScope.launch(dispatchers.io()) {
+            when (val result = deviceInfoUpdater.updateThisDevice(newName)) {
+                is Success -> {
+                    val text = "PATCH ok — ${result.data.size} devices_v2 returned; name set to \"$newName\""
+                    logcat { "Sync-UnifiedDevices: $text" }
+                    viewState.update { it.copy(renameDeviceResult = text) }
+                    command.send(ShowMessage("Device renamed"))
+                    getConnectedDevices()
+                }
+                is Error -> {
+                    val text = "Error: ${result.reason} (code: ${result.code})"
+                    logcat(LogPriority.ERROR) { "Sync-UnifiedDevices: rename device failed: $text" }
+                    viewState.update { it.copy(renameDeviceResult = text) }
+                    command.send(ShowMessage(text))
+                }
+            }
+        }
+    }
+
+    fun onFetchAndDecryptDevicesClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            val token = syncStore.token
+            if (token.isNullOrEmpty()) {
+                command.send(ShowMessage("Not signed in"))
+                return@launch
+            }
+            when (val result = syncApi.getDevices(token)) {
+                is Success -> {
+                    val entriesV2 = result.data.entriesV2.orEmpty()
+                    val text = if (entriesV2.isEmpty()) {
+                        "No devices_v2 entries"
+                    } else {
+                        val session = deviceInfoDecryptor.openSession()
+                        entriesV2.joinToString("\n\n") { describeDeviceInfo(it, session) }
+                    }
+                    logcat { "Sync-UnifiedDevices: fetch & decrypt devices:\n$text" }
+                    viewState.update { it.copy(fetchDecryptDevicesResult = text) }
+                }
+                is Error -> {
+                    val text = "Error: ${result.reason} (code: ${result.code})"
+                    logcat(LogPriority.ERROR) { "Sync-UnifiedDevices: fetch & decrypt devices failed: $text" }
+                    viewState.update { it.copy(fetchDecryptDevicesResult = text) }
+                    command.send(ShowMessage(text))
+                }
+            }
+        }
+    }
+
+    private fun describeDeviceInfo(entry: DeviceV2, session: Result<DeviceInfoDecryptor.Session>): String {
+        val id = entry.deviceId ?: "(no id)"
+        val marker = if (entry.deviceId != null && entry.deviceId == syncStore.deviceId) " (this device)" else ""
+
+        val legacy = when (val result = deviceFieldDecryptor.decrypt(entry)) {
+            is Success -> "name=${result.data.name}, type=${result.data.type ?: "(none)"}"
+            is Error -> "(cannot decrypt: ${result.reason})"
+        }
+
+        val info = entry.deviceInfo
+        val deviceInfo = when {
+            info.isNullOrEmpty() -> "(no device_info)"
+            session is Error -> "(cannot decrypt: ${session.reason})"
+            session is Success -> when (val result = session.data.decrypt(info)) {
+                is Success -> "name=${result.data.name}, type=${result.data.type ?: "(none)"}"
+                is Error -> "(cannot decrypt: ${result.reason})"
+            }
+            else -> "(cannot decrypt)"
+        }
+        return "id=$id$marker [credential=${entry.credentialId ?: "ddg"}]\n  legacy:      $legacy\n  device_info: $deviceInfo"
     }
 
     fun onDeleteCachedAccountInfoKeyClicked() {

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -214,6 +214,43 @@
         <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:primaryText="Unified Device List (device_info)" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+            android:id="@+id/renameDeviceButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="Rename device (PATCH device_info)" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/renameDeviceResultTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/keyline_4"
+            android:layout_marginEnd="@dimen/keyline_4"
+            android:layout_marginBottom="@dimen/keyline_4"
+            app:typography="body2" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+            android:id="@+id/fetchDecryptDevicesButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="Fetch &amp; decrypt devices" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/fetchDecryptDevicesResultTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/keyline_4"
+            android:layout_marginEnd="@dimen/keyline_4"
+            android:layout_marginBottom="@dimen/keyline_4"
+            app:typography="body2" />
+
+        <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             app:primaryText="3party Credential Management" />
 
         <com.duckduckgo.common.ui.view.button.DaxButtonPrimary

--- a/sync/sync-internal/src/main/res/layout/dialog_rename_device.xml
+++ b/sync/sync-internal/src/main/res/layout/dialog_rename_device.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.duckduckgo.common.ui.view.text.DaxTextInput
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/renameDeviceInput"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/keyline_4"
+    android:hint="Device name"
+    android:inputType="textNoSuggestions" />


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1217068100697970?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Dev-only plumbing for the unified device list's `device_info` capability. Accessible only from `Sync Dev Settings` screen for now. 

### Steps to test this PR

#### Rename via device_info PATCH works
- [ ] Fresh install `internal` build
- [ ] Open `Sync Dev Settings`, and tap `Create account` to quickly sign into sync
- [ ] Tap `Create & Register account_info Key` button
- [ ] Tap `Rename device (PATCH device_info)` button. Call it `test` and verify it shows `PATCH ok` with the chosen name
- [ ] Tap `Fetch & decrypt devices` and verify both legacy and device_info has `name=test`

#### 2nd device confirmation
- [ ] Install on a 2nd device, and sync with the first device
- [ ] Visit production `Sync & Backup` screen and verify you see `test` as the other device's name

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches sync cryptography, protected key unwrap, and server-side device identity; incorrect encryption or PATCH semantics could break cross-device names or leak mishandled key material paths.
> 
> **Overview**
> Adds the **unified device list** write path: when this device’s name changes, the client encrypts a cross-credential `device_info` JWE (under the cached `account_info` public key) and still encrypts legacy `name`/`type` for older clients, then **PATCHes** `/sync/devices` with all three fields every time (the server clears `info` if omitted).
> 
> New sync-impl pieces include **`AccountInfoPrivateKeyProvider`** (unwrap `account_info` private key for decrypt), **`DeviceInfoEncryptor`/`DeviceInfoDecryptor`** (RSA-OAEP JWE round-trip with a decrypt session), **`DeviceFieldEncryptor`** (mirror of existing field decrypt), and **`DeviceInfoUpdater`** orchestrating the PATCH. **`DeviceV2`** gains an `info` field; **`SyncJweCrypto`** adds **`rsaSpkiFromJwkComponents`** for JWK→SPKI encryption. **`SyncGzipInterceptor`** skips gzip on PATCH `/sync/devices` until the backend accepts it.
> 
> **Sync Dev Settings** exposes rename (dialog → PATCH) and fetch & decrypt devices (legacy vs `device_info` side by side). Unit tests cover the new encrypt/decrypt/update and remote PATCH behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71bcd4a892cb35ac3b4438a7e7bffd853d29f83d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->