### PR TITLE
PIR: Improve webviews and action handling

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirActionsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirActionsRunner.kt
@@ -145,6 +145,14 @@ class RealPirActionsRunner @AssistedInject constructor(
 
     private val runContinuation: AtomicReference<CancellableContinuation<Result<Unit>>?> = AtomicReference(null)
 
+    /**
+     * Identity of the WebView whose callbacks are authoritative. A runner executes step after step,
+     * so a callback message left on the main looper by a finished step can still be delivered once
+     * the next step is running - and the engine, jobs, WebView and continuation it would reach all
+     * belong to that next step by then.
+     */
+    private val activeWebViewToken: AtomicReference<WebViewToken?> = AtomicReference(null)
+
     private var timerJob: ConflatedJob = ConflatedJob()
     private var engineJob: ConflatedJob = ConflatedJob()
 
@@ -152,6 +160,9 @@ class RealPirActionsRunner @AssistedInject constructor(
         profileQuery: ProfileQuery,
         brokerStep: BrokerStep,
     ): Result<Unit> {
+        val token = WebViewToken()
+        activeWebViewToken.set(token)
+
         withContext(dispatcherProvider.main()) {
             logcat { "PIR-RUNNER (${this@RealPirActionsRunner}): ${Thread.currentThread().name} Creating detached WebView" }
             detachedWebView =
@@ -159,13 +170,13 @@ class RealPirActionsRunner @AssistedInject constructor(
                     context,
                     pirScriptToLoad,
                     onPageLoaded = {
-                        onLoadingComplete(it)
+                        onLoadingComplete(token, it)
                     },
                     onPageLoadFailed = {
-                        onLoadingFailed(it)
+                        onLoadingFailed(token, it)
                     },
                     onRendererGone = {
-                        onRendererGone(it)
+                        onRendererGone(token, it)
                     },
                 )
             ownsWebView = true
@@ -181,6 +192,9 @@ class RealPirActionsRunner @AssistedInject constructor(
         profileQuery: ProfileQuery,
         brokerStep: BrokerStep,
     ): Result<Unit> {
+        val token = WebViewToken()
+        activeWebViewToken.set(token)
+
         withContext(dispatcherProvider.main()) {
             logcat { "PIR-RUNNER (${this@RealPirActionsRunner}): ${Thread.currentThread().name} Adopting caller-owned WebView" }
             detachedWebView =
@@ -188,13 +202,13 @@ class RealPirActionsRunner @AssistedInject constructor(
                     webView,
                     pirScriptToLoad,
                     onPageLoaded = {
-                        onLoadingComplete(it)
+                        onLoadingComplete(token, it)
                     },
                     onPageLoadFailed = {
-                        onLoadingFailed(it)
+                        onLoadingFailed(token, it)
                     },
                     onRendererGone = {
-                        onRendererGone(it)
+                        onRendererGone(token, it)
                     },
                 )
             ownsWebView = false
@@ -233,6 +247,7 @@ class RealPirActionsRunner @AssistedInject constructor(
      * the block, and the reference is dropped here, so no later [stop] could destroy the WebView.
      */
     private suspend fun finishStep() {
+        activeWebViewToken.set(null)
         timerJob.cancel()
         engineJob.cancel()
         engine?.close()
@@ -260,7 +275,21 @@ class RealPirActionsRunner @AssistedInject constructor(
         }
     }
 
-    private fun onLoadingComplete(url: String?) {
+    /**
+     * Whether [token] belongs to a WebView this runner has already moved on from, in which case its
+     * callbacks must not touch any of the runner's now step-scoped state.
+     */
+    private fun isStale(token: WebViewToken): Boolean = token !== activeWebViewToken.get()
+
+    private fun onLoadingComplete(
+        token: WebViewToken,
+        url: String?,
+    ) {
+        if (isStale(token)) {
+            logcat { "PIR-RUNNER ($this): finished loading $url on a WebView from a finished step - stale, ignoring" }
+            return
+        }
+
         logcat { "PIR-RUNNER ($this): finished loading $url" }
         if (url == null) {
             return
@@ -273,7 +302,15 @@ class RealPirActionsRunner @AssistedInject constructor(
         )
     }
 
-    private fun onLoadingFailed(url: String?) {
+    private fun onLoadingFailed(
+        token: WebViewToken,
+        url: String?,
+    ) {
+        if (isStale(token)) {
+            logcat { "PIR-RUNNER ($this): loading $url failed on a WebView from a finished step - stale, ignoring" }
+            return
+        }
+
         logcat { "PIR-RUNNER (${this@RealPirActionsRunner}): Recovering from loading $url failure" }
         if (url == null) {
             return
@@ -285,7 +322,22 @@ class RealPirActionsRunner @AssistedInject constructor(
         )
     }
 
-    private fun onRendererGone(didCrash: Boolean) {
+    private fun onRendererGone(
+        token: WebViewToken,
+        didCrash: Boolean,
+    ) {
+        if (isStale(token)) {
+            logcat {
+                "PIR-RUNNER (${this@RealPirActionsRunner}): renderer process gone, didCrash=$didCrash " +
+                    "on a WebView from a finished step - stale, ignoring"
+            }
+            return
+        }
+
+        // No further callback from this WebView can be authoritative, and clearing the token here
+        // keeps a repeated report from tearing down whichever step is running by then.
+        activeWebViewToken.set(null)
+
         val continuation = runContinuation.getAndSet(null)
 
         if (timerJob.isActive) {
@@ -576,6 +628,7 @@ class RealPirActionsRunner @AssistedInject constructor(
         }
 
     private fun cleanUpRunner() {
+        activeWebViewToken.set(null)
         if (timerJob.isActive) {
             timerJob.cancel()
         }
@@ -647,4 +700,6 @@ class RealPirActionsRunner @AssistedInject constructor(
             engine?.dispatch(it)
         }
     }
+
+    private class WebViewToken
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirDetachedWebViewProvider.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirDetachedWebViewProvider.kt
@@ -119,6 +119,7 @@ class RealPirDetachedWebViewProvider @Inject constructor(
             webViewClient = object : WebViewClient() {
                 private var requestedUrl: String? = null
                 private var receivedError: Boolean = false
+                private var pageLoadReported: Boolean = false
 
                 override fun shouldInterceptRequest(
                     view: WebView?,
@@ -148,6 +149,7 @@ class RealPirDetachedWebViewProvider @Inject constructor(
                     logcat { "PIR-SCAN: webview onPageStarted $url" }
                     requestedUrl = url
                     receivedError = false
+                    pageLoadReported = false
                     view?.evaluateJavascript("javascript:$scriptToLoad", null)
                 }
 
@@ -155,7 +157,12 @@ class RealPirDetachedWebViewProvider @Inject constructor(
                     view: WebView?,
                     url: String?,
                 ) {
-                    if (!receivedError) {
+                    // WebView can fire onPageFinished more than once for a single navigation.
+                    // A duplicate that arrives while the engine is already awaiting its next
+                    // requested load gets consumed as that load's completion, advancing the
+                    // engine one navigation early, so report at most once per onPageStarted.
+                    if (!receivedError && !pageLoadReported) {
+                        pageLoadReported = true
                         logcat { "PIR-SCAN: webview onPageFinished receivedError $receivedError requestedUrl $requestedUrl for url $url" }
                         onPageLoaded(url)
                     }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirJobConstants.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirJobConstants.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.pir.impl.common
 
 object PirJobConstants {
-    const val DBP_INITIAL_URL = "dbp://blank"
+    const val DBP_INITIAL_URL = "about:blank"
     const val RECOVERY_URL = "https://duckduckgo.com/"
 
     /**

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirJobConstants.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirJobConstants.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.pir.impl.common
 
 object PirJobConstants {
-    const val DBP_INITIAL_URL = "about:blank"
+    const val DBP_INITIAL_URL = "dbp://blank"
     const val RECOVERY_URL = "https://duckduckgo.com/"
 
     /**

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandler.kt
@@ -59,7 +59,7 @@ class BrokerActionFailedEventHandler @Inject constructor(
          * This means we have received an error from the JS layer for the last action we pushed.
          * We end the run for the broker.
          */
-        if (!isEventValid(state)) {
+        if (!isEventValid(state, event as BrokerActionFailed)) {
             // Stale event: arrived after the broker step / action was already considered completed.
             val broker = state.brokerStep.broker
 
@@ -74,7 +74,7 @@ class BrokerActionFailedEventHandler @Inject constructor(
 
         val currentBrokerStep = state.brokerStep
         val currentAction = currentBrokerStep.step.actions[state.currentActionIndex]
-        val error = (event as BrokerActionFailed).error
+        val error = event.error
 
         // A condition action reports a failure (JsActionFailed, or a local timeout) when its expectation
         // is not met. For a condition that is expected rather than fatal: treat it as "condition not met"
@@ -140,11 +140,18 @@ class BrokerActionFailedEventHandler @Inject constructor(
         )
     }
 
-    private fun isEventValid(state: State): Boolean {
+    private fun isEventValid(
+        state: State,
+        event: BrokerActionFailed,
+    ): Boolean {
         // Broker step actions has probably been considered completed before the js error arrived
         if (state.brokerStep.step.actions.size <= state.currentActionIndex) return false
 
-        return true
+        val currentBrokerStepAction =
+            state.brokerStep.step.actions[state.currentActionIndex]
+
+        // The action IDs don't match, the error is probably for an outdated / old action
+        return !(event.error is PirError.ActionError && event.error.actionID != currentBrokerStepAction.id)
     }
 
     private fun shouldRetryFailedAction(

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealPirActionsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealPirActionsRunnerTest.kt
@@ -519,4 +519,78 @@ class RealPirActionsRunnerTest {
 
         assertTrue(result.isSuccess)
     }
+
+    @Test
+    fun whenStaleRendererGoneFromPreviousStepThenDoesNotFailCurrentStep() = runTest {
+        // A runner executes step after step (see PirWorkDistributor), and the finished step's
+        // renderer-gone message can be delivered on the main looper once the next step is already
+        // running on the same runner. That stale callback must not fail the new step, which would
+        // abort the rest of the queue and report the whole run as renderer-gone.
+        val rendererGoneCaptor = argumentCaptor<(Boolean) -> Unit>()
+        whenever(
+            mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), rendererGoneCaptor.capture()),
+        ).thenReturn(mockWebView)
+
+        val stepA = async {
+            testee.execute(testProfileQuery, testScanStep)
+        }
+
+        yield()
+
+        sideEffectFlow.tryEmit(SideEffect.CompleteExecution)
+
+        assertTrue(stepA.await().isSuccess)
+
+        val staleRendererGoneFromStepA = rendererGoneCaptor.firstValue
+
+        val stepB = async {
+            testee.execute(testProfileQuery, testScanStep)
+        }
+
+        yield()
+
+        staleRendererGoneFromStepA.invoke(false)
+
+        sideEffectFlow.tryEmit(SideEffect.CompleteExecution)
+
+        assertTrue(stepB.await().isSuccess)
+    }
+
+    @Test
+    fun whenStalePageLoadedFromPreviousStepThenIsNotDispatchedToCurrentStep() = runTest {
+        val onPageLoadedCaptor = argumentCaptor<(String?) -> Unit>()
+        whenever(
+            mockPirDetachedWebViewProvider.createInstance(any(), any(), onPageLoadedCaptor.capture(), any(), any()),
+        ).thenReturn(mockWebView)
+
+        val stepA = async {
+            testee.execute(testProfileQuery, testScanStep)
+        }
+
+        yield()
+
+        sideEffectFlow.tryEmit(SideEffect.CompleteExecution)
+
+        assertTrue(stepA.await().isSuccess)
+
+        val stalePageLoadedFromStepA = onPageLoadedCaptor.firstValue
+
+        val stepB = async {
+            testee.execute(testProfileQuery, testScanStep)
+        }
+
+        yield()
+
+        stalePageLoadedFromStepA.invoke(testUrl)
+
+        sideEffectFlow.tryEmit(SideEffect.CompleteExecution)
+
+        assertTrue(stepB.await().isSuccess)
+
+        // Only the two Started events, one per step: the finished step's load must not advance the
+        // engine the new step is driving.
+        val eventCaptor = argumentCaptor<Event>()
+        verify(mockEngine, times(2)).dispatch(eventCaptor.capture())
+        assertTrue(eventCaptor.allValues.none { it is Event.LoadUrlComplete })
+    }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandlerTest.kt
@@ -396,6 +396,39 @@ class BrokerActionFailedEventHandlerTest {
     }
 
     @Test
+    fun whenActionErrorCarriesMismatchedActionIdThenEventIsInvalidAndReturnsUnchangedState() = runTest {
+        // A leftover 60s local-timeout timer from an earlier action fires with that action's id
+        // while a later action is current; the stale error must not fail the current action.
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStep = testScanStep(
+                actions = listOf(
+                    BrokerAction.Navigate(id = "current-action-id", url = "https://example.com"),
+                ),
+            ),
+            profileQuery = testProfileQuery,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = BrokerActionFailed(
+            error = PirError.ActionError.JsActionFailed(
+                actionID = "some-other-action-id",
+                message = "Local timeout",
+            ),
+            allowRetry = true,
+        )
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        assertNull(result.nextEvent)
+        assertNull(result.sideEffect)
+    }
+
+    @Test
     fun whenConditionActionFailedInScanThenSkipsToNextActionInsteadOfRetryingOrFailing() = runTest {
         // A condition whose expectation is not met reports a JsActionFailed (or "Local timeout").
         // For a condition this is not fatal: skip to the next action instead of retrying then failing


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1217191281995705?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1217014195688232?focus=true
API Proposals URL(s) (if applicable): N/A

### Description
Improves how we handle WebView reuse and stale callbacks.

### Steps to test this PR
See https://app.asana.com/1/137249556945/project/481882893211075/task/1217200166771197?focus=true

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes broker-step orchestration and error handling in PIR scans/opt-outs; incorrect stale detection could drop real failures or allow stray events, but scope is confined to PIR WebView/action runner logic with added tests.
> 
> **Overview**
> Fixes **stale async signals** breaking PIR when the same `PirActionsRunner` runs broker step after step (e.g. via `PirWorkDistributor`). Late WebView callbacks, duplicate page-finish events, and old action timeouts could hit the **next** step’s engine and fail or advance navigations incorrectly.
> 
> **`RealPirActionsRunner`** assigns a per-step `WebViewToken` and ignores load complete, load failed, and renderer-gone callbacks when the token no longer matches. Step teardown and `stop()` clear the token so finished steps cannot disturb the current run.
> 
> **`PirDetachedWebViewProvider`** reports page load completion **once per** `onPageStarted`, so repeated `onPageFinished` for one navigation does not double-fire `LoadUrlComplete`.
> 
> **`BrokerActionFailedEventHandler`** treats `BrokerActionFailed` as invalid when a `PirError.ActionError` carries an **action ID** that does not match the current broker action (e.g. a 60s local timeout from a prior pushed action).
> 
> Tests cover stale renderer-gone and page-loaded callbacks across consecutive steps and mismatched action IDs on failure events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6417f54495110eed99a1fd592b9b4a095a4fe022. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->