### PR TITLE
Add simplified sync pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/sync.json5
+++ b/PixelDefinitions/pixels/definitions/sync.json5
@@ -36,6 +36,12 @@
                 "key": "reason",
                 "description": "The reason for the rescope token failure",
                 "type": "string"
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
             }
         ]
     },

--- a/PixelDefinitions/pixels/definitions/sync_auto_restore.json5
+++ b/PixelDefinitions/pixels/definitions/sync_auto_restore.json5
@@ -4,14 +4,30 @@
         "owners": ["CDRussell"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            }
+        ]
     },
     "sync-auto-restore_toggle_opted_out": {
         "description": "User taps Next on the Save Recovery Key screen with the auto-restore toggle OFF",
         "owners": ["CDRussell"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            }
+        ]
     },
     "sync-auto-restore_settings_ready_shown": {
         "description": "Previous Session Ready screen shown in Settings when auto-restore data is available",
@@ -25,6 +41,12 @@
                 "type": "string",
                 "description": "Which sync setup flow the user chose before seeing the restore prompt",
                 "enum": ["sync_pairing", "sync_backup", "sync_recover"]
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
             }
         ]
     },
@@ -40,6 +62,12 @@
                 "type": "string",
                 "description": "Which sync setup flow the user chose before seeing the restore prompt",
                 "enum": ["sync_pairing", "sync_backup", "sync_recover"]
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
             }
         ]
     },
@@ -55,6 +83,12 @@
                 "type": "string",
                 "description": "Which sync setup flow the user chose before seeing the restore prompt",
                 "enum": ["sync_pairing", "sync_backup", "sync_recover"]
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
             }
         ]
     },
@@ -70,6 +104,12 @@
                 "type": "string",
                 "description": "Which sync setup flow the user chose before seeing the restore prompt",
                 "enum": ["sync_pairing", "sync_backup", "sync_recover"]
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
             }
         ]
     },
@@ -78,28 +118,60 @@
         "owners": ["CDRussell"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            }
+        ]
     },
     "sync-auto-restore_settings_page_shown": {
         "description": "Sync settings page opened with the auto-restore toggle visible",
         "owners": ["CDRussell"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            }
+        ]
     },
     "sync-auto-restore_settings_page_toggle_enabled": {
         "description": "User turns the auto-restore toggle ON in Sync settings",
         "owners": ["CDRussell"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            }
+        ]
     },
     "sync-auto-restore_settings_page_toggle_disabled": {
         "description": "User turns the auto-restore toggle OFF in Sync settings",
         "owners": ["CDRussell"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            }
+        ]
     },
     "sync-auto-restore_success": {
         "description": "Auto-restore completed successfully",
@@ -113,6 +185,12 @@
                 "type": "string",
                 "description": "Whether the restore was triggered from onboarding or settings",
                 "enum": ["onboarding", "settings"]
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
             }
         ]
     },
@@ -138,6 +216,12 @@
                 "key": "errorMessage",
                 "type": "string",
                 "description": "Error message describing the failure"
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
             }
         ]
     },
@@ -153,6 +237,12 @@
                 "type": "string",
                 "description": "Which sync setup flow the user chose after skipping restore",
                 "enum": ["sync_pairing", "sync_backup", "sync_recover"]
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
             }
         ]
     },
@@ -178,6 +268,12 @@
                 "key": "errorMessage",
                 "type": "string",
                 "description": "Error message describing the failure"
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
             }
         ]
     }

--- a/PixelDefinitions/pixels/definitions/sync_settings.json5
+++ b/PixelDefinitions/pixels/definitions/sync_settings.json5
@@ -1,0 +1,98 @@
+{
+    "m_settings_sync_open": {
+        "description": "The Sync settings screen was opened",
+        "owners": ["MiSikora"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            }
+        ]
+    },
+    "m_settings_sync_back_up_this_device_tapped": {
+        "description": "User tapped Sync and Back Up This Device on the Sync settings screen",
+        "owners": ["MiSikora"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            }
+        ]
+    },
+    "m_settings_sync_recover_synced_data_tapped": {
+        "description": "User tapped Recover Your Synced Data on the Sync settings screen",
+        "owners": ["MiSikora"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            }
+        ]
+    },
+    "m_settings_sync_recovery_confirmed_tapped": {
+        "description": "User confirmed recovering synced data from the recovery flow",
+        "owners": ["MiSikora"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            }
+        ]
+    },
+    "m_settings_sync_another_device_prompt_shown": {
+        "description": "The prompt asking whether to sync this device only or sync with another device was shown",
+        "owners": ["MiSikora"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            }
+        ]
+    },
+    "m_settings_sync_another_device_prompt_option_tapped": {
+        "description": "User tapped an option on the sync another device prompt",
+        "owners": ["MiSikora"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "option",
+                "type": "string",
+                "description": "Which option the user chose on the prompt",
+                "enum": ["this_device_only", "sync_another_device"]
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            }
+        ]
+    }
+}

--- a/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -1,4 +1,37 @@
 {
+    "sync_setup_scan_qr_screen_shown": {
+        "description": "The sync setup scan QR code screen was shown to the user",
+        "owners": ["MiSikora"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the screen belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
     "sync_setup_barcode_screen_shown": {
         "description": "The sync setup barcode (QR) screen was shown to the user",
         "owners": ["CDRussell"],
@@ -16,6 +49,12 @@
                 "key": "flow_version",
                 "type": "string",
                 "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
                 "enum": ["v1", "v2"]
             },
             {
@@ -43,6 +82,12 @@
                 "key": "flow_version",
                 "type": "string",
                 "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
                 "enum": ["v1", "v2"]
             },
             {
@@ -85,6 +130,12 @@
                 "enum": ["v1", "v2"]
             },
             {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            },
+            {
                 "key": "my_kind",
                 "type": "string",
                 "description": "This device's credential kind. Always ddg for the native client",
@@ -124,6 +175,12 @@
                 "enum": ["v1", "v2"]
             },
             {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            },
+            {
                 "key": "my_kind",
                 "type": "string",
                 "description": "This device's credential kind. Always ddg for the native client",
@@ -148,6 +205,12 @@
                 "key": "flow_version",
                 "type": "string",
                 "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
                 "enum": ["v1", "v2"]
             },
             {
@@ -184,6 +247,12 @@
                 "enum": ["v1", "v2"]
             },
             {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            },
+            {
                 "key": "my_kind",
                 "type": "string",
                 "description": "This device's credential kind. Always ddg for the native client",
@@ -214,6 +283,12 @@
                 "key": "flow_version",
                 "type": "string",
                 "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
                 "enum": ["v1", "v2"]
             },
             {
@@ -302,6 +377,12 @@
                 "enum": ["v1", "v2"]
             },
             {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            },
+            {
                 "key": "my_kind",
                 "type": "string",
                 "description": "This device's credential kind. Always ddg for the native client",
@@ -350,6 +431,12 @@
                 "key": "flow_version",
                 "type": "string",
                 "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "ui_version",
+                "type": "string",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
                 "enum": ["v1", "v2"]
             },
             {

--- a/PixelDefinitions/pixels/definitions/wide_sync_setup.json5
+++ b/PixelDefinitions/pixels/definitions/wide_sync_setup.json5
@@ -32,6 +32,11 @@
                 "type": "boolean"
             },
             {
+                "key": "feature.data.ext.ui_version",
+                "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                "enum": ["v1", "v2"]
+            },
+            {
                 "key": "feature.data.ext.account_creation_latency_ms_bucketed",
                 "description": "Latency of the account creation API call in milliseconds, bucketed",
                 "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -46,6 +46,8 @@ import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_PEER_KIND
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_REASON
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_TIMEOUT_STAGE
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_UI_VERSION
+import com.duckduckgo.sync.impl.pixels.SyncPixels.AnotherDevicePromptOption
 import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
@@ -110,6 +112,10 @@ interface SyncPixels {
         apiError: Error,
     )
 
+    fun fireSyncSettingsShown()
+    fun fireBackupThisDeviceTapped()
+    fun fireRecoverSyncDataTapped()
+    fun fireRecoverSyncDataConfirmed()
     fun fireAskUserToSwitchAccount()
     fun fireUserAcceptedSwitchingAccount()
     fun fireUserCancelledSwitchingAccount()
@@ -117,6 +123,7 @@ interface SyncPixels {
     fun fireUserSwitchedLogoutError()
     fun fireUserSwitchedLoginError()
     fun fireTimeoutOnDeepLinkSetup()
+    fun fireScanCodeScreenShown(screenType: ScreenType)
     fun fireSyncBarcodeScreenShown(screenType: ScreenType)
     fun fireSyncSetupFinishedSuccessfully(
         screenType: ScreenType,
@@ -131,6 +138,8 @@ interface SyncPixels {
     fun fireSyncSetupCodeCopiedToClipboard(screenType: ScreenType)
     fun fireBarcodeScannerParseError(screenType: ScreenType, reason: SetupFailureReason? = null)
     fun fireBarcodeScannerParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType? = null)
+    fun fireSyncAnotherDevicePromptShown()
+    fun fireSyncAnotherDevicePromptOptionTapped(option: AnotherDevicePromptOption)
 
     /**
      * "Setup failed" — a v2 setup that started (code recognized) then failed with an error (not a
@@ -186,6 +195,11 @@ interface SyncPixels {
         SCANNING_CANCELLED("scanning_cancelled"),
         CONFIRMATION_DENIED("sync_confirmation_denied"),
         CANCELLED_BEFORE_FINISHED("cancelled_before_finished"),
+    }
+
+    enum class AnotherDevicePromptOption(val value: String) {
+        THIS_DEVICE_ONLY("this_device_only"),
+        WITH_ANOTHER_DEVICE("sync_another_device"),
     }
 
     enum class SetupFailureReason(val value: String) {
@@ -267,12 +281,24 @@ class RealSyncPixels @Inject constructor(
      * - [SYNC_SETUP_FLOW_VERSION]: "v2" when the device is on the v2 connect/exchange stack
      *   ([SyncFeature.canUseV2ConnectFlow]), "v1" otherwise. Independent of which code version is
      *   actually displayed (that is gated separately by [SyncFeature.canShowV2ConnectCode]).
+     * - [SYNC_SETUP_UI_VERSION]: "v2" when the simplified sync UI is enabled ([SyncFeature.useSimplifiedSync])
+     *   and "v1" on the legacy setup screens.
      * - [SYNC_SETUP_MY_KIND]: always "ddg" — this is the native DuckDuckGo client.
      */
-    private fun setupFlowMetadata(): Map<String, String> = mapOf(
-        SYNC_SETUP_FLOW_VERSION to if (syncFeature.canUseV2ConnectFlow().isEnabled()) FLOW_VERSION_V2 else FLOW_VERSION_V1,
-        SYNC_SETUP_MY_KIND to MY_KIND_DDG,
-    )
+    private fun setupFlowMetadata(): Map<String, String> = buildMap {
+        put(SYNC_SETUP_FLOW_VERSION, if (syncFeature.canUseV2ConnectFlow().isEnabled()) FLOW_VERSION_V2 else FLOW_VERSION_V1)
+        put(SYNC_SETUP_MY_KIND, MY_KIND_DDG)
+        putAll(setupUiMetadata())
+    }
+
+    /**
+     * Which sync setup UI the user is looking at: [SYNC_SETUP_UI_VERSION] is "v2" when the simplified
+     * sync UI is enabled ([SyncFeature.useSimplifiedSync]) and "v1" on the legacy setup screens.
+     */
+    private fun setupUiMetadata(): Map<String, String> = buildMap {
+        val version = if (syncFeature.useSimplifiedSync().isEnabled()) UI_VERSION_V2 else UI_VERSION_V1
+        put(SYNC_SETUP_UI_VERSION, version)
+    }
 
     /**
      * Params for the "Code recognized" pixels (scanner/manual-entry success): the screen [source],
@@ -318,11 +344,13 @@ class RealSyncPixels @Inject constructor(
     }
 
     override fun fireDailySuccessRatePixel() {
-        val dailyStats = statsRepository.getYesterdayDailyStats()
-        val payload = mapOf(
-            SyncPixelParameters.COUNT to dailyStats.attempts,
-            SyncPixelParameters.DATE to dailyStats.date,
-        ).plus(dailyStats.apiErrorStats).plus(dailyStats.operationErrorStats)
+        val payload = buildMap {
+            val dailyStats = statsRepository.getYesterdayDailyStats()
+            put(SyncPixelParameters.COUNT, dailyStats.attempts)
+            put(SyncPixelParameters.DATE, dailyStats.date)
+            putAll(dailyStats.apiErrorStats)
+            putAll(dailyStats.operationErrorStats)
+        }
         tryToFireDailyPixel(SYNC_DAILY_SUCCESS_RATE_PIXEL, payload)
     }
 
@@ -333,15 +361,30 @@ class RealSyncPixels @Inject constructor(
     }
 
     override fun fireLoginPixel() {
-        pixel.fire(SyncPixelName.SYNC_LOGIN)
+        pixel.fire(
+            SyncPixelName.SYNC_LOGIN,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireSignupConnectPixel(source: String?) {
-        pixel.fire(SyncPixelName.SYNC_SIGNUP_CONNECT, buildSourceMap(source))
+        pixel.fire(
+            SyncPixelName.SYNC_SIGNUP_CONNECT,
+            parameters = buildMap {
+                putAll(buildSourceMap(source))
+                putAll(setupUiMetadata())
+            },
+        )
     }
 
     override fun fireSignupDirectPixel(source: String?) {
-        pixel.fire(SyncPixelName.SYNC_SIGNUP_DIRECT, buildSourceMap(source))
+        pixel.fire(
+            SyncPixelName.SYNC_SIGNUP_DIRECT,
+            parameters = buildMap {
+                putAll(buildSourceMap(source))
+                putAll(setupUiMetadata())
+            },
+        )
     }
 
     override fun fireSyncAccountErrorPixel(
@@ -440,10 +483,11 @@ class RealSyncPixels @Inject constructor(
     private fun Error.fireAddingErrorAsParams(pixelName: SyncPixelName) {
         pixel.fire(
             pixelName,
-            mapOf(
-                SyncPixelParameters.ERROR_CODE to this.code.toString(),
-                SyncPixelParameters.ERROR_REASON to this.reason,
-            ),
+            parameters = buildMap {
+                put(SyncPixelParameters.ERROR_CODE, code.toString())
+                put(SyncPixelParameters.ERROR_REASON, reason)
+                putAll(setupUiMetadata())
+            },
         )
     }
 
@@ -479,52 +523,118 @@ class RealSyncPixels @Inject constructor(
     }
 
     override fun fireUserSwitchedAccount() {
-        pixel.fire(SyncPixelName.SYNC_USER_SWITCHED_ACCOUNT)
+        pixel.fire(
+            SyncPixelName.SYNC_USER_SWITCHED_ACCOUNT,
+            parameters = setupUiMetadata(),
+        )
+    }
+
+    override fun fireSyncSettingsShown() {
+        pixel.fire(
+            SyncPixelName.SYNC_SETTINGS_SCREEN_SHOWN,
+            parameters = setupUiMetadata(),
+        )
+    }
+
+    override fun fireBackupThisDeviceTapped() {
+        pixel.fire(
+            SyncPixelName.SYNC_SETTINGS_BACK_UP_THIS_DEVICE_TAPPED,
+            parameters = setupUiMetadata(),
+        )
+    }
+
+    override fun fireRecoverSyncDataTapped() {
+        pixel.fire(
+            SyncPixelName.SYNC_SETTINGS_RECOVER_SYNC_DATA_TAPPED,
+            parameters = setupUiMetadata(),
+        )
+    }
+
+    override fun fireRecoverSyncDataConfirmed() {
+        pixel.fire(
+            SyncPixelName.SYNC_SETTINGS_RECOVER_SYNC_DATA_CONFIRMED,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireAskUserToSwitchAccount() {
-        pixel.fire(SyncPixelName.SYNC_ASK_USER_TO_SWITCH_ACCOUNT)
+        pixel.fire(
+            SyncPixelName.SYNC_ASK_USER_TO_SWITCH_ACCOUNT,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireUserAcceptedSwitchingAccount() {
-        pixel.fire(SyncPixelName.SYNC_USER_ACCEPTED_SWITCHING_ACCOUNT)
+        pixel.fire(
+            SyncPixelName.SYNC_USER_ACCEPTED_SWITCHING_ACCOUNT,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireUserCancelledSwitchingAccount() {
-        pixel.fire(SyncPixelName.SYNC_USER_CANCELLED_SWITCHING_ACCOUNT)
+        pixel.fire(
+            SyncPixelName.SYNC_USER_CANCELLED_SWITCHING_ACCOUNT,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireUserSwitchedLoginError() {
-        pixel.fire(SyncPixelName.SYNC_USER_SWITCHED_LOGIN_ERROR)
+        pixel.fire(
+            SyncPixelName.SYNC_USER_SWITCHED_LOGIN_ERROR,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireTimeoutOnDeepLinkSetup() {
-        pixel.fire(SyncPixelName.SYNC_SETUP_DEEP_LINK_TIMEOUT)
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_DEEP_LINK_TIMEOUT,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireUserSwitchedLogoutError() {
-        pixel.fire(SyncPixelName.SYNC_USER_SWITCHED_LOGOUT_ERROR)
+        pixel.fire(
+            SyncPixelName.SYNC_USER_SWITCHED_LOGOUT_ERROR,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireSetupDeepLinkFlowStarted() {
-        pixel.fire(SyncPixelName.SYNC_SETUP_DEEP_LINK_FLOW_STARTED)
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_DEEP_LINK_FLOW_STARTED,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireSetupDeepLinkFlowSuccess() {
-        pixel.fire(SyncPixelName.SYNC_SETUP_DEEP_LINK_FLOW_SUCCESS)
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_DEEP_LINK_FLOW_SUCCESS,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireSetupDeepLinkFlowAbandoned() {
-        pixel.fire(SyncPixelName.SYNC_SETUP_DEEP_LINK_FLOW_ABANDONED)
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_DEEP_LINK_FLOW_ABANDONED,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireUserConfirmedToTurnOffSync() {
-        pixel.fire(SyncPixelName.SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC)
+        pixel.fire(
+            SyncPixelName.SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireUserConfirmedToTurnOffSyncAndDelete(connectedDevices: Int) {
-        val params = mapOf(CONNECTED_DEVICES_WHEN_DELETING to connectedDevices.toString())
-        pixel.fire(SyncPixelName.SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC_AND_DELETE, parameters = params)
+        pixel.fire(
+            SyncPixelName.SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC_AND_DELETE,
+            parameters = buildMap {
+                put(CONNECTED_DEVICES_WHEN_DELETING, connectedDevices.toString())
+                putAll(setupUiMetadata())
+            },
+        )
     }
 
     override fun fireSetupSyncPromoBookmarkAddedDialogDismissed() {
@@ -539,18 +649,35 @@ class RealSyncPixels @Inject constructor(
         pixel.fire(SyncPixelName.SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_SHOWN)
     }
 
+    override fun fireScanCodeScreenShown(screenType: ScreenType) {
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_SCAN_QR_SCREEN_SHOWN,
+            parameters = buildMap {
+                put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+                putAll(setupFlowMetadata())
+            },
+        )
+    }
+
     override fun fireSyncBarcodeScreenShown(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
-        pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN, parameters = params)
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN,
+            parameters = buildMap {
+                put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+                putAll(setupFlowMetadata())
+            },
+        )
     }
 
     override fun fireSyncSetupAbandoned(screenType: ScreenType, reason: CancellationReason?) {
-        val params = buildMap {
-            put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
-            if (reason != null) put(SYNC_SETUP_REASON, reason.value)
-            putAll(setupFlowMetadata())
-        }
-        pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_ABANDONED, parameters = params)
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            parameters = buildMap {
+                put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+                if (reason != null) put(SYNC_SETUP_REASON, reason.value)
+                putAll(setupFlowMetadata())
+            },
+        )
     }
 
     override fun fireSyncSetupFinishedSuccessfully(
@@ -559,8 +686,10 @@ class RealSyncPixels @Inject constructor(
         myRole: SetupRole?,
         peerKind: PeerKind?,
     ) {
-        val params = setupSuccessParams(screenType, path, myRole, peerKind)
-        pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_SUCCESS, parameters = params)
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            parameters = setupSuccessParams(screenType, path, myRole, peerKind),
+        )
     }
 
     override fun fireSyncSetupFailed(
@@ -571,54 +700,71 @@ class RealSyncPixels @Inject constructor(
         peerKind: PeerKind?,
         timeoutStage: TimeoutStage?,
     ) {
-        val params = buildMap {
-            put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
-            put(SYNC_SETUP_REASON, reason.value)
-            if (path != null) put(SYNC_SETUP_PATH, path.value)
-            if (myRole != null) put(SYNC_SETUP_MY_ROLE, myRole.value)
-            if (peerKind != null) put(SYNC_SETUP_PEER_KIND, peerKind.value)
-            if (timeoutStage != null) put(SYNC_SETUP_TIMEOUT_STAGE, timeoutStage.value)
-            putAll(setupFlowMetadata())
-        }
-        pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_FAILED, parameters = params)
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            parameters = buildMap {
+                put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+                put(SYNC_SETUP_REASON, reason.value)
+                if (path != null) put(SYNC_SETUP_PATH, path.value)
+                if (myRole != null) put(SYNC_SETUP_MY_ROLE, myRole.value)
+                if (peerKind != null) put(SYNC_SETUP_PEER_KIND, peerKind.value)
+                if (timeoutStage != null) put(SYNC_SETUP_TIMEOUT_STAGE, timeoutStage.value)
+                putAll(setupFlowMetadata())
+            },
+        )
     }
 
     override fun fireSyncSetupManualCodeScreenShown(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
-        pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN, parameters = params)
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN,
+            parameters = buildMap {
+                put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+                putAll(setupFlowMetadata())
+            },
+        )
     }
 
     override fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType?) {
-        val params = recognizedCodeParams(screenType, codeVersion, codeType)
-        pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS, parameters = params)
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS,
+            parameters = recognizedCodeParams(screenType, codeVersion, codeType),
+        )
     }
 
     override fun fireSyncSetupCodePastedParseFailure(screenType: ScreenType, reason: SetupFailureReason?) {
-        val params = buildMap {
-            put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
-            if (reason != null) put(SYNC_SETUP_REASON, reason.value)
-            putAll(setupFlowMetadata())
-        }
-        pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED, parameters = params)
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED,
+            parameters = buildMap {
+                put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+                if (reason != null) put(SYNC_SETUP_REASON, reason.value)
+                putAll(setupFlowMetadata())
+            },
+        )
     }
 
     override fun fireSyncSetupCodeCopiedToClipboard(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
-        pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_CODE_COPIED, parameters = params)
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_CODE_COPIED,
+            parameters = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value),
+        )
     }
 
     override fun fireBarcodeScannerParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType?) {
-        val params = recognizedCodeParams(screenType, codeVersion, codeType)
-        pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS, parameters = params)
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS,
+            parameters = recognizedCodeParams(screenType, codeVersion, codeType),
+        )
     }
 
     override fun fireBarcodeScannerParseError(screenType: ScreenType, reason: SetupFailureReason?) {
-        val params = buildMap {
-            put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
-            if (reason != null) put(SYNC_SETUP_REASON, reason.value)
-            putAll(setupFlowMetadata())
-        }
-        pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED, parameters = params)
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED,
+            parameters = buildMap {
+                put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+                if (reason != null) put(SYNC_SETUP_REASON, reason.value)
+                putAll(setupFlowMetadata())
+            },
+        )
     }
 
     override fun fireAiChatActive() {
@@ -634,72 +780,145 @@ class RealSyncPixels @Inject constructor(
     }
 
     override fun fireAutoRestoreSetupToggleShown() {
-        pixel.fire(SyncPixelName.SYNC_AUTO_RESTORE_TOGGLE_SHOWN)
+        pixel.fire(
+            SyncPixelName.SYNC_AUTO_RESTORE_TOGGLE_SHOWN,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireAutoRestoreSetupToggleOptedOut() {
-        pixel.fire(SyncPixelName.SYNC_AUTO_RESTORE_TOGGLE_OPTED_OUT)
+        pixel.fire(
+            SyncPixelName.SYNC_AUTO_RESTORE_TOGGLE_OPTED_OUT,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireAutoRestoreSettingsReadyShown(source: String) {
-        pixel.fire(SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_READY_SHOWN, mapOf(SyncPixelParameters.AUTO_RESTORE_SOURCE to source))
+        pixel.fire(
+            SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_READY_SHOWN,
+            parameters = buildMap {
+                put(SyncPixelParameters.AUTO_RESTORE_SOURCE, source)
+                putAll(setupUiMetadata())
+            },
+        )
     }
 
     override fun fireAutoRestoreSettingsRestoreTapped(source: String) {
-        pixel.fire(SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_RESTORE_TAPPED, mapOf(SyncPixelParameters.AUTO_RESTORE_SOURCE to source))
+        pixel.fire(
+            SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_RESTORE_TAPPED,
+            parameters = buildMap {
+                put(SyncPixelParameters.AUTO_RESTORE_SOURCE, source)
+                putAll(setupUiMetadata())
+            },
+        )
     }
 
     override fun fireAutoRestoreSettingsSkipRestoreTapped(source: String) {
-        pixel.fire(SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_SKIP_RESTORE_TAPPED, mapOf(SyncPixelParameters.AUTO_RESTORE_SOURCE to source))
+        pixel.fire(
+            SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_SKIP_RESTORE_TAPPED,
+            parameters = buildMap {
+                put(SyncPixelParameters.AUTO_RESTORE_SOURCE, source)
+                putAll(setupUiMetadata())
+            },
+        )
     }
 
     override fun fireAutoRestoreSettingsCancelled(source: String) {
-        pixel.fire(SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_CANCELLED, mapOf(SyncPixelParameters.AUTO_RESTORE_SOURCE to source))
+        pixel.fire(
+            SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_CANCELLED,
+            parameters = buildMap {
+                put(SyncPixelParameters.AUTO_RESTORE_SOURCE, source)
+                putAll(setupUiMetadata())
+            },
+        )
     }
 
     override fun fireAutoRestoreSettingsManualRecoveryShown() {
-        pixel.fire(SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_MANUAL_RECOVERY_SHOWN)
+        pixel.fire(
+            SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_MANUAL_RECOVERY_SHOWN,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireAutoRestoreSettingsPageShown() {
-        pixel.fire(SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_PAGE_SHOWN)
+        pixel.fire(
+            SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_PAGE_SHOWN,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireAutoRestoreSettingsPageToggleEnabled() {
-        pixel.fire(SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_PAGE_TOGGLE_ENABLED)
+        pixel.fire(
+            SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_PAGE_TOGGLE_ENABLED,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireAutoRestoreSettingsPageToggleDisabled() {
-        pixel.fire(SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_PAGE_TOGGLE_DISABLED)
+        pixel.fire(
+            SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_PAGE_TOGGLE_DISABLED,
+            parameters = setupUiMetadata(),
+        )
     }
 
     override fun fireAutoRestoreSuccess(source: String) {
-        pixel.fire(SyncPixelName.SYNC_AUTO_RESTORE_SUCCESS, mapOf(SyncPixelParameters.AUTO_RESTORE_SOURCE to source))
+        pixel.fire(
+            SyncPixelName.SYNC_AUTO_RESTORE_SUCCESS,
+            parameters = buildMap {
+                put(SyncPixelParameters.AUTO_RESTORE_SOURCE, source)
+                putAll(setupUiMetadata())
+            },
+        )
     }
 
     override fun fireAutoRestoreFailure(source: String, errorCode: String, errorMessage: String) {
         pixel.fire(
             SyncPixelName.SYNC_AUTO_RESTORE_FAILURE,
-            mapOf(
-                SyncPixelParameters.AUTO_RESTORE_SOURCE to source,
-                SyncPixelParameters.AUTO_RESTORE_ERROR_CODE to errorCode,
-                SyncPixelParameters.AUTO_RESTORE_ERROR_MESSAGE to errorMessage,
-            ),
+            parameters = buildMap {
+                put(SyncPixelParameters.AUTO_RESTORE_SOURCE, source)
+                put(SyncPixelParameters.AUTO_RESTORE_ERROR_CODE, errorCode)
+                put(SyncPixelParameters.AUTO_RESTORE_ERROR_MESSAGE, errorMessage)
+                putAll(setupUiMetadata())
+            },
         )
     }
 
     override fun fireAutoRestorePreservedAccountCleared(source: String) {
-        pixel.fire(SyncPixelName.SYNC_AUTO_RESTORE_PRESERVED_ACCOUNT_CLEARED, mapOf(SyncPixelParameters.AUTO_RESTORE_SOURCE to source))
+        pixel.fire(
+            SyncPixelName.SYNC_AUTO_RESTORE_PRESERVED_ACCOUNT_CLEARED,
+            parameters = buildMap {
+                put(SyncPixelParameters.AUTO_RESTORE_SOURCE, source)
+                putAll(setupUiMetadata())
+            },
+        )
     }
 
     override fun fireAutoRestorePreservedAccountClearFailed(source: String, errorCode: String, errorMessage: String) {
         pixel.fire(
             SyncPixelName.SYNC_AUTO_RESTORE_PRESERVED_ACCOUNT_CLEAR_FAILED,
-            mapOf(
-                SyncPixelParameters.AUTO_RESTORE_SOURCE to source,
-                SyncPixelParameters.AUTO_RESTORE_ERROR_CODE to errorCode,
-                SyncPixelParameters.AUTO_RESTORE_ERROR_MESSAGE to errorMessage,
-            ),
+            parameters = buildMap {
+                put(SyncPixelParameters.AUTO_RESTORE_SOURCE, source)
+                put(SyncPixelParameters.AUTO_RESTORE_ERROR_CODE, errorCode)
+                put(SyncPixelParameters.AUTO_RESTORE_ERROR_MESSAGE, errorMessage)
+                putAll(setupUiMetadata())
+            },
+        )
+    }
+
+    override fun fireSyncAnotherDevicePromptShown() {
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_ANOTHER_DEVICE_PROMPT_SHOWN,
+            parameters = setupUiMetadata(),
+        )
+    }
+
+    override fun fireSyncAnotherDevicePromptOptionTapped(option: AnotherDevicePromptOption) {
+        pixel.fire(
+            SyncPixelName.SYNC_SETUP_ANOTHER_DEVICE_PROMPT_OPTION_TAPPED,
+            parameters = buildMap {
+                put(SyncPixelParameters.OPTION, option.value)
+                putAll(setupUiMetadata())
+            },
         )
     }
 
@@ -707,6 +926,8 @@ class RealSyncPixels @Inject constructor(
         private const val SYNC_PIXELS_PREF_FILE = "com.duckduckgo.sync.pixels.v1"
         private const val FLOW_VERSION_V1 = "v1"
         private const val FLOW_VERSION_V2 = "v2"
+        const val UI_VERSION_V1 = "v1"
+        const val UI_VERSION_V2 = "v2"
         private const val MY_KIND_DDG = "ddg"
         private const val CODE_TYPE_RECOVERY = "recovery"
         private const val CODE_TYPE_LINKING = "linking"
@@ -768,6 +989,11 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_SETUP_DEEP_LINK_FLOW_SUCCESS("sync_setup_deep_link_flow_success"),
     SYNC_SETUP_DEEP_LINK_FLOW_ABANDONED("sync_setup_deep_link_flow_abandoned"),
 
+    SYNC_SETTINGS_SCREEN_SHOWN("m_settings_sync_open"),
+    SYNC_SETTINGS_BACK_UP_THIS_DEVICE_TAPPED("m_settings_sync_back_up_this_device_tapped"),
+    SYNC_SETTINGS_RECOVER_SYNC_DATA_TAPPED("m_settings_sync_recover_synced_data_tapped"),
+    SYNC_SETTINGS_RECOVER_SYNC_DATA_CONFIRMED("m_settings_sync_recovery_confirmed_tapped"),
+    SYNC_SETUP_SCAN_QR_SCREEN_SHOWN("sync_setup_scan_qr_screen_shown"),
     SYNC_SETUP_BARCODE_SCREEN_SHOWN("sync_setup_barcode_screen_shown"),
     SYNC_SETUP_BARCODE_SCANNER_SUCCESS("sync_setup_barcode_scanner_success"),
     SYNC_SETUP_BARCODE_SCANNER_FAILED("sync_setup_barcode_scanner_failed"),
@@ -783,6 +1009,8 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_SHOWN("sync_setup_promo_bookmark_added_dialog_shown"),
     SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_DISMISSED("sync_setup_promo_bookmark_added_dialog_dismissed"),
     SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_CONFIRMED("sync_setup_promo_bookmark_added_dialog_confirmed"),
+    SYNC_SETUP_ANOTHER_DEVICE_PROMPT_SHOWN("m_settings_sync_another_device_prompt_shown"),
+    SYNC_SETUP_ANOTHER_DEVICE_PROMPT_OPTION_TAPPED("m_settings_sync_another_device_prompt_option_tapped"),
     SYNC_AI_CHAT_ACTIVE("sync_ai_chat_active"),
 
     SYNC_AUTO_RESTORE_TOGGLE_SHOWN("sync-auto-restore_toggle_shown"),
@@ -817,11 +1045,13 @@ object SyncPixelParameters {
     const val ERROR_CODE = "code"
     const val ERROR_REASON = "reason"
     const val ERROR = "error"
+    const val OPTION = "option"
     const val SYNC_FEATURE_PROMOTION_SOURCE = "source"
     const val SYNC_FEATURE_PROMOTION_DISMISS_REASON = "reason"
     const val GET_OTHER_DEVICES_SCREEN_LAUNCH_SOURCE = "source"
     const val SYNC_SETUP_SCREEN_TYPE = "source"
     const val SYNC_SETUP_FLOW_VERSION = "flow_version"
+    const val SYNC_SETUP_UI_VERSION = "ui_version"
     const val SYNC_SETUP_MY_KIND = "my_kind"
     const val SYNC_SETUP_CODE_VERSION = "code_version"
     const val SYNC_SETUP_CODE_TYPE = "code_type"

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
@@ -125,6 +125,7 @@ class SyncActivityViewModel @Inject constructor(
     private val viewState = MutableStateFlow(ViewState())
 
     init {
+        syncPixels.fireSyncSettingsShown()
         viewModelScope.launch {
             syncFeature.updateSyncActivityViewStateAtomically().enabled().collect { isAtomicViewStateUpdateEnabled = it }
         }
@@ -292,6 +293,7 @@ class SyncActivityViewModel @Inject constructor(
     }
 
     fun onSyncThisDevice(source: String? = null) {
+        syncPixels.fireBackupThisDeviceTapped()
         updateViewState { it.setThisDeviceSyncInProgress() }
         viewModelScope.launch(dispatchers.io()) {
             syncSetupWideEvent.onFlowStarted(source)
@@ -309,6 +311,7 @@ class SyncActivityViewModel @Inject constructor(
     }
 
     fun onRecoverYourSyncedData() {
+        syncPixels.fireRecoverSyncDataTapped()
         viewModelScope.launch(dispatchers.io()) {
             requiresSetupAuthentication {
                 if (syncAutoRestore.canRestore()) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SyncSetupIntroViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SyncSetupIntroViewModel.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.sync.impl.SyncFeatureToggle
+import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.setup.SetupAccountActivity.Companion.Screen
 import com.duckduckgo.sync.impl.ui.setup.SetupAccountActivity.Companion.Screen.SYNC_INTRO
 import com.duckduckgo.sync.impl.ui.setup.SyncSetupIntroViewModel.Command.AbortFlow
@@ -45,6 +46,7 @@ class SyncSetupIntroViewModel @Inject constructor(
     private val syncFeatureToggle: SyncFeatureToggle,
     private val dispatchers: DispatcherProvider,
     private val syncSetupWideEvent: SyncSetupWideEvent,
+    private val syncPixels: SyncPixels,
 ) : ViewModel() {
 
     private val command = Channel<Command>(1, DROP_OLDEST)
@@ -88,6 +90,7 @@ class SyncSetupIntroViewModel @Inject constructor(
     }
 
     fun onStartRecoverDataClicked() {
+        syncPixels.fireRecoverSyncDataConfirmed()
         viewModelScope.launch {
             command.send(RecoverDataFlow)
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeViewModel.kt
@@ -88,6 +88,7 @@ class DisplayQrCodeViewModel @AssistedInject constructor(
     init {
         viewModelScope.launch(dispatchers.io()) {
             isSignedIn = accountRepository.getAccountInfo().isSignedIn
+            pixels.fireSyncBarcodeScreenShown(syncType)
             when (protocolVersion()) {
                 ProtocolVersion.V1 -> startV1Presentation()
                 ProtocolVersion.V2 -> startV2Presentation()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ProcessSyncCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ProcessSyncCodeActivity.kt
@@ -21,6 +21,7 @@ import android.animation.AnimatorListenerAdapter
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.core.content.IntentCompat
 import androidx.lifecycle.Lifecycle
@@ -79,18 +80,13 @@ class ProcessSyncCodeActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
-    private val syncCode
-        get() = requireNotNull(intent.getStringExtra(SYNC_CODE_EXTRA_KEY)) {
-            "Missing intent extra: '$SYNC_CODE_EXTRA_KEY'"
-        }
-
-    private val syncEntryPoint
-        get() = requireNotNull(IntentCompat.getSerializableExtra(intent, ORIGINAL_FLOW_EXTRA_KEY, SyncEntryPoint::class.java)) {
-            "Missing intent extra: '$ORIGINAL_FLOW_EXTRA_KEY'"
+    private val source
+        get() = requireNotNull(IntentCompat.getParcelableExtra(intent, SYNC_CODE_SOURCE_EXTRA_KEY, SyncCodeSource::class.java)) {
+            "Missing intent extra: '$SYNC_CODE_SOURCE_EXTRA_KEY'"
         }
 
     private val viewModel by viewModels<ProcessSyncCodeViewModel> {
-        Provider(vmFactory, syncCode, syncEntryPoint)
+        Provider(vmFactory, source)
     }
 
     private var acknowledgementDialog: TextAlertDialogBuilder? = null
@@ -112,6 +108,7 @@ class ProcessSyncCodeActivity : DuckDuckGoActivity() {
         configureHeadline()
         configureAcknowledgementAnimation()
         configureConnectingLabel()
+        configureBackHandling()
 
         observeViewModel()
     }
@@ -264,8 +261,15 @@ class ProcessSyncCodeActivity : DuckDuckGoActivity() {
         edgeToEdgeHandler.applySystemBarInsets(binding.root)
     }
 
+    private fun configureBackHandling() {
+        onBackPressedDispatcher.addCallback(this) {
+            viewModel.onUserCanceled()
+            finish()
+        }
+    }
+
     private fun configureHeadline() {
-        val text = if (syncEntryPoint == SyncEntryPoint.RECOVER_SYNCED_DATA) {
+        val text = if (source.entryPoint == SyncEntryPoint.RECOVER_SYNCED_DATA) {
             R.string.sync_simplified_pairing_headline_recovery
         } else {
             R.string.sync_simplified_pairing_headline
@@ -300,20 +304,14 @@ class ProcessSyncCodeActivity : DuckDuckGoActivity() {
     }
 
     companion object {
-        private const val SYNC_CODE_EXTRA_KEY = "sync_code"
-        private const val LAUNCH_SOURCE_EXTRA_KEY = "launch_source"
-        private const val ORIGINAL_FLOW_EXTRA_KEY = "original_flow"
+        private const val SYNC_CODE_SOURCE_EXTRA_KEY = "code_source"
 
         fun intent(
             context: Context,
-            syncCode: String,
-            syncEntryPoint: SyncEntryPoint,
-            launchSource: String?,
+            codeSource: SyncCodeSource,
         ): Intent {
             return Intent(context, ProcessSyncCodeActivity::class.java).apply {
-                putExtra(SYNC_CODE_EXTRA_KEY, syncCode)
-                putExtra(ORIGINAL_FLOW_EXTRA_KEY, syncEntryPoint)
-                putExtra(LAUNCH_SOURCE_EXTRA_KEY, launchSource)
+                putExtra(SYNC_CODE_SOURCE_EXTRA_KEY, codeSource)
             }
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ProcessSyncCodeContract.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ProcessSyncCodeContract.kt
@@ -18,10 +18,12 @@ package com.duckduckgo.sync.impl.ui.v2
 
 import android.content.Context
 import android.content.Intent
+import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import com.duckduckgo.sync.impl.ui.SyncEntryPoint
 import com.duckduckgo.sync.impl.ui.v2.ProcessSyncCodeContract.Input
 import com.duckduckgo.sync.impl.ui.v2.ProcessSyncCodeContract.Output
+import kotlinx.parcelize.Parcelize
 
 class ProcessSyncCodeContract : ActivityResultContract<Input, Output>() {
     override fun createIntent(
@@ -30,9 +32,7 @@ class ProcessSyncCodeContract : ActivityResultContract<Input, Output>() {
     ): Intent {
         return ProcessSyncCodeActivity.intent(
             context = context,
-            syncCode = input.syncCode,
-            syncEntryPoint = input.syncEntryPoint,
-            launchSource = input.launchSource,
+            codeSource = input.source,
         )
     }
 
@@ -53,9 +53,7 @@ class ProcessSyncCodeContract : ActivityResultContract<Input, Output>() {
     }
 
     data class Input(
-        val syncCode: String,
-        val syncEntryPoint: SyncEntryPoint,
-        val launchSource: String?,
+        val source: SyncCodeSource,
     )
 
     sealed interface Output {
@@ -64,5 +62,40 @@ class ProcessSyncCodeContract : ActivityResultContract<Input, Output>() {
         ) : Output
 
         data object Dismissed : Output
+    }
+}
+
+/** A [code] the user is setting up with, together with how it reached [ProcessSyncCodeActivity]. */
+sealed interface SyncCodeSource : Parcelable {
+    val code: String
+    val entryPoint: SyncEntryPoint
+
+    /** A code the user scanned with the camera. */
+    @Parcelize
+    data class Scanned(
+        override val code: String,
+        override val entryPoint: SyncEntryPoint,
+    ) : SyncCodeSource
+
+    /** A code the user pasted into manual entry. */
+    @Parcelize
+    data class Pasted(
+        override val code: String,
+        override val entryPoint: SyncEntryPoint,
+    ) : SyncCodeSource
+
+    /** A code that arrived from an external deep link. */
+    @Parcelize
+    data class DeepLink(
+        override val code: String,
+        override val entryPoint: SyncEntryPoint,
+    ) : SyncCodeSource
+
+    /** A stored recovery code replayed by the settings "restore previous session" path. */
+    @Parcelize
+    data class Restored(
+        override val code: String,
+    ) : SyncCodeSource {
+        override val entryPoint: SyncEntryPoint get() = SyncEntryPoint.RECOVER_SYNCED_DATA
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ProcessSyncCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ProcessSyncCodeViewModel.kt
@@ -29,12 +29,24 @@ import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode.Exchange
+import com.duckduckgo.sync.impl.SyncAuthCode.Unknown
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_EXCHANGE
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncEntryPoint
 import com.duckduckgo.sync.impl.ui.V1PairingErrorContent
 import com.duckduckgo.sync.impl.ui.V2PairingErrorContent
@@ -57,11 +69,12 @@ import kotlinx.coroutines.withContext
 import kotlin.time.Duration.Companion.seconds
 
 class ProcessSyncCodeViewModel @AssistedInject constructor(
-    @Assisted private val syncCode: String,
-    @Assisted private val syncEntryPoint: SyncEntryPoint,
+    @Assisted private val source: SyncCodeSource,
     private val accountRepository: SyncAccountRepository,
     private val codeDispatcher: SyncCodeDispatcher,
     private val syncFeature: SyncFeature,
+    private val syncPixels: SyncPixels,
+    private val syncAutoRestoreManager: SyncAutoRestoreManager,
     private val dispatchers: DispatcherProvider,
 ) : ViewModel() {
     private val _commands = Channel<Command>(Channel.BUFFERED)
@@ -70,14 +83,45 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
     private val _viewState = MutableStateFlow(ViewState())
     internal val viewState = _viewState.asStateFlow()
 
+    private val syncCode: String get() = source.code
+
+    private val screenType: ScreenType
+        get() = when {
+            source is SyncCodeSource.DeepLink -> SYNC_EXCHANGE
+            source.entryPoint == SyncEntryPoint.SYNC_NEW_ACCOUNT -> SYNC_CONNECT
+            else -> SYNC_EXCHANGE
+        }
+
     private val animationCompletionSignal = CompletableDeferred<Unit>()
 
     init {
+        if (source is SyncCodeSource.DeepLink) {
+            syncPixels.fireSetupDeepLinkFlowStarted()
+        }
+
         viewModelScope.launch(dispatchers.io()) {
-            when (val decision = codeDispatcher.route(syncCode)) {
+            val decision = codeDispatcher.route(syncCode)
+            fireCodeParsedPixel(decision)
+            when (decision) {
                 is RouteDecision.Legacy -> handleV1CodeDecision(decision)
                 is RouteDecision.V2InProgress -> handleV2CodeDecision(decision)
             }
+        }
+    }
+
+    fun onUserCanceled() {
+        when (source) {
+            is SyncCodeSource.DeepLink -> {
+                syncPixels.fireSetupDeepLinkFlowAbandoned()
+            }
+
+            // Cancelling here returns to the scanner (ReadSyncCodeActivity), which owns the single
+            // terminal "setup abandoned" pixel; firing it here too would double-count the abandon.
+            // Restored has no scanner behind it and reports no abandonment.
+            is SyncCodeSource.Scanned,
+            is SyncCodeSource.Pasted,
+            is SyncCodeSource.Restored,
+            -> Unit
         }
     }
 
@@ -122,11 +166,12 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
 
     fun onUserAcceptedSwitchingAccount(encodedStringCode: String) {
         viewModelScope.launch(dispatchers.io()) {
+            syncPixels.fireUserAcceptedSwitchingAccount()
             accountRepository.logoutAndJoinNewAccount(encodedStringCode)
                 .onSuccess {
+                    syncPixels.fireUserSwitchedAccount()
                     animationCompletionSignal.await()
-                    _commands.send(Command.SetPairingResult(pairingResult()))
-                    _commands.send(Command.Close)
+                    sendSuccess()
                 }
                 .onFailure { failure ->
                     _commands.send(Command.ShowV1Error(failure.toV1PairingError()))
@@ -136,6 +181,7 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
 
     fun onUserCancelledSwitchingAccount() {
         viewModelScope.launch {
+            syncPixels.fireUserCancelledSwitchingAccount()
             _commands.send(Command.SetPairingResult(SyncPairingResult.Failure))
             _commands.send(Command.Close)
         }
@@ -145,7 +191,12 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
         _commands.send(Command.RunAcknowledgmentAnimation)
         val authCode = decision.authCode
         withContext(dispatchers.io()) {
-            accountRepository.processCode(authCode)
+            val existingDeviceId = if (source is SyncCodeSource.Restored) {
+                syncAutoRestoreManager.retrieveRecoveryPayload()?.deviceId
+            } else {
+                null
+            }
+            accountRepository.processCode(authCode, existingDeviceId)
                 .onSuccess {
                     when (authCode) {
                         is Exchange -> {
@@ -154,8 +205,7 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
 
                         else -> {
                             animationCompletionSignal.await()
-                            _commands.send(Command.SetPairingResult(pairingResult()))
-                            _commands.send(Command.Close)
+                            sendSuccess()
                         }
                     }
                 }
@@ -173,14 +223,14 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
                 .onSuccess { result ->
                     when (result) {
                         is AccountSwitchingRequired -> {
+                            syncPixels.fireAskUserToSwitchAccount()
                             _commands.send(Command.AskSwitchAccount(result.recoveryCode))
                             isPolling = false
                         }
 
                         is LoggedIn -> {
                             animationCompletionSignal.await()
-                            _commands.send(Command.SetPairingResult(pairingResult()))
-                            _commands.send(Command.Close)
+                            sendSuccess()
                             isPolling = false
                         }
 
@@ -195,7 +245,11 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
     }
 
     private suspend fun emitV1Error(failure: Error) {
+        if (source is SyncCodeSource.Restored) {
+            fireAutoRestoreFailurePixels(failure.code.toString(), failure.reason)
+        }
         if (failure.code == ALREADY_SIGNED_IN.code && syncFeature.seamlessAccountSwitching().isEnabled()) {
+            syncPixels.fireAskUserToSwitchAccount()
             _commands.send(Command.AskSwitchAccount(syncCode))
         } else {
             _commands.send(Command.ShowV1Error(failure.toV1PairingError()))
@@ -207,6 +261,9 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
     }
 
     private suspend fun processV2Outcome(outcome: DispatchOutcome) {
+        syncPixels.fireSetupFailed(screenType, outcome)
+        syncPixels.fireSetupCancelledIfDenied(screenType, outcome)
+
         when (outcome) {
             // No-op. QR code is not show while sync is in progress in the simplified sync.
             is DispatchOutcome.LinkingCodeReady -> Unit
@@ -226,8 +283,7 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
                 }
                 animationCompletionSignal.await()
 
-                _commands.send(Command.SetPairingResult(pairingResult()))
-                _commands.send(Command.Close)
+                sendSuccess(outcome.path, outcome.myRole, outcome.peerKind)
             }
 
             is DispatchOutcome.AlreadyConnected -> {
@@ -235,26 +291,108 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
             }
 
             is DispatchOutcome.UpgradeRequired -> {
+                if (source is SyncCodeSource.Restored) {
+                    fireAutoRestoreFailurePixels(outcome.codeMajor.toString(), SetupFailureReason.NEEDS_UPGRADE.value)
+                }
                 _commands.send(Command.ShowV2Error(v2UpgradeRequiredError))
             }
 
             is DispatchOutcome.Failed -> {
+                if (source is SyncCodeSource.Restored) {
+                    fireAutoRestoreFailurePixels(outcome.code.toString(), outcome.reason)
+                }
                 _commands.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
             }
         }
     }
 
-    internal data class ViewState(
-        val isLoggedIn: Boolean = false,
-    )
-
     private suspend fun pairingResult(): SyncPairingResult = withContext(dispatchers.io()) {
         accountRepository
             .getThisConnectedDevice()
             ?.let(ParcelableDevice::fromConnectedDevice)
-            ?.let { device -> SyncPairingResult.Success(device, syncEntryPoint) }
+            ?.let { device -> SyncPairingResult.Success(device, source.entryPoint) }
             ?: SyncPairingResult.Failure
     }
+
+    private suspend fun sendSuccess(
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    ) {
+        fireLoginSuccessPixels(path, myRole, peerKind)
+        _commands.send(Command.SetPairingResult(pairingResult()))
+        _commands.send(Command.Close)
+    }
+
+    private fun fireCodeParsedPixel(decision: RouteDecision) {
+        when (source) {
+            is SyncCodeSource.Scanned -> when (decision) {
+                is RouteDecision.V2InProgress -> {
+                    syncPixels.fireBarcodeScannerParseSuccess(screenType, CodeVersion.V2, decision.codeType)
+                }
+
+                is RouteDecision.Legacy -> {
+                    if (decision.authCode !is Unknown) {
+                        syncPixels.fireBarcodeScannerParseSuccess(screenType, CodeVersion.V1)
+                    } else {
+                        syncPixels.fireBarcodeScannerParseError(screenType, SetupFailureReason.UNRECOGNIZED_CODE)
+                    }
+                }
+            }
+
+            is SyncCodeSource.Pasted -> when (decision) {
+                is RouteDecision.V2InProgress -> {
+                    syncPixels.fireSyncSetupCodePastedParseSuccess(screenType, CodeVersion.V2, decision.codeType)
+                }
+
+                is RouteDecision.Legacy -> {
+                    if (decision.authCode !is Unknown) {
+                        syncPixels.fireSyncSetupCodePastedParseSuccess(screenType, CodeVersion.V1)
+                    } else {
+                        syncPixels.fireSyncSetupCodePastedParseFailure(screenType, SetupFailureReason.UNRECOGNIZED_CODE)
+                    }
+                }
+            }
+
+            else -> Unit
+        }
+    }
+
+    private fun fireLoginSuccessPixels(
+        path: SetupPath?,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ) {
+        when (source) {
+            is SyncCodeSource.DeepLink -> {
+                syncPixels.fireSetupDeepLinkFlowSuccess()
+            }
+
+            is SyncCodeSource.Restored -> {
+                syncPixels.fireAutoRestoreSuccess(SyncPixelParameters.AUTO_RESTORE_SOURCE_SETTINGS)
+            }
+
+            else -> {
+                syncPixels.fireSyncSetupFinishedSuccessfully(screenType, path, myRole, peerKind)
+            }
+        }
+        syncPixels.fireLoginPixel()
+    }
+
+    private fun fireAutoRestoreFailurePixels(
+        errorCode: String,
+        errorMessage: String,
+    ) {
+        syncPixels.fireAutoRestoreFailure(
+            source = SyncPixelParameters.AUTO_RESTORE_SOURCE_SETTINGS,
+            errorCode = errorCode,
+            errorMessage = errorMessage,
+        )
+    }
+
+    internal data class ViewState(
+        val isLoggedIn: Boolean = false,
+    )
 
     internal sealed interface Command {
         data class AskJoinerConfirmation(
@@ -293,19 +431,17 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
     @AssistedFactory
     interface Factory {
         fun create(
-            syncCode: String,
-            syncEntryPoint: SyncEntryPoint,
+            source: SyncCodeSource,
         ): ProcessSyncCodeViewModel
 
         class Provider(
             private val assistedFactory: Factory,
-            private val syncCode: String,
-            private val syncEntryPoint: SyncEntryPoint,
+            private val source: SyncCodeSource,
         ) : ViewModelProvider.Factory {
 
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return assistedFactory.create(syncCode, syncEntryPoint) as T
+                return assistedFactory.create(source) as T
             }
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeActivity.kt
@@ -22,6 +22,8 @@ import android.graphics.Outline
 import android.os.Bundle
 import android.view.View
 import android.view.ViewOutlineProvider
+import androidx.activity.addCallback
+import androidx.activity.viewModels
 import androidx.core.content.IntentCompat
 import androidx.core.view.isGone
 import androidx.fragment.app.Fragment
@@ -29,6 +31,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import androidx.viewpager2.widget.ViewPager2
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.toPx
@@ -53,7 +56,12 @@ import javax.inject.Inject
 class ReadSyncCodeActivity : DuckDuckGoActivity() {
     private val binding by viewBinding<ActivitySyncV2ReadSyncCodeBinding>()
 
-    private val viewModel by bindViewModel<ReadSyncCodeViewModel>()
+    private val launchSource get() = intent.getStringExtra(LAUNCH_SOURCE_EXTRA_KEY)
+
+    private val syncEntryPoint
+        get() = requireNotNull(IntentCompat.getSerializableExtra(intent, ORIGINAL_FLOW_EXTRA_KEY, SyncEntryPoint::class.java)) {
+            "Missing intent extra: '$ORIGINAL_FLOW_EXTRA_KEY'"
+        }
 
     @Inject
     lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
@@ -61,12 +69,12 @@ class ReadSyncCodeActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
-    private val launchSource get() = intent.getStringExtra(LAUNCH_SOURCE_EXTRA_KEY)
+    @Inject
+    lateinit var vmFactory: ReadSyncCodeViewModel.Factory
 
-    private val syncEntryPoint
-        get() = requireNotNull(IntentCompat.getSerializableExtra(intent, ORIGINAL_FLOW_EXTRA_KEY, SyncEntryPoint::class.java)) {
-            "Missing intent extra: '$ORIGINAL_FLOW_EXTRA_KEY'"
-        }
+    private val viewModel by viewModels<ReadSyncCodeViewModel> {
+        ReadSyncCodeViewModel.Factory.Provider(vmFactory, syncEntryPoint)
+    }
 
     private val isRecoveryFlow get() = syncEntryPoint == SyncEntryPoint.RECOVER_SYNCED_DATA
 
@@ -103,6 +111,7 @@ class ReadSyncCodeActivity : DuckDuckGoActivity() {
         configureToolbar()
         configureContentAdapter()
         configureContentCorners()
+        configureBackHandling()
 
         observeViewModel()
     }
@@ -120,9 +129,7 @@ class ReadSyncCodeActivity : DuckDuckGoActivity() {
             is StartSyncProcess -> {
                 processSyncCodeLauncher.launch(
                     ProcessSyncCodeContract.Input(
-                        syncCode = command.syncCode,
-                        syncEntryPoint = syncEntryPoint,
-                        launchSource = launchSource,
+                        source = command.source,
                     ),
                 )
             }
@@ -144,8 +151,16 @@ class ReadSyncCodeActivity : DuckDuckGoActivity() {
         edgeToEdgeHandler.applyNavigationBarInsets(binding.contentPager, drawBehindGestureNav = false)
     }
 
+    private fun configureBackHandling() {
+        onBackPressedDispatcher.addCallback(this) {
+            viewModel.onUserCanceled()
+            finish()
+        }
+    }
+
     private fun configureToolbar() {
         binding.closeButton.setOnClickListener {
+            viewModel.onUserCanceled()
             finish()
         }
         binding.showQrCodeButton.isGone = isRecoveryFlow
@@ -166,8 +181,8 @@ class ReadSyncCodeActivity : DuckDuckGoActivity() {
 
             override fun createFragment(position: Int): Fragment {
                 return when (position) {
-                    SCANNER_POSITION -> ReadSyncCodeCameraFragment()
-                    MANUAL_CODE_ENTRY_POSITION -> ReadSyncCodeManualFragment()
+                    SCANNER_POSITION -> ReadSyncCodeCameraFragment.instance(syncEntryPoint)
+                    MANUAL_CODE_ENTRY_POSITION -> ReadSyncCodeManualFragment.instance(syncEntryPoint)
                     else -> error("Unknown position: $position")
                 }
             }
@@ -180,6 +195,22 @@ class ReadSyncCodeActivity : DuckDuckGoActivity() {
             }
         }
         mediator.attach()
+
+        binding.contentPager.registerOnPageChangeCallback(
+            object : ViewPager2.OnPageChangeCallback() {
+                override fun onPageSelected(position: Int) {
+                    when (position) {
+                        SCANNER_POSITION -> {
+                            viewModel.onScannerScreenShown()
+                        }
+
+                        MANUAL_CODE_ENTRY_POSITION -> {
+                            viewModel.onManualEntryScreenShown()
+                        }
+                    }
+                }
+            },
+        )
     }
 
     private fun configureContentCorners() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeCameraFragment.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeCameraFragment.kt
@@ -29,6 +29,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
 import androidx.core.view.OneShotPreDrawListener
 import androidx.core.view.doOnLayout
 import androidx.core.view.doOnPreDraw
@@ -48,6 +50,7 @@ import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.databinding.FragmentSyncV2ReadSyncCodeCameraBinding
+import com.duckduckgo.sync.impl.ui.SyncEntryPoint
 import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeCameraIntroViewModel.Command
 import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeCameraIntroViewModel.Command.ExpandScannerCutout
 import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeCameraIntroViewModel.Command.PlayIntroAnimation
@@ -72,8 +75,16 @@ class ReadSyncCodeCameraFragment : DuckDuckGoFragment() {
             "Fragment $this tried to access ViewBinding outside of View's lifecycle."
         }
 
+    private val entryPoint: SyncEntryPoint
+        get() = requireNotNull(BundleCompat.getSerializable(requireArguments(), ENTRY_POINT_ARG, SyncEntryPoint::class.java)) {
+            "Missing fragment argument: '$ENTRY_POINT_ARG'"
+        }
+
     @Inject
     lateinit var viewModelFactory: FragmentViewModelFactory
+
+    @Inject
+    lateinit var syncCodeViewModelFactory: ReadSyncCodeViewModel.Factory
 
     @Inject
     lateinit var syncFeature: SyncFeature
@@ -83,7 +94,9 @@ class ReadSyncCodeCameraFragment : DuckDuckGoFragment() {
 
     private val animationViewModel by viewModels<ReadSyncCodeCameraIntroViewModel> { viewModelFactory }
 
-    private val syncCodeViewModel by activityViewModels<ReadSyncCodeViewModel> { viewModelFactory }
+    private val syncCodeViewModel by activityViewModels<ReadSyncCodeViewModel> {
+        ReadSyncCodeViewModel.Factory.Provider(syncCodeViewModelFactory, entryPoint)
+    }
 
     private val cameraPermissionLauncher = registerForActivityResult(
         RequestPermission(),
@@ -317,6 +330,12 @@ class ReadSyncCodeCameraFragment : DuckDuckGoFragment() {
     }
 
     companion object {
+        private const val ENTRY_POINT_ARG = "entry_point"
+
+        fun instance(entryPoint: SyncEntryPoint) = ReadSyncCodeCameraFragment().apply {
+            arguments = bundleOf(ENTRY_POINT_ARG to entryPoint)
+        }
+
         private const val CUTOUT_FRACTION_START = 0.53f
         private const val CUTOUT_FRACTION_END = 0.72f
         private const val CUTOUT_HEADER_GAP_DP = 16

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeManualFragment.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeManualFragment.kt
@@ -20,12 +20,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
 import androidx.fragment.app.activityViewModels
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoFragment
-import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.sync.impl.databinding.FragmentSyncV2ReadSyncCodeManualBinding
+import com.duckduckgo.sync.impl.ui.SyncEntryPoint
 import javax.inject.Inject
 
 @InjectWith(FragmentScope::class)
@@ -36,10 +38,17 @@ class ReadSyncCodeManualFragment : DuckDuckGoFragment() {
             "Fragment $this tried to access ViewBinding outside of View's lifecycle."
         }
 
-    @Inject
-    lateinit var viewModelFactory: FragmentViewModelFactory
+    private val entryPoint: SyncEntryPoint
+        get() = requireNotNull(BundleCompat.getSerializable(requireArguments(), ENTRY_POINT_ARG, SyncEntryPoint::class.java)) {
+            "Missing fragment argument: '$ENTRY_POINT_ARG'"
+        }
 
-    private val viewModel by activityViewModels<ReadSyncCodeViewModel> { viewModelFactory }
+    @Inject
+    lateinit var syncCodeViewModelFactory: ReadSyncCodeViewModel.Factory
+
+    private val viewModel by activityViewModels<ReadSyncCodeViewModel> {
+        ReadSyncCodeViewModel.Factory.Provider(syncCodeViewModelFactory, entryPoint)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -66,5 +75,13 @@ class ReadSyncCodeManualFragment : DuckDuckGoFragment() {
     override fun onDestroyView() {
         _binding = null
         super.onDestroyView()
+    }
+
+    companion object {
+        private const val ENTRY_POINT_ARG = "entry_point"
+
+        fun instance(entryPoint: SyncEntryPoint) = ReadSyncCodeManualFragment().apply {
+            arguments = bundleOf(ENTRY_POINT_ARG to entryPoint)
+        }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeViewModel.kt
@@ -18,37 +18,73 @@ package com.duckduckgo.sync.impl.ui.v2
 
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.duckduckgo.anvil.annotations.ContributesViewModel
-import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_EXCHANGE
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
+import com.duckduckgo.sync.impl.ui.SyncEntryPoint
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@ContributesViewModel(ActivityScope::class)
-class ReadSyncCodeViewModel @Inject constructor(
+class ReadSyncCodeViewModel @AssistedInject constructor(
+    @Assisted val entryPoint: SyncEntryPoint,
     private val clipboard: Clipboard,
+    private val syncPixels: SyncPixels,
+    private val codeDispatcher: SyncCodeDispatcher,
 ) : ViewModel() {
     private val _commands = Channel<Command>(Channel.BUFFERED)
     val commands = _commands.receiveAsFlow()
+
+    private val screenType: ScreenType
+        get() = when (entryPoint) {
+            SyncEntryPoint.SYNC_NEW_ACCOUNT -> SYNC_CONNECT
+            SyncEntryPoint.ADD_DEVICE -> SYNC_EXCHANGE
+            SyncEntryPoint.RECOVER_SYNCED_DATA -> SYNC_EXCHANGE
+        }
+
+    fun onScannerScreenShown() {
+        syncPixels.fireScanCodeScreenShown(screenType)
+    }
+
+    fun onManualEntryScreenShown() {
+        syncPixels.fireSyncSetupManualCodeScreenShown(screenType)
+    }
+
+    fun onUserCanceled() {
+        val reason = if (codeDispatcher.isV2ExchangeUnderway()) {
+            CancellationReason.CANCELLED_BEFORE_FINISHED
+        } else {
+            CancellationReason.SCANNING_CANCELLED
+        }
+        syncPixels.fireSyncSetupAbandoned(screenType, reason)
+    }
 
     fun pasteSyncCode() {
         val code = clipboard.pasteFromClipboard()
         viewModelScope.launch {
             if (code.isBlank()) {
+                syncPixels.fireSyncSetupCodePastedParseFailure(screenType, SetupFailureReason.UNRECOGNIZED_CODE)
                 _commands.send(Command.ShowMessage(R.string.sync_simplified_scanner_manual_entry_invalid_code_message))
             } else {
-                _commands.send(Command.StartSyncProcess(code))
+                _commands.send(Command.StartSyncProcess(SyncCodeSource.Pasted(code, entryPoint)))
             }
         }
     }
 
     fun processScannedCode(code: String) {
         viewModelScope.launch {
-            _commands.send(Command.StartSyncProcess(code))
+            _commands.send(Command.StartSyncProcess(SyncCodeSource.Scanned(code, entryPoint)))
         }
     }
 
@@ -58,7 +94,23 @@ class ReadSyncCodeViewModel @Inject constructor(
         ) : Command
 
         data class StartSyncProcess(
-            val syncCode: String,
+            val source: SyncCodeSource,
         ) : Command
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(entryPoint: SyncEntryPoint): ReadSyncCodeViewModel
+
+        class Provider(
+            private val assistedFactory: Factory,
+            private val entryPoint: SyncEntryPoint,
+        ) : ViewModelProvider.Factory {
+
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return assistedFactory.create(entryPoint) as T
+            }
+        }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/RecoverSyncedDataActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/RecoverSyncedDataActivity.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.databinding.ActivitySyncV2RecoverSyncedDataBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.SyncEntryPoint
 import javax.inject.Inject
 
@@ -39,6 +40,9 @@ class RecoverSyncedDataActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
+    @Inject
+    lateinit var syncPixels: SyncPixels
 
     private val launchSource get() = intent.getStringExtra(LAUNCH_SOURCE_EXTRA_KEY)
 
@@ -85,6 +89,7 @@ class RecoverSyncedDataActivity : DuckDuckGoActivity() {
 
     private fun configureRecoverDataCta() {
         binding.recoverDataButton.setOnClickListener {
+            syncPixels.fireRecoverSyncDataConfirmed()
             readSyncCodeLauncher.launch(
                 ReadSyncCodeContract.Input(
                     syncEntryPoint = SyncEntryPoint.RECOVER_SYNCED_DATA,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -199,9 +199,7 @@ class SyncActivity : DuckDuckGoActivity() {
             is PreviousSessionReadyContract.Output.Resume -> {
                 processSyncCodeLauncher.launch(
                     ProcessSyncCodeContract.Input(
-                        syncCode = output.recoveryCode,
-                        syncEntryPoint = SyncEntryPoint.RECOVER_SYNCED_DATA,
-                        launchSource = launchSource,
+                        source = SyncCodeSource.Restored(output.recoveryCode),
                     ),
                 )
             }
@@ -445,9 +443,7 @@ class SyncActivity : DuckDuckGoActivity() {
                     }
                     processSyncCodeLauncher.launch(
                         ProcessSyncCodeContract.Input(
-                            syncCode = command.barcodeSyncUrl.asUrl(),
-                            syncEntryPoint = syncEntryPoint,
-                            launchSource = launchSource,
+                            source = SyncCodeSource.DeepLink(command.barcodeSyncUrl.asUrl(), syncEntryPoint),
                         ),
                     )
                 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceActivity.kt
@@ -93,10 +93,6 @@ class SyncThisDeviceActivity : DuckDuckGoActivity() {
         configureSyncWithThisCta()
 
         observeViewModel()
-
-        if (savedInstanceState == null) {
-            viewModel.onScreenShown()
-        }
     }
 
     private fun configureEdgeToEdgeInsets() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceViewModel.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.AnotherDevicePromptOption
 import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
@@ -50,7 +51,15 @@ class SyncThisDeviceViewModel @Inject constructor(
     private val _viewState = MutableStateFlow(ViewState())
     val viewState = _viewState.asStateFlow()
 
+    init {
+        syncPixels.fireSyncAnotherDevicePromptShown()
+        viewModelScope.launch {
+            syncSetupWideEvent.onIntroScreenShown()
+        }
+    }
+
     fun syncThisDevice(launchSource: String?) {
+        syncPixels.fireSyncAnotherDevicePromptOptionTapped(AnotherDevicePromptOption.THIS_DEVICE_ONLY)
         _viewState.update { it.copy(isSyncing = true) }
 
         viewModelScope.launch(dispatchers.io()) {
@@ -94,13 +103,8 @@ class SyncThisDeviceViewModel @Inject constructor(
         }
     }
 
-    fun onScreenShown() {
-        viewModelScope.launch {
-            syncSetupWideEvent.onIntroScreenShown()
-        }
-    }
-
     fun onSyncWithAnotherDeviceClicked() {
+        syncPixels.fireSyncAnotherDevicePromptOptionTapped(AnotherDevicePromptOption.WITH_ANOTHER_DEVICE)
         viewModelScope.launch {
             _commands.send(Command.SyncWithAnotherDevice)
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/wideevents/SyncSetupWideEvent.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/wideevents/SyncSetupWideEvent.kt
@@ -23,6 +23,9 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.auth.DeviceAuthenticator
+import com.duckduckgo.sync.impl.pixels.RealSyncPixels.Companion.UI_VERSION_V1
+import com.duckduckgo.sync.impl.pixels.RealSyncPixels.Companion.UI_VERSION_V2
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_UI_VERSION
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.Lazy
 import dagger.SingleInstanceIn
@@ -88,9 +91,10 @@ class SyncSetupWideEventImpl @Inject constructor(
         cachedFlowId = wideEventClient.flowStart(
             name = FLOW_NAME,
             flowEntryPoint = source,
-            metadata = mapOf(
-                KEY_USER_AUTH_REQUIRED to deviceAuthenticator.isAuthenticationRequired().toString(),
-            ),
+            metadata = buildMap {
+                put(KEY_USER_AUTH_REQUIRED, deviceAuthenticator.isAuthenticationRequired().toString())
+                putAll(uiMetadata())
+            },
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
         ).getOrNull()
     }
@@ -237,6 +241,13 @@ class SyncSetupWideEventImpl @Inject constructor(
 
         wideEventClient.flowAbort(wideEventId = id)
         cachedFlowId = null
+    }
+
+    private suspend fun uiMetadata(): Map<String, String> = withContext(dispatchers.io()) {
+        buildMap {
+            val version = if (syncFeature.get().useSimplifiedSync().isEnabled()) UI_VERSION_V2 else UI_VERSION_V1
+            put(SYNC_SETUP_UI_VERSION, version)
+        }
     }
 
     private companion object {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.SyncCodeType
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.pixels.SyncPixels.AnotherDevicePromptOption
 import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
@@ -79,12 +80,14 @@ class RealSyncPixelsTest {
 
         testee.fireDailySuccessRatePixel()
 
-        val payload = mapOf(
-            SyncPixelParameters.COUNT to dailyStats.attempts,
-            SyncPixelParameters.DATE to dailyStats.date,
-        ).plus(dailyStats.apiErrorStats)
-
-        verify(pixel).fire(SyncPixelName.SYNC_DAILY_SUCCESS_RATE_PIXEL, payload)
+        verify(pixel).fire(
+            SyncPixelName.SYNC_DAILY_SUCCESS_RATE_PIXEL,
+            buildMap {
+                put(SyncPixelParameters.COUNT, dailyStats.attempts)
+                put(SyncPixelParameters.DATE, dailyStats.date)
+                putAll(dailyStats.apiErrorStats)
+            },
+        )
     }
 
     @Test
@@ -94,45 +97,76 @@ class RealSyncPixelsTest {
         testee.fireDailySuccessRatePixel()
         testee.fireDailySuccessRatePixel()
 
-        val payload = mapOf(
-            SyncPixelParameters.COUNT to dailyStats.attempts,
-            SyncPixelParameters.DATE to dailyStats.date,
-        ).plus(dailyStats.apiErrorStats).plus(dailyStats.operationErrorStats)
-
-        verify(pixel, times(1)).fire(SyncPixelName.SYNC_DAILY_SUCCESS_RATE_PIXEL, payload)
+        verify(pixel, times(1)).fire(
+            SyncPixelName.SYNC_DAILY_SUCCESS_RATE_PIXEL,
+            buildMap {
+                put(SyncPixelParameters.COUNT, dailyStats.attempts)
+                put(SyncPixelParameters.DATE, dailyStats.date)
+                putAll(dailyStats.apiErrorStats)
+                putAll(dailyStats.operationErrorStats)
+            },
+        )
     }
 
     @Test
     fun whenLoginPixelCalledThenPixelFired() {
         testee.fireLoginPixel()
 
-        verify(pixel).fire(SyncPixelName.SYNC_LOGIN)
+        verify(pixel).fire(
+            SyncPixelName.SYNC_LOGIN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+            ),
+        )
     }
 
     @Test
     fun whenSignupDirectPixelCalledWithNoSourceThenPixelFired() {
         testee.fireSignupDirectPixel(source = null)
 
-        verify(pixel).fire(SyncPixelName.SYNC_SIGNUP_DIRECT)
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SIGNUP_DIRECT,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+            ),
+        )
     }
 
     @Test
     fun whenSignupDirectPixelCalledWithSourceThenPixelFiredIncludesSource() {
         testee.fireSignupDirectPixel(source = "foo")
-        verify(pixel).fire(SyncPixelName.SYNC_SIGNUP_DIRECT, mapOf("source" to "foo"))
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SIGNUP_DIRECT,
+            mapOf(
+                "source" to "foo",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+            ),
+        )
     }
 
     @Test
     fun whenSignupConnectPixelCalledWithNoSourceThenPixelFired() {
         testee.fireSignupConnectPixel(source = null)
 
-        verify(pixel).fire(SyncPixelName.SYNC_SIGNUP_CONNECT)
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SIGNUP_CONNECT,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+            ),
+        )
     }
 
     @Test
     fun whenSignupConnectPixelCalledWithSourceThenPixelFiredIncludesSource() {
         testee.fireSignupConnectPixel(source = "foo")
-        verify(pixel).fire(SyncPixelName.SYNC_SIGNUP_CONNECT, mapOf("source" to "foo"))
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SIGNUP_CONNECT,
+            mapOf(
+                "source" to "foo",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+            ),
+        )
     }
 
     @Test
@@ -147,6 +181,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -163,6 +198,41 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+            ),
+        )
+    }
+
+    @Test
+    fun whenScanCodeScreenShownAndV2FlowEnabledThenPixelFiredWithV2AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireScanCodeScreenShown(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_SCAN_QR_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+            ),
+        )
+    }
+
+    @Test
+    fun whenScanCodeScreenShownAndV2FlowDisabledThenPixelFiredWithV1AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireScanCodeScreenShown(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_SCAN_QR_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -179,6 +249,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -195,6 +266,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -212,6 +284,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v1",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -230,6 +303,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_CODE_TYPE to "recovery",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -248,6 +322,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_CODE_TYPE to "linking",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -265,6 +340,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v1",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -281,6 +357,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -297,6 +374,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -313,6 +391,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -330,6 +409,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_PATH to "recovery",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -354,6 +434,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_PEER_KIND to "3party",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -380,6 +461,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_PEER_KIND to "ddg",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -397,6 +479,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_REASON to "unexpected_failure",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -419,6 +502,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_MY_ROLE to "host",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -444,6 +528,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_PATH to "recovery",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -469,6 +554,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_REASON to "cancelled_before_finished",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -485,6 +571,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -505,6 +592,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_REASON to "sync_confirmation_denied",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -525,6 +613,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_REASON to "sync_confirmation_denied",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -579,6 +668,7 @@ class RealSyncPixelsTest {
             mapOf(
                 SyncPixelParameters.ERROR_CODE to "401",
                 SyncPixelParameters.ERROR_REASON to "unauthorized",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -648,6 +738,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_REASON to "unrecognized_code",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -665,6 +756,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_REASON to "unrecognized_code",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -685,6 +777,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_REASON to "session_timeout",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -705,6 +798,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_REASON to "account_creation_failed",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -725,6 +819,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_REASON to "account_upgrade_failed",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -745,6 +840,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_REASON to "already_paired",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -764,6 +860,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -789,6 +886,7 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_TIMEOUT_STAGE to "waiting_for_confirmation",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
@@ -809,6 +907,158 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_REASON to "protocol_error",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+            ),
+        )
+    }
+
+    @Test
+    fun whenLoginPixelCalledAndSimplifiedSyncEnabledThenUiVersionIsV2() {
+        syncFeature.useSimplifiedSync().setRawStoredState(State(true))
+
+        testee.fireLoginPixel()
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_LOGIN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v2",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSignupDirectPixelCalledAndSimplifiedSyncEnabledThenUiVersionIsV2() {
+        syncFeature.useSimplifiedSync().setRawStoredState(State(true))
+
+        testee.fireSignupDirectPixel(source = "foo")
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SIGNUP_DIRECT,
+            mapOf(
+                "source" to "foo",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v2",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScreenShownAndSimplifiedSyncEnabledThenUiVersionIsV2() {
+        syncFeature.useSimplifiedSync().setRawStoredState(State(true))
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncBarcodeScreenShown(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v2",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFinishedAndSimplifiedSyncEnabledButV2FlowDisabledThenUiVersionV2AndFlowVersionV1() {
+        syncFeature.useSimplifiedSync().setRawStoredState(State(true))
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupFinishedSuccessfully(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v2",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSyncSettingsShownThenPixelFiredWithUiVersion() {
+        testee.fireSyncSettingsShown()
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETTINGS_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireBackupThisDeviceTappedThenPixelFiredWithUiVersion() {
+        testee.fireBackupThisDeviceTapped()
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETTINGS_BACK_UP_THIS_DEVICE_TAPPED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireRecoverSyncDataTappedThenPixelFiredWithUiVersion() {
+        testee.fireRecoverSyncDataTapped()
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETTINGS_RECOVER_SYNC_DATA_TAPPED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireRecoverSyncDataConfirmedThenPixelFiredWithUiVersion() {
+        testee.fireRecoverSyncDataConfirmed()
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETTINGS_RECOVER_SYNC_DATA_CONFIRMED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSyncAnotherDevicePromptShownThenPixelFiredWithUiVersion() {
+        testee.fireSyncAnotherDevicePromptShown()
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ANOTHER_DEVICE_PROMPT_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSyncAnotherDevicePromptOptionTappedForThisDeviceOnlyThenPixelFiredWithOptionAndUiVersion() {
+        testee.fireSyncAnotherDevicePromptOptionTapped(AnotherDevicePromptOption.THIS_DEVICE_ONLY)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ANOTHER_DEVICE_PROMPT_OPTION_TAPPED,
+            mapOf(
+                SyncPixelParameters.OPTION to "this_device_only",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSyncAnotherDevicePromptOptionTappedForWithAnotherDeviceThenPixelFiredWithOptionAndUiVersion() {
+        testee.fireSyncAnotherDevicePromptOptionTapped(AnotherDevicePromptOption.WITH_ANOTHER_DEVICE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ANOTHER_DEVICE_PROMPT_OPTION_TAPPED,
+            mapOf(
+                SyncPixelParameters.OPTION to "sync_another_device",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
@@ -200,6 +200,29 @@ class SyncActivityViewModelTest {
     }
 
     @Test
+    fun whenViewModelCreatedThenSyncSettingsShownPixelFired() = runTest {
+        verify(syncPixels).fireSyncSettingsShown()
+    }
+
+    @Test
+    fun whenSyncThisDeviceThenBackupThisDeviceTappedPixelFired() = runTest {
+        givenUserHasDeviceAuthentication(true)
+
+        testee.onSyncThisDevice()
+
+        verify(syncPixels).fireBackupThisDeviceTapped()
+    }
+
+    @Test
+    fun whenRecoverYourSyncedDataThenRecoverSyncDataTappedPixelFired() = runTest {
+        givenUserHasDeviceAuthentication(true)
+
+        testee.onRecoverYourSyncedData()
+
+        verify(syncPixels).fireRecoverSyncDataTapped()
+    }
+
+    @Test
     fun whenSyncWithAnotherDeviceThenEmitCommandSyncWithAnotherDevice() = runTest {
         givenUserHasDeviceAuthentication(true)
         testee.onSyncWithAnotherDevice()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/setup/SyncSetupIntroViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/setup/SyncSetupIntroViewModelTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl.ui.setup
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.sync.impl.SyncFeatureToggle
+import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.setup.SetupAccountActivity.Companion.Screen.RECOVERY_INTRO
 import com.duckduckgo.sync.impl.ui.setup.SetupAccountActivity.Companion.Screen.SYNC_INTRO
 import com.duckduckgo.sync.impl.ui.setup.SyncSetupIntroViewModel.Command.AbortFlow
@@ -42,8 +43,9 @@ class SyncSetupIntroViewModelTest {
 
     private val syncFeatureToggle: SyncFeatureToggle = mock()
     private val syncSetupWideEvent: SyncSetupWideEvent = mock()
+    private val syncPixels: SyncPixels = mock()
 
-    private val testee = SyncSetupIntroViewModel(syncFeatureToggle, coroutineTestRule.testDispatcherProvider, syncSetupWideEvent)
+    private val testee = SyncSetupIntroViewModel(syncFeatureToggle, coroutineTestRule.testDispatcherProvider, syncSetupWideEvent, syncPixels)
 
     @Test
     fun whenSyncIntroArgumentThenIntroCreateAccountScreenShown() = runTest {
@@ -108,6 +110,13 @@ class SyncSetupIntroViewModelTest {
             Assert.assertTrue(command is RecoverDataFlow)
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun whenOnStartRecoveryDataClickedThenRecoverSyncDataConfirmedPixelFired() = runTest {
+        testee.onStartRecoverDataClicked()
+
+        verify(syncPixels).fireRecoverSyncDataConfirmed()
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeViewModelTest.kt
@@ -74,6 +74,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
@@ -564,7 +565,8 @@ class DisplayQrCodeViewModelTest {
 
         createTestee()
 
-        verifyNoInteractions(pixels)
+        verify(pixels).fireSyncBarcodeScreenShown(SYNC_CONNECT)
+        verifyNoMoreInteractions(pixels)
     }
 
     @Test
@@ -619,7 +621,8 @@ class DisplayQrCodeViewModelTest {
         testee.onCopyCodeClicked()
 
         verifyNoInteractions(clipboard)
-        verifyNoInteractions(pixels)
+        verify(pixels).fireSyncBarcodeScreenShown(SYNC_CONNECT)
+        verifyNoMoreInteractions(pixels)
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/ProcessSyncCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/ProcessSyncCodeViewModelTest.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountInfo
 import com.duckduckgo.sync.impl.ConnectCode
 import com.duckduckgo.sync.impl.ConnectedDevice
 import com.duckduckgo.sync.impl.DeviceType
@@ -37,6 +38,13 @@ import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncCodeType
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.autorestore.RestorePayload
+import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import com.duckduckgo.sync.impl.ui.SyncEntryPoint
@@ -62,6 +70,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.contracts.ExperimentalContracts
@@ -84,16 +93,26 @@ class ProcessSyncCodeViewModelTest {
 
     private val accountRepository = mock<SyncAccountRepository>()
     private val codeDispatcher = mock<SyncCodeDispatcher>()
+    private val syncPixels = mock<SyncPixels>()
+    private val syncAutoRestoreManager = mock<SyncAutoRestoreManager>()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
 
-    private fun createTestee() = ProcessSyncCodeViewModel(
-        syncCode = "sync-url",
-        syncEntryPoint = SyncEntryPoint.SYNC_NEW_ACCOUNT,
-        accountRepository = accountRepository,
-        codeDispatcher = codeDispatcher,
-        syncFeature = syncFeature,
-        dispatchers = coroutineTestRule.testDispatcherProvider,
-    )
+    private var accountInfo = AccountInfo()
+
+    private fun createTestee(
+        source: SyncCodeSource = SyncCodeSource.Scanned("sync-url", SyncEntryPoint.SYNC_NEW_ACCOUNT),
+    ): ProcessSyncCodeViewModel {
+        whenever(accountRepository.getAccountInfo()).thenReturn(accountInfo)
+        return ProcessSyncCodeViewModel(
+            source = source,
+            accountRepository = accountRepository,
+            codeDispatcher = codeDispatcher,
+            syncFeature = syncFeature,
+            syncPixels = syncPixels,
+            syncAutoRestoreManager = syncAutoRestoreManager,
+            dispatchers = coroutineTestRule.testDispatcherProvider,
+        )
+    }
 
     @Test
     fun `when a legacy code is routed then the acknowledgment animation runs and the code is processed`() = runTest {
@@ -678,6 +697,211 @@ class ProcessSyncCodeViewModelTest {
 
             cancel()
         }
+    }
+
+    @Test
+    fun `when a scanned v2 code is routed then a v2 barcode parse success pixel is fired`() = runTest {
+        givenV2Outcomes()
+
+        createTestee(source = SyncCodeSource.Scanned("sync-url", SyncEntryPoint.SYNC_NEW_ACCOUNT))
+
+        verify(syncPixels).fireBarcodeScannerParseSuccess(SYNC_CONNECT, CodeVersion.V2, SyncCodeType.LINKING)
+    }
+
+    @Test
+    fun `when a pasted v2 code is routed then a v2 pasted parse success pixel is fired`() = runTest {
+        givenV2Outcomes()
+
+        createTestee(source = SyncCodeSource.Pasted("sync-url", SyncEntryPoint.SYNC_NEW_ACCOUNT))
+
+        verify(syncPixels).fireSyncSetupCodePastedParseSuccess(SYNC_CONNECT, CodeVersion.V2, SyncCodeType.LINKING)
+    }
+
+    @Test
+    fun `when a scanned legacy code is unrecognized then a barcode parse error pixel is fired`() = runTest {
+        givenLegacyCode(SyncAuthCode.Unknown("garbage"))
+
+        createTestee(source = SyncCodeSource.Scanned("sync-url", SyncEntryPoint.SYNC_NEW_ACCOUNT))
+
+        verify(syncPixels).fireBarcodeScannerParseError(SYNC_CONNECT, SetupFailureReason.UNRECOGNIZED_CODE)
+    }
+
+    @Test
+    fun `when a scanned legacy v1 code is routed then a v1 barcode parse success pixel is fired`() = runTest {
+        givenLegacyCode(recoveryAuthCode)
+        givenProcessCodeSucceeds()
+
+        createTestee(source = SyncCodeSource.Scanned("sync-url", SyncEntryPoint.SYNC_NEW_ACCOUNT))
+
+        verify(syncPixels).fireBarcodeScannerParseSuccess(SYNC_CONNECT, CodeVersion.V1, null)
+    }
+
+    @Test
+    fun `when a legacy recovery login completes then login and setup finished pixels are fired`() = runTest {
+        givenLegacyCode(recoveryAuthCode)
+        givenProcessCodeSucceeds()
+        givenThisConnectedDevice()
+
+        val testee = createTestee(source = SyncCodeSource.Scanned("sync-url", SyncEntryPoint.SYNC_NEW_ACCOUNT))
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            testee.onAnimationComplete()
+            awaitItem()
+            awaitItem()
+            cancel()
+        }
+        verify(syncPixels).fireLoginPixel()
+        verify(syncPixels).fireSyncSetupFinishedSuccessfully(SYNC_CONNECT, null, null, null)
+    }
+
+    @Test
+    fun `when a deep link setup starts then the deep link started pixel is fired`() = runTest {
+        givenV2Outcomes()
+
+        createTestee(source = SyncCodeSource.DeepLink("sync-url", SyncEntryPoint.ADD_DEVICE))
+
+        verify(syncPixels).fireSetupDeepLinkFlowStarted()
+    }
+
+    @Test
+    fun `when a deep link setup completes then the deep link success pixel is fired instead of setup finished`() = runTest {
+        givenLegacyCode(recoveryAuthCode)
+        givenProcessCodeSucceeds()
+        givenThisConnectedDevice()
+
+        val testee = createTestee(source = SyncCodeSource.DeepLink("sync-url", SyncEntryPoint.ADD_DEVICE))
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            testee.onAnimationComplete()
+            awaitItem()
+            awaitItem()
+            cancel()
+        }
+        verify(syncPixels).fireLoginPixel()
+        verify(syncPixels).fireSetupDeepLinkFlowSuccess()
+        verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
+    }
+
+    @Test
+    fun `when resuming a previous session then the preserved device id is used and the auto restore success pixel is fired`() = runTest {
+        givenLegacyCode(recoveryAuthCode)
+        givenProcessCodeSucceeds()
+        givenThisConnectedDevice()
+        whenever(syncAutoRestoreManager.retrieveRecoveryPayload())
+            .thenReturn(RestorePayload(recoveryCode = "recovery-code", deviceId = "preserved-device-id"))
+
+        val testee = createTestee(source = SyncCodeSource.Restored("sync-url"))
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            testee.onAnimationComplete()
+            awaitItem()
+            awaitItem()
+            cancel()
+        }
+        verify(accountRepository).processCode(eq(recoveryAuthCode), eq("preserved-device-id"))
+        verify(syncPixels).fireAutoRestoreSuccess(SyncPixelParameters.AUTO_RESTORE_SOURCE_SETTINGS)
+        verify(syncPixels).fireLoginPixel()
+        verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
+    }
+
+    @Test
+    fun `when resuming a previous session fails then the auto restore failure pixel is fired`() = runTest {
+        givenLegacyCode(recoveryAuthCode)
+        whenever(accountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Error(code = LOGIN_FAILED.code, reason = "boom"))
+
+        val testee = createTestee(source = SyncCodeSource.Restored("sync-url"))
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            assertIs<ShowV1Error>(awaitItem())
+            cancel()
+        }
+        verify(syncPixels).fireAutoRestoreFailure(SyncPixelParameters.AUTO_RESTORE_SOURCE_SETTINGS, LOGIN_FAILED.code.toString(), "boom")
+    }
+
+    @Test
+    fun `when the user cancels a scanned setup then no abandoned pixel is fired as the scanner owns it`() = runTest {
+        givenV2Outcomes()
+
+        val testee = createTestee(source = SyncCodeSource.Scanned("sync-url", SyncEntryPoint.SYNC_NEW_ACCOUNT))
+
+        testee.onUserCanceled()
+
+        verify(syncPixels, never()).fireSyncSetupAbandoned(any(), anyOrNull())
+    }
+
+    @Test
+    fun `when the user cancels a deep link setup before it finishes then the deep link abandoned pixel is fired`() = runTest {
+        givenV2Outcomes()
+
+        val testee = createTestee(source = SyncCodeSource.DeepLink("sync-url", SyncEntryPoint.ADD_DEVICE))
+
+        testee.onUserCanceled()
+
+        verify(syncPixels).fireSetupDeepLinkFlowAbandoned()
+    }
+
+    @Test
+    fun `when the user is asked to switch accounts then the ask to switch pixel is fired`() = runTest {
+        givenSeamlessAccountSwitching(enabled = true)
+        givenLegacyCode(recoveryAuthCode)
+        whenever(accountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code, reason = "boom"))
+
+        val testee = createTestee(source = SyncCodeSource.Scanned("sync-url", SyncEntryPoint.SYNC_NEW_ACCOUNT))
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            assertIs<AskSwitchAccount>(awaitItem())
+            cancel()
+        }
+        verify(syncPixels).fireAskUserToSwitchAccount()
+    }
+
+    @Test
+    fun `when the user accepts switching accounts then the accepted pixel is fired`() = runTest {
+        givenLegacyCode(exchangeAuthCode)
+        givenProcessCodeSucceeds()
+        givenThisConnectedDevice()
+        whenever(accountRepository.pollForRecoveryCodeAndLogin())
+            .thenReturn(Result.Success(ExchangeResult.AccountSwitchingRequired("encoded-code")))
+        whenever(accountRepository.logoutAndJoinNewAccount("encoded-code")).thenReturn(Result.Success(true))
+
+        val testee = createTestee(source = SyncCodeSource.Scanned("sync-url", SyncEntryPoint.SYNC_NEW_ACCOUNT))
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            assertIs<AskSwitchAccount>(awaitItem())
+            testee.onAnimationComplete()
+            testee.onUserAcceptedSwitchingAccount("encoded-code")
+            awaitItem()
+            awaitItem()
+            cancel()
+        }
+        verify(syncPixels).fireUserAcceptedSwitchingAccount()
+        verify(syncPixels).fireUserSwitchedAccount()
+    }
+
+    @Test
+    fun `when the user cancels switching accounts then the cancelled pixel is fired`() = runTest {
+        givenLegacyCode(exchangeAuthCode)
+        givenProcessCodeSucceeds()
+        whenever(accountRepository.pollForRecoveryCodeAndLogin())
+            .thenReturn(Result.Success(ExchangeResult.AccountSwitchingRequired("encoded-code")))
+
+        val testee = createTestee(source = SyncCodeSource.Scanned("sync-url", SyncEntryPoint.SYNC_NEW_ACCOUNT))
+
+        testee.commands.test {
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            assertIs<AskSwitchAccount>(awaitItem())
+            testee.onUserCancelledSwitchingAccount()
+            awaitItem()
+            awaitItem()
+            cancel()
+        }
+        verify(syncPixels).fireUserCancelledSwitchingAccount()
     }
 
     private fun givenProcessCodeSucceeds() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/ReadSyncCodeViewModelTest.kt
@@ -21,6 +21,12 @@ import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
+import com.duckduckgo.sync.impl.ui.SyncEntryPoint
 import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeViewModel.Command.ShowMessage
 import com.duckduckgo.sync.impl.ui.v2.ReadSyncCodeViewModel.Command.StartSyncProcess
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -31,6 +37,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
@@ -42,13 +49,18 @@ class ReadSyncCodeViewModelTest {
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private val clipboard = mock<Clipboard>()
+    private val syncPixels = mock<SyncPixels>()
+    private val codeDispatcher = mock<SyncCodeDispatcher>()
 
     private val testee = ReadSyncCodeViewModel(
+        entryPoint = SyncEntryPoint.SYNC_NEW_ACCOUNT,
         clipboard = clipboard,
+        syncPixels = syncPixels,
+        codeDispatcher = codeDispatcher,
     )
 
     @Test
-    fun `when a sync code is pasted then the sync process starts with the pasted url`() = runTest {
+    fun `when a sync code is pasted then the sync process starts with the pasted url as a pasted source`() = runTest {
         whenever(clipboard.pasteFromClipboard()).thenReturn("sync-code")
 
         testee.commands.test {
@@ -56,20 +68,22 @@ class ReadSyncCodeViewModelTest {
 
             val command = awaitItem()
             assertIs<StartSyncProcess>(command)
-            assertEquals("sync-code", command.syncCode)
+            assertEquals("sync-code", command.source.code)
+            assertEquals(SyncCodeSource.Pasted("sync-code", SyncEntryPoint.SYNC_NEW_ACCOUNT), command.source)
 
             cancel()
         }
     }
 
     @Test
-    fun `when a sync code is scanned then the sync process starts with the scanned url`() = runTest {
+    fun `when a sync code is scanned then the sync process starts with the scanned url as a scanned source`() = runTest {
         testee.commands.test {
             testee.processScannedCode("sync-code")
 
             val command = awaitItem()
             assertIs<StartSyncProcess>(command)
-            assertEquals("sync-code", command.syncCode)
+            assertEquals("sync-code", command.source.code)
+            assertEquals(SyncCodeSource.Scanned("sync-code", SyncEntryPoint.SYNC_NEW_ACCOUNT), command.source)
 
             cancel()
         }
@@ -89,6 +103,39 @@ class ReadSyncCodeViewModelTest {
             expectNoEvents()
             cancel()
         }
+        verify(syncPixels).fireSyncSetupCodePastedParseFailure(SYNC_CONNECT, SetupFailureReason.UNRECOGNIZED_CODE)
+    }
+
+    @Test
+    fun `when the screen is shown then the scan code screen shown pixel is fired`() = runTest {
+        testee.onScannerScreenShown()
+
+        verify(syncPixels).fireScanCodeScreenShown(SYNC_CONNECT)
+    }
+
+    @Test
+    fun `when the manual entry screen is shown then the manual code screen shown pixel is fired`() = runTest {
+        testee.onManualEntryScreenShown()
+
+        verify(syncPixels).fireSyncSetupManualCodeScreenShown(SYNC_CONNECT)
+    }
+
+    @Test
+    fun `when the user leaves before scanning and no exchange is underway then a scanning cancelled pixel is fired`() = runTest {
+        whenever(codeDispatcher.isV2ExchangeUnderway()).thenReturn(false)
+
+        testee.onUserCanceled()
+
+        verify(syncPixels).fireSyncSetupAbandoned(SYNC_CONNECT, CancellationReason.SCANNING_CANCELLED)
+    }
+
+    @Test
+    fun `when the user leaves while an exchange is underway then a cancelled before finished pixel is fired`() = runTest {
+        whenever(codeDispatcher.isV2ExchangeUnderway()).thenReturn(true)
+
+        testee.onUserCanceled()
+
+        verify(syncPixels).fireSyncSetupAbandoned(SYNC_CONNECT, CancellationReason.CANCELLED_BEFORE_FINISHED)
     }
 }
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceViewModelTest.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.sync.impl.DeviceType
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.AnotherDevicePromptOption
 import com.duckduckgo.sync.impl.ui.v2.SyncThisDeviceViewModel.Command.AbortSyncing
 import com.duckduckgo.sync.impl.ui.v2.SyncThisDeviceViewModel.Command.FinishSyncing
 import com.duckduckgo.sync.impl.ui.v2.SyncThisDeviceViewModel.Command.ShowError
@@ -35,10 +36,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 class SyncThisDeviceViewModelTest {
@@ -102,7 +103,7 @@ class SyncThisDeviceViewModelTest {
             skipItems(1)
 
             verify(syncAccountRepository, never()).createAccount()
-            verifyNoInteractions(syncPixels)
+            verify(syncPixels, never()).fireSignupDirectPixel(anyOrNull())
 
             cancel()
         }
@@ -192,7 +193,7 @@ class SyncThisDeviceViewModelTest {
             testee.syncThisDevice(launchSource = null)
             assertIs<ShowError>(awaitItem())
 
-            verifyNoInteractions(syncPixels)
+            verify(syncPixels, never()).fireSignupDirectPixel(anyOrNull())
 
             cancel()
         }
@@ -272,9 +273,39 @@ class SyncThisDeviceViewModelTest {
     }
 
     @Test
-    fun `when the user sees the screen then the intro screen shown event is tracked`() = runTest {
-        testee.onScreenShown()
+    fun `when the view model is created then the another device prompt shown pixel is fired`() = runTest {
+        verify(syncPixels).fireSyncAnotherDevicePromptShown()
+    }
+
+    @Test
+    fun `when the view model is created then the intro screen shown event is tracked`() = runTest {
         verify(syncSetupWideEvent).onIntroScreenShown()
+    }
+
+    @Test
+    fun `when syncing this device then the this device only option pixel is fired`() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+
+        testee.commands.test {
+            testee.syncThisDevice(launchSource = null)
+            skipItems(1)
+
+            verify(syncPixels).fireSyncAnotherDevicePromptOptionTapped(AnotherDevicePromptOption.THIS_DEVICE_ONLY)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the user chooses to sync with another device then the another device option pixel is fired`() = runTest {
+        testee.commands.test {
+            testee.onSyncWithAnotherDeviceClicked()
+            skipItems(1)
+
+            verify(syncPixels).fireSyncAnotherDevicePromptOptionTapped(AnotherDevicePromptOption.WITH_ANOTHER_DEVICE)
+
+            cancel()
+        }
     }
 }
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceViewModelTest.kt
@@ -58,7 +58,7 @@ class SyncThisDeviceViewModelTest {
     private val syncPixels = mock<SyncPixels>()
     private val syncSetupWideEvent = mock<SyncSetupWideEvent>()
 
-    private val testee = SyncThisDeviceViewModel(
+    private fun createTestee() = SyncThisDeviceViewModel(
         syncAccountRepository,
         syncPixels,
         coroutineTestRule.testDispatcherProvider,
@@ -74,6 +74,8 @@ class SyncThisDeviceViewModelTest {
     fun `when the user is already signed in then syncing finishes`() = runTest {
         whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
 
+        val testee = createTestee()
+
         testee.commands.test {
             testee.syncThisDevice(launchSource = null)
             assertIs<FinishSyncing>(awaitItem())
@@ -86,6 +88,8 @@ class SyncThisDeviceViewModelTest {
     fun `when syncing finishes then the connected device is included`() = runTest {
         whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
 
+        val testee = createTestee()
+
         testee.commands.test {
             testee.syncThisDevice(launchSource = null)
             assertEquals(connectedDevice, (awaitItem() as FinishSyncing).device)
@@ -97,6 +101,8 @@ class SyncThisDeviceViewModelTest {
     @Test
     fun `when the user is already signed in then no account is created`() = runTest {
         whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+
+        val testee = createTestee()
 
         testee.commands.test {
             testee.syncThisDevice(launchSource = null)
@@ -114,6 +120,8 @@ class SyncThisDeviceViewModelTest {
         whenever(syncAccountRepository.isSignedIn()).thenReturn(false)
         whenever(syncAccountRepository.createAccount()).thenReturn(Result.Success(true))
 
+        val testee = createTestee()
+
         testee.commands.test {
             testee.syncThisDevice(launchSource = null)
             assertIs<FinishSyncing>(awaitItem())
@@ -130,6 +138,8 @@ class SyncThisDeviceViewModelTest {
         whenever(syncAccountRepository.isSignedIn()).thenReturn(false)
         whenever(syncAccountRepository.createAccount()).thenReturn(Result.Success(true))
 
+        val testee = createTestee()
+
         testee.commands.test {
             testee.syncThisDevice(launchSource = "foo")
             skipItems(1)
@@ -145,6 +155,8 @@ class SyncThisDeviceViewModelTest {
         whenever(syncAccountRepository.isSignedIn()).thenReturn(false)
         whenever(syncAccountRepository.createAccount()).thenReturn(Result.Success(true))
 
+        val testee = createTestee()
+
         testee.commands.test {
             testee.syncThisDevice(launchSource = null)
             skipItems(1)
@@ -158,6 +170,8 @@ class SyncThisDeviceViewModelTest {
     @Test
     fun `when syncing this device then the sync enabled event is tracked`() = runTest {
         whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+
+        val testee = createTestee()
 
         testee.commands.test {
             testee.syncThisDevice(launchSource = null)
@@ -174,6 +188,8 @@ class SyncThisDeviceViewModelTest {
         whenever(syncAccountRepository.isSignedIn()).thenReturn(false)
         whenever(syncAccountRepository.createAccount()).thenReturn(Result.Error(1, ""))
 
+        val testee = createTestee()
+
         testee.commands.test {
             testee.syncThisDevice(launchSource = null)
             skipItems(1)
@@ -188,6 +204,8 @@ class SyncThisDeviceViewModelTest {
     fun `when account creation fails then an error is shown`() = runTest {
         whenever(syncAccountRepository.isSignedIn()).thenReturn(false)
         whenever(syncAccountRepository.createAccount()).thenReturn(Result.Error(1, ""))
+
+        val testee = createTestee()
 
         testee.commands.test {
             testee.syncThisDevice(launchSource = null)
@@ -204,6 +222,8 @@ class SyncThisDeviceViewModelTest {
         whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
         whenever(syncAccountRepository.getThisConnectedDevice()).thenReturn(null)
 
+        val testee = createTestee()
+
         testee.commands.test {
             testee.syncThisDevice(launchSource = null)
             assertIs<ShowError>(awaitItem())
@@ -216,6 +236,8 @@ class SyncThisDeviceViewModelTest {
     fun `when the connected device cannot be retrieved then the account creation failed event is tracked`() = runTest {
         whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
         whenever(syncAccountRepository.getThisConnectedDevice()).thenReturn(null)
+
+        val testee = createTestee()
 
         testee.commands.test {
             testee.syncThisDevice(launchSource = null)
@@ -231,6 +253,8 @@ class SyncThisDeviceViewModelTest {
     fun `when syncing this device then the syncing state is shown and then cleared`() = runTest {
         whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
 
+        val testee = createTestee()
+
         testee.viewState.test {
             assertFalse(awaitItem().isSyncing)
 
@@ -244,6 +268,8 @@ class SyncThisDeviceViewModelTest {
 
     @Test
     fun `when the user chooses to sync with another device then that flow starts`() = runTest {
+        val testee = createTestee()
+
         testee.commands.test {
             testee.onSyncWithAnotherDeviceClicked()
             assertIs<SyncWithAnotherDevice>(awaitItem())
@@ -254,6 +280,8 @@ class SyncThisDeviceViewModelTest {
 
     @Test
     fun `when the user closes the screen then syncing is aborted`() = runTest {
+        val testee = createTestee()
+
         testee.commands.test {
             testee.onCloseClicked()
             assertIs<AbortSyncing>(awaitItem())
@@ -264,6 +292,8 @@ class SyncThisDeviceViewModelTest {
 
     @Test
     fun `when the user dismisses the error then syncing is aborted`() = runTest {
+        val testee = createTestee()
+
         testee.commands.test {
             testee.onErrorDismissed()
             assertIs<AbortSyncing>(awaitItem())
@@ -274,17 +304,23 @@ class SyncThisDeviceViewModelTest {
 
     @Test
     fun `when the view model is created then the another device prompt shown pixel is fired`() = runTest {
+        createTestee()
+
         verify(syncPixels).fireSyncAnotherDevicePromptShown()
     }
 
     @Test
     fun `when the view model is created then the intro screen shown event is tracked`() = runTest {
+        createTestee()
+
         verify(syncSetupWideEvent).onIntroScreenShown()
     }
 
     @Test
     fun `when syncing this device then the this device only option pixel is fired`() = runTest {
         whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+
+        val testee = createTestee()
 
         testee.commands.test {
             testee.syncThisDevice(launchSource = null)
@@ -298,6 +334,8 @@ class SyncThisDeviceViewModelTest {
 
     @Test
     fun `when the user chooses to sync with another device then the another device option pixel is fired`() = runTest {
+        val testee = createTestee()
+
         testee.commands.test {
             testee.onSyncWithAnotherDeviceClicked()
             skipItems(1)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/wideevents/SyncSetupWideEventImplTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/wideevents/SyncSetupWideEventImplTest.kt
@@ -20,7 +20,8 @@ import com.duckduckgo.app.statistics.wideevents.CleanupPolicy
 import com.duckduckgo.app.statistics.wideevents.FlowStatus
 import com.duckduckgo.app.statistics.wideevents.WideEventClient
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.auth.DeviceAuthenticator
 import kotlinx.coroutines.test.runTest
@@ -40,16 +41,15 @@ class SyncSetupWideEventImplTest {
     val coroutineRule = CoroutineTestRule()
 
     private val wideEventClient: WideEventClient = mock()
-    private val syncFeature: SyncFeature = mock()
-    private val toggle: Toggle = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
     private val deviceAuthenticator: DeviceAuthenticator = mock()
 
     private lateinit var wideEvent: SyncSetupWideEventImpl
 
     @Before
     fun setup() {
-        whenever(syncFeature.sendSyncSetupWideEvent()).thenReturn(toggle)
-        whenever(toggle.isEnabled()).thenReturn(true)
+        syncFeature.sendSyncSetupWideEvent().setRawStoredState(State(true))
+        syncFeature.useSimplifiedSync().setRawStoredState(State(false))
         whenever(deviceAuthenticator.isAuthenticationRequired()).thenReturn(true)
 
         wideEvent = SyncSetupWideEventImpl(
@@ -61,7 +61,7 @@ class SyncSetupWideEventImplTest {
     }
 
     @Test
-    fun `onFlowStarted starts a new flow with correct parameters`() = runTest {
+    fun `onFlowStarted starts a new flow with correct ui v1 parameters`() = runTest {
         whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(1L))
 
@@ -69,7 +69,22 @@ class SyncSetupWideEventImplTest {
 
         verify(wideEventClient).flowStart(
             name = "sync-setup",
-            metadata = mapOf("user_auth_required" to "true"),
+            metadata = mapOf("user_auth_required" to "true", "ui_version" to "v1"),
+            cleanupPolicy = CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
+        )
+    }
+
+    @Test
+    fun `onFlowStarted starts a new flow with correct ui v2 parameters`() = runTest {
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
+            .thenReturn(Result.success(1L))
+        syncFeature.useSimplifiedSync().setRawStoredState(State(true))
+
+        wideEvent.onFlowStarted()
+
+        verify(wideEventClient).flowStart(
+            name = "sync-setup",
+            metadata = mapOf("user_auth_required" to "true", "ui_version" to "v2"),
             cleanupPolicy = CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
         )
     }
@@ -84,7 +99,7 @@ class SyncSetupWideEventImplTest {
         verify(wideEventClient).flowStart(
             name = "sync-setup",
             flowEntryPoint = "settings",
-            metadata = mapOf("user_auth_required" to "true"),
+            metadata = mapOf("user_auth_required" to "true", "ui_version" to "v1"),
             cleanupPolicy = CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
         )
     }
@@ -104,7 +119,7 @@ class SyncSetupWideEventImplTest {
 
     @Test
     fun `feature disabled results in no interactions`() = runTest {
-        whenever(toggle.isEnabled()).thenReturn(false)
+        syncFeature.sendSyncSetupWideEvent().setRawStoredState(State(false))
 
         wideEvent.onFlowStarted()
         wideEvent.onIntroScreenShown()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1216422585541219?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Brings the simplified Sync (v2) setup flow to pixel parity with the legacy setup flow and with iOS, adds a set of new Sync settings pixels, and tags sync setup pixels with a `ui_version` parameter so each pixel records whether it came from the simplified or the legacy UI. It also changes one setup behavior so restoring a previous session reuses the current device (this is the legacy behavior).

New Sync settings pixels:
- Opening the Sync settings screen fires `m_settings_sync_open`.
- Tapping "Sync This Device" fires `m_settings_sync_back_up_this_device_tapped`.
- Starting the recover synced data flow fires `m_settings_sync_recover_synced_data_tapped`.
- Confirming recovery on the "Recover your synced data" screen fires `m_settings_sync_recovery_confirmed_tapped`.
- The prompt that asks whether to sync this device or another device fires `m_settings_sync_another_device_prompt_shown` when it appears.
- Choosing an option on that prompt fires `m_settings_sync_another_device_prompt_option_tapped`, with an `option` of `this_device_only` or `sync_another_device`.

Simplified Sync setup parity:
- The simplified scan and manual entry screens now fire the setup pixels that previously only fired in the legacy flow, including the scan QR screen shown (`sync_setup_scan_qr_screen_shown`), the barcode and manual code screens shown, code recognized success and failure, setup finished, setup failed, and setup abandoned.
- The deep link setup path now fires its started, success, and abandoned pixels from the simplified flow.
- Account switching now fires its ask to switch, accepted, cancelled, and switched pixels from the simplified flow.
- Restoring a previous session now fires the auto restore success and failure pixels.
- A `sync_login` pixel is fired on every successful setup.

`ui_version` parameter:
- Sync setup, login, signup, error, account switching, and auto restore pixels now include a `ui_version` parameter, set to `v2` when the simplified sync UI is enabled (`useSimplifiedSync`) and `v1` otherwise.
- The `sync-setup` wide event carries the same `ui_version` value in its metadata.

Behavior change:
- When restoring a previous session from Sync settings, the stored recovery payload's device id is now passed through when the code is processed, so the restore reuses the existing device record instead of registering a new device.

> [!note]
> I added only some basic tests that verify the `ui_version` parameter. I'll expand them in a followup PR after adding [TestParameterInjector](https://app.asana.com/1/137249556945/project/1212087397361015/task/1217184171405432?focus=true).

### Steps to test this PR

I think there are too many pixels to write a comprehensive testing scenario. I documented Pixels for the simplified UI in [this task](https://app.asana.com/1/137249556945/task/1216422585541219?focus=true). I tested it in the following way:

1. Set up Device A with the `useSimplifiedSync` feature flag enabled.
2. Set up Device B with the `useSimplifiedSync` feature flag disabled.
3. Split the terminal into 2 panes and run `adb -s <DEVICE_ID> logcat -s RxBasedPixel:V` in each pane.
4. Have a Device C that you'll be able to use to show QR codes, etc.
5. Run the same user journeys using both devices and compare logged pixels.

### UI changes
N/A



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are analytics definitions and pixel firing plus a targeted restore device-id pass-through; no auth or payment logic, though restore behavior differs slightly for settings session resume.
> 
> **Overview**
> Adds **sync telemetry** for the simplified setup UI and Sync settings, and tags existing setup-related pixels with **`ui_version`** (`v1` / `v2` from `useSimplifiedSync`).
> 
> **Pixel definitions:** New `sync_settings.json5` defines settings events (`m_settings_sync_open`, backup/recover taps, recovery confirm, and the “this device vs another device” prompt). `sync_setup.json5` adds `sync_setup_scan_qr_screen_shown`; `sync.json5`, `sync_auto_restore.json5`, `wide_sync_setup.json5`, and setup definitions gain **`ui_version`** (and related params where needed).
> 
> **`SyncPixels` / wiring:** `setupUiMetadata()` drives **`ui_version`** on login, signup, errors, account switching, auto-restore, setup flow metadata, and new APIs for settings + scan-QR + another-device prompt. View models and activities fire the new events and simplified-path setup pixels (parse success/failure, finished/failed/abandoned, deep link, auto-restore) from **`ProcessSyncCodeViewModel`** and **`ReadSyncCodeViewModel`**. **`SyncCodeSource`** replaces loose intent extras for how a code reached processing.
> 
> **Behavior:** Restoring a previous session passes the preserved **device id** from auto-restore into **`processCode`**, reusing the existing device record. **`sync-setup`** wide events include **`ui_version`** in metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6533461db463a850b90990118bfbf30c7e0790a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->