### PR TITLE
Quiet gradlew output via PreToolUse hook

### DIFF
--- a/.claude/hooks/android-gradle-quiet.sh
+++ b/.claude/hooks/android-gradle-quiet.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) hook: force ./gradlew runs to quiet logging so build output
+# stays small enough for an agent to read. A deliberate log-level flag always wins.
+# No-ops silently if jq is missing, leaving the command untouched.
+set -uo pipefail
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [[ -z "$cmd" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+if [[ ! "$cmd" =~ (^|[[:space:]])\./gradlew($|[[:space:]]) ]]; then
+  echo '{}'
+  exit 0
+fi
+
+if [[ "$cmd" =~ (^|[[:space:]])(-q|-w|-i|-d|--quiet|--warn|--info|--debug)($|[[:space:]]) ]]; then
+  echo '{}'
+  exit 0
+fi
+
+new_cmd=$(printf '%s' "$cmd" | sed -E 's#\./gradlew#./gradlew -q#g')
+encoded=$(printf '%s' "$new_cmd" | jq -Rs .)
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","updatedInput":{"command":%s}}}\n' "$encoded"

--- a/.claude/hooks/android-gradle-quiet.sh
+++ b/.claude/hooks/android-gradle-quiet.sh
@@ -17,7 +17,8 @@ if [[ ! "$cmd" =~ (^|[[:space:]])\./gradlew($|[[:space:]]) ]]; then
   exit 0
 fi
 
-if [[ "$cmd" =~ (^|[[:space:]])(-q|-w|-i|-d|--quiet|--warn|--info|--debug)($|[[:space:]]) ]]; then
+gradlew_segments=$(printf '%s' "$cmd" | grep -oE '\./gradlew[^&|;]*')
+if printf '%s' "$gradlew_segments" | grep -qE '(^|[[:space:]])(-q|-w|-i|-d|--quiet|--warn|--info|--debug)($|[[:space:]])'; then
   echo '{}'
   exit 0
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/android-gradle-quiet.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215830012971956?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None (no `-api` surface touched)

### Description

Gradle's default lifecycle log level emits a `> Task :module:...` line per
executed task plus every Kotlin `w:` warning. Across 87 modules a single
failed `./gradlew jvm_tests` can produce a tool result larger than the
entire session startup context (~43k tokens), and it repeats on every
retry. This adds a PreToolUse hook (`.claude/hooks/android-gradle-quiet.sh`,
registered in `.claude/settings.json`) that rewrites `./gradlew ...` to
`./gradlew -q ...`. Exit codes are surfaced independently, so the pass/fail
signal survives; failures, spotless violations and lint errors are all
error-level and come through `-q` intact.

Measured on single-module runs in a fresh worktree:
- Passing (`:common-utils:testDebugUnitTest`): 8839B → 68B (-99%)
- Failing (`:lint-rules:test`, 10 real failures): 3948B → 409B (-90%)

The hook only ever returns `updatedInput`, never `permissionDecision` — an
earlier draft returned `permissionDecision: "allow"`, which silently
auto-approved every gradle task including `installInternalRelease` and
`clean`. Keeping it out means the hook can only change log verbosity,
never widen permissions.

`-q -w -i -d --quiet --warn --info --debug` all pass through untouched, so
anyone who wants verbose output (e.g. `--info`/`--debug`) still gets it —
Gradle hard-fails on conflicting log levels, so blindly adding `-q` to an
already-flagged command would break that escape hatch.

`jq` is a soft dependency: if it's missing, the command is left untouched
rather than mangled.

### Steps to test this PR

_Hook rewrites plain gradlew commands_
- [ ] Run `./gradlew :common-utils:testDebugUnitTest` and confirm it prints only errors (no `> Task` lines)
- [ ] Run `./gradlew --info :common-utils:testDebugUnitTest` and confirm it runs unchanged with full `--info` output

### UI changes
No UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only `.claude` agent hook configuration and a local bash script; no app, API, or build logic in the Android codebase.
> 
> **Overview**
> Adds Claude **PreToolUse** tooling so agent Bash runs of `./gradlew` default to quiet logging, cutting huge Gradle task spam from tool results.
> 
> A new hook script reads the proposed command from hook JSON and, when it matches `./gradlew` without an explicit log level (`-q`, `--info`, etc.), rewrites it to insert `-q`. Commands without `gradlew`, empty input, or already-flagged verbosity are left unchanged; if `jq` is missing the hook no-ops. **`settings.json`** wires the script to the Bash **PreToolUse** matcher via `updatedInput` only (no permission auto-allow).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca7c511a5675b630f20b308b1357388716013b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->