### PR TITLE
Submit strings for translation

### DIFF
--- a/autoconsent/autoconsent-impl/src/main/res/values-bg/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-bg/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Защита от изскачащи прозорци за бисквитки</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo ще се опита да избере възможно най-поверителните настройки и ще скрива досадните изскачащи прозорци.\n<a href=\"\">Научете повече</a>]]></string>
     <string name="autoconsentToggle">Позволете на DuckDuckGo да се погрижи за изскачащите прозорци за бисквитки</string>
-    <string name="autoconsentAutoManageToggle">Автоматично управление на изскачащи прозорци за бисквитки</string>
-    <string name="autoconsentAutoManageDescription">Ще се стремим да избираме само най-поверителните налични опции за бисквитки вместо Вас, след което ще затваряме тези изскачащи прозорци.</string>
+    <string name="autoconsentAutoManageToggle">Отхвърляне на незадължителни бисквитки</string>
+    <string name="autoconsentAutoManageDescription">Ще се стремим да отхвърляме възможно най-много бисквитки вместо Вас, след което ще затваряме изскачащите прозорци.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo може автоматично да управлява предпочитанията за бисквитки, за да увеличи поверителността, да свежда до минимум бисквитките и да затваря тези изскачащи прозорци.\n<a href=\"\">Научете повече</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Изскачащи прозорци без опция за отказ</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Можете също така да разрешите на DuckDuckGo да Ви спести едно кликване, като приема бисквитки от Ваше име и затваря изскачащите прозорци без опция за отказ.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Приемане на бисквитки, които не могат да бъдат отхвърлени</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Ако няма опция за отказ, ще Ви спестим едно кликване, ще приемем тези бисквитки вместо Вас и ще затворим изскачащите прозорци.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Омръзнаха ли Ви изскачащите прозорци за бисквитки без опция за отказ?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Можем да Ви спестим едно кликване и да приемем тези бисквитки вместо Вас."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Приемане на бисквитки, които не могат да бъдат отхвърлени"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Ще продължа да ги приемам самостоятелно"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Омръзнаха ли Ви изскачащите прозорци за бисквитки, които не Ви оставят на мира?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Ще се стремим да отхвърляме възможно най-много бисквитки. Ако няма опция за отказ, ще Ви спестим едно кликване и ще приемем тези бисквитки вместо Вас."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Отхвърляне, когато е възможно, или приемане вместо мен"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Ще продължа да ги управлявам самостоятелно"</string>
+    <string name="autoconsentPopupConfirmButton">"Потвърждаване"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Можете да коригирате настройките по всяко време в <b>Настройки > Защита от изскачащи прозорци за бисквитки.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-cs/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-cs/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Ochrana před vyskakovacími okny ohledně cookies</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo se pokusí zvolit nastavení s maximálním zachováním soukromí a tato vyskakovací okna ti bude skrývat.\n<a href=\"\">Další informace</a>]]></string>
     <string name="autoconsentToggle">Nech správu vyskakovacích oken ohledně cookie na DuckDuckGo</string>
-    <string name="autoconsentAutoManageToggle">Automaticky spravovat vyskakovací okna o cookies</string>
-    <string name="autoconsentAutoManageDescription">Budeme se snažit vybírat pro tebe jen ty možnosti cookies, které nejlépe chrání soukromí, a pak tato vyskakovací okna zavřeme.</string>
+    <string name="autoconsentAutoManageToggle">Odmítnout nepovinné cookies</string>
+    <string name="autoconsentAutoManageDescription">Budeme se snažit odmítat za tebe co nejvíce cookies a pak zavírat vyskakovací okna.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo může automaticky spravovat předvolby cookies tak, aby zajistilo maximální ochranu soukromí, co nejméně cookies a zavíralo vyskakovací okna.\n<a href=\"\">Další informace</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Vyskakovací okna bez možnosti odmítnutí</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Nech DuckDuckGo, ať ti také šetří klikání přijímáním cookies za tebe a zavírá vyskakovací okna, kde není možnost cookies odmítnout.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Přijímat cookies, které nelze odmítnout</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Pokud možnost odmítnutí není k dispozici, ušetříme ti klikání, tyto cookies za tebe přijmeme a vyskakovací okna zavřeme.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Štvou tě vyskakovací okna s cookies, která ti nedovolí je odmítnout?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Můžeme ti ušetřit klikání a cookies přijímat za tebe."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Přijímat cookies, které nelze odmítnout"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Budu je dál přijímat já"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Už tě nebaví vyskakovací okna s cookies, která ti nedají pokoj?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Pokusíme se odmítnout co nejvíce cookies. Pokud možnost odmítnutí neexistuje, ušetříme ti kliknutí a tyto cookies za tebe přijmeme."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Chci je automaticky odmítat, případně přijímat"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Budu je dál řešit já"</string>
+    <string name="autoconsentPopupConfirmButton">"Potvrdit"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Kdykoli to můžeš upravit v <b>Nastavení > Ochrana před vyskakovacími okny o cookies.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-da/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-da/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Beskyttelse mod pop op-beskeder om cookies</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo vil forsøge at vælge de mest private indstillinger og skjule disse pop op-vinduer for dig.\n<a href=\"\">Mere info</a>]]></string>
     <string name="autoconsentToggle">Lad DuckDuckGo håndtere pop op-beskeder om cookies</string>
-    <string name="autoconsentAutoManageToggle">Administrer automatisk pop op-beskeder om cookies</string>
-    <string name="autoconsentAutoManageDescription">Vi vil forsøge kun at vælge de mest private cookieindstillinger for dig og derefter lukke disse pop op-vinduer.</string>
+    <string name="autoconsentAutoManageToggle">Afvis valgfrie cookies</string>
+    <string name="autoconsentAutoManageDescription">Vi vil forsøge at afvise så mange cookies som muligt for dig og derefter lukke pop op-vinduerne.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo kan automatisk administrere dine cookiepræferencer for at maksimere fortrolighed, minimere cookies og lukke disse pop op-vinduer.\n<a href=\"\">Mere info</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Pop op-vinduer uden fravalgsmulighed</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Lad også DuckDuckGo spare dig for et klik ved at acceptere cookies på dine vegne for at lukke pop op-vinduer, hvor du ikke kan fravælge dem.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Acceptér cookies, der ikke kan fravælges</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Hvis der ikke er en afvisningsmulighed, sparer vi dig for et klik, accepterer disse cookies for dig og lukker pop op-vinduerne.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Træt af cookie-pop-ups, der ikke lader dig fravælge?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Vi kan spare dig for et klik og acceptere disse cookies for dig."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Acceptér cookies, der ikke kan fravælges"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Jeg vil fortsætte med at acceptere dem selv"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Er du træt af pop op-vinduer om cookies, der ikke vil lade dig være i fred?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Vores mål er at afvise så mange cookies som muligt. Hvis der ikke er en afvisningsmulighed, sparer vi dig for et klik og accepterer disse cookies for dig."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Afvis når muligt eller acceptér for mig"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Jeg vil fortsætte med at håndtere dem selv"</string>
+    <string name="autoconsentPopupConfirmButton">"Bekræft"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Du kan justere det når som helst i <b>Indstillinger > Beskyttelse mod pop op-beskeder om cookies.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-de/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-de/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Cookie-Pop-up-Schutz</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo wird versuchen, die privatesten Einstellungen zu wählen und Pop-ups für dich auszublenden.\n<a href=\"\">Mehr erfahren</a>]]></string>
     <string name="autoconsentToggle">Lass Cookie-Pop-ups von DuckDuckGo verwalten</string>
-    <string name="autoconsentAutoManageToggle">Cookie-Pop-ups automatisch verwalten</string>
-    <string name="autoconsentAutoManageDescription">Wir werden versuchen, nur die privatesten verfügbaren Cookie-Optionen für dich auszuwählen und diese Pop-ups dann zu schließen.</string>
+    <string name="autoconsentAutoManageToggle">Optionale Cookies ablehnen</string>
+    <string name="autoconsentAutoManageDescription">Wir werden versuchen, so viele Cookies wie möglich für dich abzulehnen und dann die Pop-ups zu schließen.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo kann Cookie-Einstellungen automatisch verwalten, um die Privatsphäre zu maximieren, Cookies zu minimieren und diese Pop-ups zu schließen.\n<a href=\"\">Mehr erfahren</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Pop-ups ohne Abmeldemöglichkeit</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Lass DuckDuckGo dir außerdem einen Klick ersparen, indem Cookies in deinem Namen akzeptiert werden, um Pop-ups zu schließen, bei denen du dich nicht abmelden kannst.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Cookies akzeptieren, die nicht abgelehnt werden können</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Falls es keine Option zum Ablehnen gibt, ersparen wir dir einen Klick, akzeptieren diese Cookies für dich und schließen die Pop-ups.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Hast du genug von Cookie-Pop-ups, bei denen du dich nicht abmelden kannst?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Wir können dir einen Klick ersparen und diese Cookies für dich akzeptieren."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Cookies akzeptieren, die nicht abgelehnt werden können"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Ich nehme sie weiterhin selbst an"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Hast du genug von Cookie-Pop-ups, die dich nicht in Ruhe lassen?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Wir werden versuchen, so viele Cookies wie möglich abzulehnen. Wenn es keine Möglichkeit gibt, diese abzulehnen, ersparen wir dir einen Klick und akzeptieren diese Cookies für dich."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Wenn möglich ablehnen oder für mich akzeptieren"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Ich kümmere mich weiter selbst darum"</string>
+    <string name="autoconsentPopupConfirmButton">"Bestätigen"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Du kannst das jederzeit unter <b>Einstellungen > Cookie-Pop-up-Schutz</b>anpassen.]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-el/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-el/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Προστασία αναδυόμενων παραθύρων για cookies</string>
     <string name="autoconsentDescription"><![CDATA[Το DuckDuckGo θα προσπαθήσει να επιλέξει τις πιο ιδιωτικές ρυθμίσεις που υπάρχουν διαθέσιμες και να αποκρύψει αυτά τα αναδυόμενα παράθυρα για εσάς.\n<a href=\"\">Μάθετε περισσότερα</a>]]></string>
     <string name="autoconsentToggle">Επιτρέψτε στο DuckDuckGo να διαχειρίζεται τα αναδυόμενα παράθυρα για cookies</string>
-    <string name="autoconsentAutoManageToggle">Αυτόματη διαχείριση αναδυόμενων παραθύρων cookie</string>
-    <string name="autoconsentAutoManageDescription">Θα προσπαθήσουμε να επιλέξουμε μόνο τις πιο ιδιωτικές διαθέσιμες επιλογές cookie για εσάς και έπειτα να κλείσουμε αυτά τα αναδυόμενα παράθυρα.</string>
+    <string name="autoconsentAutoManageToggle">Απόρριψη προαιρετικών cookie</string>
+    <string name="autoconsentAutoManageDescription">Θα προσπαθήσουμε να απορρίψουμε όσο το δυνατόν περισσότερα cookie για εσάς και έπειτα να κλείσουμε τα αναδυόμενα παράθυρα.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[Το DuckDuckGo μπορεί να διαχειρίζεται αυτόματα τις προτιμήσεις για τα cookie ώστε να μεγιστοποιείται το απόρρητο, να ελαχιστοποιούνται τα cookie και να κλείνουν αυτά τα αναδυόμενα παράθυρα.\n<a href=\"\">Μάθετε περισσότερα</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Αναδυόμενα παράθυρα χωρίς επιλογή εξαίρεσης</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Επίσης, επιτρέψτε στο DuckDuckGo να σας γλιτώσει ένα κλικ αποδεχόμενο cookie εκ μέρους σας, ώστε να κλείνουν τα αναδυόμενα παράθυρα που δεν σας επιτρέπουν να εξαιρεθείτε.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Αποδοχή cookie που δεν μπορούν να απορριφθούν</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Εάν δεν υπάρχει επιλογή απόρριψης, θα σας γλιτώσουμε ένα κλικ, θα αποδεχτούμε αυτά τα cookie για εσάς και θα κλείσουμε τα αναδυόμενα παράθυρα.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Κουραστήκατε από τα αναδυόμενα παράθυρα για cookie που δεν σας επιτρέπουν να εξαιρεθείτε;"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Μπορούμε να σας γλιτώσουμε ένα κλικ και να αποδεχτούμε αυτά τα cookie για εσάς."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Αποδοχή cookie που δεν μπορούν να απορριφθούν"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Θα συνεχίσω να τα αποδέχομαι εγώ προσωπικά"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Κουραστήκατε από τα αναδυόμενα παράθυρα για cookie που δεν σας αφήνουν σε ησυχία;"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Θα προσπαθήσουμε να απορρίψουμε όσο το δυνατόν περισσότερα cookie. Εάν δεν υπάρχει επιλογή απόρριψης, θα σας γλιτώσουμε ένα κλικ και θα αποδεχτούμε αυτά τα cookie για εσάς."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Απόρριψη όποτε είναι εφικτό ή αποδοχή για μένα"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Θα συνεχίσω να τα διαχειρίζομαι εγώ προσωπικά"</string>
+    <string name="autoconsentPopupConfirmButton">"Επιβεβαίωση"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Μπορείτε να κάνετε τις απαραίτητες ρυθμίσεις οποιαδήποτε στιγμή στις <b>Ρυθμίσεις > Προστασία αναδυόμενων παραθύρων για cookie.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-es/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-es/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Protección contra ventanas emergentes de cookies</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo intentará seleccionar la configuración más privada disponible y ocultar estas ventanas emergentes por ti.<a href=\"\">Más información</a>]]></string>
     <string name="autoconsentToggle">Deja que DuckDuckGo gestione las ventanas emergentes de cookies</string>
-    <string name="autoconsentAutoManageToggle">Gestionar automáticamente las ventanas emergentes de cookies</string>
-    <string name="autoconsentAutoManageDescription">Intentaremos seleccionar solo las opciones de cookies más privadas disponibles para ti y, a continuación, cerrar estas ventanas emergentes.</string>
+    <string name="autoconsentAutoManageToggle">Rechazar cookies opcionales</string>
+    <string name="autoconsentAutoManageDescription">Intentaremos rechazar el mayor número de cookies posible por ti y, a continuación, cerrar las ventanas emergentes.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo puede gestionar automáticamente tus preferencias de cookies para maximizar la privacidad, minimizar las cookies y cerrar estas ventanas emergentes.\n<a href=\"\">Más información</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Ventanas emergentes sin opción de rechazarlas</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Deja también que DuckDuckGo te ahorre un clic al aceptar las cookies en tu nombre para cerrar las ventanas emergentes que no te dejan rechazarlas.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Aceptar cookies sin opción de rechazarlas</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Si no hay opción de rechazarlas, te ahorraremos un clic, aceptaremos estas cookies por ti y cerraremos las ventanas emergentes.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"¿Cansado de las ventanas emergentes de cookies que no te dejan rechazarlas?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Podemos ahorrarte un clic y aceptar estas cookies por ti."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Aceptar cookies sin opción de rechazarlas"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Seguiré aceptándolas por mi cuenta"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"¿Cansado de las ventanas emergentes de cookies que no te dejan en paz?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Intentaremos rechazar el mayor número de cookies posible. Si no hay opción de rechazarlas, te ahorraremos un clic y aceptaremos estas cookies por ti."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Rechazar cuando sea posible o aceptar por mí"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Seguiré gestionándolas por mi cuenta"</string>
+    <string name="autoconsentPopupConfirmButton">"Confirmar"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Puedes ajustar esto en cualquier momento en <b>Ajustes > Protección contra ventanas emergentes de cookies.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-et/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-et/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Küpsiste hüpikakna kaitse</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo proovib valida kõige privaatsemad saadaolevad seaded ja peita need hüpikaknad sinu eest.\n<a href=\"\">Loe edasi</a>]]></string>
     <string name="autoconsentToggle">Lase DuckDuckGol küpsiste hüpikaknaid hallata</string>
-    <string name="autoconsentAutoManageToggle">Halda küpsiste hüpikaknaid automaatselt</string>
-    <string name="autoconsentAutoManageDescription">Proovime sinu jaoks valida ainult kõige privaatsemad saadaolevad küpsisevalikud, seejärel sulgeda need hüpikaknad.</string>
+    <string name="autoconsentAutoManageToggle">Keeldu valikulistest küpsistest</string>
+    <string name="autoconsentAutoManageDescription">Püüame sinu jaoks blokeerida nii palju küpsiseid kui võimalik, seejärel sulgeda hüpikaknad.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo saab automaatselt hallata sinu küpsiste eelistusi, et maksimeerida privaatsust, minimeerida küpsiseid ja sulgeda need hüpikaknad.\n<a href=\"\">Loe edasi</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Hüpikaknad ilma loobumisvõimaluseta</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Luba DuckDuckGo\'l säästa sind klikkimisest, nõustudes sinu eest küpsistega, et sulgeda hüpikaknad, mis ei võimalda neist keelduda.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Nõustu küpsistega, millest ei saa loobuda</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Kui keeldumisvõimalust pole, säästame sulle ühe klõpsu, nõustume sinu eest nende küpsistega ja sulgeme hüpikaknad.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Oled väsinud küpsiste hüpikakendest, mis ei lase sul neist keelduda?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Saame säästa sind ühest klõpsust ja nõustuda nende küpsistega sinu eest."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Nõustu küpsistega, millest ei saa loobuda"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Ma nõustun nendega ka edaspidi ise"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Oled väsinud küpsiste hüpikakendest, mis ei jäta sind rahule?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Püüame blokeerida nii palju küpsiseid kui võimalik. Kui keeldumisvõimalust pole, säästame sulle ühe klõpsu ja nõustume nende küpsistega sinu eest."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Keeldu võimalusel või nõustu minu eest"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Ma jätkan nende haldamist ise"</string>
+    <string name="autoconsentPopupConfirmButton">"Kinnita"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Saad seda igal ajal muuta jaotises <b>Seaded > Küpsiste hüpikakna kaitse.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-fi/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-fi/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Evästeiden ponnahdusikkuna -suojaus</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo yrittää valita valittavissa olevista asetuksista yksityisimmät ja piilottaa nämä ponnahdusikkunat puolestasi.\n<a href=\"\">Lue lisää</a>]]></string>
     <string name="autoconsentToggle">Anna DuckDuckGo hoitaa evästeiden ponnahdusikkunat</string>
-    <string name="autoconsentAutoManageToggle">Evästeponnahdusikkunoiden automaattinen hallinta</string>
-    <string name="autoconsentAutoManageDescription">Pyrimme valitsemaan sinulle vain yksityisyyttä parhaiten suojaavat evästeasetukset ja sulkemaan sitten nämä ponnahdusikkunat.</string>
+    <string name="autoconsentAutoManageToggle">Hylkää valinnaiset evästeet</string>
+    <string name="autoconsentAutoManageDescription">Pyrimme hylkäämään puolestasi mahdollisimman monta evästettä ja sulkemaan sitten ponnahdusikkunat.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo voi hallinnoida evästeasetuksia automaattisesti yksityisyyden maksimoimiseksi, evästeiden minimoimiseksi ja näiden ponnahdusikkunoiden sulkemiseksi.\n<a href=\"\">Lue lisää</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Ponnahdusikkunat ilman kieltäytymismahdollisuutta</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Anna myös DuckDuckGon säästää sinulta yhden klikkauksen hyväksymällä evästeet puolestasi, jotta se voi sulkea ponnahdusikkunat, joissa ei voi kieltäytyä evästeistä.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Hyväksy evästeet, joita ei voi hylätä</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Jos hylkäämisvaihtoehtoa ei ole, säästämme sinulta yhden klikkauksen, hyväksymme nämä evästeet puolestasi ja suljemme ponnahdusikkunat.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Oletko kyllästynyt evästeiden ponnahdusikkunoihin, joista et voi kieltäytyä?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Voimme säästää sinulta yhden klikkauksen ja hyväksyä nämä evästeet puolestasi."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Hyväksy evästeet, joita ei voi hylätä"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Hyväksyn ne jatkossakin itse"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Oletko kyllästynyt evästeiden ponnahdusikkunoihin, jotka eivät jätä sinua rauhaan?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Pyrimme hylkäämään mahdollisimman monta evästettä. Jos hylkäämisvaihtoehtoa ei ole, säästämme sinulta yhden klikkauksen ja hyväksymme nämä evästeet puolestasi."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Hylkää, jos mahdollista, tai hyväksy puolestani"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Hoidan ne jatkossakin itse"</string>
+    <string name="autoconsentPopupConfirmButton">"Vahvista"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Voit muuttaa tätä milloin tahansa kohdassa <b>Asetukset > Evästeiden ponnahdusikkunasuojaus.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-fr/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-fr/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Protection contre les fenêtres contextuelles des cookies</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo essaiera de sélectionner les paramètres de confidentialité les plus élevés et de masquer ces fenêtres contextuelles pour vous.\n<a href=\"\">En savoir plus</a>]]></string>
     <string name="autoconsentToggle">Laisser DuckDuckGo gérer les fenêtres contextuelles des cookies</string>
-    <string name="autoconsentAutoManageToggle">Gérer automatiquement les fenêtres contextuelles (cookies)</string>
-    <string name="autoconsentAutoManageDescription">Nous nous efforcerons de ne sélectionner que les options de cookies les plus respectueuses de la vie privée pour vous, puis de fermer ces fenêtres contextuelles.</string>
+    <string name="autoconsentAutoManageToggle">Rejeter les cookies optionnels</string>
+    <string name="autoconsentAutoManageDescription">Nous nous efforcerons de rejeter le plus grand nombre de cookies possible pour vous, puis de fermer ces fenêtres contextuelles.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo peut gérer automatiquement les préférences en matière de cookies pour maximiser la confidentialité, minimiser les cookies et fermer ces fenêtres contextuelles.<a href=\"\">En savoir plus</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Fenêtres contextuelles sans option de refus</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Laissez aussi DuckDuckGo vous épargner un clic en acceptant les cookies en votre nom pour fermer les fenêtres contextuelles qui ne vous permettent pas de refuser leur utilisation.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Accepter les cookies qui ne peuvent pas être refusés</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Si aucune option de refus n\'est proposée, nous vous épargnerons un clic, accepterons ces cookies à votre place et fermerons les fenêtres contextuelles.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Vous en avez assez des fenêtres contextuelles de cookies qui ne vous permettent pas de refuser leur utilisation ?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Nous pouvons vous épargner un clic et accepter ces cookies à votre place."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Accepter les cookies qui ne peuvent pas être refusés"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Je les accepterai moi-même"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Vous en avez assez des fenêtres contextuelles sur les cookies qui ne vous laissent pas tranquille ?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Nous nous efforcerons de rejeter le plus grand nombre de cookies possible. Si aucune option de refus n'est proposée, nous vous épargnerons un clic et accepterons ces cookies à votre place."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Rejeter quand c'est possible ou accepter pour moi"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Je les gérerai moi-même"</string>
+    <string name="autoconsentPopupConfirmButton">"Confirmer"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Vous pouvez toujours modifier ces paramètres à tout moment dans Paramètres > <b>Protection contre les fenêtres contextuelles de cookies</b>.]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-hr/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-hr/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Zaštita od kolačića i skočnih prozora</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo će pokušati za tebe odabrati najprivatnije dostupne postavke i sakriti skočne prozore.\n<a href=\"\">Saznaj više</a>]]></string>
     <string name="autoconsentToggle">Neka DuckDuckGo upravlja skočnim prozorima kolačića</string>
-    <string name="autoconsentAutoManageToggle">Automatsko upravljanje skočnim prozorima kolačića</string>
-    <string name="autoconsentAutoManageDescription">Pokušat ćemo za tebe odabrati samo najprivatnije dostupne opcije kolačića, a zatim zatvoriti te skočne prozore.</string>
+    <string name="autoconsentAutoManageToggle">Odbij neobavezne kolačiće</string>
+    <string name="autoconsentAutoManageDescription">Pokušat ćemo za tebe odbiti što je više moguće kolačića, a zatim zatvoriti skočne prozore.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo može automatski upravljati postavkama kolačića za povećanje privatnosti, smanjenje kolačića i zatvaranje skočnih prozora.\n<a href=\"\">Saznaj više</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Skočni prozori bez mogućnosti isključivanja</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Dopusti da ti DuckDuckGo uštedi klik prihvaćanjem kolačića u tvoje ime kako bi zatvorio skočne prozore koji ti ne dopuštaju isključivanje.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Prihvati kolačiće koji se ne mogu odbiti</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Ako ne postoji opcija odbijanja, uštedjet ćemo ti klik, umjesto tebe prihvatiti te kolačiće i zatvoriti skočne prozore.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Umoran si od skočnih prozora s kolačićima koji ti ne dopuštaju odjavu?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Možemo ti uštedjeti klik i prihvatiti ove kolačiće umjesto tebe."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Prihvati kolačiće koji se ne mogu odbiti"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Nastavit ću ih prihvaćati sam"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Umoran si od skočnih prozora kolačića koji te ne ostavljaju na miru?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Pokušat ćemo odbiti što je više moguće kolačića. Ako ne postoji opcija odbijanja, uštedjet ćemo ti klik i umjesto tebe prihvatiti te kolačiće."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Odbij kada je moguće, ili prihvati umjesto mene"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Nastavit ću njima upravljati sam"</string>
+    <string name="autoconsentPopupConfirmButton">"Potvrdi"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Možeš prilagoditi bilo kada u odjeljku <b>Postavke > Zaštita od skočnih prozora kolačića.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-hu/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-hu/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Felugró sütiablak elleni védelem</string>
     <string name="autoconsentDescription"><![CDATA[A DuckDuckGo megpróbálja kiválasztani a rendelkezésre álló leginkább privát beállításokat, és elrejteni az ilyen felugró ablakokat.\n<a href=\"\">További részletek</a>]]></string>
     <string name="autoconsentToggle">A DuckDuckGo kezelje a felugró sütiablakokat</string>
-    <string name="autoconsentAutoManageToggle">Felugró sütiablakok automatikus kezelése</string>
-    <string name="autoconsentAutoManageDescription">Igyekszünk kiválasztani az elérhető legdiszkrétebb sütibeállításokat, és bezárni ezeket a felugró ablakokat.</string>
+    <string name="autoconsentAutoManageToggle">Opcionális sütik elutasítása</string>
+    <string name="autoconsentAutoManageDescription">Igyekszünk a lehető legtöbb sütit elutasítani, és bezárni a felugró ablakokat.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[A DuckDuckGo az adatvédelem maximalizálása, a sütik minimalizálása és a felugró ablakok bezárása érdekében képes a sütikre vonatkozó beállítások automatikus kezelésére.\n<a href=\"\">További részletek</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Le nem tiltható felugró ablakok</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Engedd, hogy a DuckDuckGo egy kattintást megspórolva elfogadja helyetted a sütiket, és bezárja a le nem tiltható felugró ablakokat.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Nem letiltható sütik elfogadása</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Ha nincs lehetőség az elutasításra, megspórolunk neked egy kattintást, elfogadjuk helyetted ezeket a sütiket, és bezárjuk a felugró ablakokat.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Eleged van már a folyton felugró sütiablakokból, amelyek nem tilthatók le?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Egy kattintást megspórolva elfogadhatjuk helyetted ezeket a sütiket."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Nem letiltható sütik elfogadása"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Továbbra is én fogadom el őket"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Eleged van már a folyton felugró sütiablakokból?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Igyekszünk a lehető legtöbb sütit elutasítani. Ha nincs lehetőség az elutasításra, megspórolunk neked egy kattintást, és elfogadjuk helyetted ezeket a sütiket."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Elutasítás, ha lehetséges; egyébként elfogadás helyettem"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Továbbra is magam kezelem őket"</string>
+    <string name="autoconsentPopupConfirmButton">"Megerősítés"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Ezt bármikor módosíthatod a <b>Beállítások > Felugró sütiablak elleni védelem</b> menüpontban.]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-it/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-it/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Protezione pop-up dei cookie</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo cercherà di selezionare le impostazioni con la massima privacy e nasconderà questi popup per te.<a href=\"\">Ulteriori informazioni</a>]]></string>
     <string name="autoconsentToggle">Lascia che DuckDuckGo gestisca i pop-up cookie</string>
-    <string name="autoconsentAutoManageToggle">Gestione automatica dei popup dei cookie</string>
-    <string name="autoconsentAutoManageDescription">Cercheremo di selezionare solo le opzioni dei cookie più private disponibili per te, quindi di chiudere questi popup.</string>
+    <string name="autoconsentAutoManageToggle">Rifiuta i cookie opzionali</string>
+    <string name="autoconsentAutoManageDescription">Cercheremo di rifiutare il maggior numero possibile di cookie per te, quindi di chiudere i pop-up.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo può gestire automaticamente le preferenze sui cookie per massimizzare la privacy, ridurre al minimo i cookie e chiudere questi popup.\n<a href=\"\">Ulteriori informazioni</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Popup senza possibilità di rifiutare</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Lascia inoltre che DuckDuckGo ti faccia risparmiare un clic accettando i cookie per tuo conto, per chiudere i pop-up che non ti permettono di rifiutare.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Accetta i cookie che non prevedono il rifiuto</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Se non è prevista un\'opzione di rifiuto, ti risparmieremo un clic, accetteremo questi cookie per te e chiuderemo i popup.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Non vuoi più vedere pop-up sui cookie che non ti permettono di rifiutare?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Possiamo farti risparmiare un clic e accettare questi cookie per te."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Accetta i cookie che non prevedono il rifiuto"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Continuerò ad accettarli io"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Non vuoi più vedere popup sui cookie che non ti lasciano in pace?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Cercheremo di rifiutare il maggior numero possibile di cookie. Se non è prevista un'opzione di rifiuto, ti risparmieremo un clic e accetteremo questi cookie per te."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Rifiuta quando possibile o accetta per me"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Continuerò a occuparmene io"</string>
+    <string name="autoconsentPopupConfirmButton">"Conferma"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Puoi modificare in qualsiasi momento in <b>Impostazioni > Protezione pop-up dei cookie.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-lt/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-lt/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Apsauga nuo slapukų iškylančiųjų langų</string>
     <string name="autoconsentDescription"><![CDATA[„DuckDuckGo“ stengsis pasirinkti didžiausią privatumą užtikrinančius nustatymus ir paslėpti šiuos iškylančiuosius langus.\n<a href=\"\">Sužinoti daugiau</a>]]></string>
     <string name="autoconsentToggle">Leiskite „DuckDuckGo“ tvarkyti slapukų iškylančiuosius langus</string>
-    <string name="autoconsentAutoManageToggle">Automatiškai valdyti slapukų iššokančiuosius langus</string>
-    <string name="autoconsentAutoManageDescription">Stengsimės parinkti tik didžiausią privatumą užtikrinančias slapukų parinktis ir uždaryti šiuos iškylančiuosius langus.</string>
+    <string name="autoconsentAutoManageToggle">Atmesti neprivalomus slapukus</string>
+    <string name="autoconsentAutoManageDescription">Stengsimės už jus atmesti kuo daugiau slapukų ir uždaryti iškylančiuosius langus.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[„DuckDuckGo“ gali automatiškai tvarkyti slapukų nuostatas, kad maksimaliai padidintų privatumą, sumažintų slapukų kiekį ir uždarytų šiuos iškylančiuosius langus.\n<a href=\"\">Sužinoti daugiau</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Iššokantieji langai be atsisakymo galimybės</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Taip pat leisti „DuckDuckGo“ išlaisvinti jus nuo paspaudimo priimant slapukus jūsų vardu, kad būtų uždaromi iškylantieji langai, kurie neleidžia jų atsisakyti.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Priimti slapukus, kurių negalima atmesti</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Jei nėra galimybės atmesti, sutaupysime jums spustelėjimą, priimsime šiuos slapukus už jus ir uždarysime iššokančiuosius langus.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Ar pavargote nuo iškylančiųjų slapukų langų, kurie neleidžia jų atsisakyti?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Galime išlaisvinti jus nuo spaudinėjimo ir priimti šiuos slapukus už jus."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Priimti slapukus, kurių negalima atmesti"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Ir toliau juos priimsiu pats"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Ar atsibodo įkyrūs slapukų iškylantieji langai?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Stengsimės atmesti kuo daugiau slapukų. Jei atmetimo parinkties nėra, sutaupysime tau paspaudimą ir šiuos slapukus priimsime už tave."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Atmesti, kai įmanoma, arba priimti už mane"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Aš ir toliau juos tvarkysiu"</string>
+    <string name="autoconsentPopupConfirmButton">"Patvirtinti"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Bet kada galite pakoreguoti nuėję į <b>Nustatymai > Apsauga nuo slapukų iškylančiųjų langų.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-lv/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-lv/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Sīkfailu uznirstošo logu aizsardzība</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo centīsies atlasīt visprivātākos pieejamos iestatījumus un paslēpt uznirstošos logus.\n<a href=\"\">Uzzināt vairāk</a>]]></string>
     <string name="autoconsentToggle">Ļauj DuckDuckGo apstrādāt sīkfailu uznirstošos logus</string>
-    <string name="autoconsentAutoManageToggle">Automātiski pārvaldīt sīkfailu uznirstošos logus</string>
-    <string name="autoconsentAutoManageDescription">Mēs centīsimies tavā vietā atlasīt tikai visprivātākās pieejamās sīkfailu opcijas un pēc tam aizvērt šos uznirstošos logus.</string>
+    <string name="autoconsentAutoManageToggle">Noraidīt neobligātos sīkfailus</string>
+    <string name="autoconsentAutoManageDescription">Mēs centīsimies tavā vietā noraidīt pēc iespējas vairāk sīkfailu un pēc tam aizvērt uznirstošos logus.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo var automātiski pārvaldīt sīkfailu preferences, lai maksimāli palielinātu privātumu, samazinātu sīkfailus un aizvērtu šos uznirstošos logus.\n<a href=\"\">Uzzināt vairāk</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Uznirstošie logi bez atteikšanās iespējas</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Ļauj arī DuckDuckGo ietaupīt tev klikšķi, tavā vārdā pieņemot sīkfailus, lai aizvērtu uznirstošos logus, no kuriem nav iespējams atteikties.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Pieņemt sīkfailus, no kuriem nevar atteikties</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Ja nav noraidīšanas iespējas, mēs ietaupīsim tev klikšķi, pieņemsim šos sīkfailus tavā vietā un aizvērsim uznirstošos logus.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Vai esi noguris no sīkfailu uznirstošajiem logiem, no kuriem nevar atteikties?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Mēs varam ietaupīt tev klikšķi un pieņemt šos sīkfailus tavā vietā."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Pieņemt sīkfailus, no kuriem nevar atteikties"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Es turpināšu tos pieņemt pats"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Vai tev ir apnikuši sīkfailu uznirstošie logi, kas neliek tevi mierā?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Mēs centīsimies noraidīt pēc iespējas vairāk sīkfailu. Ja nav noraidīšanas iespējas, mēs ietaupīsim tev klikšķi un pieņemsim šos sīkfailus tavā vietā."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Noraidīt, ja iespējams, vai pieņemt manā vietā"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Es turpināšu tos pārvaldīt pats"</string>
+    <string name="autoconsentPopupConfirmButton">"Apstiprināt"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[To vari jebkurā laikā mainīt sadaļā <b>Iestatījumi > Sīkfailu uznirstošo logu aizsardzība.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-nb/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-nb/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Beskyttelse mot popup-vinduer om informasjonskapsler</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo prøver å velge de mest private innstillingene som er tilgjengelige, og skjule disse popup-vinduene for deg.\n<a href=\"\">Finn ut mer</a>]]></string>
     <string name="autoconsentToggle">La DuckDuckGo håndtere popup-vinduer om informasjonskapsler</string>
-    <string name="autoconsentAutoManageToggle">Administrer popup-vinduer om informasjonskapsler automatisk</string>
-    <string name="autoconsentAutoManageDescription">Vi prøver å velge de mest private alternativene for informasjonskapsler som er tilgjengelige, og så lukker vi disse popup-vinduene.</string>
+    <string name="autoconsentAutoManageToggle">Avvis valgfrie informasjonskapsler</string>
+    <string name="autoconsentAutoManageDescription">Vi prøver å avvise så mange informasjonskapsler som mulig for deg, og lukker deretter popup-vinduene.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo kan administrere innstillinger for informasjonskapsler automatisk for å maksimere personvernet, minimere informasjonskapsler og lukke disse popup-vinduene.\n<a href=\"\">Finn ut mer</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Popup-vinduer uten mulighet til å reservere seg</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Du kan også la DuckDuckGo spare deg for et klikk ved å godta informasjonskapsler på dine vegne, og dermed lukke popup-vinduer som ikke gir deg muligheten til å reservere deg.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Godta informasjonskapsler som ikke kan avvises</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Hvis det ikke finnes noe alternativ for å avvise dem, sparer vi deg for et klikk, godtar disse informasjonskapslene for deg og lukker popup-vinduene.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Lei av popup-vinduer om informasjonskapsler som ikke gir deg muligheten til å reservere deg mot dem?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Vi kan spare deg for et klikk og godta disse kapslene for deg."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Godta informasjonskapsler som ikke kan avvises"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Jeg vil fortsette å godta dem selv"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Er du lei av popup-vinduer om informasjonskapsler?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Vi prøver å avvise så mange informasjonskapsler som mulig. Hvis det ikke finnes noe alternativ for å avvise dem, sparer vi deg for et klikk ved å godta dem for deg."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Avvis når det er mulig, eller godta for meg"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Jeg vil fortsette å håndtere dem selv"</string>
+    <string name="autoconsentPopupConfirmButton">"Bekreft"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Du kan når som helst gjøre endringer i <b>Innstillinger > Beskyttelse mot popup-vinduer om informasjonskapsler.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-nl/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-nl/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Bescherming tegen cookiepop-ups</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo zal proberen de meest privacyvriendelijke instellingen te selecteren en deze pop-ups voor je te verbergen.\n<a href=\"\">Meer informatie</a>]]></string>
     <string name="autoconsentToggle">Laat DuckDuckGo cookiepop-ups verwerken</string>
-    <string name="autoconsentAutoManageToggle">Cookiepop-ups automatisch beheren</string>
-    <string name="autoconsentAutoManageDescription">We proberen alleen de meest privacyvriendelijke cookie-opties voor je te selecteren en sluiten daarna deze pop-ups.</string>
+    <string name="autoconsentAutoManageToggle">Optionele cookies afwijzen</string>
+    <string name="autoconsentAutoManageDescription">We proberen zoveel mogelijk cookies voor je af te wijzen en sluiten daarna de pop-ups.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo kan cookievoorkeuren automatisch beheren om je privacy te maximaliseren, het aantal cookies te minimaliseren en deze pop-ups te sluiten.\n<a href=\"\">Meer informatie</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Pop-ups zonder afmeldmogelijkheid</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Laat DuckDuckGo je ook een klik besparen door namens jou cookies te accepteren om pop-ups te sluiten waarbij je je niet kunt afmelden.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Accepteer cookies die niet kunnen worden afgewezen</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Als er geen weigeroptie is, besparen we je een klik, accepteren we deze cookies voor je en sluiten we de pop-ups.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Ben je de cookiepop-ups zat waarbij je je niet kunt afmelden?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"We kunnen je een klik besparen en deze cookies voor je accepteren."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Accepteer cookies die niet kunnen worden afgewezen"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Ik blijf ze zelf accepteren"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Ben je de cookiepop-ups zat die je maar blijven lastigvallen?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"We proberen zoveel mogelijk cookies af te wijzen. Als er geen weigeroptie is, besparen we je een klik en accepteren we deze cookies voor je."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Wijs af waar mogelijk of accepteer voor mij"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Ik blijf ze zelf beheren"</string>
+    <string name="autoconsentPopupConfirmButton">"Bevestigen"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Je kunt dit op elk gewenst moment aanpassen in <b>Instellingen > Bescherming tegen cookiepop-ups.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-pl/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-pl/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Ochrona przed wyskakującymi okienkami dotyczącymi plików cookie</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo spróbuje wybrać najbardziej prywatne dostępne ustawienia i ukryć te wyskakujące okienka.\n<a href=\"\">Dowiedz się więcej</a>]]></string>
     <string name="autoconsentToggle">Pozwól DuckDuckGo zajmować się wyskakującymi okienkami plików cookie</string>
-    <string name="autoconsentAutoManageToggle">Automatycznie zarządzaj okienkami z prośbą o zgodę</string>
-    <string name="autoconsentAutoManageDescription">Postaramy się wybrać dla Ciebie tylko najbardziej prywatne dostępne opcje plików cookie, a następnie zamknąć wyskakujące okienka.</string>
+    <string name="autoconsentAutoManageToggle">Odrzuć opcjonalne pliki cookie</string>
+    <string name="autoconsentAutoManageDescription">Postaramy się odrzucić dla Ciebie jak najwięcej plików cookie, a następnie zamknąć wyskakujące okienka.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo może automatycznie zarządzać preferencjami dotyczącymi plików cookie, aby zmaksymalizować prywatność, zminimalizować liczbę plików cookie i zamknąć wyskakujące okienka.\n<a href=\"\">Dowiedz się więcej</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Wyskakujące okienka bez możliwości rezygnacji</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Pozwól też DuckDuckGo zaoszczędzić Ci kliknięcie, akceptując w Twoim imieniu pliki cookie, aby zamknąć wyskakujące okienka, z których nie możesz zrezygnować.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Akceptuj pliki cookie, których nie można odrzucić</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Jeśli nie będzie opcji odrzucenia, zaoszczędzimy Ci kliknięcia, zaakceptujemy te pliki cookie za Ciebie i zamkniemy wyskakujące okienka.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Masz dość wyskakujących okienek z plikami cookie, z których nie możesz zrezygnować?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Możemy zaoszczędzić Ci kliknięcia i zaakceptować te pliki cookie za Ciebie."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Akceptuj pliki cookie, których nie można odrzucić"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Nadal będę je akceptować samodzielnie"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Masz dość wyskakujących okienek z informacją o plikach cookie, które nie dają Ci spokoju?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Postaramy się odrzucić jak najwięcej plików cookie. Jeśli nie będzie opcji odrzucenia, zaoszczędzimy Ci kliknięcia i zaakceptujemy te pliki cookie za Ciebie."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Odrzucaj, gdy to możliwe, lub akceptuj za mnie"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Będę się nimi zajmować samodzielnie"</string>
+    <string name="autoconsentPopupConfirmButton">"Potwierdź"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Możesz to zawsze zmienić, wybierając <b>Ustawienia > Ochrona przed wyskakującymi okienkami dotyczącymi plików cookie.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-pt/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-pt/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Proteção contra pop-ups de cookies</string>
     <string name="autoconsentDescription"><![CDATA[O DuckDuckGo vai tentar selecionar as definições mais privadas disponíveis e ocultar pop-ups.\n<a href=\"\">Sabe mais</a>]]></string>
     <string name="autoconsentToggle">Permitir que o DuckDuckGo lide com pop-ups de cookies</string>
-    <string name="autoconsentAutoManageToggle">Gerir automaticamente pop-ups de cookies</string>
-    <string name="autoconsentAutoManageDescription">Vamos tentar selecionar apenas as opções de cookies mais privadas disponíveis por ti e, em seguida, fechar estes pop-ups.</string>
+    <string name="autoconsentAutoManageToggle">Rejeitar cookies opcionais</string>
+    <string name="autoconsentAutoManageDescription">Vamos tentar rejeitar o máximo de cookies possível por ti e, em seguida, fechar os pop-ups.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[O DuckDuckGo pode gerir automaticamente as tuas preferências de cookies para maximizar a privacidade, minimizar os cookies e fechar estes pop-ups.\n<a href=\"\">Sabe mais</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Pop-ups sem opção de exclusão</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Permite também que o DuckDuckGo te poupe um clique, aceitando cookies em teu nome para fechar pop-ups sem opção de exclusão.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Aceitar cookies que não podem ser rejeitados</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Se não houver opção de rejeição, vamos poupar-te um clique, aceitar estes cookies por ti e fechar os pop-ups.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Cansado de pop-ups de cookies sem opção de exclusão?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Podemos poupar-te um clique e aceitar estes cookies por ti."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Aceitar cookies que não podem ser rejeitados"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Prefiro continuar eu a aceitá-los"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Cansado de pop-ups de cookies que não te deixam em paz?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Vamos tentar rejeitar o máximo de cookies possível. Se não houver opção de rejeição, vamos poupar-te um clique e aceitar estes cookies por ti."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Rejeitar quando possível ou aceitar por mim"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Prefiro continuar eu a geri-los"</string>
+    <string name="autoconsentPopupConfirmButton">"Confirmar"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Podes ajustar em qualquer altura em <b>Definições > Proteção contra pop-ups de cookies.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-ro/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-ro/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Protecție pentru ferestre pop-up aferente modulelor cookie</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo va încerca să selecteze cele mai private setări disponibile și să ascundă aceste ferestre pop-up pentru tine.\n<a href=\"\">Află mai multe</a>]]></string>
     <string name="autoconsentToggle">Lasă DuckDuckGo să se ocupe de ferestrele pop-up aferente modulelor cookie</string>
-    <string name="autoconsentAutoManageToggle">Gestionează automat ferestrele pop-up pentru module cookie</string>
-    <string name="autoconsentAutoManageDescription">Vom încerca să selectăm doar cele mai private opțiuni privind modulele cookie disponibile pentru tine, apoi vom închide aceste ferestre pop-up.</string>
+    <string name="autoconsentAutoManageToggle">Respinge modulele cookie opționale</string>
+    <string name="autoconsentAutoManageDescription">Vom încerca să respingem cât mai multe module cookie pentru tine, apoi vom închide ferestrele pop-up.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo poate gestiona automat preferințele privind modulele cookie pentru a maximiza confidențialitatea, a minimiza modulele cookie și a închide aceste ferestre pop-up.\n<a href=\"\">Află mai multe</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Ferestre pop-up fără opțiune de renunțare</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">De asemenea, lasă DuckDuckGo să te scutească de un click acceptând modulele cookie în numele tău pentru a închide ferestrele pop-up care nu îți permit să renunți.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Acceptă modulele cookie care nu pot fi respinse</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Dacă nu există o opțiune de respingere, te vom scuti de un click, vom accepta aceste module cookie pentru tine și vom închide ferestrele pop-up.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Te-ai săturat de ferestrele pop-up cu module cookie care nu îți permit să renunți la ele?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Te putem scuti de un click și putem accepta aceste module cookie pentru tine."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Acceptă modulele cookie care nu pot fi respinse"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Le voi accepta în continuare personal"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Te-ai săturat de ferestrele pop-up privind modulele cookie care nu îți dau pace?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Vom încerca să respingem cât mai multe module cookie. Dacă nu există o opțiune de respingere, te vom scuti de un click și vom accepta aceste module cookie pentru tine."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Respinge când este posibil sau acceptă pentru mine"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Le voi gestiona în continuare personal"</string>
+    <string name="autoconsentPopupConfirmButton">"Confirmă"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Poți oricând să modifici din <b>Setări > Protecție pentru ferestrele pop-up privind modulele cookie.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-ru/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-ru/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Защита от всплывающих окон куки</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo по возможности откажется от куки-файлов и скроет подобные окна.\n<a href=\"\">Подробнее...</a>]]></string>
     <string name="autoconsentToggle">Разрешить DuckDuckGo взять на себя окна выбора куки-файлов</string>
-    <string name="autoconsentAutoManageToggle">Автоматическое управление окнами выбора файлов cookie</string>
-    <string name="autoconsentAutoManageDescription">Мы постараемся выбрать для вас только максимально конфиденциальные настройки файлов cookie, а затем закроем эти окна.</string>
+    <string name="autoconsentAutoManageToggle">Отклонить дополнительные файлы cookie</string>
+    <string name="autoconsentAutoManageDescription">Мы постараемся отклонить для вас как можно больше файлов cookie, а затем закроем эти окна.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo может автоматически управлять настройками файлов cookie, чтобы обеспечить максимальную конфиденциальность, минимизировать использование cookie и закрывать соответствующие всплывающие окна.\n<a href=\"\">Подробнее</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Всплывающие окна без возможности отказа</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Также разрешите DuckDuckGo экономить вам время, принимая файлы cookie за вас, чтобы закрывать всплывающие окна без возможности отказа.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Принимать файлы cookie, от которых нельзя отказаться</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Если возможности отказаться от отслеживания нет, мы сэкономим ваше время, примем эти файлы cookie за вас и закроем всплывающие окна.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Устали от всплывающих окон с уведомлениями о файлах cookie, от которых вы не можете отказаться?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Мы можем сэкономить вам время и примем эти файлы cookie за вас."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Принимать файлы cookie, от которых нельзя отказаться"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Я продолжу принимать их самостоятельно"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Устали от всплывающих окон с уведомлениями о файлах cookie, которые не дают вам покоя?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Мы постараемся отклонить как можно больше файлов cookie. Если возможности отказаться от отслеживания нет, мы сэкономим ваше время и примем эти файлы cookie за вас."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Отклонять, когда это возможно, или принимать за меня"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Я продолжу управлять файлами cookie самостоятельно"</string>
+    <string name="autoconsentPopupConfirmButton">"Подтвердить"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Эту настройку можно изменить в любое время в разделе <b>«Настройки > Защита от всплывающих окон cookie».</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-sk/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-sk/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Ochrana proti automatickému otváraniu okien o súboroch cookie</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo sa pokúsi vybrať nastavenia s najväčšou ochranou súkromia a skryje tieto vyskakovacie (pop-up) okná za teba.\n<a href=\"\">Zisti viac</a>]]></string>
     <string name="autoconsentToggle">Nechajte, aby sa DuckDuckGo postaral o vyskakovacie okná o súboroch cookie</string>
-    <string name="autoconsentAutoManageToggle">Automatická správa kontextových okien súborov cookie</string>
-    <string name="autoconsentAutoManageDescription">Budeme sa snažiť vybrať pre teba len tie možnosti súborov cookie s najväčšou ochranou súkromia a následne tieto vyskakovacie okná zatvoríme.</string>
+    <string name="autoconsentAutoManageToggle">Odmietnuť voliteľné súbory cookie</string>
+    <string name="autoconsentAutoManageDescription">Budeme sa snažiť odmietnuť čo najviac súborov cookie a následne zatvoríme vyskakovacie okná.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo môže automaticky spravovať možnosti súborov cookie s&nbsp;cieľom maximalizovať súkromie, minimalizovať súbory cookie a&nbsp;zavrieť tieto kontextové okná.\n<a href=\"\">Zisti viac</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Automaticky zobrazené okná bez možnosti odmietnutia</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Nechaj tiež DuckDuckGo, aby ti ušetril kliknutie tým, že v tvojom mene prijme súbory cookie a zatvorí vyskakovacie okná, ktoré ti neumožňujú odmietnuť ich.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Prijmi súbory cookie, ktoré nemožno odmietnuť</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Ak neexistuje možnosť odmietnutia, ušetríme ti kliknutie, tieto súbory cookie za teba prijmeme a zatvoríme vyskakovacie okná.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Už ťa unavujú vyskakovacie okná s cookies, ktoré ti neumožňujú nesúhlasiť?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Ušetríme ti kliknutie a tieto súbory cookie prijmeme za teba."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Prijmi súbory cookie, ktoré nemožno odmietnuť"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Budem ich naďalej prijímať sám/sama"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Už ťa nebavia vyskakovacie okná o súboroch cookie, ktoré ti nedajú pokoj?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Budeme sa snažiť odmietnuť čo najviac súborov cookie. Ak neexistuje možnosť odmietnutia, ušetríme ti kliknutie a tieto súbory cookie za teba prijmeme."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Odmietni, ak je to možné, alebo ich prijmi za mňa"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Budem ich naďalej spravovať sám/sama"</string>
+    <string name="autoconsentPopupConfirmButton">"Potvrdiť"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Kedykoľvek to môžeš upraviť v časti <b>Nastavenia > Ochrana proti automatickému otváraniu okien o súboroch cookie.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-sl/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-sl/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Zaščita pred pojavnimi okni piškotkov</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo bo poskusil izbrati najbolj zasebne nastavitve, ki so na voljo, in skriti ta pojavna okna za vas.\n<a href=\"\">Več o tem</a>]]></string>
     <string name="autoconsentToggle">Naj DuckDuckGo poskrbi za pojavna okna piškotkov</string>
-    <string name="autoconsentAutoManageToggle">Samodejno upravljanje pojavnih oken za piškotke</string>
-    <string name="autoconsentAutoManageDescription">Poskušali bomo izbrati le najbolj zasebne možnosti piškotkov, ki so na voljo za vas, nato pa zapreti ta pojavna okna.</string>
+    <string name="autoconsentAutoManageToggle">Zavrni izbirne piškotke</string>
+    <string name="autoconsentAutoManageDescription">Poskušali bomo zavrniti čim več piškotkov za vas, nato pa zapreti pojavna okna.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo lahko samodejno upravlja nastavitve piškotkov za povečanje zasebnosti, zmanjšanje števila piškotkov in zapiranje teh pojavnih oken.\n<a href=\"\">Več o tem</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Pojavna okna brez možnosti zavrnitve</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Prav tako vam DuckDuckGo prihrani klik tako, da namesto vas sprejme piškotke za zapiranje pojavnih oken, ki vam ne omogočajo zavrnitve.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Sprejmi piškotke, ki jih ni mogoče zavrniti</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Če možnost zavrnitve ne bo na voljo, vam bomo prihranili klik, te piškotke sprejeli namesto vas in zaprli pojavna okna.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Ste naveličani pojavnih oken s piškotki, ki vam ne omogočajo, da jih zavrnete?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Prihranimo vam lahko klik in te piškotke sprejmemo namesto vas."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Sprejmi piškotke, ki jih ni mogoče zavrniti"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Sprejemanje bom še naprej urejal/-a sam/-a"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Vas motijo pojavna okna za piškotke, ki vas ne pustijo pri miru?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Poskušali bomo zavrniti čim več piškotkov. Če možnost zavrnitve ne bo na voljo, vam bomo prihranili klik in te piškotke sprejeli namesto vas."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Zavrni, ko je mogoče, ali sprejmi zame"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Upravljanje bom še naprej urejal/-a sam/-a"</string>
+    <string name="autoconsentPopupConfirmButton">"Potrdi"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[To lahko kadar koli prilagodite v razdelku <b>Nastavitve > Zaščita pred pojavnimi okni piškotkov.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-sv/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-sv/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Skydd mot popup-fönster för cookies</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo kommer att försöka välja de mest privata inställningarna som finns tillgängliga och dölja dessa popup-fönster åt dig.\n<a href=\"\">Läs mer</a>]]></string>
     <string name="autoconsentToggle">Låt DuckDuckGo hantera popup-fönster för cookies</string>
-    <string name="autoconsentAutoManageToggle">Hantera popup-fönster för cookies automatiskt</string>
-    <string name="autoconsentAutoManageDescription">Vi strävar efter att endast välja de mest privata cookiealternativen som finns tillgängliga för dig, och sedan stänga dessa popup-fönster.</string>
+    <string name="autoconsentAutoManageToggle">Avvisa valfria cookies</string>
+    <string name="autoconsentAutoManageDescription">Vi strävar efter att avvisa så många cookies som möjligt åt dig, och sedan stänga popup-fönstren.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo kan automatiskt hantera cookieinställningar för att maximera din integritet, minimera antalet cookies och stänga dessa popup-fönster.\n<a href=\"\">Läs mer</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Popup-fönster där det inte går att välja bort cookies</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Låt även DuckDuckGo spara ett klick för dig genom att acceptera cookies i popup-fönster där det inte går att välja bort dessa.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Acceptera cookies som inte kan väljas bort</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Om det inte finns något alternativ för att avvisa sparar vi ett klick åt dig, accepterar dessa cookies åt dig och stänger popup-fönstren.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Trött på popup-fönster för cookies som inte låter dig tacka nej?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Vi kan spara dig ett klick och acceptera dessa cookies åt dig."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Acceptera cookies som inte kan väljas bort"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Jag fortsätter att acceptera dem själv"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Är du trött på att ständigt se popup-fönster för cookies?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Vi försöker avvisa så många cookies som möjligt. Om det inte finns något alternativ för att avvisa sparar vi ett klick åt dig och accepterar dessa cookies åt dig."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Avvisa när det går, eller acceptera åt mig"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Jag fortsätter att hantera dem själv"</string>
+    <string name="autoconsentPopupConfirmButton">"Bekräfta"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Du kan justera det här när som helst i <b>Inställningar > Skydd mot popup-fönster för cookies.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values-tr/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values-tr/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Çerez Açılır Pencere Engelleyici</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo, mevcut en gizli ayarları seçmeye ve bu açılır pencereleri gizlemeye çalışacaktır.\n<a href=\"\">Daha Fazla Bilgi</a>]]></string>
     <string name="autoconsentToggle">DuckDuckGo\'nun çerez açılır pencereleri için gereken işlemi yapmasına izin verin</string>
-    <string name="autoconsentAutoManageToggle">Çerez Açılır Pencerelerini Otomatik Yönet</string>
-    <string name="autoconsentAutoManageDescription">Sizin için mümkün olan en gizli çerez seçeneklerini belirlemeyi hedefleyecek ve ardından bu açılır pencereleri kapatacağız.</string>
+    <string name="autoconsentAutoManageToggle">İsteğe bağlı çerezleri reddet</string>
+    <string name="autoconsentAutoManageDescription">Mümkün olduğunca çok sayıda çerezi reddetmeyi hedefleyeceğiz, ardından açılır pencereleri kapatacağız.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo, gizliliği en üst düzeye çıkarmak, çerezleri en aza indirmek ve bu açılır pencereleri kapatmak için çerez tercihlerinizi otomatik olarak yönetebilir.\n<a href=\"\">Daha Fazla Bilgi</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Devre Dışı Bırakma Seçeneği Olmayan Açılır Pencereler</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Ayrıca, reddetme seçeneği sunmayan açılır pencereleri kapatmak için DuckDuckGo\'nun çerezleri sizin adınıza kabul etmesine izin verin ve tek bir tıklama zahmetinden bile kurtulun.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Reddedilemeyen çerezleri kabul et</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">Reddetme seçeneği yoksa, sizi bir tıklama zahmetinden kurtarmak için bu çerezleri sizin yerinize kabul edecek ve açılır pencereleri kapatacağız.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Çıkış yapmanıza izin vermeyen çerez açılır pencerelerinden bıktınız mı?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"Sizi bir tıklama zahmetinden kurtarıp bu çerezleri sizin yerinize kabul edebiliriz."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Reddedilemeyen çerezleri kabul et"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"Bunları kendim kabul etmeye devam edeceğim"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Sizi rahat bırakmayan çerez bildirimlerinden bıktınız mı?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"Mümkün olduğunca çok sayıda çerezi reddetmeyi hedefleyeceğiz. Reddetme seçeneği yoksa, sizi bir tıklama zahmetinden kurtarmak için bu çerezleri sizin yerinize kabul edeceğiz."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Mümkün olduğunda reddet veya benim adıma kabul et"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"Bunları kendim yönetmeye devam edeceğim"</string>
+    <string name="autoconsentPopupConfirmButton">"Onayla"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[Bunu dilediğiniz zaman <b>Ayarlar > Çerez Açılır Pencere Engelleyici</b> kısmından ayarlayabilirsiniz.]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values/strings-autoconsent.xml
@@ -20,9 +20,21 @@
     <string name="autoconsentTitle">Cookie Pop-Up Protection</string>
     <string name="autoconsentDescription"><![CDATA[DuckDuckGo will try to select the most private settings available and hide these pop-ups for you.\n<a href="">Learn More</a>]]></string>
     <string name="autoconsentToggle">Let DuckDuckGo handle cookie pop-ups</string>
-    <string name="autoconsentAutoManageToggle">Auto-Manage Cookie Pop-Ups</string>
-    <string name="autoconsentAutoManageDescription">We\'ll aim to only select the most private cookie options available for you, then close these pop-ups.</string>
+    <string name="autoconsentAutoManageToggle">Reject optional cookies</string>
+    <string name="autoconsentAutoManageDescription">We\'ll aim to reject as many cookies as possible for you, then close the pop-ups.</string>
     <string name="autoconsentCookiePopUpPreferenceHeaderDescription"><![CDATA[DuckDuckGo can auto-manage cookie preferences to maximize privacy, minimize cookies, and close these pop-ups.\n<a href="">Learn More</a>]]></string>
-    <string name="autoconsentPopUpsWithoutOptOutsToggle">Pop-Ups Without Opt-Outs</string>
-    <string name="autoconsentPopUpsWithoutOptOutsDescription">Also let DuckDuckGo save you a click by accepting cookies on your behalf to close pop-ups that don\'t let you opt out.</string>
+    <string name="autoconsentPopUpsWithoutOptOutsToggle">Accept cookies that can\'t be rejected</string>
+    <string name="autoconsentPopUpsWithoutOptOutsDescription">If there\'s no reject option, we\'ll save you a click, accept these cookies for you, and close the pop-ups.</string>
+    <string name="autoconsentPopupTitleWithFeatureEnabled">"Tired of cookie pop-ups that don\'t let you opt out?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureEnabled">"We can save you a click and accept these cookies for you."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Accept cookies that can\'t be rejected"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"I\'ll keep accepting them myself"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Tired of cookie pop-ups that won’t leave you alone?"</string>
+    <string name="autoconsentPopupDescriptionWithFeatureDisabled">"We\'ll aim to reject as many cookies as possible. If there\'s no reject option, we\'ll save you a click and accept these cookies for you."</string>
+    <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Reject when possible or accept for me"</string>
+    <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"I\'ll keep handling them myself"</string>
+    <string name="autoconsentPopupConfirmButton">"Confirm"</string>
+    <string name="autoconsentPopupSettingsHint" instruction="Bold part is a navigation path in the app: the Settings screen and the Cookie Pop-Up Protection section within it. Keep the &gt; separator."><![CDATA[You can adjust anytime in <b>Settings > Cookie Pop-Up Protection.</b>]]></string>
+
+
 </resources>

--- a/autoconsent/autoconsent-impl/src/main/res/values/strings-autoconsent.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/values/strings-autoconsent.xml
@@ -29,7 +29,7 @@
     <string name="autoconsentPopupDescriptionWithFeatureEnabled">"We can save you a click and accept these cookies for you."</string>
     <string name="autoconsentPopupDefaultOptionWithFeatureEnabled">"Accept cookies that can\'t be rejected"</string>
     <string name="autoconsentPopupRejectOptionWithFeatureEnabled">"I\'ll keep accepting them myself"</string>
-    <string name="autoconsentPopupTitleWithFeatureDisabled">"Tired of cookie pop-ups that won’t leave you alone?"</string>
+    <string name="autoconsentPopupTitleWithFeatureDisabled">"Tired of cookie pop-ups that won\'t leave you alone?"</string>
     <string name="autoconsentPopupDescriptionWithFeatureDisabled">"We\'ll aim to reject as many cookies as possible. If there\'s no reject option, we\'ll save you a click and accept these cookies for you."</string>
     <string name="autoconsentPopupDefaultOptionWithFeatureDisabled">"Reject when possible or accept for me"</string>
     <string name="autoconsentPopupRejectOptionWithFeatureDisabled">"I\'ll keep handling them myself"</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212227266948491/task/1217068049663232?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
* Update autoconsent settings strings
* Submir new popup strings for translation

### Steps to test this PR
n/a

### UI changes
<img width="1321" height="1346" alt="image" src="https://github.com/user-attachments/assets/80ed2e55-42fe-4d02-8f6b-8dc7aa9df46a" />


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only localization updates with no logic or security changes; main review risk is translation consistency and UI copy accuracy.
> 
> **Overview**
> Updates **autoconsent** user-facing copy across locales and adds strings for a new onboarding-style popup.
> 
> **Settings labels** shift from generic “auto-manage” wording to clearer actions: the main toggle now reads like **reject optional cookies** (with descriptions about rejecting as many cookies as possible), and the secondary toggle is reframed as **accept cookies that can’t be rejected** when no reject option exists.
> 
> **New `autoconsentPopup*` strings** cover dialog title, body, default/reject choices, confirm button, and a settings hint—separate variants when the related feature is enabled vs disabled.
> 
> Changes apply to the default `strings-autoconsent.xml` and the same keys in all listed `values-*` locale files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4c6659393f19c550e32fe72fae537bbdacc97ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->