### PR TITLE
Add a missing mock parameter in PageLoadWideEventTest

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/browser/pageload/PageLoadWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pageload/PageLoadWideEventTest.kt
@@ -116,7 +116,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when content scope measurements taken then bucketed durations are recorded as step metadata`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(777L))
         whenever(currentTimeProvider.elapsedRealtime()).thenReturn(1_000L, 1_030L, 1_260L)
 
@@ -140,7 +140,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when measurement is faster than the smallest bucket then it is recorded as zero`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(777L))
         whenever(currentTimeProvider.elapsedRealtime()).thenReturn(1_000L, 1_002L)
 
@@ -158,7 +158,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when a measurement is taken twice for the same navigation then the first one is kept`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(778L))
         whenever(currentTimeProvider.elapsedRealtime()).thenReturn(1_000L, 1_030L, 1_500L)
 
@@ -178,7 +178,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when a measurement is taken before the flow start is processed then it is still recorded`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(780L))
         whenever(currentTimeProvider.elapsedRealtime()).thenReturn(1_000L, 1_060L)
 
@@ -197,7 +197,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when measurement is for a navigation the flow did not start with then it is not recorded`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(779L))
         whenever(currentTimeProvider.elapsedRealtime()).thenReturn(1_000L, 1_030L)
 
@@ -213,7 +213,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when a stale measurement arrives after the same url reloaded then the new flow keeps its own`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(783L))
             .thenReturn(Result.success(784L))
         whenever(currentTimeProvider.elapsedRealtime()).thenReturn(1_000L, 5_000L, 5_040L, 5_100L)
@@ -243,7 +243,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when a measurement is taken after the flow finished then it is not recorded`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(782L))
         whenever(currentTimeProvider.elapsedRealtime()).thenReturn(1_000L, 1_030L)
 
@@ -267,7 +267,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when content scope optimizations differ then each one is reported under its own key`() = runTest {
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any()))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(781L))
         contentScopeOptimizations.state = ContentScopeOptimizations.State(
             injectionOptimized = true,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1217269281689923?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Fixes the `flowStart` mock stubs in `PageLoadWideEventTest` so they match the method's current signature. 

### Steps to test this PR
N/A

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Mockito stub updates with no runtime or production code changes.
> 
> **Overview**
> Updates **`PageLoadWideEventTest`** so every per-test stub of **`wideEventClient.flowStart`** uses **six** Mockito matchers instead of five, matching the current **`WideEventClient.flowStart`** signature (the extra argument is the optional sampling parameter added alongside the existing flow metadata and cleanup policy).
> 
> No production or wide-event behavior changes—only test compilation and mock correctness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9952bd95f5613be628e0f4ae5f93dabd4afa2511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->