### PR TITLE
Parameterize sync pixels tests

### DIFF
--- a/sync/sync-impl/build.gradle
+++ b/sync/sync-impl/build.gradle
@@ -109,6 +109,7 @@ dependencies {
     testImplementation AndroidX.archCore.testing
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:_"
     testImplementation 'org.json:json:_'
+    testImplementation "com.google.testparameterinjector:test-parameter-injector:_"
 
     testImplementation project(path: ':common-test')
     testImplementation project(path: ':feature-toggles-test')

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
@@ -40,8 +40,11 @@ import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import com.duckduckgo.sync.impl.stats.DailyStats
 import com.duckduckgo.sync.impl.stats.SyncStatsRepository
 import com.duckduckgo.sync.store.SharedPrefsProvider
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -49,6 +52,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
+@RunWith(TestParameterInjector::class)
 class RealSyncPixelsTest {
 
     private var pixel: Pixel = mock()
@@ -75,7 +79,7 @@ class RealSyncPixelsTest {
     }
 
     @Test
-    fun whenDailyPixelCalledThenPixelFired() {
+    fun `when daily pixel is called then pixel is fired`() {
         val dailyStats = givenSomeDailyStats()
 
         testee.fireDailySuccessRatePixel()
@@ -91,7 +95,7 @@ class RealSyncPixelsTest {
     }
 
     @Test
-    fun whenDailyPixelCalledTwiceThenPixelFiredOnce() {
+    fun `when daily pixel is called twice then pixel is fired once`() {
         val dailyStats = givenSomeDailyStats()
 
         testee.fireDailySuccessRatePixel()
@@ -109,317 +113,393 @@ class RealSyncPixelsTest {
     }
 
     @Test
-    fun whenLoginPixelCalledThenPixelFired() {
+    fun `when login pixel is fired then pixel is fired`(
+        @TestParameter ui: UiVersion,
+    ) {
+        ui.configure(syncFeature)
+
         testee.fireLoginPixel()
 
         verify(pixel).fire(
             SyncPixelName.SYNC_LOGIN,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
             ),
         )
     }
 
     @Test
-    fun whenSignupDirectPixelCalledWithNoSourceThenPixelFired() {
+    fun `when signup direct pixel is called without source then pixel is fired`(
+        @TestParameter ui: UiVersion,
+    ) {
+        ui.configure(syncFeature)
+
         testee.fireSignupDirectPixel(source = null)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SIGNUP_DIRECT,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
             ),
         )
     }
 
     @Test
-    fun whenSignupDirectPixelCalledWithSourceThenPixelFiredIncludesSource() {
+    fun `when signup direct pixel is called with source then fired pixel includes source`(
+        @TestParameter ui: UiVersion,
+    ) {
+        ui.configure(syncFeature)
+
         testee.fireSignupDirectPixel(source = "foo")
+
         verify(pixel).fire(
             SyncPixelName.SYNC_SIGNUP_DIRECT,
             mapOf(
-                "source" to "foo",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "foo",
             ),
         )
     }
 
     @Test
-    fun whenSignupConnectPixelCalledWithNoSourceThenPixelFired() {
+    fun `when signup connect pixel is called without source then pixel is fired`(
+        @TestParameter ui: UiVersion,
+    ) {
+        ui.configure(syncFeature)
+
         testee.fireSignupConnectPixel(source = null)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SIGNUP_CONNECT,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
             ),
         )
     }
 
     @Test
-    fun whenSignupConnectPixelCalledWithSourceThenPixelFiredIncludesSource() {
+    fun `when signup connect pixel is called with source then fired pixel includes source`(
+        @TestParameter ui: UiVersion,
+    ) {
+        ui.configure(syncFeature)
+
         testee.fireSignupConnectPixel(source = "foo")
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SIGNUP_CONNECT,
             mapOf(
-                "source" to "foo",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "foo",
             ),
         )
     }
 
     @Test
-    fun whenBarcodeScreenShownAndV2FlowEnabledThenPixelFiredWithV2AndDdg() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when barcode screen is shown the pixel is fired`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
-        testee.fireSyncBarcodeScreenShown(ScreenType.SYNC_CONNECT)
+        testee.fireSyncBarcodeScreenShown(screenType)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenBarcodeScreenShownAndV2FlowDisabledThenPixelFiredWithV1AndDdg() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+    fun `when scan code screen is shown the pixel is fired`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
-        testee.fireSyncBarcodeScreenShown(ScreenType.SYNC_EXCHANGE)
-
-        verify(pixel).fire(
-            SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN,
-            mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
-                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
-            ),
-        )
-    }
-
-    @Test
-    fun whenScanCodeScreenShownAndV2FlowEnabledThenPixelFiredWithV2AndDdg() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
-
-        testee.fireScanCodeScreenShown(ScreenType.SYNC_CONNECT)
+        testee.fireScanCodeScreenShown(screenType)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_SCAN_QR_SCREEN_SHOWN,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenScanCodeScreenShownAndV2FlowDisabledThenPixelFiredWithV1AndDdg() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+    fun `when manual code entry screen is shown the pixel is fired`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
-        testee.fireScanCodeScreenShown(ScreenType.SYNC_EXCHANGE)
-
-        verify(pixel).fire(
-            SyncPixelName.SYNC_SETUP_SCAN_QR_SCREEN_SHOWN,
-            mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
-                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
-            ),
-        )
-    }
-
-    @Test
-    fun whenManualCodeEntryScreenShownAndV2FlowEnabledThenPixelFiredWithV2AndDdg() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
-
-        testee.fireSyncSetupManualCodeScreenShown(ScreenType.SYNC_EXCHANGE)
+        testee.fireSyncSetupManualCodeScreenShown(screenType)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenManualCodeEntryScreenShownAndV2FlowDisabledThenPixelFiredWithV1AndDdg() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+    fun `when barcode scanner parses a v1 code then the success pixel carries no code type`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
-        testee.fireSyncSetupManualCodeScreenShown(ScreenType.SYNC_CONNECT)
-
-        verify(pixel).fire(
-            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN,
-            mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
-                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
-            ),
-        )
-    }
-
-    @Test
-    fun whenBarcodeScannerParseSuccessOnLegacyPathThenPixelFiredWithV1AndNoCodeType() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
-
-        testee.fireBarcodeScannerParseSuccess(ScreenType.SYNC_CONNECT, CodeVersion.V1)
+        testee.fireBarcodeScannerParseSuccess(screenType, CodeVersion.V1)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v1",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenBarcodeScannerParseSuccessForV2RecoveryCodeThenPixelFiredWithCodeMetadata() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when barcode scanner parses a v2 recovery code then the success pixel carries the code metadata`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
-        testee.fireBarcodeScannerParseSuccess(ScreenType.SYNC_EXCHANGE, CodeVersion.V2, SyncCodeType.RECOVERY)
+        testee.fireBarcodeScannerParseSuccess(screenType, CodeVersion.V2, SyncCodeType.RECOVERY)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_CODE_TYPE to "recovery",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenManualCodeEnteredSuccessForV2LinkingCodeThenPixelFiredWithCodeMetadata() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when a v2 linking code is entered manually then the success pixel carries the code metadata`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
-        testee.fireSyncSetupCodePastedParseSuccess(ScreenType.SYNC_CONNECT, CodeVersion.V2, SyncCodeType.LINKING)
+        testee.fireSyncSetupCodePastedParseSuccess(screenType, CodeVersion.V2, SyncCodeType.LINKING)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_CODE_TYPE to "linking",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenManualCodeEnteredSuccessOnLegacyPathThenPixelFiredWithV1AndNoCodeType() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+    fun `when a v1 code is entered manually then the success pixel carries no code type`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
-        testee.fireSyncSetupCodePastedParseSuccess(ScreenType.SYNC_EXCHANGE, CodeVersion.V1)
+        testee.fireSyncSetupCodePastedParseSuccess(screenType, CodeVersion.V1)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v1",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenBarcodeScannerParseErrorThenPixelFiredWithFlowMetadata() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+    fun `when barcode scanner parse fails without a reason then the pixel is fired`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
-        testee.fireBarcodeScannerParseError(ScreenType.SYNC_CONNECT)
+        testee.fireBarcodeScannerParseError(screenType)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenManualCodeEnteredFailureThenPixelFiredWithFlowMetadata() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when barcode scanner parse fails with a reason then the pixel carries the reason`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
-        testee.fireSyncSetupCodePastedParseFailure(ScreenType.SYNC_EXCHANGE)
+        testee.fireBarcodeScannerParseError(screenType, reason = SetupFailureReason.UNRECOGNIZED_CODE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
+                SyncPixelParameters.SYNC_SETUP_REASON to "unrecognized_code",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun `when manual code entry fails without a reason then the pixel is fired`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
+
+        testee.fireSyncSetupCodePastedParseFailure(screenType)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenSetupFinishedV1ThenPixelFiredWithFlowMetadataOnly() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+    fun `when manual code entry fails with a reason then the pixel carries the reason`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
-        testee.fireSyncSetupFinishedSuccessfully(ScreenType.SYNC_CONNECT)
+        testee.fireSyncSetupCodePastedParseFailure(screenType, reason = SetupFailureReason.UNRECOGNIZED_CODE)
 
         verify(pixel).fire(
-            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
+                SyncPixelParameters.SYNC_SETUP_REASON to "unrecognized_code",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenSetupFinishedV2RecoveryThenPixelFiredWithPathNoRoleOrPeer() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when setup finished without a path then the pixel is fired`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
-        testee.fireSyncSetupFinishedSuccessfully(ScreenType.SYNC_EXCHANGE, SetupPath.RECOVERY)
+        testee.fireSyncSetupFinishedSuccessfully(screenType)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun `when setup finished for a recovery path then the pixel carries the path`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
+
+        testee.fireSyncSetupFinishedSuccessfully(screenType, SetupPath.RECOVERY)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_PATH to "recovery",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenSetupFinishedV2PairingThenPixelFiredWithPathRoleAndPeer() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when setup finished for a pairing path then the pixel carries the path role and peer`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
         testee.fireSyncSetupFinishedSuccessfully(
-            ScreenType.SYNC_CONNECT,
+            screenType,
             SetupPath.PAIRING,
             SetupRole.HOST,
             PeerKind.THIRD_PARTY,
@@ -428,23 +508,28 @@ class RealSyncPixelsTest {
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
                 SyncPixelParameters.SYNC_SETUP_MY_ROLE to "host",
                 SyncPixelParameters.SYNC_SETUP_PEER_KIND to "3party",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenSyncSetupFailedWithPathRolePeerKindThenAllIncludedInPixel() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when setup failed with path role and peer then all are included in the pixel`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
         testee.fireSyncSetupFailed(
-            ScreenType.SYNC_CONNECT,
+            screenType,
             SetupFailureReason.TRANSPORT_FAILURE,
             SetupPath.PAIRING,
             SetupRole.JOINER,
@@ -454,65 +539,80 @@ class RealSyncPixelsTest {
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_FAILED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_REASON to "transport_failure",
                 SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
                 SyncPixelParameters.SYNC_SETUP_MY_ROLE to "joiner",
                 SyncPixelParameters.SYNC_SETUP_PEER_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenSyncSetupFailedWithoutPathRolePeerKindThenThoseParamsOmitted() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when setup failed without path role and peer then those params are omitted`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
-        testee.fireSyncSetupFailed(ScreenType.SYNC_EXCHANGE, SetupFailureReason.UNEXPECTED_FAILURE)
+        testee.fireSyncSetupFailed(screenType, SetupFailureReason.UNEXPECTED_FAILURE)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_FAILED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_REASON to "unexpected_failure",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenFireSetupFailedForUpgradeRequiredThenNeedsUpgrade() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when setup failed for an upgrade required outcome then needs upgrade reason is used`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
         testee.fireSetupFailed(
-            ScreenType.SYNC_CONNECT,
+            screenType,
             DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
         )
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_FAILED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_REASON to "needs_upgrade",
                 SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
                 SyncPixelParameters.SYNC_SETUP_MY_ROLE to "host",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenFireSetupFailedForFailedOutcomeThenReasonMappedFromCode() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when setup failed for a failed outcome then the reason is mapped and the path forwarded`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
         testee.fireSetupFailed(
-            ScreenType.SYNC_EXCHANGE,
+            screenType,
             DispatchOutcome.Failed(
                 reason = "boom",
                 code = AccountErrorCodes.INVALID_CODE.code,
@@ -523,18 +623,18 @@ class RealSyncPixelsTest {
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_FAILED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_REASON to "invalid_credentials",
                 SyncPixelParameters.SYNC_SETUP_PATH to "recovery",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenFireSetupFailedForCancellationCodesThenPixelNotFired() {
+    fun `when setup failed for cancellation codes then pixel is not fired`() {
         testee.fireSetupFailed(ScreenType.SYNC_CONNECT, DispatchOutcome.Failed(reason = "user", code = AccountErrorCodes.PAIRING_CANCELLED.code))
         testee.fireSetupFailed(ScreenType.SYNC_CONNECT, DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code))
 
@@ -542,335 +642,145 @@ class RealSyncPixelsTest {
     }
 
     @Test
-    fun whenSetupAbandonedWithReasonThenPixelFiredWithReasonAndFlowMetadata() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
-
-        testee.fireSyncSetupAbandoned(ScreenType.SYNC_CONNECT, CancellationReason.CANCELLED_BEFORE_FINISHED)
-
-        verify(pixel).fire(
-            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
-            mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
-                SyncPixelParameters.SYNC_SETUP_REASON to "cancelled_before_finished",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
-                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
-            ),
-        )
-    }
-
-    @Test
-    fun whenSetupAbandonedWithoutReasonThenReasonOmitted() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
-
-        testee.fireSyncSetupAbandoned(ScreenType.SYNC_EXCHANGE)
-
-        verify(pixel).fire(
-            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
-            mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
-                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
-            ),
-        )
-    }
-
-    @Test
-    fun whenFireSetupCancelledIfDeniedForPairingCancelledThenAbandonedFired() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
-
-        testee.fireSetupCancelledIfDenied(
-            ScreenType.SYNC_CONNECT,
-            DispatchOutcome.Failed(reason = "user_denied", code = AccountErrorCodes.PAIRING_CANCELLED.code),
-        )
-
-        verify(pixel).fire(
-            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
-            mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
-                SyncPixelParameters.SYNC_SETUP_REASON to "sync_confirmation_denied",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
-                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
-            ),
-        )
-    }
-
-    @Test
-    fun whenFireSetupCancelledIfDeniedForPeerRejectionThenAbandonedFired() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
-
-        testee.fireSetupCancelledIfDenied(
-            ScreenType.SYNC_EXCHANGE,
-            DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code),
-        )
-
-        verify(pixel).fire(
-            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
-            mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
-                SyncPixelParameters.SYNC_SETUP_REASON to "sync_confirmation_denied",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
-                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
-            ),
-        )
-    }
-
-    @Test
-    fun whenFireSetupCancelledIfDeniedForNonCancellationOutcomeThenNotFired() {
-        testee.fireSetupCancelledIfDenied(
-            ScreenType.SYNC_CONNECT,
-            DispatchOutcome.Failed(reason = "boom", code = AccountErrorCodes.PAIRING_FAILED.code),
-        )
-
-        verifyNoInteractions(pixel)
-    }
-
-    @Test
-    fun whenfireDailyApiErrorForObjectLimitExceededThenPixelSent() {
-        testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.COUNT_LIMIT.code))
-
-        verify(pixel).fire("m_sync_bookmarks_object_limit_exceeded_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
-    }
-
-    @Test
-    fun whenfireDailyApiErrorForRequestSizeLimitExceededThenPixelSent() {
-        testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.CONTENT_TOO_LARGE.code))
-
-        verify(pixel).fire("m_sync_bookmarks_request_size_limit_exceeded_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
-    }
-
-    @Test
-    fun whenfireDailyApiErrorForValidationErrorThenPixelSent() {
-        testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.VALIDATION_ERROR.code))
-
-        verify(pixel).fire("m_sync_bookmarks_validation_error_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
-    }
-
-    @Test
-    fun whenfireDailyApiErrorForTooManyRequestsThenPixelSent() {
-        testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.TOO_MANY_REQUESTS_1.code))
-        testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.TOO_MANY_REQUESTS_2.code))
-
-        verify(pixel, times(2)).fire("m_sync_bookmarks_too_many_requests_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
-    }
-
-    @Test
-    fun whenFireSyncAccountErrorPixelForRescopeTokenThenPixelSent() {
-        val error = Error(code = 401, reason = "unauthorized")
-
-        testee.fireSyncAccountErrorPixel(error, SyncAccountOperation.RESCOPE_TOKEN)
-
-        verify(pixel).fire(
-            SyncPixelName.SYNC_RESCOPE_TOKEN_FAILURE,
-            mapOf(
-                SyncPixelParameters.ERROR_CODE to "401",
-                SyncPixelParameters.ERROR_REASON to "unauthorized",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
-            ),
-        )
-    }
-
-    @Test
-    fun whenFireAiChatActiveThenDailyPixelFired() {
-        testee.fireAiChatActive()
-
-        verify(pixel).fire(SyncPixelName.SYNC_AI_CHAT_ACTIVE, emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
-    }
-
-    @Test
-    fun whenFireAiChatsRescopeTokenErrorWith400ThenValidationErrorPixelFired() {
-        val error = Error(code = API_CODE.VALIDATION_ERROR.code, reason = "bad request")
-
-        testee.fireAiChatsRescopeTokenError(error)
-
-        verify(pixel).fire("m_sync_ai_chats_validation_error_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
-    }
-
-    @Test
-    fun whenFireAiChatsRescopeTokenErrorWith409ThenObjectLimitExceededPixelFired() {
-        val error = Error(code = API_CODE.COUNT_LIMIT.code, reason = "count limit")
-
-        testee.fireAiChatsRescopeTokenError(error)
-
-        verify(pixel).fire("m_sync_ai_chats_object_limit_exceeded_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
-    }
-
-    @Test
-    fun whenFireAiChatsRescopeTokenErrorWith413ThenRequestSizeLimitExceededPixelFired() {
-        val error = Error(code = API_CODE.CONTENT_TOO_LARGE.code, reason = "too large")
-
-        testee.fireAiChatsRescopeTokenError(error)
-
-        verify(pixel).fire("m_sync_ai_chats_request_size_limit_exceeded_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
-    }
-
-    @Test
-    fun whenFireAiChatsRescopeTokenErrorWith429ThenTooManyRequestsPixelFired() {
-        val error = Error(code = API_CODE.TOO_MANY_REQUESTS_1.code, reason = "rate limited")
-
-        testee.fireAiChatsRescopeTokenError(error)
-
-        verify(pixel).fire("m_sync_ai_chats_too_many_requests_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
-    }
-
-    @Test
-    fun whenFireAiChatsRescopeTokenErrorWith401ThenNoPixelFired() {
-        val error = Error(code = API_CODE.INVALID_LOGIN_CREDENTIALS.code, reason = "unauthorized")
-
-        testee.fireAiChatsRescopeTokenError(error)
-
-        verifyNoInteractions(pixel)
-    }
-
-    @Test
-    fun whenBarcodeScannerParseErrorWithReasonThenPixelFiredWithReason() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
-
-        testee.fireBarcodeScannerParseError(ScreenType.SYNC_CONNECT, reason = SetupFailureReason.UNRECOGNIZED_CODE)
-
-        verify(pixel).fire(
-            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED,
-            mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
-                SyncPixelParameters.SYNC_SETUP_REASON to "unrecognized_code",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
-                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
-            ),
-        )
-    }
-
-    @Test
-    fun whenManualCodeEnteredFailureWithReasonThenPixelFiredWithReason() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
-
-        testee.fireSyncSetupCodePastedParseFailure(ScreenType.SYNC_EXCHANGE, reason = SetupFailureReason.UNRECOGNIZED_CODE)
-
-        verify(pixel).fire(
-            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED,
-            mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
-                SyncPixelParameters.SYNC_SETUP_REASON to "unrecognized_code",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
-                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
-            ),
-        )
-    }
-
-    @Test
-    fun whenFireSetupFailedForSessionTimeoutCodeThenSessionTimeoutReason() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when setup failed for a session timeout code then session timeout reason is used`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
         testee.fireSetupFailed(
-            ScreenType.SYNC_EXCHANGE,
+            screenType,
             DispatchOutcome.Failed(reason = "Session timed out", code = AccountErrorCodes.SESSION_TIMEOUT.code),
         )
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_FAILED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_REASON to "session_timeout",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenFireSetupFailedForCreateAccountFailedCodeThenAccountCreationFailedReason() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when setup failed for a create account failed code then account creation failed reason is used`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
         testee.fireSetupFailed(
-            ScreenType.SYNC_CONNECT,
+            screenType,
             DispatchOutcome.Failed(reason = "create_account_failed", code = AccountErrorCodes.CREATE_ACCOUNT_FAILED.code),
         )
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_FAILED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_REASON to "account_creation_failed",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenFireSetupFailedForAccountUpgradeFailedCodeThenAccountUpgradeFailedReason() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when setup failed for an account upgrade failed code then account upgrade failed reason is used`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
         testee.fireSetupFailed(
-            ScreenType.SYNC_EXCHANGE,
+            screenType,
             DispatchOutcome.Failed(reason = "upgrade_failed", code = AccountErrorCodes.ACCOUNT_UPGRADE_FAILED.code),
         )
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_FAILED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_REASON to "account_upgrade_failed",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenFireSetupFailedForAlreadyPairedCodeThenAlreadyPairedReason() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when setup failed for an already paired code then already paired reason is used`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
         testee.fireSetupFailed(
-            ScreenType.SYNC_EXCHANGE,
+            screenType,
             DispatchOutcome.Failed(reason = "same_account", code = AccountErrorCodes.ALREADY_PAIRED.code),
         )
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_FAILED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_REASON to "already_paired",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenFireSetupFailedForAlreadyConnectedOutcomeThenAlreadyPairedReasonWithPairingPath() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when setup failed for an already connected outcome then already paired reason with pairing path`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
         // v2 same-account case: both peers exchange intros and discover a matching user_id
-        testee.fireSetupFailed(ScreenType.SYNC_CONNECT, DispatchOutcome.AlreadyConnected)
+        testee.fireSetupFailed(screenType, DispatchOutcome.AlreadyConnected)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_FAILED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_REASON to "already_paired",
                 SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenFireSetupFailedWithTimeoutStageThenPixelIncludesTimeoutStageParam() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when setup failed with a timeout stage then the pixel includes the timeout stage param`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
         testee.fireSetupFailed(
-            ScreenType.SYNC_EXCHANGE,
+            screenType,
             DispatchOutcome.Failed(
                 reason = "Session timed out",
                 code = AccountErrorCodes.SESSION_TIMEOUT.code,
@@ -881,184 +791,343 @@ class RealSyncPixelsTest {
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_FAILED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_REASON to "session_timeout",
                 SyncPixelParameters.SYNC_SETUP_TIMEOUT_STAGE to "waiting_for_confirmation",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenFireSetupFailedForPairingUnavailableCodeThenProtocolErrorReason() {
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+    fun `when setup failed for a pairing unavailable code then protocol error reason is used`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
         testee.fireSetupFailed(
-            ScreenType.SYNC_EXCHANGE,
+            screenType,
             DispatchOutcome.Failed(reason = "pairing_unavailable", code = AccountErrorCodes.PAIRING_UNAVAILABLE.code),
         )
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_FAILED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_REASON to "protocol_error",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
             ),
         )
     }
 
     @Test
-    fun whenLoginPixelCalledAndSimplifiedSyncEnabledThenUiVersionIsV2() {
-        syncFeature.useSimplifiedSync().setRawStoredState(State(true))
+    fun `when setup abandoned with a reason then the pixel carries the reason`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
-        testee.fireLoginPixel()
-
-        verify(pixel).fire(
-            SyncPixelName.SYNC_LOGIN,
-            mapOf(
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v2",
-            ),
-        )
-    }
-
-    @Test
-    fun whenSignupDirectPixelCalledAndSimplifiedSyncEnabledThenUiVersionIsV2() {
-        syncFeature.useSimplifiedSync().setRawStoredState(State(true))
-
-        testee.fireSignupDirectPixel(source = "foo")
+        testee.fireSyncSetupAbandoned(screenType, CancellationReason.CANCELLED_BEFORE_FINISHED)
 
         verify(pixel).fire(
-            SyncPixelName.SYNC_SIGNUP_DIRECT,
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
             mapOf(
-                "source" to "foo",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v2",
-            ),
-        )
-    }
-
-    @Test
-    fun whenBarcodeScreenShownAndSimplifiedSyncEnabledThenUiVersionIsV2() {
-        syncFeature.useSimplifiedSync().setRawStoredState(State(true))
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
-
-        testee.fireSyncBarcodeScreenShown(ScreenType.SYNC_CONNECT)
-
-        verify(pixel).fire(
-            SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN,
-            mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
+                SyncPixelParameters.SYNC_SETUP_REASON to "cancelled_before_finished",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v2",
             ),
         )
     }
 
     @Test
-    fun whenSetupFinishedAndSimplifiedSyncEnabledButV2FlowDisabledThenUiVersionV2AndFlowVersionV1() {
-        syncFeature.useSimplifiedSync().setRawStoredState(State(true))
-        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+    fun `when setup abandoned without a reason then the reason is omitted`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
 
-        testee.fireSyncSetupFinishedSuccessfully(ScreenType.SYNC_EXCHANGE)
+        testee.fireSyncSetupAbandoned(screenType)
 
         verify(pixel).fire(
-            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
-                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v2",
             ),
         )
     }
 
     @Test
-    fun whenFireSyncSettingsShownThenPixelFiredWithUiVersion() {
+    fun `when setup cancelled if denied for a pairing cancelled code then abandoned pixel fired`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
+
+        testee.fireSetupCancelledIfDenied(
+            screenType,
+            DispatchOutcome.Failed(reason = "user_denied", code = AccountErrorCodes.PAIRING_CANCELLED.code),
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
+                SyncPixelParameters.SYNC_SETUP_REASON to "sync_confirmation_denied",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun `when setup cancelled if denied for a peer rejection code then abandoned pixel fired`(
+        @TestParameter protocol: ProtocolVersion,
+        @TestParameter ui: UiVersion,
+        @TestParameter screenType: ScreenType,
+    ) {
+        protocol.configure(syncFeature)
+        ui.configure(syncFeature)
+
+        testee.fireSetupCancelledIfDenied(
+            screenType,
+            DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code),
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to protocol.value,
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to screenType.value,
+                SyncPixelParameters.SYNC_SETUP_REASON to "sync_confirmation_denied",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun `when setup cancelled if denied for a non cancellation outcome then pixel is not fired`() {
+        testee.fireSetupCancelledIfDenied(
+            ScreenType.SYNC_CONNECT,
+            DispatchOutcome.Failed(reason = "boom", code = AccountErrorCodes.PAIRING_FAILED.code),
+        )
+
+        verifyNoInteractions(pixel)
+    }
+
+    @Test
+    fun `when daily api error for object limit exceeded then pixel is sent`() {
+        testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.COUNT_LIMIT.code))
+
+        verify(pixel).fire("m_sync_bookmarks_object_limit_exceeded_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `when daily api error for request size limit exceeded then pixel is sent`() {
+        testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.CONTENT_TOO_LARGE.code))
+
+        verify(pixel).fire("m_sync_bookmarks_request_size_limit_exceeded_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `when daily api error for validation error then pixel is sent`() {
+        testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.VALIDATION_ERROR.code))
+
+        verify(pixel).fire("m_sync_bookmarks_validation_error_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `when daily api error for too many requests then pixel is sent`() {
+        testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.TOO_MANY_REQUESTS_1.code))
+        testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.TOO_MANY_REQUESTS_2.code))
+
+        verify(pixel, times(2)).fire("m_sync_bookmarks_too_many_requests_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `when rescope token error pixel is fired then it carries the error`(
+        @TestParameter ui: UiVersion,
+    ) {
+        ui.configure(syncFeature)
+        val error = Error(code = 401, reason = "unauthorized")
+
+        testee.fireSyncAccountErrorPixel(error, SyncAccountOperation.RESCOPE_TOKEN)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_RESCOPE_TOKEN_FAILURE,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.ERROR_CODE to "401",
+                SyncPixelParameters.ERROR_REASON to "unauthorized",
+            ),
+        )
+    }
+
+    @Test
+    fun `when ai chat active then daily pixel is fired`() {
+        testee.fireAiChatActive()
+
+        verify(pixel).fire(SyncPixelName.SYNC_AI_CHAT_ACTIVE, emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `when ai chats rescope token error with 400 then validation error pixel is fired`() {
+        val error = Error(code = API_CODE.VALIDATION_ERROR.code, reason = "bad request")
+
+        testee.fireAiChatsRescopeTokenError(error)
+
+        verify(pixel).fire("m_sync_ai_chats_validation_error_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `when ai chats rescope token error with 409 then object limit exceeded pixel is fired`() {
+        val error = Error(code = API_CODE.COUNT_LIMIT.code, reason = "count limit")
+
+        testee.fireAiChatsRescopeTokenError(error)
+
+        verify(pixel).fire("m_sync_ai_chats_object_limit_exceeded_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `when ai chats rescope token error with 413 then request size limit exceeded pixel is fired`() {
+        val error = Error(code = API_CODE.CONTENT_TOO_LARGE.code, reason = "too large")
+
+        testee.fireAiChatsRescopeTokenError(error)
+
+        verify(pixel).fire("m_sync_ai_chats_request_size_limit_exceeded_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `when ai chats rescope token error with 429 then too many requests pixel is fired`() {
+        val error = Error(code = API_CODE.TOO_MANY_REQUESTS_1.code, reason = "rate limited")
+
+        testee.fireAiChatsRescopeTokenError(error)
+
+        verify(pixel).fire("m_sync_ai_chats_too_many_requests_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `when ai chats rescope token error with 401 then no pixel is fired`() {
+        val error = Error(code = API_CODE.INVALID_LOGIN_CREDENTIALS.code, reason = "unauthorized")
+
+        testee.fireAiChatsRescopeTokenError(error)
+
+        verifyNoInteractions(pixel)
+    }
+
+    @Test
+    fun `when sync settings shown then the pixel is fired`(
+        @TestParameter ui: UiVersion,
+    ) {
+        ui.configure(syncFeature)
+
         testee.fireSyncSettingsShown()
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETTINGS_SCREEN_SHOWN,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
             ),
         )
     }
 
     @Test
-    fun whenFireBackupThisDeviceTappedThenPixelFiredWithUiVersion() {
+    fun `when backup this device tapped then the pixel is fired`(
+        @TestParameter ui: UiVersion,
+    ) {
+        ui.configure(syncFeature)
+
         testee.fireBackupThisDeviceTapped()
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETTINGS_BACK_UP_THIS_DEVICE_TAPPED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
             ),
         )
     }
 
     @Test
-    fun whenFireRecoverSyncDataTappedThenPixelFiredWithUiVersion() {
+    fun `when recover sync data tapped then the pixel is fired`(
+        @TestParameter ui: UiVersion,
+    ) {
+        ui.configure(syncFeature)
+
         testee.fireRecoverSyncDataTapped()
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETTINGS_RECOVER_SYNC_DATA_TAPPED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
             ),
         )
     }
 
     @Test
-    fun whenFireRecoverSyncDataConfirmedThenPixelFiredWithUiVersion() {
+    fun `when recover sync data confirmed then the pixel is fired`(
+        @TestParameter ui: UiVersion,
+    ) {
+        ui.configure(syncFeature)
+
         testee.fireRecoverSyncDataConfirmed()
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETTINGS_RECOVER_SYNC_DATA_CONFIRMED,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
             ),
         )
     }
 
     @Test
-    fun whenFireSyncAnotherDevicePromptShownThenPixelFiredWithUiVersion() {
+    fun `when another device prompt shown then the pixel is fired`(
+        @TestParameter ui: UiVersion,
+    ) {
+        ui.configure(syncFeature)
+
         testee.fireSyncAnotherDevicePromptShown()
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ANOTHER_DEVICE_PROMPT_SHOWN,
             mapOf(
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
             ),
         )
     }
 
     @Test
-    fun whenFireSyncAnotherDevicePromptOptionTappedForThisDeviceOnlyThenPixelFiredWithOptionAndUiVersion() {
-        testee.fireSyncAnotherDevicePromptOptionTapped(AnotherDevicePromptOption.THIS_DEVICE_ONLY)
+    fun `when another device prompt option tapped then the pixel carries the option`(
+        @TestParameter ui: UiVersion,
+        @TestParameter option: AnotherDevicePromptOption,
+    ) {
+        ui.configure(syncFeature)
+
+        testee.fireSyncAnotherDevicePromptOptionTapped(option)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ANOTHER_DEVICE_PROMPT_OPTION_TAPPED,
             mapOf(
-                SyncPixelParameters.OPTION to "this_device_only",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
-            ),
-        )
-    }
-
-    @Test
-    fun whenFireSyncAnotherDevicePromptOptionTappedForWithAnotherDeviceThenPixelFiredWithOptionAndUiVersion() {
-        testee.fireSyncAnotherDevicePromptOptionTapped(AnotherDevicePromptOption.WITH_ANOTHER_DEVICE)
-
-        verify(pixel).fire(
-            SyncPixelName.SYNC_SETUP_ANOTHER_DEVICE_PROMPT_OPTION_TAPPED,
-            mapOf(
-                SyncPixelParameters.OPTION to "sync_another_device",
-                SyncPixelParameters.SYNC_SETUP_UI_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
+                SyncPixelParameters.OPTION to option.value,
             ),
         )
     }
@@ -1069,5 +1138,37 @@ class RealSyncPixelsTest {
         whenever(syncStatsRepository.getYesterdayDailyStats()).thenReturn(dailyStats)
 
         return dailyStats
+    }
+
+    enum class ProtocolVersion(
+        val value: String,
+    ) {
+        ProtocolV1("v1"),
+        ProtocolV2("v2"),
+        ;
+
+        fun configure(syncFeature: SyncFeature) {
+            val isEnabled = when (this) {
+                ProtocolV1 -> false
+                ProtocolV2 -> true
+            }
+            syncFeature.canUseV2ConnectFlow().setRawStoredState(State(isEnabled))
+        }
+    }
+
+    enum class UiVersion(
+        val value: String,
+    ) {
+        UiV1("v1"),
+        UiV2("v2"),
+        ;
+
+        fun configure(syncFeature: SyncFeature) {
+            val isEnabled = when (this) {
+                UiV1 -> false
+                UiV2 -> true
+            }
+            syncFeature.useSimplifiedSync().setRawStoredState(State(isEnabled))
+        }
     }
 }

--- a/versions.properties
+++ b/versions.properties
@@ -194,3 +194,5 @@ version.android.tools.desugar_jdk_libs=2.1.5
 version.de.siegmar..fastcsv=2.2.2
 
 version.javax.inject..javax.inject=1
+
+version.com.google.testparameterinjector..test-parameter-injector=1.22


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1217224514372553?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Refactors `RealSyncPixelsTest` to use parameterized tests via `TestParameterInjector`, removing the repetition where the same pixel assertion was duplicated once per flow version, UI version, and screen type. 

- Adds the `com.google.testparameterinjector:test-parameter-injector` test dependency, pinned in `versions.properties` and wired into `sync-impl`.
- Introduces `ProtocolVersion`, `UiVersion`, and `ScreenType` as the parameter dimensions. Any test that asserted `flow_version`, `ui_version`, or `screen_type` now takes those values as parameters instead of hardcoding them, so each such test runs across every combination.
- Renames all tests to backtick style, with the parameterized dimensions removed from the names.

### Steps to test this PR
N/A

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor in sync pixel unit tests; no production code changes.
> 
> **Overview**
> Refactors **`RealSyncPixelsTest`** to use **Google Test Parameter Injector** instead of duplicating the same Mockito assertions for every protocol (v1/v2 connect flow), UI (simplified sync v1/v2), and screen type combination.
> 
> Adds **`test-parameter-injector`** (pinned in `versions.properties`, wired in `sync-impl` test deps). Tests that assert `flow_version`, `ui_version`, and `screen_type` now take **`ProtocolVersion`**, **`UiVersion`**, and **`ScreenType`** as `@TestParameter` dimensions, with small enums that configure `SyncFeature` toggles before each run. Test names move to **backtick** style; parameterized axes are no longer baked into method names.
> 
> Signup-with-source expectations now use **`SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE`** for the source string (aligned with other setup pixels). Production **`RealSyncPixels`** behavior is unchanged—this is test structure and coverage breadth only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 155f823296f13ee993f6c032bbc07c96a2edb7d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->