### PR TITLE
[Drift Audit] Correct the plugin-points section in the architecture rule doc

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -271,9 +271,24 @@ class Foo @Inject constructor(private val plugins: ActivePluginPoint<MyPlugin>)
 
 All flags default to `TRUE` so newly contributed plugins are on by default and can be killed remotely.
 
-### Notable active plugin points in the browser
-- `JsInjectorPlugin` — hooks into `onPageStarted` / `onPageFinished` on the browser WebView
-- `ContentScopeJsMessageHandlersPlugin` — handles JS→native messages via content scope scripts
+### Notable plugin points in the browser
+
+Basic (`@ContributesPluginPoint`, consumed as `PluginPoint<T>`, no feature-flag gating):
+
+| Plugin | Point declared by | Purpose |
+|---|---|---|
+| `JsInjectorPlugin` | `UnusedJsInjectorPluginPoint` (`:app`) | hooks into `onPageStarted` / `onPageFinished` on the browser WebView |
+| `ContentScopeJsMessageHandlersPlugin` | `ContentScopeJsMessageHandlersPluginPoint` (`content-scope-scripts-impl`) | handles JS→native messages via content scope scripts |
+
+Active (`@ContributesActivePluginPoint`, consumed as `ActivePluginPoint<T>`, flag-gated):
+
+| Plugin | Plugin point `featureName` |
+|---|---|
+| `NewTabPagePlugin` | `pluginPointNewTabPagePlugin` |
+| `NewTabPageSectionPlugin` | `pluginPointNewTabPageSectionPlugin` |
+| `NewTabPageShortcutPlugin` | `pluginPointNewTabPageShortcutPlugin` |
+| `NativeInputPlugin` | `pluginPointNativeInput` |
+| `NativeInputChatTabItemPlugin` | `pluginPointNativeInputChatTabItemPlugin` |
 
 ---
 


### PR DESCRIPTION
Task/Issue URL: (app.asana.com/redacted)

### Description
`.cursor/rules/architecture.mdc` — the "Notable active plugin points in the browser" section.

**What the doc described:** the section sits immediately after the `@ContributesActivePluginPoint` documentation (remote-flag gating, `ActivePluginPoint<T>`, `isActive()`, "all flags default to `TRUE`") and is headed *"Notable **active** plugin points in the browser"*. It named exactly two:

- `JsInjectorPlugin`
- `ContentScopeJsMessageHandlersPlugin`

**Why that no longer matches the code:** neither is an active plugin point. Both are basic plugin points with no feature-flag gating:

- `app/src/main/java/com/duckduckgo/app/plugins/JsInjectorPluginPoint.kt:23` — `@ContributesPluginPoint(scope = AppScope::class, boundType = JsInjectorPlugin::class)` on `UnusedJsInjectorPluginPoint`.
- `content-scope-scripts/content-scope-scripts-impl/.../ContentScopeConfigPluginPoint.kt:36` — `@ContributesPluginPoint(scope = AppScope::class, boundType = ContentScopeJsMessageHandlersPlugin::class)` on `ContentScopeJsMessageHandlersPluginPoint`.

Corroborating: neither `JsInjectorPlugin` (`browser-api`) nor `ContentScopeJsMessageHandlersPlugin` (`content-scope-scripts-api`) extends `ActivePlugin`, which `@ContributesActivePluginPoint` requires, and every consumer injects `PluginPoint<T>`, not `ActivePluginPoint<T>` — `BrowserWebViewClient:127`, `DuckChatWebViewClient:28`, `SettingsWebViewClient:28`, `ContentScopeScriptsJsMessaging`.

The practical cost of the error is that the doc is the only place a reader is pointed at concrete examples, and it points at the wrong kind. Someone following it would expect a `pluginPoint…` remote flag and an `isActive()` gate that do not exist for these two, and would reach for `ActivePluginPoint<T>` at the injection site.

**How the doc now reads:** the heading drops "active", and the section is split into two small tables — the two basic points (with the interface that declares each point) and the active points that actually exist, each with its plugin-point `featureName` as declared in code:

| Plugin | `featureName` | Declared in |
|---|---|---|
| `NewTabPagePlugin` | `pluginPointNewTabPagePlugin` | `app/.../browser/newtab/NewTabPageProvider.kt:63` |
| `NewTabPageSectionPlugin` | `pluginPointNewTabPageSectionPlugin` | `new-tab-page-impl/.../RealNewTabPageSectionProvider.kt:100` |
| `NewTabPageShortcutPlugin` | `pluginPointNewTabPageShortcutPlugin` | `new-tab-page-impl/.../shortcuts/NewTabShortcutsProvider.kt:99` |
| `NativeInputPlugin` | `pluginPointNativeInput` | `duckchat-impl/.../nativeinput/NativeInputPlugin.kt:61` |
| `NativeInputChatTabItemPlugin` | `pluginPointNativeInputChatTabItemPlugin` | `duckchat-impl/.../inputscreen/ui/suggestions/NativeInputChatTabItemPluginPoint.kt:30` |

**One thing for a human to weigh.** I could not attribute this to a specific merged PR — no merged PR in the repo mentions `JsInjectorPluginPoint`, and the checkout available to this run is shallow, so I could not blame the file. It is possible the section was inaccurate when written rather than having drifted. I raised it anyway because the mismatch is not a judgement call — the annotation, the missing `ActivePlugin` supertype, and the `PluginPoint<T>` injection sites all agree — and because native input, where two of the real active plugin points live, is the area recent work has concentrated in ([`#9324`](https://github.com/duckduckgo/Android/pull/9324), [`#9338`](https://github.com/duckduckgo/Android/pull/9338)), which is what prompted re-reading this doc. If the preference is that Drift Audit only fixes drift traceable to a code change in its window, that is a fair reason to close this.

I also checked, and did **not** treat as drift:
- **The rest of `architecture.mdc`.** I re-verified the DI scope list against `di/.../scopes/` (all seven exist), the `GlobalActivityStarter` overload table against `navigation-api` (`start` / `startIntent` / `startForResult` all present with the documented shapes), and the plugin naming-convention claim — the `pluginPoint` prefix really is enforced at compile time (`ContributesActivePluginPointProcessor.kt:279`), as is the non-blank `featureName` (`:275`). All accurate.
- **The "URL vs. Search Classification" section** — already covered by the still-open [`#9153`](https://github.com/duckduckgo/Android/pull/9153); I stayed out of it to avoid conflicting edits.
- **`.cursor/rules/wide-events.mdc`** — the interval/`Duration` drift is covered by the still-open [`#9355`](https://github.com/duckduckgo/Android/pull/9355). Re-reading the rest against `WideEventClient.kt`, `FlowStatus`, `CleanupPolicy`, `SAMPLED_OUT_FLOW_ID` and `CompletedWideEventsProcessor` found nothing further, with one borderline call I left alone: the doc says the two transports are "controlled by the `wideEvents` remote feature flag", where in fact each has its own sub-toggle (`sendWideEventsViaPixels()` / `sendWideEventsViaPost()` in `DelegatingWideEventSender`). Those sub-toggles do belong to `WideEventFeature`, so the sentence is imprecise rather than false, and that file already has an open PR.
- **`.cursor/rules/android-design-system.mdc`** — two open Drift Audit PRs against it ([`#9300`](https://github.com/duckduckgo/Android/pull/9300), [`#9315`](https://github.com/duckduckgo/Android/pull/9315)); left alone.
- **`.cursor/rules/pixels.mdc` / `pixel-definitions.mdc`** — process/privacy guidance, untouched by anything in this window.
- **`.cursor/rules/maestro-ui-tests.mdc`** — no `.maestro/**` tag or config mechanics changed.
- **`AGENTS.md`** — re-checked the two live toolchain claims: JVM target 17 (`build.gradle:220`, `JvmTarget.JVM_17`) and JDK 21 (`.github/.java-version` = `21`), plus the `ddg.di` dual-build property (`build.gradle:255`, `gradle.properties:31`). All still true. The `targetSdk`-to-Android-16 change ([`#9283`](https://github.com/duckduckgo/Android/pull/9283)) touches nothing the docs state — they deliberately point at the build files instead of restating SDK levels.
- **Merged in this window and irrelevant to the rule docs:** the onboarding button margin ([`#9366`](https://github.com/duckduckgo/Android/pull/9366)), autoconsent and content-scope-scripts bumps ([`#9361`](https://github.com/duckduckgo/Android/pull/9361), [`#9354`](https://github.com/duckduckgo/Android/pull/9354), [`#9327`](https://github.com/duckduckgo/Android/pull/9327)), the `account_info` keypair work ([`#9311`](https://github.com/duckduckgo/Android/pull/9311), [`#9325`](https://github.com/duckduckgo/Android/pull/9325), [`#9326`](https://github.com/duckduckgo/Android/pull/9326)) — all inside `-impl` code the rule docs don't describe. [`#9364`](https://github.com/duckduckgo/Android/pull/9364) edits `.claude/skills/prepare-sbt-repro/SKILL.md`, which is a skill, not a rule doc, and skill-mirror parity belongs to `aiConfigCheck`.

A caveat on coverage: 21 of the ~31 PRs merged to `develop` in this window were hidden from me by the integrity filter, so this pass leaned on reading the docs against the current code rather than on the merge list alone.

Only prose changed — no code, and only the canonical `.cursor/rules/*.mdc` file (the `.claude/rules/architecture.md` symlink is untouched).

🤖 AI-docs Drift Auditor

### Steps to test this PR
- [ ] Confirm the two "basic" rows: `JsInjectorPluginPoint.kt` and `ContentScopeConfigPluginPoint.kt` both use `@ContributesPluginPoint`, and neither `JsInjectorPlugin` nor `ContentScopeJsMessageHandlersPlugin` extends `ActivePlugin`.
- [ ] Spot-check a consumer — e.g. `BrowserWebViewClient:127` injects `PluginPoint<JsInjectorPlugin>`, not `ActivePluginPoint<JsInjectorPlugin>`.
- [ ] Confirm each `featureName` in the "active" table matches its `@ContributesActivePluginPoint` declaration at the file/line listed above.
- [ ] Sanity-check that the active list is complete for the browser, and say so if a plugin point worth naming is missing.

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |




> [!NOTE]
> <details>
> <summary><b>🔒 Integrity filter blocked 79 items</b></summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#8891](https://github.com/duckduckgo/Android/pull/8891) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/06c894fbf0547c88e2b13e011e9ea7b7cc5eeb95](https://github.com/duckduckgo/Android/commit/06c894fbf0547c88e2b13e011e9ea7b7cc5eeb95) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/25ee1c9c63cc88f23f56b849329d20c3bb1434fe](https://github.com/duckduckgo/Android/commit/25ee1c9c63cc88f23f56b849329d20c3bb1434fe) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/09c53033342e5ac3c7f5bde8259036e8166c9730](https://github.com/duckduckgo/Android/commit/09c53033342e5ac3c7f5bde8259036e8166c9730) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/cbe8848963a6459215a032f83dc42c197d68d08c](https://github.com/duckduckgo/Android/commit/cbe8848963a6459215a032f83dc42c197d68d08c) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/89f01abdb06534d3cb362643c6a773f774e2d6c4](https://github.com/duckduckgo/Android/commit/89f01abdb06534d3cb362643c6a773f774e2d6c4) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/9d00f9300347034d8f496a8b31bc91a5ef131ed0](https://github.com/duckduckgo/Android/commit/9d00f9300347034d8f496a8b31bc91a5ef131ed0) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/17f3d599b0d3782f5e4debcdaa14d58262a02009](https://github.com/duckduckgo/Android/commit/17f3d599b0d3782f5e4debcdaa14d58262a02009) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/7a9170b2b82390d300b61574d077c92f7e88fd26](https://github.com/duckduckgo/Android/commit/7a9170b2b82390d300b61574d077c92f7e88fd26) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/a9c2e87c77985a1e68dcc2de887e2569add5000a](https://github.com/duckduckgo/Android/commit/a9c2e87c77985a1e68dcc2de887e2569add5000a) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/5a41409e1e3cc90dc595ae6db4ea6c69d769a263](https://github.com/duckduckgo/Android/commit/5a41409e1e3cc90dc595ae6db4ea6c69d769a263) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/809ce55a487fce3340271b7def13a2a044c34f45](https://github.com/duckduckgo/Android/commit/809ce55a487fce3340271b7def13a2a044c34f45) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/c14ae3df5aeacdd7be9e09733c0144ae22a8d576](https://github.com/duckduckgo/Android/commit/c14ae3df5aeacdd7be9e09733c0144ae22a8d576) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/3eafa847ca817ad4b99bca1b6d6e535248e3e99e](https://github.com/duckduckgo/Android/commit/3eafa847ca817ad4b99bca1b6d6e535248e3e99e) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/b5ffb52b369bd8e8d50c910bed9151c59a7e1ee1](https://github.com/duckduckgo/Android/commit/b5ffb52b369bd8e8d50c910bed9151c59a7e1ee1) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/57cea6cc5c1ea936d80447f95c5f71f7dcd29bdd](https://github.com/duckduckgo/Android/commit/57cea6cc5c1ea936d80447f95c5f71f7dcd29bdd) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - ... and 63 more items
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [AI-docs Semantic Drift Audit](https://github.com/duckduckgo/Android/actions/runs/30686935769/agentic_workflow) · [◷](https://github.com/search?q=repo%3Aduckduckgo%2FAndroid+%22gh-aw-workflow-id%3A+drift-audit%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: AI-docs Semantic Drift Audit, engine: claude, model: auto, id: 30686935769, workflow_id: drift-audit, run: https://github.com/duckduckgo/Android/actions/runs/30686935769 -->

<!-- gh-aw-workflow-id: drift-audit -->