### PR TITLE
Add global.is_first_daily_occurrence to wide events

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -2234,6 +2234,7 @@
             "widePixelDevMode",
             "widePixelMetaType",
             "widePixelMetaVersion",
+            "widePixelIsFirstDailyOccurrence",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide event",
@@ -2558,6 +2559,7 @@
             "widePixelDevMode",
             "widePixelMetaType",
             "widePixelMetaVersion",
+            "widePixelIsFirstDailyOccurrence",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide event",
@@ -2882,6 +2884,7 @@
             "widePixelDevMode",
             "widePixelMetaType",
             "widePixelMetaVersion",
+            "widePixelIsFirstDailyOccurrence",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide event",

--- a/PixelDefinitions/pixels/definitions/wide_data_clearing.json5
+++ b/PixelDefinitions/pixels/definitions/wide_data_clearing.json5
@@ -16,6 +16,7 @@
             "widePixelDevMode",
             "widePixelMetaType",
             "widePixelMetaVersion",
+            "widePixelIsFirstDailyOccurrence",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide event",

--- a/PixelDefinitions/pixels/definitions/wide_free_trial_conversion.json5
+++ b/PixelDefinitions/pixels/definitions/wide_free_trial_conversion.json5
@@ -17,6 +17,7 @@
             "widePixelDevMode",
             "widePixelMetaType",
             "widePixelMetaVersion",
+            "widePixelIsFirstDailyOccurrence",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide pixel",

--- a/PixelDefinitions/pixels/definitions/wide_input_screen_onboarding.json5
+++ b/PixelDefinitions/pixels/definitions/wide_input_screen_onboarding.json5
@@ -17,6 +17,7 @@
             "widePixelDevMode",
             "widePixelMetaType",
             "widePixelMetaVersion",
+            "widePixelIsFirstDailyOccurrence",
             {
                 "key": "context.name",
                 "description": "Entry point to the Input Screen onboarding flow.",

--- a/PixelDefinitions/pixels/definitions/wide_page_load.json5
+++ b/PixelDefinitions/pixels/definitions/wide_page_load.json5
@@ -17,6 +17,7 @@
             "widePixelDevMode",
             "widePixelMetaType",
             "widePixelMetaVersion",
+            "widePixelIsFirstDailyOccurrence",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide event",

--- a/PixelDefinitions/pixels/definitions/wide_post_idle_session.json5
+++ b/PixelDefinitions/pixels/definitions/wide_post_idle_session.json5
@@ -18,11 +18,7 @@
             "widePixelDevMode",
             "widePixelMetaType",
             "widePixelMetaVersion",
-            {
-                "key": "global.is_first_daily_occurrence",
-                "type": "boolean",
-                "description": "Whether this is the first occurrence of the event for the user today"
-            },
+            "widePixelIsFirstDailyOccurrence",
             {
                 "key": "feature.name",
                 "type": "string",

--- a/PixelDefinitions/pixels/definitions/wide_subscription-purchase.json5
+++ b/PixelDefinitions/pixels/definitions/wide_subscription-purchase.json5
@@ -16,6 +16,7 @@
             "widePixelDevMode",
             "widePixelMetaType",
             "widePixelMetaVersion",
+            "widePixelIsFirstDailyOccurrence",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide pixel",

--- a/PixelDefinitions/pixels/definitions/wide_subscription_restore.json5
+++ b/PixelDefinitions/pixels/definitions/wide_subscription_restore.json5
@@ -16,6 +16,7 @@
             "widePixelDevMode",
             "widePixelMetaType",
             "widePixelMetaVersion",
+            "widePixelIsFirstDailyOccurrence",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide pixel",

--- a/PixelDefinitions/pixels/definitions/wide_sync_setup.json5
+++ b/PixelDefinitions/pixels/definitions/wide_sync_setup.json5
@@ -16,6 +16,7 @@
             "widePixelDevMode",
             "widePixelMetaType",
             "widePixelMetaVersion",
+            "widePixelIsFirstDailyOccurrence",
             {
                 "key": "feature.name",
                 "description": "Feature identifier for this wide pixel",

--- a/PixelDefinitions/pixels/definitions/wide_vpn_enable.json5
+++ b/PixelDefinitions/pixels/definitions/wide_vpn_enable.json5
@@ -17,6 +17,7 @@
             "widePixelDevMode",
             "widePixelMetaType",
             "widePixelMetaVersion",
+            "widePixelIsFirstDailyOccurrence",
             {
                 "key": "context.name",
                 "description": "Entry point to the VPN enable flow.",

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -77,6 +77,11 @@
         "type": "number",
         "description": "Sample rate for this pixel, between 0 and 1"
     },
+    "widePixelIsFirstDailyOccurrence": {
+        "key": "global.is_first_daily_occurrence",
+        "type": "boolean",
+        "description": "Whether this is the first wide event completed with this feature name and status in the current UTC calendar day"
+    },
     "widePixelMetaType": {
         "key": "meta.type",
         "type": "string",

--- a/statistics/statistics-impl/schemas/com.duckduckgo.app.statistics.wideevents.db.WideEventDatabase/5.json
+++ b/statistics/statistics-impl/schemas/com.duckduckgo.app.statistics.wideevents.db.WideEventDatabase/5.json
@@ -1,0 +1,127 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "ef34b2e4e98721b7763467e6e4a91ae5",
+    "entities": [
+      {
+        "tableName": "wide_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `flow_entry_point` TEXT, `metadata` TEXT NOT NULL, `steps` TEXT NOT NULL, `status` TEXT, `cleanup_policy` TEXT NOT NULL, `active_intervals` TEXT NOT NULL, `sampling_probability` REAL NOT NULL DEFAULT 1.0, `meta_type` TEXT NOT NULL, `meta_version` TEXT NOT NULL, `is_first_daily_occurrence` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "flowEntryPoint",
+            "columnName": "flow_entry_point",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "steps",
+            "columnName": "steps",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cleanupPolicy",
+            "columnName": "cleanup_policy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeIntervals",
+            "columnName": "active_intervals",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "samplingProbability",
+            "columnName": "sampling_probability",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "1.0"
+          },
+          {
+            "fieldPath": "metaType",
+            "columnName": "meta_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metaVersion",
+            "columnName": "meta_version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFirstDailyOccurrence",
+            "columnName": "is_first_daily_occurrence",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "wide_event_daily_occurrences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`dedup_key` TEXT NOT NULL, `last_occurrence_date` TEXT NOT NULL, PRIMARY KEY(`dedup_key`))",
+        "fields": [
+          {
+            "fieldPath": "dedupKey",
+            "columnName": "dedup_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOccurrenceDate",
+            "columnName": "last_occurrence_date",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "dedup_key"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ef34b2e4e98721b7763467e6e4a91ae5')"
+    ]
+  }
+}

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/ApiWideEventSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/ApiWideEventSender.kt
@@ -58,6 +58,7 @@ class ApiWideEventSender @Inject constructor(
                 platform = PLATFORM,
                 type = TYPE,
                 sampleRate = event.samplingProbability,
+                isFirstDailyOccurrence = event.isFirstDailyOccurrence,
             ),
             app = AppSection(
                 name = APP_NAME,

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSender.kt
@@ -51,6 +51,7 @@ class PixelWideEventSender @Inject constructor(
                 put(PARAM_META_TYPE, event.metaType)
                 put(PARAM_META_VERSION, event.metaVersion)
                 put(PARAM_SAMPLE_RATE, event.samplingProbability.toString())
+                put(PARAM_IS_FIRST_DAILY_OCCURRENCE, event.isFirstDailyOccurrence.toString())
                 put(PARAM_STATUS, event.status.toParamValue())
 
                 if (event.flowEntryPoint != null) {
@@ -126,6 +127,7 @@ class PixelWideEventSender @Inject constructor(
         const val PARAM_PLATFORM = "global.platform"
         const val PARAM_TYPE = "global.type"
         const val PARAM_SAMPLE_RATE = "global.sample_rate"
+        const val PARAM_IS_FIRST_DAILY_OCCURRENCE = "global.is_first_daily_occurrence"
         const val PARAM_CONTEXT_NAME = "context.name"
         const val PARAM_STATUS = "feature.status"
         const val PARAM_APP_NAME = "app.name"

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/api/WideEventRequest.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/api/WideEventRequest.kt
@@ -35,6 +35,7 @@ data class GlobalSection(
     @field:Json(name = "platform") val platform: String,
     @field:Json(name = "type") val type: String,
     @field:Json(name = "sample_rate") val sampleRate: Float,
+    @field:Json(name = "is_first_daily_occurrence") val isFirstDailyOccurrence: Boolean,
 )
 
 data class AppSection(

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/Mappers.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/Mappers.kt
@@ -30,6 +30,7 @@ fun WideEventEntity.mapToRepositoryWideEvent(): WideEventRepository.WideEvent =
         samplingProbability = samplingProbability,
         metaType = metaType,
         metaVersion = metaVersion,
+        isFirstDailyOccurrence = isFirstDailyOccurrence,
     )
 
 fun WideEventRepository.WideEventStatus.mapToDbWideEventStatus(): WideEventEntity.WideEventStatus =

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventDailyOccurrenceEntity.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventDailyOccurrenceEntity.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.statistics.wideevents.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.time.LocalDate
+
+@Entity(tableName = "wide_event_daily_occurrences")
+data class WideEventDailyOccurrenceEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "dedup_key")
+    val dedupKey: String,
+    @ColumnInfo(name = "last_occurrence_date")
+    val lastOccurrenceDate: LocalDate,
+)

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventDao.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventDao.kt
@@ -18,9 +18,11 @@ package com.duckduckgo.app.statistics.wideevents.db
 
 import androidx.room.Dao
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
 
 @Dao
 interface WideEventDao {
@@ -50,4 +52,10 @@ interface WideEventDao {
 
     @Query("SELECT EXISTS(SELECT 1 FROM wide_events WHERE status is not null)")
     fun hasCompletedWideEvents(): Flow<Boolean>
+
+    @Query("SELECT last_occurrence_date FROM wide_event_daily_occurrences WHERE dedup_key = :dedupKey")
+    suspend fun getLastDailyOccurrenceDate(dedupKey: String): LocalDate?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertDailyOccurrence(occurrence: WideEventDailyOccurrenceEntity)
 }

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventDatabase.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventDatabase.kt
@@ -21,17 +21,21 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverter
 import androidx.room.TypeConverters
 import java.time.Instant
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 @Database(
     exportSchema = true,
-    version = 4,
+    version = 5,
     entities = [
         WideEventEntity::class,
+        WideEventDailyOccurrenceEntity::class,
     ],
 )
 @TypeConverters(
     WideEventEntityTypeConverters::class,
     InstantTypeConverter::class,
+    LocalDateTypeConverter::class,
 )
 abstract class WideEventDatabase : RoomDatabase() {
     abstract fun wideEventDao(): WideEventDao
@@ -43,4 +47,12 @@ class InstantTypeConverter {
 
     @TypeConverter
     fun toInstant(value: Long?): Instant? = value?.let { Instant.ofEpochMilli(it) }
+}
+
+class LocalDateTypeConverter {
+    @TypeConverter
+    fun fromLocalDate(localDate: LocalDate?): String? = localDate?.format(DateTimeFormatter.ISO_LOCAL_DATE)
+
+    @TypeConverter
+    fun toLocalDate(value: String?): LocalDate? = value?.let { LocalDate.parse(it, DateTimeFormatter.ISO_LOCAL_DATE) }
 }

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventDatabaseModule.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventDatabaseModule.kt
@@ -21,6 +21,7 @@ import androidx.room.Room
 import com.duckduckgo.app.statistics.wideevents.db.migration.WideEventsMigration1To2
 import com.duckduckgo.app.statistics.wideevents.db.migration.WideEventsMigration2To3
 import com.duckduckgo.app.statistics.wideevents.db.migration.WideEventsMigration3To4
+import com.duckduckgo.app.statistics.wideevents.db.migration.WideEventsMigration4To5
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
@@ -42,7 +43,7 @@ class WideEventDatabaseModule {
                 klass = WideEventDatabase::class.java,
                 name = "wide_events.db",
             )
-            .addMigrations(WideEventsMigration1To2, WideEventsMigration2To3, WideEventsMigration3To4)
+            .addMigrations(WideEventsMigration1To2, WideEventsMigration2To3, WideEventsMigration3To4, WideEventsMigration4To5)
             .fallbackToDestructiveMigration()
             .enableMultiInstanceInvalidation()
             .addTypeConverter(wideEventEntityTypeConverters)

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventEntity.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventEntity.kt
@@ -58,6 +58,8 @@ data class WideEventEntity(
     val metaType: String,
     @ColumnInfo(name = "meta_version")
     val metaVersion: String,
+    @ColumnInfo(name = "is_first_daily_occurrence", defaultValue = "0")
+    val isFirstDailyOccurrence: Boolean = false,
 ) {
     data class MetadataEntry(
         @Json(name = "key")

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventRepository.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventRepository.kt
@@ -80,6 +80,7 @@ interface WideEventRepository {
         val samplingProbability: Float = 1.0f,
         val metaType: String,
         val metaVersion: String,
+        val isFirstDailyOccurrence: Boolean = false,
     )
 
     data class WideEventStep(

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventRepositoryImpl.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/WideEventRepositoryImpl.kt
@@ -24,6 +24,8 @@ import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.Flow
 import java.time.Duration
 import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
@@ -86,9 +88,12 @@ class WideEventRepositoryImpl @Inject constructor(
         updateWideEvent(eventId) { event ->
             checkEventIsActive(event)
 
+            val dbStatus = status.mapToDbWideEventStatus()
+
             event.copy(
-                status = status.mapToDbWideEventStatus(),
+                status = dbStatus,
                 metadata = mergeMetadata(event.metadata, metadata),
+                isFirstDailyOccurrence = recordDailyOccurrence(event.name, dbStatus),
             )
         }
     }
@@ -181,9 +186,24 @@ class WideEventRepositoryImpl @Inject constructor(
         return duration
     }
 
+    private suspend fun recordDailyOccurrence(
+        eventName: String,
+        status: WideEventEntity.WideEventStatus,
+    ): Boolean {
+        val dedupKey = "$eventName:${status.statusCode}"
+        val today = LocalDate.ofInstant(timeProvider.getCurrentTime(), ZoneOffset.UTC)
+
+        if (wideEventDao.getLastDailyOccurrenceDate(dedupKey) == today) return false
+
+        wideEventDao.upsertDailyOccurrence(
+            WideEventDailyOccurrenceEntity(dedupKey = dedupKey, lastOccurrenceDate = today),
+        )
+        return true
+    }
+
     private suspend fun updateWideEvent(
         id: Long,
-        updateAction: (WideEventEntity) -> WideEventEntity,
+        updateAction: suspend (WideEventEntity) -> WideEventEntity,
     ) {
         database.withTransaction {
             val event =

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/migration/WideEventsMigration4To5.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/db/migration/WideEventsMigration4To5.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.statistics.wideevents.db.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * v5 adds the `is_first_daily_occurrence` flag, along with the table tracking the last day each
+ * (event name, status) pair was recorded. Events completed before this migration were never
+ * evaluated, so they default to false.
+ */
+internal val WideEventsMigration4To5 = object : Migration(4, 5) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE wide_events ADD COLUMN is_first_daily_occurrence INTEGER NOT NULL DEFAULT 0")
+
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `wide_event_daily_occurrences` (
+                `dedup_key` TEXT NOT NULL,
+                `last_occurrence_date` TEXT NOT NULL,
+                PRIMARY KEY(`dedup_key`)
+            )
+            """.trimIndent(),
+        )
+    }
+}

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/ApiWideEventSenderTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/ApiWideEventSenderTest.kt
@@ -94,6 +94,7 @@ class ApiWideEventSenderTest {
                 platform = "Android",
                 type = "app",
                 sampleRate = 1.0f,
+                isFirstDailyOccurrence = false,
             ),
             app = AppSection(
                 name = "DuckDuckGo Android",
@@ -138,6 +139,7 @@ class ApiWideEventSenderTest {
                 platform = "Android",
                 type = "app",
                 sampleRate = 1.0f,
+                isFirstDailyOccurrence = false,
             ),
             app = AppSection(
                 name = "DuckDuckGo Android",
@@ -177,6 +179,7 @@ class ApiWideEventSenderTest {
                 platform = "Android",
                 type = "app",
                 sampleRate = 1.0f,
+                isFirstDailyOccurrence = false,
             ),
             app = AppSection(
                 name = "DuckDuckGo Android",
@@ -216,6 +219,7 @@ class ApiWideEventSenderTest {
                 platform = "Android",
                 type = "app",
                 sampleRate = 1.0f,
+                isFirstDailyOccurrence = false,
             ),
             app = AppSection(
                 name = "DuckDuckGo Android",
@@ -255,6 +259,7 @@ class ApiWideEventSenderTest {
                 platform = "Android",
                 type = "app",
                 sampleRate = 1.0f,
+                isFirstDailyOccurrence = false,
             ),
             app = AppSection(
                 name = "DuckDuckGo Android",
@@ -292,6 +297,7 @@ class ApiWideEventSenderTest {
                 platform = "Android",
                 type = "app",
                 sampleRate = 1.0f,
+                isFirstDailyOccurrence = false,
             ),
             app = AppSection(
                 name = "DuckDuckGo Android",
@@ -334,6 +340,7 @@ class ApiWideEventSenderTest {
                 platform = "Android",
                 type = "app",
                 sampleRate = 1.0f,
+                isFirstDailyOccurrence = false,
             ),
             app = AppSection(
                 name = "DuckDuckGo Android",
@@ -405,6 +412,7 @@ class ApiWideEventSenderTest {
                 platform = "Android",
                 type = "app",
                 sampleRate = 0.1f,
+                isFirstDailyOccurrence = false,
             ),
             app = AppSection(
                 name = "DuckDuckGo Android",
@@ -444,6 +452,7 @@ class ApiWideEventSenderTest {
                 platform = "Android",
                 type = "app",
                 sampleRate = 1.0f,
+                isFirstDailyOccurrence = false,
             ),
             app = AppSection(
                 name = "DuckDuckGo Android",
@@ -453,6 +462,45 @@ class ApiWideEventSenderTest {
             ),
             feature = FeatureSection(
                 name = "some-event",
+                status = "SUCCESS",
+                data = null,
+            ),
+            context = null,
+        )
+
+        verify(wideEventService).sendWideEvent(eq(expectedRequest))
+    }
+
+    @Test
+    fun `when event is the first daily occurrence then it is included in request`() = runTest {
+        val event = createWideEvent(
+            id = 800L,
+            name = "first-occurrence-event",
+            status = WideEventRepository.WideEventStatus.SUCCESS,
+            isFirstDailyOccurrence = true,
+        )
+
+        apiWideEventSender.sendWideEvent(event)
+
+        val expectedRequest = WideEventRequest(
+            meta = MetaSection(
+                type = "android-first-occurrence-event",
+                version = "1.0.0",
+            ),
+            global = GlobalSection(
+                platform = "Android",
+                type = "app",
+                sampleRate = 1.0f,
+                isFirstDailyOccurrence = true,
+            ),
+            app = AppSection(
+                name = "DuckDuckGo Android",
+                version = "5.123.0",
+                formFactor = "phone",
+                devMode = false,
+            ),
+            feature = FeatureSection(
+                name = "first-occurrence-event",
                 status = "SUCCESS",
                 data = null,
             ),
@@ -488,6 +536,7 @@ class ApiWideEventSenderTest {
         samplingProbability: Float = 1.0f,
         metaType: String = "android-$name",
         metaVersion: String = "1.0.0",
+        isFirstDailyOccurrence: Boolean = false,
     ) = WideEventRepository.WideEvent(
         id = id,
         name = name,
@@ -505,5 +554,6 @@ class ApiWideEventSenderTest {
         samplingProbability = samplingProbability,
         metaType = metaType,
         metaVersion = metaVersion,
+        isFirstDailyOccurrence = isFirstDailyOccurrence,
     )
 }

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSenderTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSenderTest.kt
@@ -96,6 +96,7 @@ class PixelWideEventSenderTest {
                     "global.platform" to "Android",
                     "global.type" to "app",
                     "global.sample_rate" to "1.0",
+                    "global.is_first_daily_occurrence" to "false",
                     "app.name" to "DuckDuckGo Android",
                     "app.version" to "5.123.0",
                     "app.form_factor" to "phone",
@@ -146,6 +147,62 @@ class PixelWideEventSenderTest {
             )
         }
 
+    @Test
+    fun `when event is the first daily occurrence then count and daily pixels report it`() =
+        runTest {
+            val event =
+                createWideEvent(
+                    id = 456L,
+                    name = "some-event",
+                    status = WideEventRepository.WideEventStatus.SUCCESS,
+                    isFirstDailyOccurrence = true,
+                )
+
+            pixelWideEventSender.sendWideEvent(event)
+
+            verify(pixel).enqueueFire(
+                pixelName = eq("wide_some-event_c"),
+                parameters = argThat { get("global.is_first_daily_occurrence") == "true" },
+                encodedParameters = any(),
+                type = any(),
+            )
+
+            verify(pixel).enqueueFire(
+                pixelName = eq("wide_some-event_d"),
+                parameters = argThat { get("global.is_first_daily_occurrence") == "true" },
+                encodedParameters = any(),
+                type = any<Pixel.PixelType.Daily>(),
+            )
+        }
+
+    @Test
+    fun `when event is not the first daily occurrence then count and daily pixels report it`() =
+        runTest {
+            val event =
+                createWideEvent(
+                    id = 456L,
+                    name = "some-event",
+                    status = WideEventRepository.WideEventStatus.SUCCESS,
+                    isFirstDailyOccurrence = false,
+                )
+
+            pixelWideEventSender.sendWideEvent(event)
+
+            verify(pixel).enqueueFire(
+                pixelName = eq("wide_some-event_c"),
+                parameters = argThat { get("global.is_first_daily_occurrence") == "false" },
+                encodedParameters = any(),
+                type = any(),
+            )
+
+            verify(pixel).enqueueFire(
+                pixelName = eq("wide_some-event_d"),
+                parameters = argThat { get("global.is_first_daily_occurrence") == "false" },
+                encodedParameters = any(),
+                type = any<Pixel.PixelType.Daily>(),
+            )
+        }
+
     private fun createWideEvent(
         id: Long,
         name: String,
@@ -156,6 +213,7 @@ class PixelWideEventSenderTest {
         samplingProbability: Float = 1.0f,
         metaType: String = "android-$name",
         metaVersion: String = "1.0.0",
+        isFirstDailyOccurrence: Boolean = false,
     ) = WideEventRepository.WideEvent(
         id = id,
         name = name,
@@ -174,5 +232,6 @@ class PixelWideEventSenderTest {
         samplingProbability = samplingProbability,
         metaType = metaType,
         metaVersion = metaVersion,
+        isFirstDailyOccurrence = isFirstDailyOccurrence,
     )
 }

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSenderTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSenderTest.kt
@@ -53,14 +53,13 @@ class PixelWideEventSenderTest {
         .create(WideEventFeature::class.java)
         .also { it.enqueueWideEventPixels().setRawStoredState(Toggle.State(enable = true)) }
 
-    private val pixelWideEventSender =
-        PixelWideEventSender(
-            pixelSender = pixel,
-            appBuildConfig = appBuildConfig,
-            deviceInfo = deviceInfo,
-            wideEventFeature = wideEventFeature,
-            dispatchers = coroutineRule.testDispatcherProvider,
-        )
+    private val pixelWideEventSender = PixelWideEventSender(
+        pixelSender = pixel,
+        appBuildConfig = appBuildConfig,
+        deviceInfo = deviceInfo,
+        wideEventFeature = wideEventFeature,
+        dispatchers = coroutineRule.testDispatcherProvider,
+    )
 
     @Before
     fun setUp() {
@@ -70,138 +69,130 @@ class PixelWideEventSenderTest {
     }
 
     @Test
-    fun `when sendWideEvent called with completed event then sends count and daily pixels`() =
-        runTest {
-            val eventName = "subscription-purchase"
+    fun `when sendWideEvent called with completed event then sends count and daily pixels`() = runTest {
+        val eventName = "subscription-purchase"
 
-            val event =
-                createWideEvent(
-                    id = 123L,
-                    name = eventName,
-                    status = WideEventRepository.WideEventStatus.SUCCESS,
-                    flowEntryPoint = "app_settings",
-                    metadata = mapOf("plan_type" to "premium"),
-                    steps = listOf(
-                        WideEventRepository.WideEventStep(name = "init", success = true),
-                        WideEventRepository.WideEventStep(name = "refresh_data", success = false),
-                    ),
-                )
+        val event = createWideEvent(
+            id = 123L,
+            name = eventName,
+            status = WideEventRepository.WideEventStatus.SUCCESS,
+            flowEntryPoint = "app_settings",
+            metadata = mapOf("plan_type" to "premium"),
+            steps = listOf(
+                WideEventRepository.WideEventStep(name = "init", success = true),
+                WideEventRepository.WideEventStep(name = "refresh_data", success = false),
+            ),
+        )
 
-            pixelWideEventSender.sendWideEvent(event)
+        pixelWideEventSender.sendWideEvent(event)
 
-            val expectedParameters =
-                mapOf(
-                    "meta.type" to "android-subscription-purchase",
-                    "meta.version" to "1.0.0",
-                    "global.platform" to "Android",
-                    "global.type" to "app",
-                    "global.sample_rate" to "1.0",
-                    "global.is_first_daily_occurrence" to "false",
-                    "app.name" to "DuckDuckGo Android",
-                    "app.version" to "5.123.0",
-                    "app.form_factor" to "phone",
-                    "context.name" to "app_settings",
-                    "feature.status" to "SUCCESS",
-                    "app.dev_mode" to "false",
-                    "feature.data.ext.step.init" to "true",
-                    "feature.data.ext.step.refresh_data" to "false",
-                )
-            val expectedEncodedParameters = mapOf("feature.data.ext.plan_type" to "premium")
+        val expectedParameters = mapOf(
+            "meta.type" to "android-subscription-purchase",
+            "meta.version" to "1.0.0",
+            "global.platform" to "Android",
+            "global.type" to "app",
+            "global.sample_rate" to "1.0",
+            "global.is_first_daily_occurrence" to "false",
+            "app.name" to "DuckDuckGo Android",
+            "app.version" to "5.123.0",
+            "app.form_factor" to "phone",
+            "context.name" to "app_settings",
+            "feature.status" to "SUCCESS",
+            "app.dev_mode" to "false",
+            "feature.data.ext.step.init" to "true",
+            "feature.data.ext.step.refresh_data" to "false",
+        )
 
-            verify(pixel).enqueueFire(
-                pixelName = eq("wide_${eventName}_c"),
-                parameters = eq(expectedParameters),
-                encodedParameters = eq(expectedEncodedParameters),
-                type = any(),
-            )
+        val expectedEncodedParameters = mapOf("feature.data.ext.plan_type" to "premium")
 
-            verify(pixel).enqueueFire(
-                pixelName = eq("wide_${eventName}_d"),
-                parameters = eq(expectedParameters),
-                encodedParameters = eq(expectedEncodedParameters),
-                type = any<Pixel.PixelType.Daily>(),
-            )
-        }
+        verify(pixel).enqueueFire(
+            pixelName = eq("wide_${eventName}_c"),
+            parameters = eq(expectedParameters),
+            encodedParameters = eq(expectedEncodedParameters),
+            type = any(),
+        )
+
+        verify(pixel).enqueueFire(
+            pixelName = eq("wide_${eventName}_d"),
+            parameters = eq(expectedParameters),
+            encodedParameters = eq(expectedEncodedParameters),
+            type = any<Pixel.PixelType.Daily>(),
+        )
+    }
 
     @Test
-    fun `when event has stored meta type and version then stored values are sent`() =
-        runTest {
-            val event =
-                createWideEvent(
-                    id = 789L,
-                    name = "some-event",
-                    status = WideEventRepository.WideEventStatus.SUCCESS,
-                    metaType = "android-some-other-event",
-                    metaVersion = "2.1.3",
-                )
+    fun `when event has stored meta type and version then stored values are sent`() = runTest {
+        val event = createWideEvent(
+            id = 789L,
+            name = "some-event",
+            status = WideEventRepository.WideEventStatus.SUCCESS,
+            metaType = "android-some-other-event",
+            metaVersion = "2.1.3",
+        )
 
-            pixelWideEventSender.sendWideEvent(event)
+        pixelWideEventSender.sendWideEvent(event)
 
-            verify(pixel).enqueueFire(
-                pixelName = eq("wide_some-event_c"),
-                parameters = argThat {
-                    get("meta.type") == "android-some-other-event" && get("meta.version") == "2.1.3"
-                },
-                encodedParameters = any(),
-                type = any(),
-            )
-        }
+        verify(pixel).enqueueFire(
+            pixelName = eq("wide_some-event_c"),
+            parameters = argThat {
+                get("meta.type") == "android-some-other-event" && get("meta.version") == "2.1.3"
+            },
+            encodedParameters = any(),
+            type = any(),
+        )
+    }
 
     @Test
-    fun `when event is the first daily occurrence then count and daily pixels report it`() =
-        runTest {
-            val event =
-                createWideEvent(
-                    id = 456L,
-                    name = "some-event",
-                    status = WideEventRepository.WideEventStatus.SUCCESS,
-                    isFirstDailyOccurrence = true,
-                )
+    fun `when event is the first daily occurrence then count and daily pixels report it`() = runTest {
+        val event = createWideEvent(
+            id = 456L,
+            name = "some-event",
+            status = WideEventRepository.WideEventStatus.SUCCESS,
+            isFirstDailyOccurrence = true,
+        )
 
-            pixelWideEventSender.sendWideEvent(event)
+        pixelWideEventSender.sendWideEvent(event)
 
-            verify(pixel).enqueueFire(
-                pixelName = eq("wide_some-event_c"),
-                parameters = argThat { get("global.is_first_daily_occurrence") == "true" },
-                encodedParameters = any(),
-                type = any(),
-            )
+        verify(pixel).enqueueFire(
+            pixelName = eq("wide_some-event_c"),
+            parameters = argThat { get("global.is_first_daily_occurrence") == "true" },
+            encodedParameters = any(),
+            type = any(),
+        )
 
-            verify(pixel).enqueueFire(
-                pixelName = eq("wide_some-event_d"),
-                parameters = argThat { get("global.is_first_daily_occurrence") == "true" },
-                encodedParameters = any(),
-                type = any<Pixel.PixelType.Daily>(),
-            )
-        }
+        verify(pixel).enqueueFire(
+            pixelName = eq("wide_some-event_d"),
+            parameters = argThat { get("global.is_first_daily_occurrence") == "true" },
+            encodedParameters = any(),
+            type = any<Pixel.PixelType.Daily>(),
+        )
+    }
 
     @Test
-    fun `when event is not the first daily occurrence then count and daily pixels report it`() =
-        runTest {
-            val event =
-                createWideEvent(
-                    id = 456L,
-                    name = "some-event",
-                    status = WideEventRepository.WideEventStatus.SUCCESS,
-                    isFirstDailyOccurrence = false,
-                )
+    fun `when event is not the first daily occurrence then count and daily pixels report it`() = runTest {
+        val event = createWideEvent(
+            id = 456L,
+            name = "some-event",
+            status = WideEventRepository.WideEventStatus.SUCCESS,
+            isFirstDailyOccurrence = false,
+        )
 
-            pixelWideEventSender.sendWideEvent(event)
+        pixelWideEventSender.sendWideEvent(event)
 
-            verify(pixel).enqueueFire(
-                pixelName = eq("wide_some-event_c"),
-                parameters = argThat { get("global.is_first_daily_occurrence") == "false" },
-                encodedParameters = any(),
-                type = any(),
-            )
+        verify(pixel).enqueueFire(
+            pixelName = eq("wide_some-event_c"),
+            parameters = argThat { get("global.is_first_daily_occurrence") == "false" },
+            encodedParameters = any(),
+            type = any(),
+        )
 
-            verify(pixel).enqueueFire(
-                pixelName = eq("wide_some-event_d"),
-                parameters = argThat { get("global.is_first_daily_occurrence") == "false" },
-                encodedParameters = any(),
-                type = any<Pixel.PixelType.Daily>(),
-            )
-        }
+        verify(pixel).enqueueFire(
+            pixelName = eq("wide_some-event_d"),
+            parameters = argThat { get("global.is_first_daily_occurrence") == "false" },
+            encodedParameters = any(),
+            type = any<Pixel.PixelType.Daily>(),
+        )
+    }
 
     private fun createWideEvent(
         id: Long,

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/db/WideEventRepositoryTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/db/WideEventRepositoryTest.kt
@@ -738,6 +738,106 @@ class WideEventRepositoryTest {
         assertEquals("-1", event.metadata["interval_1"])
     }
 
+    @Test
+    fun `when an event is the first completed today for its name and status, it is marked as the first daily occurrence`() = runTest {
+        val eventId = insertEvent(name = "test_event")
+
+        wideEventRepository.setWideEventStatus(eventId = eventId, status = SUCCESS, metadata = emptyMap())
+
+        assertTrue(isFirstDailyOccurrence(eventId))
+    }
+
+    @Test
+    fun `when an event with the same name and status already completed today, it is not the first daily occurrence`() = runTest {
+        val firstEventId = insertEvent(name = "test_event")
+        val secondEventId = insertEvent(name = "test_event")
+
+        wideEventRepository.setWideEventStatus(eventId = firstEventId, status = SUCCESS, metadata = emptyMap())
+        wideEventRepository.setWideEventStatus(eventId = secondEventId, status = SUCCESS, metadata = emptyMap())
+
+        assertTrue(isFirstDailyOccurrence(firstEventId))
+        assertFalse(isFirstDailyOccurrence(secondEventId))
+    }
+
+    @Test
+    fun `when events share a name but differ in status, each is the first daily occurrence`() = runTest {
+        val successEventId = insertEvent(name = "test_event")
+        val failureEventId = insertEvent(name = "test_event")
+
+        wideEventRepository.setWideEventStatus(eventId = successEventId, status = SUCCESS, metadata = emptyMap())
+        wideEventRepository.setWideEventStatus(eventId = failureEventId, status = FAILURE, metadata = emptyMap())
+
+        assertTrue(isFirstDailyOccurrence(successEventId))
+        assertTrue(isFirstDailyOccurrence(failureEventId))
+    }
+
+    @Test
+    fun `when events share a status but differ in name, each is the first daily occurrence`() = runTest {
+        val firstEventId = insertEvent(name = "test_event_1")
+        val secondEventId = insertEvent(name = "test_event_2")
+
+        wideEventRepository.setWideEventStatus(eventId = firstEventId, status = SUCCESS, metadata = emptyMap())
+        wideEventRepository.setWideEventStatus(eventId = secondEventId, status = SUCCESS, metadata = emptyMap())
+
+        assertTrue(isFirstDailyOccurrence(firstEventId))
+        assertTrue(isFirstDailyOccurrence(secondEventId))
+    }
+
+    @Test
+    fun `when the same name and status completes later on the same UTC day, it is not the first daily occurrence`() = runTest {
+        val firstEventId = insertEvent(name = "test_event")
+        val secondEventId = insertEvent(name = "test_event")
+
+        wideEventRepository.setWideEventStatus(eventId = firstEventId, status = SUCCESS, metadata = emptyMap())
+        timeProvider.currentTime = Instant.parse("2025-12-03T23:59:59.00Z")
+        wideEventRepository.setWideEventStatus(eventId = secondEventId, status = SUCCESS, metadata = emptyMap())
+
+        assertFalse(isFirstDailyOccurrence(secondEventId))
+    }
+
+    @Test
+    fun `when the same name and status completes on the next UTC day, it is the first daily occurrence again`() = runTest {
+        val firstEventId = insertEvent(name = "test_event")
+        val secondEventId = insertEvent(name = "test_event")
+
+        wideEventRepository.setWideEventStatus(eventId = firstEventId, status = SUCCESS, metadata = emptyMap())
+        timeProvider.currentTime = Instant.parse("2025-12-04T00:00:00.00Z")
+        wideEventRepository.setWideEventStatus(eventId = secondEventId, status = SUCCESS, metadata = emptyMap())
+
+        assertTrue(isFirstDailyOccurrence(secondEventId))
+    }
+
+    @Test
+    fun `when an event is still active, it is not marked as the first daily occurrence`() = runTest {
+        val eventId = insertEvent(name = "test_event")
+
+        assertFalse(isFirstDailyOccurrence(eventId))
+    }
+
+    @Test
+    fun `when an event completes, it does not affect the daily occurrence of an event completed earlier`() = runTest {
+        val firstEventId = insertEvent(name = "test_event")
+        val secondEventId = insertEvent(name = "test_event")
+
+        wideEventRepository.setWideEventStatus(eventId = firstEventId, status = SUCCESS, metadata = emptyMap())
+        wideEventRepository.setWideEventStatus(eventId = secondEventId, status = SUCCESS, metadata = emptyMap())
+
+        assertTrue(isFirstDailyOccurrence(firstEventId))
+    }
+
+    private suspend fun insertEvent(name: String): Long =
+        wideEventRepository.insertWideEvent(
+            name = name,
+            flowEntryPoint = null,
+            metadata = emptyMap(),
+            cleanupPolicy = DEFAULT_CLEANUP_POLICY,
+            metaType = "android-${name.replace('_', '-')}",
+            metaVersion = "1.0.0",
+        )
+
+    private suspend fun isFirstDailyOccurrence(eventId: Long): Boolean =
+        wideEventRepository.getWideEvents(setOf(eventId)).single().isFirstDailyOccurrence
+
     companion object {
         val DEFAULT_CLEANUP_POLICY =
             WideEventRepository.CleanupPolicy.OnTimeout(

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/db/migration/WideEventsMigration4To5Test.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/db/migration/WideEventsMigration4To5Test.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.statistics.wideevents.db.migration
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.statistics.wideevents.db.WideEventDatabase
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WideEventsMigration4To5Test {
+    @get:Rule
+    val testHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        WideEventDatabase::class.java,
+        emptyList(),
+    )
+
+    @Test
+    fun `migration marks existing events as not being the first daily occurrence`() {
+        testHelper.createDatabase(TEST_DB_NAME, 4).use { db ->
+            db.insertWideEvent(id = 1, name = "some_event_name")
+        }
+
+        testHelper.runMigrationsAndValidate(TEST_DB_NAME, 5, true, WideEventsMigration4To5).use { db ->
+            assertEquals(0, db.readInt(id = 1, column = "is_first_daily_occurrence"))
+        }
+    }
+
+    @Test
+    fun `migration preserves existing event data`() {
+        testHelper.createDatabase(TEST_DB_NAME, 4).use { db ->
+            db.insertWideEvent(id = 1, name = "event-1", flowEntryPoint = "settings", metaType = "android-event-1", metaVersion = "1.2.3")
+        }
+
+        testHelper.runMigrationsAndValidate(TEST_DB_NAME, 5, true, WideEventsMigration4To5).use { db ->
+            assertEquals("event-1", db.readString(id = 1, column = "name"))
+            assertEquals("settings", db.readString(id = 1, column = "flow_entry_point"))
+            assertEquals("android-event-1", db.readString(id = 1, column = "meta_type"))
+            assertEquals("1.2.3", db.readString(id = 1, column = "meta_version"))
+        }
+    }
+
+    @Test
+    fun `migration creates a table accepting daily occurrences`() {
+        testHelper.createDatabase(TEST_DB_NAME, 4).use { db ->
+            db.insertWideEvent(id = 1)
+        }
+
+        testHelper.runMigrationsAndValidate(TEST_DB_NAME, 5, true, WideEventsMigration4To5).use { db ->
+            db.execSQL(
+                "INSERT INTO wide_event_daily_occurrences (dedup_key, last_occurrence_date) VALUES (?, ?)",
+                arrayOf<Any?>("flow:success", "2026-01-15"),
+            )
+
+            assertEquals("2026-01-15", db.readLastOccurrenceDate(dedupKey = "flow:success"))
+        }
+    }
+
+    private companion object {
+        const val TEST_DB_NAME = "wide_events_migration_test"
+    }
+}
+
+private fun SupportSQLiteDatabase.insertWideEvent(
+    id: Long,
+    name: String = "flow",
+    flowEntryPoint: String? = null,
+    metaType: String = "android-flow",
+    metaVersion: String = "1.0.0",
+) {
+    execSQL(
+        """
+        INSERT INTO wide_events (
+            id, name, created_at, flow_entry_point, metadata, steps, status, cleanup_policy, active_intervals,
+            sampling_probability, meta_type, meta_version
+        ) VALUES (
+            ?, ?, 0, ?, '[]', '[]', NULL,
+            '{"type":"OnTimeout","duration":600000,"status":"unknown","metadata":{}}',
+            '[]', 1.0, ?, ?
+        )
+        """.trimIndent(),
+        arrayOf<Any?>(id, name, flowEntryPoint, metaType, metaVersion),
+    )
+}
+
+private fun SupportSQLiteDatabase.readInt(
+    id: Long,
+    column: String,
+): Int =
+    query("SELECT $column FROM wide_events WHERE id = ?", arrayOf(id)).use { cursor ->
+        cursor.moveToFirst()
+        cursor.getInt(0)
+    }
+
+private fun SupportSQLiteDatabase.readString(
+    id: Long,
+    column: String,
+): String? =
+    query("SELECT $column FROM wide_events WHERE id = ?", arrayOf(id)).use { cursor ->
+        if (cursor.moveToFirst() && !cursor.isNull(0)) cursor.getString(0) else null
+    }
+
+private fun SupportSQLiteDatabase.readLastOccurrenceDate(dedupKey: String): String? =
+    query("SELECT last_occurrence_date FROM wide_event_daily_occurrences WHERE dedup_key = ?", arrayOf(dedupKey)).use { cursor ->
+        if (cursor.moveToFirst() && !cursor.isNull(0)) cursor.getString(0) else null
+    }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205648422731273/task/1217255814219409?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

Adds `global.is_first_daily_occurrence` to every wide event: `true` when it is the first event completed with the same feature name and status in the current UTC calendar day.

The flag is computed at completion time, inside the transaction that sets the event status, so both transports report the same value and a delayed or retried send keeps the value from the day the event completed. A new `wide_event_daily_occurrences` table holds one row per name/status pair, overwritten daily.

No public API or call-site changes — it is handled entirely inside `statistics-impl`.

### Steps to test this PR

_First daily occurrence flag_
- [x] In `DataClearingWideEvent.kt`, temporarily change `SAMPLING_PROBABILITY` from `0.05f` to `1.0f` so every burn is recorded (revert before merging)
- [x] Enable airplane mode / disconnect device from the internet
- [x] Use the fire button to clear all data
- [x] Inspect wide_events table in wide_events.db - there should be a single row with `is_first_daily_occurrence=1`
- [x] Clear all data again a couple of times
- [x] Inspect database and confirm there are more rows, but only the initial one has `is_first_daily_occurrence=1`
- [x] Disable airplane mode and inspect payloads of POST requests to `improving.duckduckgo.com/e` - `is_first_daily_occurrence` flag should be present

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wide-event persistence (migration + new table) and outbound analytics payloads, but changes are isolated to statistics-impl with no public API surface.
> 
> **Overview**
> Adds **`global.is_first_daily_occurrence`** to completed wide events so analytics can tell whether an event is the first completion that UTC day for the same feature **name** and **status**.
> 
> The flag is set inside **`setWideEventStatus`** (same DB transaction as status), using a dedup key `name:status` and a new **`wide_event_daily_occurrences`** table; **`wide_events`** gains **`is_first_daily_occurrence`** via Room v5 migration. Both the API payload and pixel parameters include the field; pixel schemas adopt the shared **`widePixelIsFirstDailyOccurrence`** param (replacing the inline definition on post-idle session).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6efda12f4607f621907e19c93867926a9fb1a7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->