### PR TITLE
Add pixel definitions for CPM popup

### DIFF
--- a/PixelDefinitions/pixels/definitions/autoconsent.json5
+++ b/PixelDefinitions/pixels/definitions/autoconsent.json5
@@ -112,6 +112,42 @@
         "suffixes": ["form_factor"],
         "parameters": ["appVersion", "consentHeuristicEnabled"]
     },
+    "cookie_popup_opt_in_shown_first": {
+        "description": "Fires the first time the Cookie Pop-up Protection opt-in dialog is shown on app launch (once per install).",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "autoconsentEnabled"]
+    },
+    "cookie_popup_opt_in_shown_repeat": {
+        "description": "Fires when the Cookie Pop-up Protection opt-in dialog is shown again on app launch (any presentation after the first).",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "autoconsentEnabled"]
+    },
+    "cookie_popup_opt_in_option_confirmed": {
+        "description": "Fires when the user confirms the Cookie Pop-up Protection opt-in dialog. cookie_popup_preference is the resulting preference; autoconsent_enabled is the feature state when the dialog was shown; time_since_shown is the bucketed time from when the dialog was first shown to confirmation.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            "autoconsentEnabled",
+            {
+                "key": "cookie_popup_preference",
+                "type": "string",
+                "description": "The resulting Cookie Pop-up Protection preference after the user confirms the opt-in dialog.",
+                "enum": ["max", "default", "off"]
+            },
+            {
+                "key": "time_since_shown",
+                "type": "string",
+                "description": "Bucketed time elapsed from when the opt-in dialog was first shown to when it was confirmed.",
+                "enum": ["0-1min", "1-5min", "5-60min", "1h-1d", "1d+"]
+            }
+        ]
+    },
     "m_autoconsent_summary": {
         "description": "Fires periodically with counts of autoconsent metrics accumulated over 2 minutes.",
         "owners": ["muodov"],

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -185,6 +185,11 @@
         "description": "Heuristic action mode derived from user preference and feature flags.",
         "enum": ["off", "tier1", "tier2", "reject"]
     },
+    "autoconsentEnabled": {
+        "key": "autoconsent_enabled",
+        "type": "boolean",
+        "description": "Whether Cookie Pop-up Protection (autoconsent) was enabled at the moment the pixel fired."
+    },
     "pirCancellationReason": {
         "key": "feature.data.ext.cancellation_reason",
         "type": "string",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212227266948491/task/1217114676790696?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only changes to pixel definitions and the params dictionary; no app logic or runtime behavior.
> 
> **Overview**
> Adds pixel definitions so the **Cookie Pop-up Protection (CPM) opt-in dialog** on app launch can be measured in the existing autoconsent pixel set.
> 
> **`cookie_popup_opt_in_shown_first`** and **`cookie_popup_opt_in_shown_repeat`** fire when the dialog is shown—the first time per install vs. any later presentation—with `appVersion` and **`autoconsent_enabled`**.
> 
> **`cookie_popup_opt_in_option_confirmed`** fires on confirm with **`cookie_popup_preference`** (`max`, `default`, `off`) and bucketed **`time_since_shown`** from first show to confirmation.
> 
> A shared **`autoconsentEnabled`** entry is added to `params_dictionary.json` (wire key `autoconsent_enabled`) for reuse across these pixels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4c0e4b614e3aa40e5aff62add5337146c1cbb90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->