### PR TITLE
Handle simplified sync deep linking

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -103,10 +103,10 @@ interface SyncFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun restrictScannedBarcodesToQrTypes(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun useSimplifiedSync(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun updateSyncActivityViewStateAtomically(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
@@ -243,7 +243,7 @@ class SyncActivityViewModel @Inject constructor(
     sealed class Command {
         data object SyncWithAnotherDevice : Command()
         data object AddAnotherDevice : Command()
-        data class DeepLinkIntoSetup(val barcodeSyncUrl: SyncBarcodeUrl) : Command()
+        data class DeepLinkIntoSetup(val barcodeSyncUrl: SyncBarcodeUrl, val isSignedIn: Boolean) : Command()
         data class AskSetupSyncDeepLink(val syncBarcodeUrl: SyncBarcodeUrl) : Command()
         data object IntroCreateAccount : Command()
         data object IntroRecoverSyncData : Command()
@@ -722,7 +722,7 @@ class SyncActivityViewModel @Inject constructor(
                     // (the Joiner/Host confirmation surfaced by the runner)
                     logcat { "Sync-setup: v2 deep link; bypassing legacy confirmation dialog" }
                     requiresSetupAuthentication {
-                        command.send(Command.DeepLinkIntoSetup(parsed))
+                        command.send(Command.DeepLinkIntoSetup(parsed, syncAccountRepository.isSignedIn()))
                     }
                 }
             }
@@ -732,7 +732,7 @@ class SyncActivityViewModel @Inject constructor(
     fun onUserAgreedToDeepLinkIntoSync(barcodeSyncUrl: SyncBarcodeUrl) {
         viewModelScope.launch(dispatchers.io()) {
             requiresSetupAuthentication {
-                command.send(Command.DeepLinkIntoSetup(barcodeSyncUrl))
+                command.send(Command.DeepLinkIntoSetup(barcodeSyncUrl, syncAccountRepository.isSignedIn()))
             }
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -48,6 +48,7 @@ import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.getActivityParams
 import com.duckduckgo.settings.api.SettingsWebViewScreenWithParams
+import com.duckduckgo.sync.api.SyncActivityFromSetupUrl
 import com.duckduckgo.sync.api.SyncActivityWithAnotherDevice
 import com.duckduckgo.sync.api.SyncMessagePlugin
 import com.duckduckgo.sync.api.SyncSettingsPlugin
@@ -91,12 +92,12 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.CreateAccoun
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.SignInFlow
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.ViewState
 import com.duckduckgo.sync.impl.ui.SyncActivityWithSourceParams
+import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl
 import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import logcat.logcat
 import javax.inject.Inject
 import com.duckduckgo.mobile.android.R as CommonR
 
@@ -136,6 +137,12 @@ class SyncActivity : DuckDuckGoActivity() {
     private val launchSource
         get() = intent.getActivityParams(SyncActivityWithSourceParams::class.java)?.source
             ?: intent.getActivityParams(SyncActivityWithAnotherDevice::class.java)?.source
+
+    private val syncSetupUrl
+        get() = intent.getActivityParams(SyncActivityFromSetupUrl::class.java)?.url
+
+    private val isAnotherDeviceSync
+        get() = intent.getActivityParams(SyncActivityWithAnotherDevice::class.java) != null
 
     private val syncThisDeviceLauncher = registerForActivityResult(
         SyncThisDeviceContract(),
@@ -311,6 +318,14 @@ class SyncActivity : DuckDuckGoActivity() {
         configureDataDeletionItem()
 
         observeViewModel()
+
+        if (savedInstanceState == null) {
+            val setupUrl = syncSetupUrl
+            when {
+                setupUrl != null -> viewModel.processSetupDeepLink(setupUrl)
+                isAnotherDeviceSync -> viewModel.onSyncWithAnotherDevice()
+            }
+        }
     }
 
     override fun onStop() {
@@ -393,8 +408,7 @@ class SyncActivity : DuckDuckGoActivity() {
             // No-op in the simplified flow.
             is AskRemoveDevice -> Unit
 
-            // No-op in the simplified flow.
-            is AskSetupSyncDeepLink -> Unit
+            is AskSetupSyncDeepLink -> askSetupSyncDeepLink(command.syncBarcodeUrl)
 
             is AskToCopyRecoveryCode -> {
                 authenticate {
@@ -414,7 +428,24 @@ class SyncActivity : DuckDuckGoActivity() {
             }
 
             is DeepLinkIntoSetup -> {
-                logcat { "TODO: Handle ${command.javaClass.simpleName} command" }
+                val authConfig = AuthConfiguration(
+                    displayTitleResource = R.string.sync_simplified_deep_link_auth_prompt_title,
+                    displayTextResource = R.string.sync_simplified_deep_link_auth_prompt_message,
+                )
+                authenticate(config = authConfig) {
+                    val originalFlow = if (command.isSignedIn) {
+                        OriginalFlow.SYNC_WITH_ANOTHER
+                    } else {
+                        OriginalFlow.SYNC_THIS_DEVICE
+                    }
+                    exchangeSyncCodeLauncher.launch(
+                        ExchangeSyncCodeContract.Input(
+                            syncUrl = command.barcodeSyncUrl.asUrl(),
+                            launchSource = launchSource,
+                            originalFlow = originalFlow,
+                        ),
+                    )
+                }
             }
 
             is IntroCreateAccount -> {
@@ -725,6 +756,22 @@ class SyncActivity : DuckDuckGoActivity() {
                 },
             )
             .setCancellable(true)
+            .show()
+    }
+
+    private fun askSetupSyncDeepLink(barcodeSyncUrl: SyncBarcodeUrl) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_simplified_deep_link_confirmation_dialog_title)
+            .setMessage(getString(R.string.sync_simplified_deep_link_confirmation_dialog_body, barcodeSyncUrl.deviceName))
+            .setPositiveButton(R.string.sync_simplified_deep_link_confirmation_dialog_primary_button)
+            .setNegativeButton(R.string.sync_simplified_deep_link_confirmation_dialog_secondary_button)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onUserAgreedToDeepLinkIntoSync(barcodeSyncUrl)
+                    }
+                },
+            )
             .show()
     }
 

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -129,7 +129,7 @@
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Got It</string>
 
     <!-- Recovery Code screen -->
-    <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name">%1$s has been added to Sync&#160;&amp;&#160;Backup.</string>
+    <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s has been added to Sync&#160;&amp;&#160;Backup.</string>
     <string name="sync_simplified_recovery_code_body">Use this code to restore your data if you lose access to this device. Keep it safe.</string>
     <string name="sync_simplified_recovery_code_label">Recovery Code</string>
     <string name="sync_simplified_recovery_code_download_button">Download Your Recovery Code</string>
@@ -154,7 +154,7 @@
 
     <!-- Edit Device screen: remove device dialog -->
     <string name="sync_simplified_edit_device_remove_dialog_title">Remove Device?</string>
-    <string name="sync_simplified_edit_device_remove_dialog_body" instruction="Placeholder is a device name">“%1$s” will no longer be able to access your synced data.</string>
+    <string name="sync_simplified_edit_device_remove_dialog_body" instruction="Placeholder is a device name. e.g., Samsung S23">“%1$s” will no longer be able to access your synced data.</string>
     <string name="sync_simplified_edit_device_remove_dialog_primary_button">Remove</string>
     <string name="sync_simplified_edit_device_remove_dialog_secondary_button">Cancel</string>
 
@@ -173,4 +173,12 @@
     <string name="sync_simplified_error_dialog_recovery_pdf_body">Unable to create the recovery PDF.</string>
     <string name="sync_simplified_error_dialog_recovery_code_body">Unable to get recovery code.</string>
     <string name="sync_simplified_pairing_failed_generic_message">Something went wrong.</string>
+
+    <!-- Deep link setup: confirmation dialog and device-auth prompt, shown on the settings screen when an inbound sync pairing link is opened -->
+    <string name="sync_simplified_deep_link_confirmation_dialog_title">Sync New Device?</string>
+    <string name="sync_simplified_deep_link_confirmation_dialog_body" instruction="Placeholder is a device name. e.g., Samsung S23">“%1$s” will be able to access your synced DuckDuckGo&#160;data.</string>
+    <string name="sync_simplified_deep_link_confirmation_dialog_primary_button">Sync Now</string>
+    <string name="sync_simplified_deep_link_confirmation_dialog_secondary_button">Cancel</string>
+    <string name="sync_simplified_deep_link_auth_prompt_title">Set up Sync&#160;&amp;&#160;Backup</string>
+    <string name="sync_simplified_deep_link_auth_prompt_message">Unlock device to set up Sync&#160;&amp;&#160;Backup</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217050743419845?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1216509582049467?focus=true
API Proposals URL(s) (if applicable): N/A

### Description

Adds sync setup deep link handling to the simplified Sync settings screen, and updates the sync feature flag defaults. 

Deep link handling:
- When the simplified Sync settings screen is opened from an inbound sync pairing link, the link is processed automatically.
- For a v2 pairing link, a device authentication prompt titled "Set up Sync & Backup" is shown when the device has a screen lock set, and the pairing then runs directly from the link without opening the QR scanner.
- For a v1 exchange link, a "Sync New Device?" dialog naming the other device is shown first. After the user taps "Sync Now", device authentication is requested when the device has a screen lock set, and the pairing runs.
- After a successful pairing, the recovery code screen is shown, the same as when a code is scanned.
- When the screen is opened through the "sync with another device" entry point, it now opens the scan or paste code flow automatically.

Feature flags:
- `useSimplifiedSync` now defaults to `INTERNAL`.
- `updateSyncActivityViewStateAtomically` now defaults to `TRUE`.

### Steps to test this PR

_Deep link into pairing with a v2 link_
- [ ] Set DuckDuckGo as the default browser on Device A.
- [ ] On Device B, already signed in to Sync & Backup, open Sync settings.
- [ ] Tap "Sync With Another Device" on Device B to show its QR code.
- [ ] On Device A, open the system camera app.
- [ ] Scan the QR code shown on Device B.
- [ ] Open the scanned link in DuckDuckGo on Device A.
- [ ] Verify  Device A goes executes the sync process.

_Confirmation dialog with a v1 exchange link_
- [ ] Set DuckDuckGo as the default browser on Device A.
- [ ] On Device B, disable the `canShowV2ConnectCode` feature flag.
- [ ] On Device B, already signed in to Sync & Backup, open Sync settings.
- [ ] Tap "Sync With Another Device" on Device B to show its QR code.
- [ ] On Device A, open the system camera app.
- [ ] Scan the QR code shown on Device B.
- [ ] Open the scanned link in DuckDuckGo on Device A.
- [ ] Verify a "Sync New Device?" dialog naming Device B is shown on Device A.
- [ ] Tap "Sync Now".
- [ ] Verify  Device A goes executes the sync process.

### UI changes
N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch sync pairing and device authentication on inbound links, which are security-sensitive, but they reuse existing exchange and auth paths rather than new crypto or server logic.
> 
> **Overview**
> Wires **inbound sync pairing links** and the **“sync with another device”** entry point into the simplified Sync settings screen (`SyncActivity` v2), and adjusts two remote feature defaults.
> 
> On first open, the screen now reads `SyncActivityFromSetupUrl` or `SyncActivityWithAnotherDevice` from the intent. A setup URL runs `processSetupDeepLink`; the other-device entry point calls `onSyncWithAnotherDevice()` so scan/paste starts without an extra tap.
> 
> **V1 exchange links** show a “Sync New Device?” confirmation naming the other device; after “Sync Now”, setup auth runs when needed, then pairing via `ExchangeSyncCodeContract` (no QR scanner). **V2 links** skip that dialog (protocol handles confirmation), request setup authentication when appropriate, and launch the same exchange flow directly. `DeepLinkIntoSetup` now carries `isSignedIn` so pairing uses `SYNC_WITH_ANOTHER` vs `SYNC_THIS_DEVICE` correctly.
> 
> Feature flags: `useSimplifiedSync` defaults to **INTERNAL**; `updateSyncActivityViewStateAtomically` defaults to **TRUE**. New simplified UI strings cover the deep-link confirmation and unlock prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f426ea5859cce8f9a95c12844e598071b97a676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->