### PR TITLE
Add one-time unified sync device list migration

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoMigrator.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoMigrator.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.annotation.WorkerThread
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.store.SyncStore
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import logcat.LogPriority.ERROR
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * One-time, per-device backfill that brings an already signed-in user into the unified device list:
+ * ensures the account's `account_info` key exists and writes this device's `device_info`.
+ */
+@WorkerThread
+interface DeviceInfoMigrator {
+    /**
+     * Runs the migration if it hasn't been done for the current account and the write feature is
+     * enabled. Concurrent calls collapse into a single run.
+     *
+     * @return [Success] when migration completed or there is nothing left to do
+     * @return [Error] if it couldn't be migrated, leaving it so that it can be tried again
+     */
+    suspend fun ensureMigrated(): Result<Unit>
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealDeviceInfoMigrator @Inject constructor(
+    private val syncStore: SyncStore,
+    private val syncApi: SyncApi,
+    private val syncFeature: SyncFeature,
+    private val syncDeviceIds: SyncDeviceIds,
+    private val accountInfoKeyManager: AccountInfoKeyManager,
+    private val deviceInfoUpdater: DeviceInfoUpdater,
+    private val dispatchers: DispatcherProvider,
+) : DeviceInfoMigrator {
+
+    private val mutex = Mutex()
+
+    override suspend fun ensureMigrated(): Result<Unit> = withContext(dispatchers.io()) {
+        mutex.withLock { migrate() }
+    }
+
+    private suspend fun migrate(): Result<Unit> {
+        logcat { "Sync-UnifiedDevices: Checking if unified device list migration is needed" }
+
+        val inputs = when (val precheck = checkPreconditions()) {
+            is Precheck.Proceed -> precheck
+            is Precheck.Stop -> return precheck.result
+        }
+
+        logcat { "Sync-UnifiedDevices: migration needed; checking server for existing device_info" }
+        when (val serverHasDeviceInfoResult = serverAlreadyHasDeviceInfo(inputs.token)) {
+            is Success -> if (serverHasDeviceInfoResult.data) {
+                logcat { "Sync-UnifiedDevices: server already has device_info for this device; marking migration done" }
+                markMigrated(inputs.userId)
+                return Success(Unit)
+            }
+            is Error -> return serverHasDeviceInfoResult
+        }
+
+        logcat { "Sync-UnifiedDevices: no device_info on server for this device; ensuring account_info key" }
+        when (val keyResult = ensureAccountInfoKey()) {
+            is Success -> Unit
+            is Error -> return keyResult
+        }
+
+        logcat { "Sync-UnifiedDevices: writing device_info for this device" }
+        return writeDeviceInfo(inputs.userId)
+    }
+
+    private fun checkPreconditions(): Precheck {
+        val userId = syncStore.userId.takeUnless { it.isNullOrEmpty() }
+            ?: run {
+                logcat { "Sync-UnifiedDevices: migration skipped — not signed in" }
+                return Precheck.Stop(Error(reason = "DeviceInfoMigration: not signed in"))
+            }
+
+        if (!syncFeature.canWriteUnifiedDeviceList().isEnabled()) {
+            logcat { "Sync-UnifiedDevices: migration skipped — canWriteUnifiedDeviceList disabled" }
+            return Precheck.Stop(Success(Unit))
+        }
+
+        if (syncStore.unifiedDeviceListMigratedForUserId == userId) {
+            logcat { "Sync-UnifiedDevices: migration already done for this account; nothing to do" }
+            return Precheck.Stop(Success(Unit))
+        }
+
+        val token = syncStore.token.takeUnless { it.isNullOrEmpty() }
+            ?: run {
+                logcat { "Sync-UnifiedDevices: migration skipped — no token" }
+                return Precheck.Stop(Error(reason = "DeviceInfoMigration: no token"))
+            }
+
+        return Precheck.Proceed(userId = userId, token = token)
+    }
+
+    /** [Success] `true` if this device already has `device_info` on the server, `false` otherwise. */
+    private fun serverAlreadyHasDeviceInfo(token: String): Result<Boolean> {
+        return when (val devices = syncApi.getDevices(token)) {
+            is Success -> {
+                val thisDevice = devices.data.entriesV2?.firstOrNull { it.deviceId == syncStore.deviceId }
+                Success(!thisDevice?.deviceInfo.isNullOrEmpty())
+            }
+            is Error -> {
+                logcat(ERROR) { "Sync-UnifiedDevices: migration getDevices failed, will retry later: ${devices.reason}" }
+                devices
+            }
+        }
+    }
+
+    private suspend fun ensureAccountInfoKey(): Result<Unit> {
+        return when (val keyResult = accountInfoKeyManager.ensureKeyRegistered()) {
+            is Success -> {
+                logcat { "Sync-UnifiedDevices: account_info key ready (kid=${keyResult.data.kid})" }
+                Success(Unit)
+            }
+            is Error -> {
+                logcat(ERROR) { "Sync-UnifiedDevices: migration ensureKeyRegistered failed, will retry later: ${keyResult.reason}" }
+                keyResult
+            }
+        }
+    }
+
+    private fun writeDeviceInfo(userId: String): Result<Unit> {
+        return when (val patch = deviceInfoUpdater.updateThisDevice(syncDeviceIds.deviceName())) {
+            is Success -> {
+                markMigrated(userId)
+                logcat { "Sync-UnifiedDevices: migration complete for this device (${patch.data.size} devices_v2 returned)" }
+                Success(Unit)
+            }
+            is Error -> {
+                logcat(ERROR) { "Sync-UnifiedDevices: migration PATCH failed, will retry later: ${patch.reason}" }
+                patch
+            }
+        }
+    }
+
+    private fun markMigrated(userId: String) {
+        syncStore.unifiedDeviceListMigratedForUserId = userId
+    }
+
+    /** The signed-in inputs the migration needs, or a terminal [Result] to short-circuit on. */
+    private sealed interface Precheck {
+        data class Proceed(val userId: String, val token: String) : Precheck
+        data class Stop(val result: Result<Unit>) : Precheck
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/triggers/DeviceInfoMigrationObserver.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/triggers/DeviceInfoMigrationObserver.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.triggers
+
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.DeviceInfoMigrator
+import com.duckduckgo.sync.store.SyncStore
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Triggers the one-time unified-device-list migration on app foreground for signed-in users.
+ * The migrator is idempotent so this stays a cheap no-op once the migration is done or while the feature is disabled.
+ */
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+class DeviceInfoMigrationObserver @Inject constructor(
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+    private val syncStore: SyncStore,
+    private val deviceInfoMigrator: DeviceInfoMigrator,
+) : MainProcessLifecycleObserver {
+
+    override fun onStart(owner: LifecycleOwner) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            if (syncStore.isSignedIn()) {
+                deviceInfoMigrator.ensureMigrated()
+            }
+        }
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
@@ -114,6 +114,7 @@ class AppSyncDeviceIdsTest {
             override var credentialId: String? = null
             override var scopedPassword: ScopedPassword? = null
             override var accountInfoPublicKey: AccountInfoPublicKey? = null
+            override var unifiedDeviceListMigratedForUserId: String? = null
             override fun isEncryptionSupported() = true
 
             override fun isSignedInFlow() = emptyFlow<Boolean>()
@@ -149,6 +150,7 @@ class AppSyncDeviceIdsTest {
             override var credentialId: String? = null
             override var scopedPassword: ScopedPassword? = null
             override var accountInfoPublicKey: AccountInfoPublicKey? = null
+            override var unifiedDeviceListMigratedForUserId: String? = null
             override fun isEncryptionSupported() = true
 
             override fun isSignedInFlow() = emptyFlow<Boolean>()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoMigratorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoMigratorTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.sync.TestSyncFixtures.token
+import com.duckduckgo.sync.TestSyncFixtures.userId
+import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class DeviceInfoMigratorTest {
+
+    private val syncStore: SyncStore = mock()
+    private val syncApi: SyncApi = mock()
+    private val syncDeviceIds: SyncDeviceIds = mock()
+    private val accountInfoKeyManager: AccountInfoKeyManager = mock()
+    private val deviceInfoUpdater: DeviceInfoUpdater = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    private lateinit var migrator: DeviceInfoMigrator
+
+    private val keyResult = AccountInfoKeyResult(kid = "kid-1", publicKey = RsaJwk(n = "n", e = "AQAB"), created = true, wrapsSent = 1)
+
+    @Before
+    fun before() {
+        migrator = RealDeviceInfoMigrator(
+            syncStore = syncStore,
+            syncApi = syncApi,
+            syncFeature = syncFeature,
+            syncDeviceIds = syncDeviceIds,
+            accountInfoKeyManager = accountInfoKeyManager,
+            deviceInfoUpdater = deviceInfoUpdater,
+            dispatchers = coroutineTestRule.testDispatcherProvider,
+        )
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
+        whenever(syncStore.userId).thenReturn(userId)
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.deviceId).thenReturn("deviceId")
+        whenever(syncDeviceIds.deviceName()).thenReturn("deviceName")
+    }
+
+    @Test
+    fun whenAlreadyMigratedForUserThenNoOpWithoutNetwork() = runTest {
+        whenever(syncStore.unifiedDeviceListMigratedForUserId).thenReturn(userId)
+
+        val result = migrator.ensureMigrated()
+
+        assertTrue(result is Result.Success)
+        verify(syncApi, never()).getDevices(any())
+    }
+
+    @Test
+    fun whenFeatureDisabledThenNoOpAndNotMarked() = runTest {
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = false))
+
+        val result = migrator.ensureMigrated()
+
+        assertTrue(result is Result.Success)
+        verify(syncApi, never()).getDevices(any())
+        verify(syncStore, never()).unifiedDeviceListMigratedForUserId = any()
+    }
+
+    @Test
+    fun whenNotSignedInThenErrorWithoutNetwork() = runTest {
+        whenever(syncStore.userId).thenReturn(null)
+
+        assertTrue(migrator.ensureMigrated() is Result.Error)
+        verify(syncApi, never()).getDevices(any())
+    }
+
+    @Test
+    fun whenServerAlreadyHasDeviceInfoThenMarkDoneWithoutKeyOrPatch() = runTest {
+        whenever(syncApi.getDevices(token)).thenReturn(
+            Result.Success(deviceEntries(deviceInfo = "existing.device.info.jwe")),
+        )
+
+        val result = migrator.ensureMigrated()
+
+        assertTrue(result is Result.Success)
+        verify(syncStore).unifiedDeviceListMigratedForUserId = userId
+        verify(accountInfoKeyManager, never()).ensureKeyRegistered()
+        verify(deviceInfoUpdater, never()).updateThisDevice(any())
+    }
+
+    @Test
+    fun whenKeyEnsuredAndPatchSucceedsThenMarkDone() = runTest {
+        whenever(syncApi.getDevices(token)).thenReturn(Result.Success(deviceEntries(deviceInfo = null)))
+        whenever(accountInfoKeyManager.ensureKeyRegistered()).thenReturn(Result.Success(keyResult))
+        whenever(deviceInfoUpdater.updateThisDevice("deviceName")).thenReturn(Result.Success(emptyList()))
+
+        val result = migrator.ensureMigrated()
+
+        assertTrue(result is Result.Success)
+        verify(deviceInfoUpdater).updateThisDevice("deviceName")
+        verify(syncStore).unifiedDeviceListMigratedForUserId = userId
+    }
+
+    @Test
+    fun whenGetDevicesFailsThenErrorAndNotMarked() = runTest {
+        whenever(syncApi.getDevices(token)).thenReturn(Result.Error(reason = "network"))
+
+        assertTrue(migrator.ensureMigrated() is Result.Error)
+        verify(accountInfoKeyManager, never()).ensureKeyRegistered()
+        verify(syncStore, never()).unifiedDeviceListMigratedForUserId = any()
+    }
+
+    @Test
+    fun whenEnsureKeyFailsThenErrorAndNotMarked() = runTest {
+        whenever(syncApi.getDevices(token)).thenReturn(Result.Success(deviceEntries(deviceInfo = null)))
+        whenever(accountInfoKeyManager.ensureKeyRegistered()).thenReturn(Result.Error(reason = "no secret key"))
+
+        assertTrue(migrator.ensureMigrated() is Result.Error)
+        verify(deviceInfoUpdater, never()).updateThisDevice(any())
+        verify(syncStore, never()).unifiedDeviceListMigratedForUserId = any()
+    }
+
+    @Test
+    fun whenPatchFailsThenErrorAndNotMarked() = runTest {
+        whenever(syncApi.getDevices(token)).thenReturn(Result.Success(deviceEntries(deviceInfo = null)))
+        whenever(accountInfoKeyManager.ensureKeyRegistered()).thenReturn(Result.Success(keyResult))
+        whenever(deviceInfoUpdater.updateThisDevice("deviceName")).thenReturn(Result.Error(reason = "patch failed"))
+
+        assertTrue(migrator.ensureMigrated() is Result.Error)
+        verify(syncStore, never()).unifiedDeviceListMigratedForUserId = any()
+    }
+
+    private fun deviceEntries(deviceInfo: String?) = DeviceEntries(
+        entries = emptyList(),
+        entriesV2 = listOf(DeviceV2(deviceId = "deviceId", deviceName = "enc", deviceType = "enc", deviceInfo = deviceInfo)),
+    )
+}

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -191,6 +191,8 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.deleteCachedAccountInfoKeyButton.setOnClickListener { viewModel.onDeleteCachedAccountInfoKeyClicked() }
         binding.renameDeviceButton.setOnClickListener { viewModel.onRenameDeviceClicked() }
         binding.fetchDecryptDevicesButton.setOnClickListener { viewModel.onFetchAndDecryptDevicesClicked() }
+        binding.runMigrationButton.setOnClickListener { viewModel.onRunMigrationClicked() }
+        binding.resetMigrationMarkerButton.setOnClickListener { viewModel.onResetMigrationMarkerClicked() }
         binding.createThirdPartyCredentialButton.setOnClickListener { viewModel.onCreateThirdPartyCredentialClicked() }
         binding.refreshThirdPartyCredentialButton.setOnClickListener { viewModel.onRefreshThirdPartyCredentialClicked() }
         binding.showThirdPartyRecoveryQrButton.setOnClickListener { viewModel.onShowThirdPartyRecoveryQrClicked() }
@@ -374,6 +376,11 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.cachedAccountInfoKeyTextView.text = viewState.cachedAccountInfoKeyResult
         binding.renameDeviceResultTextView.text = viewState.renameDeviceResult
         binding.fetchDecryptDevicesResultTextView.text = viewState.fetchDecryptDevicesResult
+        binding.canWriteUnifiedDeviceListToggle.quietlySetIsChecked(viewState.canWriteUnifiedDeviceListEnabled) { _, enabled ->
+            viewModel.onCanWriteUnifiedDeviceListFlagChanged(enabled)
+        }
+        binding.migrationStatusTextView.text = viewState.migrationStatusText
+        binding.migrationResultTextView.text = viewState.migrationResult
         if (viewState.isSignedIn) {
             viewState.connectedDevices.forEach { device ->
                 val connectedBinding = ItemConnectedDeviceBinding.inflate(layoutInflater, binding.connectedDevicesList, true)

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.sync.impl.AccountInfoKeyManager
 import com.duckduckgo.sync.impl.ConnectedDevice
 import com.duckduckgo.sync.impl.DeviceFieldDecryptor
 import com.duckduckgo.sync.impl.DeviceInfoDecryptor
+import com.duckduckgo.sync.impl.DeviceInfoMigrator
 import com.duckduckgo.sync.impl.DeviceInfoUpdater
 import com.duckduckgo.sync.impl.DeviceV2
 import com.duckduckgo.sync.impl.Result
@@ -91,6 +92,7 @@ constructor(
     private val deviceInfoUpdater: DeviceInfoUpdater,
     private val deviceInfoDecryptor: DeviceInfoDecryptor,
     private val deviceFieldDecryptor: DeviceFieldDecryptor,
+    private val deviceInfoMigrator: DeviceInfoMigrator,
     private val syncDeviceIds: SyncDeviceIds,
     @field:SuppressLint("StaticFieldLeak") private val context: Context,
 ) : ViewModel() {
@@ -138,6 +140,9 @@ constructor(
         val cachedAccountInfoKeyResult: String = "",
         val renameDeviceResult: String = "",
         val fetchDecryptDevicesResult: String = "",
+        val canWriteUnifiedDeviceListEnabled: Boolean = false,
+        val migrationStatusText: String = "",
+        val migrationResult: String = "",
     )
 
     sealed class BlockStoreValue {
@@ -328,8 +333,18 @@ constructor(
                 cachedAccountInfoKeyResult = if (accountInfo.isSignedIn) viewState.value.cachedAccountInfoKeyResult else "",
                 renameDeviceResult = if (accountInfo.isSignedIn) viewState.value.renameDeviceResult else "",
                 fetchDecryptDevicesResult = if (accountInfo.isSignedIn) viewState.value.fetchDecryptDevicesResult else "",
+                canWriteUnifiedDeviceListEnabled = syncFeature.canWriteUnifiedDeviceList().isEnabled(),
+                migrationStatusText = buildMigrationStatusText(),
+                migrationResult = if (accountInfo.isSignedIn) viewState.value.migrationResult else "",
             ),
         )
+    }
+
+    private fun buildMigrationStatusText(): String {
+        val marker = syncStore.unifiedDeviceListMigratedForUserId
+        val currentUserId = syncStore.userId
+        val doneForThisAccount = marker != null && marker == currentUserId
+        return "migrated: $doneForThisAccount"
     }
 
     fun onReadQRClicked() {
@@ -768,6 +783,40 @@ constructor(
             logcat { "Sync-UnifiedDevices: cleared cached account_info key" }
             viewState.update { it.copy(cachedAccountInfoKeyResult = "Cached account_info key cleared") }
             command.send(ShowMessage("Cached account_info key cleared"))
+        }
+    }
+
+    fun onCanWriteUnifiedDeviceListFlagChanged(enabled: Boolean) {
+        viewModelScope.launch(dispatchers.io()) {
+            logcat { "Sync-UnifiedDevices: setting canWriteUnifiedDeviceList flag = $enabled" }
+            setRawToggleState(syncFeature.canWriteUnifiedDeviceList(), enabled)
+            updateViewState()
+        }
+    }
+
+    fun onRunMigrationClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            if (syncStore.token.isNullOrEmpty()) {
+                command.send(ShowMessage("Not signed in"))
+                return@launch
+            }
+            logcat { "Sync-UnifiedDevices: running migration from dev screen" }
+            val text = when (val result = deviceInfoMigrator.ensureMigrated()) {
+                is Success -> "Migration run: success"
+                is Error -> "Migration run: error — ${result.reason} (code: ${result.code})"
+            }
+            viewState.update { it.copy(migrationResult = text, migrationStatusText = buildMigrationStatusText()) }
+            command.send(ShowMessage(text))
+            getConnectedDevices()
+        }
+    }
+
+    fun onResetMigrationMarkerClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            syncStore.unifiedDeviceListMigratedForUserId = null
+            logcat { "Sync-UnifiedDevices: reset migration marker from dev screen" }
+            viewState.update { it.copy(migrationResult = "Migration marker reset", migrationStatusText = buildMigrationStatusText()) }
+            command.send(ShowMessage("Migration marker reset"))
         }
     }
 

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -251,6 +251,50 @@
         <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:primaryText="Unified Devices Migration" />
+
+        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+            android:id="@+id/canWriteUnifiedDeviceListToggle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:showSwitch="true"
+            app:primaryText="canWriteUnifiedDeviceList" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/migrationStatusTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/keyline_4"
+            android:layout_marginEnd="@dimen/keyline_4"
+            android:layout_marginBottom="@dimen/keyline_4"
+            app:typography="body2" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+            android:id="@+id/runMigrationButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="Run migration now" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+            android:id="@+id/resetMigrationMarkerButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="Reset migration marker" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/migrationResultTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/keyline_4"
+            android:layout_marginEnd="@dimen/keyline_4"
+            android:layout_marginBottom="@dimen/keyline_4"
+            app:typography="body2" />
+
+        <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             app:primaryText="3party Credential Management" />
 
         <com.duckduckgo.common.ui.view.button.DaxButtonPrimary

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncStore.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncStore.kt
@@ -38,6 +38,12 @@ interface SyncStore {
     /** Cached public key for the account's `account_info` protected key, once registered. */
     var accountInfoPublicKey: AccountInfoPublicKey?
 
+    /**
+     * The `userId` this device last completed the unified-device-list migration for, or null if it never has.
+     * Keyed by user so a different account (via switch or re-signin) migrates afresh; [clearAll] wipes it on sign-out.
+     */
+    var unifiedDeviceListMigratedForUserId: String?
+
     fun isEncryptionSupported(): Boolean
     fun isSignedInFlow(): Flow<Boolean>
     fun isSignedIn(): Boolean
@@ -192,6 +198,18 @@ constructor(
             }
         }
 
+    override var unifiedDeviceListMigratedForUserId: String?
+        get() = encryptedPreferences?.getString(KEY_UNIFIED_DEVICE_LIST_MIGRATED_USER_ID, null)
+        set(value) {
+            encryptedPreferences?.edit(commit = true) {
+                if (value == null) {
+                    remove(KEY_UNIFIED_DEVICE_LIST_MIGRATED_USER_ID)
+                } else {
+                    putString(KEY_UNIFIED_DEVICE_LIST_MIGRATED_USER_ID, value)
+                }
+            }
+        }
+
     override fun isEncryptionSupported(): Boolean = encryptedPreferences != null
 
     override fun isSignedInFlow(): Flow<Boolean> = isSignedInStateFlow
@@ -239,5 +257,6 @@ constructor(
         private const val KEY_ACCOUNT_INFO_KID = "KEY_ACCOUNT_INFO_KID"
         private const val KEY_ACCOUNT_INFO_MODULUS = "KEY_ACCOUNT_INFO_MODULUS"
         private const val KEY_ACCOUNT_INFO_EXPONENT = "KEY_ACCOUNT_INFO_EXPONENT"
+        private const val KEY_UNIFIED_DEVICE_LIST_MIGRATED_USER_ID = "KEY_UNIFIED_DEVICE_LIST_MIGRATED_USER_ID"
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1216792641477208?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/task/1215838110052947
API Proposals URL(s) (if applicable):

### Description

Backfills existing signed-in users into the unified device list so they show up without needing a fresh login.

On app start (signed in, behind `canWriteUnifiedDeviceList`) a one-time, per-device migration runs: if this device doesn't already have `device_info` on the server, we make sure the account's `account_info` key exists and write this device's `device_info` via `PATCH /sync/devices`. It's idempotent and single-flight, records completion per-user in `SyncStore`, and just retries on the next app open if a step fails. The `ensureMigrated()` op is shared so login/rename can call it later.

Gated off by default and mirrored with the legacy device name, so no user-facing change yet. Also adds a "Unified Devices Migration" section to the internal Sync dev screen (flag toggle, run now, reset marker, status readout) to make it testable.

### Steps to test this PR

> [!NOTE]
> There is a new **Unified Devices Migration** section in `Sync Dev Settings` screen

> [!NOTE]
> Use logcat filter `Sync-UnifiedDevices:`

_Migration needed_
- [ ] Fresh install `internal` build, and launch `Sync Dev Settings`
- [ ] Turn on `canWriteUnifiedDeviceList`
- [ ] Tap the `Create account` button
- [ ] Tap `Run migration now` 
- [ ] Verify in logs: "migration needed"
- [ ] Verify in logs: "no device_info on server for this device"
- [ ] Verify in logs: "migration complete for this device"
- [ ] Tap `Fetch & decrypt devices`, verify this device shows its name under `device_info`

_Migration not needed; local flag already set_
- [ ] Tap `Run migration now` again
- [ ] Verify in logs: "migration already done for this account"

_Migration not needed; remote server has device_info already_
- [ ] Tap `Reset migration marker`
- [ ] Tap `Run migration now`
- [ ] Verify in logs: "migration needed; checking server for existing device_info"
- [ ] Verify in logs: "server already has device_info for this device; marking migration done"

_Runs automatically on foreground_
- [ ] Background the app (home button), then reopen it
- [ ] Verify in logs: "Checking if unified device list migration is needed"

_Flag off does nothing_
- [ ] Turn `canWriteUnifiedDeviceList` off
- [ ] Background the app (home button), then reopen it
- [ ] Verify in logs: "migration skipped — canWriteUnifiedDeviceList disabled"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync credentials, encrypted store, and server PATCH paths for device metadata, but behavior is feature-flagged off by default and retries only on transient failures without marking success prematurely.
> 
> **Overview**
> Adds a **one-time backfill** so existing signed-in users get into the unified device list without re-login. When `canWriteUnifiedDeviceList` is on, `DeviceInfoMigrator.ensureMigrated()` runs on app foreground (via `DeviceInfoMigrationObserver`) and is mutex-guarded and idempotent.
> 
> The migrator skips if already marked per `userId`, or if the server already has `device_info` for this device; otherwise it ensures the `account_info` key and PATCHes this device's `device_info`. Completion is stored in **`SyncStore.unifiedDeviceListMigratedForUserId`** (cleared on `clearAll`). Failures leave the marker unset for retry on the next foreground.
> 
> Internal Sync dev settings gain a **Unified Devices Migration** section: flag toggle, run/reset controls, and status readout. Unit tests cover migrator preconditions and failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1510e4c49aa00ae573a45798adc3a17fd3e6c90. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->