### PR TITLE
Add origin to Duck.ai and Pro subscription-funnel pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1113,6 +1113,27 @@
                 "type": "string",
                 "description": "The tapper's current tier",
                 "enum": ["free", "plus"]
+            },
+            {
+                "key": "origin",
+                "type": "string",
+                "description": "Subscription-funnel entry point",
+                "enum": ["funnel_duckai_android__freelabel"]
+            }
+        ]
+    },
+    "m_aichat_unified_input_free_label_shown": {
+        "description": "Subscription-funnel impression: the upgradeable 'Free' pill in the Duck.ai omnibar header became visible",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "origin",
+                "type": "string",
+                "description": "Subscription-funnel entry point",
+                "enum": ["funnel_duckai_android__freelabel"]
             }
         ]
     },
@@ -1305,6 +1326,52 @@
                 "type": "string",
                 "description": "The type of subscription flow offered",
                 "enum": ["purchase", "upgrade"]
+            },
+            {
+                "key": "origin",
+                "type": "string",
+                "description": "Subscription-funnel entry point (the gated picker) the upsell was triggered from",
+                "enum": [
+                    "funnel_addressbar_android__modelpicker",
+                    "funnel_addressbar_android__reasoningdropdown",
+                    "funnel_duckai_android__modelpicker",
+                    "funnel_duckai_android__reasoningdropdown",
+                    "funnel_duckai_android__switchmodel"
+                ]
+            }
+        ]
+    },
+    "m_aichat_unified_input_model_picker_shown": {
+        "description": "Subscription-funnel impression: the Unified Input model picker was shown to the user",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "origin",
+                "type": "string",
+                "description": "Entry point where the picker was shown",
+                "enum": [
+                    "funnel_addressbar_android__modelpicker",
+                    "funnel_duckai_android__modelpicker",
+                    "funnel_duckai_android__switchmodel"
+                ]
+            }
+        ]
+    },
+    "m_aichat_unified_input_reasoning_effort_picker_shown": {
+        "description": "Subscription-funnel impression: the Unified Input reasoning effort picker was shown to the user",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "origin",
+                "type": "string",
+                "description": "Entry point where the picker was shown (also the subscription-purchase attribution origin)",
+                "enum": ["funnel_addressbar_android__reasoningdropdown", "funnel_duckai_android__reasoningdropdown"]
             }
         ]
     },

--- a/PixelDefinitions/pixels/definitions/subscription_pixels.json5
+++ b/PixelDefinitions/pixels/definitions/subscription_pixels.json5
@@ -153,6 +153,85 @@
         "suffixes": ["daily_count_short", "form_factor"],
         "parameters": ["appVersion"]
     },
+    "m_privacy-pro_offer_screen_impression": {
+        "description": "The subscription offer screen (paywall) was shown. Carries the entry-point origin the offer was launched with.",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["count_short", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "origin",
+                "description": "Entry-point origin the offer was launched from, if available. Bounded to an allowlist of funnel entry points.",
+                "type": "string",
+                "enum": [
+                    "funnel_addressbar_android__aitoggle",
+                    "funnel_addressbar_android__modelpicker",
+                    "funnel_addressbar_android__reasoningdropdown",
+                    "funnel_appmenu_android",
+                    "funnel_appsettings_android",
+                    "funnel_duckai_android__freelabel",
+                    "funnel_duckai_android__modelpicker",
+                    "funnel_duckai_android__reasoningdropdown",
+                    "funnel_duckai_android__switchmodel",
+                    "funnel_modal_android__skippedonboardingupsell",
+                    "funnel_modal_android__subscriptionnudge",
+                    "funnel_onboarding_android",
+                    "funnel_playstore",
+                    "funnel_purchase_offer_page_android",
+                    "funnel_restore_android__viewplans",
+                    "funnel_subscriptionsettings_android__viewplans"
+                ]
+            }
+        ]
+    },
+    "m_privacy-pro_app-settings_get_click": {
+        "description": "The user tapped 'Get Subscription' (DuckDuckGo Subscription) in the app-wide Settings.",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["count_short", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "origin",
+                "description": "Subscription-funnel entry point.",
+                "type": "string",
+                "enum": ["funnel_appsettings_android"]
+            }
+        ]
+    },
+    "m_privacy-pro_terms-conditions_subscribe_click": {
+        "description": "Subscription-funnel click: the user tapped the primary Subscribe CTA on the subscription offer page. Carries the entry-point origin the offer was launched with.",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "origin",
+                "description": "Entry-point origin the offer was launched from, if available. Bounded to an allowlist of funnel entry points.",
+                "type": "string",
+                "enum": [
+                    "funnel_addressbar_android__aitoggle",
+                    "funnel_addressbar_android__modelpicker",
+                    "funnel_addressbar_android__reasoningdropdown",
+                    "funnel_appmenu_android",
+                    "funnel_appsettings_android",
+                    "funnel_duckai_android__freelabel",
+                    "funnel_duckai_android__modelpicker",
+                    "funnel_duckai_android__reasoningdropdown",
+                    "funnel_duckai_android__switchmodel",
+                    "funnel_modal_android__skippedonboardingupsell",
+                    "funnel_modal_android__subscriptionnudge",
+                    "funnel_onboarding_android",
+                    "funnel_playstore",
+                    "funnel_purchase_offer_page_android",
+                    "funnel_restore_android__viewplans",
+                    "funnel_subscriptionsettings_android__viewplans"
+                ]
+            }
+        ]
+    },
     "m_subscription_expiration_reminder_scheduled": {
         "description": "Fired when the subscription expiration reminder local notification is successfully scheduled after a purchase.",
         "owners": ["nalcalag"],

--- a/PixelDefinitions/pixels/definitions/wide_subscription-purchase.json5
+++ b/PixelDefinitions/pixels/definitions/wide_subscription-purchase.json5
@@ -25,8 +25,8 @@
                 "key": "context.name",
                 "description": "Entry point to the purchase flow. Origin string set by the offer-page URL query parameter or hardcoded at the app-settings call site. FE-controlled — new funnel names can be introduced without a schema change as long as they match the pattern. Empty string is allowed (sent when the URL carries `?origin=` with no value).",
                 "type": "string",
-                "pattern": "^(funnel_[a-z0-9_]+_android)?$",
-                "examples": ["funnel_appsettings_android", "funnel_purchase_offer_page_android"]
+                "pattern": "^(funnel_[a-z0-9_]+_android(__[a-z0-9]+)?)?$",
+                "examples": ["funnel_appsettings_android", "funnel_purchase_offer_page_android", "funnel_duckai_android__modelpicker"]
             },
             {
                 "key": "feature.data.ext.subscription_identifier",

--- a/PixelDefinitions/pixels/suffixes_dictionary.json
+++ b/PixelDefinitions/pixels/suffixes_dictionary.json
@@ -12,6 +12,11 @@
         "description": "Pixel schedule type - d=daily, c=count.",
         "enum": ["d", "c"]
     },
+    "count_short": {
+        "type": "string",
+        "description": "Pixel schedule type - c=count.",
+        "enum": ["c"]
+    },
     "form_factor": {
         "type": "string",
         "description": "Platform and device form-factor",

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -881,10 +881,14 @@ class RealNativeInputManager @Inject constructor(
                     isSubscriptionEligible -> DuckAiTier.Free
                     else -> DuckAiTier.FreeNoUpgrade
                 }
-                omnibarController.updateTierTitle(tier) {
-                    fireChatHeaderUpgradeTapped(tier)
-                    launchPurchase()
-                }
+                omnibarController.updateTierTitle(
+                    tier,
+                    onUpgradeClicked = {
+                        fireChatHeaderUpgradeTapped(tier)
+                        launchPurchase()
+                    },
+                    onUpgradeShown = { fireFreeLabelShown() },
+                )
             }
             if (!isBottom) {
                 setFloatingSubmitContainer(createFloatingSubmitContainer())
@@ -1428,7 +1432,17 @@ class RealNativeInputManager @Inject constructor(
      */
     internal fun fireChatHeaderUpgradeTapped(tier: DuckAiTier) {
         val userTier = if (tier is DuckAiTier.Paid) "plus" else "free"
-        pixel.fire(AppPixelName.AI_CHAT_UNIFIED_INPUT_CHAT_HEADER_UPGRADE_TAPPED, mapOf("user_tier" to userTier))
+        pixel.fire(
+            AppPixelName.AI_CHAT_UNIFIED_INPUT_CHAT_HEADER_UPGRADE_TAPPED,
+            mapOf("user_tier" to userTier, "origin" to PURCHASE_ORIGIN),
+        )
+    }
+
+    /**
+     * Invoked by the omnibar controller when the upgradeable free pill becomes visible.
+     */
+    private fun fireFreeLabelShown() {
+        pixel.fire(AppPixelName.AI_CHAT_UNIFIED_INPUT_FREE_LABEL_SHOWN, mapOf("origin" to PURCHASE_ORIGIN))
     }
 
     /** True if [rawUrl] points at an in-progress Duck.ai chat (Duck.ai URL with a non-blank `chatID`). */

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -60,7 +60,7 @@ interface NativeInputOmnibarController : OmnibarState {
     fun getCardView(): View?
     fun restore()
     fun forceToTop()
-    fun updateTierTitle(tier: DuckAiTier, onUpgradeClicked: () -> Unit)
+    fun updateTierTitle(tier: DuckAiTier, onUpgradeClicked: () -> Unit, onUpgradeShown: () -> Unit)
 
     /** Hide/show the subscription-tier indicator (Free pill / paid title) in the Duck.ai header. */
     fun setTierVisible(visible: Boolean)
@@ -156,6 +156,11 @@ class RealNativeInputOmnibarController(
     private var currentUpgradeClick: (() -> Unit)? = null
     private var tierVisible: Boolean = true
 
+    // Fired when the upgradeable Free pill becomes visible, for the free-label subscription impression pixel.
+    private var onUpgradeShown: (() -> Unit)? = null
+
+    private var upgradePillShown = false
+
     private fun showDuckAiTitle(omnibarView: View) {
         val header = omnibarView.findViewById<android.widget.LinearLayout?>(R.id.duckAIHeader)
         omnibarView.findViewById<View?>(R.id.aiIcon)?.gone()
@@ -165,9 +170,10 @@ class RealNativeInputOmnibarController(
         applyTierText(omnibarView)
     }
 
-    override fun updateTierTitle(tier: DuckAiTier, onUpgradeClicked: () -> Unit) {
+    override fun updateTierTitle(tier: DuckAiTier, onUpgradeClicked: () -> Unit, onUpgradeShown: () -> Unit) {
         currentTier = tier
         currentUpgradeClick = onUpgradeClicked
+        this.onUpgradeShown = onUpgradeShown
         val omnibarView = omnibar.omnibarView as? View ?: return
         applyTierText(omnibarView)
     }
@@ -178,6 +184,15 @@ class RealNativeInputOmnibarController(
     }
 
     private fun applyTierText(omnibarView: View) {
+        val pillSuppressedByKillSwitch = nativeInputStateBugKillSwitch.self().isEnabled() && !overlayActive
+
+        // Fire the free-label impression from the same conditions that render the upgradeable Free pill
+        // (below), so it measures an actual on-screen impression. This is triggered only once
+        // per hidden→shown  transition, resetting when it hides so the next display re-fires.
+        val upgradeablePillVisible = tierVisible && !pillSuppressedByKillSwitch && currentTier is DuckAiTier.Free
+        if (upgradeablePillVisible && !upgradePillShown) onUpgradeShown?.invoke()
+        upgradePillShown = upgradeablePillVisible
+
         val aiTitle = omnibarView.findViewById<TextView?>(R.id.aiTitle)
         val freePill = omnibarView.findViewById<View?>(R.id.duckAIFreePill)
         val freePillUpgrade = omnibarView.findViewById<View?>(R.id.duckAIFreePillUpgrade)
@@ -188,7 +203,7 @@ class RealNativeInputOmnibarController(
             freePill?.setOnClickListener(null)
             return
         }
-        if (nativeInputStateBugKillSwitch.self().isEnabled() && !overlayActive) {
+        if (pillSuppressedByKillSwitch) {
             freePill?.gone()
             freePill?.setOnClickListener(null)
             return
@@ -248,6 +263,8 @@ class RealNativeInputOmnibarController(
         overlayActive = false
         currentTier = DuckAiTier.Unknown
         currentUpgradeClick = null
+        onUpgradeShown = null
+        upgradePillShown = false
         tierVisible = true
         (omnibar.omnibarView as? View)?.let { removeLayoutListener(it) }
         restoreOmnibarColors()

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -66,6 +66,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT("m_aichat_duck_ai_direct_navigation_count"),
     AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_DAILY("m_aichat_duck_ai_direct_navigation_daily"),
     AI_CHAT_UNIFIED_INPUT_CHAT_HEADER_UPGRADE_TAPPED("m_aichat_unified_input_chat_header_upgrade_tapped"),
+    AI_CHAT_UNIFIED_INPUT_FREE_LABEL_SHOWN("m_aichat_unified_input_free_label_shown"),
     PREONBOARDING_SKIP_ONBOARDING_PRESSED("m_preonboarding_skip-onboarding-pressed"),
     PREONBOARDING_CONFIRM_SKIP_ONBOARDING_PRESSED("m_preonboarding_confirm-skip-onboarding-pressed"),
     PREONBOARDING_RESUME_ONBOARDING_PRESSED("m_preonboarding_resume-onboarding-pressed"),

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
@@ -192,22 +192,22 @@ class RealNativeInputManagerTest {
     }
 
     @Test
-    fun whenChatHeaderUpgradeTappedByFreeUserThenPixelFiredWithFreeTier() {
+    fun whenChatHeaderUpgradeTappedByFreeUserThenPixelFiredWithFreeTierAndOrigin() {
         testee.fireChatHeaderUpgradeTapped(DuckAiTier.Free)
 
         verify(pixel).fire(
             AppPixelName.AI_CHAT_UNIFIED_INPUT_CHAT_HEADER_UPGRADE_TAPPED,
-            mapOf("user_tier" to "free"),
+            mapOf("user_tier" to "free", "origin" to "funnel_duckai_android__freelabel"),
         )
     }
 
     @Test
-    fun whenChatHeaderUpgradeTappedByPaidUserThenPixelFiredWithPlusTier() {
+    fun whenChatHeaderUpgradeTappedByPaidUserThenPixelFiredWithPlusTierAndOrigin() {
         testee.fireChatHeaderUpgradeTapped(DuckAiTier.Paid)
 
         verify(pixel).fire(
             AppPixelName.AI_CHAT_UNIFIED_INPUT_CHAT_HEADER_UPGRADE_TAPPED,
-            mapOf("user_tier" to "plus"),
+            mapOf("user_tier" to "plus", "origin" to "funnel_duckai_android__freelabel"),
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputOmnibarControllerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputOmnibarControllerTest.kt
@@ -96,29 +96,34 @@ class RealNativeInputOmnibarControllerTest {
     }
 
     @Test
-    fun whenTierUpdatedToFreeWithoutOverlayActiveThenFreePillStaysHidden() {
+    fun whenTierUpdatedToFreeWithoutOverlayActiveThenFreePillStaysHiddenAndNoImpression() {
         whenever(omnibar.omnibarView).thenReturn(omnibarView)
         duckAIFreePill.visibility = View.VISIBLE
+        var impressions = 0
 
-        testee.updateTierTitle(DuckAiTier.Free) {}
+        testee.updateTierTitle(DuckAiTier.Free, {}) { impressions++ }
 
         assertEquals(View.GONE, duckAIFreePill.visibility)
+        assertEquals(0, impressions) // pill not rendered -> no free-label impression
     }
 
     @Test
-    fun whenOverlayActiveAndTierFreeThenFreePillShown() {
+    fun whenOverlayActiveAndTierFreeThenFreePillShownAndImpressionFired() {
         whenever(omnibar.omnibarView).thenReturn(omnibarView)
-        testee.updateTierTitle(DuckAiTier.Free) {}
+        var impressions = 0
+        testee.updateTierTitle(DuckAiTier.Free, {}) { impressions++ }
 
         testee.hideBackground()
 
         assertEquals(View.VISIBLE, duckAIFreePill.visibility)
+        assertEquals(1, impressions) // upgradeable pill rendered -> exactly one impression
     }
 
     @Test
-    fun whenOverlayActiveAndTierFreeNoUpgradeThenPillShownButUpgradeAffordanceHidden() {
+    fun whenOverlayActiveAndTierFreeNoUpgradeThenPillShownButUpgradeAffordanceHiddenAndNoImpression() {
         whenever(omnibar.omnibarView).thenReturn(omnibarView)
-        testee.updateTierTitle(DuckAiTier.FreeNoUpgrade) {}
+        var impressions = 0
+        testee.updateTierTitle(DuckAiTier.FreeNoUpgrade, {}) { impressions++ }
 
         testee.hideBackground()
 
@@ -128,18 +133,46 @@ class RealNativeInputOmnibarControllerTest {
         assertEquals(View.GONE, duckAIFreePillChevron.visibility)
         assertEquals(View.GONE, aiTitle.visibility)
         assertFalse(duckAIFreePill.isClickable)
+        assertEquals(0, impressions) // non-upgradeable pill -> no free-label impression
     }
 
     @Test
     fun whenOverlayRestoredThenLaterFreeTierUpdateDoesNotResurrectFreePill() {
         whenever(omnibar.omnibarView).thenReturn(omnibarView)
-        testee.updateTierTitle(DuckAiTier.Free) {}
+        testee.updateTierTitle(DuckAiTier.Free, {}) {}
         testee.hideBackground()
         assertEquals(View.VISIBLE, duckAIFreePill.visibility)
 
         testee.restore()
-        testee.updateTierTitle(DuckAiTier.Free) {}
+        testee.updateTierTitle(DuckAiTier.Free, {}) {}
 
         assertEquals(View.GONE, duckAIFreePill.visibility)
+    }
+
+    @Test
+    fun whenPillReDisplayedAfterRestoreThenImpressionFiresAgain() {
+        whenever(omnibar.omnibarView).thenReturn(omnibarView)
+        var impressions = 0
+
+        testee.updateTierTitle(DuckAiTier.Free, {}) { impressions++ }
+        testee.hideBackground() // pill shown -> impression 1
+
+        testee.restore()
+        testee.updateTierTitle(DuckAiTier.Free, {}) { impressions++ }
+        testee.hideBackground() // pill shown again after restore -> impression 2 (latch reset)
+
+        assertEquals(2, impressions)
+    }
+
+    @Test
+    fun whenUpgradeablePillStaysVisibleAcrossReapplyThenImpressionFiresOnce() {
+        whenever(omnibar.omnibarView).thenReturn(omnibarView)
+        var impressions = 0
+
+        testee.updateTierTitle(DuckAiTier.Free, {}) { impressions++ }
+        testee.hideBackground() // pill shown -> impression 1
+        testee.setTierVisible(true) // re-apply while still visible -> no re-fire
+
+        assertEquals(1, impressions)
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -207,7 +207,14 @@ interface DuckChatPixels {
     /** FE recovery flow: a prompt submitted after recovering the chat's model. */
     fun fireSubmitChangeModelPromptSent(surface: DuckChatPixelSurface)
 
-    fun fireSubscriptionUpsellTriggered(source: String, currentTier: String, requiredTier: String, flowType: String)
+    /** Subscription upsell triggered by tapping a gated model or reasoning option. */
+    fun fireSubscriptionUpsellTriggered(source: String, currentTier: String, requiredTier: String, flowType: String, origin: String)
+
+    /** Subscription-funnel impression: the model picker was shown. [origin] identifies the entry point. */
+    fun fireModelPickerShown(origin: String)
+
+    /** Subscription-funnel impression: the reasoning effort picker was shown. [origin] identifies the entry point. */
+    fun fireReasoningEffortPickerShown(origin: String)
     fun fireImageAttached(source: String, surface: DuckChatPixelSurface)
     fun fireImageValidationFailed(reason: String, surface: DuckChatPixelSurface)
     fun fireImageRemoved(surface: DuckChatPixelSurface)
@@ -687,7 +694,7 @@ class RealDuckChatPixels @Inject constructor(
         )
     }
 
-    override fun fireSubscriptionUpsellTriggered(source: String, currentTier: String, requiredTier: String, flowType: String) {
+    override fun fireSubscriptionUpsellTriggered(source: String, currentTier: String, requiredTier: String, flowType: String, origin: String) {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             pixel.fire(
                 DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBSCRIPTION_UPSELL_TRIGGERED,
@@ -696,7 +703,26 @@ class RealDuckChatPixels @Inject constructor(
                     DuckChatPixelParameters.UPSELL_CURRENT_TIER to currentTier,
                     DuckChatPixelParameters.UPSELL_REQUIRED_TIER to requiredTier,
                     DuckChatPixelParameters.UPSELL_FLOW_TYPE to flowType,
+                    DuckChatPixelParameters.ORIGIN to origin,
                 ),
+            )
+        }
+    }
+
+    override fun fireModelPickerShown(origin: String) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(
+                DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_MODEL_PICKER_SHOWN,
+                parameters = mapOf(DuckChatPixelParameters.ORIGIN to origin),
+            )
+        }
+    }
+
+    override fun fireReasoningEffortPickerShown(origin: String) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(
+                DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_REASONING_EFFORT_PICKER_SHOWN,
+                parameters = mapOf(DuckChatPixelParameters.ORIGIN to origin),
             )
         }
     }
@@ -1129,6 +1155,10 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_UNIFIED_INPUT_VOICE_SEARCH_TAPPED_COUNT("m_aichat_unified_input_voice_search_tapped_count"),
     DUCK_CHAT_UNIFIED_INPUT_VOICE_SEARCH_TAPPED_DAILY("m_aichat_unified_input_voice_search_tapped_daily"),
     DUCK_CHAT_UNIFIED_INPUT_STOP_GENERATION_TAPPED("m_aichat_unified_input_stop_generation_tapped"),
+
+    // Subscription-funnel impressions. The matching "click" is DUCK_CHAT_UNIFIED_INPUT_SUBSCRIPTION_UPSELL_TRIGGERED.
+    DUCK_CHAT_UNIFIED_INPUT_MODEL_PICKER_SHOWN("m_aichat_unified_input_model_picker_shown"),
+    DUCK_CHAT_UNIFIED_INPUT_REASONING_EFFORT_PICKER_SHOWN("m_aichat_unified_input_reasoning_effort_picker_shown"),
 }
 
 object DuckChatPixelParameters {
@@ -1155,6 +1185,9 @@ object DuckChatPixelParameters {
     const val UPSELL_CURRENT_TIER = "current_tier"
     const val UPSELL_REQUIRED_TIER = "required_tier"
     const val UPSELL_FLOW_TYPE = "flow_type"
+
+    // Subscription-funnel telemetry: the entry-point origin (e.g. funnel_duckai_android__modelpicker)
+    const val ORIGIN = "origin"
 
     // ai_features_state_daily
     const val DUCK_AI = "duck_ai"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -240,6 +240,7 @@ class ModelPickerView @JvmOverloads constructor(
         if (state.models.isEmpty()) return
 
         viewModel.menuShowing = true
+        viewModel.onPickerShown(currentSurface())
         onMenuShown?.invoke()
         showPopupWindow(state)
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -170,6 +170,18 @@ class ModelPickerViewModel @Inject constructor(
     private val modelChangeChannel = Channel<PickerModelChange>(capacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
     val modelChanges: Flow<PickerModelChange> = modelChangeChannel.receiveAsFlow()
 
+    /** Subscription-funnel impression: the model picker was shown to the user. */
+    fun onPickerShown(surface: PickerSurface) {
+        duckChatPixels.fireModelPickerShown(effectiveOrigin(surface))
+    }
+
+    /**
+     * The subscription-funnel origin for [surface]. [SWITCH_MODEL_ORIGIN] is used when
+     * the picker is open in the FE model-recovery ("switch model") flow.
+     */
+    private fun effectiveOrigin(surface: PickerSurface): String =
+        if (modelChangeMode) SWITCH_MODEL_ORIGIN else surface.origin
+
     fun onModelTapped(model: AIChatModel, surface: PickerSurface) {
         if (model.isAccessible) {
             if (modelChangeMode) {
@@ -197,12 +209,14 @@ class ModelPickerViewModel @Inject constructor(
             logcat { "Duck.ai picker: tapped model has no public required tier (id=${model.id}, accessTier=${model.accessTier}), ignoring." }
             return
         }
-        routeUpsell(userTier, requiredTier, surface.origin, modelState.isSubscriptionEligible)?.let { upsell ->
+        val origin = effectiveOrigin(surface)
+        routeUpsell(userTier, requiredTier, origin, modelState.isSubscriptionEligible)?.let { upsell ->
             duckChatPixels.fireSubscriptionUpsellTriggered(
                 source = "model_picker",
                 currentTier = userTier.toParam(),
                 requiredTier = requiredTier.toParam(),
                 flowType = upsell.toFlowTypeParam(),
+                origin = origin,
             )
             command.trySend(upsell)
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PickerUpsell.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PickerUpsell.kt
@@ -20,11 +20,14 @@ import com.duckduckgo.duckchat.impl.models.UserTier
 import logcat.logcat
 
 enum class PickerSurface(val origin: String) {
-    MODEL_PICKER_ADDRESS_BAR("funnel_nativeinput_android__modelpicker"),
+    MODEL_PICKER_ADDRESS_BAR("funnel_addressbar_android__modelpicker"),
     MODEL_PICKER_DUCK_AI_TAB("funnel_duckai_android__modelpicker"),
-    REASONING_PICKER_ADDRESS_BAR("funnel_nativeinput_android__reasoningpicker"),
-    REASONING_PICKER_DUCK_AI_TAB("funnel_duckai_android__reasoningpicker"),
+    REASONING_PICKER_ADDRESS_BAR("funnel_addressbar_android__reasoningdropdown"),
+    REASONING_PICKER_DUCK_AI_TAB("funnel_duckai_android__reasoningdropdown"),
 }
+
+/** Subscription origin for the FE model-recovery ("switch model") flow */
+const val SWITCH_MODEL_ORIGIN = "funnel_duckai_android__switchmodel"
 
 sealed class UpsellCommand {
     data class LaunchPurchase(val origin: String) : UpsellCommand()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
@@ -158,8 +158,12 @@ class ReasoningModePickerView @JvmOverloads constructor(
         }
 
     private fun showMenu() {
+        // Guard against a re-tap opening an already-showing popup.
+        if (popupWindow?.isShowing == true) return
         val state = viewModel.state.value
         if (!state.visible) return
+
+        viewModel.onPickerShown(currentSurface())
 
         val container = LinearLayout(context).apply {
             orientation = LinearLayout.VERTICAL

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
@@ -128,6 +128,10 @@ class ReasoningModePickerViewModel @Inject constructor(
     private val command = Channel<UpsellCommand>(capacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
     val commands: Flow<UpsellCommand> = command.receiveAsFlow()
 
+    fun onPickerShown(surface: PickerSurface) {
+        duckChatPixels.fireReasoningEffortPickerShown(surface.origin)
+    }
+
     fun onModeTapped(mode: ReasoningMode, surface: PickerSurface) {
         // Drop taps that race past the picker hiding (loading, mismatch, no accessible rows).
         if (!state.value.visible) return
@@ -165,6 +169,7 @@ class ReasoningModePickerViewModel @Inject constructor(
                 currentTier = userTier.toParam(),
                 requiredTier = requiredTier.toParam(),
                 flowType = upsell.toFlowTypeParam(),
+                origin = surface.origin,
             )
             command.trySend(upsell)
         }

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
@@ -75,7 +75,13 @@ class RealDuckChatPixelsPickerTest {
 
     @Test
     fun whenUpsellTriggeredThenSingleCountWithAllParams() = runTest {
-        testee.fireSubscriptionUpsellTriggered(source = "model_picker", currentTier = "free", requiredTier = "plus", flowType = "purchase")
+        testee.fireSubscriptionUpsellTriggered(
+            source = "model_picker",
+            currentTier = "free",
+            requiredTier = "plus",
+            flowType = "purchase",
+            origin = "funnel_duckai_android__modelpicker",
+        )
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBSCRIPTION_UPSELL_TRIGGERED,
             parameters = mapOf(
@@ -83,6 +89,7 @@ class RealDuckChatPixelsPickerTest {
                 DuckChatPixelParameters.UPSELL_CURRENT_TIER to "free",
                 DuckChatPixelParameters.UPSELL_REQUIRED_TIER to "plus",
                 DuckChatPixelParameters.UPSELL_FLOW_TYPE to "purchase",
+                DuckChatPixelParameters.ORIGIN to "funnel_duckai_android__modelpicker",
             ),
         )
     }
@@ -126,6 +133,26 @@ class RealDuckChatPixelsPickerTest {
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_PROMPT_SENT_DAILY,
             parameters = params,
             type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenModelPickerShownThenFiresShownPixelWithOrigin() = runTest {
+        testee.fireModelPickerShown(origin = "funnel_duckai_android__modelpicker")
+
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_MODEL_PICKER_SHOWN,
+            parameters = mapOf(DuckChatPixelParameters.ORIGIN to "funnel_duckai_android__modelpicker"),
+        )
+    }
+
+    @Test
+    fun whenReasoningEffortPickerShownThenFiresShownPixelWithOrigin() = runTest {
+        testee.fireReasoningEffortPickerShown(origin = "funnel_addressbar_android__reasoningdropdown")
+
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_REASONING_EFFORT_PICKER_SHOWN,
+            parameters = mapOf(DuckChatPixelParameters.ORIGIN to "funnel_addressbar_android__reasoningdropdown"),
         )
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -271,8 +271,54 @@ class ModelPickerViewModelTest {
             currentTier = "free",
             requiredTier = "plus",
             flowType = "purchase",
+            origin = "funnel_addressbar_android__modelpicker",
         )
         verify(duckChatPixels, never()).fireModelSelected(any(), any())
+    }
+
+    @Test
+    fun whenPickerShownFromAddressBarThenModelPickerShownFiredWithAddressBarOrigin() = runTest {
+        testee.onPickerShown(PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+        runCurrent()
+
+        verify(duckChatPixels).fireModelPickerShown("funnel_addressbar_android__modelpicker")
+    }
+
+    @Test
+    fun whenPickerShownFromDuckAiTabThenModelPickerShownFiredWithDuckAiOrigin() = runTest {
+        testee.onPickerShown(PickerSurface.MODEL_PICKER_DUCK_AI_TAB)
+        runCurrent()
+
+        verify(duckChatPixels).fireModelPickerShown("funnel_duckai_android__modelpicker")
+    }
+
+    @Test
+    fun whenPickerShownInModelChangeModeThenModelPickerShownFiredWithSwitchModelOrigin() = runTest {
+        nativeInputState.value = nativeInputState.value.copy(chatId = "c1", modelChangeMode = true)
+        advanceUntilIdle()
+
+        testee.onPickerShown(PickerSurface.MODEL_PICKER_DUCK_AI_TAB)
+        runCurrent()
+
+        verify(duckChatPixels).fireModelPickerShown("funnel_duckai_android__switchmodel")
+    }
+
+    @Test
+    fun whenGatedModelTappedInModelChangeModeThenUpsellFiredWithSwitchModelOrigin() = runTest {
+        nativeInputState.value = nativeInputState.value.copy(chatId = "c1", modelChangeMode = true)
+        stateFlow.value = ModelState(userTier = UserTier.FREE, isSubscriptionEligible = true)
+        advanceUntilIdle()
+
+        testee.onModelTapped(plusModel("p"), PickerSurface.MODEL_PICKER_DUCK_AI_TAB)
+        runCurrent()
+
+        verify(duckChatPixels).fireSubscriptionUpsellTriggered(
+            source = "model_picker",
+            currentTier = "free",
+            requiredTier = "plus",
+            flowType = "purchase",
+            origin = "funnel_duckai_android__switchmodel",
+        )
     }
 
     @Test
@@ -398,7 +444,7 @@ class ModelPickerViewModelTest {
             expectNoEvents()
             cancelAndConsumeRemainingEvents()
         }
-        verify(duckChatPixels, never()).fireSubscriptionUpsellTriggered(any(), any(), any(), any())
+        verify(duckChatPixels, never()).fireSubscriptionUpsellTriggered(any(), any(), any(), any(), any())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
@@ -191,6 +191,22 @@ class ReasoningModePickerViewModelTest {
     }
 
     @Test
+    fun whenPickerShownFromAddressBarThenReasoningEffortPickerShownFiredWithAddressBarOrigin() = runTest {
+        testee.onPickerShown(PickerSurface.REASONING_PICKER_ADDRESS_BAR)
+        runCurrent()
+
+        verify(duckChatPixels).fireReasoningEffortPickerShown("funnel_addressbar_android__reasoningdropdown")
+    }
+
+    @Test
+    fun whenPickerShownFromDuckAiTabThenReasoningEffortPickerShownFiredWithDuckAiOrigin() = runTest {
+        testee.onPickerShown(PickerSurface.REASONING_PICKER_DUCK_AI_TAB)
+        runCurrent()
+
+        verify(duckChatPixels).fireReasoningEffortPickerShown("funnel_duckai_android__reasoningdropdown")
+    }
+
+    @Test
     fun whenAccessibleModeTappedMatchingCurrentThenNoEffortPixel() = runTest {
         modelState.value = ModelState(
             selectedReasoningMode = ReasoningMode.FAST,
@@ -228,6 +244,7 @@ class ReasoningModePickerViewModelTest {
             currentTier = "plus",
             requiredTier = "pro",
             flowType = "upgrade",
+            origin = "funnel_addressbar_android__reasoningdropdown",
         )
         verify(duckChatPixels, never()).fireReasoningEffortSelected(any(), any())
     }
@@ -342,7 +359,7 @@ class ReasoningModePickerViewModelTest {
             expectNoEvents()
             cancelAndConsumeRemainingEvents()
         }
-        verify(duckChatPixels, never()).fireSubscriptionUpsellTriggered(any(), any(), any(), any())
+        verify(duckChatPixels, never()).fireSubscriptionUpsellTriggered(any(), any(), any(), any(), any())
     }
 
     @Test

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
@@ -91,6 +91,32 @@ object SubscriptionsConstants {
     const val FEATURE_PAGE_QUERY_PARAM_KEY = "featurePage"
     const val SUBSCRIPTIONS_PATH = "pro"
     const val PRIVACY_SUBSCRIPTIONS_PATH = "subscriptions"
+
+    // Subscription-funnel origin for the app-settings "Get Subscription" entry point. Used both to
+    // launch the buy webview (ProSettingView) and on the app-settings click pixel (SubscriptionPixelSender).
+    const val ORIGIN_APP_SETTINGS = "funnel_appsettings_android"
+
+    // Allowlist of funnel entry-point origins permitted on subscription telemetry. The offer/subscribe
+    // origin can arrive from a web-supplied `?origin=` URL param, so it is bounded to this set.
+    // TODO: Consider moving this list to the remove privacy configuration if it will change regularly.
+    val FUNNEL_ORIGIN_ALLOWLIST = setOf(
+        "funnel_addressbar_android__aitoggle",
+        "funnel_addressbar_android__modelpicker",
+        "funnel_addressbar_android__reasoningdropdown",
+        "funnel_appmenu_android",
+        "funnel_appsettings_android",
+        "funnel_duckai_android__freelabel",
+        "funnel_duckai_android__modelpicker",
+        "funnel_duckai_android__reasoningdropdown",
+        "funnel_duckai_android__switchmodel",
+        "funnel_modal_android__skippedonboardingupsell",
+        "funnel_modal_android__subscriptionnudge",
+        "funnel_onboarding_android",
+        "funnel_playstore",
+        "funnel_purchase_offer_page_android",
+        "funnel_restore_android__viewplans",
+        "funnel_subscriptionsettings_android__viewplans",
+    )
 }
 
 enum class SubscriptionTier(val value: String) {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
@@ -20,6 +20,8 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.extensions.toSanitizedLanguageTag
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.FUNNEL_ORIGIN_ALLOWLIST
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ORIGIN_APP_SETTINGS
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.ACTIVATE_SUBSCRIPTION_ENTER_EMAIL_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.ACTIVATE_SUBSCRIPTION_RESTORE_PURCHASE_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_GET_SUBSCRIPTION_CLICK
@@ -87,8 +89,8 @@ import javax.inject.Inject
 
 interface SubscriptionPixelSender {
     fun reportSubscriptionActive()
-    fun reportOfferScreenShown()
-    fun reportOfferSubscribeClick()
+    fun reportOfferScreenShown(origin: String?)
+    fun reportOfferSubscribeClick(origin: String?)
     fun reportPurchaseFailureOther(
         errorType: String,
         reason: String? = null,
@@ -162,15 +164,24 @@ class SubscriptionPixelSenderImpl @Inject constructor(
             ),
         )
 
-    override fun reportOfferScreenShown() {
+    override fun reportOfferScreenShown(origin: String?) {
         paywallMetricsManager.recordFirstPaywallSeen()?.let { dayBucket ->
             fire(PAYWALL_SHOWN_FIRST_TIME, mapOf(DAYS_SINCE_INSTALL to dayBucket))
         }
-        fire(OFFER_SCREEN_SHOWN)
+        // Subscription-funnel: carry the entry-point origin the offer was launched with so the
+        // impression joins to the click/purchase for the same origin.
+        fire(OFFER_SCREEN_SHOWN, funnelOriginParams(origin))
     }
 
-    override fun reportOfferSubscribeClick() =
-        fire(OFFER_SUBSCRIBE_CLICK)
+    override fun reportOfferSubscribeClick(origin: String?) =
+        fire(OFFER_SUBSCRIBE_CLICK, funnelOriginParams(origin))
+
+    // The origin can be supplied by a web page via the `?origin=` URL param. Only attach it to the pixel
+    // when it's one of the known funnel entry points; otherwise send no origin. The allowlist bounds the
+    // value so a web page cannot inject a unique per-user identifier that would follow the user downstream.
+    private fun funnelOriginParams(origin: String?): Map<String, String> =
+        origin?.takeIf { it in FUNNEL_ORIGIN_ALLOWLIST }
+            ?.let { mapOf("origin" to it) } ?: emptyMap()
 
     override fun reportPurchaseFailureOther(
         errorType: String,
@@ -268,7 +279,7 @@ class SubscriptionPixelSenderImpl @Inject constructor(
         fire(APP_SETTINGS_IDTR_CLICK)
 
     override fun reportAppSettingsGetSubscriptionClick() =
-        fire(APP_SETTINGS_GET_SUBSCRIPTION_CLICK)
+        fire(APP_SETTINGS_GET_SUBSCRIPTION_CLICK, mapOf("origin" to ORIGIN_APP_SETTINGS))
 
     override fun reportAppSettingsRestorePurchaseClick() =
         fire(APP_SETTINGS_RESTORE_PURCHASE_CLICK)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingView.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingView.kt
@@ -42,6 +42,7 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus.INACTIVE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.NOT_AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.WAITING
 import com.duckduckgo.subscriptions.impl.R
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants
 import com.duckduckgo.subscriptions.impl.databinding.ViewSettingsBinding
 import com.duckduckgo.subscriptions.impl.internal.SubscriptionsUrlProvider
 import com.duckduckgo.subscriptions.impl.settings.views.ProSettingViewModel.Command
@@ -217,7 +218,7 @@ class ProSettingView @JvmOverloads constructor(
                     context,
                     SubscriptionsWebViewActivityWithParams(
                         url = subscriptionsUrlProvider.buyUrl,
-                        origin = "funnel_appsettings_android",
+                        origin = SubscriptionsConstants.ORIGIN_APP_SETTINGS,
                     ),
                 )
             }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -122,6 +122,10 @@ class SubscriptionWebViewViewModel @Inject constructor(
 
     private var pendingScheduleNotificationDaysBeforeCancel: Int? = null
 
+    // Origin the offer webview was launched with, captured when the paywall is shown, so the subscribe
+    // (primary CTA) click can be attributed to the same subscription-funnel entry point.
+    private var launchOrigin: String? = null
+
     fun start() {
         subscriptionsManager.currentPurchaseState.onEach {
             val state = when (it) {
@@ -315,7 +319,7 @@ class SubscriptionWebViewViewModel @Inject constructor(
     private fun hasPurchasedSubscription() = currentPurchaseViewState.value.purchaseState is Success
 
     private fun subscriptionSelected(data: JSONObject?) {
-        pixelSender.reportOfferSubscribeClick()
+        pixelSender.reportOfferSubscribeClick(launchOrigin)
 
         viewModelScope.launch(dispatcherProvider.io()) {
             val id = runCatching { data?.getString("id") }.getOrNull()
@@ -339,6 +343,10 @@ class SubscriptionWebViewViewModel @Inject constructor(
     }
 
     private fun subscriptionChangeSelected(data: JSONObject?) {
+        // Plus->Pro upgrade CTA comes through subscriptionChangeSelected with a launch origin set;
+        // It must still fire the subscribe click so the offer_screen_impression it followed has a matching click for the upgrade origin.
+        launchOrigin?.let { pixelSender.reportOfferSubscribeClick(it) }
+
         viewModelScope.launch(dispatcherProvider.io()) {
             val targetPlanId = runCatching { data?.getString("id") }.getOrNull()
             val change = runCatching { data?.getString("change") }.getOrNull()
@@ -722,8 +730,13 @@ class SubscriptionWebViewViewModel @Inject constructor(
         }
     }
 
+    /** Captures the offer's launch origin so the subscribe-CTA click can be attributed even after process death. */
+    fun setLaunchOrigin(origin: String?) {
+        launchOrigin = origin
+    }
+
     fun paywallShown() {
-        pixelSender.reportOfferScreenShown()
+        pixelSender.reportOfferScreenShown(launchOrigin)
     }
 
     data class SubscriptionOptionsJson(

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -338,13 +338,24 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
             renderPurchaseState(it.purchaseState)
         }.launchIn(lifecycleScope)
 
-        val isSubscriptionUrl by lazy {
-            runCatching { subscriptions.isSubscriptionUrl(params.url.toUri()) }.getOrDefault(false)
-        }
-        if (savedInstanceState == null && isSubscriptionUrl) {
+        // Seed the launch origin so the subscribe-CTA click keeps it across process death
+        viewModel.setLaunchOrigin(params.origin)
+        if (savedInstanceState == null && isOfferPageUrl(params.url, params.origin)) {
             viewModel.paywallShown()
         }
     }
+
+    /**
+     * True when [url] is a subscription offer page, used to gate the offer-screen impression: the standard
+     * purchase offer ([Subscriptions.isSubscriptionUrl]), or the Plus→Pro upgrade offer (`/plans`) when
+     * opened from a funnel. The upgrade case requires a non-null [origin].
+     */
+    private fun isOfferPageUrl(url: String, origin: String?): Boolean = runCatching {
+        val uri = url.toUri()
+        val upgradeUri = subscriptionsUrlProvider.upgradeToProUrl.toUri()
+        subscriptions.isSubscriptionUrl(uri) ||
+            (origin != null && uri.host == upgradeUri.host && uri.path == upgradeUri.path)
+    }.getOrDefault(false)
 
     private fun recoverFromRenderProcessCrash(): Boolean {
         if (!subscriptionsFeature.handleSubscriptionsWebViewRenderProcessCrash().isEnabled()) return false

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSenderImplTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSenderImplTest.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 
 class SubscriptionPixelSenderImplTest {
@@ -74,6 +75,61 @@ class SubscriptionPixelSenderImplTest {
         verify(pixel).fire(
             pixelName = "m_subscription_expiration_reminder_not_fired_permissions_rejected",
             type = Count,
+        )
+    }
+
+    @Test
+    fun whenReportOfferScreenShownWithOriginThenFiresImpressionWithOrigin() {
+        testee.reportOfferScreenShown("funnel_appsettings_android")
+
+        verify(pixel).fire(
+            pixelName = "m_privacy-pro_offer_screen_impression_c",
+            type = Count,
+            parameters = mapOf("origin" to "funnel_appsettings_android"),
+        )
+    }
+
+    @Test
+    fun whenReportOfferScreenShownWithoutOriginThenFiresImpressionWithNoParams() {
+        testee.reportOfferScreenShown(null)
+
+        verify(pixel).fire(
+            pixelName = "m_privacy-pro_offer_screen_impression_c",
+            type = Count,
+        )
+    }
+
+    @Test
+    fun whenReportOfferScreenShownWithOriginNotInAllowlistThenOriginIsDropped() {
+        testee.reportOfferScreenShown("javascript:alert(1)") // malformed
+        testee.reportOfferScreenShown("") // blank
+        testee.reportOfferScreenShown("funnel_unique_user_id_1234") // well-formed but not an allowlisted entry point
+
+        verify(pixel, times(3)).fire(
+            pixelName = "m_privacy-pro_offer_screen_impression_c",
+            type = Count,
+        )
+    }
+
+    @Test
+    fun whenReportOfferSubscribeClickWithOriginThenFiresWithOrigin() {
+        testee.reportOfferSubscribeClick("funnel_duckai_android__modelpicker")
+
+        verify(pixel).fire(
+            pixelName = "m_privacy-pro_terms-conditions_subscribe_click_c",
+            type = Count,
+            parameters = mapOf("origin" to "funnel_duckai_android__modelpicker"),
+        )
+    }
+
+    @Test
+    fun whenReportAppSettingsGetSubscriptionClickThenFiresWithAppSettingsOrigin() {
+        testee.reportAppSettingsGetSubscriptionClick()
+
+        verify(pixel).fire(
+            pixelName = "m_privacy-pro_app-settings_get_click_c",
+            type = Count,
+            parameters = mapOf("origin" to "funnel_appsettings_android"),
         )
     }
 }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
@@ -861,7 +861,45 @@ class SubscriptionWebViewViewModelTest {
             id = "id",
             data = JSONObject("""{"id":"myId"}"""),
         )
-        verify(pixelSender).reportOfferSubscribeClick()
+        verify(pixelSender).reportOfferSubscribeClick(null)
+    }
+
+    @Test
+    fun whenLaunchOriginSeededThenSubscriptionSelectedPixelCarriesOrigin() = runTest {
+        viewModel.setLaunchOrigin("funnel_duckai_android__modelpicker")
+
+        viewModel.processJsCallbackMessage(
+            featureName = "test",
+            method = "subscriptionSelected",
+            id = "id",
+            data = JSONObject("""{"id":"myId"}"""),
+        )
+        verify(pixelSender).reportOfferSubscribeClick("funnel_duckai_android__modelpicker")
+    }
+
+    @Test
+    fun whenLaunchOriginSeededThenSubscriptionChangeSelectedPixelCarriesOrigin() = runTest {
+        viewModel.setLaunchOrigin("funnel_duckai_android__switchmodel")
+
+        viewModel.processJsCallbackMessage(
+            featureName = "test",
+            method = "subscriptionChangeSelected",
+            id = "id",
+            data = JSONObject("""{"id":"myId"}"""),
+        )
+        verify(pixelSender).reportOfferSubscribeClick("funnel_duckai_android__switchmodel")
+    }
+
+    @Test
+    fun whenSubscriptionChangeSelectedWithoutLaunchOriginThenNoSubscribeClickFires() = runTest {
+        // A generic plan change (no funnel launch origin) must not emit a subscribe click.
+        viewModel.processJsCallbackMessage(
+            featureName = "test",
+            method = "subscriptionChangeSelected",
+            id = "id",
+            data = JSONObject("""{"id":"myId"}"""),
+        )
+        verify(pixelSender, never()).reportOfferSubscribeClick(any())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217126669949056?focus=true 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

Adds an `origin` parameter to the native subscription-funnel entry points so the dashboard can join impression -> click -> offer/purchase per entry point. Impression = a `_shown` pixel; click = `origin` on the existing upsell/CTA pixel (iOS-aligned).

New impression pixels (`_shown`):
- `m_aichat_unified_input_model_picker_shown`: model picker opened
- `m_aichat_unified_input_reasoning_effort_picker_shown`: reasoning picker opened
- `m_aichat_unified_input_free_label_shown`: Free upgrade pill shown

`origin` added to existing pixels:
- `m_aichat_unified_input_subscription_upsell_triggered`: gated model / reasoning tap
- `m_aichat_unified_input_chat_header_upgrade_tapped`: Free pill tap
- `m_privacy-pro_offer_screen_impression`: offer page shown
- `m_privacy-pro_app-settings_get_click`: Settings "Get Subscription" tap
- `m_privacy-pro_terms-conditions_subscribe_click`: Subscribe CTA on the offer page

Origins: `funnel_{duckai,addressbar}_android__modelpicker`, `...__reasoningdropdown`, `funnel_duckai_android__switchmodel`, `funnel_duckai_android__freelabel`, `funnel_appsettings_android`.

Registry: widened the purchase wide-event `context.name` pattern to accept the `__entrypoint` origin shape; added a `count_short` suffix to the dictionary.

### Steps to test this PR

_Setup_
Internal build. Filter logcat by “pixel sent". 
Account: Free tier, subscription-eligible .

_Model & reasoning pickers_
- [x] Duck.ai tab: open model picker -> `model_picker_shown`; tap a gated model -> `subscription_upsell_triggered` + `offer_screen_impression`. Origin `funnel_duckai_android__modelpicker`
- [x] Address bar: same but from the browser address bar. Origin `funnel_addressbar_android__modelpicker`
- [x] Reasoning picker (both surfaces): open -> `reasoning_effort_picker_shown`; tap a gated mode -> `subscription_upsell_triggered`. Origin `...__reasoningdropdown`
- [x] Switch model (FE recovery mode. This is accessed by logging into a PRO account, starting a chat, then removing the subscription and trying to resume that chat, you will get a message to swtich the mode): impression + click has `…__switchmodel` instead of `modelpicker`

_Free label_
- [x] Free tier, open Duck.ai -> "Free" pill appears on top -> `free_label_shown`; 
- [x] Tap Upgrade -> `chat_header_upgrade_tapped`. Origin `...__freelabel`

_App-settings / offer page_
- [x] Main Settings screen, subscription row (shown to non-subscribers), tap "Subscribe to DuckDuckGo" (may read "Try Free Trial" / a Black Friday offer) -> `app-settings_get_click` -> offer page -> `offer_screen_impression`. Origin `funnel_appsettings_android`
- [x] On the offer page tap Subscribe -> `terms-conditions_subscribe_click` with the launch origin

_Regression_
- [x] Tapping a free/accessible model or reasoning mode fires only the existing selection pixel; no funnel click/origin

### UI changes

None, telemetry only.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes with allowlisted `origin` values on web-supplied params; no auth, billing logic, or user-data handling changes beyond pixel firing.
> 
> **Overview**
> Adds **`origin`** on native subscription-funnel entry points so analytics can join **impression → click → offer/purchase** per entry point (iOS-aligned: `_shown` for impressions, `origin` on existing upsell/CTA pixels).
> 
> **New impression pixels:** model picker shown, reasoning effort picker shown, and Free upgrade pill shown in the Duck.ai omnibar header.
> 
> **`origin` on existing pixels:** subscription upsell from gated model/reasoning taps, chat header upgrade tap, offer screen impression, app Settings “Get Subscription” tap, and Subscribe CTA on the offer page.
> 
> **Runtime wiring:** pickers fire shown pixels when menus open; upsell and header upgrade include bounded funnel origins (`funnel_addressbar_android__*`, `funnel_duckai_android__*`, including switch-model recovery). The omnibar fires the free-label impression once per visible upgradeable Free pill. Subscription webview seeds launch origin for offer impression and subscribe clicks; origins from web `?origin=` are **allowlisted** before attaching to pixels.
> 
> **Registry:** widened subscription-purchase wide-event `context.name` pattern for `__entrypoint` origins; added **`count_short`** suffix for new privacy-pro pixels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a99365db8a7d866b313dc95ead85faa4e55dbae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->