### PR TITLE
Update content scope scripts to version 16.1.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -9786,6 +9786,14 @@
     );
     if (typeof detail.kind !== "string") throw new Error("custom event requires detail.kind to be a string");
   }
+  function holdDurationBucket(elapsedMs) {
+    const seconds = elapsedMs / 1e3;
+    if (seconds < 1) return "0-1";
+    if (seconds < 5) return "1-5";
+    if (seconds < 10) return "5-10";
+    if (seconds < 30) return "10-30";
+    return "30+";
+  }
   var Pixel = class {
     /**
      * A list of known pixels
@@ -9793,7 +9801,8 @@
      *   | {name: "play.use", remember: "0" | "1"}
      *   | {name: "play.use.thumbnail"}
      *   | {name: "play.do_not_use", remember: "0" | "1"}
-     *   | {name: "play.do_not_use.dismiss"}} input
+     *   | {name: "play.do_not_use.dismiss"}
+     *   | {name: "buffering.hold_removed", reason: import('./buffering-hold.js').HoldRemovalReason, elapsedMs: number, timedOut: boolean}} input
      */
     constructor(input) {
       this.input = input;
@@ -9813,6 +9822,12 @@
         }
         case "play.do_not_use.dismiss":
           return {};
+        case "buffering.hold_removed":
+          return {
+            reason: this.input.reason,
+            duration: holdDurationBucket(this.input.elapsedMs),
+            timed_out: this.input.timedOut ? "1" : "0"
+          };
         default:
           throw new Error("unreachable");
       }
@@ -9833,50 +9848,6 @@
 
   // src/features/duckplayer/util.js
   init_define_import_meta_trackerLookup();
-  function appendImageAsBackground(parent, targetSelector, imageUrl) {
-    const canceled = false;
-    fetch(imageUrl, { method: "HEAD" }).then((x2) => {
-      const status = String(x2.status);
-      if (canceled) return console.warn("not adding image, cancelled");
-      if (status.startsWith("2")) {
-        if (!canceled) {
-          append();
-        } else {
-          console.warn("ignoring cancelled load");
-        }
-      } else {
-        markError();
-      }
-    }).catch(() => {
-      console.error("e from fetch");
-    });
-    function markError() {
-      parent.dataset.thumbLoaded = String(false);
-      parent.dataset.error = String(true);
-    }
-    function append() {
-      const targetElement = parent.querySelector(targetSelector);
-      if (!(targetElement instanceof HTMLElement)) {
-        return console.warn("could not find child with selector", targetSelector, "from", parent);
-      }
-      parent.dataset.thumbLoaded = String(true);
-      parent.dataset.thumbSrc = imageUrl;
-      const img = new Image();
-      img.src = imageUrl;
-      img.onload = function() {
-        if (canceled) return console.warn("not adding image, cancelled");
-        targetElement.style.backgroundImage = `url(${imageUrl})`;
-        targetElement.style.backgroundSize = "cover";
-      };
-      img.onerror = function() {
-        if (canceled) return console.warn("not calling markError, cancelled");
-        markError();
-        const targetElement2 = parent.querySelector(targetSelector);
-        if (!(targetElement2 instanceof HTMLElement)) return;
-        targetElement2.style.backgroundImage = "";
-      };
-    }
-  }
   var SideEffects = class {
     /**
      * @param {object} params
@@ -10718,6 +10689,66 @@
   // src/features/duckplayer/video-overlay.js
   init_define_import_meta_trackerLookup();
 
+  // src/features/duckplayer/poster.js
+  init_define_import_meta_trackerLookup();
+  async function paintFirstUsablePoster(target, candidates, { signal, onResult } = {}) {
+    const probes = candidates.map((candidate) => {
+      const url = safePosterUrl(candidate.url);
+      return url ? probe(url, candidate.verify, signal) : Promise.resolve(null);
+    });
+    for (const pending of probes) {
+      const url = await pending;
+      if (signal?.aborted) return;
+      if (!url) continue;
+      target.style.backgroundImage = `url("${url}")`;
+      target.style.backgroundSize = "cover";
+      return onResult?.(url);
+    }
+    if (!signal?.aborted) onResult?.(null);
+  }
+  async function probe(url, verify, signal) {
+    if (verify && !await headIsOk(url, signal)) return null;
+    if (!await imageLoads(url)) return null;
+    return url;
+  }
+  async function headIsOk(url, signal) {
+    try {
+      return (await fetch(url, { method: "HEAD", signal })).ok;
+    } catch {
+      return false;
+    }
+  }
+  function imageLoads(url) {
+    return new Promise((resolve) => {
+      const img = new Image();
+      img.onload = () => resolve(true);
+      img.onerror = () => resolve(false);
+      img.src = url;
+    });
+  }
+  function safePosterUrl(url) {
+    try {
+      const parsed = new URL2(url, window.location.href);
+      if (parsed.protocol !== "https:") return null;
+      return parsed.href;
+    } catch {
+      return null;
+    }
+  }
+  function appendImageAsBackground(parent, targetSelector, imageUrl) {
+    const target = parent.querySelector(targetSelector);
+    if (!(target instanceof HTMLElement)) {
+      return console.warn("could not find child with selector", targetSelector, "from", parent);
+    }
+    void paintFirstUsablePoster(target, [{ url: imageUrl, verify: true }], {
+      onResult: (paintedUrl) => {
+        parent.dataset.thumbLoaded = String(Boolean(paintedUrl));
+        if (paintedUrl) parent.dataset.thumbSrc = paintedUrl;
+        else parent.dataset.error = String(true);
+      }
+    });
+  }
+
   // src/features/duckplayer/components/ddg-video-overlay.js
   init_define_import_meta_trackerLookup();
 
@@ -11032,6 +11063,156 @@
     background-position: center center;
     background-repeat: no-repeat;
 }
+
+/* -- BUFFERING SPINNER, reproducing YouTube's Material "linspin" so it reads as the player's own */
+.ddg-vpo-spinner {
+    --ddg-vpo-spinner-size: 48px;
+    --ddg-vpo-spinner-border: 4px;
+    --ddg-vpo-spinner-color: #dddddd;
+    display: none;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: var(--ddg-vpo-spinner-size);
+    height: var(--ddg-vpo-spinner-size);
+    margin: calc(var(--ddg-vpo-spinner-size) / -2) 0 0 calc(var(--ddg-vpo-spinner-size) / -2);
+    pointer-events: none;
+}
+@media screen and (min-width: 430px) {
+    .ddg-vpo-spinner {
+        --ddg-vpo-spinner-size: 64px;
+        --ddg-vpo-spinner-border: 6px;
+    }
+}
+
+.ddg-video-player-overlay.loading .logo {
+    display: none;
+}
+.ddg-video-player-overlay.loading.spinning .ddg-vpo-spinner {
+    display: block;
+}
+
+.ddg-vpo-spinner__container {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    animation: ddg-vpo-linspin 1.5682s linear infinite;
+}
+
+.ddg-vpo-spinner__rotator {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    animation: ddg-vpo-easespin 5.332s cubic-bezier(0.4, 0, 0.2, 1) infinite both;
+}
+
+.ddg-vpo-spinner__left,
+.ddg-vpo-spinner__right {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+}
+.ddg-vpo-spinner__left {
+    right: 49%;
+}
+.ddg-vpo-spinner__right {
+    left: 49%;
+}
+
+.ddg-vpo-spinner__circle {
+    box-sizing: border-box;
+    position: absolute;
+    width: 200%;
+    height: 100%;
+    border-style: solid;
+    border-width: var(--ddg-vpo-spinner-border);
+    border-color: var(--ddg-vpo-spinner-color) var(--ddg-vpo-spinner-color) transparent;
+    border-radius: 50%;
+}
+.ddg-vpo-spinner__left .ddg-vpo-spinner__circle {
+    left: 0;
+    right: -100%;
+    border-right-color: transparent;
+    animation: ddg-vpo-left-spin 1.333s cubic-bezier(0.4, 0, 0.2, 1) infinite both;
+}
+.ddg-vpo-spinner__right .ddg-vpo-spinner__circle {
+    left: -100%;
+    right: 0;
+    border-left-color: transparent;
+    animation: ddg-vpo-right-spin 1.333s cubic-bezier(0.4, 0, 0.2, 1) infinite both;
+}
+
+@keyframes ddg-vpo-linspin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+@keyframes ddg-vpo-easespin {
+    12.5% {
+        transform: rotate(135deg);
+    }
+    25% {
+        transform: rotate(270deg);
+    }
+    37.5% {
+        transform: rotate(405deg);
+    }
+    50% {
+        transform: rotate(540deg);
+    }
+    62.5% {
+        transform: rotate(675deg);
+    }
+    75% {
+        transform: rotate(810deg);
+    }
+    87.5% {
+        transform: rotate(945deg);
+    }
+    100% {
+        transform: rotate(1080deg);
+    }
+}
+@keyframes ddg-vpo-left-spin {
+    0% {
+        transform: rotate(130deg);
+    }
+    50% {
+        transform: rotate(-5deg);
+    }
+    100% {
+        transform: rotate(130deg);
+    }
+}
+@keyframes ddg-vpo-right-spin {
+    0% {
+        transform: rotate(-130deg);
+    }
+    50% {
+        transform: rotate(5deg);
+    }
+    100% {
+        transform: rotate(-130deg);
+    }
+}
+
+/* Reduced motion: drop the multi-phase arc sweep for a single gentle rotation */
+@media (prefers-reduced-motion: reduce) {
+    .ddg-vpo-spinner__container {
+        animation-duration: 1.4s;
+    }
+    .ddg-vpo-spinner__rotator {
+        animation: none;
+    }
+    .ddg-vpo-spinner__left .ddg-vpo-spinner__circle {
+        animation: none;
+        transform: rotate(130deg);
+    }
+    .ddg-vpo-spinner__right .ddg-vpo-spinner__circle {
+        animation: none;
+        transform: rotate(-130deg);
+    }
+}
 `;
 
   // src/features/duckplayer/components/ddg-video-thumbnail-overlay-mobile.js
@@ -11041,9 +11222,17 @@
       __publicField(this, "policy", createPolicy());
       /** @type {boolean} */
       __publicField(this, "testMode", false);
+      /** @type {AbortController | null} */
+      __publicField(this, "posterLoad", null);
+    }
+    get overlay() {
+      return this.container?.querySelector(".ddg-video-player-overlay");
     }
     connectedCallback() {
       this.createMarkupAndStyles();
+    }
+    disconnectedCallback() {
+      this.posterLoad?.abort();
     }
     createMarkupAndStyles() {
       const shadow = this.attachShadow({ mode: this.testMode ? "open" : "closed" });
@@ -11063,8 +11252,48 @@
             <div class="ddg-video-player-overlay">
                 <div class="bg ddg-vpo-bg"></div>
                 <div class="logo"></div>
+                <div class="ddg-vpo-spinner" aria-hidden="true">
+                    <div class="ddg-vpo-spinner__container">
+                        <div class="ddg-vpo-spinner__rotator">
+                            <div class="ddg-vpo-spinner__left"><div class="ddg-vpo-spinner__circle"></div></div>
+                            <div class="ddg-vpo-spinner__right"><div class="ddg-vpo-spinner__circle"></div></div>
+                        </div>
+                    </div>
+                </div>
             </div>
         `.toString();
+    }
+    /**
+     * Enter the buffering hold: drop the play logo, since Duck Player has been
+     * declined and the overlay is now only standing in for the player's own startup.
+     */
+    showLoadingState() {
+      this.overlay?.classList.add("loading");
+    }
+    showSpinner() {
+      this.overlay?.classList.add("spinning");
+    }
+    /**
+     * Withdraw the spinner but keep the poster, so a video that never arrives settles on
+     * a still frame instead of the black frame the hold exists to cover.
+     */
+    hideSpinner() {
+      this.overlay?.classList.remove("spinning");
+    }
+    /**
+     * Paint a poster behind the spinner, cancelling the walk if the overlay goes away first.
+     * @param {PosterCandidate[]} candidates
+     */
+    setPosterCandidates(candidates) {
+      const bg = this.container?.querySelector(".ddg-vpo-bg");
+      if (!(bg instanceof HTMLElement)) return;
+      const controller = new AbortController();
+      this.posterLoad = controller;
+      void paintFirstUsablePoster(
+        bg,
+        candidates.map(({ url, source }) => ({ url, verify: source === "ytimg" })),
+        { signal: controller.signal }
+      );
     }
   };
   __publicField(DDGVideoThumbnailOverlay, "CUSTOM_TAG_NAME", "ddg-video-thumbnail-overlay-mobile");
@@ -11264,7 +11493,60 @@
   __publicField(_DDGVideoDrawerMobile, "DID_EXIT", "did-exit");
   var DDGVideoDrawerMobile = _DDGVideoDrawerMobile;
 
+  // src/features/duckplayer/buffering-hold.js
+  init_define_import_meta_trackerLookup();
+  var MEDIA_EVENTS = ["playing", "timeupdate", "error"];
+  var DEFAULT_SPINNER_DELAY_MS = 500;
+  var DEFAULT_SPINNER_TIMEOUT_MS = 6e4;
+  function holdUntilFirstFrame({ container, video, overlay, timings, onReport }) {
+    const { spinnerDelayMs = DEFAULT_SPINNER_DELAY_MS, spinnerTimeoutMs = DEFAULT_SPINNER_TIMEOUT_MS } = timings;
+    const startedAt = performance.now();
+    let stopped = false;
+    let timedOut = false;
+    const spinnerDelayTimer = setTimeout(() => overlay.showSpinner(), spinnerDelayMs);
+    const spinnerTimeoutTimer = setTimeout(() => {
+      timedOut = true;
+      overlay.hideSpinner();
+    }, spinnerTimeoutMs);
+    const onMediaEvent = (e) => {
+      const el = e.target;
+      if (!(el instanceof HTMLVideoElement)) return;
+      if (e.type === "error") return stop("error");
+      if (el.currentTime > 0 && !el.paused) stop("frame");
+    };
+    const stop = (reason) => {
+      if (stopped) return;
+      stopped = true;
+      clearTimeout(spinnerDelayTimer);
+      clearTimeout(spinnerTimeoutTimer);
+      for (const type of MEDIA_EVENTS) {
+        container.removeEventListener(type, onMediaEvent, { capture: true });
+      }
+      overlay.remove();
+      onReport(reason, performance.now() - startedAt, timedOut);
+    };
+    for (const type of MEDIA_EVENTS) {
+      container.addEventListener(type, onMediaEvent, { capture: true });
+    }
+    if (typeof video.requestVideoFrameCallback === "function") {
+      video.requestVideoFrameCallback(() => {
+        if (video.isConnected) stop("frame");
+      });
+    }
+    overlay.addEventListener("pointerdown", (e) => e.stopPropagation());
+    overlay.addEventListener("click", (e) => {
+      e.stopPropagation();
+      if (timedOut) stop("tap_after_timeout");
+    });
+    return { stop };
+  }
+
   // src/features/duckplayer/video-overlay.js
+  var OVERLAY_SELECTOR = [
+    DDGVideoOverlayMobile.CUSTOM_TAG_NAME,
+    DDGVideoThumbnailOverlay.CUSTOM_TAG_NAME,
+    DDGVideoDrawerMobile.CUSTOM_TAG_NAME
+  ].join(", ");
   var VideoOverlay = class {
     /**
      * @param {object} options
@@ -11280,6 +11562,8 @@
       __publicField(this, "lastVideoId", null);
       /** @type {boolean} */
       __publicField(this, "didAllowFirstVideo", false);
+      /** @type {'classic' | 'drawer' | null} */
+      __publicField(this, "appendedMobileVariant", null);
       this.userValues = userValues;
       this.settings = settings;
       this.environment = environment;
@@ -11408,12 +11692,19 @@
     shouldShowDrawerVariant() {
       return this.settings.videoDrawer?.state === "enabled" && this.settings.selectors.drawerContainer;
     }
+    bufferingFeedbackEnabled() {
+      return this.settings.bufferingFeedback?.state === "enabled";
+    }
+    fullscreenGuardEnabled() {
+      return this.settings.fullscreenGuard?.state === "enabled";
+    }
     /**
      * @param {Element} targetElement
      * @param {import("./util").VideoParams} params
      */
     appendMobileOverlay(targetElement, params) {
       this.messages.sendPixel(new Pixel({ name: "overlay" }));
+      this.appendedMobileVariant = "classic";
       this.sideEffects.add(`appending ${DDGVideoOverlayMobile.CUSTOM_TAG_NAME} to the page`, () => {
         const elem = (
           /** @type {DDGVideoOverlayMobile} */
@@ -11433,6 +11724,7 @@
           document.querySelector(DDGVideoOverlayMobile.CUSTOM_TAG_NAME)?.remove();
         };
       });
+      this.keepOverlayOutOfFullscreen();
     }
     /**
      * @param {Element} targetElement
@@ -11441,6 +11733,7 @@
      */
     appendMobileDrawer(targetElement, drawerTargetElement, params) {
       this.messages.sendPixel(new Pixel({ name: "overlay" }));
+      this.appendedMobileVariant = "drawer";
       this.sideEffects.add(
         `appending ${DDGVideoDrawerMobile.CUSTOM_TAG_NAME} and ${DDGVideoThumbnailOverlay.CUSTOM_TAG_NAME} to the page`,
         () => {
@@ -11481,6 +11774,7 @@
           };
         }
       );
+      this.keepOverlayOutOfFullscreen();
     }
     /**
      * @param {Element} targetElement
@@ -11499,6 +11793,27 @@
         return () => {
           document.querySelector(DDGVideoOverlay.CUSTOM_TAG_NAME)?.remove();
         };
+      });
+    }
+    /**
+     * A scroll gesture can fullscreen YouTube's player container. Our overlays sit inside
+     * `#movie_player` and stretch to the screen, but `#player-control-container` is outside
+     * that stacking context and hit-tests above them, so every tap lands on YouTube with no
+     * chrome left to escape to. Call this after appending, so the first check sees the overlay.
+     */
+    keepOverlayOutOfFullscreen() {
+      if (!this.fullscreenGuardEnabled()) return;
+      if (this.environment.platform.name !== "android") return;
+      this.sideEffects.add("leaving fullscreen while an overlay is showing", () => {
+        const onChange = () => {
+          if (!document.fullscreenElement) return;
+          if (!document.querySelector(OVERLAY_SELECTOR)) return;
+          Promise.resolve(document.exitFullscreen?.()).catch(() => {
+          });
+        };
+        document.addEventListener("fullscreenchange", onChange);
+        onChange();
+        return () => document.removeEventListener("fullscreenchange", onChange);
       });
     }
     /**
@@ -11609,7 +11924,9 @@
       const pixel = remember ? new Pixel({ name: "play.do_not_use", remember: "1" }) : new Pixel({ name: "play.do_not_use", remember: "0" });
       this.messages.sendPixel(pixel);
       if (!remember) {
-        return this.destroy();
+        this.destroy();
+        this.showBufferingFeedbackUntilFirstFrame();
+        return;
       }
       const next = {
         privatePlayerMode: { disabled: {} },
@@ -11624,6 +11941,64 @@
         console.log("user values response:", updatedValues);
       }
       this.destroy();
+    }
+    /**
+     * After opt-out the <video> can take many seconds to present its first frame, and
+     * YouTube paints nothing over the black player while it waits. Cover the player with
+     * the video's poster and a YouTube-style spinner until the first frame lands.
+     */
+    showBufferingFeedbackUntilFirstFrame() {
+      if (!this.bufferingFeedbackEnabled()) return;
+      if (this.appendedMobileVariant === "drawer") return;
+      const video = (
+        /** @type {HTMLVideoElement | null} */
+        document.querySelector(this.settings.selectors.videoElement)
+      );
+      const container = document.querySelector(this.settings.selectors.videoElementContainer);
+      if (!video?.isConnected || !container) return;
+      if (document.querySelector(DDGVideoThumbnailOverlay.CUSTOM_TAG_NAME)) return;
+      const { spinnerDelayMs, spinnerTimeoutMs } = this.settings.bufferingFeedback ?? {};
+      this.sideEffects.add("holding poster + spinner until first video frame", () => {
+        const overlay = (
+          /** @type {DDGVideoThumbnailOverlay} */
+          document.createElement(DDGVideoThumbnailOverlay.CUSTOM_TAG_NAME)
+        );
+        overlay.testMode = this.environment.isTestMode();
+        container.appendChild(overlay);
+        overlay.setPosterCandidates(this.buildPosterCandidates(video));
+        overlay.showLoadingState();
+        const hold = holdUntilFirstFrame({
+          container,
+          video,
+          overlay,
+          timings: { spinnerDelayMs, spinnerTimeoutMs },
+          onReport: (reason, elapsedMs, timedOut) => {
+            this.messages.sendPixel(new Pixel({ name: "buffering.hold_removed", reason, elapsedMs, timedOut }));
+          }
+        });
+        return () => hold.stop("torn_down");
+      });
+      this.keepOverlayOutOfFullscreen();
+    }
+    /**
+     * Poster candidates for the buffering hold, cheapest source first.
+     * @param {HTMLVideoElement} video
+     * @returns {import('./poster.js').PosterCandidate[]}
+     */
+    buildPosterCandidates(video) {
+      const candidates = [];
+      if (video?.poster) candidates.push({ url: video.poster, source: "page" });
+      const cued = document.querySelector(".ytp-cued-thumbnail-overlay-image, .ytp-cued-thumbnail-overlay");
+      if (cued) {
+        const match = getComputedStyle(cued).backgroundImage.match(/url\(["']?(.*?)["']?\)/);
+        if (match?.[1]) candidates.push({ url: match[1], source: "page" });
+      }
+      const params = VideoParams.forWatchPage(this.environment.getPlayerPageHref());
+      if (params) {
+        candidates.push({ url: this.environment.getLargeThumbnailSrc(params.id), source: "ytimg" });
+        candidates.push({ url: new URL(`/vi/${params.id}/hqdefault.jpg`, "https://i.ytimg.com").href, source: "ytimg" });
+      }
+      return candidates;
     }
     dismissOverlay() {
       const pixel = new Pixel({ name: "play.do_not_use.dismiss" });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^16.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.23.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.1.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "16.19.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.19.0.tgz",
-      "integrity": "sha512-lKScoBgF+YwNvTqu87g6lZS7LWlw62jNvjpyG0XFYxWJ8YBkm1Lmou3zAg02SVyBydN8wx5Hmo+6DusNn4euKQ==",
+      "version": "16.20.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.20.0.tgz",
+      "integrity": "sha512-gundZngHdnf3ak8pAkBPYZs/NN903VCmZzXqfnQOdQpCskwNm/f+JM3iwmJkPHuGNvynWBMoBoUvuU+vTamq0A==",
       "license": "MPL-2.0",
       "dependencies": {
         "tldts-experimental": "^7.4.3"
@@ -61,7 +61,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#2b57f4b72186080efade861494eef5ad6f3853a1",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#340b98699b05e7fe7b0fceacede622129e190d38",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -575,9 +575,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
-      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+      "version": "5.49.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.1.tgz",
+      "integrity": "sha512-7A2xlQ5EnGT8KPA92dUh6RbRYTVw8hEaEN9L1K68l4UOXFuV511NnAqObGoRqGOQofQcMypisu1s3xawCEHrvA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^16.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.23.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.1.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217186956585525

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [x] All tests must pass
- [x] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible YouTube Duck Player overlay, fullscreen, and post-opt-out playback UX on Android via injected scripts; no native app code changes but behavior on a high-traffic surface.
> 
> **Overview**
> Bumps **`@duckduckgo/content-scope-scripts`** from **15.23.0** to **16.1.0** (with matching **`package-lock.json`** updates, including minor transitive bumps). The Android **`contentScope.js`** bundle reflects new Duck Player behavior shipped in that release.
> 
> **Duck Player (mobile / Android)** now covers the black startup gap after a user **opts out** of Duck Player without “remember”: a thumbnail overlay shows a **poster** (refactored **`paintFirstUsablePoster`** probing with HTTPS checks and optional HEAD verification) and, after a delay, a **YouTube-style buffering spinner** until the first video frame (**`holdUntilFirstFrame`**), with timeout and tap-after-timeout handling. Analytics add **`buffering.hold_removed`** with reason, duration bucket, and timed-out flag.
> 
> On Android, while overlays are visible, a **fullscreen guard** exits fullscreen so taps aren’t trapped under YouTube’s controls. Drawer variant skips the post-opt-out buffering hold; classic mobile overlay tracks **`appendedMobileVariant`** for that logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 017c0fe67e77a89de1a7189918ca90ea2280ede9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->