### PR TITLE
Cleanup: Remove duckAiVoiceEntryPoint and default released features to true

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -197,11 +197,6 @@ interface DuckChatInternal : DuckChat {
     fun isVoiceSearchEntryPointEnabled(): Boolean
 
     /**
-     * Returns whether voice chat entry point is enabled or not.
-     */
-    fun isVoiceChatEntryPointEnabled(): Boolean
-
-    /**
      * Returns whether DuckChat is user enabled or not.
      */
     fun isDuckChatUserEnabled(): Boolean
@@ -441,7 +436,6 @@ class RealDuckChat @Inject constructor(
     private var bangRegex: Regex? = null
     private var isAddressBarEntryPointEnabled: Boolean = false
     private var isVoiceSearchEntryPointEnabled: Boolean = false
-    private var isVoiceChatEntryPointEnabled: Boolean = false
     private var isImageUploadEnabled: Boolean = false
     private var isStandaloneMigrationEnabled: Boolean = false
     private var keepSessionAliveInMinutes: Int = DEFAULT_SESSION_ALIVE
@@ -594,7 +588,6 @@ class RealDuckChat @Inject constructor(
 
     override fun isAddressBarEntryPointEnabled(): Boolean = isAddressBarEntryPointEnabled
     override fun isVoiceSearchEntryPointEnabled(): Boolean = isVoiceSearchEntryPointEnabled
-    override fun isVoiceChatEntryPointEnabled(): Boolean = isVoiceChatEntryPointEnabled
 
     override fun isDuckChatUserEnabled(): Boolean = isDuckChatUserEnabled
 
@@ -930,7 +923,6 @@ class RealDuckChat @Inject constructor(
                 }
             isAddressBarEntryPointEnabled = settingsJson?.addressBarEntryPoint ?: false
             isVoiceSearchEntryPointEnabled = duckChatFeature.duckAiVoiceSearch().isEnabled()
-            isVoiceChatEntryPointEnabled = duckChatFeature.duckAiVoiceEntryPoint().isEnabled()
             _allowDuckAiAsDigitalAssistant.emit(featureEnabled && duckChatFeature.digitalAssistantDuckAi().isEnabled())
             isImageUploadEnabled = imageUploadFeature.self().isEnabled()
             isStandaloneMigrationEnabled = duckChatFeature.standaloneMigration().isEnabled()
@@ -1000,7 +992,7 @@ class RealDuckChat @Inject constructor(
 
             val showVoiceChatEntry =
                 duckChatFeatureRepository.shouldShowInVoiceChat() &&
-                    isDuckChatFeatureEnabled && isDuckChatUserEnabled && isVoiceChatEntryPointEnabled
+                    isDuckChatFeatureEnabled && isDuckChatUserEnabled
             _showVoiceChatEntry.emit(showVoiceChatEntry)
 
             // Full screen mode (new Duck.ai header, unified input, hamburger menu) is intentionally NOT gated on

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -266,7 +266,7 @@ interface DuckChatFeature {
      * Kill switch for opening Duck.ai voice chat when the digital assistant intent is received.
      * @return `true` when the remote config has the "digitalAssistantDuckAi"
      * sub-feature flag enabled
-     * If the remote feature is not present defaults to `internal`
+     * If the remote feature is not present defaults to `true`
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun digitalAssistantDuckAi(): Toggle
@@ -280,7 +280,7 @@ interface DuckChatFeature {
 
     /**
      * @return `true` when the contextual Duck.ai sheet improvements are enabled.
-     * If the remote feature is not present defaults to `false`
+     * If the remote feature is not present defaults to `true`
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun contextualSheetImprovements(): Toggle
@@ -301,7 +301,7 @@ interface DuckChatFeature {
 
     /**
      * @return Toggle iseÉnabled `true` when the remove chat history feature is enabled.
-     * If the remote feature is not present defaults to `internal`
+     * If the remote feature is not present defaults to `true`
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun removeChatHistory(): Toggle

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -211,13 +211,6 @@ interface DuckChatFeature {
     fun chatTabAttachments(): Toggle
 
     /**
-     * @return `true` when the duck.ai voice entry point button is enabled in the input screen
-     * If the remote feature is not present defaults to `internal`
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
-    fun duckAiVoiceEntryPoint(): Toggle
-
-    /**
      * @return `true` when the fire button is shown in the contextual Duck.ai sheet,
      * allowing the user to clear their current chat.
      * If the remote feature is not present defaults to `internal`

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -268,21 +268,21 @@ interface DuckChatFeature {
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `internal`
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun digitalAssistantDuckAi(): Toggle
 
     /**
      * @return `true` when the Duck.ai voice chat foreground service (microphone) should be started
      * and stopped during a voice session.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun duckAiVoiceChatService(): Toggle
 
     /**
      * @return `true` when the contextual Duck.ai sheet improvements are enabled.
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun contextualSheetImprovements(): Toggle
 
     /**
@@ -303,7 +303,7 @@ interface DuckChatFeature {
      * @return Toggle iseÉnabled `true` when the remove chat history feature is enabled.
      * If the remote feature is not present defaults to `internal`
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun removeChatHistory(): Toggle
 
     /**

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckAiShortcutSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckAiShortcutSettingsActivity.kt
@@ -112,7 +112,6 @@ class DuckAiShortcutSettingsActivity : DuckDuckGoActivity() {
             quietlySetIsChecked(viewState.showInVoiceSearch, voiceSearchToggleListener)
         }
         binding.showDuckAiInVoiceChatToggle.apply {
-            isVisible = viewState.shouldShowVoiceChatToggle
             quietlySetIsChecked(viewState.showInVoiceChat, voiceChatToggleListener)
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckAiShortcutSettingsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckAiShortcutSettingsViewModel.kt
@@ -39,7 +39,6 @@ class DuckAiShortcutSettingsViewModel @Inject constructor(
         val showInVoiceChat: Boolean = false,
         val shouldShowAddressBarToggle: Boolean = false,
         val shouldShowVoiceSearchToggle: Boolean = false,
-        val shouldShowVoiceChatToggle: Boolean = false,
     )
 
     val viewState = combine(
@@ -55,7 +54,6 @@ class DuckAiShortcutSettingsViewModel @Inject constructor(
             showInVoiceChat = showInVoiceChat,
             shouldShowAddressBarToggle = duckChat.isAddressBarEntryPointEnabled(),
             shouldShowVoiceSearchToggle = duckChat.isVoiceSearchEntryPointEnabled(),
-            shouldShowVoiceChatToggle = duckChat.isVoiceChatEntryPointEnabled(),
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), ViewState())
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -120,7 +120,6 @@ class RealDuckChatTest {
         duckChatFeature.self().setRawStoredState(State(enable = true))
         duckChatFeature.duckAiInputScreen().setRawStoredState(State(enable = true))
         duckChatFeature.duckAiVoiceSearch().setRawStoredState(State(enable = false))
-        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
         imageUploadFeature.self().setRawStoredState(State(enable = true))
 
         testee = spy(
@@ -495,9 +494,8 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun whenDuckChatEnabledAndVoiceEntryPointEnabledThenShowVoiceChatEntryIsTrue() = runTest {
+    fun whenDuckChatEnabledThenShowVoiceChatEntryIsTrue() = runTest {
         duckChatFeature.self().setRawStoredState(State(enable = true))
-        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
         whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
 
@@ -508,22 +506,8 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun whenVoiceEntryPointDisabledThenShowVoiceChatEntryIsFalse() = runTest {
-        duckChatFeature.self().setRawStoredState(State(enable = true))
-        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = false))
-        whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(true)
-        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
-
-        testee.onPrivacyConfigDownloaded()
-        coroutineRule.testScope.advanceUntilIdle()
-
-        assertFalse(testee.showVoiceChatEntry.value)
-    }
-
-    @Test
     fun whenDuckChatFeatureDisabledThenShowVoiceChatEntryIsFalse() = runTest {
         duckChatFeature.self().setRawStoredState(State(enable = false))
-        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
         whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
 
@@ -536,7 +520,6 @@ class RealDuckChatTest {
     @Test
     fun whenDuckChatUserDisabledThenShowVoiceChatEntryIsFalse() = runTest {
         duckChatFeature.self().setRawStoredState(State(enable = true))
-        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
         whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(false)
 
@@ -550,7 +533,6 @@ class RealDuckChatTest {
     fun whenShouldShowInVoiceSearchSettingFalseThenShowVoiceChatEntryStillTrue() = runTest {
         // showVoiceChatEntry must be independent of the in-voice-search toggle user setting
         duckChatFeature.self().setRawStoredState(State(enable = true))
-        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
         whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.shouldShowInVoiceSearch()).thenReturn(false)
@@ -564,7 +546,6 @@ class RealDuckChatTest {
     @Test
     fun whenShouldShowInVoiceChatSettingFalseThenShowVoiceChatEntryIsFalse() = runTest {
         duckChatFeature.self().setRawStoredState(State(enable = true))
-        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
         whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(false)
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
 
@@ -583,7 +564,6 @@ class RealDuckChatTest {
     @Test
     fun whenSetShowInVoiceChatUserSettingThenShowVoiceChatEntryReflectsChange() = runTest {
         duckChatFeature.self().setRawStoredState(State(enable = true))
-        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
         testee.onPrivacyConfigDownloaded()
         coroutineRule.testScope.advanceUntilIdle()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -157,8 +157,6 @@ class FakeDuckChatInternal(
 
     override fun isVoiceSearchEntryPointEnabled(): Boolean = false
 
-    override fun isVoiceChatEntryPointEnabled(): Boolean = false
-
     override fun isDuckChatUserEnabled(): Boolean = enableDuckChatUserSetting.value
 
     override fun updateChatState(state: ChatState) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckAiShortcutSettingsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckAiShortcutSettingsViewModelTest.kt
@@ -180,29 +180,6 @@ class DuckAiShortcutSettingsViewModelTest {
     }
 
     @Test
-    fun whenVoiceChatEntryEnabledThenToggleShown() = runTest {
-        whenever(duckChat.isVoiceChatEntryPointEnabled()).thenReturn(true)
-        testee = DuckAiShortcutSettingsViewModel(duckChat)
-
-        testee.viewState.test {
-            val state = awaitItem()
-            assertTrue(state.shouldShowVoiceChatToggle)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun whenVoiceChatEntryDisabledThenToggleHidden() = runTest {
-        whenever(duckChat.isVoiceChatEntryPointEnabled()).thenReturn(false)
-        testee = DuckAiShortcutSettingsViewModel(duckChat)
-
-        testee.viewState.test {
-            val state = awaitItem()
-            assertFalse(state.shouldShowVoiceChatToggle)
-        }
-    }
-
-    @Test
     fun whenOnShowDuckChatInVoiceChatToggledThenCallDuckChatSetShowInVoiceChat() = runTest {
         testee.onShowDuckChatInVoiceChatToggled(true)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217117225900615?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Removed the `duckAiVoiceEntryPoint` feature flag. It has launched, so the Duck.ai voice-chat entry point is now permanently enabled.
  - Deleted the `isVoiceChatEntryPointEnabled() `accessor on `DuckChatInternal` that mirrored the flag, along with its backing field and override in `RealDuckChat`.
  - Simplified the `showVoiceChatEntry` logic — it now depends only on the `shouldShowInVoiceChat` setting, the feature being enabled, and the user being enabled.
  - The voice-chat toggle in Duck.ai shortcut settings is now always shown; removed the shouldShowVoiceChatToggle view state and its visibility gating.
  - Updated and pruned the affected unit tests to match.

Default to true the following features so we can safely remove them from the config:
- `digitalAssistantDuckAi`
- `duckAiVoiceChatService`
- `contextualSheetImprovements`
- `removeChatHistory`


### Steps to test this PR
Smoke test voice chat


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing Duck.ai voice entry and assistant-related paths change behavior when remote config is absent; defaults flip from internal/off to on for several flags.
> 
> **Overview**
> Removes the shipped **`duckAiVoiceEntryPoint`** remote flag and treats the Duck.ai voice-chat entry as always available when Duck.ai is on and the user hasn’t disabled it in shortcuts.
> 
> **Voice chat gating** no longer checks a remote entry-point flag: `showVoiceChatEntry` depends only on `shouldShowInVoiceChat`, global Duck.ai enablement, and user enablement. The shortcut-settings **“show in voice chat”** toggle is always visible (no `shouldShowVoiceChatToggle` / `isVoiceChatEntryPointEnabled`).
> 
> Several **`DuckChatFeature`** toggles now default to **true** when missing from remote config (`digitalAssistantDuckAi`, `duckAiVoiceChatService`, `contextualSheetImprovements`, `removeChatHistory`), so those behaviors stay on without explicit config entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5a08c77a28b1b26cd889d126e010f426059c7f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->