### PR TITLE
Strip IME insets from browser WebView to prevent double padding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -4277,6 +4277,11 @@ class BrowserTabFragment :
                 setAlgorithmicDarkeningAllowed(this)
             }
 
+            lifecycleScope.launch {
+                val stripImeInsets = withContext(dispatchers.io()) { androidBrowserConfigFeature.stripWebViewImeInsets().isEnabled() }
+                it.setStripImeInsetsEnabled(stripImeInsets)
+            }
+
             it.setDownloadListener { url, _, contentDisposition, mimeType, _ ->
                 lifecycleScope.launch(dispatchers.main()) {
                     viewModel.requestFileDownload(it, url, contentDisposition, mimeType, true, isBlobDownloadWebViewFeatureEnabled(it))

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -23,6 +23,7 @@ import android.print.PrintDocumentAdapter
 import android.util.AttributeSet
 import android.util.SparseArray
 import android.view.MotionEvent
+import android.view.WindowInsets
 import android.view.autofill.AutofillValue
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
@@ -32,9 +33,11 @@ import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.core.graphics.Insets
 import androidx.core.view.NestedScrollingChild3
 import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.webkit.JavaScriptReplyProxy
 import androidx.webkit.ScriptHandler
 import androidx.webkit.WebViewCompat
@@ -80,6 +83,7 @@ class DuckDuckGoWebView :
 
     private var isDestroyed: Boolean = false
     private var isSafeWebViewEnabled: Boolean = true
+    private var stripImeInsetsEnabled: Boolean = false
 
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
@@ -99,6 +103,24 @@ class DuckDuckGoWebView :
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
         helper.onViewAttached(this)
+    }
+
+    override fun onApplyWindowInsets(insets: WindowInsets): WindowInsets {
+        val adjustedInsets = if (stripImeInsetsEnabled) stripImeInsets(insets) else insets
+        return super.onApplyWindowInsets(adjustedInsets)
+    }
+
+    // Zero any IME inset passed to the WebView to avoid double-padding if the IME padding is handled by the surrounding layout.
+    // Reference https://developer.android.com/develop/ui/views/layout/webapps/understand-window-insets
+    private fun stripImeInsets(insets: WindowInsets): WindowInsets {
+        val windowInsetsCompat = WindowInsetsCompat.toWindowInsetsCompat(insets, this)
+
+        if (windowInsetsCompat.getInsets(WindowInsetsCompat.Type.ime()) == Insets.NONE) return insets
+
+        return WindowInsetsCompat.Builder(windowInsetsCompat)
+            .setInsets(WindowInsetsCompat.Type.ime(), Insets.NONE)
+            .build()
+            .toWindowInsets() ?: insets
     }
 
     override fun destroy() {
@@ -248,6 +270,15 @@ class DuckDuckGoWebView :
 
     fun setBottomMatchingBehaviourEnabled(value: Boolean) {
         helper.setBottomMatchingBehaviourEnabled(value)
+    }
+
+    /**
+     * Enable when the surrounding layout already resizes for the keyboard, so IME insets are
+     * zeroed out before reaching the WebView and it does not additionally shrink its visual
+     * viewport for them.
+     */
+    fun setStripImeInsetsEnabled(value: Boolean) {
+        stripImeInsetsEnabled = value
     }
 
     override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection? {

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -79,6 +79,13 @@ interface AndroidBrowserConfigFeature {
     fun cachedEntityLookup(): Toggle
 
     /**
+     * Zeroes IME insets before they reach the browser WebView, so the WebView does not additionally
+     * shrink its visual viewport for a keyboard the browser layout already resizes for.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun stripWebViewImeInsets(): Toggle
+
+    /**
      * @return `true` when the remote config has the global "errorPagePixel" androidBrowserConfig
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `true`


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205617573940217/task/1217145253883158?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

Since WebView M139, the WebView shrinks its visual viewport by any IME inset it receives. Our layout already resizes for the keyboard, so during IME entry both mechanisms briefly apply at once, transiently collapsing the visual viewport. This was confirmed to cause breakage on gemini.google.com, where collapsing the visual viewport clears composer focus and hides the on-screen keyboard, making it nearly impossible to use the site.

Fix: zero out `ime()` insets before they reach the browser WebView, as recommended in [Google's WebView insets guidance](https://developer.android.com/develop/ui/views/layout/webapps/understand-window-insets).

### Steps to test this PR

_Keyboard stays open on Gemini_
- [x] Navigate to https://gemini.google.com in the browser
- [x] Tap the message composer
- [x] Verify the keyboard opens and stays open (before this fix it dismissed itself within ~100ms)
- [x] Dismiss the keyboard and repeat the test a couple of times

_Kill switch_
- [x] Disable `androidBrowserConfig` > `stripWebViewImeInsets` in internal feature flag settings
- [x] Restart the app
- [x] Navigate to https://gemini.google.com
- [x] Tap the message composer
- [x] Verify the keyboard dismisses itself almost immediately after being shown
- [x] If the keyboard didn't dismiss itself (may happen occasionally), dismiss it and test again. 

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes keyboard and viewport behavior for all in-app browsing when enabled; mitigated by a remote kill switch and a narrow inset adjustment.
> 
> **Overview**
> Fixes keyboard dismissal and visual viewport collapse on sites like Gemini when **WebView M139** shrinks the visual viewport for IME insets while the browser layout already resizes for the keyboard.
> 
> **`DuckDuckGoWebView`** now optionally zeros **`ime()`** insets in **`onApplyWindowInsets`** before they reach the WebView, following Android’s WebView inset guidance. **`BrowserTabFragment`** enables this via **`setStripImeInsetsEnabled`** after reading **`androidBrowserConfig.stripWebViewImeInsets`** (defaults **on**). Disabling the flag restores the old double-padding behavior for verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77eed6094894bde4b269ff7c339b4a18c983d25a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->