### PR TITLE
[Config-driven linear onboarding dialogs] Port existing screens (skip flow + dock/widget steps)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
@@ -22,6 +22,7 @@ import android.content.Intent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
@@ -67,6 +68,7 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
     private val dialogConfigResolver: DialogConfigResolver,
     private val shownPixels: OnboardingDialogShownPixels,
     private val dispatchers: DispatcherProvider,
+    private val defaultBrowserDetector: DefaultBrowserDetector,
     private val widgetCapabilities: WidgetCapabilities,
     private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
     private val context: Context,
@@ -115,6 +117,14 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
         data class FinishAndSubmitChatPrompt(val prompt: String) : Command
         data object OnboardingSkipped : Command
         data object HandOffToBrowserActivity : Command
+        data class ShowQuickSetupDefaultBrowserDialog(val intent: Intent) : Command
+        data object OpenDefaultBrowserSystemSettings : Command
+        data object ShowRemoveWidgetBottomSheet : Command
+        data class ShowQuickSetupAddressBarPositionBottomSheet(
+            val initialSelection: OmnibarType,
+            val showSplitOption: Boolean,
+        ) : Command
+        data class ShowQuickSetupSearchOptionsBottomSheet(val initialWithAi: Boolean) : Command
     }
 
     private val _viewState = MutableStateFlow(ViewState())
@@ -133,6 +143,8 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
 
     private var addWidgetPromptFlowStarted = false
 
+    private var quickSetupDefaultBrowserDialogShown = false
+
     init {
         start()
     }
@@ -148,6 +160,40 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
                     fromSuggestion = interaction.fromSuggestion,
                 ),
             )
+
+            ContentInteraction.EditAddressBarPosition -> {
+                val screen = currentQuickSetup() ?: return
+                viewModelScope.launch {
+                    _commands.send(
+                        Command.ShowQuickSetupAddressBarPositionBottomSheet(
+                            initialSelection = screen.state.value.addressBarPosition,
+                            showSplitOption = screen.content.showSplitOption,
+                        ),
+                    )
+                }
+            }
+
+            ContentInteraction.EditSearchOptions -> {
+                val screen = currentQuickSetup() ?: return
+                viewModelScope.launch {
+                    _commands.send(Command.ShowQuickSetupSearchOptionsBottomSheet(initialWithAi = screen.state.value.withAi))
+                }
+            }
+
+            // The switch has already flipped itself, so the store has to record that before any side effect: a
+            // later corrective write of the old value (declined system dialog, resume resync) would otherwise be
+            // deduped as a no-change and never reach the binder.
+            is ContentInteraction.SetDefaultBrowserToggled -> {
+                currentQuickSetup()?.state?.update { it.copy(defaultBrowserChecked = interaction.checked) }
+                if (interaction.checked) requestDefaultBrowser() else openDefaultBrowserSettings()
+            }
+
+            is ContentInteraction.AddWidgetToggled -> {
+                currentQuickSetup()?.state?.update { it.copy(widgetChecked = interaction.checked) }
+                viewModelScope.launch {
+                    _commands.send(if (interaction.checked) Command.LaunchAddWidgetPrompt else Command.ShowRemoveWidgetBottomSheet)
+                }
+            }
         }
     }
 
@@ -178,6 +224,7 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
     fun onIntroAnimationFinished() = emit(NewUserOnboardingEvent.IntroAnimationFinished)
 
     fun onResume() {
+        syncQuickSetupSwitches()
         checkAddWidgetPromptResult()
     }
 
@@ -207,6 +254,37 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
         emit(NewUserOnboardingEvent.DefaultBrowserPromptFinished(isDefaultBrowser = false))
     }
 
+    fun onAddressBarBottomSheetResult(type: OmnibarType) {
+        currentQuickSetup()?.state?.update { it.copy(addressBarPosition = type) }
+    }
+
+    fun onSearchOptionsBottomSheetResult(withAi: Boolean) {
+        currentQuickSetup()?.state?.update { it.copy(withAi = withAi) }
+    }
+
+    /** Quick setup's own default-browser prompt: it never advances the step, which only moves on confirmation. */
+    fun onQuickSetupDefaultBrowserSet() {
+        recordDefaultBrowserDialogResult(isSet = true, fireTelemetry = false)
+    }
+
+    fun onQuickSetupDefaultBrowserNotSet() {
+        recordDefaultBrowserDialogResult(isSet = false, fireTelemetry = false)
+    }
+
+    /**
+     * Re-reads the OS state behind quick setup's two switches. Also called by the fragment when the system
+     * settings intent cannot be launched, since no activity starts and no later [onResume] follows.
+     */
+    fun syncQuickSetupSwitches() {
+        val screen = currentQuickSetup() ?: return
+        viewModelScope.launch {
+            val (isDefault, hasWidget) = withContext(dispatchers.io()) {
+                defaultBrowserDetector.isDefaultBrowser() to widgetCapabilities.hasInstalledWidgets
+            }
+            screen.state.update { it.copy(defaultBrowserChecked = isDefault, widgetChecked = hasWidget) }
+        }
+    }
+
     fun checkAddWidgetPromptResult() {
         if (addWidgetPromptFlowStarted) {
             viewModelScope.launch {
@@ -217,11 +295,45 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
         }
     }
 
-    private fun recordDefaultBrowserDialogResult(isSet: Boolean) {
+    private fun requestDefaultBrowser() {
+        viewModelScope.launch {
+            if (!quickSetupDefaultBrowserDialogShown) {
+                val intent = defaultRoleBrowserDialog.createIntent(context)
+                if (intent != null) {
+                    quickSetupDefaultBrowserDialogShown = true
+                    _commands.send(Command.ShowQuickSetupDefaultBrowserDialog(intent))
+                    return@launch
+                }
+            }
+            _commands.send(Command.OpenDefaultBrowserSystemSettings)
+        }
+    }
+
+    private fun openDefaultBrowserSettings() {
+        viewModelScope.launch { _commands.send(Command.OpenDefaultBrowserSystemSettings) }
+    }
+
+    private fun currentQuickSetup(): QuickSetupScreen? {
+        val dialog = _viewState.value.screen as? Screen.Dialog ?: return null
+        val content = dialog.config.content as? ContentConfig.QuickSetup ?: return null
+        return QuickSetupScreen(content, contentValues.contentState(dialog.stepId, content))
+    }
+
+    private class QuickSetupScreen(
+        val content: ContentConfig.QuickSetup,
+        val state: MutableStateFlow<QuickSetupContentState>,
+    )
+
+    private fun recordDefaultBrowserDialogResult(
+        isSet: Boolean,
+        fireTelemetry: Boolean = true,
+    ) {
         defaultRoleBrowserDialog.dialogShown()
         appInstallStore.defaultBrowser = isSet
-        val pixelName = if (isSet) AppPixelName.DEFAULT_BROWSER_SET else AppPixelName.DEFAULT_BROWSER_NOT_SET
-        pixel.fire(pixelName, mapOf(PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString()))
+        if (fireTelemetry) {
+            val pixelName = if (isSet) AppPixelName.DEFAULT_BROWSER_SET else AppPixelName.DEFAULT_BROWSER_NOT_SET
+            pixel.fire(pixelName, mapOf(PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString()))
+        }
     }
 
     private fun start() {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
@@ -161,7 +161,7 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
                 ),
             )
 
-            ContentInteraction.EditAddressBarPosition -> {
+            ContentInteraction.QuickSetupEditAddressBarPosition -> {
                 val screen = currentQuickSetup() ?: return
                 viewModelScope.launch {
                     _commands.send(
@@ -173,7 +173,7 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
                 }
             }
 
-            ContentInteraction.EditSearchOptions -> {
+            ContentInteraction.QuickSetupEditSearchOptions -> {
                 val screen = currentQuickSetup() ?: return
                 viewModelScope.launch {
                     _commands.send(Command.ShowQuickSetupSearchOptionsBottomSheet(initialWithAi = screen.state.value.withAi))
@@ -183,12 +183,12 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
             // The switch has already flipped itself, so the store has to record that before any side effect: a
             // later corrective write of the old value (declined system dialog, resume resync) would otherwise be
             // deduped as a no-change and never reach the binder.
-            is ContentInteraction.SetDefaultBrowserToggled -> {
+            is ContentInteraction.QuickSetupSetDefaultBrowser -> {
                 currentQuickSetup()?.state?.update { it.copy(defaultBrowserChecked = interaction.checked) }
                 if (interaction.checked) requestDefaultBrowser() else openDefaultBrowserSettings()
             }
 
-            is ContentInteraction.AddWidgetToggled -> {
+            is ContentInteraction.QuickSetupAddWidget -> {
                 currentQuickSetup()?.state?.update { it.copy(widgetChecked = interaction.checked) }
                 viewModelScope.launch {
                     _commands.send(if (interaction.checked) Command.LaunchAddWidgetPrompt else Command.ShowRemoveWidgetBottomSheet)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
@@ -269,6 +269,7 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
 
     fun onQuickSetupDefaultBrowserNotSet() {
         recordDefaultBrowserDialogResult(isSet = false, fireTelemetry = false)
+        currentQuickSetup()?.state?.update { it.copy(defaultBrowserChecked = false) }
     }
 
     /**

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
@@ -423,17 +423,14 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
             // If there's no new dialog to draw (e.g. we're displaying a system prompt), keep the current one.
             // None only when there was never anything to keep.
             _viewState.update { state -> if (state.screen == null) state.copy(screen = Screen.None) else state }
-            advancePastUnrenderedDialog(dialog)
+            handleCommandOnlyDialog(dialog)
         }
     }
 
     /**
-     * Handle commands and dialogs the renderer doesn't support yet by advancing past them, without reporting
-     * them as presented.
-     *
-     * Temporary until all dialogs are implemented in the renderer.
+     * Handler for dialogs that have no card, only a side effect.
      */
-    private suspend fun advancePastUnrenderedDialog(dialog: NewUserOnboardingActivityDialog) {
+    private suspend fun handleCommandOnlyDialog(dialog: NewUserOnboardingActivityDialog) {
         when (dialog) {
             NewUserOnboardingActivityDialog.NotificationPermission -> {
                 if (!notificationPermissionFlowStarted) {
@@ -460,23 +457,18 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
                 _commands.send(Command.LaunchAddWidgetPrompt)
             }
 
-            NewUserOnboardingActivityDialog.AddToDock -> emit(NewUserOnboardingEvent.ContinueClicked)
-
-            NewUserOnboardingActivityDialog.WidgetPrompt -> emit(NewUserOnboardingEvent.WidgetPromptSkipped)
-
-            is NewUserOnboardingActivityDialog.QuickSetup -> emit(
-                NewUserOnboardingEvent.QuickSetupConfirmed(type = OmnibarType.SINGLE_TOP, withAi = true),
-            )
-
             NewUserOnboardingActivityDialog.SyncRestore,
             NewUserOnboardingActivityDialog.InitialReinstallUser,
             NewUserOnboardingActivityDialog.Initial,
-            NewUserOnboardingActivityDialog.InputScreen,
-            is NewUserOnboardingActivityDialog.InputScreenPreview,
             is NewUserOnboardingActivityDialog.IntroAnimation,
             NewUserOnboardingActivityDialog.ComparisonChart,
             NewUserOnboardingActivityDialog.AiComparisonChart,
+            NewUserOnboardingActivityDialog.AddToDock,
+            NewUserOnboardingActivityDialog.WidgetPrompt,
             is NewUserOnboardingActivityDialog.AddressBarPosition,
+            NewUserOnboardingActivityDialog.InputScreen,
+            is NewUserOnboardingActivityDialog.InputScreenPreview,
+            is NewUserOnboardingActivityDialog.QuickSetup,
             -> Unit
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
@@ -60,6 +60,7 @@ import com.duckduckgo.app.onboardingquicksetup.ui.QuickSetupAddressBarPositionBo
 import com.duckduckgo.app.onboardingquicksetup.ui.QuickSetupSearchOptionsBottomSheet
 import com.duckduckgo.app.onboardingquicksetup.ui.RemoveWidgetInstructionsBottomSheet
 import com.duckduckgo.app.widget.AddWidgetLauncher
+import com.duckduckgo.app.widget.AddWidgetSource
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.store.AppTheme
 import com.duckduckgo.common.ui.view.toPx
@@ -312,7 +313,7 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
             is ConfigDrivenOnboardingPageViewModel.Command.ShowDefaultBrowserDialog ->
                 defaultBrowserRoleManagerDialog.launch(command.intent)
             ConfigDrivenOnboardingPageViewModel.Command.LaunchAddWidgetPrompt ->
-                addWidgetLauncher.launchAddWidget(activity, simpleWidgetPrompt = true)
+                addWidgetLauncher.launchAddWidget(activity, simpleWidgetPrompt = true, source = AddWidgetSource.ONBOARDING)
             ConfigDrivenOnboardingPageViewModel.Command.Finish -> onContinuePressed()
             is ConfigDrivenOnboardingPageViewModel.Command.FinishAndSubmitSearchQuery ->
                 (activity as? OnboardingActivity)?.finishAndSubmitSearchQuery(command.query)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
@@ -19,11 +19,13 @@ package com.duckduckgo.app.onboarding.ui.page.configdriven
 import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.os.Bundle
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -39,6 +41,8 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ContentOnboardingWelcomePageUpdateBinding
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserSystemSettings
+import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.onboarding.ui.OnboardingActivity
 import com.duckduckgo.app.onboarding.ui.page.OnboardingBackgroundAnimator
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPageFragment
@@ -52,6 +56,9 @@ import com.duckduckgo.app.onboarding.ui.page.configdriven.engine.DialogRenderEng
 import com.duckduckgo.app.onboarding.ui.page.configdriven.engine.EmbellishmentControllerImpl
 import com.duckduckgo.app.onboarding.ui.page.configdriven.engine.StepIndicatorControllerImpl
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
+import com.duckduckgo.app.onboardingquicksetup.ui.QuickSetupAddressBarPositionBottomSheet
+import com.duckduckgo.app.onboardingquicksetup.ui.QuickSetupSearchOptionsBottomSheet
+import com.duckduckgo.app.onboardingquicksetup.ui.RemoveWidgetInstructionsBottomSheet
 import com.duckduckgo.app.widget.AddWidgetLauncher
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.store.AppTheme
@@ -63,6 +70,9 @@ import com.duckduckgo.common.utils.device.isTablet
 import com.duckduckgo.di.scopes.FragmentScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import logcat.LogPriority.WARN
+import logcat.asLog
+import logcat.logcat
 import javax.inject.Inject
 import com.duckduckgo.mobile.android.R as CommonR
 
@@ -104,6 +114,14 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
             viewModel.onDefaultBrowserSet()
         } else {
             viewModel.onDefaultBrowserNotSet()
+        }
+    }
+
+    private val quickSetupDefaultBrowserRoleManagerDialog = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            viewModel.onQuickSetupDefaultBrowserSet()
+        } else {
+            viewModel.onQuickSetupDefaultBrowserNotSet()
         }
     }
 
@@ -198,6 +216,31 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
             .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
             .onEach { command -> handleCommand(command) }
             .launchIn(viewLifecycleOwner.lifecycleScope)
+
+        registerQuickSetupBottomSheetResultListeners()
+    }
+
+    private fun registerQuickSetupBottomSheetResultListeners() {
+        childFragmentManager.setFragmentResultListener(
+            QuickSetupAddressBarPositionBottomSheet.REQUEST_KEY,
+            viewLifecycleOwner,
+        ) { _, bundle ->
+            val selectedName = bundle.getString(QuickSetupAddressBarPositionBottomSheet.RESULT_KEY_SELECTED_POSITION)
+                ?: return@setFragmentResultListener
+            viewModel.onAddressBarBottomSheetResult(OmnibarType.valueOf(selectedName))
+        }
+        childFragmentManager.setFragmentResultListener(
+            QuickSetupSearchOptionsBottomSheet.REQUEST_KEY,
+            viewLifecycleOwner,
+        ) { _, bundle ->
+            viewModel.onSearchOptionsBottomSheetResult(withAi = bundle.getBoolean(QuickSetupSearchOptionsBottomSheet.RESULT_KEY_WITH_AI))
+        }
+        childFragmentManager.setFragmentResultListener(
+            RemoveWidgetInstructionsBottomSheet.REQUEST_KEY,
+            viewLifecycleOwner,
+        ) { _, _ ->
+            viewModel.syncQuickSetupSwitches()
+        }
     }
 
     /**
@@ -278,6 +321,31 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
             ConfigDrivenOnboardingPageViewModel.Command.OnboardingSkipped -> onSkipPressed()
             ConfigDrivenOnboardingPageViewModel.Command.HandOffToBrowserActivity ->
                 (activity as? OnboardingActivity)?.handOffToBrowserActivity()
+            is ConfigDrivenOnboardingPageViewModel.Command.ShowQuickSetupDefaultBrowserDialog ->
+                quickSetupDefaultBrowserRoleManagerDialog.launch(command.intent)
+            ConfigDrivenOnboardingPageViewModel.Command.OpenDefaultBrowserSystemSettings -> openDefaultBrowserSystemSettings()
+            ConfigDrivenOnboardingPageViewModel.Command.ShowRemoveWidgetBottomSheet ->
+                RemoveWidgetInstructionsBottomSheet().show(childFragmentManager, RemoveWidgetInstructionsBottomSheet.TAG)
+            is ConfigDrivenOnboardingPageViewModel.Command.ShowQuickSetupAddressBarPositionBottomSheet ->
+                QuickSetupAddressBarPositionBottomSheet
+                    .newInstance(initialSelection = command.initialSelection, showSplitOption = command.showSplitOption)
+                    .show(childFragmentManager, QuickSetupAddressBarPositionBottomSheet.TAG)
+            is ConfigDrivenOnboardingPageViewModel.Command.ShowQuickSetupSearchOptionsBottomSheet ->
+                QuickSetupSearchOptionsBottomSheet
+                    .newInstance(initialWithAi = command.initialWithAi)
+                    .show(childFragmentManager, QuickSetupSearchOptionsBottomSheet.TAG)
+        }
+    }
+
+    private fun openDefaultBrowserSystemSettings() {
+        try {
+            startActivity(DefaultBrowserSystemSettings.intent())
+        } catch (e: ActivityNotFoundException) {
+            val errorMessage = getString(R.string.cannotLaunchDefaultAppSettings)
+            logcat(WARN) { "$errorMessage: ${e.asLog()}" }
+            Toast.makeText(requireContext(), errorMessage, Toast.LENGTH_SHORT).show()
+            // No activity launches, so the resume-driven resync never arrives for this attempt.
+            viewModel.syncQuickSetupSwitches()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
@@ -61,6 +61,11 @@ sealed interface ContentConfig {
         val body: TextConfig,
     ) : ContentConfig
 
+    data class WidgetPrompt(
+        override val title: TextConfig,
+        val body: TextConfig,
+    ) : ContentConfig
+
     data class InputScreenPreview(
         override val title: TextConfig,
         val isSearchDefault: Boolean,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
@@ -75,6 +75,23 @@ sealed interface ContentConfig {
     ) : ContentConfig, Stateful<InputScreenPreviewContentState> {
         override fun initialState() = InputScreenPreviewContentState(isSearchSelected = isSearchDefault)
     }
+
+    data class QuickSetup(
+        override val title: TextConfig,
+        val showSplitOption: Boolean,
+        val hideSetDefaultBrowserRow: Boolean,
+        val hideAddWidgetRow: Boolean,
+        val hideAddressBarRow: Boolean,
+        val initialAddressBarPosition: OmnibarType,
+        val initialWithAi: Boolean,
+    ) : ContentConfig, Stateful<QuickSetupContentState> {
+        override fun initialState() = QuickSetupContentState(
+            defaultBrowserChecked = false,
+            widgetChecked = false,
+            addressBarPosition = initialAddressBarPosition,
+            withAi = initialWithAi,
+        )
+    }
 }
 
 data class AddressBarContentState(val position: OmnibarType)
@@ -82,3 +99,10 @@ data class AddressBarContentState(val position: OmnibarType)
 data class InputScreenContentState(val withAi: Boolean)
 
 data class InputScreenPreviewContentState(val isSearchSelected: Boolean)
+
+data class QuickSetupContentState(
+    val defaultBrowserChecked: Boolean,
+    val widgetChecked: Boolean,
+    val addressBarPosition: OmnibarType,
+    val withAi: Boolean,
+)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
@@ -56,6 +56,11 @@ sealed interface ContentConfig {
         override fun initialState() = InputScreenContentState(withAi = initialWithAi)
     }
 
+    data class AddToDock(
+        override val title: TextConfig,
+        val body: TextConfig,
+    ) : ContentConfig
+
     data class InputScreenPreview(
         override val title: TextConfig,
         val isSearchDefault: Boolean,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogBinder.kt
@@ -41,6 +41,14 @@ sealed interface ContentInteraction {
         val isChat: Boolean,
         val fromSuggestion: Boolean,
     ) : ContentInteraction
+
+    data object EditAddressBarPosition : ContentInteraction
+
+    data object EditSearchOptions : ContentInteraction
+
+    data class SetDefaultBrowserToggled(val checked: Boolean) : ContentInteraction
+
+    data class AddWidgetToggled(val checked: Boolean) : ContentInteraction
 }
 
 /** Binds a stateless [ContentConfig] to its include layout. */

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogBinder.kt
@@ -42,13 +42,13 @@ sealed interface ContentInteraction {
         val fromSuggestion: Boolean,
     ) : ContentInteraction
 
-    data object EditAddressBarPosition : ContentInteraction
+    data object QuickSetupEditAddressBarPosition : ContentInteraction
 
-    data object EditSearchOptions : ContentInteraction
+    data object QuickSetupEditSearchOptions : ContentInteraction
 
-    data class SetDefaultBrowserToggled(val checked: Boolean) : ContentInteraction
+    data class QuickSetupSetDefaultBrowser(val checked: Boolean) : ContentInteraction
 
-    data class AddWidgetToggled(val checked: Boolean) : ContentInteraction
+    data class QuickSetupAddWidget(val checked: Boolean) : ContentInteraction
 }
 
 /** Binds a stateless [ContentConfig] to its include layout. */

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
@@ -88,6 +88,20 @@ class DialogConfigResolver @Inject constructor(
             ),
         )
 
+        NewUserOnboardingActivityDialog.AddToDock -> DialogConfig(
+            background = OnboardingBackgroundStep.AddToDock,
+            embellishment = Embellishment.None,
+            cardArrow = CardArrowConfig.Hidden,
+            content = ContentConfig.AddToDock(
+                title = TextConfig.Resource(R.string.preOnboardingDockStepTitle),
+                body = TextConfig.Resource(R.string.preOnboardingAddToDockBody),
+            ),
+            primaryCta = CtaConfig(
+                text = TextConfig.Resource(R.string.preOnboardingAddToDockPrimaryCta),
+                action = CtaAction.Emit(NewUserOnboardingEvent.ContinueClicked),
+            ),
+        )
+
         NewUserOnboardingActivityDialog.InputScreen -> DialogConfig(
             background = OnboardingBackgroundStep.InputType,
             embellishment = Embellishment.LeftWing,
@@ -122,7 +136,6 @@ class DialogConfigResolver @Inject constructor(
         NewUserOnboardingActivityDialog.NotificationPermission,
         NewUserOnboardingActivityDialog.DefaultBrowserPrompt,
         NewUserOnboardingActivityDialog.AddWidget,
-        NewUserOnboardingActivityDialog.AddToDock,
         NewUserOnboardingActivityDialog.WidgetPrompt,
         is NewUserOnboardingActivityDialog.QuickSetup,
         -> null // to be implemented in following tasks

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
@@ -102,6 +102,24 @@ class DialogConfigResolver @Inject constructor(
             ),
         )
 
+        NewUserOnboardingActivityDialog.WidgetPrompt -> DialogConfig(
+            background = OnboardingBackgroundStep.AddWidget,
+            embellishment = Embellishment.LeftWing,
+            cardArrow = CardArrowConfig.AtEnd,
+            content = ContentConfig.WidgetPrompt(
+                title = TextConfig.Resource(R.string.experimentHomeScreenWidgetBottomSheetDialogTitle),
+                body = TextConfig.Resource(R.string.experimentHomeScreenWidgetBottomSheetDialogSubTitle),
+            ),
+            primaryCta = CtaConfig(
+                text = TextConfig.Resource(R.string.preOnboardingWidgetPromptPrimaryCta),
+                action = CtaAction.Emit(NewUserOnboardingEvent.AddWidgetRequested),
+            ),
+            secondaryCta = CtaConfig(
+                text = TextConfig.Resource(R.string.experimentHomeScreenWidgetBottomSheetDialogGhostButton),
+                action = CtaAction.Emit(NewUserOnboardingEvent.WidgetPromptSkipped),
+            ),
+        )
+
         NewUserOnboardingActivityDialog.InputScreen -> DialogConfig(
             background = OnboardingBackgroundStep.InputType,
             embellishment = Embellishment.LeftWing,
@@ -136,7 +154,6 @@ class DialogConfigResolver @Inject constructor(
         NewUserOnboardingActivityDialog.NotificationPermission,
         NewUserOnboardingActivityDialog.DefaultBrowserPrompt,
         NewUserOnboardingActivityDialog.AddWidget,
-        NewUserOnboardingActivityDialog.WidgetPrompt,
         is NewUserOnboardingActivityDialog.QuickSetup,
         -> null // to be implemented in following tasks
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
@@ -150,11 +150,31 @@ class DialogConfigResolver @Inject constructor(
             ),
         )
 
+        is NewUserOnboardingActivityDialog.QuickSetup -> DialogConfig(
+            background = OnboardingBackgroundStep.QuickSetup,
+            embellishment = Embellishment.BottomWing,
+            cardArrow = CardArrowConfig.AtEnd,
+            content = ContentConfig.QuickSetup(
+                title = TextConfig.Resource(R.string.preOnboardingReinstallQuickSetupTitle),
+                showSplitOption = dialog.showSplitOption,
+                hideSetDefaultBrowserRow = dialog.hideSetDefaultBrowserRow,
+                hideAddWidgetRow = dialog.hideAddWidgetRow,
+                hideAddressBarRow = dialog.hideAddressBarRow,
+                initialAddressBarPosition = OmnibarType.SINGLE_TOP,
+                initialWithAi = true,
+            ),
+            primaryCta = CtaConfig(
+                text = TextConfig.Resource(
+                    if (isCustomAiFlow) R.string.preOnboardingDaxDialog3ButtonCustomAi else R.string.preOnboardingReinstallStartBrowsing,
+                ),
+                action = CtaAction.Submit,
+            ),
+        )
+
         is NewUserOnboardingActivityDialog.IntroAnimation,
         NewUserOnboardingActivityDialog.NotificationPermission,
         NewUserOnboardingActivityDialog.DefaultBrowserPrompt,
         NewUserOnboardingActivityDialog.AddWidget,
-        is NewUserOnboardingActivityDialog.QuickSetup,
         -> null // to be implemented in following tasks
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
@@ -175,7 +175,7 @@ class DialogConfigResolver @Inject constructor(
         NewUserOnboardingActivityDialog.NotificationPermission,
         NewUserOnboardingActivityDialog.DefaultBrowserPrompt,
         NewUserOnboardingActivityDialog.AddWidget,
-        -> null // to be implemented in following tasks
+        -> null // command-only: no card to render
     }
 
     private fun comparisonChart(chart: ComparisonChartConfig) = DialogConfig(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/AddToDockBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/AddToDockBinder.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.page.configdriven.binders
+
+import android.graphics.SurfaceTexture
+import android.media.MediaPlayer
+import android.view.Surface
+import android.view.TextureView
+import android.view.View
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.IncludeBrandDesignAddToDockBinding
+import com.duckduckgo.app.onboarding.ui.page.configdriven.BindScope
+import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentConfig
+import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentHandle
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DialogBinder
+import com.duckduckgo.common.utils.extensions.preventWidows
+
+class AddToDockBinder(
+    private val binding: IncludeBrandDesignAddToDockBinding,
+) : DialogBinder<ContentConfig.AddToDock> {
+
+    override val view: View = binding.root
+
+    private var videoPlayer: MediaPlayer? = null
+
+    override fun bind(content: ContentConfig.AddToDock, scope: BindScope): ContentHandle = with(binding) {
+        val context = root.context
+
+        addToDockBody.text = content.body.resolve(context).preventWidows()
+        setUpVideo()
+
+        addToDockTitle.setTitle(content.title.resolve(context))
+
+        ContentHandle(
+            title = addToDockTitle,
+            fadeTargets = listOf(addToDockBody, addToDockMedia),
+            unbind = { releaseVideo() },
+        )
+    }
+
+    private fun setUpVideo() = with(binding) {
+        addToDockPreviewVideo.setVideoSize(VIDEO_WIDTH, VIDEO_HEIGHT)
+        addToDockPreviewVideo.surfaceTextureListener = object : TextureView.SurfaceTextureListener {
+            override fun onSurfaceTextureAvailable(
+                surface: SurfaceTexture,
+                width: Int,
+                height: Int,
+            ) {
+                playVideo(surface)
+            }
+
+            override fun onSurfaceTextureSizeChanged(
+                surface: SurfaceTexture,
+                width: Int,
+                height: Int,
+            ) = Unit
+
+            override fun onSurfaceTextureDestroyed(surface: SurfaceTexture): Boolean {
+                releaseVideo()
+                return true
+            }
+
+            override fun onSurfaceTextureUpdated(surface: SurfaceTexture) = Unit
+        }
+    }
+
+    private fun playVideo(surfaceTexture: SurfaceTexture) {
+        releaseVideo()
+        videoPlayer = MediaPlayer().apply {
+            setSurface(Surface(surfaceTexture))
+            binding.root.context.resources.openRawResourceFd(R.raw.onboarding_add_to_home_screen_tutorial).use { setDataSource(it) }
+            isLooping = true
+            setVolume(0f, 0f)
+            setOnVideoSizeChangedListener { _, width, height -> binding.addToDockPreviewVideo.setVideoSize(width, height) }
+            setOnPreparedListener { it.start() }
+            prepareAsync()
+        }
+    }
+
+    private fun releaseVideo() {
+        videoPlayer?.release()
+        videoPlayer = null
+    }
+
+    private companion object {
+        // Seeds AspectRatioTextureView's first measurement before MediaPlayer reports the real size: at
+        // wrap_content a zero height never produces a surface, so playback would never start.
+        const val VIDEO_WIDTH = 1080
+        const val VIDEO_HEIGHT = 944
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/QuickSetupBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/QuickSetupBinder.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.page.configdriven.binders
+
+import android.view.View
+import androidx.core.view.isVisible
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.IncludeBrandDesignReinstallerQuickSetupBinding
+import com.duckduckgo.app.browser.omnibar.OmnibarType
+import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingEvent
+import com.duckduckgo.app.onboarding.ui.page.configdriven.BindScope
+import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentConfig
+import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentHandle
+import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentInteraction
+import com.duckduckgo.app.onboarding.ui.page.configdriven.QuickSetupContentState
+import com.duckduckgo.app.onboarding.ui.page.configdriven.StatefulDialogBinder
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * The address-bar-position row is always shown: only the search-options row and the divider above it follow
+ * `hideAddressBarRow`, matching the legacy screen.
+ */
+class QuickSetupBinder(
+    private val binding: IncludeBrandDesignReinstallerQuickSetupBinding,
+) : StatefulDialogBinder<ContentConfig.QuickSetup, QuickSetupContentState> {
+
+    override val view: View = binding.root
+
+    override fun bind(
+        content: ContentConfig.QuickSetup,
+        state: MutableStateFlow<QuickSetupContentState>,
+        scope: BindScope,
+    ): ContentHandle = with(binding) {
+        val context = root.context
+
+        setDefaultBrowserItem.isVisible = !content.hideSetDefaultBrowserRow
+        setDefaultBrowserDivider.isVisible = !content.hideSetDefaultBrowserRow
+        addWidgetItem.isVisible = !content.hideAddWidgetRow
+        addWidgetDivider.isVisible = !content.hideAddWidgetRow
+        addressBarSearchOptionsItem.isVisible = !content.hideAddressBarRow
+        addressBarSearchOptionsDivider.isVisible = !content.hideAddressBarRow
+
+        setDefaultBrowserItem.setOnCheckedChangeListener { checked ->
+            scope.execute(ContentInteraction.SetDefaultBrowserToggled(checked))
+        }
+        addWidgetItem.setOnCheckedChangeListener { checked ->
+            scope.execute(ContentInteraction.AddWidgetToggled(checked))
+        }
+        addressBarPositionItem.setOnClickListener { scope.execute(ContentInteraction.EditAddressBarPosition) }
+        addressBarSearchOptionsItem.setOnClickListener { scope.execute(ContentInteraction.EditSearchOptions) }
+
+        scope.coroutineScope.launch {
+            state.collect { render(it) }
+        }
+
+        quickSetupTitle.setTitle(content.title.resolve(context))
+
+        ContentHandle(
+            title = quickSetupTitle,
+            fadeTargets = listOf(quickSetupOptionsContainer),
+            result = { NewUserOnboardingEvent.QuickSetupConfirmed(state.value.addressBarPosition, state.value.withAi) },
+        )
+    }
+
+    /** Switches render silently so re-rendering a collected value never re-fires the listener that produced it. */
+    private fun render(state: QuickSetupContentState) = with(binding) {
+        setDefaultBrowserItem.setCheckedSilently(state.defaultBrowserChecked)
+        addWidgetItem.setCheckedSilently(state.widgetChecked)
+        addressBarPositionItem.setIcon(addressBarPositionIconRes(state.addressBarPosition))
+        addressBarPositionItem.setSecondaryText(addressBarPositionLabelRes(state.addressBarPosition))
+        addressBarSearchOptionsItem.setIcon(searchOptionsIconRes(state.withAi))
+        addressBarSearchOptionsItem.setSecondaryText(searchOptionsLabelRes(state.withAi))
+    }
+
+    private fun addressBarPositionIconRes(type: OmnibarType): Int = when (type) {
+        OmnibarType.SINGLE_TOP -> R.drawable.ic_address_bar_top_24
+        OmnibarType.SINGLE_BOTTOM -> R.drawable.ic_address_bar_bottom_24
+        OmnibarType.SPLIT -> R.drawable.ic_address_bar_split_24
+    }
+
+    private fun addressBarPositionLabelRes(type: OmnibarType): Int = when (type) {
+        OmnibarType.SINGLE_TOP -> R.string.preOnboardingAddressBarPositionTop
+        OmnibarType.SINGLE_BOTTOM -> R.string.preOnboardingAddressBarPositionBottom
+        OmnibarType.SPLIT -> R.string.preOnboardingAddressBarPositionSplit
+    }
+
+    private fun searchOptionsIconRes(withAi: Boolean): Int = if (withAi) R.drawable.ic_ai_24 else R.drawable.ic_search_24
+
+    private fun searchOptionsLabelRes(withAi: Boolean): Int =
+        if (withAi) R.string.quickSetupInputScreenSearchAndDuckAi else R.string.quickSetupInputScreenSearchOnly
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/QuickSetupBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/QuickSetupBinder.kt
@@ -74,6 +74,12 @@ class QuickSetupBinder(
             title = quickSetupTitle,
             fadeTargets = listOf(quickSetupOptionsContainer),
             result = { NewUserOnboardingEvent.QuickSetupConfirmed(state.value.addressBarPosition, state.value.withAi) },
+            unbind = {
+                setDefaultBrowserItem.setOnCheckedChangeListener {}
+                addWidgetItem.setOnCheckedChangeListener {}
+                addressBarPositionItem.setOnClickListener(null)
+                addressBarSearchOptionsItem.setOnClickListener(null)
+            },
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/QuickSetupBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/QuickSetupBinder.kt
@@ -56,13 +56,13 @@ class QuickSetupBinder(
         addressBarSearchOptionsDivider.isVisible = !content.hideAddressBarRow
 
         setDefaultBrowserItem.setOnCheckedChangeListener { checked ->
-            scope.execute(ContentInteraction.SetDefaultBrowserToggled(checked))
+            scope.execute(ContentInteraction.QuickSetupSetDefaultBrowser(checked))
         }
         addWidgetItem.setOnCheckedChangeListener { checked ->
-            scope.execute(ContentInteraction.AddWidgetToggled(checked))
+            scope.execute(ContentInteraction.QuickSetupAddWidget(checked))
         }
-        addressBarPositionItem.setOnClickListener { scope.execute(ContentInteraction.EditAddressBarPosition) }
-        addressBarSearchOptionsItem.setOnClickListener { scope.execute(ContentInteraction.EditSearchOptions) }
+        addressBarPositionItem.setOnClickListener { scope.execute(ContentInteraction.QuickSetupEditAddressBarPosition) }
+        addressBarSearchOptionsItem.setOnClickListener { scope.execute(ContentInteraction.QuickSetupEditSearchOptions) }
 
         scope.coroutineScope.launch {
             state.collect { render(it) }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/WidgetPromptBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/WidgetPromptBinder.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.page.configdriven.binders
+
+import android.view.View
+import com.duckduckgo.app.browser.databinding.IncludeBrandDesignWidgetPromptBinding
+import com.duckduckgo.app.onboarding.ui.page.configdriven.BindScope
+import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentConfig
+import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentHandle
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DialogBinder
+import com.duckduckgo.common.utils.extensions.preventWidows
+
+class WidgetPromptBinder(
+    private val binding: IncludeBrandDesignWidgetPromptBinding,
+) : DialogBinder<ContentConfig.WidgetPrompt> {
+
+    override val view: View = binding.root
+
+    override fun bind(content: ContentConfig.WidgetPrompt, scope: BindScope): ContentHandle = with(binding) {
+        val context = root.context
+
+        widgetPromptBody.text = content.body.resolve(context).preventWidows()
+        widgetPromptTitle.setTitle(content.title.resolve(context))
+
+        ContentHandle(
+            title = widgetPromptTitle,
+            fadeTargets = listOf(widgetPromptBody, widgetPromptMedia),
+        )
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.onboarding.ui.page.configdriven.BindScope
 import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentConfig
 import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentHandle
 import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentValueStore
+import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.AddToDockBinder
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.AddressBarBinder
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.ComparisonChartBinder
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.InputScreenBinder
@@ -54,6 +55,7 @@ class ContentControllerImpl(
     private val inputScreen = InputScreenBinder(binding.inputScreenContent, isLightMode)
     private val inputScreenPreview = InputScreenPreviewBinder(binding.inputScreenPreviewContent)
     private val welcome = WelcomeBinder(binding.welcomeContent)
+    private val addToDock = AddToDockBinder(binding.addToDockContent)
 
     private var boundView: View? = null
 
@@ -93,6 +95,10 @@ class ContentControllerImpl(
             is ContentConfig.InputScreenPreview -> {
                 boundView = inputScreenPreview.view
                 inputScreenPreview.bind(content, contentValues.contentState(stepId, content), scope)
+            }
+            is ContentConfig.AddToDock -> {
+                boundView = addToDock.view
+                addToDock.bind(content, scope)
             }
         }
         boundView?.isVisible = true

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.AddressBarBind
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.ComparisonChartBinder
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.InputScreenBinder
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.InputScreenPreviewBinder
+import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.QuickSetupBinder
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.WelcomeBinder
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.WidgetPromptBinder
 import com.duckduckgo.onboarding.api.LinearOnboardingStepId
@@ -55,6 +56,7 @@ class ContentControllerImpl(
     private val addressBar = AddressBarBinder(binding.addressBarContent, isLightMode)
     private val inputScreen = InputScreenBinder(binding.inputScreenContent, isLightMode)
     private val inputScreenPreview = InputScreenPreviewBinder(binding.inputScreenPreviewContent)
+    private val quickSetup = QuickSetupBinder(binding.reinstallerQuickSetupContent)
     private val welcome = WelcomeBinder(binding.welcomeContent)
     private val addToDock = AddToDockBinder(binding.addToDockContent)
     private val widgetPrompt = WidgetPromptBinder(binding.widgetPromptContent)
@@ -97,6 +99,10 @@ class ContentControllerImpl(
             is ContentConfig.InputScreenPreview -> {
                 boundView = inputScreenPreview.view
                 inputScreenPreview.bind(content, contentValues.contentState(stepId, content), scope)
+            }
+            is ContentConfig.QuickSetup -> {
+                boundView = quickSetup.view
+                quickSetup.bind(content, contentValues.contentState(stepId, content), scope)
             }
             is ContentConfig.AddToDock -> {
                 boundView = addToDock.view

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.ComparisonChar
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.InputScreenBinder
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.InputScreenPreviewBinder
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.WelcomeBinder
+import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.WidgetPromptBinder
 import com.duckduckgo.onboarding.api.LinearOnboardingStepId
 
 interface ContentController {
@@ -56,6 +57,7 @@ class ContentControllerImpl(
     private val inputScreenPreview = InputScreenPreviewBinder(binding.inputScreenPreviewContent)
     private val welcome = WelcomeBinder(binding.welcomeContent)
     private val addToDock = AddToDockBinder(binding.addToDockContent)
+    private val widgetPrompt = WidgetPromptBinder(binding.widgetPromptContent)
 
     private var boundView: View? = null
 
@@ -99,6 +101,10 @@ class ContentControllerImpl(
             is ContentConfig.AddToDock -> {
                 boundView = addToDock.view
                 addToDock.bind(content, scope)
+            }
+            is ContentConfig.WidgetPrompt -> {
+                boundView = widgetPrompt.view
+                widgetPrompt.bind(content, scope)
             }
         }
         boundView?.isVisible = true

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
@@ -572,6 +572,27 @@ class ConfigDrivenOnboardingPageViewModelTest {
         }
     }
 
+    // Unlike the sibling test above, no onResume() follows: ActivityResultRegistry dispatches the declined
+    // result before onResume runs, so the switch must correct itself synchronously from the result alone.
+    @Test
+    fun `corrects the default browser switch back to unset as soon as the system dialog is declined`() = runTest {
+        whenever(mockDefaultRoleBrowserDialog.createIntent(any())).thenReturn(Intent())
+        val testee = startAt(quickSetupDialog)
+        advanceUntilIdle()
+
+        quickSetupStateFlow(testee).test {
+            assertFalse(awaitItem().defaultBrowserChecked)
+
+            testee.onContentInteraction(ContentInteraction.SetDefaultBrowserToggled(checked = true))
+            advanceUntilIdle()
+            assertTrue(awaitItem().defaultBrowserChecked)
+
+            testee.onQuickSetupDefaultBrowserNotSet()
+            advanceUntilIdle()
+            assertFalse(awaitItem().defaultBrowserChecked)
+        }
+    }
+
     @Test
     fun `restores the widget switch after the remove widget sheet is dismissed without removing it`() = runTest {
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
@@ -616,5 +637,16 @@ class ConfigDrivenOnboardingPageViewModelTest {
 
         assertEquals(emptyList<LinearOnboardingEvent>(), recordedEvents)
         verifyNoInteractions(pixel)
+    }
+
+    @Test
+    fun `records the quick setup default browser set result against the shared default browser state`() = runTest {
+        val testee = startAt(quickSetupDialog)
+        advanceUntilIdle()
+
+        testee.onQuickSetupDefaultBrowserSet()
+
+        verify(mockDefaultRoleBrowserDialog).dialogShown()
+        verify(mockAppInstallStore).defaultBrowser = true
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
@@ -21,6 +21,8 @@ import android.content.Context
 import android.content.Intent
 import app.cash.turbine.test
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
+import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.CustomAiOnboardingStore
@@ -75,6 +77,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
     private val pixel: Pixel = mock()
     private val mockAppInstallStore: AppInstallStore = mock()
     private val mockWidgetCapabilities: WidgetCapabilities = mock()
+    private val mockDefaultBrowserDetector: DefaultBrowserDetector = mock()
     private val customAiOnboardingStore: CustomAiOnboardingStore = mock()
     private val newUserOnboardingPlanBootstrapper: NewUserOnboardingPlanBootstrapper = mock()
     private val mockOnboardingStore: OnboardingStore = mock()
@@ -115,6 +118,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
         shownPixels = mockShownPixels,
         dispatchers = coroutineRule.testDispatcherProvider,
         widgetCapabilities = mockWidgetCapabilities,
+        defaultBrowserDetector = mockDefaultBrowserDetector,
         defaultRoleBrowserDialog = mockDefaultRoleBrowserDialog,
         context = mockContext,
         pixel = pixel,
@@ -143,6 +147,20 @@ class ConfigDrivenOnboardingPageViewModelTest {
     ): ConfigDrivenOnboardingPageViewModel {
         realOrchestrator.startPlan(planAt(dialog, id, transition, result))
         return createViewModel(realOrchestrator)
+    }
+
+    private val quickSetupDialog = NewUserOnboardingActivityDialog.QuickSetup(
+        showSplitOption = true,
+        hideSetDefaultBrowserRow = false,
+        hideAddWidgetRow = false,
+        hideAddressBarRow = false,
+        isReinstallUser = false,
+    )
+
+    private fun quickSetupState(testee: ConfigDrivenOnboardingPageViewModel): QuickSetupContentState {
+        val dialog = testee.viewState.value.screen as Screen.Dialog
+        val content = dialog.config.content as ContentConfig.QuickSetup
+        return testee.contentValues.contentState(dialog.stepId, content).value
     }
 
     private suspend fun startAtBrowserStep(): ConfigDrivenOnboardingPageViewModel {
@@ -424,5 +442,98 @@ class ConfigDrivenOnboardingPageViewModelTest {
         val content = (testee.viewState.value.screen as Screen.Dialog).config.content as ContentConfig.Welcome
         assertEquals(TextConfig.Resource(R.string.syncRestoreDialogBrandDesignTitle), content.title)
         assertTrue(recordedEvents.isEmpty())
+    }
+
+    @Test
+    fun `asks for the address bar bottom sheet with the current quick setup selection`() = runTest {
+        val testee = startAt(quickSetupDialog)
+        advanceUntilIdle()
+
+        testee.commands.test {
+            testee.onContentInteraction(ContentInteraction.EditAddressBarPosition)
+            advanceUntilIdle()
+            assertEquals(
+                Command.ShowQuickSetupAddressBarPositionBottomSheet(
+                    initialSelection = OmnibarType.SINGLE_TOP,
+                    showSplitOption = true,
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `writes the address bar bottom sheet result into the quick setup state`() = runTest {
+        val testee = startAt(quickSetupDialog)
+        advanceUntilIdle()
+
+        testee.onAddressBarBottomSheetResult(OmnibarType.SINGLE_BOTTOM)
+
+        assertEquals(OmnibarType.SINGLE_BOTTOM, quickSetupState(testee).addressBarPosition)
+    }
+
+    @Test
+    fun `writes the search options bottom sheet result into the quick setup state`() = runTest {
+        val testee = startAt(quickSetupDialog)
+        advanceUntilIdle()
+
+        testee.onSearchOptionsBottomSheetResult(withAi = false)
+
+        assertFalse(quickSetupState(testee).withAi)
+    }
+
+    @Test
+    fun `mirrors the default browser toggle into the quick setup state before showing the system dialog`() = runTest {
+        whenever(mockDefaultRoleBrowserDialog.createIntent(any())).thenReturn(Intent())
+        val testee = startAt(quickSetupDialog)
+        advanceUntilIdle()
+
+        testee.commands.test {
+            testee.onContentInteraction(ContentInteraction.SetDefaultBrowserToggled(checked = true))
+            advanceUntilIdle()
+            assertTrue(quickSetupState(testee).defaultBrowserChecked)
+            assertTrue(awaitItem() is Command.ShowQuickSetupDefaultBrowserDialog)
+        }
+    }
+
+    @Test
+    fun `opens the system browser settings when no default browser dialog is available`() = runTest {
+        whenever(mockDefaultRoleBrowserDialog.createIntent(any())).thenReturn(null)
+        val testee = startAt(quickSetupDialog)
+        advanceUntilIdle()
+
+        testee.commands.test {
+            testee.onContentInteraction(ContentInteraction.SetDefaultBrowserToggled(checked = true))
+            advanceUntilIdle()
+            assertEquals(Command.OpenDefaultBrowserSystemSettings, awaitItem())
+        }
+    }
+
+    @Test
+    fun `asks for the remove widget instructions when the widget toggle is turned off`() = runTest {
+        val testee = startAt(quickSetupDialog)
+        advanceUntilIdle()
+
+        testee.commands.test {
+            testee.onContentInteraction(ContentInteraction.AddWidgetToggled(checked = false))
+            advanceUntilIdle()
+            assertFalse(quickSetupState(testee).widgetChecked)
+            assertEquals(Command.ShowRemoveWidgetBottomSheet, awaitItem())
+        }
+    }
+
+    @Test
+    fun `resyncs the quick setup switches from the system on resume`() = runTest {
+        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
+        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
+        val testee = startAt(quickSetupDialog)
+        advanceUntilIdle()
+
+        testee.onResume()
+        advanceUntilIdle()
+
+        val state = quickSetupState(testee)
+        assertTrue(state.defaultBrowserChecked)
+        assertTrue(state.widgetChecked)
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
@@ -455,7 +455,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
         advanceUntilIdle()
 
         testee.commands.test {
-            testee.onContentInteraction(ContentInteraction.EditAddressBarPosition)
+            testee.onContentInteraction(ContentInteraction.QuickSetupEditAddressBarPosition)
             advanceUntilIdle()
             assertEquals(
                 Command.ShowQuickSetupAddressBarPositionBottomSheet(
@@ -494,7 +494,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
         advanceUntilIdle()
 
         testee.commands.test {
-            testee.onContentInteraction(ContentInteraction.SetDefaultBrowserToggled(checked = true))
+            testee.onContentInteraction(ContentInteraction.QuickSetupSetDefaultBrowser(checked = true))
             advanceUntilIdle()
             assertTrue(quickSetupState(testee).defaultBrowserChecked)
             assertTrue(awaitItem() is Command.ShowQuickSetupDefaultBrowserDialog)
@@ -508,7 +508,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
         advanceUntilIdle()
 
         testee.commands.test {
-            testee.onContentInteraction(ContentInteraction.SetDefaultBrowserToggled(checked = true))
+            testee.onContentInteraction(ContentInteraction.QuickSetupSetDefaultBrowser(checked = true))
             advanceUntilIdle()
             assertEquals(Command.OpenDefaultBrowserSystemSettings, awaitItem())
         }
@@ -525,7 +525,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
         advanceUntilIdle()
 
         testee.commands.test {
-            testee.onContentInteraction(ContentInteraction.AddWidgetToggled(checked = false))
+            testee.onContentInteraction(ContentInteraction.QuickSetupAddWidget(checked = false))
             advanceUntilIdle()
             assertFalse(quickSetupState(testee).widgetChecked)
             assertEquals(Command.ShowRemoveWidgetBottomSheet, awaitItem())
@@ -561,7 +561,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
         quickSetupStateFlow(testee).test {
             assertFalse(awaitItem().defaultBrowserChecked)
 
-            testee.onContentInteraction(ContentInteraction.SetDefaultBrowserToggled(checked = true))
+            testee.onContentInteraction(ContentInteraction.QuickSetupSetDefaultBrowser(checked = true))
             advanceUntilIdle()
             assertTrue(awaitItem().defaultBrowserChecked)
 
@@ -583,7 +583,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
         quickSetupStateFlow(testee).test {
             assertFalse(awaitItem().defaultBrowserChecked)
 
-            testee.onContentInteraction(ContentInteraction.SetDefaultBrowserToggled(checked = true))
+            testee.onContentInteraction(ContentInteraction.QuickSetupSetDefaultBrowser(checked = true))
             advanceUntilIdle()
             assertTrue(awaitItem().defaultBrowserChecked)
 
@@ -604,7 +604,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
         quickSetupStateFlow(testee).test {
             assertTrue(awaitItem().widgetChecked)
 
-            testee.onContentInteraction(ContentInteraction.AddWidgetToggled(checked = false))
+            testee.onContentInteraction(ContentInteraction.QuickSetupAddWidget(checked = false))
             advanceUntilIdle()
             assertFalse(awaitItem().widgetChecked)
 
@@ -619,7 +619,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
         val testee = startAt(quickSetupDialog)
         advanceUntilIdle()
 
-        testee.onContentInteraction(ContentInteraction.AddWidgetToggled(checked = true))
+        testee.onContentInteraction(ContentInteraction.QuickSetupAddWidget(checked = true))
         advanceUntilIdle()
         testee.onResume()
         advanceUntilIdle()

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
@@ -47,6 +47,7 @@ import com.duckduckgo.onboarding.api.LinearOnboardingResult
 import com.duckduckgo.onboarding.api.LinearOnboardingState
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition
 import com.duckduckgo.onboarding.impl.LinearOnboardingOrchestratorImpl
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -65,6 +66,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @SuppressLint("DenyListedApi")
 class ConfigDrivenOnboardingPageViewModelTest {
 
@@ -157,11 +159,14 @@ class ConfigDrivenOnboardingPageViewModelTest {
         isReinstallUser = false,
     )
 
-    private fun quickSetupState(testee: ConfigDrivenOnboardingPageViewModel): QuickSetupContentState {
+    private fun quickSetupStateFlow(testee: ConfigDrivenOnboardingPageViewModel): MutableStateFlow<QuickSetupContentState> {
         val dialog = testee.viewState.value.screen as Screen.Dialog
         val content = dialog.config.content as ContentConfig.QuickSetup
-        return testee.contentValues.contentState(dialog.stepId, content).value
+        return testee.contentValues.contentState(dialog.stepId, content)
     }
+
+    private fun quickSetupState(testee: ConfigDrivenOnboardingPageViewModel): QuickSetupContentState =
+        quickSetupStateFlow(testee).value
 
     private suspend fun startAtBrowserStep(): ConfigDrivenOnboardingPageViewModel {
         val browserStep = NewUserBrowserActivityStep(
@@ -483,7 +488,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
     }
 
     @Test
-    fun `mirrors the default browser toggle into the quick setup state before showing the system dialog`() = runTest {
+    fun `mirrors the default browser toggle into the quick setup state and shows the system dialog`() = runTest {
         whenever(mockDefaultRoleBrowserDialog.createIntent(any())).thenReturn(Intent())
         val testee = startAt(quickSetupDialog)
         advanceUntilIdle()
@@ -511,7 +516,12 @@ class ConfigDrivenOnboardingPageViewModelTest {
 
     @Test
     fun `asks for the remove widget instructions when the widget toggle is turned off`() = runTest {
+        // Seeded true so the mirror assertion below is meaningful: the state's own initial value is already
+        // false, so turning the switch off would leave it unchanged whether or not the mirror ran.
+        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
         val testee = startAt(quickSetupDialog)
+        advanceUntilIdle()
+        testee.onResume()
         advanceUntilIdle()
 
         testee.commands.test {
@@ -535,5 +545,76 @@ class ConfigDrivenOnboardingPageViewModelTest {
         val state = quickSetupState(testee)
         assertTrue(state.defaultBrowserChecked)
         assertTrue(state.widgetChecked)
+    }
+
+    // Endpoint-only assertions can't tell a real correction from a no-op: the corrected value here equals the
+    // pre-toggle value, so it would read the same whether or not the mirror ever ran. Collecting the flow pins
+    // the actual sequence of writes instead — with the mirror removed, the flow after the toggle would never
+    // emit at all, since a MutableStateFlow drops writes that don't change the value.
+    @Test
+    fun `corrects the default browser switch back to unset after the system dialog is declined`() = runTest {
+        whenever(mockDefaultRoleBrowserDialog.createIntent(any())).thenReturn(Intent())
+        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
+        val testee = startAt(quickSetupDialog)
+        advanceUntilIdle()
+
+        quickSetupStateFlow(testee).test {
+            assertFalse(awaitItem().defaultBrowserChecked)
+
+            testee.onContentInteraction(ContentInteraction.SetDefaultBrowserToggled(checked = true))
+            advanceUntilIdle()
+            assertTrue(awaitItem().defaultBrowserChecked)
+
+            testee.onQuickSetupDefaultBrowserNotSet()
+            testee.onResume()
+            advanceUntilIdle()
+            assertFalse(awaitItem().defaultBrowserChecked)
+        }
+    }
+
+    @Test
+    fun `restores the widget switch after the remove widget sheet is dismissed without removing it`() = runTest {
+        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
+        val testee = startAt(quickSetupDialog)
+        advanceUntilIdle()
+        testee.onResume()
+        advanceUntilIdle()
+
+        quickSetupStateFlow(testee).test {
+            assertTrue(awaitItem().widgetChecked)
+
+            testee.onContentInteraction(ContentInteraction.AddWidgetToggled(checked = false))
+            advanceUntilIdle()
+            assertFalse(awaitItem().widgetChecked)
+
+            testee.syncQuickSetupSwitches()
+            advanceUntilIdle()
+            assertTrue(awaitItem().widgetChecked)
+        }
+    }
+
+    @Test
+    fun `does not treat the quick setup add-widget toggle as the standalone add-widget step`() = runTest {
+        val testee = startAt(quickSetupDialog)
+        advanceUntilIdle()
+
+        testee.onContentInteraction(ContentInteraction.AddWidgetToggled(checked = true))
+        advanceUntilIdle()
+        testee.onResume()
+        advanceUntilIdle()
+
+        assertEquals(emptyList<LinearOnboardingEvent>(), recordedEvents)
+    }
+
+    @Test
+    fun `records the quick setup default browser result without advancing the plan or firing the shared pixel`() = runTest {
+        val testee = startAt(quickSetupDialog)
+        advanceUntilIdle()
+
+        testee.onQuickSetupDefaultBrowserSet()
+        advanceUntilIdle()
+
+        assertEquals(emptyList<LinearOnboardingEvent>(), recordedEvents)
+        verifyNoInteractions(pixel)
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
@@ -287,4 +287,34 @@ class DialogConfigResolverTest {
         assertFalse(content.showModeToggle)
         assertEquals(InputScreenPreviewContentState(isSearchSelected = false), content.initialState())
     }
+
+    @Test
+    fun `resolves the widget prompt dialog with add and skip ctas`() {
+        val config = testee.resolve(NewUserOnboardingActivityDialog.WidgetPrompt, isCustomAiFlow = false)!!
+
+        assertEquals(OnboardingBackgroundStep.AddWidget, config.background)
+        assertEquals(Embellishment.LeftWing, config.embellishment)
+        assertEquals(CardArrowConfig.AtEnd, config.cardArrow)
+        assertEquals(
+            ContentConfig.WidgetPrompt(
+                title = TextConfig.Resource(R.string.experimentHomeScreenWidgetBottomSheetDialogTitle),
+                body = TextConfig.Resource(R.string.experimentHomeScreenWidgetBottomSheetDialogSubTitle),
+            ),
+            config.content,
+        )
+        assertEquals(
+            CtaConfig(
+                TextConfig.Resource(R.string.preOnboardingWidgetPromptPrimaryCta),
+                CtaAction.Emit(NewUserOnboardingEvent.AddWidgetRequested),
+            ),
+            config.primaryCta,
+        )
+        assertEquals(
+            CtaConfig(
+                TextConfig.Resource(R.string.experimentHomeScreenWidgetBottomSheetDialogGhostButton),
+                CtaAction.Emit(NewUserOnboardingEvent.WidgetPromptSkipped),
+            ),
+            config.secondaryCta,
+        )
+    }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
@@ -317,4 +317,55 @@ class DialogConfigResolverTest {
             config.secondaryCta,
         )
     }
+
+    @Test
+    fun `resolves quick setup with the plan's row visibility and a submitting cta`() {
+        val dialog = NewUserOnboardingActivityDialog.QuickSetup(
+            showSplitOption = true,
+            hideSetDefaultBrowserRow = true,
+            hideAddWidgetRow = false,
+            hideAddressBarRow = true,
+            isReinstallUser = true,
+        )
+
+        val config = testee.resolve(dialog, isCustomAiFlow = false)!!
+
+        assertEquals(OnboardingBackgroundStep.QuickSetup, config.background)
+        assertEquals(Embellishment.BottomWing, config.embellishment)
+        assertEquals(CardArrowConfig.AtEnd, config.cardArrow)
+        assertEquals(
+            ContentConfig.QuickSetup(
+                title = TextConfig.Resource(R.string.preOnboardingReinstallQuickSetupTitle),
+                showSplitOption = true,
+                hideSetDefaultBrowserRow = true,
+                hideAddWidgetRow = false,
+                hideAddressBarRow = true,
+                initialAddressBarPosition = OmnibarType.SINGLE_TOP,
+                initialWithAi = true,
+            ),
+            config.content,
+        )
+        assertEquals(
+            CtaConfig(TextConfig.Resource(R.string.preOnboardingReinstallStartBrowsing), CtaAction.Submit),
+            config.primaryCta,
+        )
+    }
+
+    @Test
+    fun `resolves quick setup with custom ai cta copy in the custom ai flow`() {
+        val dialog = NewUserOnboardingActivityDialog.QuickSetup(
+            showSplitOption = false,
+            hideSetDefaultBrowserRow = false,
+            hideAddWidgetRow = false,
+            hideAddressBarRow = false,
+            isReinstallUser = false,
+        )
+
+        val config = testee.resolve(dialog, isCustomAiFlow = true)!!
+
+        assertEquals(
+            CtaConfig(TextConfig.Resource(R.string.preOnboardingDaxDialog3ButtonCustomAi), CtaAction.Submit),
+            config.primaryCta,
+        )
+    }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolverTest.kt
@@ -96,7 +96,30 @@ class DialogConfigResolverTest {
     @Test
     fun `resolves no config for a dialog that has no config-driven screen yet`() {
         assertNull(testee.resolve(NewUserOnboardingActivityDialog.NotificationPermission, isCustomAiFlow = false))
-        assertNull(testee.resolve(NewUserOnboardingActivityDialog.AddToDock, isCustomAiFlow = false))
+    }
+
+    @Test
+    fun `resolves the add to dock dialog with no decoration and no arrow`() {
+        val config = testee.resolve(NewUserOnboardingActivityDialog.AddToDock, isCustomAiFlow = false)!!
+
+        assertEquals(OnboardingBackgroundStep.AddToDock, config.background)
+        assertEquals(Embellishment.None, config.embellishment)
+        assertEquals(CardArrowConfig.Hidden, config.cardArrow)
+        assertEquals(
+            ContentConfig.AddToDock(
+                title = TextConfig.Resource(R.string.preOnboardingDockStepTitle),
+                body = TextConfig.Resource(R.string.preOnboardingAddToDockBody),
+            ),
+            config.content,
+        )
+        assertEquals(
+            CtaConfig(
+                TextConfig.Resource(R.string.preOnboardingAddToDockPrimaryCta),
+                CtaAction.Emit(NewUserOnboardingEvent.ContinueClicked),
+            ),
+            config.primaryCta,
+        )
+        assertNull(config.secondaryCta)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1217183142109150?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1216854264994244
API Proposals URL(s) (if applicable): 

### Description

Step 3 of the tech design: ports the remaining screens to the config-driven onboarding renderer. This PR covers below binders:
- Add to dock
- Add widget
- Quick Setup

### Steps to test this PR
- [x] Apply below patch:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
index df50491818..446dd61735 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
@@ -155,10 +155,10 @@ class NewUserOnboardingPlanProvider @Inject constructor(
                 add(initialStep(firstDialog))
                 add(comparisonChartStep())
                 add(defaultBrowserPromptStep())
-                if (showDock) {
+                if (true) {
                     add(addToDockStep())
                 }
-                if (showWidget) {
+                if (true) {
                     add(widgetPromptStep(ctx))
                     add(addWidgetStep(ctx))
                 }
diff --git a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
index b6a1e4d352..41a8d85ad4 100644
--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
@@ -58,6 +58,6 @@ interface OnboardingBrandDesignUpdateToggles {
     /**
      * Selects the config-driven renderer for the brand-design onboarding dialogs.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun configDrivenDialogs(): Toggle
 }

```
_base flow_
- [x] Clean install.
- [x] Verify add to dock step:
  - [x] Transitions to a card that has no arrow/Dax but doesn't sink to the middle/bottom of the screen, including on tablets.
  - [x] Renders video correctly, also after rotation
- [x] Verify add widget step:
  - [x] Opens the system dialog on primary click.
  - [x] Skips on secondary click.

_skip flow_
- [x] Clean install.
- [x] Click "I've been here before".
- [x] Verify quick setup step:
  - [x] Toggle both switches (declining the system prompt reverts the switch),
  - [x] Open the address bar and search options bottom sheets
  - [x] Confirm configuration and verify it's applied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches onboarding default-browser and widget flows with OS callbacks and settings intents; mistakes could mis-sync UI or skip plan events, but changes are scoped to config-driven onboarding with strong test coverage.
> 
> **Overview**
> Ports **Add to Dock**, **Widget Prompt**, and **Quick Setup** into the config-driven onboarding renderer so they render as real cards instead of being auto-skipped in `handleCommandOnlyDialog`.
> 
> **Add to Dock** and **Widget Prompt** get new `ContentConfig` types, `DialogConfigResolver` mappings, and binders (`AddToDockBinder` with looping tutorial video; `WidgetPromptBinder` for static copy). **Quick Setup** is a stateful screen with toggles for default browser and widget, rows for address bar position and search/AI options, and primary CTA that submits `QuickSetupConfirmed` with the live state.
> 
> The view model adds **Quick Setup orchestration**: `ContentInteraction` handlers mirror switch state before side effects, commands for quick-setup default-browser dialog, system settings, add-widget prompt, remove-widget sheet, and the two quick-setup bottom sheets; `syncQuickSetupSwitches` on resume (and when settings cannot open) resyncs from `DefaultBrowserDetector` and widget install state; quick-setup default-browser results update stores without advancing the plan or firing the shared onboarding default-browser pixels.
> 
> `ConfigDrivenWelcomePageFragment` registers a separate activity result for quick-setup default browser, bottom sheet result listeners, and maps the new commands—including `AddWidgetSource.ONBOARDING` for the widget prompt path.
> 
> Tests cover resolver output and the quick-setup state/command behavior (toggle correction, isolation from standalone add-widget step).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34763b9344bed805aed7700e53bcd0b5353f1fb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->