### PR TITLE
Replace ScrollView with NestedScrollView in sync settings

### DIFF
--- a/sync/sync-impl/src/main/res/layout/activity_sync_v2.xml
+++ b/sync/sync-impl/src/main/res/layout/activity_sync_v2.xml
@@ -24,7 +24,7 @@
         android:id="@+id/includeToolbar"
         layout="@layout/include_default_toolbar" />
 
-    <ScrollView
+    <androidx.core.widget.NestedScrollView
         android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -77,5 +77,5 @@
                 android:visibility="gone" />
 
         </LinearLayout>
-    </ScrollView>
+    </androidx.core.widget.NestedScrollView>
 </LinearLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217243919899683?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Replaces the `ScrollView` in the simplified Sync settings screen with a `NestedScrollView`. This gives the screen smoother scrolling and fling behavior, and lets it cooperate with nested scrolling containers.

### Steps to test this PR

_Scroll and fling the simplified Sync settings screen_
- [ ] Go to "Sync & Backup"
- [ ] Sync this device.
- [ ] Scroll the content up and down.
- [ ] Fling the content quickly with the fling gesture starting from the device list.
- [ ] Verify scrolling and flinging feel smooth.
- [ ] Verify all items on the screen remain reachable.

### UI changes
| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/f036f65c-b404-4339-83db-451a6952c6b0" /> | <video src="https://github.com/user-attachments/assets/5ba05ceb-93c9-439c-903b-97fbfe395ffe" /> |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single layout swap with no logic or data changes; low risk aside from verifying scroll/fling UX on the enabled sync settings state.
> 
> **Overview**
> Swaps the root content scroller in **`activity_sync_v2.xml`** from `ScrollView` to **`androidx.core.widget.NestedScrollView`**, keeping the same id (`contentScrollView`) and scrollbar attributes.
> 
> This aligns the simplified Sync & Backup settings layout with nested scrolling (e.g. the device list inside **`view_sync_v2_enabled`**) so flings and scroll gestures can cooperate with child scrollers instead of fighting a plain `ScrollView`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 011446e645ab481f2724a6b75dbb9b675ac67acb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->