### PR TITLE
[Drift Audit] Maestro rule doc lists stale test category directories

### DIFF
--- a/.cursor/rules/maestro-ui-tests.mdc
+++ b/.cursor/rules/maestro-ui-tests.mdc
@@ -18,25 +18,31 @@ keywords: ["maestro", "ui tests", "testing", "maestro cloud", "tags"]
 
 ## Types of UI tests
 The Maestro tests are organized into the following (non-exhaustive) main categories: 
-- `ad_click_detection` - Tests for ad click detection functionality 
-- `ads_preview` - Tests for Android Design System (ADS) preview functionality  
-- `app_tp` - App Tracking Protection tests 
-- `autofill` - Password manager and autofill functionality tests 
-- `bookmarks` - Bookmark management tests 
-- `browsing` - General web browsing tests 
-- `custom_tabs` - Custom tabs functionality tests 
+- `ad_click_detection_flows` - Tests for ad click detection functionality
+- `ads_preview_flows` - Tests for Android Design System (ADS) preview functionality
+- `app_tp` - App Tracking Protection tests
+- `autofill` - Password manager and autofill functionality tests
+- `binary_upload` - Smoke test used to validate an uploaded build binary
+- `bookmarks` - Bookmark management tests
+- `browsing` - General web browsing tests
+- `custom_tabs` - Custom tabs functionality tests
+- `deeplink` - Deeplink / `duck` scheme navigation tests
 - `duckplayer` - DuckPlayer tests. Some of these can only be run locally.
-- `favorites` - Favorites management tests 
+- `favorites` - Favorites management tests
 - `fire_button` - Fire button (data clearing) tests
 - `input_screen` - Input Screen and Experimental Address Bar that provides Search and Duck.ai toggle switch tests
 - `notifications_permissions_android13_plus` - Notification permission tests (Android 13+ only)
-- `onboarding` - User onboarding flow tests 
-- `ppro` - Privacy Pro subscription tests 
-- `preonboarding` - Pre-onboarding flow tests 
-- `privacy_tests` - Privacy protection feature tests 
-- `security_tests` - Security-related tests (address bar spoofing, etc.) 
-- `sync` - Sync & Backup functionality tests 
-- `tabs` - Tab management tests 
+- `omnibar` - Omnibar tests, including the split omnibar layout
+- `onboarding` - User onboarding and pre-onboarding flow tests
+- `performance` - Page load benchmarks (cold and warm)
+- `ppro` - Privacy Pro subscription tests
+- `privacy_tests` - Privacy protection feature tests
+- `privacy_tests_internal` - Privacy protection tests that require an `internal` build
+- `security_tests` - Security-related tests (address bar spoofing, etc.)
+- `serp` - Tests driven from the search results page
+- `sync_flows` - Sync & Backup functionality tests
+- `tabs` - Tab management tests
+- `unified_input_screen` - Unified input bar tests, exercising the `nativeInputToggle` / `inputWithAiToggle` combinations across omnibar positions
 
 ## Shared flows
 Inside `.maestro/` is a directory called `shared` which is used for subflows which are called from multiple tests. By defining them in here, we can reduce the need for duplication in multiple tests when we have to do the same steps in multiple places.


### PR DESCRIPTION
Task/Issue URL: (app.asana.com/redacted)

### Description
`.cursor/rules/maestro-ui-tests.mdc` — the "Types of UI tests" section described a `.maestro/` layout that no longer exists. The doc is the map agents use to locate and run Maestro suites, so a wrong directory name produces a `maestro test` command that fails.

Verified against the `.maestro/` tree on `develop` (`ee431b8`):

**Directories listed under names that no longer exist** — the doc's commands (`maestro test .maestro/sync`) do not resolve:

| Doc said | Actual directory |
|---|---|
| `ad_click_detection` | `ad_click_detection_flows` |
| `ads_preview` | `ads_preview_flows` |
| `sync` | `sync_flows` |

**`preonboarding` listed as a top-level category, but no such directory exists.** Those tests now live inside `.maestro/onboarding/` as `preonboarding_returning_user_quick_setup_customize.yaml` and `preonboarding_returning_user_quick_setup_start_browsing.yaml`. The doc now folds pre-onboarding into the `onboarding` entry.

**Directories absent from the list.** The most significant is `unified_input_screen`: `#9367` (merged 2026-08-03) turned its `unifiedInputTest` tag back on (`tags: []` → `tags: [unifiedInputTest]` in `unified_input_open_duckai_back_to_ntp.yaml`) and un-commented the AI-off omnibar-position combos, making it an active tagged CI suite. An agent reading the doc would conclude input-bar tests live only in `input_screen`. Also added, each described from its own flow headers: `binary_upload`, `deeplink`, `omnibar`, `performance`, `privacy_tests_internal`, `serp`.

The section keeps its "(non-exhaustive)" framing; only the category list changed. Every entry in the updated list resolves to a directory on disk, and every directory in `.maestro/` other than `shared/` is now listed. No test files, tags, or code were touched.

Note on scope: these are bare backticked names, not paths, so `AiConfigChecker.extractReferences` never classified them as references (it only treats tokens containing `/` as paths, or `:`-prefixed tokens as modules) — this drift was invisible to `aiConfigCheck` rather than a regression in it.

I also re-checked `.cursor/rules/wide-events.mdc` against the sampling work in `#7965` / `#9346` and `.cursor/rules/pixel-definitions.mdc` against `#9279`. Both still match the code — `samplingProbability`, the `SAMPLED_OUT_FLOW_ID` sentinel, `FlowStatus`, `CleanupPolicy`, the pixel/POST transport split and its default toggle values, and the `PixelDefinitions` npm scripts all read correctly. No changes needed there.

🤖 AI-docs Drift Auditor

### Steps to test this PR
- [ ] Read the updated rule doc against the linked code change and confirm it now matches.
- [ ] Confirm every backticked category name in the list is a real directory: `for d in $(grep -oP '^- `\K[a-z0-9_]+(?=`)' .cursor/rules/maestro-ui-tests.mdc); do [ -d ".maestro/$d" ] || echo "MISSING: $d"; done` — prints nothing.
- [ ] Confirm nothing is left out: `for d in .maestro/*/; do n=$(basename "$d"); [ "$n" = shared ] && continue; grep -q "^- \`$n\`" .cursor/rules/maestro-ui-tests.mdc || echo "UNLISTED: $n"; done` — prints nothing.
- [ ] Confirm `.maestro/unified_input_screen/` carries the `unifiedInputTest` tag, and that pre-onboarding flows are the `preonboarding_*.yaml` files inside `.maestro/onboarding/`.

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |




> [!NOTE]
> <details>
> <summary><b>🔒 Integrity filter blocked 7 items</b></summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#8891](https://github.com/duckduckgo/Android/pull/8891) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#9341](https://github.com/duckduckgo/Android/pull/9341) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8913](https://github.com/duckduckgo/Android/pull/8913) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8899](https://github.com/duckduckgo/Android/pull/8899) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8777](https://github.com/duckduckgo/Android/pull/8777) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8487](https://github.com/duckduckgo/Android/pull/8487) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8381](https://github.com/duckduckgo/Android/pull/8381) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [AI-docs Semantic Drift Audit](https://github.com/duckduckgo/Android/actions/runs/30882410117/agentic_workflow) · [◷](https://github.com/search?q=repo%3Aduckduckgo%2FAndroid+%22gh-aw-workflow-id%3A+drift-audit%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: AI-docs Semantic Drift Audit, engine: claude, model: auto, id: 30882410117, workflow_id: drift-audit, run: https://github.com/duckduckgo/Android/actions/runs/30882410117 -->

<!-- gh-aw-workflow-id: drift-audit -->