### PR TITLE
EdgeToEdge: Fix Bookmark edit, Bookmark new folder and PDF viewer screens

### DIFF
--- a/android-design-system/design-system/src/main/res/layout/include_default_toolbar.xml
+++ b/android-design-system/design-system/src/main/res/layout/include_default_toolbar.xml
@@ -22,6 +22,7 @@
     android:id="@+id/appBarLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?attr/daxColorToolbar"
     android:outlineProvider="none"
     android:theme="@style/Widget.DuckDuckGo.ToolbarTheme">
 

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfViewerActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfViewerActivity.kt
@@ -37,6 +37,9 @@ import com.duckduckgo.browser.api.ui.BrowserScreens.PdfViewerActivityParams
 import com.duckduckgo.browser.api.ui.BrowserScreens.PdfViewerSource
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.getActivityParams
 import javax.inject.Inject
@@ -48,14 +51,27 @@ class PdfViewerActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var pixel: Pixel
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityPdfViewerBinding by viewBinding()
 
     private lateinit var source: PdfViewerSource
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.MISC)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
         // Default inset is too wide between the back arrow and title on this screen.
         binding.includeToolbar.toolbar.contentInsetStartWithNavigation =
             TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 16f, resources.displayMetrics).toInt()
@@ -106,6 +122,12 @@ class PdfViewerActivity : DuckDuckGoActivity() {
                 }
             },
         )
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.pdfViewerContainer)
     }
 
     private fun showFullFileNameOnTitleTap(toolbar: Toolbar, fileName: String) {

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/dialogs/AddBookmarkFolderDialogFragment.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/dialogs/AddBookmarkFolderDialogFragment.kt
@@ -18,10 +18,13 @@ package com.duckduckgo.savedsites.impl.dialogs
 
 import android.os.Bundle
 import android.view.View
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.saved.sites.impl.R
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import java.util.*
 
+@InjectWith(FragmentScope::class)
 class AddBookmarkFolderDialogFragment : SavedSiteDialogFragment() {
 
     interface AddBookmarkFolderListener {

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/dialogs/EditBookmarkFolderDialogFragment.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/dialogs/EditBookmarkFolderDialogFragment.kt
@@ -19,11 +19,14 @@ package com.duckduckgo.savedsites.impl.dialogs
 import android.os.Bundle
 import android.view.View
 import androidx.core.text.toSpannable
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.saved.sites.impl.R
 import com.duckduckgo.saved.sites.impl.R.plurals
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.impl.folders.BookmarkFoldersActivity
 
+@InjectWith(FragmentScope::class)
 class EditBookmarkFolderDialogFragment : SavedSiteDialogFragment() {
 
     interface EditBookmarkFolderListener {

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/dialogs/EditSavedSiteDialogFragment.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/dialogs/EditSavedSiteDialogFragment.kt
@@ -20,18 +20,21 @@ import android.os.Bundle
 import android.text.Editable
 import android.text.Spanned
 import android.view.View
+import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.view.listitem.DaxListItem.ImageBackground.Circular
 import com.duckduckgo.common.ui.view.quietlySetIsChecked
 import com.duckduckgo.common.ui.view.text.DaxTextInput
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.common.utils.text.TextChangedWatcher
+import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.saved.sites.impl.R
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
 
+@InjectWith(FragmentScope::class)
 class EditSavedSiteDialogFragment : SavedSiteDialogFragment() {
 
     interface EditSavedSiteListener {

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/dialogs/SavedSiteDialogFragment.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/dialogs/SavedSiteDialogFragment.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.savedsites.impl.dialogs
 
 import android.app.Dialog
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
@@ -27,12 +28,16 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.WindowCompat
 import androidx.fragment.app.DialogFragment
 import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
 import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.showKeyboard
 import com.duckduckgo.common.ui.view.text.DaxTextInput
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.common.utils.text.TextChangedWatcher
 import com.duckduckgo.saved.sites.impl.R
 import com.duckduckgo.saved.sites.impl.databinding.DialogFragmentSavedSiteBinding
@@ -41,9 +46,24 @@ import com.duckduckgo.savedsites.impl.folders.BookmarkFoldersActivity
 import com.duckduckgo.savedsites.impl.folders.BookmarkFoldersActivity.Companion.KEY_BOOKMARK_FOLDER_ID
 import com.duckduckgo.savedsites.impl.folders.BookmarkFoldersActivity.Companion.KEY_BOOKMARK_FOLDER_NAME
 import com.duckduckgo.savedsites.impl.folders.BookmarkFoldersActivity.Companion.KEY_CURRENT_FOLDER
+import dagger.android.support.AndroidSupportInjection
+import dev.zacsweers.metro.HasMemberInjections
+import javax.inject.Inject
 import com.duckduckgo.mobile.android.R as CommonR
 
+@HasMemberInjections
 abstract class SavedSiteDialogFragment : DialogFragment() {
+
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
 
     abstract fun onConfirmation()
     abstract fun configureUI()
@@ -106,7 +126,17 @@ abstract class SavedSiteDialogFragment : DialogFragment() {
         initialParentFolderId = arguments?.getString(EditBookmarkFolderDialogFragment.KEY_PARENT_FOLDER_ID)
         addTextWatchers()
         showKeyboard(binding.titleInput)
+        if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.MISC)) {
+            configureEdgeToEdgeInsets()
+        }
         return binding.root
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        dialog?.window?.let { WindowCompat.setDecorFitsSystemWindows(it, false) }
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.savedSiteAppBar.appBarLayout)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.savedSiteContent)
     }
 
     private fun addTextWatchers() {

--- a/saved-sites/saved-sites-impl/src/main/res/layout/dialog_fragment_saved_site.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/layout/dialog_fragment_saved_site.xml
@@ -25,6 +25,7 @@
         layout="@layout/include_default_toolbar" />
 
     <ScrollView
+        android:id="@+id/savedSiteContent"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fillViewport="true">


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1217181833384068?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Fixes broken edge-to-edge rendering on three screens under targetSdk 36, where content previously drew under the system bars. Each opts into edge-to-edge and applies window insets following the established EdgeToEdgeBucket.MISC gated pattern.

  - External PDF viewer (PdfViewerActivity): enables transparent edge-to-edge and applies horizontal, status-bar, and navigation-bar insets to the toolbar and PDF container.
  - Bookmark edit, add-folder, and edit-folder dialogs (SavedSiteDialogFragment): the full-screen dialog has its own window that the host activity's edge-to-edge doesn't reach, so it now opts in via
  setDecorFitsSystemWindows(false) and pads the toolbar and scroll content (including for the IME).
  - Adds DI to the shared dialog base and @InjectWith(FragmentScope::class) to the three concrete dialogs so the inset handling is wired up.
  - All changes are gated on the edgeToEdge misc toggle (enabled by default).


### Steps to test this PR

- [x] Add Bookmark
- [x] Open Menu > Bookmark
- [x] Select menu for the bookmarked item
- [x] Verify that screen looks visually correct
- [x] Go back and select the Add folder
- [x] Verify that screen looks visually correct
- [x] Open a PDF with the DDG debug app
- [x] Verify that screen looks visually correct

### UI changes
 | Before | After | 
  |---|---|
  |<img width="344" height="738" alt="Screenshot 2026-08-05 at 14 11 39" src="https://github.com/user-attachments/assets/49701486-3cab-4bef-8d0e-22e9a37beb9c" /> | <img width="352" height="729" alt="Screenshot 2026-08-05 at 14 13 45" src="https://github.com/user-attachments/assets/ddfc006a-875b-4fab-8f83-d3c15872889b" /> | 
  | <img width="351" height="734" alt="Screenshot 2026-08-05 at 14 12 07" src="https://github.com/user-attachments/assets/f5583813-7cc2-4cd1-a33a-652a3e34201e" /> | <img width="351" height="732" alt="Screenshot 2026-08-05 at 14 14 11" src="https://github.com/user-attachments/assets/1c384649-fa9d-4133-8caf-f77c4c7078df" /> | 
  | <img width="353" height="730" alt="Screenshot 2026-08-05 at 14 12 43" src="https://github.com/user-attachments/assets/7be6a0ed-ac05-4c83-b65e-07b834b778b9" /> | <img width="351" height="742" alt="Screenshot 2026-08-05 at 14 14 42" src="https://github.com/user-attachments/assets/9c2d39c0-3348-4174-b3db-5e44e9dd06b1" /> | 









<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only inset and layout changes following existing edge-to-edge patterns; no auth, data, or business-logic changes.
> 
> **Overview**
> Fixes **edge-to-edge** layout on the external PDF viewer and full-screen bookmark dialogs so content no longer sits under the status and navigation bars on targetSdk 36.
> 
> **PdfViewerActivity** follows the same **MISC** bucket pattern as other activities: transparent edge-to-edge when enabled, then horizontal, status-bar, and navigation-bar insets on the root, toolbar app bar, and PDF container.
> 
> **Saved site dialogs** (edit bookmark, add folder, edit folder) use a separate window, so the base **SavedSiteDialogFragment** now injects edge-to-edge helpers, opts the dialog window in with `setDecorFitsSystemWindows(false)`, and applies insets to the toolbar and scrollable content (including IME). Concrete dialog fragments are wired with `@InjectWith(FragmentScope::class)`.
> 
> **include_default_toolbar** sets `AppBarLayout` background to `?attr/daxColorToolbar` so the bar matches the toolbar under transparent edge-to-edge. The saved-site dialog layout adds an id on the scroll view for navigation-bar inset handling.
> 
> All behavior is gated on `edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.MISC)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 955cfabed591823ab7033c2507bfdc7f57b5a251. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->