### PR TITLE
Sync: read device_info in the device list, preferring it over legacy device data

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoPrivateKeyProvider.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoPrivateKeyProvider.kt
@@ -23,17 +23,24 @@ import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
 import javax.inject.Inject
 
 /**
- * Supplies the account's `account_info` private key, unwrapped for the current credential and
- * encoded as base64url PKCS#8.
+ * Supplies the account's `account_info` private key, unwrapped for the current credential and encoded as base64url PKCS#8.
+ *
+ * The *wrapped* key entry (still encrypted, as on disk) is cached in memory keyed by account+credential: the `account_info` key is
+ * immutable for the account lifetime, so a burst of reads (e.g. repeated device-list renders) does a single `GET /sync/keys` instead of
+ * hammering it and tripping rate limits. The key is unwrapped on every call, so the plaintext key is only ever held transiently by the
+ * caller — it is not persisted or cached. Only successful fetches are cached; the cache is cleared on sign-out and
+ * refreshed automatically on an account/credential switch.
  */
 @WorkerThread
 interface AccountInfoPrivateKeyProvider {
     fun privateKey(): Result<String>
 }
 
+@SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealAccountInfoPrivateKeyProvider @Inject constructor(
     private val syncStore: SyncStore,
@@ -41,22 +48,53 @@ class RealAccountInfoPrivateKeyProvider @Inject constructor(
     private val protectedKeyUnwrapper: ProtectedKeyUnwrapper,
 ) : AccountInfoPrivateKeyProvider {
 
+    private val fetchLock = Any()
+
+    @Volatile
+    private var cachedEntry: CachedEntry? = null
+
+    private data class CachedEntry(val userId: String, val credentialId: String, val wrappedEntry: ProtectedKeyEntry)
+
     override fun privateKey(): Result<String> {
         val token = syncStore.token.takeUnless { it.isNullOrEmpty() }
-            ?: return Error(reason = "AccountInfoPrivateKey: not signed in")
+            ?: run {
+                cachedEntry = null
+                return Error(reason = "AccountInfoPrivateKey: not signed in")
+            }
+        val userId = syncStore.userId.takeUnless { it.isNullOrEmpty() }
+            ?: run {
+                cachedEntry = null
+                return Error(reason = "AccountInfoPrivateKey: no user id")
+            }
         val credentialId = syncStore.credentialId ?: CREDENTIAL_ID_DDG
 
-        val entry = when (val result = syncApi.getProtectedKeys(token)) {
-            is Success -> result.data.firstOrNull { it.purpose == SYNC_PURPOSE_ACCOUNT_INFO && it.encryptedWith == credentialId }
-                ?: return Error(reason = "AccountInfoPrivateKey: no account_info key wrapped for credential=$credentialId")
-            is Error -> return result
-        }
-
-        val rawKeyBytes = when (val result = protectedKeyUnwrapper.unwrap(entry)) {
+        val entry = when (val result = wrappedEntry(token, userId, credentialId)) {
             is Success -> result.data
             is Error -> return result
         }
 
-        return Success(Base64.encodeToString(rawKeyBytes, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP))
+        return when (val result = protectedKeyUnwrapper.unwrap(entry)) {
+            is Success -> Success(Base64.encodeToString(result.data, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP))
+            is Error -> result
+        }
+    }
+
+    /** Returns the wrapped `account_info` entry from cache, or fetches it once (deduping a concurrent burst) and caches it. */
+    private fun wrappedEntry(token: String, userId: String, credentialId: String): Result<ProtectedKeyEntry> {
+        cachedEntry?.let { if (it.userId == userId && it.credentialId == credentialId) return Success(it.wrappedEntry) }
+
+        return synchronized(fetchLock) {
+            // another thread may have populated the cache while we waited on the lock
+            cachedEntry?.let { if (it.userId == userId && it.credentialId == credentialId) return@synchronized Success(it.wrappedEntry) }
+
+            val entry = when (val result = syncApi.getProtectedKeys(token)) {
+                is Success -> result.data.firstOrNull { it.purpose == SYNC_PURPOSE_ACCOUNT_INFO && it.encryptedWith == credentialId }
+                    ?: return@synchronized Error(reason = "AccountInfoPrivateKey: no account_info key wrapped for credential=$credentialId")
+                is Error -> return@synchronized result
+            }
+
+            cachedEntry = CachedEntry(userId = userId, credentialId = credentialId, wrappedEntry = entry)
+            Success(entry)
+        }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptor.kt
@@ -16,27 +16,31 @@
 
 package com.duckduckgo.sync.impl
 
+import androidx.annotation.WorkerThread
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
+import logcat.LogPriority
 import logcat.LogPriority.WARN
 import logcat.logcat
 import javax.inject.Inject
 
 /**
- * Decrypts `entries_v2` with one-shot refresh-on-3p-failure. Splits the result so the caller
- * can differentiate between those successfully decrypted and those with decryption failure.
+ * Decrypts `entries_v2`, preferring the cross-credential `device_info` when the unified device list read flag is on,
+ * and falling back to the legacy `name`/`type` otherwise.
  *
- * 3p failures only get classified as corrupted when `refresh()` returned `Success(true)` —
- * otherwise we can't tell stale-SP from corruption, so we render a fallback row instead of
- * logging the device out over a possibly-transient condition. ddg failures are always
- * corrupted (primary key doesn't drift).
+ * Failure handling depends on the read flag:
+ * - flag ON: we never auto-logout (decision 1216781918336689). Every device is rendered; anything that can't be decrypted (legacy or device_info)
+ *            becomes an "Unknown device" placeholder the user can manually remove.
+ * - flag OFF (today's behaviour): a 3p failure with an inconclusive refresh renders a fallback; ddg failures — and
+ *   3p failures confirmed after a fresh scoped password — are marked undecryptable and logged out by the caller.
  */
+@WorkerThread
 interface ThirdPartyDeviceListDecryptor {
     fun decryptAll(entries: List<DeviceV2>): DecryptAllResult
 
     companion object {
         const val FALLBACK_TYPE_3PARTY = "Browser"
-        const val FALLBACK_NAME = "Unknown"
+        const val FALLBACK_NAME = "Unknown device"
     }
 }
 
@@ -49,54 +53,180 @@ data class DecryptAllResult(
 class RealThirdPartyDeviceListDecryptor @Inject constructor(
     private val deviceFieldDecryptor: DeviceFieldDecryptor,
     private val thirdPartyCredentialManager: ThirdPartyCredentialManager,
+    private val deviceInfoDecryptor: DeviceInfoDecryptor,
+    private val syncFeature: SyncFeature,
 ) : ThirdPartyDeviceListDecryptor {
 
     override fun decryptAll(entries: List<DeviceV2>): DecryptAllResult {
         if (entries.isEmpty()) return DecryptAllResult(emptyList(), emptyList())
 
-        val firstPass = entries.map { it to deviceFieldDecryptor.decrypt(it) }
-        var finalPass = firstPass
+        val readEnabled = syncFeature.canReadUnifiedDeviceList().isEnabled()
 
-        // if there are 3rd party failures, allow a refresh attempt on 3p credentials and retry at decrypting
-        var refreshGotFreshSp = false
-        if (firstPass.anyThirdPartyFailure()) {
-            val refreshResult = thirdPartyCredentialManager.refresh()
-            refreshGotFreshSp = refreshResult is Result.Success && refreshResult.data
-            finalPass = entries.map { it to deviceFieldDecryptor.decrypt(it) }
-        }
+        val viaDeviceInfo = mutableListOf<DecryptedDevice>()
+        val legacyEntries = mutableListOf<DeviceV2>()
 
-        val decrypted = mutableListOf<DecryptedDevice>()
-        val undecryptable = mutableListOf<String>()
-        finalPass.forEach { (entry, result) ->
-            when (result) {
-                is Result.Success -> decrypted += result.data
-                is Result.Error -> classifyFailure(entry, result, refreshGotFreshSp, decrypted, undecryptable)
+        // a single session can decrypt every device's blob since device_info is encrypted using account-wide account_info key
+        // only open one if the read flag is on and some entry actually carries device_info to decrypt
+        val session = if (readEnabled && entries.any { !it.deviceInfo.isNullOrEmpty() }) openDeviceInfoSession() else null
+
+        entries.forEach { entry ->
+            val resolved = session?.let { decryptDeviceInfo(entry, it) }
+            if (resolved != null) {
+                viaDeviceInfo += resolved
+            } else {
+                // entries it can't resolve (e.g. feature flag off, or undecryptable device_info) fall through to the legacy path
+                legacyEntries += entry
             }
         }
-        return DecryptAllResult(decrypted, undecryptable)
+
+        // read flag on ⇒ never auto-logout; undecryptable entries become "Unknown device" placeholders instead
+        val legacy = decryptLegacy(legacyEntries, neverAutoLogout = readEnabled)
+
+        logcat(LogPriority.VERBOSE) {
+            "Sync-UnifiedDevices: ${entries.size} devices → ${viaDeviceInfo.size} via device_info, " +
+                "${legacy.viaLegacy.size} via legacy, ${legacy.fallbacks.size} placeholder, ${legacy.undecryptable.size} undecryptable"
+        }
+        return DecryptAllResult(
+            decrypted = viaDeviceInfo + legacy.viaLegacy + legacy.fallbacks,
+            undecryptable = legacy.undecryptable,
+        )
+    }
+
+    private fun decryptDeviceInfo(
+        entry: DeviceV2,
+        session: DeviceInfoDecryptor.Session,
+    ): DecryptedDevice? {
+        val deviceId = entry.deviceId ?: return null
+        val deviceInfo = entry.deviceInfo?.takeUnless { it.isEmpty() } ?: return null
+        return when (val result = session.decrypt(deviceInfo)) {
+            is Result.Success -> DecryptedDevice(deviceId = deviceId, name = result.data.name, type = result.data.type)
+            is Result.Error -> {
+                logcat(WARN) { "Sync-UnifiedDevices: $deviceId device_info decrypt failed, falling back to legacy: ${result.reason}" }
+                null
+            }
+        }
+    }
+
+    /**
+     * Called only with entries where device_info was not resolved.
+     * Reasons for it not being resolved include where the FF is off, device_info is absent, or it is undecryptable.
+     */
+    private fun decryptLegacy(entries: List<DeviceV2>, neverAutoLogout: Boolean): LegacyDecryptResult {
+        if (entries.isEmpty()) return LegacyDecryptResult(emptyList(), emptyList(), emptyList())
+
+        val results = decryptWithRefreshRetry(entries)
+        return classifyResults(results, neverAutoLogout)
+    }
+
+    /**
+     * The per-entry legacy decrypt results, plus whether the 3p refresh (if one ran) produced a fresh scoped password.
+     * That flag lets [classifyFailure] tell a confirmed failure from an inconclusive one.
+     */
+    private data class LegacyDecryptionAttempt(
+        val results: List<Pair<DeviceV2, Result<DecryptedDevice>>>,
+        val refreshGotFreshScopedPassword: Boolean,
+    )
+
+    /**
+     * Decrypts every entry's legacy fields. A 3p failure can just be a stale scoped password rather than corruption,
+     * so on any 3p failure we refresh the 3p credentials once and re-decrypt everything. Whether that refresh produced
+     * a fresh scoped password is carried through so [classifyFailure] can tell a confirmed failure from an inconclusive one.
+     */
+    private fun decryptWithRefreshRetry(entries: List<DeviceV2>): LegacyDecryptionAttempt {
+        val firstPass = entries.map { it to deviceFieldDecryptor.decrypt(it) }
+        if (!firstPass.anyThirdPartyFailure()) return LegacyDecryptionAttempt(firstPass, refreshGotFreshScopedPassword = false)
+
+        val refreshResult = thirdPartyCredentialManager.refresh()
+        val refreshGotFreshScopedPassword = refreshResult is Result.Success && refreshResult.data
+        logcat(WARN) { "Sync-UnifiedDevices: 3p decrypt failure, refreshed 3p credentials (freshSp=$refreshGotFreshScopedPassword)" }
+        return LegacyDecryptionAttempt(entries.map { it to deviceFieldDecryptor.decrypt(it) }, refreshGotFreshScopedPassword)
+    }
+
+    private fun classifyResults(attempt: LegacyDecryptionAttempt, neverAutoLogout: Boolean): LegacyDecryptResult {
+        val viaLegacy = mutableListOf<DecryptedDevice>()
+        val fallbacks = mutableListOf<DecryptedDevice>()
+        val undecryptable = mutableListOf<String>()
+        attempt.results.forEach { (entry, result) ->
+            when (result) {
+                is Result.Success -> viaLegacy += result.data
+                is Result.Error -> when (val outcome = classifyFailure(entry, result, attempt.refreshGotFreshScopedPassword, neverAutoLogout)) {
+                    is FailureOutcome.Fallback -> fallbacks += outcome.device
+                    is FailureOutcome.PermanentlyUndecryptable -> undecryptable += outcome.deviceId
+                    FailureOutcome.Drop -> {}
+                }
+            }
+        }
+        return LegacyDecryptResult(viaLegacy, fallbacks, undecryptable)
     }
 
     private fun List<Pair<DeviceV2, Result<DecryptedDevice>>>.anyThirdPartyFailure(): Boolean =
         any { (entry, result) -> result is Result.Error && entry.credentialId == CREDENTIAL_ID_3PARTY }
 
+    private fun openDeviceInfoSession(): DeviceInfoDecryptor.Session? =
+        when (val result = deviceInfoDecryptor.openSession()) {
+            is Result.Success -> result.data
+            is Result.Error -> {
+                logcat(WARN) { "Sync-UnifiedDevices: device_info session unavailable (code=${result.code}), using legacy: ${result.reason}" }
+                null
+            }
+        }
+
+    /**
+     * Decides what to do with a device we couldn't decrypt.
+     *
+     * When [neverAutoLogout] is set (unified list read enabled), we always render an "Unknown device" placeholder —
+     * we never log a device out over a decrypt failure (decision 1216781918336689).
+     *
+     * Otherwise (read flag off) we keep today's behaviour: a 3p failure with an inconclusive refresh renders a fallback
+     * (can't tell stale-SP from corruption); anything else — ddg, or 3p confirmed after a fresh SP — is real corruption
+     * and is marked for logout.
+     */
     private fun classifyFailure(
         entry: DeviceV2,
         result: Result.Error,
         refreshGotFreshSp: Boolean,
-        decrypted: MutableList<DecryptedDevice>,
-        undecryptable: MutableList<String>,
-    ) {
-        val id = entry.deviceId ?: return
-        if (entry.credentialId == CREDENTIAL_ID_3PARTY && !refreshGotFreshSp) {
-            logcat(WARN) { "DeviceListDecryptor: $id → Unknown fallback (refresh inconclusive): ${result.reason}" }
-            decrypted += DecryptedDevice(
-                deviceId = id,
-                name = ThirdPartyDeviceListDecryptor.FALLBACK_NAME,
-                type = ThirdPartyDeviceListDecryptor.FALLBACK_TYPE_3PARTY,
-            )
-        } else {
-            logcat(WARN) { "DeviceListDecryptor: $id marked for logout (${entry.credentialId}): ${result.reason}" }
-            undecryptable += id
+        neverAutoLogout: Boolean,
+    ): FailureOutcome {
+        val id = entry.deviceId ?: return FailureOutcome.Drop
+
+        if (neverAutoLogout) {
+            logcat(WARN) { "Sync-UnifiedDevices: $id → Unknown device placeholder (${entry.credentialId}): ${result.reason}" }
+            return FailureOutcome.Fallback(placeholderDevice(id, entry.credentialId))
         }
+
+        if (entry.credentialId == CREDENTIAL_ID_3PARTY && !refreshGotFreshSp) {
+            logcat(WARN) { "Sync-UnifiedDevices: $id → Unknown fallback (refreshing SP was inconclusive): ${result.reason}" }
+            return FailureOutcome.Fallback(placeholderDevice(id, entry.credentialId))
+        }
+        logcat(WARN) { "Sync-UnifiedDevices: $id marked for logout (${entry.credentialId}): ${result.reason}" }
+        return FailureOutcome.PermanentlyUndecryptable(id)
+    }
+
+    private fun placeholderDevice(deviceId: String, credentialId: String?): DecryptedDevice =
+        DecryptedDevice(
+            deviceId = deviceId,
+            name = ThirdPartyDeviceListDecryptor.FALLBACK_NAME,
+            type = if (credentialId == CREDENTIAL_ID_3PARTY) ThirdPartyDeviceListDecryptor.FALLBACK_TYPE_3PARTY else null,
+        )
+
+    /**
+     * Outcome of the legacy per-credential pass, split so the caller can report and merge each bucket.
+     * [viaLegacy] decrypted successfully; [fallbacks] rendered as an "Unknown device" placeholder; [undecryptable] marked for logout.
+     */
+    private data class LegacyDecryptResult(
+        val viaLegacy: List<DecryptedDevice>,
+        val fallbacks: List<DecryptedDevice>,
+        val undecryptable: List<String>,
+    )
+
+    private sealed interface FailureOutcome {
+        /** Render an "Unknown device" placeholder row. */
+        data class Fallback(val device: DecryptedDevice) : FailureOutcome
+
+        /** Confirmed undecryptable (ddg failure, or 3p failure after a fresh scoped password) */
+        data class PermanentlyUndecryptable(val deviceId: String) : FailureOutcome
+
+        /** No device id, so we can neither render nor log it out. */
+        object Drop : FailureOutcome
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoPrivateKeyProviderTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoPrivateKeyProviderTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.sync.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.sync.TestSyncFixtures.token
+import com.duckduckgo.sync.TestSyncFixtures.userId
 import com.duckduckgo.sync.store.SyncStore
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -26,6 +27,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -82,8 +84,53 @@ class AccountInfoPrivateKeyProviderTest {
         assertTrue(provider.privateKey() is Result.Error)
     }
 
+    @Test
+    fun whenCalledTwiceForSameAccountThenWrappedKeyFetchedOnceButUnwrappedEachCall() {
+        stubSignedIn()
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Result.Success(listOf(ddgKey)))
+        whenever(protectedKeyUnwrapper.unwrap(ddgKey)).thenReturn(Result.Success(byteArrayOf(-5, -16, 0)))
+
+        val first = provider.privateKey()
+        val second = provider.privateKey()
+
+        assertEquals(Result.Success("-_AA"), first)
+        assertEquals(Result.Success("-_AA"), second)
+        // the wrapped entry is cached (one network fetch), but we unwrap per call so the plaintext key is never cached
+        verify(syncApi, times(1)).getProtectedKeys(token)
+        verify(protectedKeyUnwrapper, times(2)).unwrap(ddgKey)
+    }
+
+    @Test
+    fun whenFetchFailsThenNotCachedAndRetriedNextCall() {
+        stubSignedIn()
+        whenever(syncApi.getProtectedKeys(token))
+            .thenReturn(Result.Error(code = 418, reason = ""))
+            .thenReturn(Result.Success(listOf(ddgKey)))
+        whenever(protectedKeyUnwrapper.unwrap(ddgKey)).thenReturn(Result.Success(byteArrayOf(-5, -16, 0)))
+
+        val first = provider.privateKey()
+        val second = provider.privateKey()
+
+        assertTrue(first is Result.Error)
+        assertEquals(Result.Success("-_AA"), second)
+        verify(syncApi, times(2)).getProtectedKeys(token)
+    }
+
+    @Test
+    fun whenSignedOutAfterCachingThenCacheClearedAndErrorOnNextCall() {
+        stubSignedIn()
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Result.Success(listOf(ddgKey)))
+        whenever(protectedKeyUnwrapper.unwrap(ddgKey)).thenReturn(Result.Success(byteArrayOf(-5, -16, 0)))
+        provider.privateKey()
+
+        whenever(syncStore.token).thenReturn(null)
+
+        assertTrue(provider.privateKey() is Result.Error)
+    }
+
     private fun stubSignedIn() {
         whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.userId).thenReturn(userId)
         whenever(syncStore.credentialId).thenReturn("ddg")
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptorTest.kt
@@ -17,6 +17,9 @@
 package com.duckduckgo.sync.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.sync.impl.DeviceInfoDecryptor.Session
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.ThirdPartyDeviceListDecryptor.Companion.FALLBACK_NAME
@@ -39,12 +42,20 @@ class ThirdPartyDeviceListDecryptorTest {
 
     private val fieldDecryptor: DeviceFieldDecryptor = mock()
     private val thirdPartyCredentialManager: ThirdPartyCredentialManager = mock()
+    private val deviceInfoDecryptor: DeviceInfoDecryptor = mock()
+    private val session: Session = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
 
     private lateinit var decryptor: ThirdPartyDeviceListDecryptor
 
     @Before
     fun before() {
-        decryptor = RealThirdPartyDeviceListDecryptor(fieldDecryptor, thirdPartyCredentialManager)
+        decryptor = RealThirdPartyDeviceListDecryptor(fieldDecryptor, thirdPartyCredentialManager, deviceInfoDecryptor, syncFeature)
+    }
+
+    private fun enableReadFlag() {
+        syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(enable = true))
+        whenever(deviceInfoDecryptor.openSession()).thenReturn(Success(session))
     }
 
     @Test
@@ -209,5 +220,157 @@ class ThirdPartyDeviceListDecryptorTest {
 
         assertEquals(listOf("d1", "d2"), result.undecryptable)
         verify(thirdPartyCredentialManager, never()).refresh()
+    }
+
+    @Test
+    fun whenReadFlagOffThenDeviceInfoNeverReadAndLegacyUsed() {
+        val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
+        whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
+
+        val result = decryptor.decryptAll(listOf(ddg))
+
+        assertEquals(listOf(DecryptedDevice("d1", "Legacy Pixel", "phone")), result.decrypted)
+        verify(deviceInfoDecryptor, never()).openSession()
+    }
+
+    @Test
+    fun whenReadFlagOnButNoEntryHasDeviceInfoThenSessionNeverOpenedAndLegacyUsed() {
+        syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(enable = true))
+        val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
+        val tp = DeviceV2(deviceId = "d2", credentialId = "3party", deviceName = "ENC", deviceInfo = "")
+        whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Pixel", "phone")))
+        whenever(fieldDecryptor.decrypt(tp)).thenReturn(Success(DecryptedDevice("d2", "Chrome", "Browser")))
+
+        val result = decryptor.decryptAll(listOf(ddg, tp))
+
+        assertEquals(2, result.decrypted.size)
+        verify(deviceInfoDecryptor, never()).openSession()
+    }
+
+    @Test
+    fun whenReadFlagOnAndDeviceInfoDecryptsThenDeviceInfoPreferredAndLegacyNotUsed() {
+        enableReadFlag()
+        val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
+        whenever(session.decrypt("info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Unified Pixel", type = "phone")))
+
+        val result = decryptor.decryptAll(listOf(ddg))
+
+        assertEquals(listOf(DecryptedDevice("d1", "Unified Pixel", "phone")), result.decrypted)
+        assertTrue(result.undecryptable.isEmpty())
+        verify(fieldDecryptor, never()).decrypt(any())
+        verify(deviceInfoDecryptor, times(1)).openSession()
+    }
+
+    @Test
+    fun whenReadFlagOnAndDeviceInfoDecryptsForBothCredentialsThenCrossCredentialReadWorksWithoutRefresh() {
+        enableReadFlag()
+        val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC1", deviceInfo = "ddg.info.jwe")
+        val tp = DeviceV2(deviceId = "d2", credentialId = "3party", deviceName = "ENC2", deviceInfo = "3p.info.jwe")
+        whenever(session.decrypt("ddg.info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Pixel", type = "phone")))
+        whenever(session.decrypt("3p.info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Chrome", type = "Browser")))
+
+        val result = decryptor.decryptAll(listOf(ddg, tp))
+
+        assertEquals(
+            listOf(DecryptedDevice("d1", "Pixel", "phone"), DecryptedDevice("d2", "Chrome", "Browser")),
+            result.decrypted,
+        )
+        assertTrue(result.undecryptable.isEmpty())
+        verify(fieldDecryptor, never()).decrypt(any())
+        verify(thirdPartyCredentialManager, never()).refresh()
+    }
+
+    @Test
+    fun whenReadFlagOnButDeviceInfoAbsentThenFallsBackToLegacy() {
+        enableReadFlag()
+        val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
+        whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
+
+        val result = decryptor.decryptAll(listOf(ddg))
+
+        assertEquals(listOf(DecryptedDevice("d1", "Legacy Pixel", "phone")), result.decrypted)
+        verify(session, never()).decrypt(any())
+    }
+
+    @Test
+    fun whenReadFlagOnAndDeviceInfoUndecryptableThenFallsBackToLegacyNotDropped() {
+        enableReadFlag()
+        val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "corrupt.jwe")
+        whenever(session.decrypt("corrupt.jwe")).thenReturn(Error(reason = "bad device_info"))
+        whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
+
+        val result = decryptor.decryptAll(listOf(ddg))
+
+        assertEquals(listOf(DecryptedDevice("d1", "Legacy Pixel", "phone")), result.decrypted)
+        assertTrue(result.undecryptable.isEmpty())
+    }
+
+    @Test
+    fun whenReadFlagOnButSessionFailsToOpenThenWholeListDegradesToLegacy() {
+        syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(enable = true))
+        whenever(deviceInfoDecryptor.openSession()).thenReturn(Error(reason = "no account_info key"))
+        val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
+        whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
+
+        val result = decryptor.decryptAll(listOf(ddg))
+
+        assertEquals(listOf(DecryptedDevice("d1", "Legacy Pixel", "phone")), result.decrypted)
+        verify(session, never()).decrypt(any())
+    }
+
+    @Test
+    fun whenReadFlagOnAndSomeResolveViaDeviceInfoThenOnlyRemainderUseLegacy() {
+        enableReadFlag()
+        val viaInfo = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC1", deviceInfo = "info.jwe")
+        val viaLegacy = DeviceV2(deviceId = "d2", credentialId = "3party", deviceName = "ENC2", deviceInfo = null)
+        whenever(session.decrypt("info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Pixel", type = "phone")))
+        whenever(fieldDecryptor.decrypt(viaLegacy)).thenReturn(Success(DecryptedDevice("d2", "Chrome", "Browser")))
+
+        val result = decryptor.decryptAll(listOf(viaInfo, viaLegacy))
+
+        assertEquals(2, result.decrypted.size)
+        assertTrue(result.decrypted.contains(DecryptedDevice("d1", "Pixel", "phone")))
+        assertTrue(result.decrypted.contains(DecryptedDevice("d2", "Chrome", "Browser")))
+        verify(fieldDecryptor, never()).decrypt(viaInfo)
+        verify(fieldDecryptor, times(1)).decrypt(viaLegacy)
+    }
+
+    @Test
+    fun whenReadFlagOnAndDdgLegacyFailsThenRenderedAsPlaceholderNotLoggedOut() {
+        syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(enable = true))
+        val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
+        whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Error(reason = "primaryKey rotated?"))
+
+        val result = decryptor.decryptAll(listOf(ddg))
+
+        assertEquals(listOf(DecryptedDevice("d1", FALLBACK_NAME, null)), result.decrypted)
+        assertTrue(result.undecryptable.isEmpty())
+        verify(thirdPartyCredentialManager, never()).refresh()
+    }
+
+    @Test
+    fun whenReadFlagOnAnd3PartyLegacyFailsAfterFreshSpThenPlaceholderNotLoggedOut() {
+        syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(enable = true))
+        val tp = DeviceV2(deviceId = "d1", credentialId = "3party", deviceName = "ENC", deviceInfo = null)
+        whenever(fieldDecryptor.decrypt(tp)).thenReturn(Error(reason = "still bad"))
+        whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(true))
+
+        val result = decryptor.decryptAll(listOf(tp))
+
+        assertEquals(listOf(DecryptedDevice("d1", FALLBACK_NAME, FALLBACK_TYPE_3PARTY)), result.decrypted)
+        assertTrue(result.undecryptable.isEmpty())
+    }
+
+    @Test
+    fun whenReadFlagOnAndBothDeviceInfoAndLegacyFailThenRenderedAsPlaceholderNotLoggedOut() {
+        enableReadFlag()
+        val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "corrupt.jwe")
+        whenever(session.decrypt("corrupt.jwe")).thenReturn(Error(reason = "bad device_info"))
+        whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Error(reason = "bad legacy"))
+
+        val result = decryptor.decryptAll(listOf(ddg))
+
+        assertEquals(listOf(DecryptedDevice("d1", FALLBACK_NAME, null)), result.decrypted)
+        assertTrue(result.undecryptable.isEmpty())
     }
 }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -379,6 +379,9 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.canWriteUnifiedDeviceListToggle.quietlySetIsChecked(viewState.canWriteUnifiedDeviceListEnabled) { _, enabled ->
             viewModel.onCanWriteUnifiedDeviceListFlagChanged(enabled)
         }
+        binding.canReadUnifiedDeviceListToggle.quietlySetIsChecked(viewState.canReadUnifiedDeviceListEnabled) { _, enabled ->
+            viewModel.onCanReadUnifiedDeviceListFlagChanged(enabled)
+        }
         binding.migrationStatusTextView.text = viewState.migrationStatusText
         binding.migrationResultTextView.text = viewState.migrationResult
         if (viewState.isSignedIn) {

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -141,6 +141,7 @@ constructor(
         val renameDeviceResult: String = "",
         val fetchDecryptDevicesResult: String = "",
         val canWriteUnifiedDeviceListEnabled: Boolean = false,
+        val canReadUnifiedDeviceListEnabled: Boolean = false,
         val migrationStatusText: String = "",
         val migrationResult: String = "",
     )
@@ -334,6 +335,7 @@ constructor(
                 renameDeviceResult = if (accountInfo.isSignedIn) viewState.value.renameDeviceResult else "",
                 fetchDecryptDevicesResult = if (accountInfo.isSignedIn) viewState.value.fetchDecryptDevicesResult else "",
                 canWriteUnifiedDeviceListEnabled = syncFeature.canWriteUnifiedDeviceList().isEnabled(),
+                canReadUnifiedDeviceListEnabled = syncFeature.canReadUnifiedDeviceList().isEnabled(),
                 migrationStatusText = buildMigrationStatusText(),
                 migrationResult = if (accountInfo.isSignedIn) viewState.value.migrationResult else "",
             ),
@@ -790,6 +792,14 @@ constructor(
         viewModelScope.launch(dispatchers.io()) {
             logcat { "Sync-UnifiedDevices: setting canWriteUnifiedDeviceList flag = $enabled" }
             setRawToggleState(syncFeature.canWriteUnifiedDeviceList(), enabled)
+            updateViewState()
+        }
+    }
+
+    fun onCanReadUnifiedDeviceListFlagChanged(enabled: Boolean) {
+        viewModelScope.launch(dispatchers.io()) {
+            logcat { "Sync-UnifiedDevices: setting canReadUnifiedDeviceList flag = $enabled" }
+            setRawToggleState(syncFeature.canReadUnifiedDeviceList(), enabled)
             updateViewState()
         }
     }

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -260,6 +260,13 @@
             app:showSwitch="true"
             app:primaryText="canWriteUnifiedDeviceList" />
 
+        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+            android:id="@+id/canReadUnifiedDeviceListToggle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:showSwitch="true"
+            app:primaryText="canReadUnifiedDeviceList" />
+
         <com.duckduckgo.common.ui.view.text.DaxTextView
             android:id="@+id/migrationStatusTextView"
             android:layout_width="match_parent"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216792641477211?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/72649045549333/task/1215838110052947?focus=true
API Proposals URL(s) (if applicable):

### Description
Adds the `read` side of the unified device list, reading from `device_info` where it can and preferring that over the legacy device name/type.
Gated by sync feature flag: `canReadUnifiedDeviceList`. The logic is defined in [Define feature flag for unified device list support [ 2h ]](https://app.asana.com/1/137249556945/task/1216781918336697?focus=true) for when flag is enabled and disabled. When the flag is on, undecryptable devices are no longer logged out; they render as "Unknown device"

Adds in-memory cache of the wrapped account_info key entry in `RealAccountInfoPrivateKeyProvider`, as otherwise it's unnecessarily hammering the server and will get rate limited.

Pixels will come later.

### Steps to test this PR
> [!NOTE]
> Logcat filter: `Sync-UnifiedDevices`

**Setup**
- [ ] Fresh install `internal` build
- [ ] Launch `Sync Dev Settings` and tap `Create account` to quickly set up sync
- [ ] Find the "Unified Devices Migration" section in the dev screen and enable both `canReadUnifiedDeviceList` and `canWriteUnifiedDeviceList` toggles

**Device list reads from legacy when `device_info` omitted**
- [ ] Scroll to top and tap `Launch Sync Settings` to visit production `Sync & Backup` screen
- [ ] Verify you see a single device (your one), with its name rendering correctly
- [ ] Verify in logs: `0 via device_info, 1 via legacy`

**Device list reads from device_info if it's available**
- [ ] Go back to `Sync Dev Settings` and tap `Run migration now`, verifying that `migrated: true`
- [ ] Scroll to top and tap `Launch Sync Settings` to visit production `Sync & Backup` screen
- [ ] Verify in logs: `1 via device_info, 0 via legacy`

> [!WARNING]
> For the error handling scenarios, don't use this with your real sync setup as it could log other devices out

> [!NOTE]
> Sync with another device so that you have 2 devices connected. You're about to apply patches to one of them to test error handling.

**Error handling (device_info undecryptable)**
- [ ] Apply "[Patch A: device_info undecryptable](https://app.asana.com/1/137249556945/project/72649045549333/task/1217190449287765?focus=true)" to one device (let's call it DEVICE A), install and launch app
- [ ] Visit `Sync Dev Settings` and tap `Launch Sync Settings` to visit production `Sync & Backup` screen
- [ ] Verify in logs that `DEV forcing device_info undecryptable` to confirm the patch is working, and
- [ ] Verify in logs ` 0 via device_info, 2 via legacy`


**Error handling (legacy undecryptable)**
- [ ] Discard local changes (to get rid of first patch)
- [ ] Apply "[Patch B: legacy undecryptable](https://app.asana.com/1/137249556945/project/72649045549333/task/1217190449287766?focus=true)" to DEVICE A only, install and launch app
- [ ] Visit `Sync Dev Settings` and tap `Launch Sync Settings` to visit production `Sync & Backup` screen
- [ ] Verify in logs that `2 devices → 1 via device_info, 0 via legacy, 1 placeholder, 0 undecryptable`

**Error handling (legacy undecryptable with canRead FF off)**
- [ ] Still on DEVICE A (with the patch), disable `canReadUnifiedDeviceList`, then return to production device list. This will auto-logout the other device, so you'll see:
  - [ ] Verify in logs, first `2 devices → 0 via device_info, 1 via legacy, 0 placeholder, 1 undecryptable`
  - [ ] And then after a few seconds, `1 devices → 0 via device_info, 1 via legacy, 0 placeholder, 0 undecryptable`



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production device-list decryption and when peers are auto-logged out (flag-gated), plus sync key fetch caching; crypto paths are involved but plaintext keys are not cached and legacy behavior remains when the flag is off.
> 
> **Overview**
> Adds the **read** path for the unified device list behind **`canReadUnifiedDeviceList`**. When enabled, connected devices are decrypted from cross-credential **`device_info`** (one `DeviceInfoDecryptor` session per list) when present, with legacy name/type as fallback; when the flag is off, behavior stays on the legacy-only path.
> 
> With the read flag **on**, decrypt failures no longer feed **`undecryptable`** for auto-logout—devices show as **"Unknown device"** placeholders instead (flag off keeps the existing logout rules for confirmed corruption).
> 
> **`RealAccountInfoPrivateKeyProvider`** now caches only the **wrapped** `account_info` key per user+credential (single `GET /sync/keys` under burst reads), clears on sign-out, and still unwraps on every `privateKey()` call.
> 
> Internal Sync Dev Settings adds a **`canReadUnifiedDeviceList`** toggle alongside the write flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48da81b84adaf2c2f5a441ca6afdcf67407c7434. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->