### PR TITLE
Remove gzip exclusion from /sync/devices endpoint now that backend supports it

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncGzipInterceptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncGzipInterceptor.kt
@@ -54,11 +54,8 @@ class SyncGzipInterceptor @Inject constructor(
             return chain.proceed(chain.request())
         }
 
-        // The /sync/devices endpoint rejects gzip bodies as invalid_json, so skip compression here until the backend supports it.
-        val isDevicesEndpoint = chain.request().url.encodedPath.endsWith("/sync/devices")
-
         // check if it's http operation is PATCH
-        if (chain.request().method == "PATCH" && !isDevicesEndpoint && syncFeature.gzipPatchRequests().isEnabled()) {
+        if (chain.request().method == "PATCH" && syncFeature.gzipPatchRequests().isEnabled()) {
             kotlin.runCatching {
                 val originalRequest = chain.request()
                 val body = originalRequest.body ?: return chain.proceed(originalRequest)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217193238272991?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
The backend now accepts gzipped `PATCH` bodies on `/sync/devices`. When we [first integrated](https://github.com/duckduckgo/Android/pull/9369) with this endpoint `gzip` wasn't supported, so `SyncGzipInterceptor` explicitly skipped compression for it. This removes that exclusion so devices `PATCH` requests are compressed like every other sync `PATCH`.

### Steps to test this PR
- QA optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how device PATCH payloads are sent to the sync API; compression failures still fall back to the uncompressed request via existing error handling.
> 
> **Overview**
> **`SyncGzipInterceptor`** no longer skips gzip for PATCH requests to **`/sync/devices`**. Those calls now follow the same rule as other sync PATCH traffic when **`gzipPatchRequests`** is enabled.
> 
> The workaround for backend **`invalid_json`** on gzipped device PATCH bodies is removed, along with the **`isDevicesEndpoint`** check and related comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40717bcbcee9da8a2859f3b9fa0efa20be2f969b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->