### PR TITLE
Update PIR broker bundle - 2026-08-03

### DIFF
--- a/pir/pir-impl/src/main/assets/brokers/cyberbackgroundchecks.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/cyberbackgroundchecks.com.json
@@ -1,7 +1,7 @@
 {
   "name": "Cyber Background Checks",
   "url": "cyberbackgroundchecks.com",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1705644000000,
   "optOutUrl": "https://cyberbackgroundchecks.com/donotsellmyinfo",
@@ -14,6 +14,17 @@
           "actionType": "navigate",
           "id": "9f5caaf9-5bd7-494e-bfbb-e33c4927cdb3",
           "url": "https://www.cyberbackgroundchecks.com/people/${firstName|hyphenated}-${lastName|hyphenated}/${state|hyphenated}/${city|hyphenated}"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "detect Cloudflare challenge page - blocks the scan, we cannot solve it in a webview",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(., '_cf_chl_opt')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'] or .//div[@id='cf-error-details'])]"
+            }
+          ],
+          "id": "cfc-fa028201-d974-4b70-ae9d-63ac2fc5f3da"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/privatereports.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/privatereports.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PrivateReports",
   "url": "privatereports.com",
-  "version": "0.997.0",
+  "version": "0.998.0",
   "optOutUrl": "https://www.privatereports.com/api/helper/optOutLight/search",
   "steps": [
     {
@@ -528,8 +528,8 @@
     }
   ],
   "schedulingConfig": {
-    "retryError": 48,
-    "confirmOptOutScan": 72,
+    "retryError": 72,
+    "confirmOptOutScan": 96,
     "maintenanceScan": 240
   },
   "addedDatetime": 1737035696264,

--- a/pir/pir-impl/src/main/assets/brokers/smartbackgroundchecks.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/smartbackgroundchecks.com.json
@@ -1,7 +1,7 @@
 {
   "name": "SmartBackgroundChecks",
   "url": "smartbackgroundchecks.com",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1678082400000,
   "optOutUrl": "https://www.smartbackgroundchecks.com/optout",
@@ -14,6 +14,28 @@
           "actionType": "navigate",
           "id": "290d3add-c786-4ecf-a528-50b2a240f791",
           "url": "https://www.smartbackgroundchecks.com/people/${firstName|hyphenated}-${lastName|hyphenated}/${city|hyphenated}/${state|hyphenated}"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "detect Cloudflare challenge page - first gate, blocks the scan",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(., '_cf_chl_opt')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'] or .//div[@id='cf-error-details'])]"
+            }
+          ],
+          "id": "cfc-4b63420c-3be7-4abe-bb1b-491636360628"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "detect Datadome interstitial - second gate, only reached after Cloudflare clears",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//iframe[contains(@src,'captcha-delivery.com')])]"
+            }
+          ],
+          "id": "43ff3f91-f08c-460b-86c6-84b29384a72d"
         },
         {
           "actionType": "extract",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217102787878664

## PIR Broker Bundle Update

Automated update of PIR broker JSON files from the remote bundle.

### Changes

**Updated (3):**
- cyberbackgroundchecks.com.json (0.7.0 → 0.8.0)
- privatereports.com.json (0.997.0 → 0.998.0)
- smartbackgroundchecks.com.json (0.7.0 → 0.8.0)

### Checklist

- [x] Verify broker changes look correct
- [x] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect live PIR scan/opt-out timing and failure detection for three brokers; mis-tuned XPath gates could false-fail scans or delay retries, but scope is limited to broker JSON assets.
> 
> **Overview**
> This bundle refresh bumps three broker definitions and tightens scan flows where sites now interpose bot protection.
> 
> **Cyber Background Checks** and **SmartBackgroundChecks** add early **expectation** steps after navigate so scans fail clearly when a Cloudflare challenge (Turnstile, challenge-platform scripts, etc.) is shown—something the webview cannot solve. SmartBackgroundChecks also adds a second gate for **Datadome** (`captcha-delivery.com` iframes) after Cloudflare clears.
> 
> **PrivateReports** only adjusts `schedulingConfig`: `retryError` 48→72 hours and `confirmOptOutScan` 72→96 hours, spacing retries and confirmation scans when opt-out flows are slower or flaky.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb2e49112aee53306a62bb9f82cbd52004d9f5db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->