### PR TITLE
[Config-driven linear onboarding dialogs] Extract intro animators

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
@@ -128,8 +128,6 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
     /** Last step id a [DialogConfig] was published for; drives the [ViewState.animateEntry] policy. */
     private var lastPresentedStepId: LinearOnboardingStepId? = null
 
-    private var introStarted = false
-
     private var notificationPermissionFlowStarted = false
 
     private var addWidgetPromptFlowStarted = false
@@ -156,7 +154,6 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
     }
 
     fun onIntroAnimationStarted() {
-        introStarted = true
         _viewState.update { state ->
             val screen = state.screen
             if (screen is Screen.Intro.Play) {
@@ -274,7 +271,7 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
         if (dialog is NewUserOnboardingActivityDialog.IntroAnimation) {
             _viewState.update {
                 it.copy(
-                    screen = if (introStarted) {
+                    screen = if (it.screen is Screen.Intro.Restore) {
                         Screen.Intro.Restore(withDuckAi = dialog.withDuckAi)
                     } else {
                         Screen.Intro.Play(withDuckAi = dialog.withDuckAi)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
@@ -75,10 +75,35 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
 ) : ViewModel() {
 
     data class ViewState(
-        val stepId: LinearOnboardingStepId? = null,
-        val config: DialogConfig? = null,
-        val animateEntry: Boolean = true,
+        val screen: Screen? = null,
     )
+
+    sealed interface Screen {
+
+        sealed interface Intro : Screen {
+            val withDuckAi: Boolean
+
+            data class Play(override val withDuckAi: Boolean) : Intro
+
+            /**
+             * A view already started the intro.
+             * Ignore this state if the view played the intro, snap to end state if the view hasn't (for example, when recreated).
+             */
+            data class Restore(override val withDuckAi: Boolean) : Intro
+        }
+
+        data class Dialog(
+            val stepId: LinearOnboardingStepId,
+            val config: DialogConfig,
+            val animateEntry: Boolean,
+        ) : Screen
+
+        /**
+         * The flow is on a step this view draws nothing for and there is no earlier screen to keep showing, which
+         * only happens on a fresh view model, for example after a mid-flow re-entry.
+         */
+        data object None : Screen
+    }
 
     sealed interface Command {
         data object RequestNotificationPermissions : Command
@@ -103,6 +128,8 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
     /** Last step id a [DialogConfig] was published for; drives the [ViewState.animateEntry] policy. */
     private var lastPresentedStepId: LinearOnboardingStepId? = null
 
+    private var introStarted = false
+
     private var notificationPermissionFlowStarted = false
 
     private var addWidgetPromptFlowStarted = false
@@ -116,12 +143,31 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
     fun onContentInteraction(interaction: ContentInteraction) = Unit // No-op until dialogs with local state are implemented in follow-ups.
 
     fun onDialogRendered(stepId: LinearOnboardingStepId) {
-        _viewState.update {
+        _viewState.update { state ->
+            val screen = state.screen
             // The dialog for this step has been rendered.
             // Disable entry animation for potential re-draws (like config change/rotation).
-            if (it.stepId == stepId) it.copy(animateEntry = false) else it
+            if (screen is Screen.Dialog && screen.stepId == stepId) {
+                state.copy(screen = screen.copy(animateEntry = false))
+            } else {
+                state
+            }
         }
     }
+
+    fun onIntroAnimationStarted() {
+        introStarted = true
+        _viewState.update { state ->
+            val screen = state.screen
+            if (screen is Screen.Intro.Play) {
+                state.copy(screen = Screen.Intro.Restore(withDuckAi = screen.withDuckAi))
+            } else {
+                state
+            }
+        }
+    }
+
+    fun onIntroAnimationFinished() = emit(NewUserOnboardingEvent.IntroAnimationFinished)
 
     fun onResume() {
         checkAddWidgetPromptResult()
@@ -224,18 +270,37 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
         state: LinearOnboardingState.InProgress,
     ) {
         val dialog = step.resolveDialog()
+
+        if (dialog is NewUserOnboardingActivityDialog.IntroAnimation) {
+            _viewState.update {
+                it.copy(
+                    screen = if (introStarted) {
+                        Screen.Intro.Restore(withDuckAi = dialog.withDuckAi)
+                    } else {
+                        Screen.Intro.Play(withDuckAi = dialog.withDuckAi)
+                    },
+                )
+            }
+            return
+        }
+
         val config = dialogConfigResolver.resolve(dialog, customAiOnboardingStore.isEnabled())
         if (config != null) {
             _viewState.update {
                 it.copy(
-                    stepId = step.id,
-                    config = config.copy(stepIndicator = state.stepIndicatorProgress()),
-                    animateEntry = step.id != lastPresentedStepId,
+                    screen = Screen.Dialog(
+                        stepId = step.id,
+                        config = config.copy(stepIndicator = state.stepIndicatorProgress()),
+                        animateEntry = step.id != lastPresentedStepId,
+                    ),
                 )
             }
             lastPresentedStepId = step.id
             emit(NewUserOnboardingEvent.Presented)
         } else {
+            // If there's no new dialog to draw (e.g. we're displaying a system prompt), keep the current one.
+            // None only when there was never anything to keep.
+            _viewState.update { state -> if (state.screen == null) state.copy(screen = Screen.None) else state }
             advancePastUnrenderedDialog(dialog)
         }
     }
@@ -248,8 +313,6 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
      */
     private suspend fun advancePastUnrenderedDialog(dialog: NewUserOnboardingActivityDialog) {
         when (dialog) {
-            is NewUserOnboardingActivityDialog.IntroAnimation -> emit(NewUserOnboardingEvent.IntroAnimationFinished)
-
             NewUserOnboardingActivityDialog.NotificationPermission -> {
                 if (!notificationPermissionFlowStarted) {
                     notificationPermissionFlowStarted = true
@@ -292,6 +355,7 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
                 NewUserOnboardingEvent.QuickSetupConfirmed(type = OmnibarType.SINGLE_TOP, withAi = true),
             )
 
+            is NewUserOnboardingActivityDialog.IntroAnimation,
             NewUserOnboardingActivityDialog.ComparisonChart,
             NewUserOnboardingActivityDialog.AiComparisonChart,
             is NewUserOnboardingActivityDialog.AddressBarPosition,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
@@ -94,8 +94,6 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
     private var cardBottomInsetPx = 0
 
     private val requestNotificationPermission = registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-        // A result pending across a recreation is dispatched before the new view is attached to the window, so gating
-        // this on the view would swallow it and leave the flow parked on this step for good.
         viewModel.notificationPermissionFlowFinished(granted)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
@@ -30,7 +30,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.ViewGroupCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.doOnLayout
-import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
@@ -89,9 +88,12 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
     }
 
     private var engine: DialogRenderEngine? = null
+    private var intro: OnboardingIntroChoreographer? = null
 
     /** Fed to the embellishment controller's fit corrector; kept in sync by the window-insets listener below. */
     private var cardBottomInsetPx = 0
+
+    private var hasRenderedOnce = false
 
     private val requestNotificationPermission = registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
         if (view?.windowVisibility == View.VISIBLE) {
@@ -143,6 +145,8 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
 
         val cardAnchor = CardAnchorControllerImpl(binding, CardAnchorResolver(deviceInfo.isTablet()))
 
+        intro = OnboardingIntroChoreographer(binding)
+
         engine = DialogRenderEngine(
             content = ContentControllerImpl(
                 binding = binding.daxDialogCta,
@@ -178,7 +182,14 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
 
         viewModel.viewState
             .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
-            .onEach { state -> if (state.config != null) renderConfig(state) }
+            .onEach { state ->
+                when (val screen = state.screen) {
+                    is ConfigDrivenOnboardingPageViewModel.Screen.Intro -> showIntro(screen)
+                    is ConfigDrivenOnboardingPageViewModel.Screen.Dialog -> renderDialog(screen)
+                    ConfigDrivenOnboardingPageViewModel.Screen.None -> intro?.dismissUnplayed()
+                    null -> Unit
+                }
+            }
             .launchIn(viewLifecycleOwner.lifecycleScope)
 
         viewModel.commands
@@ -187,18 +198,20 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
             .launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
-    /**
-     * Temporary until the intro animators are implemented in the follow-up.
-     */
-    private fun settleIntroViews() {
-        binding.logoAnimation.isVisible = false
-        binding.welcomeTitle.alpha = 0f
-        binding.duckAiIntroAnimation.isVisible = false
+    private fun showIntro(screen: ConfigDrivenOnboardingPageViewModel.Screen.Intro) {
+        when (screen) {
+            is ConfigDrivenOnboardingPageViewModel.Screen.Intro.Play -> {
+                viewModel.onIntroAnimationStarted()
+                intro?.play(withDuckAi = screen.withDuckAi) { viewModel.onIntroAnimationFinished() }
+            }
+            is ConfigDrivenOnboardingPageViewModel.Screen.Intro.Restore -> {
+                if (intro?.restore(withDuckAi = screen.withDuckAi) == true) viewModel.onIntroAnimationFinished()
+            }
+        }
     }
 
-    private fun renderConfig(state: ConfigDrivenOnboardingPageViewModel.ViewState) {
+    private fun renderDialog(screen: ConfigDrivenOnboardingPageViewModel.Screen.Dialog) {
         val engine = engine ?: return
-        settleIntroViews()
 
         // A retained view model emits before a recreated view has been laid out, and the decoration fit
         // check measures the root's height, so measuring at 0 would hide the decoration for good.
@@ -206,22 +219,31 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
             binding.root.doOnLayout {
                 // isLaidOut is only set after the layout listeners have run, it still reads false from in here,
                 // so we need to dispatch to a separate function
-                render(engine, viewModel.viewState.value)
+                (viewModel.viewState.value.screen as? ConfigDrivenOnboardingPageViewModel.Screen.Dialog)?.let { render(engine, it) }
             }
             return
         }
 
-        render(engine, state)
+        render(engine, screen)
     }
 
     private fun render(
         engine: DialogRenderEngine,
-        state: ConfigDrivenOnboardingPageViewModel.ViewState,
+        screen: ConfigDrivenOnboardingPageViewModel.Screen.Dialog,
     ) {
-        val stepId = state.stepId ?: return
-        val config = state.config ?: return
-        engine.render(stepId, config, state.animateEntry)
-        viewModel.onDialogRendered(stepId)
+        // We assume that if intro is played, it's always done so before any dialog is rendered.
+        // Once the first dialog arrives, if:
+        // - intro visuals on screen: clear them and the background cross-fades from them
+        // - no intro visual on screen (like a mid-flow re-entry from another activity): nothing to animate from, snap new background
+        // Later renders always animate the background.
+        val animateBackground = if (hasRenderedOnce) {
+            screen.animateEntry
+        } else {
+            hasRenderedOnce = true
+            (intro?.clearForFirstDialog() ?: false) && screen.animateEntry
+        }
+        engine.render(screen.stepId, screen.config, animate = screen.animateEntry, animateBackground = animateBackground)
+        viewModel.onDialogRendered(screen.stepId)
     }
 
     private fun handleCommand(command: ConfigDrivenOnboardingPageViewModel.Command) {
@@ -261,6 +283,9 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
         super.onDestroyView()
         engine?.release()
         engine = null
+        intro?.release()
+        intro = null
+        hasRenderedOnce = false
     }
 
     private companion object {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
@@ -93,12 +93,10 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
     /** Fed to the embellishment controller's fit corrector; kept in sync by the window-insets listener below. */
     private var cardBottomInsetPx = 0
 
-    private var hasRenderedOnce = false
-
     private val requestNotificationPermission = registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-        if (view?.windowVisibility == View.VISIBLE) {
-            viewModel.notificationPermissionFlowFinished(granted)
-        }
+        // A result pending across a recreation is dispatched before the new view is attached to the window, so gating
+        // this on the view would swallow it and leave the flow parked on this step for good.
+        viewModel.notificationPermissionFlowFinished(granted)
     }
 
     private val defaultBrowserRoleManagerDialog = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -235,14 +233,15 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
         // Once the first dialog arrives, if:
         // - intro visuals on screen: clear them and the background cross-fades from them
         // - no intro visual on screen (like a mid-flow re-entry from another activity): nothing to animate from, snap new background
-        // Later renders always animate the background.
-        val animateBackground = if (hasRenderedOnce) {
-            screen.animateEntry
-        } else {
-            hasRenderedOnce = true
-            (intro?.clearForFirstDialog() ?: false) && screen.animateEntry
-        }
-        engine.render(screen.stepId, screen.config, animate = screen.animateEntry, animateBackground = animateBackground)
+        // Later renders always animate the background. The handover is unconditional so that a render which does not
+        // animate still takes the background off the choreographer.
+        val canCrossFadeBackground = intro?.clearForDialog() == true
+        engine.render(
+            screen.stepId,
+            screen.config,
+            animate = screen.animateEntry,
+            animateBackground = canCrossFadeBackground && screen.animateEntry,
+        )
         viewModel.onDialogRendered(screen.stepId)
     }
 
@@ -285,7 +284,6 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
         engine = null
         intro?.release()
         intro = null
-        hasRenderedOnce = false
     }
 
     private companion object {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroChoreographer.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroChoreographer.kt
@@ -1,0 +1,423 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.page.configdriven
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.AnimatorSet
+import android.animation.ObjectAnimator
+import android.content.Context
+import android.graphics.Typeface
+import android.util.TypedValue
+import android.view.View
+import android.view.animation.PathInterpolator
+import androidx.core.content.ContextCompat
+import androidx.core.content.res.ResourcesCompat
+import androidx.core.view.doOnLayout
+import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import com.airbnb.lottie.FontAssetDelegate
+import com.airbnb.lottie.LottieProperty
+import com.airbnb.lottie.model.KeyPath
+import com.duckduckgo.app.browser.databinding.ContentOnboardingWelcomePageUpdateBinding
+import com.duckduckgo.fonts.R as FontsR
+import com.duckduckgo.mobile.android.R as CommonR
+
+/**
+ * One-time welcome intro/outro choreography for [ConfigDrivenWelcomePageFragment].
+ */
+class OnboardingIntroChoreographer(
+    private val binding: ContentOnboardingWelcomePageUpdateBinding,
+) {
+
+    private var introAnimatorSet: AnimatorSet? = null
+    private var outroAnimatorSet: AnimatorSet? = null
+    private var backgroundIntroAnimatorSet: AnimatorSet? = null
+
+    private var visualsOnScreen = false
+
+    private var cleared = false
+
+    private var released = false
+
+    init {
+        binding.logoAnimation.apply {
+            enableMergePathsForKitKatAndAbove(true)
+            setMaxFrame(60) // If we go past frame 60 the logo disappears
+            repeatCount = 0
+        }
+        binding.backgroundPrimary.enableMergePathsForKitKatAndAbove(true)
+    }
+
+    private fun buildIntroAnimatorSet(): AnimatorSet {
+        val layout = binding.welcomeTitle.layout
+        val maxLineWidth = (0 until layout.lineCount).maxOf { layout.getLineWidth(it) }
+        val textIntroScale = (binding.welcomeTitle.width.toFloat() / maxLineWidth).coerceAtMost(MAX_TEXT_INTRO_SCALE)
+
+        with(binding.logoAnimation) {
+            scaleX = LOGO_INTRO_SCALE
+            scaleY = LOGO_INTRO_SCALE
+        }
+
+        with(binding.welcomeTitle) {
+            scaleX = textIntroScale
+            scaleY = textIntroScale
+        }
+
+        val textFadeInterpolator = PathInterpolator(0.33f, 0.00f, 0.67f, 1.00f)
+        val textSlideInterpolator = PathInterpolator(0.40f, 0.00f, 0.74f, 1.00f)
+        val scaleInterpolator = PathInterpolator(0.33f, 0.00f, 0.67f, 1.00f)
+
+        val alphaAnimator = ObjectAnimator.ofFloat(binding.welcomeTitle, View.ALPHA, 0f, 1f).apply {
+            startDelay = TEXT_INTRO_DELAY
+            duration = TEXT_INTRO_OPACITY_DURATION
+            interpolator = textFadeInterpolator
+        }
+
+        val guidelineAnimator = ObjectAnimator.ofFloat(
+            binding.textGuideline,
+            "guidelinePercent",
+            GUIDELINE_START_PERCENT,
+            GUIDELINE_END_PERCENT,
+        ).apply {
+            startDelay = TEXT_INTRO_DELAY
+            duration = TEXT_INTRO_TRANSLATE_DURATION
+            interpolator = textSlideInterpolator
+        }
+
+        val logoScaleX = ObjectAnimator.ofFloat(binding.logoAnimation, View.SCALE_X, LOGO_INTRO_SCALE, 1f).apply {
+            startDelay = TEXT_INTRO_DELAY
+            duration = LOGO_SCALE_DURATION
+            interpolator = scaleInterpolator
+        }
+
+        val logoScaleY = ObjectAnimator.ofFloat(binding.logoAnimation, View.SCALE_Y, LOGO_INTRO_SCALE, 1f).apply {
+            startDelay = TEXT_INTRO_DELAY
+            duration = LOGO_SCALE_DURATION
+            interpolator = scaleInterpolator
+        }
+
+        val textScaleX = ObjectAnimator.ofFloat(binding.welcomeTitle, View.SCALE_X, textIntroScale, 1f).apply {
+            startDelay = TEXT_INTRO_DELAY
+            duration = TEXT_INTRO_TRANSLATE_DURATION
+            interpolator = textSlideInterpolator
+        }
+
+        val textScaleY = ObjectAnimator.ofFloat(binding.welcomeTitle, View.SCALE_Y, textIntroScale, 1f).apply {
+            startDelay = TEXT_INTRO_DELAY
+            duration = TEXT_INTRO_TRANSLATE_DURATION
+            interpolator = textSlideInterpolator
+        }
+
+        return AnimatorSet().apply {
+            playTogether(alphaAnimator, guidelineAnimator, logoScaleX, logoScaleY, textScaleX, textScaleY)
+        }
+    }
+
+    private fun buildBackgroundIntroAnimatorSet(): AnimatorSet {
+        val slideDistance = binding.root.resources.displayMetrics.heightPixels * BACKGROUND_SLIDE_UP_SCREEN_PERCENT
+        val easing = PathInterpolator(0.33f, 0.00f, 0.67f, 1.00f)
+
+        with(binding.backgroundPrimary) {
+            translationY = slideDistance
+            scaleX = BACKGROUND_INTRO_SCALE
+            scaleY = BACKGROUND_INTRO_SCALE
+        }
+
+        val slideUp = ObjectAnimator.ofFloat(binding.backgroundPrimary, View.TRANSLATION_Y, slideDistance, 0f).apply {
+            duration = BACKGROUND_SLIDE_UP_DURATION
+            interpolator = easing
+        }
+        val scaleX = ObjectAnimator.ofFloat(binding.backgroundPrimary, View.SCALE_X, BACKGROUND_INTRO_SCALE, 1f).apply {
+            duration = BACKGROUND_SLIDE_UP_DURATION
+            interpolator = easing
+        }
+        val scaleY = ObjectAnimator.ofFloat(binding.backgroundPrimary, View.SCALE_Y, BACKGROUND_INTRO_SCALE, 1f).apply {
+            duration = BACKGROUND_SLIDE_UP_DURATION
+            interpolator = easing
+        }
+
+        return AnimatorSet().apply {
+            playTogether(slideUp, scaleX, scaleY)
+        }
+    }
+
+    private fun buildOutroAnimatorSet(): AnimatorSet {
+        val fadeEasing = PathInterpolator(0.33f, 0.00f, 0.67f, 1.00f)
+
+        val logoFade = ObjectAnimator.ofFloat(binding.logoAnimation, View.ALPHA, 1f, 0f).apply {
+            duration = OUTRO_FADE_DURATION
+            interpolator = fadeEasing
+        }
+
+        val textFade = ObjectAnimator.ofFloat(binding.welcomeTitle, View.ALPHA, 1f, 0f).apply {
+            duration = OUTRO_FADE_DURATION
+            interpolator = fadeEasing
+        }
+
+        val animators = mutableListOf<Animator>(logoFade, textFade)
+        // duckAiIntroAnimation starts invisible and is only ever shown on a withDuckAi run, whether it played
+        // or was snapped, so its current visibility is exactly the signal for whether to fade it out too.
+        if (binding.duckAiIntroAnimation.isVisible) {
+            val duckAiIntroFade = ObjectAnimator.ofFloat(binding.duckAiIntroAnimation, View.ALPHA, 1f, 0f).apply {
+                duration = OUTRO_FADE_DURATION
+                interpolator = fadeEasing
+            }
+            animators += duckAiIntroFade
+        }
+
+        return AnimatorSet().apply {
+            playTogether(animators)
+        }
+    }
+
+    fun play(withDuckAi: Boolean, onFinished: () -> Unit) {
+        visualsOnScreen = true
+        // The animators measure the title's laid-out width and the screen height.
+        binding.root.doOnLayout {
+            if (!released) startIntroAnimation(withDuckAi, onFinished)
+        }
+    }
+
+    /**
+     * Snaps the intro visuals to their end state.
+     *
+     * @return true when this call put visuals on screen, false when they are there already.
+     */
+    fun restore(withDuckAi: Boolean): Boolean {
+        if (visualsOnScreen) return false
+        visualsOnScreen = true
+        snapIntroViews()
+        if (withDuckAi) {
+            prepareDuckAiIntroAnimation()
+            with(binding.duckAiIntroAnimation) {
+                isVisible = true
+                alpha = 1f
+                progress = 1f
+            }
+        }
+        return true
+    }
+
+    /**
+     * Clears the intro for the arriving first dialog: fades the visuals out when they are on screen, snaps them away
+     * when this view never showed them.
+     *
+     * @return true if there were intro visuals on screen to fade
+     */
+    fun clearForFirstDialog(): Boolean {
+        if (cleared) return visualsOnScreen
+        cleared = true
+        if (visualsOnScreen) {
+            settleRunningIntro()
+            playOutro()
+        } else {
+            snapToOutroEndState()
+        }
+        return visualsOnScreen
+    }
+
+    private fun settleRunningIntro() {
+        introAnimatorSet?.removeAllListeners()
+        binding.logoAnimation.apply {
+            removeAllAnimatorListeners()
+            removeAllUpdateListeners()
+            cancelAnimation()
+        }
+        binding.duckAiIntroAnimation.apply {
+            removeAllAnimatorListeners()
+            cancelAnimation()
+        }
+        snapIntroViews()
+    }
+
+    /**
+     * Clears the intro views if they were never shown.
+     * Does nothing if the intro was already on screen or has been cleared.
+     */
+    fun dismissUnplayed() {
+        if (visualsOnScreen || cleared) return
+        cleared = true
+        snapToOutroEndState()
+    }
+
+    private fun startIntroAnimation(withDuckAi: Boolean, onFinished: () -> Unit) {
+        binding.backgroundPrimary.setMinFrame(BACKGROUND_MIN_FRAME)
+        backgroundIntroAnimatorSet = buildBackgroundIntroAnimatorSet()
+
+        binding.logoAnimation.apply {
+            var bgStarted = false
+            addAnimatorUpdateListener {
+                // Start background animation once when logo reaches the "drop" frame
+                if (!bgStarted && frame >= BACKGROUND_TRIGGER_LOGO_FRAME) {
+                    bgStarted = true
+                    binding.backgroundPrimary.playAnimation()
+                    backgroundIntroAnimatorSet?.start()
+                }
+            }
+            addAnimatorListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationEnd(animation: Animator) {
+                    if (!withDuckAi) onFinished()
+                }
+            })
+            playAnimation()
+        }
+        introAnimatorSet = buildIntroAnimatorSet().apply {
+            // Every interruption ([settleRunningIntro], [release]) detaches this listener before cancelling,
+            // so it only ever observes a natural end.
+            addListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationEnd(animation: Animator) {
+                    if (!withDuckAi) return
+                    prepareDuckAiIntroAnimation()
+                    binding.duckAiIntroAnimation.isVisible = true
+                    binding.duckAiIntroAnimation.addAnimatorListener(object : AnimatorListenerAdapter() {
+                        override fun onAnimationEnd(animation: Animator) = onFinished()
+                    })
+                    binding.duckAiIntroAnimation.playAnimation()
+                }
+            })
+            start()
+        }
+    }
+
+    private fun prepareDuckAiIntroAnimation() {
+        binding.duckAiIntroAnimation.apply {
+            // compute the view height so that it scales correctly with font size
+            val targetTextPx = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_SP,
+                DUCK_AI_INTRO_TEXT_SP,
+                resources.displayMetrics,
+            )
+            val viewHeightPx = (targetTextPx * DUCK_AI_INTRO_CANVAS_H / DUCK_AI_INTRO_TEXT_CANVAS_UNITS).toInt()
+            updateLayoutParams {
+                height = viewHeightPx
+            }
+
+            setFontAssetDelegate(object : FontAssetDelegate() {
+                override fun fetchFont(fontFamily: String): Typeface {
+                    return ResourcesCompat.getFont(context, FontsR.font.ducksansdisplay_regular)
+                        ?: Typeface.DEFAULT
+                }
+            })
+
+            val textColor = resolveOnboardingTextPrimary(context)
+            addValueCallback(KeyPath("**", "Duck.ai"), LottieProperty.COLOR) { textColor }
+            addValueCallback(KeyPath("**", "+"), LottieProperty.COLOR) { textColor }
+        }
+    }
+
+    private fun resolveOnboardingTextPrimary(context: Context): Int {
+        val typedValue = TypedValue()
+        context.theme.resolveAttribute(CommonR.attr.onboardingTextPrimary, typedValue, true)
+        return if (typedValue.resourceId != 0) {
+            ContextCompat.getColor(context, typedValue.resourceId)
+        } else {
+            typedValue.data
+        }
+    }
+
+    private fun snapIntroViews() {
+        introAnimatorSet?.cancel()
+        backgroundIntroAnimatorSet?.cancel()
+
+        with(binding.welcomeTitle) {
+            alpha = 1f
+            scaleX = 1f
+            scaleY = 1f
+        }
+        binding.textGuideline.setGuidelinePercent(GUIDELINE_END_PERCENT)
+
+        with(binding.logoAnimation) {
+            alpha = 1f
+            scaleX = 1f
+            scaleY = 1f
+            setMinFrame(BACKGROUND_MIN_FRAME)
+            progress = 1f
+        }
+
+        with(binding.backgroundPrimary) {
+            alpha = 1f
+            translationY = 0f
+            scaleX = 1f
+            scaleY = 1f
+            setMinFrame(BACKGROUND_MIN_FRAME)
+            progress = 1f
+        }
+
+        if (binding.duckAiIntroAnimation.isVisible) {
+            binding.duckAiIntroAnimation.progress = 1f
+        }
+    }
+
+    private fun snapToOutroEndState() {
+        snapIntroViews()
+        binding.welcomeTitle.alpha = 0f
+        binding.logoAnimation.alpha = 0f
+        binding.duckAiIntroAnimation.alpha = 0f
+    }
+
+    private fun playOutro() {
+        outroAnimatorSet = buildOutroAnimatorSet().apply { start() }
+    }
+
+    fun release() {
+        released = true
+        introAnimatorSet?.removeAllListeners()
+        introAnimatorSet?.cancel()
+        introAnimatorSet = null
+        outroAnimatorSet?.cancel()
+        outroAnimatorSet = null
+        backgroundIntroAnimatorSet?.cancel()
+        backgroundIntroAnimatorSet = null
+
+        binding.logoAnimation.apply {
+            removeAllAnimatorListeners()
+            removeAllUpdateListeners()
+            cancelAnimation()
+        }
+        binding.backgroundPrimary.cancelAnimation()
+        binding.duckAiIntroAnimation.apply {
+            removeAllAnimatorListeners()
+            cancelAnimation()
+        }
+    }
+
+    private companion object {
+        const val GUIDELINE_START_PERCENT = 0.5f
+        const val GUIDELINE_END_PERCENT = 0.39125f
+
+        const val DUCK_AI_INTRO_TEXT_SP = 24f
+        const val DUCK_AI_INTRO_CANVAS_H = 260f
+        const val DUCK_AI_INTRO_TEXT_CANVAS_UNITS = 69f
+
+        const val TEXT_INTRO_DELAY = 400L
+        const val TEXT_INTRO_OPACITY_DURATION = 400L
+        const val TEXT_INTRO_TRANSLATE_DURATION = 600L
+        const val MAX_TEXT_INTRO_SCALE = 1.3f
+
+        const val LOGO_INTRO_SCALE = 2.5f
+        const val LOGO_SCALE_DURATION = 600L
+
+        const val BACKGROUND_MIN_FRAME = 27
+        const val BACKGROUND_TRIGGER_LOGO_FRAME = 6
+        const val BACKGROUND_SLIDE_UP_DURATION = 500L
+        const val BACKGROUND_SLIDE_UP_SCREEN_PERCENT = 0.15f
+        const val BACKGROUND_INTRO_SCALE = 2.5f
+
+        const val OUTRO_FADE_DURATION = 300L
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroChoreographer.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroChoreographer.kt
@@ -238,12 +238,8 @@ class OnboardingIntroChoreographer(
         binding.logoAnimation.apply {
             removeAllAnimatorListeners()
             removeAllUpdateListeners()
-            cancelAnimation()
         }
-        binding.duckAiIntroAnimation.apply {
-            removeAllAnimatorListeners()
-            cancelAnimation()
-        }
+        binding.duckAiIntroAnimation.removeAllAnimatorListeners()
         snapIntroViews()
     }
 
@@ -333,6 +329,12 @@ class OnboardingIntroChoreographer(
     private fun snapIntroViews() {
         introAnimatorSet?.cancel()
         backgroundIntroAnimatorSet?.cancel()
+
+        // A Lottie view replays itself on restore, possibly after this snap. Only cancelling drops that pending play,
+        // and it has to come first because it also clears frame calls waiting on a composition.
+        binding.logoAnimation.cancelAnimation()
+        binding.backgroundPrimary.cancelAnimation()
+        binding.duckAiIntroAnimation.cancelAnimation()
 
         with(binding.welcomeTitle) {
             alpha = 1f

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroChoreographer.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroChoreographer.kt
@@ -39,6 +39,9 @@ import com.duckduckgo.mobile.android.R as CommonR
 
 /**
  * One-time welcome intro/outro choreography for [ConfigDrivenWelcomePageFragment].
+ *
+ * Drives `backgroundPrimary` until [clearForDialog] hands that view to the render engine's `BackgroundController`,
+ * which owns it from then on, so the two never animate it at the same time.
  */
 class OnboardingIntroChoreographer(
     private val binding: ContentOnboardingWelcomePageUpdateBinding,
@@ -48,11 +51,7 @@ class OnboardingIntroChoreographer(
     private var outroAnimatorSet: AnimatorSet? = null
     private var backgroundIntroAnimatorSet: AnimatorSet? = null
 
-    private var visualsOnScreen = false
-
-    private var cleared = false
-
-    private var released = false
+    private val state = OnboardingIntroState()
 
     init {
         binding.logoAnimation.apply {
@@ -186,10 +185,10 @@ class OnboardingIntroChoreographer(
     }
 
     fun play(withDuckAi: Boolean, onFinished: () -> Unit) {
-        visualsOnScreen = true
+        state.play()
         // The animators measure the title's laid-out width and the screen height.
         binding.root.doOnLayout {
-            if (!released) startIntroAnimation(withDuckAi, onFinished)
+            if (state.canStart()) startIntroAnimation(withDuckAi, onFinished)
         }
     }
 
@@ -199,8 +198,7 @@ class OnboardingIntroChoreographer(
      * @return true when this call put visuals on screen, false when they are there already.
      */
     fun restore(withDuckAi: Boolean): Boolean {
-        if (visualsOnScreen) return false
-        visualsOnScreen = true
+        if (!state.restore()) return false
         snapIntroViews()
         if (withDuckAi) {
             prepareDuckAiIntroAnimation()
@@ -214,21 +212,25 @@ class OnboardingIntroChoreographer(
     }
 
     /**
-     * Clears the intro for the arriving first dialog: fades the visuals out when they are on screen, snaps them away
-     * when this view never showed them.
+     * Hands `backgroundPrimary` to an arriving dialog: fades the intro visuals out when they are on screen, snaps them
+     * away when this view never showed them, and does nothing once an earlier dialog has taken over. Safe to call for
+     * every dialog.
      *
-     * @return true if there were intro visuals on screen to fade
+     * @return true when the dialog's background can cross-fade from what is on screen
      */
-    fun clearForFirstDialog(): Boolean {
-        if (cleared) return visualsOnScreen
-        cleared = true
-        if (visualsOnScreen) {
-            settleRunningIntro()
-            playOutro()
-        } else {
-            snapToOutroEndState()
+    fun clearForDialog(): Boolean {
+        val handover = state.handOverToDialog()
+        when (handover) {
+            OnboardingIntroState.Handover.FadeOut -> {
+                settleRunningIntro()
+                playOutro()
+            }
+            OnboardingIntroState.Handover.SnapAway -> snapToOutroEndState()
+            OnboardingIntroState.Handover.AlreadyDismissed,
+            OnboardingIntroState.Handover.AlreadyHandedOver,
+            -> Unit
         }
-        return visualsOnScreen
+        return handover.canCrossFadeBackground
     }
 
     private fun settleRunningIntro() {
@@ -250,9 +252,7 @@ class OnboardingIntroChoreographer(
      * Does nothing if the intro was already on screen or has been cleared.
      */
     fun dismissUnplayed() {
-        if (visualsOnScreen || cleared) return
-        cleared = true
-        snapToOutroEndState()
+        if (state.dismissUnplayed()) snapToOutroEndState()
     }
 
     private fun startIntroAnimation(withDuckAi: Boolean, onFinished: () -> Unit) {
@@ -375,7 +375,7 @@ class OnboardingIntroChoreographer(
     }
 
     fun release() {
-        released = true
+        state.release()
         introAnimatorSet?.removeAllListeners()
         introAnimatorSet?.cancel()
         introAnimatorSet = null

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroState.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroState.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.page.configdriven
+
+/**
+ * Ordering rules behind [OnboardingIntroChoreographer]: what a call is allowed to do to the intro views given what
+ * happened to them already.
+ *
+ * Split out of the choreographer so the orderings a rotation lands on can be exercised without a view binding.
+ */
+class OnboardingIntroState {
+
+    private var visualsOnScreen = false
+
+    /** The intro is out of play: faded out for a dialog, or snapped away without ever being shown. */
+    private var cleared = false
+
+    /** A dialog has taken the background over from the intro. */
+    private var handedOver = false
+
+    private var released = false
+
+    /** Records that this view is playing the intro. */
+    fun play() {
+        visualsOnScreen = true
+    }
+
+    /** @return true when an intro start deferred until layout should still run, false when something overtook it */
+    fun canStart(): Boolean = !released && !cleared
+
+    /** @return true when the caller should snap the intro views to their end state, false when they are there already */
+    fun restore(): Boolean {
+        if (visualsOnScreen) return false
+        visualsOnScreen = true
+        return true
+    }
+
+    /** @return what an arriving dialog leaves the caller to do with the intro views */
+    fun handOverToDialog(): Handover {
+        if (handedOver) return Handover.AlreadyHandedOver
+        handedOver = true
+        if (cleared) return Handover.AlreadyDismissed
+        cleared = true
+        return if (visualsOnScreen) Handover.FadeOut else Handover.SnapAway
+    }
+
+    /** @return true when the caller should snap the intro away, false when it was shown or is already out of play */
+    fun dismissUnplayed(): Boolean {
+        if (visualsOnScreen || cleared) return false
+        cleared = true
+        return true
+    }
+
+    fun release() {
+        released = true
+    }
+
+    /**
+     * @param canCrossFadeBackground true when the arriving dialog's background can cross-fade from what is on screen
+     */
+    enum class Handover(val canCrossFadeBackground: Boolean) {
+        /** The intro visuals are on screen, fade them out. */
+        FadeOut(canCrossFadeBackground = true),
+
+        /** This view never showed the intro, snap the views past it. */
+        SnapAway(canCrossFadeBackground = false),
+
+        /** The intro was already snapped away unplayed. */
+        AlreadyDismissed(canCrossFadeBackground = false),
+
+        /** An earlier dialog already took the background over. */
+        AlreadyHandedOver(canCrossFadeBackground = true),
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroState.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroState.kt
@@ -19,8 +19,6 @@ package com.duckduckgo.app.onboarding.ui.page.configdriven
 /**
  * Ordering rules behind [OnboardingIntroChoreographer]: what a call is allowed to do to the intro views given what
  * happened to them already.
- *
- * Split out of the choreographer so the orderings a rotation lands on can be exercised without a view binding.
  */
 class OnboardingIntroState {
 
@@ -34,12 +32,11 @@ class OnboardingIntroState {
 
     private var released = false
 
-    /** Records that this view is playing the intro. */
     fun play() {
         visualsOnScreen = true
     }
 
-    /** @return true when an intro start deferred until layout should still run, false when something overtook it */
+    /** @return true when should run, false when something overtook it */
     fun canStart(): Boolean = !released && !cleared
 
     /** @return true when the caller should snap the intro views to their end state, false when they are there already */

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngine.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngine.kt
@@ -67,11 +67,14 @@ class DialogRenderEngine(
      *
      * Re-rendering the [stepId] + [config] that is currently bound is a no-op, [animate] included, so a caller that can fire more
      * than once for one state does not need to de-duplicate itself.
+     *
+     * [animateBackground] splits the background off the [animate] policy, where needed.
      */
     fun render(
         stepId: LinearOnboardingStepId,
         config: DialogConfig,
         animate: Boolean,
+        animateBackground: Boolean = animate,
     ) {
         if (stepId == previousStepId && config == previous && bound != null) return
 
@@ -80,7 +83,7 @@ class DialogRenderEngine(
         unbindCurrent()
         if (freshStage) content.resetStage()
 
-        background.apply(previous?.background, config.background, animate)
+        background.apply(previous?.background, config.background, animateBackground)
         stepIndicator.apply(previous?.stepIndicator, config.stepIndicator, animate)
         cardArrow.apply(previous?.cardArrow, config.cardArrow, animate)
 

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingPlanBootstrap
 import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingPlanProvider
 import com.duckduckgo.app.onboarding.ui.page.OnboardingBackgroundStep
 import com.duckduckgo.app.onboarding.ui.page.configdriven.ConfigDrivenOnboardingPageViewModel.Command
+import com.duckduckgo.app.onboarding.ui.page.configdriven.ConfigDrivenOnboardingPageViewModel.Screen
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -48,6 +49,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -152,10 +154,10 @@ class ConfigDrivenOnboardingPageViewModelTest {
         val testee = startAt(NewUserOnboardingActivityDialog.ComparisonChart)
         advanceUntilIdle()
 
-        val state = testee.viewState.value
-        assertEquals("step", state.stepId)
-        assertEquals(OnboardingBackgroundStep.ComparisonChart, state.config!!.background)
-        assertTrue(state.animateEntry)
+        val screen = testee.viewState.value.screen as Screen.Dialog
+        assertEquals("step", screen.stepId)
+        assertEquals(OnboardingBackgroundStep.ComparisonChart, screen.config.background)
+        assertTrue(screen.animateEntry)
     }
 
     @Test
@@ -165,7 +167,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
 
         testee.onDialogRendered("step")
 
-        assertFalse(testee.viewState.value.animateEntry)
+        assertFalse((testee.viewState.value.screen as Screen.Dialog).animateEntry)
     }
 
     @Test
@@ -175,7 +177,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
 
         testee.onDialogRendered("a_different_step")
 
-        assertTrue(testee.viewState.value.animateEntry)
+        assertTrue((testee.viewState.value.screen as Screen.Dialog).animateEntry)
     }
 
     @Test
@@ -232,5 +234,148 @@ class ConfigDrivenOnboardingPageViewModelTest {
             advanceUntilIdle()
             assertEquals(Command.HandOffToBrowserActivity, awaitItem())
         }
+    }
+
+    @Test
+    fun `asks for the intro to play on the intro step, passing through withDuckAi`() = runTest {
+        val testee = startAt(NewUserOnboardingActivityDialog.IntroAnimation(withDuckAi = true))
+        advanceUntilIdle()
+
+        assertEquals(Screen.Intro.Play(withDuckAi = true), testee.viewState.value.screen)
+    }
+
+    @Test
+    fun `asks for the intro to be restored once it has started, without waiting for it to finish`() = runTest {
+        val testee = startAt(NewUserOnboardingActivityDialog.IntroAnimation(withDuckAi = true))
+        advanceUntilIdle()
+
+        testee.onIntroAnimationStarted()
+
+        assertEquals(Screen.Intro.Restore(withDuckAi = true), testee.viewState.value.screen)
+    }
+
+    @Test
+    fun `keeps the intro on screen while the flow crosses a step with no dialog to render`() = runTest {
+        val introStep = NewUserOnboardingActivityStep(
+            id = "intro",
+            pixelName = null,
+            transition = { event ->
+                if (event is NewUserOnboardingEvent.IntroAnimationFinished) {
+                    LinearOnboardingTransition.Advance
+                } else {
+                    LinearOnboardingTransition.Stay
+                }
+            },
+            resolveDialog = { NewUserOnboardingActivityDialog.IntroAnimation(withDuckAi = true) },
+        )
+        val promptStep = NewUserOnboardingActivityStep(
+            id = "prompt",
+            pixelName = null,
+            transition = { LinearOnboardingTransition.Stay },
+            resolveDialog = { NewUserOnboardingActivityDialog.DefaultBrowserPrompt },
+        )
+        realOrchestrator.startPlan(
+            LinearOnboardingPlan(id = NewUserOnboardingPlanProvider.ROOT_PLAN_ID, steps = listOf(introStep, promptStep)),
+        )
+        val testee = createViewModel(realOrchestrator)
+        advanceUntilIdle()
+        testee.onIntroAnimationStarted()
+
+        testee.onIntroAnimationFinished()
+        advanceUntilIdle()
+
+        assertEquals(Screen.Intro.Restore(withDuckAi = true), testee.viewState.value.screen)
+    }
+
+    @Test
+    fun `keeps the last dialog on screen while the flow crosses a step with no dialog to render`() = runTest {
+        val comparisonStep = NewUserOnboardingActivityStep(
+            id = "comparison",
+            pixelName = null,
+            transition = { event ->
+                if (event is NewUserOnboardingEvent.IntroAnimationFinished) {
+                    LinearOnboardingTransition.Advance
+                } else {
+                    LinearOnboardingTransition.Stay
+                }
+            },
+            resolveDialog = { NewUserOnboardingActivityDialog.ComparisonChart },
+        )
+        val promptStep = NewUserOnboardingActivityStep(
+            id = "prompt",
+            pixelName = null,
+            transition = { LinearOnboardingTransition.Stay },
+            resolveDialog = { NewUserOnboardingActivityDialog.DefaultBrowserPrompt },
+        )
+        realOrchestrator.startPlan(
+            LinearOnboardingPlan(id = NewUserOnboardingPlanProvider.ROOT_PLAN_ID, steps = listOf(comparisonStep, promptStep)),
+        )
+        val testee = createViewModel(realOrchestrator)
+        advanceUntilIdle()
+
+        testee.onIntroAnimationFinished()
+        advanceUntilIdle()
+
+        assertEquals("comparison", (testee.viewState.value.screen as Screen.Dialog).stepId)
+    }
+
+    @Test
+    fun `asks for nothing to be drawn on a step with no dialog to render`() = runTest {
+        val testee = startAt(NewUserOnboardingActivityDialog.DefaultBrowserPrompt)
+        advanceUntilIdle()
+
+        assertEquals(Screen.None, testee.viewState.value.screen)
+    }
+
+    @Test
+    fun `asks for nothing before the flow has reached a step`() = runTest {
+        val testee = createViewModel()
+        advanceUntilIdle()
+
+        assertNull(testee.viewState.value.screen)
+    }
+
+    @Test
+    fun `stops asking for the intro once the flow leaves the intro step`() = runTest {
+        val introStep = NewUserOnboardingActivityStep(
+            id = "intro",
+            pixelName = null,
+            transition = { event ->
+                if (event is NewUserOnboardingEvent.IntroAnimationFinished) {
+                    LinearOnboardingTransition.Advance
+                } else {
+                    LinearOnboardingTransition.Stay
+                }
+            },
+            resolveDialog = { NewUserOnboardingActivityDialog.IntroAnimation() },
+        )
+        val comparisonStep = NewUserOnboardingActivityStep(
+            id = "comparison",
+            pixelName = null,
+            transition = { LinearOnboardingTransition.Stay },
+            resolveDialog = { NewUserOnboardingActivityDialog.ComparisonChart },
+        )
+        realOrchestrator.startPlan(
+            LinearOnboardingPlan(id = NewUserOnboardingPlanProvider.ROOT_PLAN_ID, steps = listOf(introStep, comparisonStep)),
+        )
+        val testee = createViewModel(realOrchestrator)
+        advanceUntilIdle()
+        testee.onIntroAnimationStarted()
+
+        testee.onIntroAnimationFinished()
+        advanceUntilIdle()
+
+        assertEquals("comparison", (testee.viewState.value.screen as Screen.Dialog).stepId)
+    }
+
+    @Test
+    fun `emits IntroAnimationFinished to the orchestrator when the intro finishes`() = runTest {
+        val testee = startAt(dialog = NewUserOnboardingActivityDialog.IntroAnimation())
+        advanceUntilIdle()
+
+        testee.onIntroAnimationFinished()
+        advanceUntilIdle()
+
+        assertEquals(listOf(NewUserOnboardingEvent.IntroAnimationFinished), recordedEvents)
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroStateTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroStateTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.page.configdriven
+
+import com.duckduckgo.app.onboarding.ui.page.configdriven.OnboardingIntroState.Handover
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OnboardingIntroStateTest {
+
+    private val testee = OnboardingIntroState()
+
+    @Test
+    fun `a view that is playing the intro has nothing to restore`() {
+        testee.play()
+
+        assertFalse(testee.restore())
+    }
+
+    @Test
+    fun `a view that never played the intro restores it once`() {
+        assertTrue(testee.restore())
+        assertFalse(testee.restore())
+    }
+
+    @Test
+    fun `a dialog arriving over a playing intro fades it out and can cross-fade the background`() {
+        testee.play()
+
+        val handover = testee.handOverToDialog()
+
+        assertEquals(Handover.FadeOut, handover)
+        assertTrue(handover.canCrossFadeBackground)
+    }
+
+    @Test
+    fun `a dialog arriving over a restored intro fades it out`() {
+        testee.restore()
+
+        assertEquals(Handover.FadeOut, testee.handOverToDialog())
+    }
+
+    @Test
+    fun `a dialog arriving with no intro on screen snaps it away and snaps the background`() {
+        val handover = testee.handOverToDialog()
+
+        assertEquals(Handover.SnapAway, handover)
+        assertFalse(handover.canCrossFadeBackground)
+    }
+
+    @Test
+    fun `later dialogs leave the intro alone and keep animating the background`() {
+        testee.play()
+        testee.handOverToDialog()
+
+        val handover = testee.handOverToDialog()
+
+        assertEquals(Handover.AlreadyHandedOver, handover)
+        assertTrue(handover.canCrossFadeBackground)
+    }
+
+    @Test
+    fun `a dialog arriving after the intro was dismissed unplayed snaps the background`() {
+        assertTrue(testee.dismissUnplayed())
+
+        val handover = testee.handOverToDialog()
+
+        assertEquals(Handover.AlreadyDismissed, handover)
+        assertFalse(handover.canCrossFadeBackground)
+    }
+
+    @Test
+    fun `dismissing after a dialog took over is a no-op`() {
+        testee.play()
+        testee.handOverToDialog()
+
+        assertFalse(testee.dismissUnplayed())
+    }
+
+    @Test
+    fun `dismissing an intro that is on screen is a no-op`() {
+        testee.play()
+
+        assertFalse(testee.dismissUnplayed())
+    }
+
+    @Test
+    fun `dismissing twice snaps the intro away once`() {
+        assertTrue(testee.dismissUnplayed())
+        assertFalse(testee.dismissUnplayed())
+    }
+
+    @Test
+    fun `a deferred intro start runs while nothing has overtaken it`() {
+        testee.play()
+
+        assertTrue(testee.canStart())
+    }
+
+    @Test
+    fun `releasing mid-play stops a deferred intro start`() {
+        testee.play()
+        testee.release()
+
+        assertFalse(testee.canStart())
+    }
+
+    @Test
+    fun `a dialog taking over stops a deferred intro start`() {
+        testee.handOverToDialog()
+
+        assertFalse(testee.canStart())
+    }
+
+    @Test
+    fun `dismissing unplayed stops a deferred intro start`() {
+        testee.dismissUnplayed()
+
+        assertFalse(testee.canStart())
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngineTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngineTest.kt
@@ -150,6 +150,15 @@ class DialogRenderEngineTest {
     }
 
     @Test
+    fun `a snapped background still lets the card and its embellishments animate`() = runTest {
+        testee.render(COMPARISON_STEP, comparisonConfig(), animate = true, animateBackground = false)
+
+        assertFalse(background.animated)
+        assertEquals(listOf(true, true, true), cardStage.animateFlags)
+        assertTrue(embellishments.animated)
+    }
+
+    @Test
     fun `an emit cta forwards its event as-is`() = runTest {
         testee.render(COMPARISON_STEP, comparisonConfig(), animate = false)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216987945331691?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1216854264994244?focus=true
API Proposals URL(s) (if applicable):

### Description

Ports the welcome intro/outro choreography from `BrandDesignUpdateWelcomePage` to the config-driven page, behind the same remote toggle as the rest of the config-driven work.

Two pieces:

1. **`OnboardingIntroChoreographer`** owns the intro views and everything that happens to them: play, snap to end state, fade out for the first dialog, tear down. The animators are a straight port, same durations, interpolators and Lottie frames.
2. **`ViewState.screen`** replaces the flat `stepId` / `config` / `animateEntry` triple with a sealed `Screen` (`Intro.Play`, `Intro.Restore`, `Dialog`, `None`). The view model states which screen is current instead of the view inferring it from flags.

#### What changed vs legacy

- **Rotating mid-intro keeps the first dialog's background cross-fade.** Legacy snapped it after a mid-intro recreation. Bug fix.
_before -> after (ignore different step used, important is the transition)_

<img width="480" height="532" alt="transition_after_rotation" src="https://github.com/user-attachments/assets/b6de563d-b330-4550-bd02-ca0e6e0ebeb2" />

- **Any first dialog fades the intro out and no longer waits for the background transition to end.** Legacy faded only into the welcome dialog and snapped the intro away for every other dialog. Now, no step order is assumed. Welcome steps' binders will come with a card reveal delay configured instead.
- **The tablet `enterStartX` override is dropped.** Legacy shortened the entering background's travel on tablets for the first dialog. The entering view is transparent for most of its travel, so the difference is not visible. Verified on a Galaxy Tab S9+.
_before -> after_ (ignore different step used, important is the **intro background** transition)

<img width="872" height="698" alt="tablet_intro_background_fade" src="https://github.com/user-attachments/assets/b7bd5b49-e0c0-4c1e-b69d-1627e0dac341" />

### Steps to test this PR

_Fresh onboarding_
- [ ] Apply below patch:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
index b6a1e4d352..41a8d85ad4 100644
--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
@@ -58,6 +58,6 @@ interface OnboardingBrandDesignUpdateToggles {
     /**
      * Selects the config-driven renderer for the brand-design onboarding dialogs.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun configDrivenDialogs(): Toggle
 }

```
- [ ] Clear app data, launch.
- [ ] Logo drops, background slides up, title fades and scales in.
- [ ] First dialog arrives: logo and title fade out while the background cross-fades to the dialog backdrop.

_duck.ai variant_
- [ ] Additionally apply below patch:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
index df50491818..cf6a6196ba 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
@@ -101,7 +101,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
         onCompleted: suspend () -> Unit,
         onSkipped: suspend () -> Unit,
     ): LinearOnboardingPlan =
-        if (customAiOnboardingResolver.resolve()) {
+        if (true) {
             // in custom AI onboarding path, the input toggle is enabled by default
             duckChat.setCosmeticInputScreenUserSetting(enabled = true)
             onboardingStore.storeInputScreenSelection(selected = true)

```
- [ ] Enable the custom duck.ai onboarding flow, clear data, launch.
- [ ] The duck.ai lockup plays after the title settles, in the correct font and text colour, in both light and dark mode.
- [ ] First dialog arrives: the lockup fades out along with the logo and title.

_Rotation_
- [ ] Rotate mid-intro. Intro finishes and transitions to the dialog without any artifacts.
- [ ] Rotate after intro settles. Intro finishes and transitions to the dialog without any artifacts.
- [ ] Rotate on the first dialog. Dialog redraws with no entry animation and no intro visuals reappearing.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-run onboarding UI and orchestrator handoff timing; mistakes could skip steps or show broken transitions, but changes are localized and covered by new ViewModel/state tests.
> 
> **Overview**
> Ports the brand-design welcome **logo/title/background intro** from the legacy page into **config-driven onboarding**, gated behind the same remote toggle as the rest of that work.
> 
> **View model** replaces flat `stepId` / `config` / `animateEntry` with a sealed **`Screen`** (`Intro.Play`, `Intro.Restore`, `Dialog`, `None`). The intro step is handled explicitly (play vs restore after rotation), `IntroAnimationFinished` is emitted when the choreographer completes, and steps with no UI (system prompts) keep the last screen or publish `None` instead of auto-skipping the intro.
> 
> **Fragment** wires **`OnboardingIntroChoreographer`** for play/restore/outro and hands `backgroundPrimary` to **`DialogRenderEngine`** on the first dialog via `clearForDialog()`, using a new **`animateBackground`** flag so the backdrop can cross-fade from the intro when appropriate.
> 
> **Behavior vs legacy:** first dialog always fades intro visuals (not only welcome); rotation mid-intro preserves background cross-fade; optional duck.ai Lottie after the title uses theme text color and Duck Sans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 620a168fe3465c57f515668654c81cf9b9171905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->