### PR TITLE
Avoid signing out of a device when renaming it

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -114,4 +114,7 @@ interface SyncFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun canReadUnifiedDeviceList(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun preventStaleTokenLogout(): Toggle
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -192,6 +192,7 @@ class SyncServiceRemote @Inject constructor(
     private val syncService: SyncService,
     private val syncStore: SyncStore,
     private val setKeysIfAbsentCall: SetKeysIfAbsentCall,
+    private val syncFeature: SyncFeature,
 ) : SyncApi {
     override fun createAccount(
         userID: String,
@@ -564,14 +565,14 @@ class SyncServiceRemote @Inject constructor(
             } else {
                 Result.Error(reason = "internal error")
             }
-            error.removeKeysIfInvalid()
+            error.removeKeysIfInvalid(token)
             error
         }
     }
 
     private fun mapRescopeTokenError(response: Response<TokenRescopeResponse?>): Result<String> {
         val error = response.toUnparsedError()
-        error.removeKeysIfInvalid()
+        error.removeKeysIfInvalid(response.requestAuthToken())
         return error
     }
 
@@ -589,12 +590,12 @@ class SyncServiceRemote @Inject constructor(
                     val code = if (error.code == -1) response.code() else error.code
                     Result.Error(code, error.error)
                 } ?: Result.Error(code = response.code(), reason = response.message().toString())
-                error.removeKeysIfInvalid()
+                error.removeKeysIfInvalid(response.requestAuthToken())
                 return error
             }
         }.getOrElse {
             val result = Result.Error(response.code(), reason = response.message())
-            result.removeKeysIfInvalid()
+            result.removeKeysIfInvalid(response.requestAuthToken())
             return result
         }
     }
@@ -619,7 +620,7 @@ class SyncServiceRemote @Inject constructor(
         keys: List<ProtectedKeyEntry>,
     ): Result<SetKeysIfAbsentResult> {
         val result = setKeysIfAbsentCall.execute(token, purpose, keys)
-        if (result is Result.Error) result.removeKeysIfInvalid()
+        if (result is Result.Error) result.removeKeysIfInvalid(token)
         return result
     }
 
@@ -687,10 +688,21 @@ class SyncServiceRemote @Inject constructor(
         return onSuccess(response) { Result.Success(Unit) }
     }
 
-    private fun Result.Error.removeKeysIfInvalid() {
-        if (code == API_CODE.INVALID_LOGIN_CREDENTIALS.code) {
+    private fun Result.Error.removeKeysIfInvalid(requestToken: String?) {
+        if (code != API_CODE.INVALID_LOGIN_CREDENTIALS.code) return
+
+        // A 401 for a token that has since been rotated is stale and must not sign the device out:
+        // renaming a device re-logs in (issuing a fresh token), so a concurrent request that raced the
+        // token swap can 401 on the old token while the account is still valid. Only wipe local state
+        // when the token that failed is still the current one (or unknown, preserving prior behavior).
+        val tokenStillCurrent = requestToken == null || requestToken == syncStore.token
+        if (!syncFeature.preventStaleTokenLogout().isEnabled() || tokenStillCurrent) {
             syncStore.clearAll()
         }
+    }
+
+    private fun Response<*>.requestAuthToken(): String? {
+        return raw().request.header("Authorization")?.removePrefix("Bearer ")
     }
 
     private class Adapters {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
@@ -17,6 +17,8 @@
 package com.duckduckgo.sync.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.TestSyncFixtures.accountCreatedFailDupUser
 import com.duckduckgo.sync.TestSyncFixtures.accountCreatedFailInvalid
 import com.duckduckgo.sync.TestSyncFixtures.accountCreatedSuccess
@@ -90,7 +92,10 @@ class SyncServiceRemoteTest {
     private val syncService: SyncService = mock()
     private val syncStore: SyncStore = mock()
     private val setKeysIfAbsentCall: SetKeysIfAbsentCall = mock()
-    private val syncRemote = SyncServiceRemote(syncService, syncStore, setKeysIfAbsentCall)
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java).apply {
+        preventStaleTokenLogout().setRawStoredState(State(true))
+    }
+    private val syncRemote = SyncServiceRemote(syncService, syncStore, setKeysIfAbsentCall, syncFeature)
 
     @Test
     fun whenCreateAccountSucceedsThenReturnAccountCreatedSuccess() {
@@ -416,6 +421,30 @@ class SyncServiceRemoteTest {
 
     @Test
     fun whenSetKeysIfAbsentReturnsInvalidCredentialsThenClearStore() {
+        whenever(syncStore.token).thenReturn(token)
+        whenever(setKeysIfAbsentCall.execute(any(), any(), any()))
+            .thenReturn(Result.Error(code = API_CODE.INVALID_LOGIN_CREDENTIALS.code, reason = "unexpected status code"))
+
+        syncRemote.setKeysIfAbsent(token, "account_info", emptyList())
+
+        verify(syncStore).clearAll()
+    }
+
+    @Test
+    fun whenSetKeysIfAbsentReturnsInvalidCredentialsForRotatedTokenThenDoNotClearStore() {
+        whenever(syncStore.token).thenReturn("newRotatedToken")
+        whenever(setKeysIfAbsentCall.execute(any(), any(), any()))
+            .thenReturn(Result.Error(code = API_CODE.INVALID_LOGIN_CREDENTIALS.code, reason = "unexpected status code"))
+
+        syncRemote.setKeysIfAbsent(token, "account_info", emptyList())
+
+        verify(syncStore, never()).clearAll()
+    }
+
+    @Test
+    fun whenPreventStaleTokenLogoutDisabledAndInvalidCredentialsForRotatedTokenThenClearStore() {
+        syncFeature.preventStaleTokenLogout().setRawStoredState(State(false))
+        whenever(syncStore.token).thenReturn("newRotatedToken")
         whenever(setKeysIfAbsentCall.execute(any(), any(), any()))
             .thenReturn(Result.Error(code = API_CODE.INVALID_LOGIN_CREDENTIALS.code, reason = "unexpected status code"))
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1217093845234581?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1216509582049467?focus=true
API Proposals URL(s) (if applicable): N/A

### Description

I ran into this right after setting up sync on a fresh device. I renamed the device from the Sync settings, and when I returned to the screen the device was no longer synced. On a second device the renamed entry was still listed, and because this device had dropped out of the account I could sync it again, which left me with a duplicate and three devices in the list.

The rename does not use a dedicated endpoint. It re-authenticates the device, which issues a new sync token and replaces the one already stored. While that happens the app is still doing other authenticated work in the background, such as periodically refreshing the device list. If one of those requests is in flight with the old token at the moment it gets rotated, the server rejects it with an invalid credentials response. That response was treated as a signal that the account was gone, so the local sync data was cleared even though the account was still valid. Because nothing was actually removed on the server, the device kept appearing on other devices and syncing again created a duplicate.

This was less likely to happen before the Sync settings redesign. The rename used to be a dialog opened directly on the main Sync settings screen, so the rename and any refresh stayed on one screen. In the redesign the rename is confirmed on a separate screen, and the device list is refreshed when coming back to the main screen after the edit is confirmed. That return refresh lands right after the token is rotated, which makes the timing that triggers the bug much more likely.

The fix records which token each request used and compares it against the token currently stored when an invalid credentials response comes back. The local account is only cleared when the failing request used the token that is still current, or when the request carried no token at all. A rejection for a token that has since been replaced is treated as stale and ignored, so a rename no longer signs the device out. A genuine invalid credentials response for the current token still clears the account as before.

The behavior is behind the `preventStaleTokenLogout` flag, which is on by default. 

### Steps to test this PR

This was a race condition and is hard to reproduce reliably, so the steps below are a smoke test to confirm that renaming keeps the device synced.

_Rename a device_
- [ ] Set up Sync & Backup on a device.
- [ ] Tap the device in the list of synced devices.
- [ ] Tap "Edit Name".
- [ ] Enter a new name.
- [ ] Tap "Done".
- [ ] Verify the device is still synced and shows its new name.

### UI changes
N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when sync invalid-credentials responses wipe local account state; mitigated by a default-on feature flag and unchanged handling when the current token fails.
> 
> **Overview**
> Fixes devices dropping out of sync after **renaming**, when a background request still used the **old token** and a **401 invalid credentials** response triggered **`syncStore.clearAll()`**.
> 
> **`removeKeysIfInvalid`** now compares the failing request’s token to **`syncStore.token`** (from the **`Authorization`** header when available). Local state is cleared only when the failed token is still current, or when the request token is unknown—preserving prior behavior for those paths.
> 
> The behavior is gated by **`preventStaleTokenLogout`** (default **on**). With the flag off, invalid credentials still clear the store even for a rotated token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be102d5e22eb0ba305638e020739f9bf59561227. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->