### PR TITLE
Target16: Fix address bar being visible under gesture nav bar

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1198,6 +1198,15 @@ class BrowserTabFragment :
 
         if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BROWSER)) {
             edgeToEdgeHandler.applyNavigationBarInsetsAsMargin(binding.rootView)
+            val hasBottomBar = !tabDisplayedInCustomTabScreen &&
+                (omnibar.omnibarType == OmnibarType.SPLIT || omnibar.omnibarType == OmnibarType.SINGLE_BOTTOM)
+            if (hasBottomBar) {
+                edgeToEdgeHandler.applyNavigationBarScrim(
+                    binding.rootView,
+                    requireContext().getColorFromAttr(com.duckduckgo.mobile.android.R.attr.preferredNavigationBarColor),
+                    coverGestureNav = true,
+                )
+            }
         }
 
         if (savedInstanceState == null) {

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
@@ -271,9 +271,7 @@ class EdgeToEdgeHandler @Inject constructor() {
      * e.g. a collapsible/draggable BottomSheetDialog, whose sheet surface only extends behind the bar while it is
      * settled expanded. The caller must already pad its content clear of the navigation bar (e.g. via
      * applyBottomSystemBarInsetPadding) so the scrim only repaints the otherwise-empty strip; where the surface
-     * does cover the strip the scrim sits on top in the identical colour and is seamless. Idempotent per window;
-     * no scrim under gesture navigation (the tappable-element inset is 0 there), so the surface stays edge-to-edge
-     * behind the gesture pill.
+     * does cover the strip the scrim sits on top in the identical colour and is seamless. Idempotent per window.
      *
      * Unlike the status-bar scrim, the colour is passed in rather than resolved from a framework attr: the
      * navigation-bar colour is transparent under the edge-to-edge themes, and `common-utils` can't reference the
@@ -281,8 +279,17 @@ class EdgeToEdgeHandler @Inject constructor() {
      *
      * @param anchor Any view attached to the target window; its window content frame hosts the scrim.
      * @param scrimColor The colour painted behind the navigation bar (typically the surface colour).
+     * @param coverGestureNav When false (default) the scrim uses the *tappable* inset: the button-bar height under
+     *   2/3-button navigation but 0 under gesture navigation, so nothing is painted behind the gesture pill and a
+     *   surface that draws itself edge-to-edge stays visible there. Pass true when the caller reserves the *full*
+     *   navigation-bar inset (e.g. as bottom margin) so its own surface never reaches the bar in any mode — then the
+     *   scrim uses the navigation-bar inset and paints the strip behind the gesture pill too.
      */
-    fun applyNavigationBarScrim(anchor: View, @ColorInt scrimColor: Int) {
+    fun applyNavigationBarScrim(
+        anchor: View,
+        @ColorInt scrimColor: Int,
+        coverGestureNav: Boolean = false,
+    ) {
         val contentRoot = anchor.rootView?.findViewById<ViewGroup>(android.R.id.content) ?: return
         if (contentRoot.findViewWithTag<View>(NAVIGATION_BAR_SCRIM_TAG) != null) return
 
@@ -293,10 +300,13 @@ class EdgeToEdgeHandler @Inject constructor() {
         }
         contentRoot.addView(scrim)
 
+        val insetType = if (coverGestureNav) {
+            WindowInsetsCompat.Type.navigationBars() or WindowInsetsCompat.Type.displayCutout()
+        } else {
+            WindowInsetsCompat.Type.tappableElement()
+        }
         ViewCompat.setOnApplyWindowInsetsListener(scrim) { v, insets ->
-            // tappableElement (not navigationBars): the button-bar height under 2/3-button navigation, but 0 under
-            // gesture navigation — so no scrim is painted there and the surface stays edge-to-edge behind the pill.
-            val bottom = insets.getInsets(WindowInsetsCompat.Type.tappableElement()).bottom
+            val bottom = insets.getInsets(insetType).bottom
             if (v.layoutParams.height != bottom) {
                 v.updateLayoutParams { height = bottom }
             }

--- a/common/common-utils/src/test/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandlerTest.kt
+++ b/common/common-utils/src/test/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandlerTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.utils.edgetoedge
+
+import android.app.Activity
+import android.graphics.Color
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+
+@RunWith(AndroidJUnit4::class)
+class EdgeToEdgeHandlerTest {
+
+    private val testee = EdgeToEdgeHandler()
+
+    private lateinit var activity: Activity
+    private lateinit var content: ViewGroup
+    private lateinit var anchor: View
+
+    @Before
+    fun setup() {
+        activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        content = activity.findViewById(android.R.id.content)
+        anchor = View(activity).also { content.addView(it) }
+    }
+
+    @Test
+    fun whenCoverGestureNavThenScrimSizedToNavigationBarInsetUnderGestureNav() {
+        testee.applyNavigationBarScrim(anchor, Color.RED, coverGestureNav = true)
+
+        // Gesture navigation: a navigation bar is present but nothing is tappable there.
+        dispatchInsets(navigationBar = 100, tappableElement = 0)
+
+        assertEquals(100, scrim().layoutParams.height)
+    }
+
+    @Test
+    fun whenNotCoverGestureNavThenScrimCollapsedUnderGestureNav() {
+        testee.applyNavigationBarScrim(anchor, Color.RED, coverGestureNav = false)
+
+        dispatchInsets(navigationBar = 100, tappableElement = 0)
+
+        assertEquals(0, scrim().layoutParams.height)
+    }
+
+    @Test
+    fun whenButtonNavThenScrimSizedToButtonBarHeightRegardlessOfCoverGestureNav() {
+        // 2/3-button navigation: the navigation bar is tappable, so both modes report the same height.
+        testee.applyNavigationBarScrim(anchor, Color.RED, coverGestureNav = false)
+
+        dispatchInsets(navigationBar = 100, tappableElement = 100)
+
+        assertEquals(100, scrim().layoutParams.height)
+    }
+
+    @Test
+    fun whenCoverGestureNavThenScrimIncludesBottomDisplayCutout() {
+        testee.applyNavigationBarScrim(anchor, Color.RED, coverGestureNav = true)
+
+        dispatchInsets(navigationBar = 40, tappableElement = 0, displayCutout = 80)
+
+        assertEquals(80, scrim().layoutParams.height)
+    }
+
+    @Test
+    fun whenAppliedTwiceThenOnlyOneScrimAdded() {
+        testee.applyNavigationBarScrim(anchor, Color.RED, coverGestureNav = true)
+        testee.applyNavigationBarScrim(anchor, Color.RED, coverGestureNav = true)
+
+        val scrims = (0 until content.childCount)
+            .map { content.getChildAt(it) }
+            .count { it.tag == NAVIGATION_BAR_SCRIM_TAG }
+        assertEquals(1, scrims)
+    }
+
+    private fun scrim(): View = content.findViewWithTag(NAVIGATION_BAR_SCRIM_TAG)
+
+    private fun dispatchInsets(
+        navigationBar: Int,
+        tappableElement: Int,
+        displayCutout: Int = 0,
+    ) {
+        val insets = WindowInsetsCompat.Builder()
+            .setInsets(WindowInsetsCompat.Type.navigationBars(), Insets.of(0, 0, 0, navigationBar))
+            .setInsets(WindowInsetsCompat.Type.tappableElement(), Insets.of(0, 0, 0, tappableElement))
+            .setInsets(WindowInsetsCompat.Type.displayCutout(), Insets.of(0, 0, 0, displayCutout))
+            .build()
+        ViewCompat.dispatchApplyWindowInsets(scrim(), insets)
+    }
+
+    private companion object {
+        private const val NAVIGATION_BAR_SCRIM_TAG = "edge_to_edge_navigation_bar_scrim"
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217198119726975?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
   - Under edge-to-edge with a bottom-anchored omnibar, the strip behind the transparent navigation bar showed the window background instead of the bar colour. This paints that strip with preferredNavigationBarColor so it reads as a continuous bottom bar.
  - The scrim is only added when a bottom bar is actually present — SPLIT or SINGLE_BOTTOM omnibar, and not a custom tab (custom tabs render their own toolbar).
  - New `coverGestureNav` flag on `applyNavigationBarScrim` sizes the scrim to the full navigation-bar (+ display cutout) inset so it covers the gesture pill area too; the existing bottom-sheet caller keeps the tappable-inset default (no scrim behind the pill).
  - Gated by the existing EdgeToEdgeBucket.BROWSER edge-to-edge flag.

### Steps to test this PR
Please test the following on a device running Android 16 up and also a device running below Android 16

- [x] Set navigation on device to Gesture Navigation
- [x] Set address bar to be at the Bottom
- [x] Create a new tab and open bbc.com
- [x] Scroll the screen
- [x] Verify that address bar gets completely hidden and also gets shown completely
- [x] Set address bar to be at the Split
- [x] Create a new tab and open bbc.com
- [x] Scroll the screen
- [x] Verify that address bar and bottom bar gets completely hidden and also gets shown completely
- [x] Set address bar to be at the Top
- [x] Create a new tab and open bbc.com
- [x] Scroll the screen
- [x] Verify that address bar behavior is same as before
- [x] Set navigation to 3 button navigation
- [x] Create a new tab and open bbc.com (Still with top bar)
- [x] Scroll the screen
- [x] Verify that address bar behavior is same as before
- [x] Set address bar to be at the Bottom
- [x] Create a new tab and open bbc.com
- [x] Scroll the screen
- [x] Verify that address bar gets completely hidden and also gets shown completely
- [x] Set address bar to be at the Split
- [x] Create a new tab and open bbc.com
- [x] Scroll the screen
- [x] Verify that address bar and bottom bar gets completely hidden and also gets shown completely




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized edge-to-edge UI fix in browser tab and shared scrim helper; default scrim behavior unchanged for existing callers.
> 
> **Overview**
> Fixes a visible strip under **gesture navigation** when the address bar sits at the bottom or in split mode under edge-to-edge: the browser tab now installs a **navigation-bar scrim** (matching `preferredNavigationBarColor`) whenever split or single-bottom omnibar is shown, not in custom tabs.
> 
> `EdgeToEdgeHandler.applyNavigationBarScrim` adds **`coverGestureNav`** (default `false`). With `true`, scrim height follows **navigation bar + display cutout** insets instead of **tappable** insets, so the painted strip covers the gesture-pill area when content is already lifted via bottom margin. Existing callers (e.g. bottom sheets) keep the default and stay edge-to-edge behind the pill.
> 
> Adds **Robolectric tests** for scrim sizing under gesture vs button nav, cutout, and idempotent install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7606f11984661e3f510db0d2437825de79d5c626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->