### PR TITLE
Ensure all release-blocking checks are performed when creating hotfix

### DIFF
--- a/.github/workflows/hotfix_orchestrator.yml
+++ b/.github/workflows/hotfix_orchestrator.yml
@@ -1,0 +1,68 @@
+name: Hotfix - Orchestrate (prepare, verify, finish)
+
+on:
+  workflow_dispatch:
+    inputs:
+      app-version:
+        description: 'Hotfix version to release (e.g. 5.284.1)'
+        required: true
+        type: string
+      commit-hashes:
+        description: 'Commit SHA(s) to cherry-pick into the hotfix (space- or comma-separated)'
+        required: true
+        type: string
+      release-notes:
+        description: 'Release notes for the Play Store listing'
+        required: false
+        default: 'Bug fixes and other improvements'
+        type: string
+
+jobs:
+  prepare:
+    uses: ./.github/workflows/hotfix_prepare.yml
+    with:
+      app-version: ${{ inputs.app-version }}
+      commit-hashes: ${{ inputs.commit-hashes }}
+      release-notes: ${{ inputs.release-notes }}
+    secrets: inherit
+
+  # Create the Asana hotfix tracking task up-front; mirrors the manual "task first, then tag" order
+  create-hotfix-task:
+    needs: prepare
+    uses: ./.github/workflows/hotfix_create_task.yml
+    with:
+      app-version: ${{ inputs.app-version }}
+      commit-hashes: ${{ inputs.commit-hashes }}
+    secrets: inherit
+
+  resolve-hotfix-sha:
+    name: Resolve hotfix branch HEAD SHA
+    needs: prepare
+    runs-on: ubuntu-latest
+    outputs:
+      commit_sha: ${{ steps.resolve.outputs.commit_sha }}
+    steps:
+      - name: Checkout hotfix branch
+        uses: actions/checkout@v4
+        with:
+          ref: hotfix/${{ inputs.app-version }}
+          token: ${{ secrets.GT_DAXMOBILE }}
+          fetch-depth: 1
+      - name: Resolve SHA
+        id: resolve
+        run: echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  release-blocking-checks:
+    needs: resolve-hotfix-sha
+    uses: ./.github/workflows/release_blocking_checks.yml
+    with:
+      commit: ${{ needs.resolve-hotfix-sha.outputs.commit_sha }}
+      create_asana_tasks: false
+    secrets: inherit
+
+  finish:
+    needs: release-blocking-checks
+    uses: ./.github/workflows/hotfix_finish.yml
+    with:
+      app-version: ${{ inputs.app-version }}
+    secrets: inherit

--- a/.github/workflows/nightly-orchestrator.yml
+++ b/.github/workflows/nightly-orchestrator.yml
@@ -22,29 +22,15 @@ jobs:
           echo "Using commit: ${{ github.sha }}"
           echo "commit_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
 
-  call-nightly:
+  call-release-blocking-checks:
     needs: resolve-commit
-    uses: ./.github/workflows/nightly.yml
-    with:
-      commit: ${{ needs.resolve-commit.outputs.commit_sha }}
-    secrets: inherit
-
-  call-end-to-end:
-    needs: [resolve-commit, call-nightly]
-    uses: ./.github/workflows/e2e-nightly-full-suite.yml
-    with:
-      commit: ${{ needs.resolve-commit.outputs.commit_sha }}
-    secrets: inherit
-
-  call-privacy:
-    needs: [ resolve-commit, call-end-to-end ]
-    uses: ./.github/workflows/privacy.yml
+    uses: ./.github/workflows/release_blocking_checks.yml
     with:
       commit: ${{ needs.resolve-commit.outputs.commit_sha }}
     secrets: inherit
 
   call-update-content-scope:
-    needs: [ resolve-commit, call-privacy ]
+    needs: [ resolve-commit, call-release-blocking-checks ]
     uses: ./.github/workflows/update-content-scope.yml
     with:
       commit: ${{ needs.resolve-commit.outputs.commit_sha }}
@@ -60,7 +46,7 @@ jobs:
   tag_lgc_when_successful:
     name: Tag last good commit when successful
     runs-on: ubuntu-latest
-    needs: [ resolve-commit, call-nightly, call-end-to-end, call-privacy, call-update-content-scope, call-update-ref-tests]
+    needs: [ resolve-commit, call-release-blocking-checks, call-update-content-scope, call-update-ref-tests]
     if: ${{ success() }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/release_blocking_checks.yml
+++ b/.github/workflows/release_blocking_checks.yml
@@ -1,0 +1,66 @@
+name: Release Blocking Checks
+
+run-name: 'Release Blocking Checks (${{ inputs.ddg_di || ''AnvilDagger'' }})'
+
+on:
+  workflow_call:
+    inputs:
+      commit:
+        description: 'Commit SHA to check out and test'
+        required: true
+        type: string
+      create_asana_tasks:
+        description: 'Create Asana failure tasks / release blockers on failure (set false for hotfix verification)'
+        required: false
+        type: boolean
+        default: true
+      ddg_di:
+        description: 'DI framework to build with (AnvilDagger or Metro)'
+        required: false
+        type: string
+        default: 'AnvilDagger'
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: 'Commit SHA to check out and test'
+        required: true
+        type: string
+      create_asana_tasks:
+        description: 'Create Asana failure tasks / release blockers on failure'
+        required: false
+        type: boolean
+        default: true
+      ddg_di:
+        description: 'DI framework to build with (AnvilDagger or Metro)'
+        required: false
+        type: string
+        default: 'AnvilDagger'
+
+concurrency:
+  group: ${{ github.workflow_ref }}-${{ github.ref }}-${{ inputs.commit }}
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: ./.github/workflows/nightly.yml
+    with:
+      commit: ${{ inputs.commit }}
+      ddg_di: ${{ inputs.ddg_di }}
+    secrets: inherit
+
+  end-to-end:
+    needs: nightly
+    uses: ./.github/workflows/e2e-nightly-full-suite.yml
+    with:
+      commit: ${{ inputs.commit }}
+      create_asana_tasks: ${{ inputs.create_asana_tasks }}
+      ddg_di: ${{ inputs.ddg_di }}
+    secrets: inherit
+
+  privacy:
+    needs: end-to-end
+    uses: ./.github/workflows/privacy.yml
+    with:
+      commit: ${{ inputs.commit }}
+      ddg_di: ${{ inputs.ddg_di }}
+    secrets: inherit

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -510,7 +510,7 @@ platform :android do
                 skip_git_hooks: true
             )
 
-            UI.important(text:"Hotfix branch created. Apply your changes that need to be included in the hotfix now. Run `fastlane hotfix-finish` when you've made your changes and are happy it all works.")
+            UI.important(text:"Hotfix branch created. Apply your changes that need to be included in the hotfix now. Prefer the 'Hotfix - Orchestrate' GitHub Actions workflow, which runs the full release-blocking test suite (the same suite that gates LGC creation) before finishing. Only run `fastlane hotfix-finish` directly if you have separately confirmed the release-blocking checks pass on the hotfix branch.")
        end
 
        desc "Finish a hotfix in progress"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1211195376835786?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Ensure all release-blocking checks are performed when creating a hotfix. For ease of management over what is a release-blocking check, these have been pulled out to their own definition so that they can be shared between hotfix and normal releases.

Once this PR lands, the hotfix process will become:
1. Run the new Hotfix Orchestrator, providing the following info:
  - `app-version`
  - `commit-hashes`
  - `release-notes` [optional]

It will perform the following actions:
1. `prepare`, validates the version SHAs, checks tag doesn't exist, creates `hotfix/x.y.z` using `fastlane hotfix-start`, cherry picks each SHA and pushes the hotfix branch
2. `create-hotfix-task`, creates the Asana "Android Release x.y.z" task (building on #9262)
3. `resolve-hotfix-sha`, grabs the HEAD SHA of the new hotfix branch
4. `release-blocking-checks`, runs the full suite of release blocking checks (same checks that LGC does)
5. `finish`, uses `fastlane-hotfix-finish` to merge the hotfix to `main` and `develop`, create git tag `x.y.z` and pushes

> [!IMPORTANT]
> The fix needs to be landed on `develop` first. If the fix isn't yet merged, there's no SHA to cherry-pick from.

#### What's different after this PR
**Before:** a hotfix is done by manually dispatching these separate workflows:
- `hotfix_prepare`
- `hotfix_create_task`
- `hotfix_finish`

**After:** just run `hotfix_orchestrator`, which does all 3 of the above in addition to also running the release-blocking-checks.

### Steps to test this PR
Hard to test this in isolation before merging and without making destructive side-effects as a result of trying to test. 
- [x] Review the changes to make sure they make sense.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release and hotfix CI orchestration and git merge/tag timing; misconfigured job dependencies could block or skip hotfix finishes, but no app runtime code changes.
> 
> **Overview**
> Hotfixes are now driven by a single **Hotfix - Orchestrate** workflow that runs prepare, Asana task creation, **release-blocking checks on the hotfix branch HEAD**, and finish—replacing the need to manually chain three workflows without verification.
> 
> A new reusable **`release_blocking_checks.yml`** workflow centralizes the same **nightly → E2E → privacy** pipeline that gates LGC tagging. The nightly orchestrator now calls this workflow instead of invoking those jobs directly; LGC tagging and downstream content-scope/ref-test jobs still run after checks succeed.
> 
> For hotfix verification, **`create_asana_tasks: false`** is passed so E2E failures do not open release-blocker Asana tasks. **`hotfix-finish`** guidance in Fastlane now points teams to the orchestrator and warns against finishing without passing the release-blocking suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d4199b510d34c806f0053416889c0a5e1ce63a6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->