### PR TITLE
Change native input buttons background

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -1270,7 +1270,7 @@ class RealNativeInputManager @Inject constructor(
         val omnibarCard = omnibarController.getCardView() ?: return false
         // Apply focused-state layout so the widget is measured at its final size; otherwise
         // padding/bottom-row/toggle-row visibility land after the 200ms enter as a second step.
-        widgetFrom(widgetView)?.beginEnterAnimationPreview(isBottom)
+        widgetFrom(widgetView)?.beginEnterAnimationPreview(isBottom, inputModeCapability)
         val margins = animator.init(widgetCard, omnibarCard, omnibarCard.width, omnibarCard.height, isBottom)
             ?: return false
 

--- a/app/src/main/res/layout/input_mode_widget_card_view.xml
+++ b/app/src/main/res/layout/input_mode_widget_card_view.xml
@@ -46,7 +46,7 @@
 
             <com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
                 android:id="@+id/inputModeWidget"
-                android:paddingHorizontal="8dp"
+                android:paddingHorizontal="@dimen/keyline_1"
                 android:paddingVertical="4dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
@@ -61,6 +61,7 @@
             android:layout_width="wrap_content"
             android:layout_height="?attr/actionBarSize"
             android:layout_gravity="top"
+            android:layout_marginStart="-12dp"
             android:layout_marginEnd="@dimen/keyline_1"
             android:layout_marginTop="-2dp"
             android:visibility="gone" />

--- a/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
+++ b/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
@@ -81,6 +81,7 @@
             android:layout_width="wrap_content"
             android:layout_height="?attr/actionBarSize"
             android:layout_gravity="bottom"
+            android:layout_marginStart="-8dp"
             android:layout_marginBottom="-2dp"
             android:visibility="gone" />
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -131,7 +131,7 @@ interface NativeInputWidget {
     fun hasInputFocus(): Boolean
     fun clearInputFocus()
     fun requestInputFocus()
-    fun beginEnterAnimationPreview(isBottom: Boolean)
+    fun beginEnterAnimationPreview(isBottom: Boolean, inputMode: NativeInputState.InputMode)
     fun endEnterAnimationPreview()
     fun selectAllText()
     fun selectChatTab()
@@ -618,7 +618,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
             } else {
                 inputModeCardExtendedEndMargin
             }
-            marginStart = inputModeCardExtendedEndMargin
         }
     }
 
@@ -1317,7 +1316,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
     }
 
-    override fun beginEnterAnimationPreview(isBottom: Boolean) {
+    override fun beginEnterAnimationPreview(isBottom: Boolean, inputMode: NativeInputState.InputMode) {
         doOnAttach {
             if (inputField.hasFocus()) return@doOnAttach
             if (nativeInputState == null) {
@@ -1331,7 +1330,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
                     ?.takeIf { ::nativeInputStateProvider.isInitialized }
                     ?.let { nativeInputStateProvider.stateForTab(it).value }
                 applyState(
-                    publishedState ?: NativeInputState.zero().copy(
+                    (publishedState ?: NativeInputState.zero()).copy(
+                        inputMode = inputMode,
                         inputPosition = if (isBottom) NativeInputState.InputPosition.BOTTOM else NativeInputState.InputPosition.TOP,
                     ),
                 )
@@ -1600,17 +1600,25 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val lp = card.layoutParams as? MarginLayoutParams ?: return
         // Only the top browser search-only omnibar takes the wide-omnibar shape; isBottom is part of this
         // condition (not an early return) so a bottom Duck.ai frame still reaches the reset below.
-        if (state.inputContext == NativeInputState.InputContext.BROWSER && !state.toggleVisible && !state.isBottom) {
+        val isBrowserSearchOnly = state.inputContext == NativeInputState.InputContext.BROWSER && !state.toggleVisible
+        if (isBrowserSearchOnly && !state.isBottom) {
             val targetTopMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginTop)
-            val targetStartMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginHorizontal)
-            val targetEndMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_1)
+            val targetHorizontalMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginHorizontal)
             card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)
             lp.topMargin = targetTopMargin - card.paddingTop
-            lp.marginStart = targetStartMargin - card.paddingLeft
-            lp.marginEnd = targetEndMargin - card.paddingRight
+            lp.marginStart = targetHorizontalMargin - card.paddingLeft
+            lp.marginEnd = targetHorizontalMargin - card.paddingRight
+        } else if (isBrowserSearchOnly && state.isBottom) {
+            // Bottom search-only omnibar: 16dp leading (paddingStart keyline_2 + this keyline_2) and 16dp
+            // trailing (paddingEnd keyline_1 + this) so the field is centred when full-width.
+            lp.marginStart = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_2)
+            lp.marginEnd = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginHorizontal) -
+                card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_1)
         } else {
             // Reset the start margin so the omnibar value doesn't leak onto the shared Duck.ai card.
+            // The bottom card keeps keyline_1 (Duck.ai needs 8dp with the wrapper's paddingEnd).
             lp.marginStart = 0
+            lp.marginEnd = if (state.isBottom) card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_1) else 0
         }
         card.layoutParams = lp
     }

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
@@ -17,7 +17,7 @@
         android:id="@+id/inputModeUnifiedBack"
         android:layout_width="36dp"
         android:layout_height="36dp"
-        android:background="@drawable/selectable_circular_container_ripple"
+        android:background="@drawable/selectable_item_rounded_corner_background"
         android:importantForAccessibility="no"
         android:scaleType="centerInside"
         android:visibility="gone"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
@@ -30,7 +30,7 @@
         android:id="@+id/inputModeWidgetLayout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/keyline_2"
+        android:layout_marginStart="@dimen/keyline_empty"
         android:orientation="horizontal"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/inputModeUnifiedBack"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_start_chat.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_start_chat.xml
@@ -23,7 +23,7 @@
         android:layout_width="36dp"
         android:layout_height="36dp"
         android:layout_gravity="end|center_vertical"
-        android:background="@drawable/selectable_circular_container_ripple"
+        android:background="@drawable/selectable_item_rounded_corner_background"
         android:contentDescription="@string/duckChatStartChatContentDescription"
         android:scaleType="center"
         android:src="@drawable/ic_ai_chat_24"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1217211344690575?focus=true 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Changes:
- Remove button background
- Adjust margins to center the native input properly
- Adjust position of the inline back button, the contextual sheet button, and the hint
- Fix the issue where on first open the native input has more rounded corners than expected (only in top mode)

Note: No change has been made on the Toggle ON mode. 

### Steps to test this PR

_Visual test_

- [x] Enable `nativeInputSearchOnly` feature flag
- [x] Select “Search Only” mode in the settings
- [x] Verify background for back arrow and contextual sheet button are clear
- [ ] Verify back arrow, hint text, and contextual sheet button are properly aligned with the omnibar
- [ ] Verify that the margins on both sides of the input field are symetric
- [ ] Type something in the field to extend it. Verify margins are still symetric. 

_Variations_
- [ ] Test in bottom bar and split bar mode
- [ ] Test Light and dark mode

_Regression_
- [ ] Validate the toggle ON mode is untouched.

### UI changes
| Before  | After |
| ------ | ------ |
| <img width="540" height="1200" alt="Screenshot_20260806_235446" src="https://github.com/user-attachments/assets/a2f41f1a-caba-403b-8546-2b4bfa92ed31" /> | <img width="540" height="1200" alt="Screenshot_20260806_234833" src="https://github.com/user-attachments/assets/ad2d9631-fdce-4c43-9623-9e9cca9c03b4" /> |
| <img width="540" height="1200" alt="Screenshot_20260806_235458" src="https://github.com/user-attachments/assets/4a3bbe07-b895-40b3-8334-fd8e2ce5122c" /> | <img width="540" height="1200" alt="Screenshot_20260806_234850" src="https://github.com/user-attachments/assets/0f755aeb-90a2-4ec6-bbab-078fc7076d93" /> |
| <img width="540" height="1200" alt="Screenshot_20260806_235518" src="https://github.com/user-attachments/assets/e43bcc85-5bca-46ed-8e6d-ce42d87e508f" /> | <img width="540" height="1200" alt="Screenshot_20260807_000739" src="https://github.com/user-attachments/assets/fccd7f1a-fbcb-4133-ba0c-1cc42fb711f3" /> |
| <img width="540" height="1200" alt="Screenshot_20260806_235427" src="https://github.com/user-attachments/assets/1ff22062-23a2-4e26-94c0-9666c660910b" /> | <img width="540" height="1200" alt="Screenshot_20260806_235125" src="https://github.com/user-attachments/assets/6df28f8c-b0ce-405c-a14f-a9ec30e12fbd" /> |
| <img width="540" height="1200" alt="Screenshot_20260806_235539" src="https://github.com/user-attachments/assets/6ef89372-9517-411c-b7c4-ba0f65028ed3" /> | <img width="540" height="1200" alt="Screenshot_20260806_235004" src="https://github.com/user-attachments/assets/b3f25534-c48c-4c36-b4c6-0d1e325b5111" /> |
| <img width="540" height="1200" alt="Screenshot_20260806_235547" src="https://github.com/user-attachments/assets/1f8ce459-cab9-4f26-86e6-c08e4bb023e9" /> | <img width="540" height="1200" alt="Screenshot_20260806_235016" src="https://github.com/user-attachments/assets/06102636-53ce-4471-b68a-b63fb20204eb" /> |













<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and layout-only changes in native input search-only mode; no auth, data, or core navigation logic changes beyond margin/state seeding for animations.
> 
> **Overview**
> Polishes **search-only** native input visuals: back arrow, contextual sheet, and start-chat controls use **rounded-corner ripples** instead of circular container backgrounds so the chrome reads as clear/flat against the omnibar.
> 
> **Layout and margins** are adjusted so the field and inline nav buttons align with the omnibar—top/bottom card padding, negative inline-button offsets, and unified-back spacing (`keyline_empty` on the widget row). **Symmetric horizontal margins** for browser search-only are applied in `applyOmnibarShape` (top wide-omnibar shape; bottom 16dp leading/trailing via card margins). Removing the extra **start margin** when main Fire/Tabs/Menu buttons hide stops the card from shifting asymmetrically.
> 
> **Enter animation**: `beginEnterAnimationPreview` now receives **`inputMode`** from the manager so the pre-measure state seed matches search-only (toggle hidden) before the morph, fixing **over-rounded corners on first open** in top mode.
> 
> Toggle-on (Search & Duck.ai) behavior is intentionally unchanged per the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a56b14368ccb17a10206b48d00ad09b923098652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->