### PR TITLE
Apply correct edge to edge handling in simplified sync

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/DisplayQrCodeActivity.kt
@@ -217,7 +217,7 @@ class DisplayQrCodeActivity : DuckDuckGoActivity() {
     private fun configureEdgeToEdgeInsets() {
         edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
         edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
-        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     companion object {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceActivity.kt
@@ -115,7 +115,7 @@ class EditDeviceActivity : DuckDuckGoActivity() {
     private fun configureEdgeToEdgeInsets() {
         edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
         edgeToEdgeHandler.applyStatusBarInsets(binding.toolbar)
-        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     private fun observeViewModel() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -623,7 +623,7 @@ class SyncActivity : DuckDuckGoActivity() {
     private fun configureEdgeToEdgeInsets() {
         edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
         edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
-        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     private fun configureToolbar() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1217224514372555?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Fixes edge-to-edge handling on the scrolling screens of the simplified Sync flow. These screens were reserving no space at the bottom under gesture navigation, so the last piece of content sat underneath the gesture pill instead of clearing it. The affected screens are the simplified Sync Settings screen, the QR code screen shown when syncing with another device, and the edit device screen. Each of these hosts its content in a scrolling container.

### Steps to test this PR

_Sync Settings screen_
- [ ] Open "Sync & Backup"
- [ ] If content fits fully on the screen increase the font size or test with a smaller device.
- [ ] Scroll to the bottom of the screen.
- [ ] Verify the last item rests above the navigation bar and is not obscured by the gesture pill.

### UI changes
| Before  | After |
| - | - |
| <img width="540" alt="Screenshot_20260806-090458" src="https://github.com/user-attachments/assets/96e16f25-071d-4d73-a23d-13db5294401e" /> | <img width="540"  alt="Screenshot_20260806-090405" src="https://github.com/user-attachments/assets/df72253b-bb9d-4cb3-be62-8f991d98e7da" /> |




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only inset API swap on three Sync activities; no logic, networking, or data changes.
> 
> **Overview**
> Fixes bottom edge-to-edge handling on three simplified Sync v2 screens that use a scroll view: **Sync settings** (`SyncActivity`), **display QR code** (`DisplayQrCodeActivity`), and **edit device** (`EditDeviceActivity`).
> 
> Each screen’s `configureEdgeToEdgeInsets()` now calls `applyScrollableNavigationBarInsets` on `contentScrollView` instead of `applyNavigationBarInsets(..., drawBehindGestureNav = true)`. That matches the pattern used elsewhere for scrolling content so the list reserves bottom padding and the last row sits above the gesture navigation pill instead of underneath it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aaea52c53251b446769ab87e0e41daff665ac04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->