### PR TITLE
Fix search-only omnibar margin leaking onto the Duck.ai input

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1301,20 +1301,23 @@ class NativeInputModeWidget @JvmOverloads constructor(
         // fall through and reset card.radius to largeShapeCornerRadius on all four corners.
         if (isContextualWidget) return
         val state = nativeInputState ?: return
-        if (state.inputContext != NativeInputState.InputContext.BROWSER) return
-        if (state.isBottom) return
-        if (state.toggleVisible) return
         val card = parent as? MaterialCardView ?: return
-        card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)
-        val targetTopMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginTop)
-        val targetStartMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginHorizontal)
-        val targetEndMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_1)
-        (card.layoutParams as? MarginLayoutParams)?.let { lp ->
+        val lp = card.layoutParams as? MarginLayoutParams ?: return
+        // Only the top browser search-only omnibar takes the wide-omnibar shape; isBottom is part of this
+        // condition (not an early return) so a bottom Duck.ai frame still reaches the reset below.
+        if (state.inputContext == NativeInputState.InputContext.BROWSER && !state.toggleVisible && !state.isBottom) {
+            val targetTopMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginTop)
+            val targetStartMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginHorizontal)
+            val targetEndMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_1)
+            card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)
             lp.topMargin = targetTopMargin - card.paddingTop
             lp.marginStart = targetStartMargin - card.paddingLeft
             lp.marginEnd = targetEndMargin - card.paddingRight
-            card.layoutParams = lp
+        } else {
+            // Reset the start margin so the omnibar value doesn't leak onto the shared Duck.ai card.
+            lp.marginStart = 0
         }
+        card.layoutParams = lp
     }
 
     override fun bindInputEvents(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1217145379104435?focus=true 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
In **search-only** address-bar mode, the Duck.ai input field showed an extra ~16dp gap on its leading (start) side. The native input's shared card was picking up the browser omnibar's start margin and keeping it when the same widget re-rendered as the Duck.ai input.`applyOmnibarShape()` sets the browser omnibar's margin on the shared input card, but had no reset path when shared with other places. 

**Fix:**
In `applyOmnibarShape()`:
- The `else` branch now resets `marginStart` to its resting value (`0`) for any non-omnibar state, so the margin can't leak onto the shared Duck.ai card.


Test the omnibar in each location (top, bottom, split) in **Search only** mode:

- [ ] **Browser omnibar**: on the NTP or a loaded page, focus the omnibar. The native input opens with the correct omnibar shape
- [ ] **Duck.ai input (the fix)**: open/load Duck.ai. The input field's leading margin is correct (no extra ~16dp gap between the leading edge and the field)
- [ ] Unfocus the Native field in duck.ai, no gaps between the field and the fire button

### Regression spot-checks
- **Contextual Duck.ai sheet** : No impact on look.
- **Search _ Duck.ai mode**: No impact on look.
- 
### UI changes
| Before  | After |
| ------ | ----- |
|<img width="540" height="1200" alt="Screenshot_20260805_120605" src="https://github.com/user-attachments/assets/100f2169-616f-4455-92ce-ced24f1948e6" />|<img width="540" height="1200" alt="Screenshot_20260805_120408" src="https://github.com/user-attachments/assets/cc3e947a-7c0a-49b7-83a1-583a5b779e5c" />|
|<img width="540" height="1200" alt="Screenshot_20260805_120609" src="https://github.com/user-attachments/assets/6baeabb7-494c-4c0a-87dd-75e9b9965c38" />|<img width="540" height="1200" alt="Screenshot_20260805_120411" src="https://github.com/user-attachments/assets/908bcbdb-fc55-4eb6-b74c-f5f915dba892" />|




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI layout logic in `NativeInputModeWidget` with no auth, data, or API changes; risk is limited to omnibar/Duck.ai card positioning regressions.
> 
> **Overview**
> Fixes **search-only omnibar horizontal margin leaking** onto the shared Duck.ai input card when both widgets observe the same per-tab state.
> 
> `applyOmnibarShape()` no longer exits early for non-browser, bottom, or toggle-visible states. It now applies the wide top **search-only browser** shape (radius + margins) only when `BROWSER`, toggle hidden, and not bottom; **every other state** clears `marginStart` on the parent `MaterialCardView` so omnibar margins don’t stick on Duck.ai layouts. Layout params are always updated after that branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8e7328c1f4af48292bd062ac1f35a93784fe96f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->