### PR TITLE
Contextual/NativeInput: Add unifiedInputSurface for voice chat and voice search clicks

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1046,28 +1046,28 @@
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_voice_tapped_daily": {
         "description": "(Daily Pixel) User tapped the voice chat button in the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_voice_search_tapped_count": {
         "description": "User tapped the in-field microphone for voice search in the Unified Input",
         "owners": ["karlenDimla"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_voice_search_tapped_daily": {
         "description": "(Daily Pixel) User tapped the in-field microphone for voice search in the Unified Input",
         "owners": ["karlenDimla"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_image_attached_count": {
         "description": "User attached an image in the Unified Input",

--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1042,15 +1042,29 @@
         "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_voice_tapped_count": {
-        "description": "User tapped the voice button in the Unified Input",
+        "description": "User tapped the voice chat button in the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
     },
     "m_aichat_unified_input_voice_tapped_daily": {
-        "description": "(Daily Pixel) User tapped the voice button in the Unified Input",
+        "description": "(Daily Pixel) User tapped the voice chat button in the Unified Input",
         "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_voice_search_tapped_count": {
+        "description": "User tapped the in-field microphone for voice search in the Unified Input",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_voice_search_tapped_daily": {
+        "description": "(Daily Pixel) User tapped the in-field microphone for voice search in the Unified Input",
+        "owners": ["karlenDimla"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -214,8 +214,8 @@ interface DuckChatPixels {
     fun fireFileAttached(surface: DuckChatPixelSurface)
     fun fireFileRemoved(surface: DuckChatPixelSurface)
     fun fireFileValidationFailed(reason: String, surface: DuckChatPixelSurface)
-    fun fireVoiceTapped()
-    fun fireVoiceSearchTapped()
+    fun fireVoiceTapped(surface: DuckChatPixelSurface)
+    fun fireVoiceSearchTapped(surface: DuckChatPixelSurface)
     fun fireStopGenerationTapped(surface: DuckChatPixelSurface)
     fun fireDuckAiChatHistorySuggestionClicked()
     fun fireDuckAiSearchDuckDuckGoSuggestionClicked()
@@ -746,14 +746,16 @@ class RealDuckChatPixels @Inject constructor(
         ),
     )
 
-    override fun fireVoiceTapped() = fireCountAndDaily(
+    override fun fireVoiceTapped(surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_TAPPED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_TAPPED_DAILY,
+        surfaceParams(surface),
     )
 
-    override fun fireVoiceSearchTapped() = fireCountAndDaily(
+    override fun fireVoiceSearchTapped(surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_SEARCH_TAPPED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_SEARCH_TAPPED_DAILY,
+        surfaceParams(surface),
     )
 
     override fun fireStopGenerationTapped(surface: DuckChatPixelSurface) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -215,6 +215,7 @@ interface DuckChatPixels {
     fun fireFileRemoved(surface: DuckChatPixelSurface)
     fun fireFileValidationFailed(reason: String, surface: DuckChatPixelSurface)
     fun fireVoiceTapped()
+    fun fireVoiceSearchTapped()
     fun fireStopGenerationTapped(surface: DuckChatPixelSurface)
     fun fireDuckAiChatHistorySuggestionClicked()
     fun fireDuckAiSearchDuckDuckGoSuggestionClicked()
@@ -750,6 +751,11 @@ class RealDuckChatPixels @Inject constructor(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_TAPPED_DAILY,
     )
 
+    override fun fireVoiceSearchTapped() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_SEARCH_TAPPED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_SEARCH_TAPPED_DAILY,
+    )
+
     override fun fireStopGenerationTapped(surface: DuckChatPixelSurface) {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             pixel.fire(
@@ -1119,6 +1125,8 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_UNIFIED_INPUT_FILE_VALIDATION_FAILED_DAILY("m_aichat_unified_input_file_validation_failed_daily"),
     DUCK_CHAT_UNIFIED_INPUT_VOICE_TAPPED_COUNT("m_aichat_unified_input_voice_tapped_count"),
     DUCK_CHAT_UNIFIED_INPUT_VOICE_TAPPED_DAILY("m_aichat_unified_input_voice_tapped_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_VOICE_SEARCH_TAPPED_COUNT("m_aichat_unified_input_voice_search_tapped_count"),
+    DUCK_CHAT_UNIFIED_INPUT_VOICE_SEARCH_TAPPED_DAILY("m_aichat_unified_input_voice_search_tapped_daily"),
     DUCK_CHAT_UNIFIED_INPUT_STOP_GENERATION_TAPPED("m_aichat_unified_input_stop_generation_tapped"),
 }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -262,6 +262,8 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 
     fun fireVoiceTapped() = duckChatPixels.fireVoiceTapped()
 
+    fun fireVoiceSearchTapped() = duckChatPixels.fireVoiceSearchTapped()
+
     fun fireStopGenerationTapped() = duckChatPixels.fireStopGenerationTapped(currentSurface())
 
     fun fireClearPressed(isSearchMode: Boolean) = duckChatPixels.fireOmnibarClearButtonPressed(isSearchMode)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -260,9 +260,9 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 
     fun fireSentPromptInChat() = duckChatPixels.fireSentPromptInChat()
 
-    fun fireVoiceTapped() = duckChatPixels.fireVoiceTapped()
+    fun fireVoiceTapped() = duckChatPixels.fireVoiceTapped(currentSurface())
 
-    fun fireVoiceSearchTapped() = duckChatPixels.fireVoiceSearchTapped()
+    fun fireVoiceSearchTapped() = duckChatPixels.fireVoiceSearchTapped(currentSurface())
 
     fun fireStopGenerationTapped() = duckChatPixels.fireStopGenerationTapped(currentSurface())
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -317,13 +317,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
         onVoiceChatClick?.invoke()
     }
 
-    // The in-field microphone doubles as the Duck.ai voice entry whenever the Duck.ai tab is selected
-    // — including an active Duck.ai chat page, where configure(isDuckAiMode = true) selects the chat
-    // tab and the bottom-row voice-chat chip is hidden, leaving the mic as the only voice affordance.
-    // Count those as a unified voice tap; a search-tab mic tap is plain voice search, not Duck.ai.
     private val voiceSearchClickWithPixel: () -> Unit = {
         if (isChatTabSelected()) {
-            viewModel.fireVoiceTapped()
+            viewModel.fireVoiceSearchTapped()
         }
         onVoiceSearchClick?.invoke()
     }

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
@@ -147,24 +147,26 @@ class RealDuckChatPixelsAttachmentsTest {
 
     @Test
     fun whenVoiceTappedThenCountAndDaily() = runTest {
-        testee.fireVoiceTapped()
+        testee.fireVoiceTapped(DuckChatPixelSurface.DUCK_AI)
 
-        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_TAPPED_COUNT, parameters = emptyMap())
+        val surfaceParams = mapOf(DuckChatPixelParameters.SURFACE to "duck_ai")
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_TAPPED_COUNT, parameters = surfaceParams)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_TAPPED_DAILY,
-            parameters = emptyMap(),
+            parameters = surfaceParams,
             type = Pixel.PixelType.Daily(),
         )
     }
 
     @Test
     fun whenVoiceSearchTappedThenCountAndDaily() = runTest {
-        testee.fireVoiceSearchTapped()
+        testee.fireVoiceSearchTapped(DuckChatPixelSurface.DUCK_AI)
 
-        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_SEARCH_TAPPED_COUNT, parameters = emptyMap())
+        val surfaceParams = mapOf(DuckChatPixelParameters.SURFACE to "duck_ai")
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_SEARCH_TAPPED_COUNT, parameters = surfaceParams)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_SEARCH_TAPPED_DAILY,
-            parameters = emptyMap(),
+            parameters = surfaceParams,
             type = Pixel.PixelType.Daily(),
         )
     }

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
@@ -158,6 +158,18 @@ class RealDuckChatPixelsAttachmentsTest {
     }
 
     @Test
+    fun whenVoiceSearchTappedThenCountAndDaily() = runTest {
+        testee.fireVoiceSearchTapped()
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_SEARCH_TAPPED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_SEARCH_TAPPED_DAILY,
+            parameters = emptyMap(),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
     fun whenStopTappedThenSingleCount() = runTest {
         testee.fireStopGenerationTapped(DuckChatPixelSurface.DUCK_AI)
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -1635,13 +1635,13 @@ class NativeInputModeWidgetViewModelTest {
     @Test
     fun whenVoiceTappedThenVoicePixel() {
         testee.fireVoiceTapped()
-        verify(duckChatPixels).fireVoiceTapped()
+        verify(duckChatPixels).fireVoiceTapped(any())
     }
 
     @Test
     fun whenVoiceSearchTappedThenVoiceSearchPixel() {
         testee.fireVoiceSearchTapped()
-        verify(duckChatPixels).fireVoiceSearchTapped()
+        verify(duckChatPixels).fireVoiceSearchTapped(any())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -1639,6 +1639,12 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
+    fun whenVoiceSearchTappedThenVoiceSearchPixel() {
+        testee.fireVoiceSearchTapped()
+        verify(duckChatPixels).fireVoiceSearchTapped()
+    }
+
+    @Test
     fun whenStopGenerationTappedThenStopPixel() {
         testee.fireStopGenerationTapped()
         verify(duckChatPixels).fireStopGenerationTapped(any())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217108456740157?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
 - New m_aichat_unified_input_voice_search_tapped pixel (count + daily), fired when the in-field microphone is tapped in the Unified Input — distinct from the existing voice-chat pixel fired by the voice-chat chip.
 - Added the unifiedInputSurface (surface) parameter to both m_aichat_unified_input_voice_tapped and m_aichat_unified_input_voice_search_tapped, reporting address_bar / duck_ai / contextual_chat based on the native input widget's current input context.
 - DuckChatPixels.fireVoiceTapped / fireVoiceSearchTapped now take a DuckChatPixelSurface, with the ViewModel deriving it via currentSurface().


### Steps to test this PR
Filter `pixel sent: m_aichat_unified_input_voice_` on your logcat

- [x] Open new tab and focus native input
- [x] Click on microphone icon
- [x] Verify pixel is emitted `Pixel sent: m_aichat_unified_input_voice_search_tapped_count with params: {surface=address_bar} {}`
- [x] Close the voice search
- [x] Click on the voice chat icon (wave icon)
- [x] Verify pixel is emitted `Pixel sent: m_aichat_unified_input_voice_tapped_count with params: {surface= address_bar} {}`
- [x] Close voice chat
- [x] Open a website on a new tab
- [x] Open contextual sheet
- [x] Click on microphone icon
- [x] Verify pixel is emitted `Pixel sent: m_aichat_unified_input_voice_search_tapped_count with params: {surface=contextual_chat} {}`
- [x] Close the voice search
- [x] Click on the voice chat icon (wave icon)
- [x] Verify pixel is emitted `Pixel sent: m_aichat_unified_input_voice_tapped_count with params: {surface= contextual_chat} {}`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes to pixel definitions and firing paths; no auth, data handling, or core user flows modified.
> 
> **Overview**
> Unified Input analytics now distinguish **voice chat** (bottom-row button) from **in-field microphone** taps, and both include **`unifiedInputSurface`** so events can be broken down by address bar, Duck.ai tab, or contextual sheet.
> 
> **Voice chat** pixels (`m_aichat_unified_input_voice_tapped_*`) gain the `unifiedInputSurface` parameter and updated descriptions; **`fireVoiceTapped`** now requires a `DuckChatPixelSurface` and sends `surface` via `surfaceParams`.
> 
> New **voice search** count/daily pixels (`m_aichat_unified_input_voice_search_tapped_*`) track in-field mic taps when the Duck.ai/chat tab is selected. **`NativeInputModeWidget`** routes those mic taps to **`fireVoiceSearchTapped`** instead of **`fireVoiceTapped`** (voice chat button still uses voice tapped).
> 
> Tests cover surface parameters and the new voice-search firing path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fba1b76db242e02e5d77d32bba0deff7061cb6a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->