### PR TITLE
[Config-driven linear onboarding dialogs] Port existing screens (forward flows)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrector.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrector.kt
@@ -107,11 +107,11 @@ class OnboardingDecorationFitCorrector(
         val overflow = (cardContainerHeight - viewportHeight).coerceAtLeast(0)
         val available = root.height - root.paddingTop - root.paddingBottom
         val dialogParams = dialog.layoutParams as ViewGroup.MarginLayoutParams
-        // A keyboard overlays the window rather than shrinking it, so `available` already covers the room the card
-        // gave up above the decoration. Counting it would shrink the decoration, which grows the inset, which
-        // shrinks the decoration again, until it is gone.
-        val cardBottomMargin = if (reservesInsetAboveDecoration) 0 else dialogParams.bottomMargin
-        val dialogSpace = dialogHeight + overflow + dialogParams.topMargin + cardBottomMargin
+        // The card's bottom margin never counts against the decoration's room. With a decoration shown it is
+        // either zero (synced above) or a reserved inset, and the keyboard that inset clears overlays the
+        // window rather than shrinking it, so `available` already covers the room the card gave up. Counting
+        // it would shrink the decoration, which grows the inset, which shrinks it again, until it is gone.
+        val dialogSpace = dialogHeight + overflow + dialogParams.topMargin
         val decorationParams = deco.layoutParams as ViewGroup.MarginLayoutParams
 
         val target = BrandDesignUpdateOnboardingLayoutHelper.computeDecorationHeight(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrector.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrector.kt
@@ -83,10 +83,6 @@ class OnboardingDecorationFitCorrector(
 
         val deco = decoration
         val decorationShown = deco != null && !deco.isGone
-        // The card reserves the bottom-bar inset when it is the bottom-most element: bottom-anchored AND no
-        // decoration shown below it. A shown decoration is at least its min height, which exceeds any bar
-        // inset, so it covers the bar for the card; reserving the inset then would feed dialogSpace and hide
-        // that very decoration.
         if (syncCardBottomInset(decorationShown)) return false
 
         // While onboardingImprovementsV2 is off the corrector stays inert: syncCardBottomInset above
@@ -155,7 +151,12 @@ class OnboardingDecorationFitCorrector(
     ): Int {
         if (!enabled) return 0
         if (params.bottomToBottom == ConstraintLayout.LayoutParams.PARENT_ID) {
-            return if (decorationShown) 0 else cardBottomInsetPx()
+            // On the legacy path a shown decoration exceeds any bar inset and covers it for the card;
+            // reserving the inset then would feed dialogSpace and hide that very decoration. On the
+            // config-driven path a decoration that leaves the card bottom-anchored sits beside or over
+            // it, covering nothing below it, so the card still has to clear the inset — the keyboard.
+            if (decorationShown && !reservesInsetAboveDecoration) return 0
+            return cardBottomInsetPx()
         }
         val deco = decoration?.takeIf { decorationShown && reservesInsetAboveDecoration } ?: return 0
         return (cardBottomInsetPx() - roomBelowCard(deco)).coerceAtLeast(0)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrector.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrector.kt
@@ -40,6 +40,9 @@ class OnboardingDecorationFitCorrector(
      * does not already cover. Only the config-driven renderer sets this: its undecorated band anchors the card on
      * screens the legacy renderer pinned to the parent bottom, so without this the card has no way to clear an
      * inset taller than the band, i.e. the keyboard.
+     *
+     * The whole reservation hangs off this flag, so the legacy renderer's geometry is untouched: the reserved
+     * inset stays out of the decoration's fit, and the card's span above the decoration is what clamps it.
      */
     var reservesInsetAboveDecoration: Boolean = false
 
@@ -93,9 +96,10 @@ class OnboardingDecorationFitCorrector(
         // has already reverted any reserved inset, and the shrink/hide logic below must not run.
         if (!enabled) return true
 
-        if (deco == null) return !syncBottomAnchoredClamp()
+        if (deco == null) return !syncCardClamp()
         if (deco.isGone) return true
         if (BrandDesignUpdateOnboardingLayoutHelper.isInScrollableContainer(dialog, root)) return true
+        if (reservesInsetAboveDecoration && syncCardClamp()) return false
 
         val viewport = cardContainer.parent as? View ?: return true
 
@@ -110,7 +114,12 @@ class OnboardingDecorationFitCorrector(
         val overflow = (cardContainerHeight - viewportHeight).coerceAtLeast(0)
         val available = root.height - root.paddingTop - root.paddingBottom
         val dialogParams = dialog.layoutParams as ViewGroup.MarginLayoutParams
-        val dialogSpace = dialogHeight + overflow + dialogParams.topMargin + dialogParams.bottomMargin
+        // An inset reserved above the decoration buys room the decoration is not competing for: a keyboard
+        // overlays the window rather than shrinking it, so `available` already covers the room the card gave up.
+        // Counting it would shrink the decoration, which grows the inset, which shrinks the decoration, until it
+        // is gone. Without that reservation the margin is 0 here anyway, a decoration being shown.
+        val cardBottomMargin = if (reservesInsetAboveDecoration) 0 else dialogParams.bottomMargin
+        val dialogSpace = dialogHeight + overflow + dialogParams.topMargin + cardBottomMargin
         val decorationParams = deco.layoutParams as ViewGroup.MarginLayoutParams
 
         val target = BrandDesignUpdateOnboardingLayoutHelper.computeDecorationHeight(
@@ -164,11 +173,19 @@ class OnboardingDecorationFitCorrector(
     }
 
     // Clamp only on overflow: constrainedHeight rounds a fitting wrap down a pixel → a permanent scrollbar.
-    private fun syncBottomAnchoredClamp(): Boolean {
+    private fun syncCardClamp(): Boolean {
         val params = dialog.layoutParams as? ConstraintLayout.LayoutParams ?: return false
-        if (params.bottomToBottom != ConstraintLayout.LayoutParams.PARENT_ID) return false
+        val roomBelowCard = when {
+            params.bottomToBottom == ConstraintLayout.LayoutParams.PARENT_ID -> 0
+            // Anchored above a decoration: unclamped the card overruns it instead of scrolling, so a card lifted
+            // clear of the keyboard would still spill under it.
+            params.bottomToTop != ConstraintLayout.LayoutParams.UNSET ->
+                decoration?.takeIf { !it.isGone }?.let { roomBelowCard(it) } ?: return false
+            else -> return false
+        }
         val content = cardContainer.measuredHeight.takeIf { it > 0 } ?: return false
-        val span = root.height - root.paddingTop - root.paddingBottom - params.topMargin - params.bottomMargin
+        val span = root.height - root.paddingTop - root.paddingBottom -
+            params.topMargin - params.bottomMargin - roomBelowCard
         val shouldClamp = dialog.paddingTop + content > span
         if (params.constrainedHeight == shouldClamp) return false
         dialog.updateLayoutParams<ConstraintLayout.LayoutParams> { constrainedHeight = shouldClamp }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrector.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrector.kt
@@ -35,6 +35,14 @@ class OnboardingDecorationFitCorrector(
     // TODO: remove when onboardingImprovementsV2 flag is removed
     var enabled: Boolean = false
 
+    /**
+     * Whether a card anchored above a decoration still reserves the part of its bottom inset that the decoration
+     * does not already cover. Only the config-driven renderer sets this: its undecorated band anchors the card on
+     * screens the legacy renderer pinned to the parent bottom, so without this the card has no way to clear an
+     * inset taller than the band, i.e. the keyboard.
+     */
+    var reservesInsetAboveDecoration: Boolean = false
+
     private var decoration: View? = null
     private var minHeightPx = 0
     private var maxHeightPx = 0
@@ -75,10 +83,10 @@ class OnboardingDecorationFitCorrector(
 
         val deco = decoration
         val decorationShown = deco != null && !deco.isGone
-        // The card reserves the bottom-bar inset only when it is the bottom-most element: bottom-anchored
-        // AND no decoration shown below it. A shown decoration is at least its min height, which exceeds
-        // any bar inset, so it covers the bar for the card; reserving the inset then would feed dialogSpace
-        // and hide that very decoration.
+        // The card reserves the bottom-bar inset when it is the bottom-most element: bottom-anchored AND no
+        // decoration shown below it. A shown decoration is at least its min height, which exceeds any bar
+        // inset, so it covers the bar for the card; reserving the inset then would feed dialogSpace and hide
+        // that very decoration. See [reservesInsetAboveDecoration] for the insets a decoration cannot cover.
         if (syncCardBottomInset(decorationShown)) return false
 
         // While onboardingImprovementsV2 is off the corrector stays inert: syncCardBottomInset above
@@ -130,11 +138,29 @@ class OnboardingDecorationFitCorrector(
 
     private fun syncCardBottomInset(decorationShown: Boolean): Boolean {
         val params = dialog.layoutParams as? ConstraintLayout.LayoutParams ?: return false
-        val bottomAnchored = params.bottomToBottom == ConstraintLayout.LayoutParams.PARENT_ID
-        val desired = if (enabled && bottomAnchored && !decorationShown) cardBottomInsetPx() else 0
+        val desired = desiredCardBottomInset(params, decorationShown)
         if (params.bottomMargin == desired) return false
         dialog.updateLayoutParams<ConstraintLayout.LayoutParams> { bottomMargin = desired }
         return true
+    }
+
+    private fun desiredCardBottomInset(
+        params: ConstraintLayout.LayoutParams,
+        decorationShown: Boolean,
+    ): Int {
+        if (!enabled) return 0
+        if (params.bottomToBottom == ConstraintLayout.LayoutParams.PARENT_ID) {
+            return if (decorationShown) 0 else cardBottomInsetPx()
+        }
+        val deco = decoration?.takeIf { decorationShown && reservesInsetAboveDecoration } ?: return 0
+        return (cardBottomInsetPx() - roomBelowCard(deco)).coerceAtLeast(0)
+    }
+
+    private fun roomBelowCard(decoration: View): Int {
+        val params = decoration.layoutParams as ViewGroup.MarginLayoutParams
+        // The applied height, not the laid-out one: the corrector runs before the frame that lays the shrink out.
+        val height = params.height.takeIf { it > 0 } ?: decoration.measuredHeight
+        return height + params.bottomMargin
     }
 
     // Clamp only on overflow: constrainedHeight rounds a fitting wrap down a pixel → a permanent scrollbar.

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrector.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrector.kt
@@ -36,13 +36,10 @@ class OnboardingDecorationFitCorrector(
     var enabled: Boolean = false
 
     /**
-     * Whether a card anchored above a decoration still reserves the part of its bottom inset that the decoration
-     * does not already cover. Only the config-driven renderer sets this: its undecorated band anchors the card on
-     * screens the legacy renderer pinned to the parent bottom, so without this the card has no way to clear an
-     * inset taller than the band, i.e. the keyboard.
-     *
-     * The whole reservation hangs off this flag, so the legacy renderer's geometry is untouched: the reserved
-     * inset stays out of the decoration's fit, and the card's span above the decoration is what clamps it.
+     * Whether a card anchored above a decoration also reserves the part of its bottom inset the decoration does not
+     * cover. Only the config-driven renderer needs it: its undecorated band anchors the card on screens the legacy
+     * renderer pinned to the parent bottom, so otherwise the card cannot clear an inset taller than the band, i.e.
+     * the keyboard.
      */
     var reservesInsetAboveDecoration: Boolean = false
 
@@ -89,7 +86,7 @@ class OnboardingDecorationFitCorrector(
         // The card reserves the bottom-bar inset when it is the bottom-most element: bottom-anchored AND no
         // decoration shown below it. A shown decoration is at least its min height, which exceeds any bar
         // inset, so it covers the bar for the card; reserving the inset then would feed dialogSpace and hide
-        // that very decoration. See [reservesInsetAboveDecoration] for the insets a decoration cannot cover.
+        // that very decoration.
         if (syncCardBottomInset(decorationShown)) return false
 
         // While onboardingImprovementsV2 is off the corrector stays inert: syncCardBottomInset above
@@ -114,10 +111,9 @@ class OnboardingDecorationFitCorrector(
         val overflow = (cardContainerHeight - viewportHeight).coerceAtLeast(0)
         val available = root.height - root.paddingTop - root.paddingBottom
         val dialogParams = dialog.layoutParams as ViewGroup.MarginLayoutParams
-        // An inset reserved above the decoration buys room the decoration is not competing for: a keyboard
-        // overlays the window rather than shrinking it, so `available` already covers the room the card gave up.
-        // Counting it would shrink the decoration, which grows the inset, which shrinks the decoration, until it
-        // is gone. Without that reservation the margin is 0 here anyway, a decoration being shown.
+        // A keyboard overlays the window rather than shrinking it, so `available` already covers the room the card
+        // gave up above the decoration. Counting it would shrink the decoration, which grows the inset, which
+        // shrinks the decoration again, until it is gone.
         val cardBottomMargin = if (reservesInsetAboveDecoration) 0 else dialogParams.bottomMargin
         val dialogSpace = dialogHeight + overflow + dialogParams.topMargin + cardBottomMargin
         val decorationParams = deco.layoutParams as ViewGroup.MarginLayoutParams
@@ -177,8 +173,7 @@ class OnboardingDecorationFitCorrector(
         val params = dialog.layoutParams as? ConstraintLayout.LayoutParams ?: return false
         val roomBelowCard = when {
             params.bottomToBottom == ConstraintLayout.LayoutParams.PARENT_ID -> 0
-            // Anchored above a decoration: unclamped the card overruns it instead of scrolling, so a card lifted
-            // clear of the keyboard would still spill under it.
+            // Anchored above a decoration: unclamped, the card overruns it instead of scrolling.
             params.bottomToTop != ConstraintLayout.LayoutParams.UNSET ->
                 decoration?.takeIf { !it.isGone }?.let { roomBelowCard(it) } ?: return false
             else -> return false

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
@@ -138,7 +138,17 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
 
     fun onEvent(event: NewUserOnboardingEvent) = emit(event)
 
-    fun onContentInteraction(interaction: ContentInteraction) = Unit // No-op until dialogs with local state are implemented in follow-ups.
+    fun onContentInteraction(interaction: ContentInteraction) {
+        when (interaction) {
+            is ContentInteraction.SubmitInput -> emit(
+                NewUserOnboardingEvent.InputDemoQuerySubmitted(
+                    query = interaction.query,
+                    isChat = interaction.isChat,
+                    fromSuggestion = interaction.fromSuggestion,
+                ),
+            )
+        }
+    }
 
     fun onDialogRendered(stepId: LinearOnboardingStepId) {
         _viewState.update { state ->

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
@@ -347,23 +347,19 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
                 _commands.send(Command.LaunchAddWidgetPrompt)
             }
 
-            NewUserOnboardingActivityDialog.SyncRestore -> emit(NewUserOnboardingEvent.SkipRequested)
-
-            NewUserOnboardingActivityDialog.InitialReinstallUser,
-            NewUserOnboardingActivityDialog.Initial,
-            NewUserOnboardingActivityDialog.AddToDock,
-            -> emit(NewUserOnboardingEvent.ContinueClicked)
+            NewUserOnboardingActivityDialog.AddToDock -> emit(NewUserOnboardingEvent.ContinueClicked)
 
             NewUserOnboardingActivityDialog.WidgetPrompt -> emit(NewUserOnboardingEvent.WidgetPromptSkipped)
-
-            NewUserOnboardingActivityDialog.InputScreen -> emit(NewUserOnboardingEvent.InputModeConfirmed(withAi = true))
-
-            is NewUserOnboardingActivityDialog.InputScreenPreview -> emit(NewUserOnboardingEvent.ContinueClicked)
 
             is NewUserOnboardingActivityDialog.QuickSetup -> emit(
                 NewUserOnboardingEvent.QuickSetupConfirmed(type = OmnibarType.SINGLE_TOP, withAi = true),
             )
 
+            NewUserOnboardingActivityDialog.SyncRestore,
+            NewUserOnboardingActivityDialog.InitialReinstallUser,
+            NewUserOnboardingActivityDialog.Initial,
+            NewUserOnboardingActivityDialog.InputScreen,
+            is NewUserOnboardingActivityDialog.InputScreenPreview,
             is NewUserOnboardingActivityDialog.IntroAnimation,
             NewUserOnboardingActivityDialog.ComparisonChart,
             NewUserOnboardingActivityDialog.AiComparisonChart,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
@@ -65,6 +65,7 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
     private val orchestrator: LinearOnboardingOrchestrator,
     private val newUserOnboardingPlanBootstrapper: NewUserOnboardingPlanBootstrapper,
     private val dialogConfigResolver: DialogConfigResolver,
+    private val shownPixels: OnboardingDialogShownPixels,
     private val dispatchers: DispatcherProvider,
     private val widgetCapabilities: WidgetCapabilities,
     private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
@@ -293,6 +294,7 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
 
         val config = dialogConfigResolver.resolve(dialog, customAiOnboardingStore.isEnabled())
         if (config != null) {
+            shownPixels.fireFor(dialog)
             _viewState.update {
                 it.copy(
                     screen = Screen.Dialog(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
@@ -141,7 +141,7 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
 
     fun onContentInteraction(interaction: ContentInteraction) {
         when (interaction) {
-            is ContentInteraction.SubmitInput -> emit(
+            is ContentInteraction.SubmitInputPreview -> emit(
                 NewUserOnboardingEvent.InputDemoQuerySubmitted(
                     query = interaction.query,
                     isChat = interaction.isChat,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
@@ -252,8 +252,8 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
         engine: DialogRenderEngine,
         screen: ConfigDrivenOnboardingPageViewModel.Screen.Dialog,
     ) {
-        // We assume that if intro is played, it's always done so before any dialog is rendered. The handover is
-        // unconditional so that a render which does not animate still takes the background off the choreographer.
+        // Not gated on animateEntry: a render that does not animate must still take the background over
+        // from the choreographer, or the intro visuals stay behind the dialog.
         intro?.clearForDialog()
         engine.render(
             screen.stepId,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
@@ -26,6 +26,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.ViewGroupCompat
 import androidx.core.view.WindowInsetsCompat
@@ -123,6 +124,8 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        applyLayoutOverrides()
+
         ViewGroupCompat.installCompatInsetsDispatch(binding.root)
         ViewCompat.setOnApplyWindowInsetsListener(binding.daxDialogCta.root) { v, windowInsets ->
             val insets = windowInsets.getInsets(
@@ -192,6 +195,22 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
             .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
             .onEach { command -> handleCommand(command) }
             .launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+    /**
+     * The shared layout holds the values from before onboardingImprovementsV2, which that flag flips at runtime.
+     * This renderer only ever runs with those improvements on, so it applies them unconditionally.
+     *
+     * The card's own [ConstraintLayout.LayoutParams.constrainedHeight] has to go: the card wraps a `ScrollView`,
+     * and inside a wrap_content parent ConstraintLayout resolves the wrap at the pre-`constraintWidth_max` width,
+     * where a body line that will wrap in the capped card still fits on one line. The card then keeps that short
+     * height and its content scrolls even with room to spare.
+     */
+    private fun applyLayoutOverrides() {
+        binding.bottomWingAnimation.adjustViewBounds = true
+        binding.daxDialogCta.cardView.updateLayoutParams<ConstraintLayout.LayoutParams> {
+            constrainedHeight = false
+        }
     }
 
     private fun showIntro(screen: ConfigDrivenOnboardingPageViewModel.Screen.Intro) {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
@@ -255,17 +255,13 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
         screen: ConfigDrivenOnboardingPageViewModel.Screen.Dialog,
     ) {
         // We assume that if intro is played, it's always done so before any dialog is rendered.
-        // Once the first dialog arrives, if:
-        // - intro visuals on screen: clear them and the background cross-fades from them
-        // - no intro visual on screen (like a mid-flow re-entry from another activity): nothing to animate from, snap new background
-        // Later renders always animate the background. The handover is unconditional so that a render which does not
-        // animate still takes the background off the choreographer.
-        val canCrossFadeBackground = intro?.clearForDialog() == true
+        // The handover is unconditional so that a render which does not animate still takes the background
+        // off the choreographer.
+        intro?.clearForDialog()
         engine.render(
             screen.stepId,
             screen.config,
             animate = screen.animateEntry,
-            animateBackground = canCrossFadeBackground && screen.animateEntry,
         )
         viewModel.onDialogRendered(screen.stepId)
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
@@ -136,9 +136,8 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
                 topMargin = insets.top
             }
             // Under adjustResize, systemBars().bottom already includes the keyboard height while the IME shows,
-            // which would leave the card measuring against a gap that is about to disappear. Unless the focus
-            // is inside the card: the keyboard is then the card's own, and reserving its height is what
-            // constrains the card above it, so the content it would otherwise cover stays scrollable.
+            // which would leave the card measuring against a gap that is about to disappear. Unless the focus is
+            // inside the card: reserving the keyboard's height is then what keeps the card's content scrollable.
             val cardOwnsTheKeyboard = v.findFocus() != null
             if (!windowInsets.isVisible(WindowInsetsCompat.Type.ime()) || cardOwnsTheKeyboard) {
                 cardBottomInsetPx = insets.bottom + DIALOG_BOTTOM_INSET_GAP_DP.toPx()
@@ -202,14 +201,13 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
     }
 
     /**
-     * The shared layout holds the values from before [OnboardingBrandDesignUpdateToggles.onboardingImprovementsV2], which that flag flips at runtime.
-     * This renderer only ever runs with those improvements on, so it applies them unconditionally.
+     * The shared layout holds the values from before [OnboardingBrandDesignUpdateToggles.onboardingImprovementsV2],
+     * which that flag flips at runtime. This renderer only ever runs with those improvements on.
      *
-     * Both [ConstraintLayout.LayoutParams.constrainedHeight] flags have to go. The card wraps a `ScrollView`, and
+     * Both [ConstraintLayout.LayoutParams.constrainedHeight] flags have to go: the card wraps a `ScrollView`, and
      * inside a wrap_content parent ConstraintLayout resolves the wrap before `constraintWidth_max` narrows the
-     * card, so a body line that will wrap in the final card is still on one line. Under either flag the card keeps
-     * that short height and its content scrolls with room to spare. The corrector still owns the flag on the card
-     * root, and puts it back the moment a bottom-anchored card genuinely overflows.
+     * card, so the card keeps a height measured for text that will wrap and scrolls with room to spare. The
+     * corrector puts the flag back on the card root once the card genuinely overflows.
      */
     private fun applyLayoutOverrides() {
         binding.bottomWingAnimation.adjustViewBounds = true
@@ -254,9 +252,8 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
         engine: DialogRenderEngine,
         screen: ConfigDrivenOnboardingPageViewModel.Screen.Dialog,
     ) {
-        // We assume that if intro is played, it's always done so before any dialog is rendered.
-        // The handover is unconditional so that a render which does not animate still takes the background
-        // off the choreographer.
+        // We assume that if intro is played, it's always done so before any dialog is rendered. The handover is
+        // unconditional so that a render which does not animate still takes the background off the choreographer.
         intro?.clearForDialog()
         engine.render(
             screen.stepId,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
@@ -51,6 +51,7 @@ import com.duckduckgo.app.onboarding.ui.page.configdriven.engine.ContentControll
 import com.duckduckgo.app.onboarding.ui.page.configdriven.engine.DialogRenderEngine
 import com.duckduckgo.app.onboarding.ui.page.configdriven.engine.EmbellishmentControllerImpl
 import com.duckduckgo.app.onboarding.ui.page.configdriven.engine.StepIndicatorControllerImpl
+import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.widget.AddWidgetLauncher
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.store.AppTheme
@@ -135,8 +136,11 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
                 topMargin = insets.top
             }
             // Under adjustResize, systemBars().bottom already includes the keyboard height while the IME shows,
-            // which would leave the card measuring against a gap that is about to disappear.
-            if (!windowInsets.isVisible(WindowInsetsCompat.Type.ime())) {
+            // which would leave the card measuring against a gap that is about to disappear. Unless the focus
+            // is inside the card: the keyboard is then the card's own, and reserving its height is what
+            // constrains the card above it, so the content it would otherwise cover stays scrollable.
+            val cardOwnsTheKeyboard = v.findFocus() != null
+            if (!windowInsets.isVisible(WindowInsetsCompat.Type.ime()) || cardOwnsTheKeyboard) {
                 cardBottomInsetPx = insets.bottom + DIALOG_BOTTOM_INSET_GAP_DP.toPx()
             }
             windowInsets
@@ -198,7 +202,7 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
     }
 
     /**
-     * The shared layout holds the values from before onboardingImprovementsV2, which that flag flips at runtime.
+     * The shared layout holds the values from before [OnboardingBrandDesignUpdateToggles.onboardingImprovementsV2], which that flag flips at runtime.
      * This renderer only ever runs with those improvements on, so it applies them unconditionally.
      *
      * Both [ConstraintLayout.LayoutParams.constrainedHeight] flags have to go. The card wraps a `ScrollView`, and

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
@@ -201,14 +201,18 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
      * The shared layout holds the values from before onboardingImprovementsV2, which that flag flips at runtime.
      * This renderer only ever runs with those improvements on, so it applies them unconditionally.
      *
-     * The card's own [ConstraintLayout.LayoutParams.constrainedHeight] has to go: the card wraps a `ScrollView`,
-     * and inside a wrap_content parent ConstraintLayout resolves the wrap at the pre-`constraintWidth_max` width,
-     * where a body line that will wrap in the capped card still fits on one line. The card then keeps that short
-     * height and its content scrolls even with room to spare.
+     * Both [ConstraintLayout.LayoutParams.constrainedHeight] flags have to go. The card wraps a `ScrollView`, and
+     * inside a wrap_content parent ConstraintLayout resolves the wrap before `constraintWidth_max` narrows the
+     * card, so a body line that will wrap in the final card is still on one line. Under either flag the card keeps
+     * that short height and its content scrolls with room to spare. The corrector still owns the flag on the card
+     * root, and puts it back the moment a bottom-anchored card genuinely overflows.
      */
     private fun applyLayoutOverrides() {
         binding.bottomWingAnimation.adjustViewBounds = true
         binding.daxDialogCta.cardView.updateLayoutParams<ConstraintLayout.LayoutParams> {
+            constrainedHeight = false
+        }
+        binding.daxDialogCta.root.updateLayoutParams<ConstraintLayout.LayoutParams> {
             constrainedHeight = false
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
@@ -48,6 +48,16 @@ sealed interface ContentConfig {
     ) : ContentConfig, Stateful<AddressBarContentState> {
         override fun initialState() = AddressBarContentState(position = initialPosition)
     }
+
+    data class InputScreen(
+        override val title: TextConfig,
+        val description: TextConfig,
+        val initialWithAi: Boolean,
+    ) : ContentConfig, Stateful<InputScreenContentState> {
+        override fun initialState() = InputScreenContentState(withAi = initialWithAi)
+    }
 }
 
 data class AddressBarContentState(val position: OmnibarType)
+
+data class InputScreenContentState(val withAi: Boolean)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.onboarding.ui.page.configdriven
 
 import com.duckduckgo.app.browser.omnibar.OmnibarType
+import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
 import com.duckduckgo.app.onboarding.ui.page.ComparisonChartConfig
 
 /** A screen with working state the user edits before submitting. */
@@ -56,8 +57,20 @@ sealed interface ContentConfig {
     ) : ContentConfig, Stateful<InputScreenContentState> {
         override fun initialState() = InputScreenContentState(withAi = initialWithAi)
     }
+
+    data class InputScreenPreview(
+        override val title: TextConfig,
+        val isSearchDefault: Boolean,
+        val showModeToggle: Boolean,
+        val searchSuggestions: List<DaxDialogIntroOption>,
+        val chatSuggestions: List<DaxDialogIntroOption>,
+    ) : ContentConfig, Stateful<InputScreenPreviewContentState> {
+        override fun initialState() = InputScreenPreviewContentState(isSearchSelected = isSearchDefault)
+    }
 }
 
 data class AddressBarContentState(val position: OmnibarType)
 
 data class InputScreenContentState(val withAi: Boolean)
+
+data class InputScreenPreviewContentState(val isSearchSelected: Boolean)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
@@ -32,8 +32,6 @@ sealed interface ContentConfig {
     data class Welcome(
         override val title: TextConfig,
         val body1: TextConfig,
-        /** The plain welcome copy keeps its raw line breaks; the sync-restore and custom-AI variants carry markup. */
-        val body1AsHtml: Boolean,
         val body2: TextConfig?,
     ) : ContentConfig
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
@@ -28,6 +28,14 @@ sealed interface ContentConfig {
 
     val title: TextConfig
 
+    data class Welcome(
+        override val title: TextConfig,
+        val body1: TextConfig,
+        /** The plain welcome copy keeps its raw line breaks; the sync-restore and custom-AI variants carry markup. */
+        val body1AsHtml: Boolean,
+        val body2: TextConfig?,
+    ) : ContentConfig
+
     data class ComparisonChart(
         override val title: TextConfig,
         val config: ComparisonChartConfig,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogBinder.kt
@@ -25,6 +25,12 @@ class BindScope(
     /** Cancelled by the engine at unbind, so state observation dies with the binding. */
     val coroutineScope: CoroutineScope,
     val execute: (ContentInteraction) -> Unit,
+    /**
+     * Asks the card to tween its bounds, over the given duration, into the layout change the binder makes next:
+     * a view it reveals or resizes would otherwise resize the card in a single frame. Call it immediately before
+     * that change. No-op on a render the engine is not animating.
+     */
+    val animateCardBounds: (durationMs: Long) -> Unit = {},
 )
 
 /** Interactions a bound screen raises outside the shared CTA buttons interactions. */

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogBinder.kt
@@ -36,8 +36,7 @@ class BindScope(
 /** Interactions a bound screen raises outside the shared CTA buttons interactions. */
 sealed interface ContentInteraction {
 
-    /** The input demo's typed query, IME action or suggestion tap. */
-    data class SubmitInput(
+    data class SubmitInputPreview(
         val query: String,
         val isChat: Boolean,
         val fromSuggestion: Boolean,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogBinder.kt
@@ -28,9 +28,9 @@ class BindScope(
     /**
      * Asks the card to tween its bounds, over the given duration, into the layout change the binder makes next:
      * a view it reveals or resizes would otherwise resize the card in a single frame. Call it immediately before
-     * that change. No-op on a render the engine is not animating.
+     * that change. No-op while a snapped or skipped entrance is still landing the screen in place.
      */
-    val animateCardBounds: (durationMs: Long) -> Unit = {},
+    val animateCardBounds: (durationMs: Long) -> Unit,
 )
 
 /** Interactions a bound screen raises outside the shared CTA buttons interactions. */

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogBinder.kt
@@ -28,7 +28,15 @@ class BindScope(
 )
 
 /** Interactions a bound screen raises outside the shared CTA buttons interactions. */
-sealed interface ContentInteraction
+sealed interface ContentInteraction {
+
+    /** The input demo's typed query, IME action or suggestion tap. */
+    data class SubmitInput(
+        val query: String,
+        val isChat: Boolean,
+        val fromSuggestion: Boolean,
+    ) : ContentInteraction
+}
 
 /** Binds a stateless [ContentConfig] to its include layout. */
 interface DialogBinder<C : ContentConfig> {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfig.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfig.kt
@@ -28,6 +28,7 @@ data class DialogConfig(
     val background: OnboardingBackgroundStep,
     val embellishment: Embellishment = Embellishment.None,
     val cardArrow: CardArrowConfig = CardArrowConfig.Hidden,
+    val cardEntry: CardEntry = CardEntry.Immediate,
     val content: ContentConfig,
     val primaryCta: CtaConfig? = null,
     val secondaryCta: CtaConfig? = null,
@@ -38,6 +39,9 @@ data class DialogConfig(
 enum class Embellishment { WalkingDax, BobbingDax, BottomWing, LeftWing, None }
 
 enum class CardArrowConfig { Hidden, AtStart, AtEnd }
+
+/** When the card's one-time fade-in starts. [AfterBackgroundTransition] holds it back until an animated background transition has finished. */
+enum class CardEntry { Immediate, AfterBackgroundTransition }
 
 data class CtaConfig(
     val text: TextConfig,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
@@ -49,13 +49,47 @@ class DialogConfigResolver @Inject constructor() {
             ),
         )
 
+        NewUserOnboardingActivityDialog.Initial -> welcome(
+            content = welcomeContent(isCustomAiFlow),
+            primaryCta = CtaConfig(
+                text = TextConfig.Resource(R.string.preOnboardingDaxDialog1ButtonBrandDesign),
+                action = CtaAction.Emit(NewUserOnboardingEvent.ContinueClicked),
+            ),
+        )
+
+        NewUserOnboardingActivityDialog.InitialReinstallUser -> welcome(
+            content = welcomeContent(isCustomAiFlow),
+            primaryCta = CtaConfig(
+                text = TextConfig.Resource(R.string.preOnboardingDaxDialog1ButtonBrandDesign),
+                action = CtaAction.Emit(NewUserOnboardingEvent.ContinueClicked),
+            ),
+            secondaryCta = CtaConfig(
+                text = TextConfig.Resource(R.string.preOnboardingDaxDialog1SecondaryButton),
+                action = CtaAction.Emit(NewUserOnboardingEvent.SkipRequested),
+            ),
+        )
+
+        NewUserOnboardingActivityDialog.SyncRestore -> welcome(
+            content = ContentConfig.Welcome(
+                title = TextConfig.Resource(R.string.syncRestoreDialogBrandDesignTitle),
+                body1 = TextConfig.Resource(R.string.syncRestoreDialogBrandDesignBody1),
+                body1AsHtml = true,
+                body2 = null,
+            ),
+            primaryCta = CtaConfig(
+                text = TextConfig.Resource(R.string.syncRestoreDialogPrimaryCta),
+                action = CtaAction.Emit(NewUserOnboardingEvent.RestoreRequested),
+            ),
+            secondaryCta = CtaConfig(
+                text = TextConfig.Resource(R.string.syncRestoreDialogSecondaryCta),
+                action = CtaAction.Emit(NewUserOnboardingEvent.SkipRequested),
+            ),
+        )
+
         is NewUserOnboardingActivityDialog.IntroAnimation,
         NewUserOnboardingActivityDialog.NotificationPermission,
         NewUserOnboardingActivityDialog.DefaultBrowserPrompt,
         NewUserOnboardingActivityDialog.AddWidget,
-        NewUserOnboardingActivityDialog.SyncRestore,
-        NewUserOnboardingActivityDialog.InitialReinstallUser,
-        NewUserOnboardingActivityDialog.Initial,
         NewUserOnboardingActivityDialog.AddToDock,
         NewUserOnboardingActivityDialog.WidgetPrompt,
         NewUserOnboardingActivityDialog.InputScreen,
@@ -73,5 +107,27 @@ class DialogConfigResolver @Inject constructor() {
             text = TextConfig.Resource(chart.primaryCtaTextRes),
             action = CtaAction.Emit(NewUserOnboardingEvent.ContinueClicked),
         ),
+    )
+
+    private fun welcome(
+        content: ContentConfig.Welcome,
+        primaryCta: CtaConfig,
+        secondaryCta: CtaConfig? = null,
+    ) = DialogConfig(
+        background = OnboardingBackgroundStep.Welcome,
+        embellishment = Embellishment.WalkingDax,
+        cardArrow = CardArrowConfig.AtStart,
+        content = content,
+        primaryCta = primaryCta,
+        secondaryCta = secondaryCta,
+    )
+
+    private fun welcomeContent(isCustomAiFlow: Boolean) = ContentConfig.Welcome(
+        title = TextConfig.Resource(R.string.preOnboardingWelcomeDialogTitle),
+        body1 = TextConfig.Resource(
+            if (isCustomAiFlow) R.string.preOnboardingWelcomeDialogBodyCustomAi else R.string.preOnboardingWelcomeDialogBody1,
+        ),
+        body1AsHtml = isCustomAiFlow,
+        body2 = if (isCustomAiFlow) null else TextConfig.Resource(R.string.preOnboardingWelcomeDialogBody2),
     )
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
@@ -20,11 +20,14 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingActivityDialog
 import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingEvent
+import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.ui.page.ComparisonChartConfig
 import com.duckduckgo.app.onboarding.ui.page.OnboardingBackgroundStep
 import javax.inject.Inject
 
-class DialogConfigResolver @Inject constructor() {
+class DialogConfigResolver @Inject constructor(
+    private val onboardingStore: OnboardingStore,
+) {
 
     fun resolve(
         dialog: NewUserOnboardingActivityDialog,
@@ -101,13 +104,27 @@ class DialogConfigResolver @Inject constructor() {
             ),
         )
 
+        is NewUserOnboardingActivityDialog.InputScreenPreview -> DialogConfig(
+            background = OnboardingBackgroundStep.InputType,
+            embellishment = Embellishment.None,
+            cardArrow = CardArrowConfig.Hidden,
+            content = ContentConfig.InputScreenPreview(
+                title = TextConfig.Resource(
+                    if (isCustomAiFlow) R.string.preOnboardingInputModeDemoTitleCustomAi else R.string.preOnboardingInputModeDemoTitle,
+                ),
+                isSearchDefault = dialog.isSearchDefault,
+                showModeToggle = !isCustomAiFlow,
+                searchSuggestions = onboardingStore.getSearchOptions(),
+                chatSuggestions = onboardingStore.getChatSuggestions(),
+            ),
+        )
+
         is NewUserOnboardingActivityDialog.IntroAnimation,
         NewUserOnboardingActivityDialog.NotificationPermission,
         NewUserOnboardingActivityDialog.DefaultBrowserPrompt,
         NewUserOnboardingActivityDialog.AddWidget,
         NewUserOnboardingActivityDialog.AddToDock,
         NewUserOnboardingActivityDialog.WidgetPrompt,
-        is NewUserOnboardingActivityDialog.InputScreenPreview,
         is NewUserOnboardingActivityDialog.QuickSetup,
         -> null // to be implemented in following tasks
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
@@ -91,7 +91,7 @@ class DialogConfigResolver @Inject constructor(
         NewUserOnboardingActivityDialog.InputScreen -> DialogConfig(
             background = OnboardingBackgroundStep.InputType,
             embellishment = Embellishment.LeftWing,
-            cardArrow = CardArrowConfig.AtStart,
+            cardArrow = CardArrowConfig.AtEnd,
             content = ContentConfig.InputScreen(
                 title = TextConfig.Resource(R.string.preOnboardingInputScreenTitleUpdated),
                 description = TextConfig.Resource(R.string.preOnboardingInputScreenDescription),

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
@@ -148,6 +148,7 @@ class DialogConfigResolver @Inject constructor(
         background = OnboardingBackgroundStep.Welcome,
         embellishment = Embellishment.WalkingDax,
         cardArrow = CardArrowConfig.AtStart,
+        cardEntry = CardEntry.AfterBackgroundTransition,
         content = content,
         primaryCta = primaryCta,
         secondaryCta = secondaryCta,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
@@ -76,7 +76,6 @@ class DialogConfigResolver @Inject constructor(
             content = ContentConfig.Welcome(
                 title = TextConfig.Resource(R.string.syncRestoreDialogBrandDesignTitle),
                 body1 = TextConfig.Resource(R.string.syncRestoreDialogBrandDesignBody1),
-                body1AsHtml = true,
                 body2 = null,
             ),
             primaryCta = CtaConfig(
@@ -159,7 +158,6 @@ class DialogConfigResolver @Inject constructor(
         body1 = TextConfig.Resource(
             if (isCustomAiFlow) R.string.preOnboardingWelcomeDialogBodyCustomAi else R.string.preOnboardingWelcomeDialogBody1,
         ),
-        body1AsHtml = isCustomAiFlow,
         body2 = if (isCustomAiFlow) null else TextConfig.Resource(R.string.preOnboardingWelcomeDialogBody2),
     )
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
@@ -86,13 +86,27 @@ class DialogConfigResolver @Inject constructor() {
             ),
         )
 
+        NewUserOnboardingActivityDialog.InputScreen -> DialogConfig(
+            background = OnboardingBackgroundStep.InputType,
+            embellishment = Embellishment.LeftWing,
+            cardArrow = CardArrowConfig.AtStart,
+            content = ContentConfig.InputScreen(
+                title = TextConfig.Resource(R.string.preOnboardingInputScreenTitleUpdated),
+                description = TextConfig.Resource(R.string.preOnboardingInputScreenDescription),
+                initialWithAi = true,
+            ),
+            primaryCta = CtaConfig(
+                text = TextConfig.Resource(R.string.preOnboardingInputScreenButton),
+                action = CtaAction.Submit,
+            ),
+        )
+
         is NewUserOnboardingActivityDialog.IntroAnimation,
         NewUserOnboardingActivityDialog.NotificationPermission,
         NewUserOnboardingActivityDialog.DefaultBrowserPrompt,
         NewUserOnboardingActivityDialog.AddWidget,
         NewUserOnboardingActivityDialog.AddToDock,
         NewUserOnboardingActivityDialog.WidgetPrompt,
-        NewUserOnboardingActivityDialog.InputScreen,
         is NewUserOnboardingActivityDialog.InputScreenPreview,
         is NewUserOnboardingActivityDialog.QuickSetup,
         -> null // to be implemented in following tasks

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingDialogShownPixels.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingDialogShownPixels.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.page.configdriven
+
+import com.duckduckgo.app.onboarding.CustomAiOnboardingPixelName
+import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingActivityDialog
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_ADDRESS_BAR_POSITION_SHOWN_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_CHOOSE_SEARCH_EXPERIENCE_IMPRESSIONS_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_COMPARISON_CHART_SHOWN_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_INTRO_REINSTALL_USER_SHOWN_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_INTRO_SHOWN_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SYNC_RESTORE_SHOWN_UNIQUE
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
+import javax.inject.Inject
+
+/**
+ * The once-ever "dialog shown" pixels, keyed on the dialog being applied. Exhaustive with no `else`, so a new
+ * dialog cannot compile until it has been given an explicit decision, even when that decision is to fire nothing.
+ */
+class OnboardingDialogShownPixels @Inject constructor(private val pixel: Pixel) {
+
+    fun fireFor(dialog: NewUserOnboardingActivityDialog) {
+        when (dialog) {
+            NewUserOnboardingActivityDialog.SyncRestore -> pixel.fire(PREONBOARDING_SYNC_RESTORE_SHOWN_UNIQUE, type = Unique())
+            NewUserOnboardingActivityDialog.InitialReinstallUser ->
+                pixel.fire(PREONBOARDING_INTRO_REINSTALL_USER_SHOWN_UNIQUE, type = Unique())
+            NewUserOnboardingActivityDialog.Initial -> pixel.fire(PREONBOARDING_INTRO_SHOWN_UNIQUE, type = Unique())
+            NewUserOnboardingActivityDialog.ComparisonChart -> pixel.fire(PREONBOARDING_COMPARISON_CHART_SHOWN_UNIQUE, type = Unique())
+            NewUserOnboardingActivityDialog.AiComparisonChart ->
+                pixel.fire(CustomAiOnboardingPixelName.AI_COMPARISON_SCREEN_SHOW, type = Unique())
+            is NewUserOnboardingActivityDialog.AddressBarPosition ->
+                pixel.fire(PREONBOARDING_ADDRESS_BAR_POSITION_SHOWN_UNIQUE, type = Unique())
+            NewUserOnboardingActivityDialog.InputScreen ->
+                pixel.fire(PREONBOARDING_CHOOSE_SEARCH_EXPERIENCE_IMPRESSIONS_UNIQUE, type = Unique())
+            is NewUserOnboardingActivityDialog.InputScreenPreview,
+            is NewUserOnboardingActivityDialog.QuickSetup,
+            NewUserOnboardingActivityDialog.AddToDock,
+            NewUserOnboardingActivityDialog.WidgetPrompt,
+            is NewUserOnboardingActivityDialog.IntroAnimation,
+            NewUserOnboardingActivityDialog.NotificationPermission,
+            NewUserOnboardingActivityDialog.DefaultBrowserPrompt,
+            NewUserOnboardingActivityDialog.AddWidget,
+            -> Unit
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroChoreographer.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroChoreographer.kt
@@ -223,9 +223,7 @@ class OnboardingIntroChoreographer(
                 playOutro()
             }
             OnboardingIntroState.Handover.SnapAway -> snapToOutroEndState()
-            OnboardingIntroState.Handover.AlreadyDismissed,
-            OnboardingIntroState.Handover.AlreadyHandedOver,
-            -> Unit
+            OnboardingIntroState.Handover.AlreadyGone -> Unit
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroChoreographer.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroChoreographer.kt
@@ -215,12 +215,9 @@ class OnboardingIntroChoreographer(
      * Hands `backgroundPrimary` to an arriving dialog: fades the intro visuals out when they are on screen, snaps them
      * away when this view never showed them, and does nothing once an earlier dialog has taken over. Safe to call for
      * every dialog.
-     *
-     * @return true when the dialog's background can cross-fade from what is on screen
      */
-    fun clearForDialog(): Boolean {
-        val handover = state.handOverToDialog()
-        when (handover) {
+    fun clearForDialog() {
+        when (state.handOverToDialog()) {
             OnboardingIntroState.Handover.FadeOut -> {
                 settleRunningIntro()
                 playOutro()
@@ -230,7 +227,6 @@ class OnboardingIntroChoreographer(
             OnboardingIntroState.Handover.AlreadyHandedOver,
             -> Unit
         }
-        return handover.canCrossFadeBackground
     }
 
     private fun settleRunningIntro() {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroState.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroState.kt
@@ -27,9 +27,6 @@ class OnboardingIntroState {
     /** The intro is out of play: faded out for a dialog, or snapped away without ever being shown. */
     private var cleared = false
 
-    /** A dialog has taken the background over from the intro. */
-    private var handedOver = false
-
     private var released = false
 
     fun play() {
@@ -48,9 +45,7 @@ class OnboardingIntroState {
 
     /** @return what an arriving dialog leaves the caller to do with the intro views */
     fun handOverToDialog(): Handover {
-        if (handedOver) return Handover.AlreadyHandedOver
-        handedOver = true
-        if (cleared) return Handover.AlreadyDismissed
+        if (cleared) return Handover.AlreadyGone
         cleared = true
         return if (visualsOnScreen) Handover.FadeOut else Handover.SnapAway
     }
@@ -73,10 +68,7 @@ class OnboardingIntroState {
         /** This view never showed the intro, snap the views past it. */
         SnapAway,
 
-        /** The intro was already snapped away unplayed. */
-        AlreadyDismissed,
-
-        /** An earlier dialog already took the background over. */
-        AlreadyHandedOver,
+        /** The intro is already out of play: an earlier dialog took over, or it was snapped away unplayed. */
+        AlreadyGone,
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroState.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroState.kt
@@ -66,20 +66,17 @@ class OnboardingIntroState {
         released = true
     }
 
-    /**
-     * @param canCrossFadeBackground true when the arriving dialog's background can cross-fade from what is on screen
-     */
-    enum class Handover(val canCrossFadeBackground: Boolean) {
+    enum class Handover {
         /** The intro visuals are on screen, fade them out. */
-        FadeOut(canCrossFadeBackground = true),
+        FadeOut,
 
         /** This view never showed the intro, snap the views past it. */
-        SnapAway(canCrossFadeBackground = false),
+        SnapAway,
 
         /** The intro was already snapped away unplayed. */
-        AlreadyDismissed(canCrossFadeBackground = false),
+        AlreadyDismissed,
 
         /** An earlier dialog already took the background over. */
-        AlreadyHandedOver(canCrossFadeBackground = true),
+        AlreadyHandedOver,
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenBinder.kt
@@ -64,7 +64,10 @@ class InputScreenBinder(
             fadeTargets = listOf(inputScreenPicker, inputScreenDescription),
             onContentReady = { inputScreenPicker.startWithAiAnimation(delayedStart = true) },
             result = { NewUserOnboardingEvent.InputModeConfirmed(state.value.withAi) },
-            unbind = { inputScreenPicker.cancelLottieAnimations() },
+            unbind = {
+                inputScreenPicker.setOnSelectionChangedListener {}
+                inputScreenPicker.cancelLottieAnimations()
+            },
         )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenBinder.kt
@@ -16,9 +16,6 @@
 
 package com.duckduckgo.app.onboarding.ui.page.configdriven.binders
 
-import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
-import android.animation.ValueAnimator
 import android.view.View
 import com.duckduckgo.app.browser.databinding.IncludeBrandDesignInputScreenBinding
 import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingEvent
@@ -65,25 +62,9 @@ class InputScreenBinder(
         ContentHandle(
             title = inputScreenTitle,
             fadeTargets = listOf(inputScreenPicker, inputScreenDescription),
-            afterFade = { withAiFlourishTrigger() },
+            onContentReady = { inputScreenPicker.startWithAiAnimation(delayedStart = true) },
             result = { NewUserOnboardingEvent.InputModeConfirmed(state.value.withAi) },
             unbind = { inputScreenPicker.cancelLottieAnimations() },
         )
     }
-
-    /**
-     * The picker's flourish runs on its own coroutine, not on an animator timeline, so there is nothing to hand
-     * the engine directly. This zero-duration animator exists only so the engine still owns starting it.
-     */
-    private fun withAiFlourishTrigger(): Animator =
-        ValueAnimator.ofInt(0, 1).apply {
-            duration = 0L
-            addListener(
-                object : AnimatorListenerAdapter() {
-                    override fun onAnimationStart(animation: Animator) {
-                        binding.inputScreenPicker.startWithAiAnimation(delayedStart = true)
-                    }
-                },
-            )
-        }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenBinder.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.page.configdriven.binders
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.ValueAnimator
+import android.view.View
+import com.duckduckgo.app.browser.databinding.IncludeBrandDesignInputScreenBinding
+import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingEvent
+import com.duckduckgo.app.onboarding.ui.page.configdriven.BindScope
+import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentConfig
+import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentHandle
+import com.duckduckgo.app.onboarding.ui.page.configdriven.InputScreenContentState
+import com.duckduckgo.app.onboarding.ui.page.configdriven.StatefulDialogBinder
+import com.duckduckgo.app.onboardingquicksetup.ui.BrandDesignInputScreenPicker.Transition
+import com.duckduckgo.common.utils.extensions.html
+import com.duckduckgo.common.utils.extensions.preventWidows
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class InputScreenBinder(
+    private val binding: IncludeBrandDesignInputScreenBinding,
+    private val isLightMode: () -> Boolean,
+) : StatefulDialogBinder<ContentConfig.InputScreen, InputScreenContentState> {
+
+    override val view: View = binding.root
+
+    override fun bind(
+        content: ContentConfig.InputScreen,
+        state: MutableStateFlow<InputScreenContentState>,
+        scope: BindScope,
+    ): ContentHandle = with(binding) {
+        val context = root.context
+
+        inputScreenPicker.setLightMode(isLightMode())
+        inputScreenPicker.setSelection(state.value.withAi, Transition.NONE)
+        inputScreenPicker.setOnSelectionChangedListener { withAi -> state.update { it.copy(withAi = withAi) } }
+        scope.coroutineScope.launch {
+            // The replayed first value would crossfade and start the Lottie loop at bind time, which the
+            // entrance trigger below owns.
+            state.drop(1).collect { inputScreenPicker.setSelection(it.withAi, Transition.CROSSFADE_ANIMATE) }
+        }
+
+        inputScreenDescription.text = content.description.resolve(context).preventWidows().html(context)
+
+        inputScreenTitle.setTitle(content.title.resolve(context))
+
+        ContentHandle(
+            title = inputScreenTitle,
+            fadeTargets = listOf(inputScreenPicker, inputScreenDescription),
+            afterFade = { withAiFlourishTrigger() },
+            result = { NewUserOnboardingEvent.InputModeConfirmed(state.value.withAi) },
+            unbind = { inputScreenPicker.cancelLottieAnimations() },
+        )
+    }
+
+    /**
+     * The picker's flourish runs on its own coroutine, not on an animator timeline, so there is nothing to hand
+     * the engine directly. This zero-duration animator exists only so the engine still owns starting it.
+     */
+    private fun withAiFlourishTrigger(): Animator =
+        ValueAnimator.ofInt(0, 1).apply {
+            duration = 0L
+            addListener(
+                object : AnimatorListenerAdapter() {
+                    override fun onAnimationStart(animation: Animator) {
+                        binding.inputScreenPicker.startWithAiAnimation(delayedStart = true)
+                    }
+                },
+            )
+        }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
@@ -74,9 +74,6 @@ class InputScreenPreviewBinder(
         inputText.isFocusableInTouchMode = true
 
         inputModeToggle.isVisible = content.showModeToggle
-        if (content.showModeToggle && !state.value.isSearchSelected) {
-            inputModeToggle.getTabAt(CHAT_TAB_INDEX)?.select()
-        }
         applyMode(content, state.value.isSearchSelected, scope)
 
         val tabListener = object : TabLayout.OnTabSelectedListener {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.page.configdriven.binders
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.AnimatorSet
+import android.animation.ObjectAnimator
+import android.os.Build
+import android.text.InputType
+import android.view.View
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.isVisible
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.IncludeBrandDesignInputScreenPreviewBinding
+import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
+import com.duckduckgo.app.onboarding.ui.page.configdriven.BindScope
+import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentConfig
+import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentHandle
+import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentInteraction
+import com.duckduckgo.app.onboarding.ui.page.configdriven.InputScreenPreviewContentState
+import com.duckduckgo.app.onboarding.ui.page.configdriven.StatefulDialogBinder
+import com.duckduckgo.common.ui.view.addBottomShadow
+import com.google.android.material.tabs.TabLayout
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import com.duckduckgo.mobile.android.R as CommonR
+
+/**
+ * The mode tabs are the only write path into the state; everything mode-dependent renders from the collector,
+ * so a tab tap and a replayed value take the same path.
+ *
+ * Legacy wraps each mode switch in a `beginDelayedTransition` on the shared card view so the field resizes
+ * smoothly between the one-line search input and the three-line chat input. A binder has no handle on the card,
+ * so the field snaps to its new size instead.
+ */
+class InputScreenPreviewBinder(
+    private val binding: IncludeBrandDesignInputScreenPreviewBinding,
+) : StatefulDialogBinder<ContentConfig.InputScreenPreview, InputScreenPreviewContentState> {
+
+    override val view: View = binding.root
+
+    override fun bind(
+        content: ContentConfig.InputScreenPreview,
+        state: MutableStateFlow<InputScreenPreviewContentState>,
+        scope: BindScope,
+    ): ContentHandle = with(binding) {
+        val context = root.context
+
+        if (Build.VERSION.SDK_INT >= 28) {
+            inputModeDemoCard.addBottomShadow()
+        }
+
+        inputText.isFocusable = true
+        inputText.isFocusableInTouchMode = true
+
+        inputModeToggle.isVisible = content.showModeToggle
+        if (content.showModeToggle && !state.value.isSearchSelected) {
+            inputModeToggle.getTabAt(CHAT_TAB_INDEX)?.select()
+        }
+        applyMode(content, state.value.isSearchSelected, scope)
+
+        inputModeToggle.addOnTabSelectedListener(
+            object : TabLayout.OnTabSelectedListener {
+                override fun onTabSelected(tab: TabLayout.Tab) {
+                    state.update { it.copy(isSearchSelected = tab.position == SEARCH_TAB_INDEX) }
+                }
+
+                override fun onTabUnselected(tab: TabLayout.Tab) = Unit
+
+                override fun onTabReselected(tab: TabLayout.Tab) = Unit
+            },
+        )
+        scope.coroutineScope.launch {
+            state.collect {
+                applyMode(content, it.isSearchSelected, scope)
+                val target = if (it.isSearchSelected) SEARCH_TAB_INDEX else CHAT_TAB_INDEX
+                if (inputModeToggle.selectedTabPosition != target) {
+                    inputModeToggle.getTabAt(target)?.select()
+                }
+            }
+        }
+
+        inputScreenPreviewTitle.setTitle(content.title.resolve(context))
+
+        ContentHandle(
+            title = inputScreenPreviewTitle,
+            fadeTargets = listOfNotNull(inputModeToggle.takeIf { content.showModeToggle }, inputModeDemoCard),
+            afterFade = { suggestionButtonsAnimator() },
+            onContentReady = { showKeyboardIfRoom() },
+        )
+    }
+
+    private fun applyMode(
+        content: ContentConfig.InputScreenPreview,
+        isSearchSelected: Boolean,
+        scope: BindScope,
+    ) = with(binding) {
+        bindSuggestionButtons(
+            suggestions = if (isSearchSelected) content.searchSuggestions else content.chatSuggestions,
+            isSearchSelected = isSearchSelected,
+            scope = scope,
+        )
+
+        val submitTypedQuery = {
+            val query = inputText.text?.toString().orEmpty().trim()
+            if (query.isNotEmpty()) {
+                scope.execute(ContentInteraction.SubmitInput(query, isChat = !isSearchSelected, fromSuggestion = false))
+            }
+        }
+        inputModeDemoActionIcon.setOnClickListener { submitTypedQuery() }
+        inputText.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                submitTypedQuery()
+                true
+            } else {
+                false
+            }
+        }
+
+        if (isSearchSelected) {
+            inputText.minLines = 1
+            inputText.maxLines = 1
+            inputText.inputType = InputType.TYPE_CLASS_TEXT
+            inputText.imeOptions = EditorInfo.IME_ACTION_SEARCH
+            inputText.setHint(R.string.preOnboardingInputModeDemoSearchHint)
+            inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_find_search_24)
+        } else {
+            inputText.minLines = CHAT_INPUT_LINES
+            inputText.maxLines = CHAT_INPUT_LINES
+            inputText.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+            inputText.imeOptions = EditorInfo.IME_ACTION_UNSPECIFIED
+            inputText.setHint(R.string.preOnboardingInputModeDemoChatHint)
+            inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_arrow_right_24)
+        }
+
+        // A mode switch can land while the field is already focused, so the IME has to be told to pick up the
+        // new action and Enter behaviour.
+        if (inputText.hasFocus()) {
+            ContextCompat.getSystemService(root.context, InputMethodManager::class.java)?.restartInput(inputText)
+        }
+    }
+
+    private fun bindSuggestionButtons(
+        suggestions: List<DaxDialogIntroOption>,
+        isSearchSelected: Boolean,
+        scope: BindScope,
+    ) = with(binding) {
+        suggestionButtons().forEachIndexed { index, button ->
+            suggestions[index].setOptionView(button)
+            button.setOnClickListener {
+                scope.execute(
+                    ContentInteraction.SubmitInput(
+                        query = suggestions[index].link,
+                        isChat = !isSearchSelected,
+                        fromSuggestion = true,
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun suggestionButtons() = listOf(binding.suggestion1, binding.suggestion2, binding.suggestion3)
+
+    /**
+     * Staggers the suggestion buttons in. They are only tappable once the stagger completes: the card stops
+     * intercepting touches as the entrance starts, so a button revealed here would otherwise be tappable while
+     * still invisible.
+     */
+    private fun suggestionButtonsAnimator(): Animator {
+        val buttons = suggestionButtons()
+        buttons.forEach {
+            it.alpha = 0f
+            it.isClickable = false
+            it.isVisible = true
+        }
+
+        val fades = buttons.mapIndexed { index, button ->
+            ObjectAnimator.ofFloat(button, View.ALPHA, 0f, 1f).apply {
+                duration = SUGGESTION_FADE_DURATION_MS
+                startDelay = index * SUGGESTION_FADE_DURATION_MS
+            }
+        }
+
+        return AnimatorSet().apply {
+            playTogether(fades)
+            startDelay = SUGGESTIONS_START_DELAY_MS
+            addListener(
+                object : AnimatorListenerAdapter() {
+                    override fun onAnimationEnd(animation: Animator) {
+                        buttons.forEach {
+                            it.alpha = 1f
+                            it.isClickable = true
+                            it.isVisible = true
+                        }
+                    }
+                },
+            )
+        }
+    }
+
+    private fun showKeyboardIfRoom() {
+        if (binding.root.resources.configuration.screenHeightDp < MIN_SCREEN_HEIGHT_FOR_KEYBOARD_DP) return
+        with(binding) {
+            root.post {
+                if (!root.isAttachedToWindow) return@post
+                inputText.requestFocus()
+                ViewCompat.getWindowInsetsController(inputText)?.show(WindowInsetsCompat.Type.ime())
+            }
+        }
+    }
+
+    private companion object {
+        const val SEARCH_TAB_INDEX = 0
+        const val CHAT_TAB_INDEX = 1
+        const val CHAT_INPUT_LINES = 3
+        const val SUGGESTION_FADE_DURATION_MS = 500L
+        const val SUGGESTIONS_START_DELAY_MS = 500L
+        const val MIN_SCREEN_HEIGHT_FOR_KEYBOARD_DP = 600
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
@@ -41,6 +41,9 @@ import com.duckduckgo.app.onboarding.ui.page.configdriven.StatefulDialogBinder
 import com.duckduckgo.common.ui.view.addBottomShadow
 import com.google.android.material.tabs.TabLayout
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectIndexed
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import com.duckduckgo.mobile.android.R as CommonR
@@ -83,16 +86,14 @@ class InputScreenPreviewBinder(
         }
         inputModeToggle.addOnTabSelectedListener(tabListener)
         scope.coroutineScope.launch {
-            var appliedIsSearchSelected = state.value.isSearchSelected
-            state.collect {
+            state.map { it.isSearchSelected }.distinctUntilChanged().collectIndexed { index, isSearchSelected ->
                 // The field is one line in search and three in chat, so switching modes resizes the card. The
-                // replayed first value is already applied above, and re-emissions of the same mode do not resize.
-                if (it.isSearchSelected != appliedIsSearchSelected) {
-                    appliedIsSearchSelected = it.isSearchSelected
+                // replayed first value is already applied above, so only a later switch resizes anything.
+                if (index > 0) {
                     scope.animateCardBounds(MODE_SWITCH_DURATION_MS)
                 }
-                applyMode(content, it.isSearchSelected, scope)
-                val target = if (it.isSearchSelected) SEARCH_TAB_INDEX else CHAT_TAB_INDEX
+                applyMode(content, isSearchSelected, scope)
+                val target = if (isSearchSelected) SEARCH_TAB_INDEX else CHAT_TAB_INDEX
                 if (inputModeToggle.selectedTabPosition != target) {
                     inputModeToggle.getTabAt(target)?.select()
                 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
@@ -79,17 +79,16 @@ class InputScreenPreviewBinder(
         }
         applyMode(content, state.value.isSearchSelected, scope)
 
-        inputModeToggle.addOnTabSelectedListener(
-            object : TabLayout.OnTabSelectedListener {
-                override fun onTabSelected(tab: TabLayout.Tab) {
-                    state.update { it.copy(isSearchSelected = tab.position == SEARCH_TAB_INDEX) }
-                }
+        val tabListener = object : TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(tab: TabLayout.Tab) {
+                state.update { it.copy(isSearchSelected = tab.position == SEARCH_TAB_INDEX) }
+            }
 
-                override fun onTabUnselected(tab: TabLayout.Tab) = Unit
+            override fun onTabUnselected(tab: TabLayout.Tab) = Unit
 
-                override fun onTabReselected(tab: TabLayout.Tab) = Unit
-            },
-        )
+            override fun onTabReselected(tab: TabLayout.Tab) = Unit
+        }
+        inputModeToggle.addOnTabSelectedListener(tabListener)
         scope.coroutineScope.launch {
             state.collect {
                 applyMode(content, it.isSearchSelected, scope)
@@ -107,6 +106,7 @@ class InputScreenPreviewBinder(
             fadeTargets = listOfNotNull(inputModeToggle.takeIf { content.showModeToggle }, inputModeDemoCard),
             afterFade = { suggestionButtonsAnimator() },
             onContentReady = { showKeyboardIfRoom() },
+            unbind = { inputModeToggle.removeOnTabSelectedListener(tabListener) },
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
@@ -125,7 +125,7 @@ class InputScreenPreviewBinder(
         val submitTypedQuery = {
             val query = inputText.text?.toString().orEmpty().trim()
             if (query.isNotEmpty()) {
-                scope.execute(ContentInteraction.SubmitInput(query, isChat = !isSearchSelected, fromSuggestion = false))
+                scope.execute(ContentInteraction.SubmitInputPreview(query, isChat = !isSearchSelected, fromSuggestion = false))
             }
         }
         inputModeDemoActionIcon.setOnClickListener { submitTypedQuery() }
@@ -170,7 +170,7 @@ class InputScreenPreviewBinder(
             suggestions[index].setOptionView(button)
             button.setOnClickListener {
                 scope.execute(
-                    ContentInteraction.SubmitInput(
+                    ContentInteraction.SubmitInputPreview(
                         query = suggestions[index].link,
                         isChat = !isSearchSelected,
                         fromSuggestion = true,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
@@ -48,10 +48,6 @@ import com.duckduckgo.mobile.android.R as CommonR
 /**
  * The mode tabs are the only write path into the state; everything mode-dependent renders from the collector,
  * so a tab tap and a replayed value take the same path.
- *
- * Legacy wraps each mode switch in a `beginDelayedTransition` on the shared card view so the field resizes
- * smoothly between the one-line search input and the three-line chat input. A binder has no handle on the card,
- * so the field snaps to its new size instead.
  */
 class InputScreenPreviewBinder(
     private val binding: IncludeBrandDesignInputScreenPreviewBinding,
@@ -87,7 +83,14 @@ class InputScreenPreviewBinder(
         }
         inputModeToggle.addOnTabSelectedListener(tabListener)
         scope.coroutineScope.launch {
+            var appliedIsSearchSelected = state.value.isSearchSelected
             state.collect {
+                // The field is one line in search and three in chat, so switching modes resizes the card. The
+                // replayed first value is already applied above, and re-emissions of the same mode do not resize.
+                if (it.isSearchSelected != appliedIsSearchSelected) {
+                    appliedIsSearchSelected = it.isSearchSelected
+                    scope.animateCardBounds(MODE_SWITCH_DURATION_MS)
+                }
                 applyMode(content, it.isSearchSelected, scope)
                 val target = if (it.isSearchSelected) SEARCH_TAB_INDEX else CHAT_TAB_INDEX
                 if (inputModeToggle.selectedTabPosition != target) {
@@ -101,7 +104,7 @@ class InputScreenPreviewBinder(
         ContentHandle(
             title = inputScreenPreviewTitle,
             fadeTargets = listOfNotNull(inputModeToggle.takeIf { content.showModeToggle }, inputModeDemoCard),
-            afterFade = { suggestionButtonsAnimator() },
+            afterFade = { suggestionButtonsAnimator(scope) },
             onContentReady = { showKeyboardIfRoom() },
             unbind = { inputModeToggle.removeOnTabSelectedListener(tabListener) },
         )
@@ -183,8 +186,10 @@ class InputScreenPreviewBinder(
      * intercepting touches as the entrance starts, so a button revealed here would otherwise be tappable while
      * still invisible.
      */
-    private fun suggestionButtonsAnimator(): Animator {
+    private fun suggestionButtonsAnimator(scope: BindScope): Animator {
         val buttons = suggestionButtons()
+        // The buttons enter from gone, so the card grows as they are shown; tween it instead of jumping a frame.
+        scope.animateCardBounds(SUGGESTION_FADE_DURATION_MS)
         buttons.forEach {
             it.alpha = 0f
             it.isClickable = false
@@ -231,6 +236,7 @@ class InputScreenPreviewBinder(
         const val CHAT_TAB_INDEX = 1
         const val CHAT_INPUT_LINES = 3
         const val SUGGESTION_FADE_DURATION_MS = 500L
+        const val MODE_SWITCH_DURATION_MS = 400L
         const val SUGGESTIONS_START_DELAY_MS = 500L
         const val MIN_SCREEN_HEIGHT_FOR_KEYBOARD_DP = 600
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/WelcomeBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/WelcomeBinder.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.app.onboarding.ui.page.configdriven.BindScope
 import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentConfig
 import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentHandle
 import com.duckduckgo.app.onboarding.ui.page.configdriven.DialogBinder
-import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.common.utils.extensions.preventWidows
 
 class WelcomeBinder(
@@ -35,9 +34,7 @@ class WelcomeBinder(
     override fun bind(content: ContentConfig.Welcome, scope: BindScope): ContentHandle = with(binding) {
         val context = root.context
 
-        // Decoded unconditionally: the copy variants that may carry markup are indistinguishable here, and
-        // decoding is a no-op on the plain ones.
-        bodyText1.text = content.body1.resolve(context).preventWidows().html(context)
+        bodyText1.text = content.body1.resolve(context).preventWidows()
         // Set explicitly: a previous render of the single-line copy leaves this hidden.
         bodyText2.isVisible = content.body2 != null
         content.body2?.let { bodyText2.text = it.resolve(context).preventWidows() }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/WelcomeBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/WelcomeBinder.kt
@@ -35,8 +35,9 @@ class WelcomeBinder(
     override fun bind(content: ContentConfig.Welcome, scope: BindScope): ContentHandle = with(binding) {
         val context = root.context
 
-        val body1 = content.body1.resolve(context).preventWidows()
-        bodyText1.text = if (content.body1AsHtml) body1.html(context) else body1
+        // Decoded unconditionally: the copy variants that may carry markup are indistinguishable here, and
+        // decoding is a no-op on the plain ones.
+        bodyText1.text = content.body1.resolve(context).preventWidows().html(context)
         // Set explicitly: a previous render of the single-line copy leaves this hidden.
         bodyText2.isVisible = content.body2 != null
         content.body2?.let { bodyText2.text = it.resolve(context).preventWidows() }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/WelcomeBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/WelcomeBinder.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.page.configdriven.binders
+
+import android.view.View
+import androidx.core.view.isVisible
+import com.duckduckgo.app.browser.databinding.IncludeBrandDesignDialogWelcomeBinding
+import com.duckduckgo.app.onboarding.ui.page.configdriven.BindScope
+import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentConfig
+import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentHandle
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DialogBinder
+import com.duckduckgo.common.utils.extensions.html
+import com.duckduckgo.common.utils.extensions.preventWidows
+
+class WelcomeBinder(
+    private val binding: IncludeBrandDesignDialogWelcomeBinding,
+) : DialogBinder<ContentConfig.Welcome> {
+
+    override val view: View = binding.root
+
+    override fun bind(content: ContentConfig.Welcome, scope: BindScope): ContentHandle = with(binding) {
+        val context = root.context
+
+        val body1 = content.body1.resolve(context).preventWidows()
+        bodyText1.text = if (content.body1AsHtml) body1.html(context) else body1
+        // Set explicitly: a previous render of the single-line copy leaves this hidden.
+        bodyText2.isVisible = content.body2 != null
+        content.body2?.let { bodyText2.text = it.resolve(context).preventWidows() }
+
+        titleText.setTitle(content.title.resolve(context))
+
+        ContentHandle(
+            title = titleText,
+            fadeTargets = listOfNotNull(bodyText1, bodyText2.takeIf { content.body2 != null }),
+        )
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/CardStage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/CardStage.kt
@@ -42,6 +42,12 @@ interface CardStage {
     /** Tweens the card's bounds from the outgoing screen's size to the newly bound one's. */
     fun morph(animate: Boolean, onEnd: () -> Unit)
 
+    /**
+     * Tweens the card's bounds over [durationMs] into the layout change its caller makes next, for a resize a
+     * bound screen drives itself rather than one that comes with a new screen.
+     */
+    fun beginBoundsTransition(durationMs: Long)
+
     fun showCtaButtons(primary: CtaConfig?, secondary: CtaConfig?, onClick: (CtaConfig) -> Unit)
 
     /** Hides [contentTargets] and the visible CTAs so an entrance can fade them in. */
@@ -121,6 +127,12 @@ class CardStageImpl(private val binding: ContentOnboardingWelcomePageUpdateBindi
         TransitionManager.beginDelayedTransition(morphScene, transition)
         // Guarantees a layout pass is observed even if none of this render's view mutations triggered one.
         morphScene.requestLayout()
+    }
+
+    override fun beginBoundsTransition(durationMs: Long) {
+        // A view that has never been laid out has zero bounds, which the transition would tween the card out of.
+        if (!morphScene.isLaidOut) return
+        TransitionManager.beginDelayedTransition(morphScene, ChangeBounds().setDuration(durationMs))
     }
 
     override fun showCtaButtons(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/CardStage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/CardStage.kt
@@ -33,8 +33,11 @@ import com.duckduckgo.app.onboarding.ui.page.configdriven.CtaConfig
 import com.duckduckgo.common.ui.view.button.DaxButton
 
 interface CardStage {
-    /** Fades the card root in. Nothing to do once the card is on stage, so only the first render of a run fades. */
-    fun reveal(animate: Boolean, onEnd: () -> Unit)
+    /**
+     * Fades the card root in, after [extraStartDelayMs] on top of the stage's own lead-in. Nothing to do once the
+     * card is on stage, so only the first render of a run fades.
+     */
+    fun reveal(animate: Boolean, extraStartDelayMs: Long = 0L, onEnd: () -> Unit)
 
     /** Tweens the card's bounds from the outgoing screen's size to the newly bound one's. */
     fun morph(animate: Boolean, onEnd: () -> Unit)
@@ -67,7 +70,11 @@ class CardStageImpl(private val binding: ContentOnboardingWelcomePageUpdateBindi
 
     private var ctaViews = emptyList<View>()
 
-    override fun reveal(animate: Boolean, onEnd: () -> Unit) {
+    override fun reveal(
+        animate: Boolean,
+        extraStartDelayMs: Long,
+        onEnd: () -> Unit,
+    ) {
         val card = binding.daxDialogCta.root
         card.isVisible = true
         // Alpha already 1 means the card is on stage from an earlier render, so there is nothing to fade.
@@ -81,7 +88,7 @@ class CardStageImpl(private val binding: ContentOnboardingWelcomePageUpdateBindi
             return
         }
         val reveal = ObjectAnimator.ofFloat(card, View.ALPHA, 1f).apply {
-            startDelay = CARD_FADE_IN_START_DELAY_MS
+            startDelay = CARD_FADE_IN_START_DELAY_MS + extraStartDelayMs
             duration = CARD_FADE_IN_DURATION_MS
             addListener(
                 object : AnimatorListenerAdapter() {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentHandle
 import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentValueStore
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.AddressBarBinder
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.ComparisonChartBinder
+import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.WelcomeBinder
 import com.duckduckgo.onboarding.api.LinearOnboardingStepId
 
 interface ContentController {
@@ -48,6 +49,7 @@ class ContentControllerImpl(
 
     private val comparisonChart = ComparisonChartBinder(binding.comparisonChartContent)
     private val addressBar = AddressBarBinder(binding.addressBarContent, isLightMode)
+    private val welcome = WelcomeBinder(binding.welcomeContent)
 
     private var boundView: View? = null
 
@@ -68,6 +70,10 @@ class ContentControllerImpl(
         scope: BindScope,
     ): ContentHandle {
         val handle = when (content) {
+            is ContentConfig.Welcome -> {
+                boundView = welcome.view
+                welcome.bind(content, scope)
+            }
             is ContentConfig.ComparisonChart -> {
                 boundView = comparisonChart.view
                 comparisonChart.bind(content, scope)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentValueStore
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.AddressBarBinder
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.ComparisonChartBinder
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.InputScreenBinder
+import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.InputScreenPreviewBinder
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.WelcomeBinder
 import com.duckduckgo.onboarding.api.LinearOnboardingStepId
 
@@ -51,6 +52,7 @@ class ContentControllerImpl(
     private val comparisonChart = ComparisonChartBinder(binding.comparisonChartContent)
     private val addressBar = AddressBarBinder(binding.addressBarContent, isLightMode)
     private val inputScreen = InputScreenBinder(binding.inputScreenContent, isLightMode)
+    private val inputScreenPreview = InputScreenPreviewBinder(binding.inputScreenPreviewContent)
     private val welcome = WelcomeBinder(binding.welcomeContent)
 
     private var boundView: View? = null
@@ -87,6 +89,10 @@ class ContentControllerImpl(
             is ContentConfig.InputScreen -> {
                 boundView = inputScreen.view
                 inputScreen.bind(content, contentValues.contentState(stepId, content), scope)
+            }
+            is ContentConfig.InputScreenPreview -> {
+                boundView = inputScreenPreview.view
+                inputScreenPreview.bind(content, contentValues.contentState(stepId, content), scope)
             }
         }
         boundView?.isVisible = true

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentHandle
 import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentValueStore
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.AddressBarBinder
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.ComparisonChartBinder
+import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.InputScreenBinder
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.WelcomeBinder
 import com.duckduckgo.onboarding.api.LinearOnboardingStepId
 
@@ -49,6 +50,7 @@ class ContentControllerImpl(
 
     private val comparisonChart = ComparisonChartBinder(binding.comparisonChartContent)
     private val addressBar = AddressBarBinder(binding.addressBarContent, isLightMode)
+    private val inputScreen = InputScreenBinder(binding.inputScreenContent, isLightMode)
     private val welcome = WelcomeBinder(binding.welcomeContent)
 
     private var boundView: View? = null
@@ -81,6 +83,10 @@ class ContentControllerImpl(
             is ContentConfig.AddressBar -> {
                 boundView = addressBar.view
                 addressBar.bind(content, contentValues.contentState(stepId, content), scope)
+            }
+            is ContentConfig.InputScreen -> {
+                boundView = inputScreen.view
+                inputScreen.bind(content, contentValues.contentState(stepId, content), scope)
             }
         }
         boundView?.isVisible = true

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngine.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngine.kt
@@ -89,7 +89,10 @@ class DialogRenderEngine(
         val freshStage = previous == null
         skipRunningAnimations()
         unbindCurrent()
-        if (freshStage) content.resetStage()
+        if (freshStage) {
+            content.resetStage()
+            embellishments.resetStage()
+        }
 
         background.apply(previous?.background, config.background, animateBackground)
         stepIndicator.apply(previous?.stepIndicator, config.stepIndicator, animate)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngine.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngine.kt
@@ -54,6 +54,9 @@ class DialogRenderEngine(
     /** The animation policy of the render that is bound, which a binder-driven card resize follows too. */
     private var renderAnimating = false
 
+    /** Set once the bound screen's entrance has run its course, animated, snapped or skipped. */
+    private var entranceSettled = false
+
     /**
      * While set, every remaining stage runs snapped. Settling an in-flight entrance unwinds the rest of the
      * chain synchronously, and those stages must land on their end state rather than start fresh animations.
@@ -94,6 +97,7 @@ class DialogRenderEngine(
 
         if (animate) isAnimating = true
         renderAnimating = animate
+        entranceSettled = false
 
         val scope = createBindScope()
         bindScope = scope
@@ -129,6 +133,7 @@ class DialogRenderEngine(
                         if (bound !== handle) return@fadeInContent
                         playAfterFade(handle, animating(animate))
                         handle.onContentReady?.invoke()
+                        entranceSettled = true
                         isAnimating = false
                     }
                 }
@@ -172,8 +177,14 @@ class DialogRenderEngine(
 
     private fun animating(animate: Boolean) = animate && !settling
 
+    /**
+     * While the entrance is running, a resize the bound screen drives follows the render's own policy, so a
+     * snapped or skipped entrance stays snapped. Once the screen is on stage, the entrance policy has expired:
+     * an interaction resizes the card the same way whether the screen animated in or was drawn in place.
+     */
     private fun animateCardBounds(durationMs: Long) {
-        if (!animating(renderAnimating)) return
+        if (settling) return
+        if (!entranceSettled && !renderAnimating) return
         cardStage.beginBoundsTransition(durationMs)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngine.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngine.kt
@@ -75,14 +75,11 @@ class DialogRenderEngine(
      *
      * Re-rendering the [stepId] + [config] that is currently bound is a no-op, [animate] included, so a caller that can fire more
      * than once for one state does not need to de-duplicate itself.
-     *
-     * [animateBackground] splits the background off the [animate] policy, where needed.
      */
     fun render(
         stepId: LinearOnboardingStepId,
         config: DialogConfig,
         animate: Boolean,
-        animateBackground: Boolean = animate,
     ) {
         if (stepId == previousStepId && config == previous && bound != null) return
 
@@ -94,7 +91,7 @@ class DialogRenderEngine(
             embellishments.resetStage()
         }
 
-        background.apply(previous?.background, config.background, animateBackground)
+        background.apply(previous?.background, config.background, animate)
         stepIndicator.apply(previous?.stepIndicator, config.stepIndicator, animate)
         cardArrow.apply(previous?.cardArrow, config.cardArrow, animate)
 
@@ -118,7 +115,7 @@ class DialogRenderEngine(
         cardAnchor.apply(settledDecoration)
 
         // A snapped background is already in place, so there is nothing for the card to wait on.
-        val revealDelayMs = if (config.cardEntry == CardEntry.AfterBackgroundTransition && animateBackground) {
+        val revealDelayMs = if (config.cardEntry == CardEntry.AfterBackgroundTransition && animate) {
             OnboardingBackgroundAnimator.EXIT_DURATION
         } else {
             0L

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngine.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngine.kt
@@ -51,6 +51,9 @@ class DialogRenderEngine(
     private var bindScope: CoroutineScope? = null
     private var afterFadeAnimator: Animator? = null
 
+    /** The animation policy of the render that is bound, which a binder-driven card resize follows too. */
+    private var renderAnimating = false
+
     /**
      * While set, every remaining stage runs snapped. Settling an in-flight entrance unwinds the rest of the
      * chain synchronously, and those stages must land on their end state rather than start fresh animations.
@@ -90,10 +93,15 @@ class DialogRenderEngine(
         cardArrow.apply(previous?.cardArrow, config.cardArrow, animate)
 
         if (animate) isAnimating = true
+        renderAnimating = animate
 
         val scope = createBindScope()
         bindScope = scope
-        val handle = content.bind(stepId, config.content, BindScope(coroutineScope = scope, execute = execute))
+        val handle = content.bind(
+            stepId,
+            config.content,
+            BindScope(coroutineScope = scope, execute = execute, animateCardBounds = ::animateCardBounds),
+        )
         bound = handle
 
         cardStage.showCtaButtons(config.primaryCta, config.secondaryCta) { cta -> performCta(cta.action, handle) }
@@ -163,6 +171,11 @@ class DialogRenderEngine(
     }
 
     private fun animating(animate: Boolean) = animate && !settling
+
+    private fun animateCardBounds(durationMs: Long) {
+        if (!animating(renderAnimating)) return
+        cardStage.beginBoundsTransition(durationMs)
+    }
 
     private fun unbindCurrent() {
         val handle = bound ?: return

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngine.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngine.kt
@@ -19,7 +19,9 @@ package com.duckduckgo.app.onboarding.ui.page.configdriven.engine
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingEvent
+import com.duckduckgo.app.onboarding.ui.page.OnboardingBackgroundAnimator
 import com.duckduckgo.app.onboarding.ui.page.configdriven.BindScope
+import com.duckduckgo.app.onboarding.ui.page.configdriven.CardEntry
 import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentHandle
 import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentInteraction
 import com.duckduckgo.app.onboarding.ui.page.configdriven.CtaAction
@@ -101,8 +103,15 @@ class DialogRenderEngine(
         val settledDecoration = embellishments.transition(previous?.embellishment, config.embellishment, animate)
         cardAnchor.apply(settledDecoration)
 
+        // A snapped background is already in place, so there is nothing for the card to wait on.
+        val revealDelayMs = if (config.cardEntry == CardEntry.AfterBackgroundTransition && animateBackground) {
+            OnboardingBackgroundAnimator.EXIT_DURATION
+        } else {
+            0L
+        }
+
         // Every deferred stage below bails if the bound view has changed since dispatch
-        cardStage.reveal(animate) {
+        cardStage.reveal(animate, revealDelayMs) {
             if (bound !== handle) return@reveal
             cardStage.morph(animating(animate)) {
                 if (bound !== handle) return@morph

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngine.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngine.kt
@@ -51,11 +51,11 @@ class DialogRenderEngine(
     private var bindScope: CoroutineScope? = null
     private var afterFadeAnimator: Animator? = null
 
-    /** The animation policy of the render that is bound, which a binder-driven card resize follows too. */
-    private var renderAnimating = false
-
-    /** Set once the bound screen's entrance has run its course, animated, snapped or skipped. */
-    private var entranceSettled = false
+    /**
+     * The bound render's animation policy while its entrance is in flight; null once the entrance has run its
+     * course, animated, snapped or skipped, and the policy has expired.
+     */
+    private var entrancePolicy: Boolean? = null
 
     /**
      * While set, every remaining stage runs snapped. Settling an in-flight entrance unwinds the rest of the
@@ -96,8 +96,7 @@ class DialogRenderEngine(
         cardArrow.apply(previous?.cardArrow, config.cardArrow, animate)
 
         if (animate) isAnimating = true
-        renderAnimating = animate
-        entranceSettled = false
+        entrancePolicy = animate
 
         val scope = createBindScope()
         bindScope = scope
@@ -133,7 +132,7 @@ class DialogRenderEngine(
                         if (bound !== handle) return@fadeInContent
                         playAfterFade(handle, animating(animate))
                         handle.onContentReady?.invoke()
-                        entranceSettled = true
+                        entrancePolicy = null
                         isAnimating = false
                     }
                 }
@@ -183,8 +182,7 @@ class DialogRenderEngine(
      * an interaction resizes the card the same way whether the screen animated in or was drawn in place.
      */
     private fun animateCardBounds(durationMs: Long) {
-        if (settling) return
-        if (!entranceSettled && !renderAnimating) return
+        if (settling || entrancePolicy == false) return
         cardStage.beginBoundsTransition(durationMs)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentController.kt
@@ -36,8 +36,8 @@ import com.duckduckgo.common.ui.view.toPx
 
 interface EmbellishmentController {
     /**
-     * Clears every decoration off the stage, so a render with no predecessor to exit does not inherit the layout
-     * footprint of whichever decorations the XML leaves visible.
+     * Clears every decoration, so a render with no predecessor to exit does not inherit the footprint of whichever
+     * decorations the XML leaves visible.
      */
     fun resetStage()
 
@@ -293,9 +293,9 @@ class EmbellishmentControllerImpl(
 
     /**
      * A screen with no decoration still reserves the room one would have taken, so its card sits at a
-     * comparable height rather than dropping to the parent bottom. The floor is the card's bottom inset, so
-     * that a band shrunk by a tall card still covers the bottom bar; anything the band cannot cover the card
-     * reserves for itself, via [OnboardingDecorationFitCorrector.reservesInsetAboveDecoration].
+     * comparable height rather than dropping to the parent bottom. The floor is the card's bottom inset, so that a
+     * band shrunk by a tall card still covers the bottom bar; the card reserves whatever the band cannot cover,
+     * via [OnboardingDecorationFitCorrector.reservesInsetAboveDecoration].
      */
     private fun buildUndecoratedBand(): Decoration {
         val view = binding.undecoratedBand

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentController.kt
@@ -37,6 +37,12 @@ import com.duckduckgo.common.ui.view.toPx
 
 interface EmbellishmentController {
     /**
+     * Clears every decoration off the stage, so a render with no predecessor to exit does not inherit the layout
+     * footprint of whichever decorations the XML leaves visible.
+     */
+    fun resetStage()
+
+    /**
      * Returns what the fit check settled on, synchronously: the caller anchors the card to it in the same frame,
      * so the card's reposition is picked up by the render's card morph instead of snapping into place later.
      */
@@ -94,6 +100,10 @@ class EmbellishmentControllerImpl(
     init {
         fitCorrector.enabled = true
         fitCorrector.attach()
+    }
+
+    override fun resetStage() {
+        decorations.values.forEach { it.hide() }
     }
 
     override fun transition(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentController.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.app.onboarding.ui.page.configdriven.engine
 
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
-import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
 import android.animation.ValueAnimator
 import android.view.View
@@ -245,18 +244,10 @@ class EmbellishmentControllerImpl(
             enter = {
                 view.isVisible = true
                 view.alpha = 0f
-                val fade = ObjectAnimator.ofFloat(view, View.ALPHA, 0f, 1f)
-                    .setDuration(WALKING_DAX_FADE_DURATION)
-                val slide = ObjectAnimator.ofFloat(
-                    view,
-                    View.TRANSLATION_X,
-                    -WALKING_DAX_START_X_DP.toPx().toFloat(),
-                    -WALKING_DAX_FINAL_X_DP.toPx().toFloat(),
-                ).setDuration(WALKING_DAX_SLIDE_DURATION)
-                val set = AnimatorSet().apply {
+                val fade = ObjectAnimator.ofFloat(view, View.ALPHA, 0f, 1f).apply {
                     interpolator = WALKING_DAX_INTERPOLATOR
                     startDelay = WALKING_DAX_DELAY
-                    playTogether(fade, slide)
+                    duration = WALKING_DAX_FADE_DURATION
                     addListener(
                         object : AnimatorListenerAdapter() {
                             override fun onAnimationStart(animation: Animator) {
@@ -265,8 +256,19 @@ class EmbellishmentControllerImpl(
                         },
                     )
                 }
-                set.start()
-                listOf(set)
+                val slide = ObjectAnimator.ofFloat(
+                    view,
+                    View.TRANSLATION_X,
+                    -WALKING_DAX_START_X_DP.toPx().toFloat(),
+                    -WALKING_DAX_FINAL_X_DP.toPx().toFloat(),
+                ).apply {
+                    interpolator = WALKING_DAX_INTERPOLATOR
+                    startDelay = WALKING_DAX_DELAY
+                    duration = WALKING_DAX_SLIDE_DURATION
+                }
+                fade.start()
+                slide.start()
+                listOf(fade, slide)
             },
             exit = {
                 hide()

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentController.kt
@@ -99,6 +99,7 @@ class EmbellishmentControllerImpl(
 
     init {
         fitCorrector.enabled = true
+        fitCorrector.reservesInsetAboveDecoration = true
         fitCorrector.attach()
     }
 
@@ -290,8 +291,9 @@ class EmbellishmentControllerImpl(
 
     /**
      * A screen with no decoration still reserves the room one would have taken, so its card sits at a
-     * comparable height rather than dropping to the parent bottom. The floor is the card's bottom inset,
-     * because the card anchors above the band and so never reserves that inset itself.
+     * comparable height rather than dropping to the parent bottom. The floor is the card's bottom inset, so
+     * that a band shrunk by a tall card still covers the bottom bar; anything the band cannot cover the card
+     * reserves for itself, via [OnboardingDecorationFitCorrector.reservesInsetAboveDecoration].
      */
     private fun buildUndecoratedBand(): Decoration {
         val view = binding.undecoratedBand

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentPlacement.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentPlacement.kt
@@ -28,8 +28,8 @@ import com.duckduckgo.app.onboarding.ui.page.configdriven.Embellishment
 object EmbellishmentPlacement {
 
     fun of(embellishment: Embellishment): Placement = when (embellishment) {
-        // Bias 1 keeps the card pressed down against the dax on a phone; a tablet has room to spare above the
-        // dax, so the card centres in it instead of hanging off the artwork.
+        // Bias 1 presses the card down against the dax on a phone; a tablet has room to spare above it, so the
+        // card centres instead of hanging off the artwork.
         Embellishment.WalkingDax -> Placement(anchorsCardOnPhone = true, biasPhone = 1f, biasTablet = 0.5f, drawsArtwork = true)
         Embellishment.BottomWing -> Placement(anchorsCardOnPhone = true, biasPhone = 0f, biasTablet = 0.5f, drawsArtwork = true)
         // The side decorations reserve no room on a phone, where the card runs down past them instead.

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentPlacement.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentPlacement.kt
@@ -28,8 +28,9 @@ import com.duckduckgo.app.onboarding.ui.page.configdriven.Embellishment
 object EmbellishmentPlacement {
 
     fun of(embellishment: Embellishment): Placement = when (embellishment) {
-        // Bias 1 keeps the card pressed down against the dax, on phone and tablet alike.
-        Embellishment.WalkingDax -> Placement(anchorsCardOnPhone = true, biasPhone = 1f, biasTablet = 1f, drawsArtwork = true)
+        // Bias 1 keeps the card pressed down against the dax on a phone; a tablet has room to spare above the
+        // dax, so the card centres in it instead of hanging off the artwork.
+        Embellishment.WalkingDax -> Placement(anchorsCardOnPhone = true, biasPhone = 1f, biasTablet = 0.5f, drawsArtwork = true)
         Embellishment.BottomWing -> Placement(anchorsCardOnPhone = true, biasPhone = 0f, biasTablet = 0.5f, drawsArtwork = true)
         // The side decorations reserve no room on a phone, where the card runs down past them instead.
         Embellishment.LeftWing -> Placement(anchorsCardOnPhone = false, biasPhone = 0f, biasTablet = 0.5f, drawsArtwork = true)

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrectorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrectorTest.kt
@@ -60,6 +60,7 @@ class OnboardingDecorationFitCorrectorTest {
         viewportMeasuredHeight: Int = viewportHeight,
         bottomOverlapPx: Int = 0,
         cardBottomInsetPx: Int = 0,
+        cardBottomInsetPxProvider: () -> Int = { cardBottomInsetPx },
         enabled: Boolean = true,
         reservesInsetAboveDecoration: Boolean = false,
         onDecorationHidden: () -> Unit = {},
@@ -106,7 +107,7 @@ class OnboardingDecorationFitCorrectorTest {
         }
         decoration.layout(0, 0, 200, decorationHeight)
 
-        val corrector = OnboardingDecorationFitCorrector(root, dialog, cardContainer, onDecorationHidden, { cardBottomInsetPx })
+        val corrector = OnboardingDecorationFitCorrector(root, dialog, cardContainer, onDecorationHidden, cardBottomInsetPxProvider)
         corrector.enabled = enabled
         corrector.reservesInsetAboveDecoration = reservesInsetAboveDecoration
         corrector.track(decoration, minHeightPx = minHeightPx, maxHeightPx = maxHeightPx, bottomOverlapPx = bottomOverlapPx)
@@ -552,6 +553,40 @@ class OnboardingDecorationFitCorrectorTest {
 
         assertFalse(h.corrector.correctOnce())
         assertEquals(300, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
+    }
+
+    @Test
+    fun whenTheInsetDropsThenTheReservationAndTheClampRelease() {
+        // The keyboard hiding must give the card its room back: a reservation that only ever grows parks
+        // the card at the top of the screen for the rest of the flow.
+        var inset = 863
+        val h = harness(
+            rootHeight = 1200,
+            dialogHeight = 600,
+            contentHeight = 600,
+            viewportHeight = 600,
+            decorationHeight = 422,
+            minHeightPx = 247,
+            maxHeightPx = 422,
+            cardBottomInsetPxProvider = { inset },
+            reservesInsetAboveDecoration = true,
+        )
+        (h.dialog.layoutParams as ConstraintLayout.LayoutParams).apply {
+            bottomToBottom = ConstraintLayout.LayoutParams.UNSET
+            bottomToTop = h.decoration.id
+        }
+
+        assertFalse(h.corrector.correctOnce())
+        assertEquals(441, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
+        assertFalse(h.corrector.correctOnce())
+        assertTrue((h.dialog.layoutParams as ConstraintLayout.LayoutParams).constrainedHeight)
+
+        inset = 0
+
+        assertFalse(h.corrector.correctOnce())
+        assertEquals(0, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
+        assertFalse(h.corrector.correctOnce())
+        assertFalse((h.dialog.layoutParams as ConstraintLayout.LayoutParams).constrainedHeight)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrectorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrectorTest.kt
@@ -61,6 +61,7 @@ class OnboardingDecorationFitCorrectorTest {
         bottomOverlapPx: Int = 0,
         cardBottomInsetPx: Int = 0,
         enabled: Boolean = true,
+        reservesInsetAboveDecoration: Boolean = false,
         onDecorationHidden: () -> Unit = {},
     ): Harness {
         val root = ConstraintLayout(context)
@@ -106,6 +107,7 @@ class OnboardingDecorationFitCorrectorTest {
 
         val corrector = OnboardingDecorationFitCorrector(root, dialog, cardContainer, onDecorationHidden, { cardBottomInsetPx })
         corrector.enabled = enabled
+        corrector.reservesInsetAboveDecoration = reservesInsetAboveDecoration
         corrector.track(decoration, minHeightPx = minHeightPx, maxHeightPx = maxHeightPx, bottomOverlapPx = bottomOverlapPx)
         return Harness(corrector, dialog, decoration)
     }
@@ -501,6 +503,124 @@ class OnboardingDecorationFitCorrectorTest {
         }
 
         assertFalse(h.corrector.correctOnce())
+        assertEquals(0, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
+    }
+
+    // reservesInsetAboveDecoration opts a renderer into the card also reserving whatever part of the inset the
+    // decoration it is anchored above cannot cover — the config-driven undecorated band versus the keyboard.
+
+    @Test
+    fun whenInsetExceedsTheDecorationBelowThenCardReservesTheRemainder() {
+        val h = harness(
+            rootHeight = 1200,
+            dialogHeight = 600,
+            contentHeight = 600,
+            viewportHeight = 600,
+            decorationHeight = 200,
+            minHeightPx = 247,
+            maxHeightPx = 299,
+            cardBottomInsetPx = 500,
+            reservesInsetAboveDecoration = true,
+        )
+        (h.dialog.layoutParams as ConstraintLayout.LayoutParams).apply {
+            bottomToBottom = ConstraintLayout.LayoutParams.UNSET
+            bottomToTop = h.decoration.id
+        }
+
+        assertFalse(h.corrector.correctOnce())
+        assertEquals(300, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
+    }
+
+    @Test
+    fun whenDecorationBelowAlreadyCoversTheInsetThenCardReservesNothing() {
+        val h = harness(
+            rootHeight = 1200,
+            dialogHeight = 600,
+            contentHeight = 600,
+            viewportHeight = 600,
+            decorationHeight = 200,
+            minHeightPx = 247,
+            maxHeightPx = 299,
+            cardBottomInsetPx = 108,
+            reservesInsetAboveDecoration = true,
+        )
+        (h.dialog.layoutParams as ConstraintLayout.LayoutParams).apply {
+            bottomToBottom = ConstraintLayout.LayoutParams.UNSET
+            bottomToTop = h.decoration.id
+        }
+
+        h.corrector.correctOnce()
+        assertEquals(0, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
+    }
+
+    @Test
+    fun whenDecorationBelowHasABottomMarginThenThatCountsAsRoomItCovers() {
+        val h = harness(
+            rootHeight = 1200,
+            dialogHeight = 600,
+            contentHeight = 600,
+            viewportHeight = 600,
+            decorationHeight = 200,
+            decorationBottomMargin = 56,
+            minHeightPx = 247,
+            maxHeightPx = 299,
+            cardBottomInsetPx = 500,
+            reservesInsetAboveDecoration = true,
+        )
+        (h.dialog.layoutParams as ConstraintLayout.LayoutParams).apply {
+            bottomToBottom = ConstraintLayout.LayoutParams.UNSET
+            bottomToTop = h.decoration.id
+        }
+
+        assertFalse(h.corrector.correctOnce())
+        assertEquals(244, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
+    }
+
+    @Test
+    fun whenDecorationBelowIsGoneThenTheHostReanchorsInsteadOfTheCardReservingTheInset() {
+        // A gone decoration means onDecorationHidden has already asked the host to re-anchor the card, after
+        // which the bottom-anchored branch reserves the whole inset. Reserving it here too would double up.
+        val h = harness(
+            rootHeight = 1200,
+            dialogHeight = 600,
+            contentHeight = 600,
+            viewportHeight = 600,
+            decorationHeight = 200,
+            minHeightPx = 247,
+            maxHeightPx = 299,
+            cardBottomInsetPx = 500,
+            reservesInsetAboveDecoration = true,
+        )
+        h.decoration.isGone = true
+        (h.dialog.layoutParams as ConstraintLayout.LayoutParams).apply {
+            bottomToBottom = ConstraintLayout.LayoutParams.UNSET
+            bottomToTop = h.decoration.id
+        }
+
+        assertTrue(h.corrector.correctOnce())
+        assertEquals(0, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
+    }
+
+    @Test
+    fun whenDisabledThenNoInsetIsReservedAboveADecoration() {
+        val h = harness(
+            rootHeight = 1200,
+            dialogHeight = 600,
+            contentHeight = 600,
+            viewportHeight = 600,
+            decorationHeight = 200,
+            minHeightPx = 247,
+            maxHeightPx = 299,
+            cardBottomInsetPx = 500,
+            enabled = false,
+            reservesInsetAboveDecoration = true,
+        )
+        (h.dialog.layoutParams as ConstraintLayout.LayoutParams).apply {
+            bottomToBottom = ConstraintLayout.LayoutParams.UNSET
+            bottomToTop = h.decoration.id
+        }
+
+        assertTrue(h.corrector.correctOnce())
         assertEquals(0, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
     }
 

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrectorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrectorTest.kt
@@ -577,6 +577,36 @@ class OnboardingDecorationFitCorrectorTest {
     }
 
     @Test
+    fun whenDecorationBelowHasNoAppliedHeightThenItsMeasuredHeightCountsAsRoomItCovers() {
+        // The engine applies an explicit height before handing the decoration over, so this pins the
+        // fallback: should that invariant ever break, the reservation must come from the measured height
+        // rather than silently treating WRAP_CONTENT as the room the decoration covers.
+        val h = harness(
+            rootHeight = 1200,
+            dialogHeight = 600,
+            contentHeight = 600,
+            viewportHeight = 600,
+            decorationHeight = 200,
+            minHeightPx = 247,
+            maxHeightPx = 299,
+            cardBottomInsetPx = 500,
+            reservesInsetAboveDecoration = true,
+        )
+        (h.decoration.layoutParams as ViewGroup.MarginLayoutParams).height = ViewGroup.LayoutParams.WRAP_CONTENT
+        h.decoration.measure(
+            View.MeasureSpec.makeMeasureSpec(200, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(200, View.MeasureSpec.EXACTLY),
+        )
+        (h.dialog.layoutParams as ConstraintLayout.LayoutParams).apply {
+            bottomToBottom = ConstraintLayout.LayoutParams.UNSET
+            bottomToTop = h.decoration.id
+        }
+
+        assertFalse(h.corrector.correctOnce())
+        assertEquals(300, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
+    }
+
+    @Test
     fun whenDecorationBelowHasABottomMarginThenThatCountsAsRoomItCovers() {
         val h = harness(
             rootHeight = 1200,

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrectorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrectorTest.kt
@@ -98,6 +98,7 @@ class OnboardingDecorationFitCorrectorTest {
         dialog.measureExactly(dialogMeasuredHeight)
 
         val decoration = View(context)
+        decoration.id = View.generateViewId()
         root.addView(decoration)
         (decoration.layoutParams as ViewGroup.MarginLayoutParams).apply {
             height = decorationHeight
@@ -621,6 +622,116 @@ class OnboardingDecorationFitCorrectorTest {
         }
 
         assertTrue(h.corrector.correctOnce())
+        assertEquals(0, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
+    }
+
+    @Test
+    fun whenCardReservesAnInsetAboveTheDecorationThenThatInsetDoesNotShrinkTheDecoration() {
+        // The reserved inset buys room out from under a keyboard, which the decoration is not competing for.
+        // Counting it against the decoration shrinks it, which grows the inset, until the decoration is gone.
+        val h = harness(
+            rootHeight = 1752,
+            dialogHeight = 873,
+            dialogTopMargin = 64,
+            contentHeight = 822,
+            viewportHeight = 822,
+            decorationHeight = 422,
+            minHeightPx = 66,
+            maxHeightPx = 422,
+            cardBottomInsetPx = 863,
+            reservesInsetAboveDecoration = true,
+        )
+        (h.dialog.layoutParams as ConstraintLayout.LayoutParams).apply {
+            bottomToBottom = ConstraintLayout.LayoutParams.UNSET
+            bottomToTop = h.decoration.id
+        }
+
+        assertFalse(h.corrector.correctOnce()) // reserves 863 - 422 = 441
+        assertEquals(441, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
+
+        // Settles there: the decoration keeps its height, so the reservation does not grow on the next pass.
+        h.corrector.correctOnce()
+        h.corrector.correctOnce()
+        assertEquals(422, h.decoration.layoutParams.height)
+        assertFalse(h.decoration.isGone)
+        assertEquals(441, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
+    }
+
+    @Test
+    fun whenCardAboveDecorationOverflowsItsRemainingSpanThenClampEnabled() {
+        // span = 1752 - 64 (top margin) - 441 (reserved inset) - 422 (decoration) = 825 < content 873.
+        // Without the clamp the card overruns the decoration instead of scrolling, so a card lifted clear of
+        // the keyboard still spills under it.
+        val h = harness(
+            rootHeight = 1752,
+            dialogHeight = 873,
+            dialogTopMargin = 64,
+            contentHeight = 873,
+            viewportHeight = 873,
+            decorationHeight = 422,
+            minHeightPx = 66,
+            maxHeightPx = 422,
+            cardBottomInsetPx = 863,
+            reservesInsetAboveDecoration = true,
+        )
+        (h.dialog.layoutParams as ConstraintLayout.LayoutParams).apply {
+            bottomToBottom = ConstraintLayout.LayoutParams.UNSET
+            bottomToTop = h.decoration.id
+            constrainedHeight = false
+        }
+
+        assertFalse(h.corrector.correctOnce()) // reserves the inset
+        assertFalse(h.corrector.correctOnce()) // then clamps
+        assertTrue((h.dialog.layoutParams as ConstraintLayout.LayoutParams).constrainedHeight)
+    }
+
+    @Test
+    fun whenCardAboveDecorationFitsItsRemainingSpanThenClampDisabled() {
+        val h = harness(
+            rootHeight = 1752,
+            dialogHeight = 600,
+            dialogTopMargin = 64,
+            contentHeight = 600,
+            viewportHeight = 600,
+            decorationHeight = 422,
+            minHeightPx = 66,
+            maxHeightPx = 422,
+            cardBottomInsetPx = 66,
+            reservesInsetAboveDecoration = true,
+        )
+        (h.dialog.layoutParams as ConstraintLayout.LayoutParams).apply {
+            bottomToBottom = ConstraintLayout.LayoutParams.UNSET
+            bottomToTop = h.decoration.id
+            constrainedHeight = true
+        }
+
+        assertFalse(h.corrector.correctOnce())
+        assertFalse((h.dialog.layoutParams as ConstraintLayout.LayoutParams).constrainedHeight)
+    }
+
+    @Test
+    fun whenNotReservingAnInsetAboveTheDecorationThenAnOverflowingCardIsNotClamped() {
+        // Legacy inertness: the card is anchored above a decoration and overflows the span that leaves it, but
+        // without the reservation the corrector must not touch the card's wrap.
+        val h = harness(
+            rootHeight = 1752,
+            dialogHeight = 873,
+            dialogTopMargin = 64,
+            contentHeight = 873,
+            viewportHeight = 873,
+            decorationHeight = 422,
+            minHeightPx = 66,
+            maxHeightPx = 422,
+            cardBottomInsetPx = 863,
+        )
+        (h.dialog.layoutParams as ConstraintLayout.LayoutParams).apply {
+            bottomToBottom = ConstraintLayout.LayoutParams.UNSET
+            bottomToTop = h.decoration.id
+            constrainedHeight = false
+        }
+
+        h.corrector.correctOnce()
+        assertFalse((h.dialog.layoutParams as ConstraintLayout.LayoutParams).constrainedHeight)
         assertEquals(0, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
     }
 

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrectorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrectorTest.kt
@@ -507,9 +507,6 @@ class OnboardingDecorationFitCorrectorTest {
         assertEquals(0, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
     }
 
-    // reservesInsetAboveDecoration opts a renderer into the card also reserving whatever part of the inset the
-    // decoration it is anchored above cannot cover — the config-driven undecorated band versus the keyboard.
-
     @Test
     fun whenInsetExceedsTheDecorationBelowThenCardReservesTheRemainder() {
         val h = harness(
@@ -579,8 +576,6 @@ class OnboardingDecorationFitCorrectorTest {
 
     @Test
     fun whenDecorationBelowIsGoneThenTheHostReanchorsInsteadOfTheCardReservingTheInset() {
-        // A gone decoration means onDecorationHidden has already asked the host to re-anchor the card, after
-        // which the bottom-anchored branch reserves the whole inset. Reserving it here too would double up.
         val h = harness(
             rootHeight = 1200,
             dialogHeight = 600,
@@ -627,8 +622,6 @@ class OnboardingDecorationFitCorrectorTest {
 
     @Test
     fun whenCardReservesAnInsetAboveTheDecorationThenThatInsetDoesNotShrinkTheDecoration() {
-        // The reserved inset buys room out from under a keyboard, which the decoration is not competing for.
-        // Counting it against the decoration shrinks it, which grows the inset, until the decoration is gone.
         val h = harness(
             rootHeight = 1752,
             dialogHeight = 873,
@@ -649,7 +642,7 @@ class OnboardingDecorationFitCorrectorTest {
         assertFalse(h.corrector.correctOnce()) // reserves 863 - 422 = 441
         assertEquals(441, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
 
-        // Settles there: the decoration keeps its height, so the reservation does not grow on the next pass.
+        // Settles: the decoration keeps its height, so the reservation does not grow on the next pass.
         h.corrector.correctOnce()
         h.corrector.correctOnce()
         assertEquals(422, h.decoration.layoutParams.height)
@@ -660,8 +653,6 @@ class OnboardingDecorationFitCorrectorTest {
     @Test
     fun whenCardAboveDecorationOverflowsItsRemainingSpanThenClampEnabled() {
         // span = 1752 - 64 (top margin) - 441 (reserved inset) - 422 (decoration) = 825 < content 873.
-        // Without the clamp the card overruns the decoration instead of scrolling, so a card lifted clear of
-        // the keyboard still spills under it.
         val h = harness(
             rootHeight = 1752,
             dialogHeight = 873,
@@ -711,8 +702,6 @@ class OnboardingDecorationFitCorrectorTest {
 
     @Test
     fun whenNotReservingAnInsetAboveTheDecorationThenAnOverflowingCardIsNotClamped() {
-        // Legacy inertness: the card is anchored above a decoration and overflows the span that leaves it, but
-        // without the reservation the corrector must not touch the card's wrap.
         val h = harness(
             rootHeight = 1752,
             dialogHeight = 873,

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrectorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/OnboardingDecorationFitCorrectorTest.kt
@@ -460,6 +460,31 @@ class OnboardingDecorationFitCorrectorTest {
     }
 
     @Test
+    fun whenSideDecorationLeavesCardBottomAnchoredThenCardStillReservesTheInset() {
+        // Config-driven phone regime with a side decoration (LeftWing, BobbingDax): the card stays pinned
+        // to the parent bottom while the decoration sits beside it, covering nothing below the card, so
+        // the card must still clear the full inset — the keyboard.
+        val h = harness(
+            rootHeight = 2000,
+            dialogHeight = 600,
+            contentHeight = 600,
+            viewportHeight = 600,
+            decorationHeight = 422,
+            minHeightPx = 247,
+            maxHeightPx = 422,
+            cardBottomInsetPx = 863,
+            reservesInsetAboveDecoration = true,
+        )
+        (h.dialog.layoutParams as ConstraintLayout.LayoutParams).apply {
+            bottomToTop = ConstraintLayout.LayoutParams.UNSET
+            bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID
+        }
+
+        assertFalse(h.corrector.correctOnce())
+        assertEquals(863, (h.dialog.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin)
+    }
+
+    @Test
     fun whenDecorationShownAboveCardThenNoBottomInset() {
         // Tablet regime: card stacked above a shown decoration (bottomToTop). No inset; a stale one left
         // by a previous bottom-anchored state is cleared so it cannot steal the decoration's fit room.

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
@@ -391,7 +391,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
         val testee = startAt(NewUserOnboardingActivityDialog.ComparisonChart)
         advanceUntilIdle()
 
-        testee.onContentInteraction(ContentInteraction.SubmitInput(query = "cats", isChat = true, fromSuggestion = true))
+        testee.onContentInteraction(ContentInteraction.SubmitInputPreview(query = "cats", isChat = true, fromSuggestion = true))
         advanceUntilIdle()
 
         assertEquals(

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import app.cash.turbine.test
+import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.CustomAiOnboardingStore
@@ -413,5 +414,15 @@ class ConfigDrivenOnboardingPageViewModelTest {
         advanceUntilIdle()
 
         verifyNoInteractions(mockShownPixels)
+    }
+
+    @Test
+    fun `renders the sync restore dialog instead of skipping onboarding`() = runTest {
+        val testee = startAt(NewUserOnboardingActivityDialog.SyncRestore)
+        advanceUntilIdle()
+
+        val content = (testee.viewState.value.screen as Screen.Dialog).config.content as ContentConfig.Welcome
+        assertEquals(TextConfig.Resource(R.string.syncRestoreDialogBrandDesignTitle), content.title)
+        assertTrue(recordedEvents.isEmpty())
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingActivityStep
 import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingEvent
 import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingPlanBootstrapper
 import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingPlanProvider
+import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.ui.page.OnboardingBackgroundStep
 import com.duckduckgo.app.onboarding.ui.page.configdriven.ConfigDrivenOnboardingPageViewModel.Command
 import com.duckduckgo.app.onboarding.ui.page.configdriven.ConfigDrivenOnboardingPageViewModel.Screen
@@ -73,6 +74,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
     private val mockWidgetCapabilities: WidgetCapabilities = mock()
     private val customAiOnboardingStore: CustomAiOnboardingStore = mock()
     private val newUserOnboardingPlanBootstrapper: NewUserOnboardingPlanBootstrapper = mock()
+    private val mockOnboardingStore: OnboardingStore = mock()
 
     // Default harness: mock orchestrator left NotStarted, so the view model renders no dialog and emits no
     // commands on its own — the interaction tests drive a single method and assert exactly what it emits.
@@ -105,7 +107,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
     ): ConfigDrivenOnboardingPageViewModel = ConfigDrivenOnboardingPageViewModel(
         orchestrator = orchestrator,
         newUserOnboardingPlanBootstrapper = newUserOnboardingPlanBootstrapper,
-        dialogConfigResolver = DialogConfigResolver(),
+        dialogConfigResolver = DialogConfigResolver(mockOnboardingStore),
         dispatchers = coroutineRule.testDispatcherProvider,
         widgetCapabilities = mockWidgetCapabilities,
         defaultRoleBrowserDialog = mockDefaultRoleBrowserDialog,
@@ -377,5 +379,19 @@ class ConfigDrivenOnboardingPageViewModelTest {
         advanceUntilIdle()
 
         assertEquals(listOf(NewUserOnboardingEvent.IntroAnimationFinished), recordedEvents)
+    }
+
+    @Test
+    fun `forwards a submitted input demo query to the orchestrator`() = runTest {
+        val testee = startAt(NewUserOnboardingActivityDialog.ComparisonChart)
+        advanceUntilIdle()
+
+        testee.onContentInteraction(ContentInteraction.SubmitInput(query = "cats", isChat = true, fromSuggestion = true))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(NewUserOnboardingEvent.InputDemoQuerySubmitted(query = "cats", isChat = true, fromSuggestion = true)),
+            recordedEvents,
+        )
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
@@ -58,6 +58,8 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 @SuppressLint("DenyListedApi")
@@ -75,6 +77,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
     private val customAiOnboardingStore: CustomAiOnboardingStore = mock()
     private val newUserOnboardingPlanBootstrapper: NewUserOnboardingPlanBootstrapper = mock()
     private val mockOnboardingStore: OnboardingStore = mock()
+    private val mockShownPixels: OnboardingDialogShownPixels = mock()
 
     // Default harness: mock orchestrator left NotStarted, so the view model renders no dialog and emits no
     // commands on its own — the interaction tests drive a single method and assert exactly what it emits.
@@ -108,6 +111,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
         orchestrator = orchestrator,
         newUserOnboardingPlanBootstrapper = newUserOnboardingPlanBootstrapper,
         dialogConfigResolver = DialogConfigResolver(mockOnboardingStore),
+        shownPixels = mockShownPixels,
         dispatchers = coroutineRule.testDispatcherProvider,
         widgetCapabilities = mockWidgetCapabilities,
         defaultRoleBrowserDialog = mockDefaultRoleBrowserDialog,
@@ -393,5 +397,21 @@ class ConfigDrivenOnboardingPageViewModelTest {
             listOf(NewUserOnboardingEvent.InputDemoQuerySubmitted(query = "cats", isChat = true, fromSuggestion = true)),
             recordedEvents,
         )
+    }
+
+    @Test
+    fun `fires the shown pixel for a dialog it renders`() = runTest {
+        startAt(NewUserOnboardingActivityDialog.ComparisonChart)
+        advanceUntilIdle()
+
+        verify(mockShownPixels).fireFor(NewUserOnboardingActivityDialog.ComparisonChart)
+    }
+
+    @Test
+    fun `fires no shown pixel for a command only dialog`() = runTest {
+        startAt(NewUserOnboardingActivityDialog.NotificationPermission)
+        advanceUntilIdle()
+
+        verifyNoInteractions(mockShownPixels)
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
@@ -100,6 +100,34 @@ class DialogConfigResolverTest {
     }
 
     @Test
+    fun `resolves the initial welcome dialog with a card entry that follows the background`() {
+        val config = testee.resolve(NewUserOnboardingActivityDialog.Initial, isCustomAiFlow = false)!!
+
+        assertEquals(CardEntry.AfterBackgroundTransition, config.cardEntry)
+    }
+
+    @Test
+    fun `resolves the reinstall welcome dialog with a card entry that follows the background`() {
+        val config = testee.resolve(NewUserOnboardingActivityDialog.InitialReinstallUser, isCustomAiFlow = false)!!
+
+        assertEquals(CardEntry.AfterBackgroundTransition, config.cardEntry)
+    }
+
+    @Test
+    fun `resolves the sync restore dialog with a card entry that follows the background`() {
+        val config = testee.resolve(NewUserOnboardingActivityDialog.SyncRestore, isCustomAiFlow = false)!!
+
+        assertEquals(CardEntry.AfterBackgroundTransition, config.cardEntry)
+    }
+
+    @Test
+    fun `resolves a mid-flow dialog with an immediate card entry`() {
+        val config = testee.resolve(NewUserOnboardingActivityDialog.ComparisonChart, isCustomAiFlow = false)!!
+
+        assertEquals(CardEntry.Immediate, config.cardEntry)
+    }
+
+    @Test
     fun `resolves the initial welcome dialog with a continue cta`() {
         val config = testee.resolve(NewUserOnboardingActivityDialog.Initial, isCustomAiFlow = false)!!
 

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
@@ -222,7 +222,7 @@ class DialogConfigResolverTest {
 
         assertEquals(OnboardingBackgroundStep.InputType, config.background)
         assertEquals(Embellishment.LeftWing, config.embellishment)
-        assertEquals(CardArrowConfig.AtStart, config.cardArrow)
+        assertEquals(CardArrowConfig.AtEnd, config.cardArrow)
         val content = config.content as ContentConfig.InputScreen
         assertEquals(TextConfig.Resource(R.string.preOnboardingInputScreenTitleUpdated), content.title)
         assertEquals(TextConfig.Resource(R.string.preOnboardingInputScreenDescription), content.description)

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
@@ -138,7 +138,6 @@ class DialogConfigResolverTest {
             ContentConfig.Welcome(
                 title = TextConfig.Resource(R.string.preOnboardingWelcomeDialogTitle),
                 body1 = TextConfig.Resource(R.string.preOnboardingWelcomeDialogBody1),
-                body1AsHtml = false,
                 body2 = TextConfig.Resource(R.string.preOnboardingWelcomeDialogBody2),
             ),
             config.content,
@@ -161,7 +160,6 @@ class DialogConfigResolverTest {
             ContentConfig.Welcome(
                 title = TextConfig.Resource(R.string.preOnboardingWelcomeDialogTitle),
                 body1 = TextConfig.Resource(R.string.preOnboardingWelcomeDialogBodyCustomAi),
-                body1AsHtml = true,
                 body2 = null,
             ),
             config.content,
@@ -176,7 +174,6 @@ class DialogConfigResolverTest {
             ContentConfig.Welcome(
                 title = TextConfig.Resource(R.string.preOnboardingWelcomeDialogTitle),
                 body1 = TextConfig.Resource(R.string.preOnboardingWelcomeDialogBody1),
-                body1AsHtml = false,
                 body2 = TextConfig.Resource(R.string.preOnboardingWelcomeDialogBody2),
             ),
             config.content,
@@ -199,7 +196,6 @@ class DialogConfigResolverTest {
             ContentConfig.Welcome(
                 title = TextConfig.Resource(R.string.syncRestoreDialogBrandDesignTitle),
                 body1 = TextConfig.Resource(R.string.syncRestoreDialogBrandDesignBody1),
-                body1AsHtml = true,
                 body2 = null,
             ),
             config.content,

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
@@ -18,17 +18,29 @@ package com.duckduckgo.app.onboarding.ui.page.configdriven
 
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.omnibar.OmnibarType
+import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
 import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingActivityDialog
 import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingEvent
+import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.ui.page.ComparisonChartConfig
 import com.duckduckgo.app.onboarding.ui.page.OnboardingBackgroundStep
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 
 class DialogConfigResolverTest {
 
-    private val testee = DialogConfigResolver()
+    private val searchOptions = listOf(DaxDialogIntroOption(optionText = "search", iconRes = 0, link = "how to fix a bike"))
+    private val chatSuggestions = listOf(DaxDialogIntroOption(optionText = "chat", iconRes = 0, link = "explain quantum computing"))
+    private val onboardingStore: OnboardingStore = mock {
+        on { getSearchOptions() } doReturn searchOptions
+        on { getChatSuggestions() } doReturn chatSuggestions
+    }
+
+    private val testee = DialogConfigResolver(onboardingStore)
 
     @Test
     fun `resolves the comparison chart with the browser chart config`() {
@@ -196,5 +208,36 @@ class DialogConfigResolverTest {
             config.primaryCta,
         )
         assertNull(config.secondaryCta)
+    }
+
+    @Test
+    fun `resolves the input screen preview with store suggestions and no cta`() {
+        val config = testee.resolve(NewUserOnboardingActivityDialog.InputScreenPreview(isSearchDefault = true), isCustomAiFlow = false)!!
+
+        assertEquals(OnboardingBackgroundStep.InputType, config.background)
+        assertEquals(Embellishment.None, config.embellishment)
+        assertEquals(CardArrowConfig.Hidden, config.cardArrow)
+        assertEquals(
+            ContentConfig.InputScreenPreview(
+                title = TextConfig.Resource(R.string.preOnboardingInputModeDemoTitle),
+                isSearchDefault = true,
+                showModeToggle = true,
+                searchSuggestions = searchOptions,
+                chatSuggestions = chatSuggestions,
+            ),
+            config.content,
+        )
+        assertNull(config.primaryCta)
+        assertNull(config.secondaryCta)
+    }
+
+    @Test
+    fun `resolves the input screen preview without a mode toggle in the custom ai flow`() {
+        val config = testee.resolve(NewUserOnboardingActivityDialog.InputScreenPreview(isSearchDefault = false), isCustomAiFlow = true)!!
+
+        val content = config.content as ContentConfig.InputScreenPreview
+        assertEquals(TextConfig.Resource(R.string.preOnboardingInputModeDemoTitleCustomAi), content.title)
+        assertFalse(content.showModeToggle)
+        assertEquals(InputScreenPreviewContentState(isSearchSelected = false), content.initialState())
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
@@ -179,4 +179,22 @@ class DialogConfigResolverTest {
             config.secondaryCta,
         )
     }
+
+    @Test
+    fun `resolves the input screen with a submitting cta and ai preselected`() {
+        val config = testee.resolve(NewUserOnboardingActivityDialog.InputScreen, isCustomAiFlow = false)!!
+
+        assertEquals(OnboardingBackgroundStep.InputType, config.background)
+        assertEquals(Embellishment.LeftWing, config.embellishment)
+        assertEquals(CardArrowConfig.AtStart, config.cardArrow)
+        val content = config.content as ContentConfig.InputScreen
+        assertEquals(TextConfig.Resource(R.string.preOnboardingInputScreenTitleUpdated), content.title)
+        assertEquals(TextConfig.Resource(R.string.preOnboardingInputScreenDescription), content.description)
+        assertEquals(InputScreenContentState(withAi = true), content.initialState())
+        assertEquals(
+            CtaConfig(TextConfig.Resource(R.string.preOnboardingInputScreenButton), CtaAction.Submit),
+            config.primaryCta,
+        )
+        assertNull(config.secondaryCta)
+    }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
@@ -83,8 +83,100 @@ class DialogConfigResolverTest {
 
     @Test
     fun `resolves no config for a dialog that has no config-driven screen yet`() {
-        assertNull(testee.resolve(NewUserOnboardingActivityDialog.Initial, isCustomAiFlow = false))
         assertNull(testee.resolve(NewUserOnboardingActivityDialog.NotificationPermission, isCustomAiFlow = false))
         assertNull(testee.resolve(NewUserOnboardingActivityDialog.AddToDock, isCustomAiFlow = false))
+    }
+
+    @Test
+    fun `resolves the initial welcome dialog with a continue cta`() {
+        val config = testee.resolve(NewUserOnboardingActivityDialog.Initial, isCustomAiFlow = false)!!
+
+        assertEquals(OnboardingBackgroundStep.Welcome, config.background)
+        assertEquals(Embellishment.WalkingDax, config.embellishment)
+        assertEquals(CardArrowConfig.AtStart, config.cardArrow)
+        assertEquals(
+            ContentConfig.Welcome(
+                title = TextConfig.Resource(R.string.preOnboardingWelcomeDialogTitle),
+                body1 = TextConfig.Resource(R.string.preOnboardingWelcomeDialogBody1),
+                body1AsHtml = false,
+                body2 = TextConfig.Resource(R.string.preOnboardingWelcomeDialogBody2),
+            ),
+            config.content,
+        )
+        assertEquals(
+            CtaConfig(
+                TextConfig.Resource(R.string.preOnboardingDaxDialog1ButtonBrandDesign),
+                CtaAction.Emit(NewUserOnboardingEvent.ContinueClicked),
+            ),
+            config.primaryCta,
+        )
+        assertNull(config.secondaryCta)
+    }
+
+    @Test
+    fun `resolves the initial welcome dialog with single line html copy in the custom ai flow`() {
+        val config = testee.resolve(NewUserOnboardingActivityDialog.Initial, isCustomAiFlow = true)!!
+
+        assertEquals(
+            ContentConfig.Welcome(
+                title = TextConfig.Resource(R.string.preOnboardingWelcomeDialogTitle),
+                body1 = TextConfig.Resource(R.string.preOnboardingWelcomeDialogBodyCustomAi),
+                body1AsHtml = true,
+                body2 = null,
+            ),
+            config.content,
+        )
+    }
+
+    @Test
+    fun `resolves the reinstall welcome dialog with a skip secondary cta`() {
+        val config = testee.resolve(NewUserOnboardingActivityDialog.InitialReinstallUser, isCustomAiFlow = false)!!
+
+        assertEquals(
+            ContentConfig.Welcome(
+                title = TextConfig.Resource(R.string.preOnboardingWelcomeDialogTitle),
+                body1 = TextConfig.Resource(R.string.preOnboardingWelcomeDialogBody1),
+                body1AsHtml = false,
+                body2 = TextConfig.Resource(R.string.preOnboardingWelcomeDialogBody2),
+            ),
+            config.content,
+        )
+        assertEquals(
+            CtaConfig(
+                TextConfig.Resource(R.string.preOnboardingDaxDialog1SecondaryButton),
+                CtaAction.Emit(NewUserOnboardingEvent.SkipRequested),
+            ),
+            config.secondaryCta,
+        )
+    }
+
+    @Test
+    fun `resolves the sync restore dialog with its own copy and restore cta`() {
+        val config = testee.resolve(NewUserOnboardingActivityDialog.SyncRestore, isCustomAiFlow = true)!!
+
+        assertEquals(OnboardingBackgroundStep.Welcome, config.background)
+        assertEquals(
+            ContentConfig.Welcome(
+                title = TextConfig.Resource(R.string.syncRestoreDialogBrandDesignTitle),
+                body1 = TextConfig.Resource(R.string.syncRestoreDialogBrandDesignBody1),
+                body1AsHtml = true,
+                body2 = null,
+            ),
+            config.content,
+        )
+        assertEquals(
+            CtaConfig(
+                TextConfig.Resource(R.string.syncRestoreDialogPrimaryCta),
+                CtaAction.Emit(NewUserOnboardingEvent.RestoreRequested),
+            ),
+            config.primaryCta,
+        )
+        assertEquals(
+            CtaConfig(
+                TextConfig.Resource(R.string.syncRestoreDialogSecondaryCta),
+                CtaAction.Emit(NewUserOnboardingEvent.SkipRequested),
+            ),
+            config.secondaryCta,
+        )
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingDialogShownPixelsTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingDialogShownPixelsTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.page.configdriven
+
+import com.duckduckgo.app.onboarding.CustomAiOnboardingPixelName
+import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingActivityDialog
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+
+class OnboardingDialogShownPixelsTest {
+
+    private val pixel: Pixel = mock()
+    private val testee = OnboardingDialogShownPixels(pixel)
+
+    @Test
+    fun `fires the intro shown pixel once ever for the initial dialog`() {
+        testee.fireFor(NewUserOnboardingActivityDialog.Initial)
+
+        verify(pixel).fire(AppPixelName.PREONBOARDING_INTRO_SHOWN_UNIQUE, type = Unique())
+    }
+
+    @Test
+    fun `fires the reinstall intro shown pixel for the reinstall dialog`() {
+        testee.fireFor(NewUserOnboardingActivityDialog.InitialReinstallUser)
+
+        verify(pixel).fire(AppPixelName.PREONBOARDING_INTRO_REINSTALL_USER_SHOWN_UNIQUE, type = Unique())
+    }
+
+    @Test
+    fun `fires the sync restore shown pixel for the sync restore dialog`() {
+        testee.fireFor(NewUserOnboardingActivityDialog.SyncRestore)
+
+        verify(pixel).fire(AppPixelName.PREONBOARDING_SYNC_RESTORE_SHOWN_UNIQUE, type = Unique())
+    }
+
+    @Test
+    fun `fires the comparison chart shown pixel for the comparison chart`() {
+        testee.fireFor(NewUserOnboardingActivityDialog.ComparisonChart)
+
+        verify(pixel).fire(AppPixelName.PREONBOARDING_COMPARISON_CHART_SHOWN_UNIQUE, type = Unique())
+    }
+
+    @Test
+    fun `fires the ai comparison shown pixel for the ai comparison chart`() {
+        testee.fireFor(NewUserOnboardingActivityDialog.AiComparisonChart)
+
+        verify(pixel).fire(CustomAiOnboardingPixelName.AI_COMPARISON_SCREEN_SHOW, type = Unique())
+    }
+
+    @Test
+    fun `fires the address bar shown pixel for the address bar dialog`() {
+        testee.fireFor(NewUserOnboardingActivityDialog.AddressBarPosition(showSplitOption = false))
+
+        verify(pixel).fire(AppPixelName.PREONBOARDING_ADDRESS_BAR_POSITION_SHOWN_UNIQUE, type = Unique())
+    }
+
+    @Test
+    fun `fires the search experience shown pixel for the input screen`() {
+        testee.fireFor(NewUserOnboardingActivityDialog.InputScreen)
+
+        verify(pixel).fire(AppPixelName.PREONBOARDING_CHOOSE_SEARCH_EXPERIENCE_IMPRESSIONS_UNIQUE, type = Unique())
+    }
+
+    @Test
+    fun `fires nothing for the dialogs legacy had no shown pixel for`() {
+        testee.fireFor(NewUserOnboardingActivityDialog.AddToDock)
+        testee.fireFor(NewUserOnboardingActivityDialog.WidgetPrompt)
+        testee.fireFor(NewUserOnboardingActivityDialog.InputScreenPreview(isSearchDefault = true))
+
+        verifyNoInteractions(pixel)
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingDialogShownPixelsTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingDialogShownPixelsTest.kt
@@ -85,6 +85,15 @@ class OnboardingDialogShownPixelsTest {
         testee.fireFor(NewUserOnboardingActivityDialog.AddToDock)
         testee.fireFor(NewUserOnboardingActivityDialog.WidgetPrompt)
         testee.fireFor(NewUserOnboardingActivityDialog.InputScreenPreview(isSearchDefault = true))
+        testee.fireFor(
+            NewUserOnboardingActivityDialog.QuickSetup(
+                showSplitOption = true,
+                hideSetDefaultBrowserRow = false,
+                hideAddWidgetRow = false,
+                hideAddressBarRow = false,
+                isReinstallUser = false,
+            ),
+        )
 
         verifyNoInteractions(pixel)
     }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroStateTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroStateTest.kt
@@ -40,13 +40,10 @@ class OnboardingIntroStateTest {
     }
 
     @Test
-    fun `a dialog arriving over a playing intro fades it out and can cross-fade the background`() {
+    fun `a dialog arriving over a playing intro fades it out`() {
         testee.play()
 
-        val handover = testee.handOverToDialog()
-
-        assertEquals(Handover.FadeOut, handover)
-        assertTrue(handover.canCrossFadeBackground)
+        assertEquals(Handover.FadeOut, testee.handOverToDialog())
     }
 
     @Test
@@ -57,32 +54,23 @@ class OnboardingIntroStateTest {
     }
 
     @Test
-    fun `a dialog arriving with no intro on screen snaps it away and snaps the background`() {
-        val handover = testee.handOverToDialog()
-
-        assertEquals(Handover.SnapAway, handover)
-        assertFalse(handover.canCrossFadeBackground)
+    fun `a dialog arriving with no intro on screen snaps it away`() {
+        assertEquals(Handover.SnapAway, testee.handOverToDialog())
     }
 
     @Test
-    fun `later dialogs leave the intro alone and keep animating the background`() {
+    fun `later dialogs leave the intro alone`() {
         testee.play()
         testee.handOverToDialog()
 
-        val handover = testee.handOverToDialog()
-
-        assertEquals(Handover.AlreadyHandedOver, handover)
-        assertTrue(handover.canCrossFadeBackground)
+        assertEquals(Handover.AlreadyHandedOver, testee.handOverToDialog())
     }
 
     @Test
-    fun `a dialog arriving after the intro was dismissed unplayed snaps the background`() {
+    fun `a dialog arriving after the intro was dismissed unplayed leaves it alone`() {
         assertTrue(testee.dismissUnplayed())
 
-        val handover = testee.handOverToDialog()
-
-        assertEquals(Handover.AlreadyDismissed, handover)
-        assertFalse(handover.canCrossFadeBackground)
+        assertEquals(Handover.AlreadyDismissed, testee.handOverToDialog())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroStateTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/OnboardingIntroStateTest.kt
@@ -63,14 +63,14 @@ class OnboardingIntroStateTest {
         testee.play()
         testee.handOverToDialog()
 
-        assertEquals(Handover.AlreadyHandedOver, testee.handOverToDialog())
+        assertEquals(Handover.AlreadyGone, testee.handOverToDialog())
     }
 
     @Test
     fun `a dialog arriving after the intro was dismissed unplayed leaves it alone`() {
         assertTrue(testee.dismissUnplayed())
 
-        assertEquals(Handover.AlreadyDismissed, testee.handOverToDialog())
+        assertEquals(Handover.AlreadyGone, testee.handOverToDialog())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/CardAnchorResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/CardAnchorResolverTest.kt
@@ -74,11 +74,19 @@ class CardAnchorResolverTest {
     }
 
     @Test
-    fun `the walking dax presses the card down onto itself`() {
+    fun `on a phone the walking dax presses the card down onto itself`() {
         val resolution = CardAnchorResolver(isTablet = false).resolve(settled(Embellishment.WalkingDax))
 
         assertSame(decorationView, resolution.anchorTo)
         assertEquals(1f, resolution.verticalBias)
+    }
+
+    @Test
+    fun `on a tablet the walking dax anchors the card above it without pressing it down`() {
+        val resolution = CardAnchorResolver(isTablet = true).resolve(settled(Embellishment.WalkingDax))
+
+        assertSame(decorationView, resolution.anchorTo)
+        assertEquals(0.5f, resolution.verticalBias)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngineTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngineTest.kt
@@ -127,21 +127,14 @@ class DialogRenderEngineTest {
 
     @Test
     fun `a card entry that follows the background waits for the background transition to end`() = runTest {
-        testee.render(WELCOME_STEP, welcomeConfig(), animate = true, animateBackground = true)
+        testee.render(WELCOME_STEP, welcomeConfig(), animate = true)
 
         assertEquals(listOf(OnboardingBackgroundAnimator.EXIT_DURATION), cardStage.revealDelaysMs)
     }
 
     @Test
-    fun `a card entry that follows the background does not wait when the background snaps`() = runTest {
-        testee.render(WELCOME_STEP, welcomeConfig(), animate = true, animateBackground = false)
-
-        assertEquals(listOf(0L), cardStage.revealDelaysMs)
-    }
-
-    @Test
     fun `an immediate card entry never waits for the background`() = runTest {
-        testee.render(COMPARISON_STEP, comparisonConfig(), animate = true, animateBackground = true)
+        testee.render(COMPARISON_STEP, comparisonConfig(), animate = true)
 
         assertEquals(listOf(0L), cardStage.revealDelaysMs)
     }
@@ -180,15 +173,6 @@ class DialogRenderEngineTest {
         assertFalse(background.animated)
         assertFalse(embellishments.animated)
         assertEquals(1, cardStage.fadeCount)
-    }
-
-    @Test
-    fun `a snapped background still lets the card and its embellishments animate`() = runTest {
-        testee.render(COMPARISON_STEP, comparisonConfig(), animate = true, animateBackground = false)
-
-        assertFalse(background.animated)
-        assertEquals(listOf(true, true, true), cardStage.animateFlags)
-        assertTrue(embellishments.animated)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngineTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngineTest.kt
@@ -246,6 +246,38 @@ class DialogRenderEngineTest {
     }
 
     @Test
+    fun `a bound screen's own resize tweens the card's bounds`() = runTest {
+        testee.render(COMPARISON_STEP, comparisonConfig(), animate = true)
+
+        content.boundScope?.animateCardBounds?.invoke(400L)
+
+        assertEquals(listOf(400L), cardStage.boundsTransitionsMs)
+    }
+
+    @Test
+    fun `a bound screen's own resize snaps on a snapped render`() = runTest {
+        testee.render(COMPARISON_STEP, comparisonConfig(), animate = false)
+
+        content.boundScope?.animateCardBounds?.invoke(400L)
+
+        assertTrue(cardStage.boundsTransitionsMs.isEmpty())
+    }
+
+    @Test
+    fun `a resize a settling entrance asks for snaps rather than outliving the skip`() = runTest {
+        content.afterFade = {
+            content.boundScope?.animateCardBounds?.invoke(500L)
+            mock()
+        }
+        cardStage.autoComplete = false
+        testee.render(COMPARISON_STEP, comparisonConfig(), animate = true)
+
+        testee.skipRunningAnimations()
+
+        assertTrue(cardStage.boundsTransitionsMs.isEmpty())
+    }
+
+    @Test
     fun `content ready runs once the entrance settles, not before`() = runTest {
         var readyCount = 0
         content.onContentReady = { readyCount++ }
@@ -394,6 +426,7 @@ private class FakeContentController : ContentController {
     var onContentReady: (() -> Unit)? = null
     var handleResult: (() -> NewUserOnboardingEvent)? = null
     var unbindCount = 0
+    var boundScope: BindScope? = null
 
     override fun resetStage() {
         stageReset = true
@@ -401,6 +434,7 @@ private class FakeContentController : ContentController {
 
     override fun bind(stepId: LinearOnboardingStepId, content: ContentConfig, scope: BindScope): ContentHandle {
         bindCount++
+        boundScope = scope
         return ContentHandle(
             title = null,
             fadeTargets = emptyList(),
@@ -425,6 +459,7 @@ private class FakeCardStage(private val record: (String) -> Unit = {}) : CardSta
     var fadeCount = 0
     val animateFlags = mutableListOf<Boolean>()
     val revealDelaysMs = mutableListOf<Long>()
+    val boundsTransitionsMs = mutableListOf<Long>()
 
     private val pending = mutableListOf<() -> Unit>()
     private var primary: CtaConfig? = null
@@ -438,6 +473,10 @@ private class FakeCardStage(private val record: (String) -> Unit = {}) : CardSta
     override fun morph(animate: Boolean, onEnd: () -> Unit) {
         record("morph")
         stage(animate, onEnd)
+    }
+
+    override fun beginBoundsTransition(durationMs: Long) {
+        boundsTransitionsMs += durationMs
     }
 
     override fun fadeInContent(contentTargets: List<View>, animate: Boolean, onEnd: () -> Unit) {

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngineTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngineTest.kt
@@ -401,7 +401,6 @@ class DialogRenderEngineTest {
             content = ContentConfig.Welcome(
                 title = TextConfig.Literal("welcome"),
                 body1 = TextConfig.Literal("body one"),
-                body1AsHtml = false,
                 body2 = null,
             ),
             primaryCta = CtaConfig(

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngineTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngineTest.kt
@@ -83,6 +83,7 @@ class DialogRenderEngineTest {
         testee.render(COMPARISON_STEP, comparisonConfig(), animate = true)
 
         assertTrue(content.stageReset)
+        assertTrue(embellishments.stageReset)
         assertEquals(null to OnboardingBackgroundStep.ComparisonChart, background.applied)
         assertEquals(null to Embellishment.BottomWing, embellishments.applied)
         assertEquals(null to CardArrowConfig.AtEnd, cardArrow.applied)
@@ -93,10 +94,12 @@ class DialogRenderEngineTest {
     fun `second render diffs each axis against the previous config`() = runTest {
         testee.render(COMPARISON_STEP, comparisonConfig(), animate = true)
         content.stageReset = false
+        embellishments.stageReset = false
 
         testee.render(ADDRESS_BAR_STEP, addressBarConfig(), animate = true)
 
         assertFalse(content.stageReset)
+        assertFalse(embellishments.stageReset)
         assertEquals(OnboardingBackgroundStep.ComparisonChart to OnboardingBackgroundStep.AddressBar, background.applied)
         assertEquals(Embellishment.BottomWing to Embellishment.BobbingDax, embellishments.applied)
         assertEquals(
@@ -618,8 +621,13 @@ private class FakeEmbellishmentController : EmbellishmentController {
     var animated = false
     var skipped = false
     var released = false
+    var stageReset = false
 
     var settledResult: SettledDecoration? = null
+
+    override fun resetStage() {
+        stageReset = true
+    }
 
     override fun transition(
         previous: Embellishment?,

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngineTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngineTest.kt
@@ -22,9 +22,11 @@ import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingEvent
 import com.duckduckgo.app.onboarding.orchestrator.StepProgress
 import com.duckduckgo.app.onboarding.ui.page.ComparisonChartConfig
+import com.duckduckgo.app.onboarding.ui.page.OnboardingBackgroundAnimator
 import com.duckduckgo.app.onboarding.ui.page.OnboardingBackgroundStep
 import com.duckduckgo.app.onboarding.ui.page.configdriven.BindScope
 import com.duckduckgo.app.onboarding.ui.page.configdriven.CardArrowConfig
+import com.duckduckgo.app.onboarding.ui.page.configdriven.CardEntry
 import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentConfig
 import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentHandle
 import com.duckduckgo.app.onboarding.ui.page.configdriven.CtaAction
@@ -118,6 +120,34 @@ class DialogRenderEngineTest {
         testee.render(COMPARISON_STEP, comparisonConfig(), animate = true)
 
         assertSame(settled, cardAnchor.appliedWith)
+    }
+
+    @Test
+    fun `a card entry that follows the background waits for the background transition to end`() = runTest {
+        testee.render(WELCOME_STEP, welcomeConfig(), animate = true, animateBackground = true)
+
+        assertEquals(listOf(OnboardingBackgroundAnimator.EXIT_DURATION), cardStage.revealDelaysMs)
+    }
+
+    @Test
+    fun `a card entry that follows the background does not wait when the background snaps`() = runTest {
+        testee.render(WELCOME_STEP, welcomeConfig(), animate = true, animateBackground = false)
+
+        assertEquals(listOf(0L), cardStage.revealDelaysMs)
+    }
+
+    @Test
+    fun `an immediate card entry never waits for the background`() = runTest {
+        testee.render(COMPARISON_STEP, comparisonConfig(), animate = true, animateBackground = true)
+
+        assertEquals(listOf(0L), cardStage.revealDelaysMs)
+    }
+
+    @Test
+    fun `a snapped render does not wait for the background`() = runTest {
+        testee.render(WELCOME_STEP, welcomeConfig(), animate = false)
+
+        assertEquals(listOf(0L), cardStage.revealDelaysMs)
     }
 
     @Test
@@ -306,6 +336,24 @@ class DialogRenderEngineTest {
     private companion object {
         const val COMPARISON_STEP: LinearOnboardingStepId = "comparison_chart"
         const val ADDRESS_BAR_STEP: LinearOnboardingStepId = "address_bar_position"
+        const val WELCOME_STEP: LinearOnboardingStepId = "welcome"
+
+        fun welcomeConfig() = DialogConfig(
+            background = OnboardingBackgroundStep.Welcome,
+            embellishment = Embellishment.WalkingDax,
+            cardArrow = CardArrowConfig.AtStart,
+            cardEntry = CardEntry.AfterBackgroundTransition,
+            content = ContentConfig.Welcome(
+                title = TextConfig.Literal("welcome"),
+                body1 = TextConfig.Literal("body one"),
+                body1AsHtml = false,
+                body2 = null,
+            ),
+            primaryCta = CtaConfig(
+                text = TextConfig.Literal("next"),
+                action = CtaAction.Emit(NewUserOnboardingEvent.ContinueClicked),
+            ),
+        )
 
         fun comparisonConfig() = DialogConfig(
             background = OnboardingBackgroundStep.ComparisonChart,
@@ -376,12 +424,16 @@ private class FakeCardStage(private val record: (String) -> Unit = {}) : CardSta
     var released = false
     var fadeCount = 0
     val animateFlags = mutableListOf<Boolean>()
+    val revealDelaysMs = mutableListOf<Long>()
 
     private val pending = mutableListOf<() -> Unit>()
     private var primary: CtaConfig? = null
     private var onCtaClick: ((CtaConfig) -> Unit)? = null
 
-    override fun reveal(animate: Boolean, onEnd: () -> Unit) = stage(animate, onEnd)
+    override fun reveal(animate: Boolean, extraStartDelayMs: Long, onEnd: () -> Unit) {
+        revealDelaysMs += extraStartDelayMs
+        stage(animate, onEnd)
+    }
 
     override fun morph(animate: Boolean, onEnd: () -> Unit) {
         record("morph")

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngineTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/DialogRenderEngineTest.kt
@@ -255,12 +255,24 @@ class DialogRenderEngineTest {
     }
 
     @Test
-    fun `a bound screen's own resize snaps on a snapped render`() = runTest {
+    fun `a resize a snapped entrance asks for snaps too`() = runTest {
+        content.afterFade = {
+            content.boundScope?.animateCardBounds?.invoke(500L)
+            mock()
+        }
+
+        testee.render(COMPARISON_STEP, comparisonConfig(), animate = false)
+
+        assertTrue(cardStage.boundsTransitionsMs.isEmpty())
+    }
+
+    @Test
+    fun `a bound screen's own resize still tweens once a snapped render is on stage`() = runTest {
         testee.render(COMPARISON_STEP, comparisonConfig(), animate = false)
 
         content.boundScope?.animateCardBounds?.invoke(400L)
 
-        assertTrue(cardStage.boundsTransitionsMs.isEmpty())
+        assertEquals(listOf(400L), cardStage.boundsTransitionsMs)
     }
 
     @Test
@@ -275,6 +287,17 @@ class DialogRenderEngineTest {
         testee.skipRunningAnimations()
 
         assertTrue(cardStage.boundsTransitionsMs.isEmpty())
+    }
+
+    @Test
+    fun `a bound screen's own resize still tweens once a skipped entrance is on stage`() = runTest {
+        cardStage.autoComplete = false
+        testee.render(COMPARISON_STEP, comparisonConfig(), animate = true)
+        testee.skipRunningAnimations()
+
+        content.boundScope?.animateCardBounds?.invoke(400L)
+
+        assertEquals(listOf(400L), cardStage.boundsTransitionsMs)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentPlacementTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentPlacementTest.kt
@@ -25,12 +25,12 @@ import org.junit.Test
 class EmbellishmentPlacementTest {
 
     @Test
-    fun `the walking dax presses the card down onto itself on both form factors`() {
+    fun `the walking dax presses the card down onto itself on a phone and centres it on a tablet`() {
         val placement = EmbellishmentPlacement.of(Embellishment.WalkingDax)
 
         assertTrue(placement.anchorsCardOnPhone)
         assertEquals(1f, placement.biasPhone)
-        assertEquals(1f, placement.biasTablet)
+        assertEquals(0.5f, placement.biasTablet)
         assertTrue(placement.drawsArtwork)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1217183142109149?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1216854264994244
API Proposals URL(s) (if applicable): 

### Description

Step 3 of the tech design: ports the remaining screens to the config-driven onboarding renderer. This PR covers below binders:
- Welcome
- Input selection
- Input preview

**Divergences from the legacy implementation** (`BrandDesignUpdateWelcomePage.kt`):
- The input screen's "with AI" Lottie flourish always starts after the 2s initial delay. Legacy's snapped render (rotation, process restore) started the loop immediately. This fixes an unintentional divergence.
- The input preview's card resizes (mode switch, suggestion reveal) go through the render engine. Same visual, but the tween is suppressed while a snapped or skipped entrance is still landing the screen, where legacy always ran it:

<img width="324" height="360" alt="input_preview_snap" src="https://github.com/user-attachments/assets/f0b8c810-a0bb-433c-9016-4a0fa29c214c" />

**Divergences from the tech design:**
- Shown pixels are a 1:1 port used only by the new view model, not the shared utility the TD proposed for both arms. Parity is guarded by the exhaustive mapping and tests instead; the legacy path is untouched, which keeps this PR flag-off safe. We can look into the alternative approach of moving these pixels into plan provider in a follow up, since we'd need to make changes to both old and new code paths.
- `BindScope` gained `animateCardBounds`, which the TD didn't have. A binder only reaches its own layout, so it had no way to animate a card resize, if one was needed. The binder requests the tween but the engine owns it, so the request is safely ignored during snapped transitions.
- `DialogConfig` gained a `CardEntry` param (`Immediate` / `AfterBackgroundTransition`). The welcome dialogs arrive while the intro background is still crossing over, and without it the card faded in over the moving background. The timing precisely matches legacy.

### Steps to test this PR
- [x] Apply below patch:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
index b6a1e4d352..41a8d85ad4 100644
--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
@@ -58,6 +58,6 @@ interface OnboardingBrandDesignUpdateToggles {
     /**
      * Selects the config-driven renderer for the brand-design onboarding dialogs.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun configDrivenDialogs(): Toggle
 }

```
_base flow_
- [x] Clean install.
- [x] Walk the full flow: welcome, comparison chart, address bar, input screen, input preview, — each renders with its background, Dax embellishment, card arrow and CTAs.
- [x] Rotate on each screen — the snapped re-render keeps in-progress state (address bar selection, switches, input mode).
- [x] Tap during a transition to skip animations.
- [x] Input preview: switch the search/AI tabs (card resizes smoothly), submit a typed query and a suggestion.

_sync restore flow_
- [x] Finish onboarding, go to settings, and enable sync on the device.
- [x] Uninstall the app (do not clear caches).
- [ ] Reinstall the app.
- [ ] Verify restore content is displayed on the welcome step.

_Custom AI flow_
- [x] Additionally apply this diff:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
index fe3752cbb2..af220bb09d 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
@@ -100,6 +100,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     }
 
     override suspend fun resolve() = resolveMutex.withLock {
+        return@withLock true
         withContext(dispatcherProvider.io()) {
             // Ensure the install referrer (and therefore the processing function) has resolved before reading.
             withTimeoutOrNull(MAX_REFERRER_WAIT_TIME_MS) { referrerStateListener.get().waitForReferrerCode() }
@@ -116,6 +117,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     }
 
     override suspend fun isEnabled(): Boolean = resolveMutex.withLock {
+        return@withLock true
         withContext(dispatcherProvider.io()) {
             preferences.getBoolean(PREFS_KEY_ENABLED, false)
         }

```

- [x] Clean install.
- [x] Walk the full flow: welcome, AI comparison, input preview, Duck.ai demo, browser comparison, address bar


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared decoration fit correction and onboarding layout/keyboard behavior across many screens; regressions could show as clipped cards, hidden Dax art, or wrong sync-restore flow, though coverage is heavy in unit tests.
> 
> **Overview**
> Ports **welcome**, **sync restore**, **input selection**, and **input preview** onto the config-driven onboarding renderer, with new binders, `DialogConfigResolver` mappings, and `ContentConfig` types wired through `ContentController` and `DialogRenderEngine`.
> 
> **Layout and decorations:** `OnboardingDecorationFitCorrector` gains `reservesInsetAboveDecoration` and revised inset/clamp math so cards above decorations can clear the keyboard without shrinking decorations; the embellishment controller enables this for the config-driven path. The welcome fragment applies layout overrides (drops default `constrainedHeight`, wing `adjustViewBounds`) and keeps bottom inset when focus is inside the card during IME.
> 
> **Render engine UX:** `CardEntry.AfterBackgroundTransition` delays card fade-in after welcome backgrounds; `BindScope.animateCardBounds` tweens card resizes (mode switch, suggestions) with suppression during snapped/skipped entrances. Intro handover always clears choreographer visuals on every dialog render; shown pixels fire via exhaustive `OnboardingDialogShownPixels`.
> 
> **View model:** Config-driven path renders sync restore instead of skipping; input preview submits forward `InputDemoQuerySubmitted`; several orchestrator dialogs no longer auto-continue at activity level (handled by config UI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69e3560cdea1f9e33b592689b1965ab9159d966d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->