### PR TITLE
Measure changes using existing PageLoadWideEvent

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_page_load.json5
+++ b/PixelDefinitions/pixels/definitions/wide_page_load.json5
@@ -36,6 +36,31 @@
                 "enum": ["0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
             },
             {
+                "key": "feature.data.ext.elapsed_time_to_content_scope_experiments_ms_bucketed",
+                "description": "Duration from page_start until the active content scope experiments were resolved, bucketed. Uses lower end of the bucket. Recorded during the page_content_scope_experiments_resolved step, so it is absent when the navigation ended before the experiments resolved.",
+                "enum": ["0", "5", "10", "25", "50", "100", "200", "400", "800", "1600", "3200", "6400"]
+            },
+            {
+                "key": "feature.data.ext.elapsed_time_to_js_injection_complete_ms_bucketed",
+                "description": "Duration from page_start until every JS injector plugin has run for the navigation, content scope scripts among them, bucketed. Also covers resolving the active experiments and the browser tab's own page-started handling, so it is an upper bound on content scope injection rather than a measure of it alone. Uses lower end of the bucket. Recorded during the page_js_injection_complete step, so it is absent when the navigation ended before injection completed.",
+                "enum": ["0", "5", "10", "25", "50", "100", "200", "400", "800", "1600", "3200", "6400"]
+            },
+            {
+                "key": "feature.data.ext.content_scope_injection_optimized",
+                "description": "Whether the optimized content scope script assembly path is enabled. Temporary: recorded to compare the durations above across kill-switch states during rollout of the content scope performance work.",
+                "type": "boolean"
+            },
+            {
+                "key": "feature.data.ext.content_scope_messaging_optimized",
+                "description": "Whether inbound content scope JS messages are queued off the WebView JavaBridge thread. Temporary: recorded to compare overall page load time across kill-switch states during rollout of the content scope performance work.",
+                "type": "boolean"
+            },
+            {
+                "key": "feature.data.ext.content_scope_experiments_cached",
+                "description": "Whether resolved content scope experiments are held between privacy config updates. Temporary: recorded to compare the durations above across kill-switch states during rollout of the content scope performance work.",
+                "type": "boolean"
+            },
+            {
                 "key": "feature.data.ext.webview_version",
                 "description": "WebView major version",
                 "type": "string"
@@ -68,6 +93,16 @@
             {
                 "key": "feature.data.ext.step.page_start",
                 "description": "Parameter present when page load begins",
+                "type": "boolean"
+            },
+            {
+                "key": "feature.data.ext.step.page_content_scope_experiments_resolved",
+                "description": "Parameter present when the active content scope experiments have been resolved for the navigation",
+                "type": "boolean"
+            },
+            {
+                "key": "feature.data.ext.step.page_js_injection_complete",
+                "description": "Parameter present when every JS injector plugin has run for the navigation",
                 "type": "boolean"
             },
             {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -99,6 +99,7 @@ import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 
 private const val ABOUT_BLANK = "about:blank"
@@ -528,12 +529,15 @@ class BrowserWebViewClient @Inject constructor(
 
         lastInterceptedAppSchemeUrl = null
 
+        var wideEventNavigation: Pair<String, Long>? = null
         url?.let {
             // See https://app.asana.com/0/0/1206159443951489/f (WebView limitations)
             if (it != ABOUT_BLANK && start == null) {
                 start = currentTimeProvider.elapsedRealtime()
                 webViewClientListener?.getCurrentTabId()?.let { tabId ->
-                    pageLoadWideEvent.onPageStarted(tabId, it)
+                    val navigationId = wideEventNavigationIdCounter.incrementAndGet()
+                    pageLoadWideEvent.onPageStarted(tabId, it, navigationId)
+                    wideEventNavigation = tabId to navigationId
                 }
                 incrementAndTrackLoad() // increment the request counter
                 requestInterceptor.onPageStarted(url)
@@ -550,11 +554,21 @@ class BrowserWebViewClient @Inject constructor(
         }
         val navigationList = webView.safeCopyBackForwardList() ?: return
 
+        // This coroutine can outlive the navigation that scheduled it, so the measurements below are reported against
+        // the tab and navigation captured when the flow was started: the listener can be gone by then (tab closed
+        // mid-navigation), and the tab can already be loading something else, which must not claim them. Only a page
+        // start that began a flow reports them, so a mid-load hop leaves wideEventNavigation null.
         appCoroutineScope.launch(dispatcherProvider.main()) {
             val activeExperiments = contentScopeExperiments.getActiveExperiments()
+            wideEventNavigation?.let { (tabId, navigationId) ->
+                pageLoadWideEvent.onContentScopeExperimentsResolved(tabId, navigationId)
+            }
             webViewClientListener?.pageStarted(WebViewNavigationState(navigationList), activeExperiments)
             jsPlugins.getPlugins().forEach {
                 it.onPageStarted(webView, url, webViewClientListener?.getSite()?.isDesktopMode, activeExperiments)
+            }
+            wideEventNavigation?.let { (tabId, navigationId) ->
+                pageLoadWideEvent.onJsInjectionComplete(tabId, navigationId)
             }
         }
         if (url != null && url == lastPageStarted) {
@@ -989,6 +1003,12 @@ class BrowserWebViewClient @Inject constructor(
 
     companion object {
         val parallelRequestCounter = AtomicInteger(0)
+
+        // Identifies each navigation that starts a page load wide event flow, so a measurement reported once that
+        // navigation may already be over cannot be attributed to a later one. Static, because a tab's client is
+        // recreated with the tab's fragment while the flows and the coroutines reporting into them outlive it.
+        private val wideEventNavigationIdCounter = AtomicLong(0)
+
         private val activeRequestTimeoutJobs = ConcurrentHashMap<String, Job>()
         private const val REQUEST_TIMEOUT_MS = 30000L // 30 seconds
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -554,10 +554,6 @@ class BrowserWebViewClient @Inject constructor(
         }
         val navigationList = webView.safeCopyBackForwardList() ?: return
 
-        // This coroutine can outlive the navigation that scheduled it, so the measurements below are reported against
-        // the tab and navigation captured when the flow was started: the listener can be gone by then (tab closed
-        // mid-navigation), and the tab can already be loading something else, which must not claim them. Only a page
-        // start that began a flow reports them, so a mid-load hop leaves wideEventNavigation null.
         appCoroutineScope.launch(dispatcherProvider.main()) {
             val activeExperiments = contentScopeExperiments.getActiveExperiments()
             wideEventNavigation?.let { (tabId, navigationId) ->

--- a/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.autoconsent.api.Autoconsent
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.contentscopescripts.api.ContentScopeOptimizations
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.Lazy
@@ -54,8 +55,11 @@ interface PageLoadWideEvent {
      * Called when a page starts loading.
      * @param tabId The unique identifier for the tab
      * @param url The URL of the page being loaded
+     * @param navigationId Identifies this navigation for the measurements that are reported against it later. Must be
+     * unique for the lifetime of the process, and the same value must be passed to [onContentScopeExperimentsResolved]
+     * and [onJsInjectionComplete] for this navigation.
      */
-    fun onPageStarted(tabId: String, url: String)
+    fun onPageStarted(tabId: String, url: String, navigationId: Long)
 
     /**
      * Called when a page becomes visible to the user.
@@ -71,6 +75,24 @@ interface PageLoadWideEvent {
      * @param url The URL of the page being loaded
      */
     fun onProgressChanged(tabId: String, url: String)
+
+    /**
+     * Called once the active content scope experiments have been resolved, which page start awaits before it can inject.
+     *
+     * Attributed by [navigationId] rather than by url, because callers defer this past the point where their navigation
+     * can end: a later load of the same url in the same tab would otherwise be able to claim the measurement.
+     * @param tabId The unique identifier for the tab
+     * @param navigationId The id given to [onPageStarted] for the navigation that triggered the injection
+     */
+    fun onContentScopeExperimentsResolved(tabId: String, navigationId: Long)
+
+    /**
+     * Called once every [com.duckduckgo.browser.api.JsInjectorPlugin] has run for this navigation, content scope
+     * scripts among them.
+     * @param tabId The unique identifier for the tab
+     * @param navigationId The id given to [onPageStarted] for the navigation that triggered the injection
+     */
+    fun onJsInjectionComplete(tabId: String, navigationId: Long)
 
     /**
      * Called when a page finishes loading (either successfully or with an error).
@@ -98,6 +120,7 @@ class RealPageLoadWideEvent @Inject constructor(
     private val webViewVersionProvider: WebViewVersionProvider,
     private val autoconsent: Autoconsent,
     private val optimizeTrackerEvaluationRCWrapper: OptimizeTrackerEvaluationRCWrapper,
+    private val contentScopeOptimizations: ContentScopeOptimizations,
     private val androidBrowserConfigFeature: Lazy<AndroidBrowserConfigFeature>,
     private val currentTimeProvider: CurrentTimeProvider,
     private val dispatchers: DispatcherProvider,
@@ -114,8 +137,9 @@ class RealPageLoadWideEvent @Inject constructor(
     private val mutex = Mutex()
     private val activeFlows = ConcurrentHashMap<String, PageLoadState>()
 
-    override fun onPageStarted(tabId: String, url: String) {
+    override fun onPageStarted(tabId: String, url: String, navigationId: Long) {
         if (!shouldTrackUrl(url)) return
+        val startedAt = currentTimeProvider.elapsedRealtime()
         coroutineScope.launch {
             mutex.withLock {
                 if (!isFeatureEnabled()) return@launch
@@ -134,7 +158,7 @@ class RealPageLoadWideEvent @Inject constructor(
                 )
 
                 result.onSuccess { flowId ->
-                    activeFlows[tabId] = PageLoadState(flowId, url)
+                    activeFlows[tabId] = PageLoadState(flowId, url, navigationId, startedAt)
                     logcat { "Page load flow started: tabId=$tabId, url=$url, flowId=$flowId" }
 
                     wideEventClient.flowStep(
@@ -185,6 +209,24 @@ class RealPageLoadWideEvent @Inject constructor(
         }
     }
 
+    override fun onContentScopeExperimentsResolved(tabId: String, navigationId: Long) {
+        recordElapsedSincePageStart(
+            tabId = tabId,
+            navigationId = navigationId,
+            stepName = STEP_CONTENT_SCOPE_EXPERIMENTS_RESOLVED,
+            key = KEY_ELAPSED_TIME_TO_CONTENT_SCOPE_EXPERIMENTS,
+        )
+    }
+
+    override fun onJsInjectionComplete(tabId: String, navigationId: Long) {
+        recordElapsedSincePageStart(
+            tabId = tabId,
+            navigationId = navigationId,
+            stepName = STEP_JS_INJECTION_COMPLETE,
+            key = KEY_ELAPSED_TIME_TO_JS_INJECTION_COMPLETE,
+        )
+    }
+
     override fun onProgressChanged(tabId: String, url: String) {
         updateWideEventAsync(tabId, url) { flowId ->
             wideEventClient.intervalEnd(
@@ -227,6 +269,8 @@ class RealPageLoadWideEvent @Inject constructor(
                 },
             )
 
+            val optimizations = contentScopeOptimizations.current()
+
             val flowStatus = if (isSuccess) {
                 FlowStatus.Success
             } else {
@@ -242,6 +286,9 @@ class RealPageLoadWideEvent @Inject constructor(
                     KEY_IS_TAB_IN_FOREGROUND_ON_FINISH to isTabInForegroundOnFinish.toString(),
                     KEY_ACTIVE_REQUESTS_ON_LOAD_START to activeRequestsOnLoadStart.toString(),
                     KEY_CONCURRENT_REQUESTS_ON_FINISH to concurrentRequestsOnFinish.toString(),
+                    KEY_CONTENT_SCOPE_INJECTION_OPTIMIZED to optimizations.injectionOptimized.toString(),
+                    KEY_CONTENT_SCOPE_MESSAGING_OPTIMIZED to optimizations.messagingOptimized.toString(),
+                    KEY_CONTENT_SCOPE_EXPERIMENTS_CACHED to optimizations.experimentsCached.toString(),
                 ),
             )
 
@@ -251,9 +298,7 @@ class RealPageLoadWideEvent @Inject constructor(
 
     private fun isInProgress(tabId: String, url: String): Boolean {
         val state = activeFlows[tabId] ?: return false
-        val ageMillis = currentTimeProvider.currentTimeMillis() - state.createdAt
-        val isStale = ageMillis > CLEANUP_TIMEOUT.inWholeMilliseconds
-        return state.url == url && !isStale
+        return state.url == url && !state.isStale()
     }
 
     private fun shouldTrackUrl(url: String): Boolean {
@@ -263,6 +308,48 @@ class RealPageLoadWideEvent @Inject constructor(
             PageLoadedSites.perfSites.any { site -> UriString.sameOrSubdomain(url, site) }
         }.getOrDefault(false)
     }
+
+    /**
+     * These durations are milliseconds wide, so they cannot be measured with [WideEventClient.intervalStart] /
+     * [WideEventClient.intervalEnd].
+     */
+    private fun recordElapsedSincePageStart(
+        tabId: String,
+        navigationId: Long,
+        stepName: String,
+        key: String,
+    ) {
+        val measuredAt = currentTimeProvider.elapsedRealtime()
+        coroutineScope.launch {
+            mutex.withLock {
+                if (!isFeatureEnabled()) return@withLock
+                val state = activeFlows[tabId] ?: return@withLock
+                // Matched on the navigation rather than the url: callers defer these measurements past the point where
+                // their navigation can end, and a later load of the same url in this tab must not claim them.
+                if (state.navigationId != navigationId) {
+                    logcat { "Dropping $key from navigation $navigationId, tabId=$tabId is on ${state.navigationId}" }
+                    return@withLock
+                }
+                if (state.isStale()) return@withLock
+                // First value wins, so a callback repeated for this navigation cannot overwrite the measurement already
+                // taken for it.
+                if (!state.recordedMeasurementKeys.add(key)) {
+                    logcat { "Ignoring repeat $key measurement for flowId=${state.flowId}" }
+                    return@withLock
+                }
+                val bucket = lowerBoundBucket(measuredAt - state.startedAt)
+                wideEventClient.flowStep(
+                    wideEventId = state.flowId,
+                    stepName = stepName,
+                    metadata = mapOf(key to bucket),
+                )
+                logcat { "Recorded $key=$bucket for flowId=${state.flowId}" }
+            }
+        }
+    }
+
+    private fun lowerBoundBucket(durationMs: Long): String =
+        (CONTENT_SCOPE_BUCKETS_MS.lastOrNull { it <= durationMs } ?: 0L).toString()
 
     private fun updateWideEventAsync(
         tabId: String,
@@ -301,8 +388,15 @@ class RealPageLoadWideEvent @Inject constructor(
     private inner class PageLoadState(
         val flowId: Long,
         val url: String,
+        val navigationId: Long,
+        val startedAt: Long,
         val createdAt: Long = currentTimeProvider.currentTimeMillis(),
-    )
+    ) {
+        val recordedMeasurementKeys: MutableSet<String> = mutableSetOf()
+
+        fun isStale(): Boolean =
+            currentTimeProvider.currentTimeMillis() - createdAt > CLEANUP_TIMEOUT.inWholeMilliseconds
+    }
 
     private companion object {
         const val ABOUT_BLANK = "about:blank"
@@ -317,14 +411,23 @@ class RealPageLoadWideEvent @Inject constructor(
             30.seconds,
             1.minutes,
         )
+
+        val CONTENT_SCOPE_BUCKETS_MS: List<Long> = listOf(5, 10, 25, 50, 100, 200, 400, 800, 1600, 3200, 6400)
         const val PAGE_LOAD_FEATURE_NAME = "page-load"
         const val STEP_PAGE_START = "page_start"
         const val STEP_PAGE_VISIBLE = "page_visible"
         const val STEP_PAGE_ESCAPED_FIXED_PROGRESS = "page_escaped_fixed_progress"
         const val STEP_PAGE_FINISH = "page_finish"
+        const val STEP_CONTENT_SCOPE_EXPERIMENTS_RESOLVED = "page_content_scope_experiments_resolved"
+        const val STEP_JS_INJECTION_COMPLETE = "page_js_injection_complete"
         const val KEY_ELAPSED_TIME_TO_FINISH = "elapsed_time_to_finish_ms_bucketed"
         const val KEY_ELAPSED_TIME_TO_VISIBLE = "elapsed_time_to_visible_ms_bucketed"
         const val KEY_ELAPSED_TIME_TO_ESCAPED_FIXED_PROGRESS = "elapsed_time_to_escaped_fixed_progress_ms_bucketed"
+        const val KEY_ELAPSED_TIME_TO_CONTENT_SCOPE_EXPERIMENTS = "elapsed_time_to_content_scope_experiments_ms_bucketed"
+        const val KEY_ELAPSED_TIME_TO_JS_INJECTION_COMPLETE = "elapsed_time_to_js_injection_complete_ms_bucketed"
+        const val KEY_CONTENT_SCOPE_INJECTION_OPTIMIZED = "content_scope_injection_optimized"
+        const val KEY_CONTENT_SCOPE_MESSAGING_OPTIMIZED = "content_scope_messaging_optimized"
+        const val KEY_CONTENT_SCOPE_EXPERIMENTS_CACHED = "content_scope_experiments_cached"
         const val KEY_PROGRESS = "progress"
         const val KEY_OUTCOME = "outcome"
         const val KEY_ERROR_CODE = "error_code"

--- a/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
@@ -159,7 +159,7 @@ class RealPageLoadWideEvent @Inject constructor(
 
                 result.onSuccess { flowId ->
                     activeFlows[tabId] = PageLoadState(flowId, url, navigationId, startedAt)
-                    logcat { "Page load flow started: tabId=$tabId, url=$url, flowId=$flowId" }
+                    logcat { "Page load flow started: tabId=$tabId, url=$url, flowId=$flowId, navigationId=$navigationId" }
 
                     wideEventClient.flowStep(
                         wideEventId = flowId,

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -97,6 +97,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -104,8 +105,10 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -1449,7 +1452,81 @@ class BrowserWebViewClientTest {
         whenever(mockWebView.settings).thenReturn(mock())
         whenever(listener.getCurrentTabId()).thenReturn(tabId)
         testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
-        verify(pageLoadWideEvent).onPageStarted(tabId, EXAMPLE_URL)
+        verify(pageLoadWideEvent).onPageStarted(eq(tabId), eq(EXAMPLE_URL), any())
+    }
+
+    @Test
+    fun whenPageStartedThenJsInjectionCompleteRecordedOnlyAfterEveryPluginRan() {
+        val mockWebView = getImmediatelyInvokedMockWebView()
+        val tabId = "test-tab-123"
+        whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
+        whenever(mockWebView.settings).thenReturn(mock())
+        whenever(listener.getCurrentTabId()).thenReturn(tabId)
+        var pluginsStartedWhenRecorded = -1
+        doAnswer { pluginsStartedWhenRecorded = jsPlugins.plugin.countStarted }
+            .whenever(pageLoadWideEvent).onJsInjectionComplete(any(), any())
+
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+
+        assertEquals(1, pluginsStartedWhenRecorded)
+        val navigationId = argumentCaptor<Long>()
+        verify(pageLoadWideEvent).onPageStarted(eq(tabId), eq(EXAMPLE_URL), navigationId.capture())
+        inOrder(pageLoadWideEvent, listener).apply {
+            verify(pageLoadWideEvent).onContentScopeExperimentsResolved(tabId, navigationId.firstValue)
+            verify(listener).pageStarted(any(), any())
+            verify(pageLoadWideEvent).onJsInjectionComplete(tabId, navigationId.firstValue)
+        }
+    }
+
+    @Test
+    fun whenPageStartedAgainMidLoadThenOnlyTheNavigationThatStartedTheFlowReportsMeasurements() {
+        val mockWebView = getImmediatelyInvokedMockWebView()
+        val tabId = "test-tab-123"
+        whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
+        whenever(mockWebView.settings).thenReturn(mock())
+        whenever(listener.getCurrentTabId()).thenReturn(tabId)
+
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        // A hop within the same load does not start a flow, so its deferred measurements have no navigation to land on.
+        testee.onPageStarted(mockWebView, "$EXAMPLE_URL/redirected", null)
+
+        verify(pageLoadWideEvent, times(1)).onPageStarted(any(), any(), any())
+        verify(pageLoadWideEvent, times(1)).onContentScopeExperimentsResolved(any(), any())
+        verify(pageLoadWideEvent, times(1)).onJsInjectionComplete(any(), any())
+    }
+
+    @Test
+    fun whenPageStartedTwiceForSeparateLoadsThenEachReportsItsOwnNavigationId() {
+        val mockWebView = getImmediatelyInvokedMockWebView()
+        val tabId = "test-tab-123"
+        whenever(mockWebView.progress).thenReturn(100)
+        whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
+        whenever(mockWebView.settings).thenReturn(mock())
+        whenever(listener.getCurrentTabId()).thenReturn(tabId)
+        whenever(listener.isTabInForeground()).thenReturn(true)
+
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        testee.onPageFinished(mockWebView, EXAMPLE_URL)
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+
+        val navigationIds = argumentCaptor<Long>()
+        verify(pageLoadWideEvent, times(2)).onPageStarted(eq(tabId), eq(EXAMPLE_URL), navigationIds.capture())
+        assertNotEquals(navigationIds.firstValue, navigationIds.secondValue)
+        verify(pageLoadWideEvent).onJsInjectionComplete(tabId, navigationIds.firstValue)
+        verify(pageLoadWideEvent).onJsInjectionComplete(tabId, navigationIds.secondValue)
+    }
+
+    @Test
+    fun whenPageStartedWithoutTabIdThenJsInjectionCompleteNotRecorded() {
+        val mockWebView = getImmediatelyInvokedMockWebView()
+        whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
+        whenever(mockWebView.settings).thenReturn(mock())
+        whenever(listener.getCurrentTabId()).thenReturn(null)
+
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+
+        verify(pageLoadWideEvent, never()).onContentScopeExperimentsResolved(any(), any())
+        verify(pageLoadWideEvent, never()).onJsInjectionComplete(any(), any())
     }
 
     @Test
@@ -1460,7 +1537,7 @@ class BrowserWebViewClientTest {
         whenever(mockWebView.settings).thenReturn(mock())
         whenever(listener.getCurrentTabId()).thenReturn(tabId)
         testee.onPageStarted(mockWebView, "about:blank", null)
-        verify(pageLoadWideEvent, never()).onPageStarted(any(), any())
+        verify(pageLoadWideEvent, never()).onPageStarted(any(), any(), any())
     }
 
     @Test
@@ -1470,7 +1547,7 @@ class BrowserWebViewClientTest {
         whenever(mockWebView.settings).thenReturn(mock())
         whenever(listener.getCurrentTabId()).thenReturn(null)
         testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
-        verify(pageLoadWideEvent, never()).onPageStarted(any(), any())
+        verify(pageLoadWideEvent, never()).onPageStarted(any(), any(), any())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/pageload/PageLoadWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pageload/PageLoadWideEventTest.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.autoconsent.api.Autoconsent
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.contentscopescripts.api.ContentScopeOptimizations
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -52,6 +53,7 @@ class PageLoadWideEventTest {
     private val optimizeTrackerEvaluationRCWrapper: OptimizeTrackerEvaluationRCWrapper = mock()
     private val currentTimeProvider: CurrentTimeProvider = mock()
     private val androidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+    private val contentScopeOptimizations = FakeContentScopeOptimizations()
 
     private lateinit var pageLoadWideEvent: PageLoadWideEvent
 
@@ -77,6 +79,7 @@ class PageLoadWideEventTest {
             webViewVersionProvider = webViewVersionProvider,
             autoconsent = autoconsent,
             optimizeTrackerEvaluationRCWrapper = optimizeTrackerEvaluationRCWrapper,
+            contentScopeOptimizations = contentScopeOptimizations,
             androidBrowserConfigFeature = { androidBrowserConfigFeature },
             currentTimeProvider = currentTimeProvider,
             dispatchers = coroutineRule.testDispatcherProvider,
@@ -89,7 +92,7 @@ class PageLoadWideEventTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(Result.success(123L))
 
-        pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com")
+        pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         verify(wideEventClient).flowStart(
@@ -107,6 +110,197 @@ class PageLoadWideEventTest {
         verify(wideEventClient).intervalStart(eq(123L), eq("elapsed_time_to_finish_ms_bucketed"), eq(null), any())
         verify(wideEventClient).intervalStart(eq(123L), eq("elapsed_time_to_visible_ms_bucketed"), eq(null), any())
         verify(wideEventClient).intervalStart(eq(123L), eq("elapsed_time_to_escaped_fixed_progress_ms_bucketed"), eq(null), any())
+        verify(wideEventClient, never()).intervalStart(eq(123L), eq("elapsed_time_to_content_scope_experiments_ms_bucketed"), any(), any())
+        verify(wideEventClient, never()).intervalStart(eq(123L), eq("elapsed_time_to_js_injection_complete_ms_bucketed"), any(), any())
+    }
+
+    @Test
+    fun `when content scope measurements taken then bucketed durations are recorded as step metadata`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+            .thenReturn(Result.success(777L))
+        whenever(currentTimeProvider.elapsedRealtime()).thenReturn(1_000L, 1_030L, 1_260L)
+
+        pageLoadWideEvent.onPageStarted("tab_cs", "https://reddit.com", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        pageLoadWideEvent.onContentScopeExperimentsResolved("tab_cs", 1L)
+        pageLoadWideEvent.onJsInjectionComplete("tab_cs", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowStep(
+            wideEventId = 777L,
+            stepName = "page_content_scope_experiments_resolved",
+            metadata = mapOf("elapsed_time_to_content_scope_experiments_ms_bucketed" to "25"),
+        )
+        verify(wideEventClient).flowStep(
+            wideEventId = 777L,
+            stepName = "page_js_injection_complete",
+            metadata = mapOf("elapsed_time_to_js_injection_complete_ms_bucketed" to "200"),
+        )
+    }
+
+    @Test
+    fun `when measurement is faster than the smallest bucket then it is recorded as zero`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+            .thenReturn(Result.success(777L))
+        whenever(currentTimeProvider.elapsedRealtime()).thenReturn(1_000L, 1_002L)
+
+        pageLoadWideEvent.onPageStarted("tab_cs", "https://reddit.com", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        pageLoadWideEvent.onContentScopeExperimentsResolved("tab_cs", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowStep(
+            wideEventId = 777L,
+            stepName = "page_content_scope_experiments_resolved",
+            metadata = mapOf("elapsed_time_to_content_scope_experiments_ms_bucketed" to "0"),
+        )
+    }
+
+    @Test
+    fun `when a measurement is taken twice for the same navigation then the first one is kept`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+            .thenReturn(Result.success(778L))
+        whenever(currentTimeProvider.elapsedRealtime()).thenReturn(1_000L, 1_030L, 1_500L)
+
+        pageLoadWideEvent.onPageStarted("tab_cs", "https://reddit.com", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        pageLoadWideEvent.onJsInjectionComplete("tab_cs", 1L)
+        pageLoadWideEvent.onJsInjectionComplete("tab_cs", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient, times(1)).flowStep(eq(778L), eq("page_js_injection_complete"), any(), any())
+        verify(wideEventClient).flowStep(
+            wideEventId = 778L,
+            stepName = "page_js_injection_complete",
+            metadata = mapOf("elapsed_time_to_js_injection_complete_ms_bucketed" to "25"),
+        )
+    }
+
+    @Test
+    fun `when a measurement is taken before the flow start is processed then it is still recorded`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+            .thenReturn(Result.success(780L))
+        whenever(currentTimeProvider.elapsedRealtime()).thenReturn(1_000L, 1_060L)
+
+        // No advanceUntilIdle in between: the measurement is submitted to the serialized scope while the flow start is
+        // still queued ahead of it, which is what happens in production.
+        pageLoadWideEvent.onPageStarted("tab_cs", "https://reddit.com", 1L)
+        pageLoadWideEvent.onJsInjectionComplete("tab_cs", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowStep(
+            wideEventId = 780L,
+            stepName = "page_js_injection_complete",
+            metadata = mapOf("elapsed_time_to_js_injection_complete_ms_bucketed" to "50"),
+        )
+    }
+
+    @Test
+    fun `when measurement is for a navigation the flow did not start with then it is not recorded`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+            .thenReturn(Result.success(779L))
+        whenever(currentTimeProvider.elapsedRealtime()).thenReturn(1_000L, 1_030L)
+
+        pageLoadWideEvent.onPageStarted("tab_cs", "https://reddit.com", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        // A later navigation in this tab reports its injection. Dropping it is deliberate: this flow was started for a
+        // different navigation, so measuring from its page start would report a duration that never happened.
+        pageLoadWideEvent.onJsInjectionComplete("tab_cs", 2L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient, never()).flowStep(any(), eq("page_js_injection_complete"), any(), any())
+    }
+
+    @Test
+    fun `when a stale measurement arrives after the same url reloaded then the new flow keeps its own`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+            .thenReturn(Result.success(783L))
+            .thenReturn(Result.success(784L))
+        whenever(currentTimeProvider.elapsedRealtime()).thenReturn(1_000L, 5_000L, 5_040L, 5_100L)
+
+        pageLoadWideEvent.onPageStarted("tab_cs", "https://reddit.com", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        finishPageLoad("tab_cs", "https://reddit.com")
+        // The same url loads again in this tab while the first navigation's deferred callback is still pending, so the
+        // late measurement arrives with a live flow in place for the same tab and url.
+        pageLoadWideEvent.onPageStarted("tab_cs", "https://reddit.com", 2L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        pageLoadWideEvent.onJsInjectionComplete("tab_cs", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient, never()).flowStep(any(), eq("page_js_injection_complete"), any(), any())
+
+        pageLoadWideEvent.onJsInjectionComplete("tab_cs", 2L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        // Measured from the second navigation's page start, and not blocked by the stale one having been seen first.
+        verify(wideEventClient).flowStep(
+            wideEventId = 784L,
+            stepName = "page_js_injection_complete",
+            metadata = mapOf("elapsed_time_to_js_injection_complete_ms_bucketed" to "100"),
+        )
+    }
+
+    @Test
+    fun `when a measurement is taken after the flow finished then it is not recorded`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+            .thenReturn(Result.success(782L))
+        whenever(currentTimeProvider.elapsedRealtime()).thenReturn(1_000L, 1_030L)
+
+        pageLoadWideEvent.onPageStarted("tab_cs", "https://reddit.com", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        finishPageLoad("tab_cs", "https://reddit.com")
+        pageLoadWideEvent.onJsInjectionComplete("tab_cs", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient, never()).flowStep(any(), eq("page_js_injection_complete"), any(), any())
+    }
+
+    @Test
+    fun `when no flow is active then content scope measurements are dropped`() = runTest {
+        pageLoadWideEvent.onJsInjectionComplete("tab_without_flow", 1L)
+        pageLoadWideEvent.onContentScopeExperimentsResolved("tab_without_flow", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verifyNoInteractions(wideEventClient)
+    }
+
+    @Test
+    fun `when content scope optimizations differ then each one is reported under its own key`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+            .thenReturn(Result.success(781L))
+        contentScopeOptimizations.state = ContentScopeOptimizations.State(
+            injectionOptimized = true,
+            messagingOptimized = false,
+            experimentsCached = true,
+        )
+
+        pageLoadWideEvent.onPageStarted("tab_cs", "https://reddit.com", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        finishPageLoad("tab_cs", "https://reddit.com")
+
+        val metadata = capturedFlowFinishMetadata(781L)
+        assertEquals("true", metadata["content_scope_injection_optimized"])
+        assertEquals("false", metadata["content_scope_messaging_optimized"])
+        assertEquals("true", metadata["content_scope_experiments_cached"])
+    }
+
+    private fun finishPageLoad(tabId: String, url: String) {
+        pageLoadWideEvent.onPageLoadFinished(
+            tabId = tabId,
+            url = url,
+            errorDescription = null,
+            isTabInForegroundOnFinish = true,
+            activeRequestsOnLoadStart = 0,
+            concurrentRequestsOnFinish = 0,
+        )
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+    }
+
+    private suspend fun capturedFlowFinishMetadata(flowId: Long): Map<String, String> {
+        val captor = argumentCaptor<Map<String, String>>()
+        verify(wideEventClient).flowFinish(eq(flowId), any(), captor.capture())
+        return captor.firstValue
     }
 
     @Test
@@ -114,7 +308,7 @@ class PageLoadWideEventTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(Result.success(456L))
 
-        pageLoadWideEvent.onPageStarted("tab_2", "https://twitter.com")
+        pageLoadWideEvent.onPageStarted("tab_2", "https://twitter.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
         pageLoadWideEvent.onPageVisible("tab_2", "https://twitter.com", 50)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
@@ -142,7 +336,7 @@ class PageLoadWideEventTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(Result.success(789L))
 
-        pageLoadWideEvent.onPageStarted("tab_3", "https://reddit.com")
+        pageLoadWideEvent.onPageStarted("tab_3", "https://reddit.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
         pageLoadWideEvent.onProgressChanged("tab_3", "https://reddit.com")
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
@@ -168,7 +362,7 @@ class PageLoadWideEventTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(Result.success(999L))
 
-        pageLoadWideEvent.onPageStarted("tab_4", "https://espn.com")
+        pageLoadWideEvent.onPageStarted("tab_4", "https://espn.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
         pageLoadWideEvent.onPageLoadFinished(
             tabId = "tab_4",
@@ -197,6 +391,9 @@ class PageLoadWideEventTest {
                 "is_tab_in_foreground_on_finish" to "true",
                 "active_requests_on_load_start" to "5",
                 "concurrent_requests_on_finish" to "2",
+                "content_scope_injection_optimized" to "true",
+                "content_scope_messaging_optimized" to "true",
+                "content_scope_experiments_cached" to "true",
             ),
         )
     }
@@ -206,7 +403,7 @@ class PageLoadWideEventTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(Result.success(888L))
 
-        pageLoadWideEvent.onPageStarted("tab_5", "https://wikipedia.org")
+        pageLoadWideEvent.onPageStarted("tab_5", "https://wikipedia.org", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
         pageLoadWideEvent.onPageLoadFinished(
             tabId = "tab_5",
@@ -237,6 +434,9 @@ class PageLoadWideEventTest {
                 "is_tab_in_foreground_on_finish" to "false",
                 "active_requests_on_load_start" to "3",
                 "concurrent_requests_on_finish" to "0",
+                "content_scope_injection_optimized" to "true",
+                "content_scope_messaging_optimized" to "true",
+                "content_scope_experiments_cached" to "true",
             ),
         )
     }
@@ -262,7 +462,7 @@ class PageLoadWideEventTest {
     fun `when feature disabled then results in no interactions`() = runTest {
         androidBrowserConfigFeature.sendPageLoadWideEvent().setRawStoredState(Toggle.State(false))
 
-        pageLoadWideEvent.onPageStarted("tab_9", "https://github.com")
+        pageLoadWideEvent.onPageStarted("tab_9", "https://github.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
         pageLoadWideEvent.onPageVisible("tab_9", "https://github.com", 50)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
@@ -287,9 +487,9 @@ class PageLoadWideEventTest {
             .thenReturn(Result.success(100L))
             .thenReturn(Result.success(200L))
 
-        pageLoadWideEvent.onPageStarted("tab_a", "https://ebay.com")
+        pageLoadWideEvent.onPageStarted("tab_a", "https://ebay.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
-        pageLoadWideEvent.onPageStarted("tab_b", "https://weather.com")
+        pageLoadWideEvent.onPageStarted("tab_b", "https://weather.com", 2L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         pageLoadWideEvent.onPageVisible("tab_a", "https://ebay.com", 30)
@@ -316,7 +516,7 @@ class PageLoadWideEventTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(Result.failure(Exception("Flow start failed")))
 
-        pageLoadWideEvent.onPageStarted("tab_fail", "https://reddit.com")
+        pageLoadWideEvent.onPageStarted("tab_fail", "https://reddit.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Should not crash and should not call flowStep
@@ -330,7 +530,7 @@ class PageLoadWideEventTest {
             .thenReturn(Result.success(500L))
 
         // Start page load
-        pageLoadWideEvent.onPageStarted("tab_complete", "https://duckduckgo.com")
+        pageLoadWideEvent.onPageStarted("tab_complete", "https://duckduckgo.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Page becomes visible
@@ -382,11 +582,11 @@ class PageLoadWideEventTest {
             .thenReturn(Result.success(900L))
 
         // Start first page load
-        pageLoadWideEvent.onPageStarted("tab_8", "https://espn.com")
+        pageLoadWideEvent.onPageStarted("tab_8", "https://espn.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Start second page load with different URL - should abort first flow
-        pageLoadWideEvent.onPageStarted("tab_8", "https://twitter.com")
+        pageLoadWideEvent.onPageStarted("tab_8", "https://twitter.com", 2L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Verify first flow was aborted
@@ -402,9 +602,9 @@ class PageLoadWideEventTest {
             .thenReturn(Result.success(1000L))
 
         // Start page load twice with same URL
-        pageLoadWideEvent.onPageStarted("tab_10", "https://reddit.com")
+        pageLoadWideEvent.onPageStarted("tab_10", "https://reddit.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
-        pageLoadWideEvent.onPageStarted("tab_10", "https://reddit.com")
+        pageLoadWideEvent.onPageStarted("tab_10", "https://reddit.com", 2L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Verify flowStart was only called once and flowAbort was never called
@@ -414,7 +614,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when onPageStarted called with about blank then does not start flow`() = runTest {
-        pageLoadWideEvent.onPageStarted("tab_1", "about:blank")
+        pageLoadWideEvent.onPageStarted("tab_1", "about:blank", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Verify flowStart was never called
@@ -424,7 +624,7 @@ class PageLoadWideEventTest {
     @Test
     fun `when onPageStarted called with untracked url then does not start flow`() = runTest {
         // example.com is not in PageLoadedSites.perfSites
-        pageLoadWideEvent.onPageStarted("tab_1", "https://untracked-site.com")
+        pageLoadWideEvent.onPageStarted("tab_1", "https://untracked-site.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Verify flowStart was never called
@@ -437,7 +637,7 @@ class PageLoadWideEventTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(Result.success(123L))
 
-        pageLoadWideEvent.onPageStarted("tab_1", "https://mobile.twitter.com/duckduckgo")
+        pageLoadWideEvent.onPageStarted("tab_1", "https://mobile.twitter.com/duckduckgo", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Verify flowStart was called
@@ -454,7 +654,7 @@ class PageLoadWideEventTest {
         // Start with a tracked URL
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(Result.success(123L))
-        pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com")
+        pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Clear invocations from setup
@@ -474,7 +674,7 @@ class PageLoadWideEventTest {
         // Start with a tracked URL
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(Result.success(123L))
-        pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com")
+        pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Clear invocations from setup
@@ -494,7 +694,7 @@ class PageLoadWideEventTest {
         // Start with a tracked URL
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(Result.success(123L))
-        pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com")
+        pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Clear invocations from setup
@@ -522,7 +722,7 @@ class PageLoadWideEventTest {
         // Start with a tracked URL
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(Result.success(123L))
-        pageLoadWideEvent.onPageStarted("tab_1", "https://espn.com")
+        pageLoadWideEvent.onPageStarted("tab_1", "https://espn.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Clear invocations from setup
@@ -543,5 +743,15 @@ class PageLoadWideEventTest {
         verify(wideEventClient, never()).flowStep(any(), any(), any(), any())
         verify(wideEventClient, never()).intervalEnd(any(), any())
         verify(wideEventClient, never()).flowFinish(any(), any(), any())
+    }
+
+    private class FakeContentScopeOptimizations : ContentScopeOptimizations {
+        var state = ContentScopeOptimizations.State(
+            injectionOptimized = true,
+            messagingOptimized = true,
+            experimentsCached = true,
+        )
+
+        override suspend fun current(): ContentScopeOptimizations.State = state
     }
 }

--- a/content-scope-scripts/content-scope-scripts-api/src/main/java/com/duckduckgo/contentscopescripts/api/ContentScopeOptimizations.kt
+++ b/content-scope-scripts/content-scope-scripts-api/src/main/java/com/duckduckgo/contentscopescripts/api/ContentScopeOptimizations.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.contentscopescripts.api
+
+/**
+ * Reports which of the content scope scripts performance optimisations are currently active.
+ *
+ * Intended for telemetry that measures work these optimisations affect, so a measurement can be attributed to the code
+ * path that produced it instead of being pooled across states. Not a way to branch behaviour: each optimisation is
+ * applied by content scope scripts itself, and consumers must not re-implement those decisions.
+ */
+interface ContentScopeOptimizations {
+
+    /**
+     * @return the state of each optimisation at the time of the call. The values are read live, so they reflect any
+     * privacy config update already applied, and two calls within one flow may disagree.
+     */
+    suspend fun current(): State
+
+    data class State(
+        /**
+         * Whether the optimised content scope script assembly path is in use.
+         */
+        val injectionOptimized: Boolean,
+        /**
+         * Whether inbound content scope JS messages are queued off the WebView JavaBridge thread.
+         */
+        val messagingOptimized: Boolean,
+        /**
+         * Whether resolved content scope experiments are held between privacy config updates.
+         */
+        val experimentsCached: Boolean,
+    )
+}

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeOptimizations.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeOptimizations.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.contentscopescripts.impl
+
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.contentscopescripts.api.ContentScopeOptimizations
+import com.duckduckgo.contentscopescripts.api.ContentScopeOptimizations.State
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+class RealContentScopeOptimizations @Inject constructor(
+    private val contentScopeScriptsFeature: ContentScopeScriptsFeature,
+    private val dispatcherProvider: DispatcherProvider,
+) : ContentScopeOptimizations {
+
+    override suspend fun current(): State = withContext(dispatcherProvider.io()) {
+        State(
+            injectionOptimized = contentScopeScriptsFeature.optimizeContentScopeInjection().isEnabled(),
+            messagingOptimized = contentScopeScriptsFeature.optimizeContentScopeMessaging().isEnabled(),
+            experimentsCached = contentScopeScriptsFeature.cacheContentScopeExperiments().isEnabled(),
+        )
+    }
+}

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeOptimizationsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeOptimizationsTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.contentscopescripts.impl
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class RealContentScopeOptimizationsTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val contentScopeScriptsFeature = FakeFeatureToggleFactory.create(ContentScopeScriptsFeature::class.java)
+
+    private val testee = RealContentScopeOptimizations(
+        contentScopeScriptsFeature = contentScopeScriptsFeature,
+        dispatcherProvider = coroutineRule.testDispatcherProvider,
+    )
+
+    @Test
+    fun whenEveryFlagIsEnabledThenEveryOptimizationIsReportedActive() = runTest {
+        setFlags(injection = true, messaging = true, experiments = true)
+
+        val state = testee.current()
+
+        assertTrue(state.injectionOptimized)
+        assertTrue(state.messagingOptimized)
+        assertTrue(state.experimentsCached)
+    }
+
+    @Test
+    fun whenEveryFlagIsDisabledThenNoOptimizationIsReportedActive() = runTest {
+        setFlags(injection = false, messaging = false, experiments = false)
+
+        val state = testee.current()
+
+        assertFalse(state.injectionOptimized)
+        assertFalse(state.messagingOptimized)
+        assertFalse(state.experimentsCached)
+    }
+
+    @Test
+    fun whenOnlyInjectionIsEnabledThenOnlyInjectionIsReportedActive() = runTest {
+        setFlags(injection = true, messaging = false, experiments = false)
+
+        val state = testee.current()
+
+        assertTrue(state.injectionOptimized)
+        assertFalse(state.messagingOptimized)
+        assertFalse(state.experimentsCached)
+    }
+
+    @Test
+    fun whenOnlyMessagingIsEnabledThenOnlyMessagingIsReportedActive() = runTest {
+        setFlags(injection = false, messaging = true, experiments = false)
+
+        val state = testee.current()
+
+        assertFalse(state.injectionOptimized)
+        assertTrue(state.messagingOptimized)
+        assertFalse(state.experimentsCached)
+    }
+
+    @Test
+    fun whenOnlyExperimentCachingIsEnabledThenOnlyExperimentCachingIsReportedActive() = runTest {
+        setFlags(injection = false, messaging = false, experiments = true)
+
+        val state = testee.current()
+
+        assertFalse(state.injectionOptimized)
+        assertFalse(state.messagingOptimized)
+        assertTrue(state.experimentsCached)
+    }
+
+    @Test
+    fun whenAFlagFlipsAfterAReadThenTheNextReadReportsTheNewValue() = runTest {
+        setFlags(injection = false, messaging = false, experiments = false)
+        assertFalse(testee.current().injectionOptimized)
+
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+
+        assertTrue(testee.current().injectionOptimized)
+    }
+
+    private fun setFlags(
+        injection: Boolean,
+        messaging: Boolean,
+        experiments: Boolean,
+    ) {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = injection))
+        contentScopeScriptsFeature.optimizeContentScopeMessaging().setRawStoredState(State(enable = messaging))
+        contentScopeScriptsFeature.cacheContentScopeExperiments().setRawStoredState(State(enable = experiments))
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1216755882810230?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1217073072365128?focus=true
API Proposals URL(s) (if applicable): https://app.asana.com/1/137249556945/project/1212087397361015/task/1217155210744833?focus=true

### Description

This PR adds two per-navigation measurements to the existing page-load flow:

  - elapsed_time_to_content_scope_experiments_ms_bucketed — page start until the active experiments resolve
  - elapsed_time_to_js_injection_complete_ms_bucketed — page start until every JS injector plugin has run

Both read the clock on the caller's thread and are written through as metadata on two new steps (page_content_scope_experiments_resolved, page_js_injection_complete), which the wide event client merges into the flow's metadata. They don't use intervalStart/intervalEnd because these durations are milliseconds wide, and the queueing and database latency behind those calls is of the same order as what's being measured. Millisecond-scale buckets (5…6400ms) for the same reason — the existing page-load buckets start at 1s and would flatten every value to zero.

Kill-switch state comes from a new ContentScopeOptimizations api in :content-scope-scripts-api, recorded as three booleans on flow finish. The api and those three fields are temporary and should be removed with the kill switches.

No behaviour change to page loading itself — telemetry only.

### Steps to test this PR

Prerequisite to be able to see the wide event as it's sent only by 5% and you're unlikely to be in that group:
Open `PageLoadWideEvent` and replace the:
```
    private suspend fun isFeatureEnabled(): Boolean = withContext(dispatchers.io()) {
        androidBrowserConfigFeature.get().sendPageLoadWideEvent().isEnabled()
    }
```

with:

`private suspend fun isFeatureEnabled(): Boolean = true`

- [x] Make the above changes, build and install the app. The 3 optimizations flags are enabled in internal.
- [x] Filter logcat by `wide_page-load`
- [x] Skip onboarding and navigate on sites like bbc.com, foxnews.com, wikipedia.org
- [x] Notice the wide event pixel is sent and contains:
1/ elapsed_time_to_content_scope_experiments_ms_bucketed
2/ elapsed_time_to_js_injection_complete_ms_bucketed
each value from {0, 5, 10, 25, 50, 100, 200, 400, 800, 1600, 3200, 6400}
3/ content_scope_injection_optimized=true
4/ content_scope_messaging_optimized=true
5/ content_scope_experiments_cached=true
- [x] From dev settings disable one of or all of the 3 flags: optimizeContentScopeInjection, optimizeContentScopeMessaging, cacheContentScopeExperiments and restart the app
- [x]  Navigate on sites like bbc.com, foxnews.com, wikipedia.org
- [x] Notice the wide event pixel is sent and the params from points 3-5 above have the value false if you disabled them.

Testing the specific issue cursorbot pointed earlier:
- [x] Run this to see the filtered logs: `adb logcat -c && adb logcat | grep -E "Page load flow started|Recorded elapsed_time|Dropping elapsed_time|Ignoring repeat|Page visible recorded|Exited max progress threshold|Cancelling previous flow|Page load finished|No active flow found|Failed to start page load flow"`
- [x] Start loading reddit.com and, before it finishes, navigate away to ebay.com in the same tab.
- [x] Let ebay.com finish.
- [x] Within 5 minutes, load reddit.com again in that same tab.

Example from my run:
```
08-07 13:19:52.063 24737 26111 D StandaloneCoroutine: Page load flow started: tabId=12bad50d-d0eb-46d7-b212-038d4f23aa32, url=https://www.reddit.com/, flowId=73, navigationId=11
08-07 13:19:52.122 24737 24887 D RealPageLoadWideEvent: Exited max progress threshold: flowId=73
08-07 13:19:52.134 24737 24887 D StandaloneCoroutine: Recorded elapsed_time_to_content_scope_experiments_ms_bucketed=25 for flowId=73
08-07 13:19:52.147 24737 24887 D StandaloneCoroutine: Recorded elapsed_time_to_js_injection_complete_ms_bucketed=50 for flowId=73
08-07 13:19:52.260 24737 26790 D RealPageLoadWideEvent: Page visible recorded: flowId=73, progress=10
08-07 13:20:08.145 24737 26831 D StandaloneCoroutine: Dropping elapsed_time_to_content_scope_experiments_ms_bucketed from navigation 12, tabId=12bad50d-d0eb-46d7-b212-038d4f23aa32 is on 11
08-07 13:20:08.167 24737 24886 D StandaloneCoroutine: Dropping elapsed_time_to_js_injection_complete_ms_bucketed from navigation 12, tabId=12bad50d-d0eb-46d7-b212-038d4f23aa32 is on 11
08-07 13:20:08.456 24737 26828 D RealPageLoadWideEvent: Page visible recorded: flowId=73, progress=29
08-07 13:20:11.503 24737 26782 D RealPageLoadWideEvent: Exited max progress threshold: flowId=73
08-07 13:20:11.577 24737 24887 D RealPageLoadWideEvent: Page load finished: tabId=12bad50d-d0eb-46d7-b212-038d4f23aa32, flowId=73, outcome=success
```

You should see the measurements for `elapsed_time_to_content_scope_experiments_ms_bucketed` and `elapsed_time_to_js_injection_complete_ms_bucketed` were dropped when navigation changed. However, this surfaced an issue in Prod with the page load measurements in this case. Will add a separate task to address this.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only additions to page-load wide events and a read-only optimization state API; no changes to navigation, injection, or WebView loading behavior.
> 
> **Overview**
> Extends the existing **page-load** wide event with telemetry for content scope work during navigation—**no changes to how pages load**.
> 
> Two **millisecond-bucketed** durations (5–6400ms) are recorded as step metadata instead of `intervalStart`/`intervalEnd`, because the measured spans are short and interval queue/DB latency would swamp them. **elapsed_time_to_content_scope_experiments_ms_bucketed** fires at `page_content_scope_experiments_resolved`; **elapsed_time_to_js_injection_complete_ms_bucketed** at `page_js_injection_complete` after all `JsInjectorPlugin` hooks run.
> 
> A per-navigation **`navigationId`** ties deferred measurements to the load that started the flow so a later same-URL navigation cannot steal them. `BrowserWebViewClient` emits experiments-resolved and JS-injection-complete in order around `pageStarted` and plugin injection.
> 
> On flow finish, three **temporary** booleans from new **`ContentScopeOptimizations`** reflect kill-switch state (injection, messaging, experiments cache) for rollout comparison. Pixel definitions and tests cover bucketing, first-wins repeats, stale/dropped measurements, and flag reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c11748ed9e401d51623f9be9b675050fa75e749a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->