### PR TITLE
Fix dark mode detection when user setting is based on schedule

### DIFF
--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/AppComponentsActivity.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/AppComponentsActivity.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.common.ui.internal.ui
 
-import android.app.UiModeManager
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
@@ -44,6 +43,7 @@ import com.duckduckgo.common.ui.applyTheme
 import com.duckduckgo.common.ui.internal.R
 import com.duckduckgo.common.ui.internal.ui.store.AppComponentsPrefsDataStore
 import com.duckduckgo.common.ui.internal.ui.store.appComponentsDataStore
+import com.duckduckgo.common.ui.isInNightMode
 import com.duckduckgo.common.ui.store.ThemingSharedPreferences
 import com.duckduckgo.common.ui.view.listitem.OneLineListItem
 import com.duckduckgo.common.utils.DefaultDispatcherProvider
@@ -117,10 +117,7 @@ class AppComponentsActivity : AppCompatActivity() {
 
     private fun isDarkThemeEnabled(selectedTheme: DuckDuckGoTheme): Boolean {
         return when (selectedTheme) {
-            DuckDuckGoTheme.SYSTEM_DEFAULT -> {
-                val uiManager = getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
-                uiManager.nightMode == UiModeManager.MODE_NIGHT_YES
-            }
+            DuckDuckGoTheme.SYSTEM_DEFAULT -> isInNightMode()
             DuckDuckGoTheme.DARK -> true
             else -> false
         }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/DuckDuckGoActivity.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/DuckDuckGoActivity.kt
@@ -17,9 +17,7 @@
 package com.duckduckgo.common.ui
 
 import android.annotation.SuppressLint
-import android.app.UiModeManager
 import android.content.BroadcastReceiver
-import android.content.Context
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.graphics.Color
@@ -111,13 +109,7 @@ abstract class DuckDuckGoActivity : DaggerActivity() {
 
     fun isDarkThemeEnabled(): Boolean {
         return when (themingDataStore.theme) {
-            DuckDuckGoTheme.SYSTEM_DEFAULT -> {
-                val uiManager = getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
-                when (uiManager.nightMode) {
-                    UiModeManager.MODE_NIGHT_YES -> true
-                    else -> false
-                }
-            }
+            DuckDuckGoTheme.SYSTEM_DEFAULT -> isInNightMode()
             DARK -> true
             else -> false
         }

--- a/feedback/feedback-impl/src/main/java/com/duckduckgo/feedback/impl/ui/initial/InitialFeedbackFragment.kt
+++ b/feedback/feedback-impl/src/main/java/com/duckduckgo/feedback/impl/ui/initial/InitialFeedbackFragment.kt
@@ -16,13 +16,12 @@
 
 package com.duckduckgo.feedback.impl.ui.initial
 
-import android.app.UiModeManager
 import android.os.Bundle
-import androidx.core.content.ContextCompat.getSystemService
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoTheme.DARK
 import com.duckduckgo.common.ui.DuckDuckGoTheme.LIGHT
 import com.duckduckgo.common.ui.DuckDuckGoTheme.SYSTEM_DEFAULT
+import com.duckduckgo.common.ui.isInNightMode
 import com.duckduckgo.common.ui.store.ThemingDataStore
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.FragmentScope
@@ -55,13 +54,7 @@ class InitialFeedbackFragment : FeedbackFragment(R.layout.content_feedback) {
         super.onActivityCreated(savedInstanceState)
 
         when (themingDataStore.theme) {
-            SYSTEM_DEFAULT -> {
-                val uiManager = getSystemService(requireContext(), UiModeManager::class.java)
-                when (uiManager?.nightMode) {
-                    UiModeManager.MODE_NIGHT_YES -> renderDarkButtons()
-                    else -> renderLightButtons()
-                }
-            }
+            SYSTEM_DEFAULT -> if (requireContext().isInNightMode()) renderDarkButtons() else renderLightButtons()
             DARK -> renderDarkButtons()
             LIGHT -> renderLightButtons()
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1217187293280095?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

When the app theme is "System default", `isDarkThemeEnabled()` read the `UiModeManager.nightMode` *setting*, which only reports `MODE_NIGHT_YES` for a manual toggle — a scheduled dark theme (sunset/custom/bedtime) or battery saver reports `AUTO`/`CUSTOM` and was treated as light. `enableEdgeToEdge()` then applied light system bars on a dark UI, making status bar icons black. Now resolves night mode from the configuration's `uiMode` (`isInNightMode()`), the same source `applyTheme()` uses. Same fix applied to the equivalent checks in `InitialFeedbackFragment` and the internal `AppComponentsActivity`.

Fixes https://github.com/duckduckgo/Android/issues/9370.

### Steps to test this PR

_Prerequisites - both should be met by default, but confirm just in case_
- [x] App theme to "System default"
- [x] `edgeToEdge` feature flag is enabled

_UI elements matching scheduled dark theme_
- [x] Set OS Dark theme → Schedule → custom time covering now, relaunch the app
- [x] Verify status bar icons are white on the dark UI
- [x] Navigate to app settings -> send feedback
- [x] Verify buttons have dark backround

_No regression with manual toggle_
- [x] Toggle OS dark theme manually (no schedule) and verify status bar theme is consistent with the rest of the UI.

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1080" height="2400" alt="Screenshot_20260805_134641" src="https://github.com/user-attachments/assets/3cd862e5-b33c-4059-b84a-4c78feb0880f" />|<img width="1080" height="2400" alt="Screenshot_20260805_135203" src="https://github.com/user-attachments/assets/b4730957-dbcc-4f29-8127-fe1e909c6915" />|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized theming and system-bar styling changes with no auth, data, or security impact; behavior should better match OS scheduled dark mode.
> 
> **Overview**
> When the app theme is **System default**, dark/light decisions for edge-to-edge system bars and feedback button assets no longer use **`UiModeManager.nightMode`**, which only reflects a manual OS dark toggle and misreports scheduled or battery-saver dark mode as light.
> 
> **`DuckDuckGoActivity.isDarkThemeEnabled()`**, **`AppComponentsActivity`**, and **`InitialFeedbackFragment`** now use **`isInNightMode()`** (configuration **`uiMode`**) for **`SYSTEM_DEFAULT`**, aligning with **`applyTheme()`** so status bar icon styling and feedback imagery match the actual UI theme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89673d286d581cda776e039704d7bd7482fd7c86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->