### PR TITLE
Align retention metric windows with canonical NA definition

### DIFF
--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/AppUseMetricPixelsPlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/AppUseMetricPixelsPlugin.kt
@@ -29,70 +29,18 @@ import javax.inject.Inject
 class AppUseMetricPixelsPlugin @Inject constructor(private val inventory: FeatureTogglesInventory) : MetricsPixelPlugin {
 
     override suspend fun getMetrics(): List<MetricsPixel> {
-        return inventory.getAllActiveExperimentToggles().flatMap { toggle ->
-            listOf(
-                MetricsPixel(
-                    metric = "app_use",
-                    type = MetricType.COUNT_WHEN_IN_WINDOW,
-                    value = "1",
-                    toggle = toggle,
-                    conversionWindow = (1..14).map { ConversionWindow(lowerWindow = it, upperWindow = it) } +
-                        listOf(
-                            ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                            ConversionWindow(lowerWindow = 1, upperWindow = 4),
-                            ConversionWindow(lowerWindow = 8, upperWindow = 14),
-                        ),
-                ),
-                MetricsPixel(
-                    metric = "app_use",
-                    type = MetricType.COUNT_WHEN_IN_WINDOW,
-                    value = "4",
-                    toggle = toggle,
-                    conversionWindow = listOf(
+        return inventory.getAllActiveExperimentToggles().map { toggle ->
+            MetricsPixel(
+                metric = "app_use",
+                type = MetricType.COUNT_WHEN_IN_WINDOW,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = (1..14).map { ConversionWindow(lowerWindow = it, upperWindow = it) } +
+                    listOf(
+                        ConversionWindow(lowerWindow = 1, upperWindow = 4),
                         ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
                     ),
-                ),
-                MetricsPixel(
-                    metric = "app_use",
-                    type = MetricType.COUNT_WHEN_IN_WINDOW,
-                    value = "6",
-                    toggle = toggle,
-                    conversionWindow = listOf(
-                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
-                    ),
-                ),
-                MetricsPixel(
-                    metric = "app_use",
-                    type = MetricType.COUNT_WHEN_IN_WINDOW,
-                    value = "11",
-                    toggle = toggle,
-                    conversionWindow = listOf(
-                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
-                    ),
-                ),
-                MetricsPixel(
-                    metric = "app_use",
-                    type = MetricType.COUNT_WHEN_IN_WINDOW,
-                    value = "21",
-                    toggle = toggle,
-                    conversionWindow = listOf(
-                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
-                    ),
-                ),
-                MetricsPixel(
-                    metric = "app_use",
-                    type = MetricType.COUNT_WHEN_IN_WINDOW,
-                    value = "30",
-                    toggle = toggle,
-                    conversionWindow = listOf(
-                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
-                    ),
-                ),
             )
         }
     }

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/DuckAiPromptSentMetricPixelsPlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/DuckAiPromptSentMetricPixelsPlugin.kt
@@ -29,69 +29,17 @@ import javax.inject.Inject
 class DuckAiPromptSentMetricPixelsPlugin @Inject constructor(private val inventory: FeatureTogglesInventory) : MetricsPixelPlugin {
 
     override suspend fun getMetrics(): List<MetricsPixel> {
-        return inventory.getAllActiveExperimentToggles().flatMap { toggle ->
-            listOf(
-                MetricsPixel(
-                    metric = "duck_ai_prompt_sent",
-                    type = MetricType.COUNT_WHEN_IN_WINDOW,
-                    value = "1",
-                    toggle = toggle,
-                    conversionWindow = listOf(
-                        ConversionWindow(lowerWindow = 0, upperWindow = 0),
-                        ConversionWindow(lowerWindow = 1, upperWindow = 1),
-                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
-                    ),
-                ),
-                MetricsPixel(
-                    metric = "duck_ai_prompt_sent",
-                    type = MetricType.COUNT_WHEN_IN_WINDOW,
-                    value = "4",
-                    toggle = toggle,
-                    conversionWindow = listOf(
-                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
-                    ),
-                ),
-                MetricsPixel(
-                    metric = "duck_ai_prompt_sent",
-                    type = MetricType.COUNT_WHEN_IN_WINDOW,
-                    value = "6",
-                    toggle = toggle,
-                    conversionWindow = listOf(
-                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
-                    ),
-                ),
-                MetricsPixel(
-                    metric = "duck_ai_prompt_sent",
-                    type = MetricType.COUNT_WHEN_IN_WINDOW,
-                    value = "11",
-                    toggle = toggle,
-                    conversionWindow = listOf(
-                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
-                    ),
-                ),
-                MetricsPixel(
-                    metric = "duck_ai_prompt_sent",
-                    type = MetricType.COUNT_WHEN_IN_WINDOW,
-                    value = "21",
-                    toggle = toggle,
-                    conversionWindow = listOf(
-                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
-                    ),
-                ),
-                MetricsPixel(
-                    metric = "duck_ai_prompt_sent",
-                    type = MetricType.COUNT_WHEN_IN_WINDOW,
-                    value = "30",
-                    toggle = toggle,
-                    conversionWindow = listOf(
-                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
-                    ),
+        return inventory.getAllActiveExperimentToggles().map { toggle ->
+            MetricsPixel(
+                metric = "duck_ai_prompt_sent",
+                type = MetricType.COUNT_WHEN_IN_WINDOW,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = listOf(
+                    ConversionWindow(lowerWindow = 0, upperWindow = 0),
+                    ConversionWindow(lowerWindow = 1, upperWindow = 1),
+                    ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                    ConversionWindow(lowerWindow = 8, upperWindow = 14),
                 ),
             )
         }

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/SearchMetricPixelsPlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/SearchMetricPixelsPlugin.kt
@@ -50,7 +50,7 @@ class SearchMetricPixelsPlugin @Inject constructor(private val inventory: Featur
                     toggle = toggle,
                     conversionWindow = listOf(
                         ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
                     ),
                 ),
                 MetricsPixel(
@@ -58,26 +58,20 @@ class SearchMetricPixelsPlugin @Inject constructor(private val inventory: Featur
                     type = MetricType.COUNT_WHEN_IN_WINDOW,
                     value = "6",
                     toggle = toggle,
-                    conversionWindow = (0..14).map { ConversionWindow(lowerWindow = it, upperWindow = it) } +
-                        listOf(
-                            ConversionWindow(lowerWindow = 1, upperWindow = 4),
-                            ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                            ConversionWindow(lowerWindow = 8, upperWindow = 14),
-                            ConversionWindow(lowerWindow = 8, upperWindow = 15),
-                        ),
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
+                    ),
                 ),
                 MetricsPixel(
                     metric = "search",
                     type = MetricType.COUNT_WHEN_IN_WINDOW,
                     value = "11",
                     toggle = toggle,
-                    conversionWindow = (0..14).map { ConversionWindow(lowerWindow = it, upperWindow = it) } +
-                        listOf(
-                            ConversionWindow(lowerWindow = 1, upperWindow = 4),
-                            ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                            ConversionWindow(lowerWindow = 8, upperWindow = 14),
-                            ConversionWindow(lowerWindow = 8, upperWindow = 15),
-                        ),
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
+                    ),
                 ),
                 MetricsPixel(
                     metric = "search",
@@ -86,7 +80,7 @@ class SearchMetricPixelsPlugin @Inject constructor(private val inventory: Featur
                     toggle = toggle,
                     conversionWindow = listOf(
                         ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
                     ),
                 ),
                 MetricsPixel(
@@ -96,7 +90,7 @@ class SearchMetricPixelsPlugin @Inject constructor(private val inventory: Featur
                     toggle = toggle,
                     conversionWindow = listOf(
                         ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
                     ),
                 ),
             )

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/AppUseMetricPixelsPluginTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/AppUseMetricPixelsPluginTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.impl.metrics
+
+import android.annotation.SuppressLint
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.MetricType
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.feature.toggles.codegen.TestTriggerFeature
+import com.duckduckgo.feature.toggles.impl.RealFeatureTogglesInventory
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+@SuppressLint("DenyListedApi")
+class AppUseMetricPixelsPluginTest {
+    @get:Rule
+    @Suppress("unused")
+    val coroutineRule = CoroutineTestRule()
+
+    private val testFeature = FakeFeatureToggleFactory.create(TestTriggerFeature::class.java)
+
+    private val plugin = AppUseMetricPixelsPlugin(
+        RealFeatureTogglesInventory(
+            setOf(FakeFeatureTogglesInventory(listOf(testFeature.experimentFooFeature()))),
+            coroutineRule.testDispatcherProvider,
+        ),
+    )
+
+    @Test
+    fun `when experiment enrolled, only value 1 is defined`() = runTest {
+        enrollExperiment()
+
+        val metrics = plugin.getMetrics()
+
+        assertEquals(listOf("1"), metrics.map { it.value })
+        assertTrue(metrics.all { it.metric == "app_use" && it.type == MetricType.COUNT_WHEN_IN_WINDOW })
+    }
+
+    @Test
+    fun `when experiment enrolled, value 1 keeps daily coverage plus the aggregate windows`() = runTest {
+        enrollExperiment()
+
+        val windows = plugin.getMetrics().single().conversionWindow
+
+        val expected = (1..14).map { ConversionWindow(lowerWindow = it, upperWindow = it) } +
+            listOf(
+                ConversionWindow(lowerWindow = 1, upperWindow = 4),
+                ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                ConversionWindow(lowerWindow = 8, upperWindow = 14),
+            )
+        assertEquals(expected.size, windows.size)
+        assertEquals(expected.toSet(), windows.toSet())
+    }
+
+    @Test
+    fun `when no experiment enrolled, no metrics are defined`() = runTest {
+        assertTrue(plugin.getMetrics().isEmpty())
+    }
+
+    private fun enrollExperiment() {
+        val today = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
+        val cohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = today)
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(
+                remoteEnableState = true,
+                enable = true,
+                cohorts = listOf(cohort),
+                assignedCohort = cohort,
+            ),
+        )
+    }
+}

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/DuckAiPromptSentMetricPixelsPluginTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/DuckAiPromptSentMetricPixelsPluginTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.impl.metrics
+
+import android.annotation.SuppressLint
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.MetricType
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.feature.toggles.codegen.TestTriggerFeature
+import com.duckduckgo.feature.toggles.impl.RealFeatureTogglesInventory
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+@SuppressLint("DenyListedApi")
+class DuckAiPromptSentMetricPixelsPluginTest {
+    @get:Rule
+    @Suppress("unused")
+    val coroutineRule = CoroutineTestRule()
+
+    private val testFeature = FakeFeatureToggleFactory.create(TestTriggerFeature::class.java)
+
+    private val plugin = DuckAiPromptSentMetricPixelsPlugin(
+        RealFeatureTogglesInventory(
+            setOf(FakeFeatureTogglesInventory(listOf(testFeature.experimentFooFeature()))),
+            coroutineRule.testDispatcherProvider,
+        ),
+    )
+
+    @Test
+    fun `when experiment enrolled, only value 1 is defined`() = runTest {
+        enrollExperiment()
+
+        val metrics = plugin.getMetrics()
+
+        assertEquals(listOf("1"), metrics.map { it.value })
+        assertTrue(metrics.all { it.metric == "duck_ai_prompt_sent" && it.type == MetricType.COUNT_WHEN_IN_WINDOW })
+    }
+
+    @Test
+    fun `when experiment enrolled, value 1 uses days 0 and 1 plus the aggregate windows`() = runTest {
+        enrollExperiment()
+
+        val windows = plugin.getMetrics().single().conversionWindow
+
+        val expected = listOf(
+            ConversionWindow(lowerWindow = 0, upperWindow = 0),
+            ConversionWindow(lowerWindow = 1, upperWindow = 1),
+            ConversionWindow(lowerWindow = 5, upperWindow = 7),
+            ConversionWindow(lowerWindow = 8, upperWindow = 14),
+        )
+        assertEquals(expected, windows)
+    }
+
+    @Test
+    fun `when no experiment enrolled, no metrics are defined`() = runTest {
+        assertTrue(plugin.getMetrics().isEmpty())
+    }
+
+    private fun enrollExperiment() {
+        val today = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
+        val cohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = today)
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(
+                remoteEnableState = true,
+                enable = true,
+                cohorts = listOf(cohort),
+                assignedCohort = cohort,
+            ),
+        )
+    }
+}

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt
@@ -90,6 +90,7 @@ class RetentionMetricsAtbLifecyclePluginTest {
         atbLifecyclePlugin.onSearchRetentionAtbRefreshed("", "")
 
         val expected = searchMetricPixelsPlugin.getMetrics()
+        assertTrue(expected.isNotEmpty())
         assertEquals(expected.size, fakeMetricsPixelExtension.sentMetrics.size)
         assertTrue(fakeMetricsPixelExtension.sentMetrics.all { it.metric == "search" })
     }
@@ -102,6 +103,7 @@ class RetentionMetricsAtbLifecyclePluginTest {
         atbLifecyclePlugin.onAppRetentionAtbRefreshed("", "")
 
         val expected = appUseMetricPixelsPlugin.getMetrics()
+        assertTrue(expected.isNotEmpty())
         assertEquals(expected.size, fakeMetricsPixelExtension.sentMetrics.size)
         assertTrue(fakeMetricsPixelExtension.sentMetrics.all { it.metric == "app_use" })
     }
@@ -186,6 +188,7 @@ class RetentionMetricsAtbLifecyclePluginTest {
         atbLifecyclePlugin.onDuckAiRetentionAtbRefreshed("", "", emptyMap())
 
         val expected = duckAiPromptSentMetricPixelsPlugin.getMetrics()
+        assertTrue(expected.isNotEmpty())
         assertEquals(expected.size, fakeMetricsPixelExtension.sentMetrics.size)
         assertTrue(fakeMetricsPixelExtension.sentMetrics.all { it.metric == "duck_ai_prompt_sent" })
     }
@@ -238,18 +241,21 @@ class RetentionMetricsAtbLifecyclePluginTest {
     }
 
     private suspend fun setCohorts(today: String) {
+        val cohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = today)
         testFeature.experimentFooFeature().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
-                assignedCohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = today),
+                cohorts = listOf(cohort),
+                assignedCohort = cohort,
             ),
         )
         testFeature.fooFeature().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
-                assignedCohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = today),
+                cohorts = listOf(cohort),
+                assignedCohort = cohort,
             ),
         )
     }

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/SearchMetricPixelsPluginTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/SearchMetricPixelsPluginTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.impl.metrics
+
+import android.annotation.SuppressLint
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.MetricType
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.feature.toggles.codegen.TestTriggerFeature
+import com.duckduckgo.feature.toggles.impl.RealFeatureTogglesInventory
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+@SuppressLint("DenyListedApi")
+class SearchMetricPixelsPluginTest {
+    @get:Rule
+    @Suppress("unused")
+    val coroutineRule = CoroutineTestRule()
+
+    private val testFeature = FakeFeatureToggleFactory.create(TestTriggerFeature::class.java)
+
+    private val plugin = SearchMetricPixelsPlugin(
+        RealFeatureTogglesInventory(
+            setOf(FakeFeatureTogglesInventory(listOf(testFeature.experimentFooFeature()))),
+            coroutineRule.testDispatcherProvider,
+        ),
+    )
+
+    @Test
+    fun `when experiment enrolled, metrics are defined for the canonical value thresholds`() = runTest {
+        enrollExperiment()
+
+        val metrics = plugin.getMetrics()
+
+        assertEquals(listOf("1", "4", "6", "11", "21", "30"), metrics.map { it.value })
+        assertTrue(metrics.all { it.metric == "search" && it.type == MetricType.COUNT_WHEN_IN_WINDOW })
+    }
+
+    @Test
+    fun `when experiment enrolled, value 1 keeps daily coverage plus the aggregate windows`() = runTest {
+        enrollExperiment()
+
+        val windows = plugin.getMetrics().single { it.value == "1" }.conversionWindow
+
+        val expected = (0..14).map { ConversionWindow(lowerWindow = it, upperWindow = it) } +
+            listOf(
+                ConversionWindow(lowerWindow = 1, upperWindow = 4),
+                ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                ConversionWindow(lowerWindow = 8, upperWindow = 14),
+            )
+        assertEquals(expected.size, windows.size)
+        assertEquals(expected.toSet(), windows.toSet())
+    }
+
+    @Test
+    fun `when experiment enrolled, count thresholds only use the aggregate windows`() = runTest {
+        enrollExperiment()
+
+        val thresholdMetrics = plugin.getMetrics().filter { it.value != "1" }
+
+        val expected = listOf(
+            ConversionWindow(lowerWindow = 5, upperWindow = 7),
+            ConversionWindow(lowerWindow = 8, upperWindow = 14),
+        )
+        assertTrue(thresholdMetrics.all { it.conversionWindow == expected })
+    }
+
+    @Test
+    fun `when experiment enrolled, no metric uses the pre-alignment 8 to 15 window`() = runTest {
+        enrollExperiment()
+
+        val windows = plugin.getMetrics().flatMap { it.conversionWindow }
+
+        assertTrue(windows.none { it.upperWindow == 15 })
+    }
+
+    @Test
+    fun `when no experiment enrolled, no metrics are defined`() = runTest {
+        assertTrue(plugin.getMetrics().isEmpty())
+    }
+
+    private fun enrollExperiment() {
+        val today = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
+        val cohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = today)
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(
+                remoteEnableState = true,
+                enable = true,
+                cohorts = listOf(cohort),
+                assignedCohort = cohort,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205648422731273/task/1216723453190782?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

### Steps to test this PR

QA-optional

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which retention pixels fire and their day windows, which can shift experiment analytics and cohort comparisons; scope is metrics configuration only, not user-facing behavior.
> 
> **Overview**
> Aligns experiment retention **metrics pixels** with the canonical NA conversion-window definition and removes metrics that duplicated higher count thresholds where only the baseline count is needed.
> 
> **App use** and **Duck AI prompt sent** plugins now emit a single `COUNT_WHEN_IN_WINDOW` metric per active experiment toggle (value `"1"`) instead of separate pixels for 4, 6, 11, 21, and 30. Aggregate windows use **8–14** instead of **8–15** everywhere they appear.
> 
> **Search** keeps the full threshold set (`1`, `4`, `6`, `11`, `21`, `30`) but tightens windows: **8–15** becomes **8–14**, and thresholds **6** and **11** no longer include per-day **0–14** windows—only the shared aggregates (**5–7** and **8–14**), matching the other count thresholds.
> 
> New unit tests lock in window sets and threshold coverage; **RetentionMetricsAtbLifecyclePlugin** tests set `cohorts` on enrolled toggles and assert metrics are non-empty when ATB refresh fires.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b424a99700c4a988eb0baa646911fa0cf816e2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->