### PR TITLE
Sync: wire device_info writing into the login flow for the unified device list

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/LoginDeviceInfoWriter.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/LoginDeviceInfoWriter.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.store.SyncStore
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.withContext
+import logcat.LogPriority.ERROR
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * Runs after a successful native (ddg) login to bring this device into the unified device list.
+ * Best-effort by design: the login has already written the legacy device name/type, so a failure here must never fail the login.
+ */
+interface LoginDeviceInfoWriter {
+    /**
+     * Do the best-effort unified-device-list write for a freshly-completed ddg login. [loginResponseKeys] is the login response's keys[],
+     * used to spot a 3party-only account_info key that this native device should re-wrap for ddg.
+     */
+    suspend fun onLogin(loginResponseKeys: List<ProtectedKeyEntry>?): Result<Unit>
+}
+
+@ContributesBinding(AppScope::class)
+class RealLoginDeviceInfoWriter @Inject constructor(
+    private val syncStore: SyncStore,
+    private val syncApi: SyncApi,
+    private val syncFeature: SyncFeature,
+    private val protectedKeyUnwrapper: ProtectedKeyUnwrapper,
+    private val nativeLib: SyncLib,
+    private val deviceInfoMigrator: DeviceInfoMigrator,
+    private val dispatchers: DispatcherProvider,
+) : LoginDeviceInfoWriter {
+
+    /**
+     *  If the account_info key exists wrapped only for 3party, it first adds the missing ddg wrap so this device can read the list
+     *  It then runs the shared [DeviceInfoMigrator.ensureMigrated] to ensure the key exists and PATCH this device's device_info.
+     *
+     *  No-op when the write feature flag is off.
+     */
+    override suspend fun onLogin(loginResponseKeys: List<ProtectedKeyEntry>?): Result<Unit> = withContext(dispatchers.io()) {
+        if (!syncFeature.canWriteUnifiedDeviceList().isEnabled()) return@withContext Success(Unit)
+        addDdgWrapIfThirdPartyOnly(loginResponseKeys)
+        deviceInfoMigrator.ensureMigrated()
+    }
+
+    /** Silent no-op unless the account_info key is present, 3party-only, and we hold the scoped password to unwrap it. */
+    private fun addDdgWrapIfThirdPartyOnly(loginResponseKeys: List<ProtectedKeyEntry>?) {
+        val accountInfoKeys = loginResponseKeys.orEmpty().filter { it.purpose == SYNC_PURPOSE_ACCOUNT_INFO }
+        if (accountInfoKeys.isEmpty()) {
+            logcat { "Sync-UnifiedDevices: no account_info key in login response; migration will create it" }
+            return
+        }
+
+        // if encrypted with DDG, nothing to do as already ddg-readable
+        if (accountInfoKeys.any { it.encryptedWith == CREDENTIAL_ID_DDG }) {
+            logcat { "Sync-UnifiedDevices: account_info already has a ddg wrap; no re-wrap needed" }
+            return
+        }
+
+        val threeParty = accountInfoKeys.firstOrNull { it.encryptedWith == CREDENTIAL_ID_3PARTY }
+        if (threeParty == null) {
+            logcat { "Sync-UnifiedDevices: account_info has no ddg or 3party wrap; nothing to re-wrap" }
+            return
+        }
+        if (syncStore.scopedPassword?.raw.isNullOrEmpty()) {
+            logcat { "Sync-UnifiedDevices: account_info is 3party-only but no scoped password held; skipping ddg re-wrap" }
+            return
+        }
+        val token = syncStore.token.takeUnless { it.isNullOrEmpty() } ?: run {
+            logcat { "Sync-UnifiedDevices: account_info is 3party-only but no token; skipping ddg re-wrap" }
+            return
+        }
+        val accountSecretKey = syncStore.secretKey?.takeUnless { it.isEmpty() } ?: run {
+            logcat { "Sync-UnifiedDevices: account_info is 3party-only but no account secret key; skipping ddg re-wrap" }
+            return
+        }
+
+        logcat { "Sync-UnifiedDevices: account_info is 3party-only; re-wrapping for ddg (kid=${threeParty.kid})" }
+        val ddgEntry = when (val result = buildDdgWrap(threeParty, accountSecretKey)) {
+            is Success -> result.data
+            is Error -> {
+                logcat(ERROR) { "Sync-UnifiedDevices: failed to build ddg wrap for account_info: ${result.reason}" }
+                return
+            }
+        }
+
+        // Add the missing ddg wrap via set-if-absent, reusing the existing key's kid.
+        // Best-effort; any failure just leaves this device's reads degraded until the key converges; it never blocks the device_info write below.
+        when (val result = syncApi.setKeysIfAbsent(token, SYNC_PURPOSE_ACCOUNT_INFO, listOf(ddgEntry))) {
+            is Success -> logcat { "Sync-UnifiedDevices: added ddg wrap for account_info (kid=${threeParty.kid}); set-if-absent → ${result.data}" }
+            is Error -> logcat(ERROR) { "Sync-UnifiedDevices: set-if-absent of ddg account_info wrap failed: ${result.reason}" }
+        }
+    }
+
+    /** Unwrap [source] with the scoped password and re-wrap the raw private key for `ddg`, preserving its kid and public key. */
+    private fun buildDdgWrap(source: ProtectedKeyEntry, accountSecretKey: String): Result<ProtectedKeyEntry> {
+        val rawPrivateKeyBytes = when (val result = protectedKeyUnwrapper.unwrap(source)) {
+            is Success -> result.data
+            is Error -> return result
+        }
+        val wireEncryptedPrivateKey = when (val result = ddgWrapPrivateKey(rawPrivateKeyBytes, accountSecretKey, nativeLib, "LoginReWrap")) {
+            is Success -> result.data
+            is Error -> return result
+        }
+        return Success(
+            ProtectedKeyEntry(
+                kid = source.kid,
+                purpose = SYNC_PURPOSE_ACCOUNT_INFO,
+                encryptedWith = CREDENTIAL_ID_DDG,
+                encryptedPrivateKey = wireEncryptedPrivateKey,
+                publicKey = source.publicKey,
+            ),
+        )
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyMinting.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyMinting.kt
@@ -54,12 +54,10 @@ internal fun mintDdgWrappedProtectedKey(
         Base64.decode(rsa.privateKeyBase64, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
     }.getOrElse { return it.asLoggedError("$errorPrefix: failed to decode private key bytes") }
 
-    val ddgEncryptedPrivateKey = runCatching {
-        val result = nativeLib.encryptData(privateKeyBytes, accountSecretKey).also {
-            it.checkResult("$errorPrefix: libsodium encryption of private key failed")
-        }
-        Base64.encodeToString(result.encryptedData, Base64.NO_WRAP).applyUrlSafetyFromB64()
-    }.getOrElse { return it.asErrorResult() }
+    val ddgEncryptedPrivateKey = when (val wrapped = ddgWrapPrivateKey(privateKeyBytes, accountSecretKey, nativeLib, errorPrefix)) {
+        is Success -> wrapped.data
+        is Result.Error -> return wrapped
+    }
 
     val entry = ProtectedKeyEntry(
         kid = UUID.randomUUID().toString(),
@@ -70,3 +68,19 @@ internal fun mintDdgWrappedProtectedKey(
     )
     return Success(MintedProtectedKey(entry = entry, rawPrivateKeyBytes = privateKeyBytes))
 }
+
+/**
+ * Wrap raw private-key bytes for the `ddg` credential: libsodium-secretbox under the account secret key, base64url-encoded for the wire.
+ * The inverse of [ProtectedKeyUnwrapper]'s ddg path, shared by fresh mints and re-wraps of an existing key.
+ */
+internal fun ddgWrapPrivateKey(
+    rawPrivateKeyBytes: ByteArray,
+    accountSecretKey: String,
+    nativeLib: SyncLib,
+    errorPrefix: String,
+): Result<String> = runCatching {
+    val encrypted = nativeLib.encryptData(rawPrivateKeyBytes, accountSecretKey).also {
+        it.checkResult("$errorPrefix: libsodium encryption of private key failed")
+    }
+    Success(Base64.encodeToString(encrypted.encryptedData, Base64.NO_WRAP).applyUrlSafetyFromB64())
+}.getOrElse { it.asErrorResult() }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -170,6 +170,7 @@ class AppSyncAccountRepository @Inject constructor(
     private val syncJweCrypto: SyncJweCrypto,
     private val thirdPartyCredentialManager: ThirdPartyCredentialManager,
     private val thirdPartyDeviceListDecryptor: ThirdPartyDeviceListDecryptor,
+    private val loginDeviceInfoWriter: LoginDeviceInfoWriter,
 ) : SyncAccountRepository {
 
     // Bounded backoff for the 3party→ddg upgrade network calls.
@@ -1276,6 +1277,11 @@ class AppSyncAccountRepository @Inject constructor(
                     }
                     result.data.keys?.let { keys ->
                         logcat { "Sync-ScopedToken: ${keys.size} protected key(s) in response" }
+                    }
+
+                    // Best-effort unified-device-list write; gated internally and never fails the login.
+                    appCoroutineScope.launch(dispatcherProvider.io()) {
+                        loginDeviceInfoWriter.onLogin(result.data.keys)
                     }
                 }
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.sync.impl
 
 import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.duckduckgo.common.utils.DefaultDispatcherProvider
+import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.TestSyncFixtures.aDevice
@@ -83,13 +83,13 @@ import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
 import com.duckduckgo.sync.store.ScopedPassword
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.moshi.Moshi
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
@@ -131,6 +131,10 @@ class AppSyncAccountRepositoryTest {
     private val syncJweCrypto: SyncJweCrypto = mock()
     private val thirdPartyCredentialManager: ThirdPartyCredentialManager = mock()
     private val thirdPartyDeviceListDecryptor: ThirdPartyDeviceListDecryptor = mock()
+    private val loginDeviceInfoWriter: LoginDeviceInfoWriter = mock()
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
 
     @Before
     fun before() {
@@ -142,8 +146,8 @@ class AppSyncAccountRepositoryTest {
             syncStore,
             syncEngine,
             syncPixels,
-            TestScope(),
-            DefaultDispatcherProvider(),
+            coroutineTestRule.testScope,
+            coroutineTestRule.testDispatcherProvider,
             syncFeature,
             deviceKeyGenerator,
             syncCodeUrlWrapper = syncCodeUrlWrapper,
@@ -151,6 +155,7 @@ class AppSyncAccountRepositoryTest {
             syncJweCrypto = syncJweCrypto,
             thirdPartyCredentialManager = thirdPartyCredentialManager,
             thirdPartyDeviceListDecryptor = thirdPartyDeviceListDecryptor,
+            loginDeviceInfoWriter = loginDeviceInfoWriter,
         )
         (syncRepo as AppSyncAccountRepository).upgradeRetryDelayMillis = 0L // keep retry-path tests instant
 
@@ -1216,6 +1221,32 @@ class AppSyncAccountRepositoryTest {
         assertEquals(Success(true), result)
         verify(syncStore).credentialId = "ddg"
         verify(syncStore, times(0)).scopedPassword = any()
+    }
+
+    @Test
+    fun whenV2LoginSucceedsThenLoginDeviceInfoWriterIsNotified() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        prepareToProvideDeviceIds()
+        prepareForEncryption()
+        whenever(nativeLib.prepareForLogin(primaryKey)).thenReturn(validLoginKeys)
+        whenever(syncApi.login(anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull())).thenReturn(loginSuccess)
+
+        syncRepo.processCode(SyncAuthCode.Recovery(RecoveryCode(primaryKey = primaryKey, userId = userId)))
+
+        verify(loginDeviceInfoWriter).onLogin(anyOrNull())
+    }
+
+    @Test
+    fun whenLegacyLoginSucceedsThenLoginDeviceInfoWriterNotNotified() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+        prepareToProvideDeviceIds()
+        prepareForEncryption()
+        whenever(nativeLib.prepareForLogin(primaryKey)).thenReturn(validLoginKeys)
+        whenever(syncApi.login(anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull())).thenReturn(loginSuccess)
+
+        syncRepo.processCode(SyncAuthCode.Recovery(RecoveryCode(primaryKey = primaryKey, userId = userId)))
+
+        verify(loginDeviceInfoWriter, never()).onLogin(anyOrNull())
     }
 
     // A3: Signup with scoped access credentials flag

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/LoginDeviceInfoWriterTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/LoginDeviceInfoWriterTest.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.sync.TestSyncFixtures.token
+import com.duckduckgo.sync.TestSyncFixtures.userId
+import com.duckduckgo.sync.crypto.EncryptBytesResult
+import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.store.ScopedPassword
+import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class LoginDeviceInfoWriterTest {
+
+    private val syncStore: SyncStore = mock()
+    private val syncApi: SyncApi = mock()
+    private val protectedKeyUnwrapper: ProtectedKeyUnwrapper = mock()
+    private val nativeLib: SyncLib = mock()
+    private val deviceInfoMigrator: DeviceInfoMigrator = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    private lateinit var writer: RealLoginDeviceInfoWriter
+
+    private val secretKey = "accountSecretKey"
+
+    @Before
+    fun before() {
+        writer = RealLoginDeviceInfoWriter(
+            syncStore = syncStore,
+            syncApi = syncApi,
+            syncFeature = syncFeature,
+            protectedKeyUnwrapper = protectedKeyUnwrapper,
+            nativeLib = nativeLib,
+            deviceInfoMigrator = deviceInfoMigrator,
+            dispatchers = coroutineTestRule.testDispatcherProvider,
+        )
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.secretKey).thenReturn(secretKey)
+        whenever(syncStore.userId).thenReturn(userId)
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword("c2NvcGVk"))
+        runBlocking { whenever(deviceInfoMigrator.ensureMigrated()).thenReturn(Result.Success(Unit)) }
+    }
+
+    @Test
+    fun whenAccountInfoKeyAbsentThenNoReWrapButStillMigrates() = runTest {
+        val result = writer.onLogin(loginResponseKeys = emptyList())
+
+        assertTrue(result is Result.Success)
+        verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
+        verify(deviceInfoMigrator).ensureMigrated()
+    }
+
+    @Test
+    fun whenAccountInfoKeyAlreadyDdgWrappedThenNoReWrap() = runTest {
+        writer.onLogin(loginResponseKeys = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_DDG)))
+
+        verify(protectedKeyUnwrapper, never()).unwrap(any())
+        verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
+        verify(deviceInfoMigrator).ensureMigrated()
+    }
+
+    @Test
+    fun whenAccountInfo3partyOnlyAndScopedPasswordHeldThenReWrapsForDdgThenMigrates() = runTest {
+        whenever(protectedKeyUnwrapper.unwrap(any())).thenReturn(Result.Success("rawKey".toByteArray()))
+        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey)))
+            .thenReturn(EncryptBytesResult(0, "ddgWrapped".toByteArray()))
+        whenever(syncApi.setKeysIfAbsent(eq(token), eq(SYNC_PURPOSE_ACCOUNT_INFO), any()))
+            .thenReturn(Result.Success(SetKeysIfAbsentResult.Created))
+
+        writer.onLogin(loginResponseKeys = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
+
+        verify(syncApi).setKeysIfAbsent(
+            eq(token),
+            eq(SYNC_PURPOSE_ACCOUNT_INFO),
+            check { keys ->
+                assertTrue(keys.size == 1)
+                assertTrue(keys.first().encryptedWith == CREDENTIAL_ID_DDG)
+                assertTrue(keys.first().kid == "kid-1")
+            },
+        )
+        verify(deviceInfoMigrator).ensureMigrated()
+    }
+
+    @Test
+    fun whenAccountInfo3partyOnlyButNoScopedPasswordThenSkipsReWrapButStillMigrates() = runTest {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+
+        writer.onLogin(loginResponseKeys = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
+
+        verify(protectedKeyUnwrapper, never()).unwrap(any())
+        verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
+        verify(deviceInfoMigrator).ensureMigrated()
+    }
+
+    @Test
+    fun whenUnwrapFailsThenSkipsReWrapButStillMigrates() = runTest {
+        whenever(protectedKeyUnwrapper.unwrap(any())).thenReturn(Result.Error(reason = "cannot unwrap"))
+
+        writer.onLogin(loginResponseKeys = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
+
+        verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
+        verify(deviceInfoMigrator).ensureMigrated()
+    }
+
+    @Test
+    fun whenSetKeysIfAbsentFailsThenStillMigrates() = runTest {
+        whenever(protectedKeyUnwrapper.unwrap(any())).thenReturn(Result.Success("rawKey".toByteArray()))
+        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey)))
+            .thenReturn(EncryptBytesResult(0, "ddgWrapped".toByteArray()))
+        whenever(syncApi.setKeysIfAbsent(any(), any(), any())).thenReturn(Result.Error(reason = "server error"))
+
+        val result = writer.onLogin(loginResponseKeys = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
+
+        assertTrue(result is Result.Success)
+        verify(deviceInfoMigrator).ensureMigrated()
+    }
+
+    @Test
+    fun whenWriteFeatureDisabledThenNothingRuns() = runTest {
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = false))
+
+        val result = writer.onLogin(listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
+
+        assertTrue(result is Result.Success)
+        verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
+        verify(deviceInfoMigrator, never()).ensureMigrated()
+    }
+
+    private fun accountInfoEntry(encryptedWith: String) = ProtectedKeyEntry(
+        kid = "kid-1",
+        purpose = SYNC_PURPOSE_ACCOUNT_INFO,
+        encryptedWith = encryptedWith,
+        encryptedPrivateKey = "wrapped-private-key",
+        publicKey = RsaJwk(n = "n", e = "AQAB"),
+    )
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216792641477210?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Adds LoginDeviceInfoWriter, invoked fire-and-forget after a successful native (ddg) login. It brings the signed-in device into the unified device list world.

Login is the point where a device that just authenticated should publish its device_info and, if needed, make the account key readable by its own credential.

**Behaviour / safety**
  • Gated on SyncFeature.canWriteUnifiedDeviceList(), which is still off by default
  • Best-effort: the legacy name/type written by the login itself is the must-succeed part; nothing here can fail or block login

### Steps to test this PR

**Creating account**
- [ ] Fresh install `internal` variant
- [ ] Configure feature flags
    - [ ] `canUseV2ConnectFlow` - should be enabled already, just check
    - [ ] `canWriteUnifiedDeviceList` leave it **disabled**. 
    - [ ] `canReadUnifiedDeviceList` make this **enabled**
- [ ] Open `Sync Dev Settings` and tap `Create account`. Copy the recovery code by tapping on it as you'll need it later
- [ ] Tap `Fetch & decrypt devices` and verify `no device_info`

**Sign out / sign in**
- [ ] Enable `canWriteUnifiedDeviceList`
- [ ] Tap `Reset migration marker` (just in case a migration ran)
- [ ] Sign out of sync
- [ ] Sign back in using the recovery code from earlier
- [ ] Verify you see the following logs:
```
     Sync-UnifiedDevices: no account_info key in login response; migration will create it
     Sync-UnifiedDevices: registering account_info key (…, wraps=1)
     Sync-UnifiedDevices: setKeysIfAbsent purpose=account_info, wraps=1
     Sync-UnifiedDevices: set-if-absent 201 — our keypair won
     Sync-UnifiedDevices: writing device_info for this device
     Sync-UnifiedDevices: patchDevices ok — 1 devices_v2 returned
     Sync-UnifiedDevices: migration complete for this device (1 devices_v2 returned)
```

