### PR TITLE
Contextual/DuckAi: Remove contextualSheetImprovements OFF path

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -134,34 +134,6 @@
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_aichat_contextual_page_context_placeholder_shown_count": {
-        "description": "User has seen the page context placeholder presented in the Contextual sheet",
-        "owners": ["malmstein"],
-        "triggers": ["other"],
-        "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
-    },
-    "m_aichat_contextual_page_context_placeholder_shown_daily": {
-        "description": "(Daily Pixel) User has seen the page context placeholder presented in the Contextual sheet",
-        "owners": ["malmstein"],
-        "triggers": ["other"],
-        "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
-    },
-    "m_aichat_contextual_page_context_placeholder_tapped_count": {
-        "description": "User has added the page context via the placeholder shown in the native side of the Contextual sheet",
-        "owners": ["malmstein"],
-        "triggers": ["other"],
-        "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
-    },
-    "m_aichat_contextual_page_context_placeholder_tapped_daily": {
-        "description": "(Daily Pixel) User has added the page context via the placeholder shown in the native side of the Contextual sheet",
-        "owners": ["malmstein"],
-        "triggers": ["other"],
-        "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
-    },
     "m_aichat_contextual_page_context_invalid_empty": {
         "description": "User attempted to attach page context but the context string was empty",
         "owners": ["malmstein"],

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -692,9 +692,6 @@ class DuckChatContextualFragment :
         binding.duckAiContextualPageRemove.setOnClickListener {
             viewModel.removePageContext()
         }
-        binding.duckAiAttachContextLayout.setOnClickListener {
-            viewModel.addPageContext(fromPlaceholderTap = true)
-        }
         binding.contextualPromptQuickAction.setOnClickListener {
             val currentInput = if (viewModel.viewState.value.contextualNativeInputEnabled) {
                 binding.contextualNativeInputWidget.text
@@ -882,19 +879,12 @@ class DuckChatContextualFragment :
 
                     renderPageContext(viewState.contextTitle, viewState.contextUrl, viewState.tabId)
 
-                    when {
-                        viewState.quickActionState == DuckChatContextualViewModel.QuickActionState.ASK_ABOUT_PAGE -> {
-                            binding.duckAiContextualLayout.gone()
-                            binding.duckAiAttachContextLayout.gone()
-                        }
-                        viewState.showContext -> {
-                            binding.duckAiContextualLayout.show()
-                            binding.duckAiAttachContextLayout.gone()
-                        }
-                        else -> {
-                            binding.duckAiContextualLayout.gone()
-                            binding.duckAiAttachContextLayout.show()
-                        }
+                    if (viewState.quickActionState != DuckChatContextualViewModel.QuickActionState.ASK_ABOUT_PAGE &&
+                        viewState.showContext
+                    ) {
+                        binding.duckAiContextualLayout.show()
+                    } else {
+                        binding.duckAiContextualLayout.gone()
                     }
                     clearInputField()
                 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -682,11 +682,8 @@ class DuckChatContextualFragment :
         }
 
         binding.duckAiContextualClearText.setOnClickListener {
-            // Clear the field directly: typed text isn't mirrored into viewState.prompt, so relying on
-            // onPromptCleared() alone is a no-op re-render (prompt is usually already empty) and the
-            // visible text would stay. Still notify the ViewModel to keep prompt state consistent.
+            // Typed text lives only in the EditText (it isn't mirrored into the ViewModel), so clear it directly.
             clearInputField()
-            viewModel.onPromptCleared()
         }
 
         binding.contextualFullScreen.setOnClickListener {
@@ -860,11 +857,9 @@ class DuckChatContextualFragment :
         }
 
         applyQuickActionVisibility(viewState)
-        binding.legacyInputField.setHint(viewState.chatHintResId)
+        binding.legacyInputField.setHint(R.string.contextualSheetImprovedHint)
 
-        if (viewState.showChatsIcon) {
-            binding.contextualNewChat.setImageResource(com.duckduckgo.mobile.android.R.drawable.ic_chats_24)
-        }
+        binding.contextualNewChat.setImageResource(com.duckduckgo.mobile.android.R.drawable.ic_chats_24)
 
         when (viewState.sheetMode) {
             DuckChatContextualViewModel.SheetMode.INPUT -> {
@@ -875,11 +870,7 @@ class DuckChatContextualFragment :
                 )
                 contextualNativeInputManager.onInputMode()
 
-                if (viewState.showChatsIcon) {
-                    binding.contextualNewChat.show()
-                } else {
-                    binding.contextualNewChat.gone()
-                }
+                binding.contextualNewChat.show()
                 binding.contextualFire.gone()
 
                 if (viewState.contextualNativeInputEnabled) {
@@ -905,12 +896,7 @@ class DuckChatContextualFragment :
                             binding.duckAiAttachContextLayout.show()
                         }
                     }
-                    if (viewState.prompt.isNotEmpty()) {
-                        binding.legacyInputField.setText(viewState.prompt)
-                        binding.legacyInputField.setSelection(viewState.prompt.length)
-                    } else {
-                        clearInputField()
-                    }
+                    clearInputField()
                 }
             }
 
@@ -943,8 +929,7 @@ class DuckChatContextualFragment :
 
     private fun applyQuickActionVisibility(viewState: DuckChatContextualViewModel.ViewState) {
         val isSummarizeQuickAction =
-            viewState.quickActionState == DuckChatContextualViewModel.QuickActionState.LEGACY_SUMMARIZE ||
-                viewState.quickActionState == DuckChatContextualViewModel.QuickActionState.SUBMIT_SUMMARIZE
+            viewState.quickActionState == DuckChatContextualViewModel.QuickActionState.SUBMIT_SUMMARIZE
 
         binding.contextualSuggestionsView.setReservedQuickActionSlots(
             if (viewState.quickActionState == DuckChatContextualViewModel.QuickActionState.ASK_ABOUT_PAGE) 1 else 0,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -94,10 +94,6 @@ class DuckChatContextualViewModel @Inject constructor(
         @field:StringRes val labelResId: Int,
         @field:DrawableRes val iconResId: Int,
     ) {
-        LEGACY_SUMMARIZE(
-            labelResId = R.string.duckAIContextualPromptSummarize,
-            iconResId = com.duckduckgo.mobile.android.R.drawable.ic_arrow_down_right_16,
-        ),
         ASK_ABOUT_PAGE(
             labelResId = R.string.duckAIContextualPromptAskAboutPage,
             iconResId = R.drawable.ic_page_content_attach_16,
@@ -173,41 +169,22 @@ class DuckChatContextualViewModel @Inject constructor(
                 contextUrl = "",
                 contextTitle = "",
                 tabId = "",
-                prompt = "",
                 isFireButtonEnabled = false,
-                quickActionState = QuickActionState.LEGACY_SUMMARIZE,
+                quickActionState = QuickActionState.ASK_ABOUT_PAGE,
                 contextualNativeInputEnabled = duckChatInternal.isContextualNativeInputEnabled(),
             ),
         )
     val viewState: StateFlow<ViewState> = _viewState.asStateFlow()
 
-    private var isContextualSheetImprovementsEnabled: Boolean = false
-
     init {
         viewModelScope.launch(dispatchers.io()) {
-            isContextualSheetImprovementsEnabled = duckChatFeature.contextualSheetImprovements().isEnabled()
-            val initialQuickActionState = if (isContextualSheetImprovementsEnabled) {
-                QuickActionState.ASK_ABOUT_PAGE
-            } else {
-                QuickActionState.LEGACY_SUMMARIZE
-            }
-            val chatHintResId = if (isContextualSheetImprovementsEnabled) {
-                R.string.contextualSheetImprovedHint
-            } else {
-                R.string.input_screen_chat_hint
-            }
             _viewState.update {
                 it.copy(
                     isFireButtonEnabled = duckChatFeature.contextualFireButton().isEnabled(),
-                    quickActionState = initialQuickActionState,
-                    chatHintResId = chatHintResId,
-                    showChatsIcon = isContextualSheetImprovementsEnabled,
                     contextualSuggestionsEnabled = duckChatFeature.contextualSuggestedPrompts().isEnabled(),
                 )
             }
-            if (isContextualSheetImprovementsEnabled) {
-                observeRecentChats()
-            }
+            observeRecentChats()
         }
 
         duckChat.observeNativeChatInputEnabled()
@@ -244,12 +221,8 @@ class DuckChatContextualViewModel @Inject constructor(
         val contextUrl: String = "",
         val contextTitle: String = "",
         val tabId: String = "",
-        val prompt: String = "",
         val isFireButtonEnabled: Boolean = false,
-        val quickActionState: QuickActionState = QuickActionState.LEGACY_SUMMARIZE,
-        @StringRes val chatHintResId: Int = R.string.input_screen_chat_hint,
-        // When true, the legacy "+" icon is replaced by the chats icon and shown regardless of sheet mode.
-        val showChatsIcon: Boolean = false,
+        val quickActionState: QuickActionState = QuickActionState.ASK_ABOUT_PAGE,
         val recentChats: List<ChatHistoryItem> = emptyList(),
         val nativeChatInputEnabled: Boolean = false,
         val contextualNativeInputEnabled: Boolean = false,
@@ -417,7 +390,6 @@ class DuckChatContextualViewModel @Inject constructor(
                 _viewState.value =
                     _viewState.value.copy(
                         sheetMode = SheetMode.WEBVIEW,
-                        prompt = "",
                         // The context has already been captured in contextPrompt above, so drop the
                         // page-context chip from the input once the prompt is sent — mirroring how image
                         // attachments are cleared on submit.
@@ -730,37 +702,8 @@ class DuckChatContextualViewModel @Inject constructor(
         sheetMode == SheetMode.INPUT &&
             quickActionState == QuickActionState.ASK_ABOUT_PAGE
 
-    fun replacePrompt(
-        input: String,
-        prompt: String,
-    ) {
-        logcat { "Duck.ai Contextual: add predefined Summarize prompt" }
-        viewModelScope.launch {
-            val newPrompt = if (input.isEmpty()) {
-                prompt
-            } else {
-                input.plus(" ").plus(prompt)
-            }
-            val hasValidContext = isContextValid(currentPageContext)
-            if (hasValidContext) {
-                pageContextState = pageContextState.copy(attachedPage = pageContextState.currentPage)
-            }
-            _viewState.update { current ->
-                current.copy(
-                    prompt = newPrompt,
-                    showContext = hasValidContext,
-                )
-            }
-        }
-    }
-
     fun onQuickActionClicked(currentInput: String) {
         when (_viewState.value.quickActionState) {
-            QuickActionState.LEGACY_SUMMARIZE -> {
-                duckChatPixels.reportContextualSummarizePromptSelected()
-                replacePrompt(currentInput, context.getString(R.string.duckAIContextualPromptSummarize))
-            }
-
             QuickActionState.ASK_ABOUT_PAGE -> {
                 if (!isContextValid(currentPageContext)) {
                     // Page context not ready yet; stay in ASK_ABOUT_PAGE so the user can retry.
@@ -813,17 +756,6 @@ class DuckChatContextualViewModel @Inject constructor(
         addPageContext()
         commandChannel.trySend(Command.FocusInput)
         _viewState.update { it.copy(quickActionState = QuickActionState.SUBMIT_SUMMARIZE) }
-    }
-
-    fun onPromptCleared() {
-        logcat { "Duck.ai Contextual: onPromptCleared" }
-        viewModelScope.launch {
-            _viewState.update { current ->
-                current.copy(
-                    prompt = "",
-                )
-            }
-        }
     }
 
     fun onFullModeRequested() {
@@ -907,8 +839,8 @@ class DuckChatContextualViewModel @Inject constructor(
                         showContext = showContext,
                         userRemovedContext = remainsUserRemoved,
                         quickActionState = when {
-                            isContextualSheetImprovementsEnabled && newlyAutoAttached -> QuickActionState.SUBMIT_SUMMARIZE
-                            isContextualSheetImprovementsEnabled && dropStaleAttachment -> QuickActionState.ASK_ABOUT_PAGE
+                            newlyAutoAttached -> QuickActionState.SUBMIT_SUMMARIZE
+                            dropStaleAttachment -> QuickActionState.ASK_ABOUT_PAGE
                             else -> inputMode.quickActionState
                         },
                     )
@@ -962,12 +894,7 @@ class DuckChatContextualViewModel @Inject constructor(
     fun onChatsIconClicked() {
         val state = _viewState.value
         logcat {
-            "Duck.ai Contextual: onChatsIconClicked improvementsEnabled=$isContextualSheetImprovementsEnabled " +
-                "recentChats=${state.recentChats.size} sheetMode=${state.sheetMode}"
-        }
-        if (!isContextualSheetImprovementsEnabled) {
-            onNewChatRequested()
-            return
+            "Duck.ai Contextual: onChatsIconClicked recentChats=${state.recentChats.size} sheetMode=${state.sheetMode}"
         }
         duckChatPixels.reportContextualChatsMenuTapped()
         if (state.recentChats.isEmpty()) {
@@ -1026,17 +953,11 @@ class DuckChatContextualViewModel @Inject constructor(
                 withContext(dispatchers.main()) {
                     clearSheetUrl()
                     pageContextState = pageContextState.copy(attachedPage = "")
-                    val resetQuickActionState = if (isContextualSheetImprovementsEnabled) {
-                        QuickActionState.ASK_ABOUT_PAGE
-                    } else {
-                        QuickActionState.LEGACY_SUMMARIZE
-                    }
                     _viewState.update {
                         it.copy(
                             sheetMode = SheetMode.INPUT,
                             showFullscreen = true,
-                            prompt = "",
-                            quickActionState = resetQuickActionState,
+                            quickActionState = QuickActionState.ASK_ABOUT_PAGE,
                             // Reset the page-context attachment so a fresh chat doesn't silently inherit
                             // the previous chat's context: generateContextPrompt() keys off showContext, and
                             // resetQuickActionState hides the attached-context chip, so a stale showContext

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -329,9 +329,6 @@ class DuckChatContextualViewModel @Inject constructor(
                         )
                     }
                 }
-                if (_viewState.value.showsAttachContextPlaceholder()) {
-                    duckChatPixels.reportContextualPlaceholderContextShown()
-                }
                 if (_viewState.value.showsAskAboutPageQuickAction()) {
                     duckChatPixels.reportContextualAskAboutPageShown()
                 }
@@ -626,23 +623,14 @@ class DuckChatContextualViewModel @Inject constructor(
                 },
             )
         }
-        if (_viewState.value.showsAttachContextPlaceholder()) {
-            duckChatPixels.reportContextualPlaceholderContextShown()
-        }
         if (_viewState.value.showsAskAboutPageQuickAction()) {
             duckChatPixels.reportContextualAskAboutPageShown()
         }
         duckChatPixels.reportContextualPageContextRemovedNative()
     }
 
-    // fromPlaceholderTap distinguishes a tap on the duckAiAttachContextLayout placeholder (which
-    // reports the placeholder-tapped pixel) from internal reuse such as the ASK_ABOUT_PAGE quick
-    // action, which attaches the same context but is not a placeholder tap.
-    fun addPageContext(fromPlaceholderTap: Boolean = false) {
+    fun addPageContext() {
         logcat { "Duck.ai Contextual: addPageContext" }
-        if (fromPlaceholderTap) {
-            duckChatPixels.reportContextualPlaceholderContextTapped()
-        }
         viewModelScope.launch {
             if (isContextValid(currentPageContext, reportInvalidPixels = true)) {
                 duckChatPixels.reportContextualPageContextManuallyAttachedNative()
@@ -689,14 +677,6 @@ class DuckChatContextualViewModel @Inject constructor(
         }
         return title != null && content != null
     }
-
-    // Mirrors the Fragment's visibility logic for the "attach page content" placeholder
-    // (duckAiAttachContextLayout): it is only shown in INPUT mode, when not in the
-    // ASK_ABOUT_PAGE quick action, and when no context is currently attached.
-    private fun ViewState.showsAttachContextPlaceholder(): Boolean =
-        sheetMode == SheetMode.INPUT &&
-            quickActionState != QuickActionState.ASK_ABOUT_PAGE &&
-            !showContext
 
     private fun ViewState.showsAskAboutPageQuickAction(): Boolean =
         sheetMode == SheetMode.INPUT &&
@@ -968,9 +948,6 @@ class DuckChatContextualViewModel @Inject constructor(
                     }
                     sheetState?.let { commandChannel.trySend(Command.ChangeSheetState(it)) }
 
-                    if (sheetState == BottomSheetBehavior.STATE_HALF_EXPANDED && _viewState.value.showsAttachContextPlaceholder()) {
-                        duckChatPixels.reportContextualPlaceholderContextShown()
-                    }
                     if (sheetState == BottomSheetBehavior.STATE_HALF_EXPANDED && _viewState.value.showsAskAboutPageQuickAction()) {
                         duckChatPixels.reportContextualAskAboutPageShown()
                     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -253,13 +253,6 @@ interface DuckChatFeature {
     fun duckAiVoiceChatService(): Toggle
 
     /**
-     * @return `true` when the contextual Duck.ai sheet improvements are enabled.
-     * If the remote feature is not present defaults to `true`
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
-    fun contextualSheetImprovements(): Toggle
-
-    /**
      * @return `true` when context-aware suggested prompts are shown on the contextual Duck.ai start surface.
      * If the remote feature is not present defaults to `internal`.
      */

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -160,8 +160,6 @@ interface DuckChatPixels {
     fun reportContextualRecentChatsPopupDisplayed()
     fun reportContextualRecentChatSelected()
     fun reportContextualViewAllChatsTapped()
-    fun reportContextualPlaceholderContextTapped()
-    fun reportContextualPlaceholderContextShown()
     fun reportContextualPageContextInvalidEmpty()
     fun reportContextualPageContextInvalidNoTitle()
     fun reportContextualPageContextInvalidNoContent()
@@ -534,20 +532,6 @@ class RealDuckChatPixels @Inject constructor(
         appCoroutineScope.launch(dispatcherProvider.io()) {
             pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_VIEW_ALL_CHATS_TAPPED_COUNT)
             pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_VIEW_ALL_CHATS_TAPPED_DAILY, type = Pixel.PixelType.Daily())
-        }
-    }
-
-    override fun reportContextualPlaceholderContextTapped() {
-        appCoroutineScope.launch(dispatcherProvider.io()) {
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_TAPPED_COUNT)
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_TAPPED_DAILY, type = Pixel.PixelType.Daily())
-        }
-    }
-
-    override fun reportContextualPlaceholderContextShown() {
-        appCoroutineScope.launch(dispatcherProvider.io()) {
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_COUNT)
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_DAILY, type = Pixel.PixelType.Daily())
         }
     }
 
@@ -1076,10 +1060,6 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_CONTEXTUAL_RECENT_CHAT_SELECTED_DAILY("m_aichat_contextual_recent_chat_selected_daily"),
     DUCK_CHAT_CONTEXTUAL_VIEW_ALL_CHATS_TAPPED_COUNT("m_aichat_contextual_view_all_chats_tapped_count"),
     DUCK_CHAT_CONTEXTUAL_VIEW_ALL_CHATS_TAPPED_DAILY("m_aichat_contextual_view_all_chats_tapped_daily"),
-    DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_COUNT("m_aichat_contextual_page_context_placeholder_shown_count"),
-    DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_DAILY("m_aichat_contextual_page_context_placeholder_shown_daily"),
-    DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_TAPPED_COUNT("m_aichat_contextual_page_context_placeholder_tapped_count"),
-    DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_TAPPED_DAILY("m_aichat_contextual_page_context_placeholder_tapped_daily"),
     DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_EMPTY_COUNT("m_aichat_contextual_page_context_invalid_empty_c"),
     DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_EMPTY_DAILY("m_aichat_contextual_page_context_invalid_empty_d"),
     DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_TITLE_COUNT("m_aichat_contextual_page_context_invalid_no_title_c"),
@@ -1374,10 +1354,6 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_RECENT_CHAT_SELECTED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_VIEW_ALL_CHATS_TAPPED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_VIEW_ALL_CHATS_TAPPED_DAILY.pixelName to PixelParameter.removeAtb(),
-            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_COUNT.pixelName to PixelParameter.removeAtb(),
-            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_DAILY.pixelName to PixelParameter.removeAtb(),
-            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_TAPPED_COUNT.pixelName to PixelParameter.removeAtb(),
-            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_TAPPED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_EMPTY_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_EMPTY_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_TITLE_COUNT.pixelName to PixelParameter.removeAtb(),

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
@@ -342,41 +342,6 @@
                     </androidx.constraintlayout.widget.ConstraintLayout>
 
                     <androidx.constraintlayout.widget.ConstraintLayout
-                        android:id="@+id/duckAiAttachContextLayout"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:padding="@dimen/keyline_2"
-                        android:layout_marginTop="@dimen/keyline_2"
-                        android:background="@drawable/background_dashed_outline">
-
-                        <com.google.android.material.imageview.ShapeableImageView
-                            android:id="@+id/duckAiContextualAttachContextIcon"
-                            android:layout_width="24dp"
-                            android:layout_height="24dp"
-                            android:layout_gravity="center"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toTopOf="parent"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            android:src="@drawable/ic_page_content_attach_24"
-                            app:shapeAppearanceOverlay="@style/Widget.DuckDuckGo.DuckChatContextualFavicon"
-                            android:importantForAccessibility="no" />
-
-                        <com.duckduckgo.common.ui.view.text.DaxTextView
-                            android:id="@+id/duckAiContextualAttachContextLabel"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            app:textType="secondary"
-                            android:text="@string/duckAIContextualAttachPageContent"
-                            android:paddingEnd="@dimen/keyline_2"
-                            android:layout_marginStart="@dimen/keyline_2"
-                            app:typography="body2_bold"
-                            app:layout_constraintStart_toEndOf="@+id/duckAiContextualAttachContextIcon"
-                            app:layout_constraintTop_toTopOf="@id/duckAiContextualAttachContextIcon"
-                            app:layout_constraintBottom_toBottomOf="@+id/duckAiContextualAttachContextIcon" />
-
-                    </androidx.constraintlayout.widget.ConstraintLayout>
-
-                    <androidx.constraintlayout.widget.ConstraintLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:id="@+id/duckAiContextualActions"

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
@@ -249,7 +249,7 @@
                             android:background="@null"
                             android:fontFamily="sans-serif"
                             android:gravity="start|top"
-                            android:hint="@string/input_screen_chat_hint"
+                            android:hint="@string/contextualSheetImprovedHint"
                             android:lineSpacingMultiplier="1.2"
                             android:minHeight="40dp"
                             android:paddingVertical="@dimen/keyline_2"

--- a/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Търсене или въвеждане на адрес</string>
     <string name="input_screen_search_only_hint">Търсене</string>
-    <string name="input_screen_chat_hint">Задавайте въпроси поверително</string>
     <string name="input_screen_user_pref_without_ai">Само търсене</string>
     <string name="input_screen_user_pref_with_ai">Търсене и Duck.ai</string>
     <string name="input_screen_user_pref_description">Изпробвайте новата опция за задаване на въпроси към Duck.ai директно от адресната лента. <annotation type="share_feedback">Споделяне на отзив</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Обобщи тази страница</string>
     <string name="duckAIContextualAutomaticContextTitle">Автоматично изпращане на съдържанието на страницата</string>
     <string name="duckAIContextualAutomaticContextMessage">Автоматично изпращане на съдържанието на страницата до Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Прикачи съдържанието на страницата</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Попитайте за страницата</string>
@@ -344,6 +342,5 @@
     <string name="duckAiSettingsTitle">Настройки на Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Попитайте за раздела</string>
     <string name="duckChatContextualAskAboutPage">Попитайте за страницата</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Vyhledejte nebo zadejte adresu</string>
     <string name="input_screen_search_only_hint">Vyhledávání</string>
-    <string name="input_screen_chat_hint">Zeptej se soukromě</string>
     <string name="input_screen_user_pref_without_ai">Jen vyhledávání</string>
     <string name="input_screen_user_pref_with_ai">Vyhledávání a Duck.ai</string>
     <string name="input_screen_user_pref_description">Vyzkoušej novou možnost zeptat se Duck.ai přímo z adresního řádku. <annotation type="share_feedback">Sdílet zpětnou vazbu</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Shrnout tuhle stránku</string>
     <string name="duckAIContextualAutomaticContextTitle">Automaticky odesílat obsah stránky</string>
     <string name="duckAIContextualAutomaticContextMessage">Automaticky odesílat obsah stránky do Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Připojit obsah stránky</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Zeptat se ohledně stránky</string>
@@ -346,6 +344,5 @@
     <string name="duckAiSettingsTitle">Nastavení Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Zeptat se ohledně karty</string>
     <string name="duckChatContextualAskAboutPage">Zeptat se ohledně stránky</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Søg eller indtast adresse</string>
     <string name="input_screen_search_only_hint">Søg</string>
-    <string name="input_screen_chat_hint">Spørg privat</string>
     <string name="input_screen_user_pref_without_ai">Kun søgning</string>
     <string name="input_screen_user_pref_with_ai">Søg &amp; Duck.ai</string>
     <string name="input_screen_user_pref_description">Prøv den nye mulighed for at spørge Duck.ai direkte fra adresselinjen. <annotation type="share_feedback">Del feedback</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Sammenfat denne side</string>
     <string name="duckAIContextualAutomaticContextTitle">Send automatisk sideindhold</string>
     <string name="duckAIContextualAutomaticContextMessage">Send automatisk sideindhold til Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Vedhæft sideindhold</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Spørg om siden</string>
@@ -344,6 +342,5 @@
     <string name="duckAiSettingsTitle">Duck.ai-indstillinger</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Spørg om fanen</string>
     <string name="duckChatContextualAskAboutPage">Spørg om siden</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Adresse suchen oder eingeben</string>
     <string name="input_screen_search_only_hint">Suche</string>
-    <string name="input_screen_chat_hint">Privat fragen</string>
     <string name="input_screen_user_pref_without_ai">Nur Suchen</string>
     <string name="input_screen_user_pref_with_ai">Suche &amp; Duck.ai</string>
     <string name="input_screen_user_pref_description">Probiere die neue Option aus, um Duck.ai direkt über die Adressleiste zu fragen. <annotation type="share_feedback">Feedback teilen</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Diese Seite zusammenfassen</string>
     <string name="duckAIContextualAutomaticContextTitle">Automatisch Seiteninhalte senden</string>
     <string name="duckAIContextualAutomaticContextMessage">Seiteninhalt automatisch an Duck.ai senden</string>
-    <string name="duckAIContextualAttachPageContent">Seiteninhalt anhängen</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Frage zur Seite</string>
@@ -344,6 +342,5 @@
     <string name="duckAiSettingsTitle">Duck.ai-Einstellungen</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Frage zum Tab</string>
     <string name="duckChatContextualAskAboutPage">Frage zur Seite</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Αναζήτηση ή εισαγωγή διεύθυνσης</string>
     <string name="input_screen_search_only_hint">Αναζήτηση</string>
-    <string name="input_screen_chat_hint">Ρωτήστε ιδιωτικά</string>
     <string name="input_screen_user_pref_without_ai">Αναζήτηση μόνο</string>
     <string name="input_screen_user_pref_with_ai">Αναζήτηση και Duck.ai</string>
     <string name="input_screen_user_pref_description">Δοκιμάστε την καινούργια επιλογή μας για να ρωτήσετε το Duck.ai απευθείας από τη Γραμμή διευθύνσεων. <annotation type="share_feedback">Κοινοποίηση σχολίων</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Συνοψίστε αυτήν τη σελίδα</string>
     <string name="duckAIContextualAutomaticContextTitle">Αυτόματη αποστολή περιεχομένου σελίδας</string>
     <string name="duckAIContextualAutomaticContextMessage">Αυτόματη αποστολή περιεχομένου σελίδας στο Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Επισύναψη περιεχομένου σελίδας</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Ρωτήστε για τη σελίδα</string>
@@ -344,6 +342,5 @@
     <string name="duckAiSettingsTitle">Ρυθμίσεις Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Ρώτα για την καρτέλα</string>
     <string name="duckChatContextualAskAboutPage">Ρώτα για τη σελίδα</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Buscar o introducir dirección</string>
     <string name="input_screen_search_only_hint">Buscar</string>
-    <string name="input_screen_chat_hint">Pregunta en privado</string>
     <string name="input_screen_user_pref_without_ai">Solo buscar</string>
     <string name="input_screen_user_pref_with_ai">Búsqueda y Duck.ai</string>
     <string name="input_screen_user_pref_description">Prueba la nueva opción para preguntar directamente a Duck.ai desde la barra de direcciones. <annotation type="share_feedback">Comparte tus comentarios</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Resumir esta página</string>
     <string name="duckAIContextualAutomaticContextTitle">Enviar contenido de la página automáticamente</string>
     <string name="duckAIContextualAutomaticContextMessage">Envía automáticamente el contenido de la página a Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Adjuntar contenido de la página</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Preguntar sobre la página</string>
@@ -344,6 +342,5 @@
     <string name="duckAiSettingsTitle">Configuración de Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Preguntar sobre la pestaña</string>
     <string name="duckChatContextualAskAboutPage">Preguntar sobre la página</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Otsi või sisesta aadress</string>
     <string name="input_screen_search_only_hint">Otsi</string>
-    <string name="input_screen_chat_hint">Küsi privaatselt</string>
     <string name="input_screen_user_pref_without_ai">Ainult otsi</string>
     <string name="input_screen_user_pref_with_ai">Otsi ja Duck.ai</string>
     <string name="input_screen_user_pref_description">\"Proovi meie uut valikut küsida Duck.ai käest otse aadressiribalt.\" <annotation type="share_feedback">Jaga tagasisidet</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Loo lehekülje kokkuvõte</string>
     <string name="duckAIContextualAutomaticContextTitle">Saada lehe sisu automaatselt</string>
     <string name="duckAIContextualAutomaticContextMessage">Saada lehe sisu automaatselt Duck.ai-le</string>
-    <string name="duckAIContextualAttachPageContent">Lisa lehe sisu</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Küsi lehe kohta</string>
@@ -344,6 +342,5 @@
     <string name="duckAiSettingsTitle">Duck.ai seaded</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Küsi vahekaardi kohta</string>
     <string name="duckChatContextualAskAboutPage">Küsi lehe kohta</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Hae tai anna osoite</string>
     <string name="input_screen_search_only_hint">Hae</string>
-    <string name="input_screen_chat_hint">Kysy yksityisesti</string>
     <string name="input_screen_user_pref_without_ai">Vain haku</string>
     <string name="input_screen_user_pref_with_ai">Haku ja Duck.ai</string>
     <string name="input_screen_user_pref_description">Kokeile uutta vaihtoehtoa kysyä Duck.ai:lta suoraan osoiteriviltä. <annotation type="share_feedback">Anna palautetta</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Yhteenveto tästä sivusta</string>
     <string name="duckAIContextualAutomaticContextTitle">Lähetä sivun sisältö automaattisesti</string>
     <string name="duckAIContextualAutomaticContextMessage">Lähetä sivun sisältö automaattisesti Duck.ai:lle</string>
-    <string name="duckAIContextualAttachPageContent">Liitä sivun sisältö</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Kysy sivusta</string>
@@ -344,6 +342,5 @@
     <string name="duckAiSettingsTitle">Duck.ai-asetukset</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Kysy välilehdestä</string>
     <string name="duckChatContextualAskAboutPage">Kysy sivusta</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Rechercher ou saisir une adresse</string>
     <string name="input_screen_search_only_hint">Rechercher</string>
-    <string name="input_screen_chat_hint">Demander en privé</string>
     <string name="input_screen_user_pref_without_ai">Recherche uniquement</string>
     <string name="input_screen_user_pref_with_ai">Recherche et Duck.ai</string>
     <string name="input_screen_user_pref_description">Essayez la nouvelle option pour interroger Duck.ai directement à partir de la barre d\'adresse. <annotation type="share_feedback">Partagez vos commentaires</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Résumer cette page</string>
     <string name="duckAIContextualAutomaticContextTitle">Envoyer automatiquement le contenu de la page</string>
     <string name="duckAIContextualAutomaticContextMessage">Envoyer automatiquement le contenu de la page à Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Joindre le contenu de la page</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Posez des questions sur la page</string>
@@ -344,6 +342,5 @@
     <string name="duckAiSettingsTitle">Paramètres Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Posez des questions sur l\'onglet</string>
     <string name="duckChatContextualAskAboutPage">Posez des questions sur la page</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Pretraži ili unesi adresu</string>
     <string name="input_screen_search_only_hint">Pretraživanje</string>
-    <string name="input_screen_chat_hint">Pitaj privatno</string>
     <string name="input_screen_user_pref_without_ai">Samo pretraživanje</string>
     <string name="input_screen_user_pref_with_ai">Pretraživanje i Duck.ai</string>
     <string name="input_screen_user_pref_description">Isprobaj novu opciju za izravno postavljanje pitanja s adresne trake usluzi Duck.ai. <annotation type="share_feedback">Podijeli povratne informacije</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Sažmi ovu stranicu</string>
     <string name="duckAIContextualAutomaticContextTitle">Automatski pošalji sadržaj stranice</string>
     <string name="duckAIContextualAutomaticContextMessage">Automatski pošalji sadržaj stranice Duck.ai-ju</string>
-    <string name="duckAIContextualAttachPageContent">Priloži sadržaj stranice</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Pitaj o stranici</string>
@@ -346,6 +344,5 @@
     <string name="duckAiSettingsTitle">Postavke usluge Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Pitaj o kartici</string>
     <string name="duckChatContextualAskAboutPage">Pitaj o stranici</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Keresés vagy cím megadása</string>
     <string name="input_screen_search_only_hint">Keresés</string>
-    <string name="input_screen_chat_hint">Kérdezz privátban</string>
     <string name="input_screen_user_pref_without_ai">Csak keresés</string>
     <string name="input_screen_user_pref_with_ai">Keresés és Duck.ai</string>
     <string name="input_screen_user_pref_description">Próbáld ki azt az új lehetőséget, hogy közvetlenül a címsorban tehetsz fel kérdéseket a Duck.ai számára. <annotation type="share_feedback">Visszajelzés küldése</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Oldal összefoglalása</string>
     <string name="duckAIContextualAutomaticContextTitle">Oldal tartalmának automatikus küldése</string>
     <string name="duckAIContextualAutomaticContextMessage">Az oldal tartalmának automatikus küldése a Duck.ai részére</string>
-    <string name="duckAIContextualAttachPageContent">Oldal tartalmának csatolása</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Kérdezz az oldalról</string>
@@ -344,6 +342,5 @@
     <string name="duckAiSettingsTitle">Duck.ai-beállítások</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Kérdés a lapról</string>
     <string name="duckChatContextualAskAboutPage">Kérdés az oldalról</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Cerca o digita l\'indirizzo</string>
     <string name="input_screen_search_only_hint">Ricerca</string>
-    <string name="input_screen_chat_hint">Chiedi in privato</string>
     <string name="input_screen_user_pref_without_ai">Solo ricerca</string>
     <string name="input_screen_user_pref_with_ai">Ricerca e Duck.ai</string>
     <string name="input_screen_user_pref_description">Prova la nuova opzione per chiedere a Duck.ai direttamente dalla barra degli indirizzi. <annotation type="share_feedback">Condividi feedback</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Riassumi questa pagina</string>
     <string name="duckAIContextualAutomaticContextTitle">Invia automaticamente il contenuto della pagina</string>
     <string name="duckAIContextualAutomaticContextMessage">Invia automaticamente il contenuto della pagina a Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Allega il contenuto della pagina</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Richiedi informazioni sulla pagina</string>
@@ -344,6 +342,5 @@
     <string name="duckAiSettingsTitle">Impostazioni di Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Chiedi informazioni sulla scheda</string>
     <string name="duckChatContextualAskAboutPage">Richiedi informazioni sulla pagina</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Ieškoti arba įvesti adresą</string>
     <string name="input_screen_search_only_hint">Paieška</string>
-    <string name="input_screen_chat_hint">Klauskite privačiai</string>
     <string name="input_screen_user_pref_without_ai">Tik paieška</string>
     <string name="input_screen_user_pref_with_ai">Paieška ir „Duck.ai“</string>
     <string name="input_screen_user_pref_description">Išbandykite naują parinktį ir užduokite klausimus „Duck.ai“ tiesiai iš adresų juostos. <annotation type="share_feedback">Bendrinti atsiliepimą</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Apibendrinti šį puslapį</string>
     <string name="duckAIContextualAutomaticContextTitle">Automatiškai siųsti puslapio turinį</string>
     <string name="duckAIContextualAutomaticContextMessage">Automatiškai siųsti puslapio turinį į „Duck.ai“</string>
-    <string name="duckAIContextualAttachPageContent">Pridėkite puslapio turinį</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Klausk apie puslapį</string>
@@ -346,6 +344,5 @@
     <string name="duckAiSettingsTitle">„Duck.ai“ nuostatos</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Klausti apie kortelę</string>
     <string name="duckChatContextualAskAboutPage">Klausk apie puslapį</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Meklē vai ievadi adresi</string>
     <string name="input_screen_search_only_hint">Meklēt</string>
-    <string name="input_screen_chat_hint">Pajautāt privāti</string>
     <string name="input_screen_user_pref_without_ai">Meklēt tikai</string>
     <string name="input_screen_user_pref_with_ai">Meklēšana &amp; Duck.ai</string>
     <string name="input_screen_user_pref_description">Izmēģini jauno iespēju jautāt Duck.ai tieši no adreses joslas. <annotation type="share_feedback">Dalies ar atsauksmi</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Apkopot šo lapu</string>
     <string name="duckAIContextualAutomaticContextTitle">Automātiski nosūtīt lapas saturu</string>
     <string name="duckAIContextualAutomaticContextMessage">Automātiski nosūtīt lapas saturu uz Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Pievienot lapas saturu</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Jautā par lapu</string>
@@ -345,6 +343,5 @@
     <string name="duckAiSettingsTitle">Duck.ai iestatījumi</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Jautā par cilni</string>
     <string name="duckChatContextualAskAboutPage">Jautā par lapu</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Søk eller skriv inn adresse</string>
     <string name="input_screen_search_only_hint">Søk</string>
-    <string name="input_screen_chat_hint">Spør privat</string>
     <string name="input_screen_user_pref_without_ai">Bare søk</string>
     <string name="input_screen_user_pref_with_ai">Søk og Duck.ai</string>
     <string name="input_screen_user_pref_description">Prøv den nye valgmuligheten for å spørre Duck.ai direkte fra adressefeltet. <annotation type="share_feedback">Del tilbakemelding</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Oppsummer denne siden</string>
     <string name="duckAIContextualAutomaticContextTitle">Send sideinnhold automatisk</string>
     <string name="duckAIContextualAutomaticContextMessage">Send sideinnhold automatisk til Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Legg ved sideinnhold</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Spør om siden</string>
@@ -344,6 +342,5 @@
     <string name="duckAiSettingsTitle">Innstillinger for Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Spør om fanen</string>
     <string name="duckChatContextualAskAboutPage">Spør om siden</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Zoek of voer een adres in</string>
     <string name="input_screen_search_only_hint">Zoeken</string>
-    <string name="input_screen_chat_hint">Vraag privé</string>
     <string name="input_screen_user_pref_without_ai">Alleen zoeken</string>
     <string name="input_screen_user_pref_with_ai">Zoeken en Duck.ai</string>
     <string name="input_screen_user_pref_description">Probeer de nieuwe optie om direct een vraag te stellen aan Duck.ai vanuit de adresbalk. <annotation type="share_feedback">Feedback delen</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Deze pagina samenvatten</string>
     <string name="duckAIContextualAutomaticContextTitle">Pagina-inhoud automatisch verzenden</string>
     <string name="duckAIContextualAutomaticContextMessage">Pagina-inhoud automatisch naar Duck.ai verzenden</string>
-    <string name="duckAIContextualAttachPageContent">Pagina-inhoud bijvoegen</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Stel een vraag over de pagina</string>
@@ -344,6 +342,5 @@
     <string name="duckAiSettingsTitle">Instellingen Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Stel een vraag over het tabblad</string>
     <string name="duckChatContextualAskAboutPage">Stel een vraag over de pagina</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Wyszukaj lub wprowadź adres</string>
     <string name="input_screen_search_only_hint">Szukaj</string>
-    <string name="input_screen_chat_hint">Zapytaj prywatnie</string>
     <string name="input_screen_user_pref_without_ai">Tylko wyszukiwanie</string>
     <string name="input_screen_user_pref_with_ai">Wyszukiwanie i Duck.ai</string>
     <string name="input_screen_user_pref_description">Wypróbuj nową opcję umożliwiającą zapytanie Duck.ai bezpośrednio z paska adresu. <annotation type="share_feedback">Podziel się opinią</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Podsumuj tę stronę</string>
     <string name="duckAIContextualAutomaticContextTitle">Automatycznie wysyłaj zawartość strony</string>
     <string name="duckAIContextualAutomaticContextMessage">Automatycznie wysyłaj zawartość strony do Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Dołącz zawartość strony</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Zapytaj o stronę</string>
@@ -346,6 +344,5 @@
     <string name="duckAiSettingsTitle">Ustawienia Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Zapytaj o kartę</string>
     <string name="duckChatContextualAskAboutPage">Zapytaj o stronę</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Pesquisar ou inserir endereço</string>
     <string name="input_screen_search_only_hint">Pesquisar</string>
-    <string name="input_screen_chat_hint">Perguntar em privado</string>
     <string name="input_screen_user_pref_without_ai">Pesquisar apenas</string>
     <string name="input_screen_user_pref_with_ai">Pesquisa e Duck.ai</string>
     <string name="input_screen_user_pref_description">Utiliza a nova opção para perguntar diretamente ao Duck.ai na barra de endereço. <annotation type="share_feedback">Partilhar comentários</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Resumir esta página</string>
     <string name="duckAIContextualAutomaticContextTitle">Enviar automaticamente o conteúdo da página</string>
     <string name="duckAIContextualAutomaticContextMessage">Enviar automaticamente o conteúdo da página para o Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Anexar contexto da página</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Pergunta sobre a página</string>
@@ -344,6 +342,5 @@
     <string name="duckAiSettingsTitle">Definições do Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Perguntar sobre o separador</string>
     <string name="duckChatContextualAskAboutPage">Perguntar sobre a página</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Caută sau introdu adresa</string>
     <string name="input_screen_search_only_hint">Caută</string>
-    <string name="input_screen_chat_hint">Întreabă în mod privat</string>
     <string name="input_screen_user_pref_without_ai">Doar căutare</string>
     <string name="input_screen_user_pref_with_ai">Caută pe Duck.ai</string>
     <string name="input_screen_user_pref_description">Încearcă noua opțiune de a adresa o întrebare către Duck.ai direct din bara de adrese. <annotation type="share_feedback">Trimite feedback</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Rezumă această pagină</string>
     <string name="duckAIContextualAutomaticContextTitle">Trimite automat conținutul paginii</string>
     <string name="duckAIContextualAutomaticContextMessage">Trimite automat conținutul paginii către Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Atașează conținutul paginii</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Întreabă despre pagină</string>
@@ -345,6 +343,5 @@
     <string name="duckAiSettingsTitle">Setări Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Întreabă despre filă</string>
     <string name="duckChatContextualAskAboutPage">Întreabă despre pagină</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Введите поисковый запрос или адрес сайта</string>
     <string name="input_screen_search_only_hint">Поиск</string>
-    <string name="input_screen_chat_hint">Задать вопрос (конфиденциально)</string>
     <string name="input_screen_user_pref_without_ai">Только поиск</string>
     <string name="input_screen_user_pref_with_ai">Поиск и Duck.ai</string>
     <string name="input_screen_user_pref_description">Новая функция! Вопрос чат-боту Duck.ai прямо из адресной строки. <annotation type="share_feedback">Оставить отзыв</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Кратко изложи содержимое страницы</string>
     <string name="duckAIContextualAutomaticContextTitle">Автоматически отправлять содержимое страницы</string>
     <string name="duckAIContextualAutomaticContextMessage">Автоматически отправлять содержимое страницы в Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Добавить содержимое страницы</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Задайте вопрос о странице</string>
@@ -346,6 +344,5 @@
     <string name="duckAiSettingsTitle">Настройки Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Задать вопрос о вкладке</string>
     <string name="duckChatContextualAskAboutPage">Задать вопрос о странице</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Vyhľadajte alebo zadajte adresu</string>
     <string name="input_screen_search_only_hint">Vyhľadávať</string>
-    <string name="input_screen_chat_hint">Spýtaj sa súkromne</string>
     <string name="input_screen_user_pref_without_ai">Len vyhľadávanie</string>
     <string name="input_screen_user_pref_with_ai">Vyhľadávanie &amp; Duck.ai</string>
     <string name="input_screen_user_pref_description">Vyskúšaj novú možnosť pýtať sa Duck.ai priamo z panela s adresou. <annotation type="share_feedback">Zdieľaj spätnú väzbu</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Zhrň túto stránku</string>
     <string name="duckAIContextualAutomaticContextTitle">Automaticky odoslať obsah stránky</string>
     <string name="duckAIContextualAutomaticContextMessage">Automaticky odoslať obsah stránky do Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Pripoj obsah stránky</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Opýtaj sa na stránku</string>
@@ -346,6 +344,5 @@
     <string name="duckAiSettingsTitle">Nastavenia Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Opýtaj sa na kartu</string>
     <string name="duckChatContextualAskAboutPage">Opýtaj sa na stránku</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Poišči ali vnesi naslov</string>
     <string name="input_screen_search_only_hint">Iskanje</string>
-    <string name="input_screen_chat_hint">Vprašaj zasebno</string>
     <string name="input_screen_user_pref_without_ai">Samo iskanje</string>
     <string name="input_screen_user_pref_with_ai">Iskanje in Duck.ai</string>
     <string name="input_screen_user_pref_description">Preizkusite novo možnost, da vprašate Duck.ai neposredno iz naslovne vrstice. <annotation type="share_feedback">Podajte povratne informacije</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Povzemi to stran</string>
     <string name="duckAIContextualAutomaticContextTitle">Samodejno pošiljanje vsebine strani</string>
     <string name="duckAIContextualAutomaticContextMessage">Vsebino strani samodejno pošljite Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Priloži vsebino strani</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Vprašajte o strani</string>
@@ -346,6 +344,5 @@
     <string name="duckAiSettingsTitle">Nastavitve Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Vprašajte o zavihku</string>
     <string name="duckChatContextualAskAboutPage">Vprašajte o strani</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Sök eller ange adress</string>
     <string name="input_screen_search_only_hint">Sökning</string>
-    <string name="input_screen_chat_hint">Fråga privat</string>
     <string name="input_screen_user_pref_without_ai">Sök endast</string>
     <string name="input_screen_user_pref_with_ai">Sök &amp; Duck.ai</string>
     <string name="input_screen_user_pref_description">Prova den nya funktionen att fråga Duck.ai direkt från adressfältet. <annotation type="share_feedback">Berätta vad du tycker</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Sammanfatta denna sida</string>
     <string name="duckAIContextualAutomaticContextTitle">Skicka sidinnehåll automatiskt</string>
     <string name="duckAIContextualAutomaticContextMessage">Skicka sidinnehåll automatiskt till Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Bifoga sidans innehåll</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Fråga om sidan</string>
@@ -344,6 +342,5 @@
     <string name="duckAiSettingsTitle">Duck.ai-inställningar</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Fråga om fliken</string>
     <string name="duckChatContextualAskAboutPage">Fråga om sidan</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
@@ -60,7 +60,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Adres ara veya gir</string>
     <string name="input_screen_search_only_hint">Arama yap</string>
-    <string name="input_screen_chat_hint">Özel olarak sor</string>
     <string name="input_screen_user_pref_without_ai">Yalnızca Arama</string>
     <string name="input_screen_user_pref_with_ai">Arama ve Duck.ai</string>
     <string name="input_screen_user_pref_description">Adres Çubuğundan doğrudan Duck.ai\'a soru sormanızı sağlayan yeni seçeneği deneyin. <annotation type="share_feedback">Geri Bildirim Paylaş</annotation></string>
@@ -121,7 +120,6 @@
     <string name="duckAIContextualPromptSummarize">Bu Sayfayı Özetle</string>
     <string name="duckAIContextualAutomaticContextTitle">Sayfa İçeriğini Otomatik Olarak Gönder</string>
     <string name="duckAIContextualAutomaticContextMessage">Sayfa içeriğini otomatik olarak Duck.ai\'a gönder</string>
-    <string name="duckAIContextualAttachPageContent">Sayfa İçeriğini Ekle</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Sayfa Hakkında Soru Sor</string>
@@ -344,6 +342,5 @@
     <string name="duckAiSettingsTitle">Duck.ai Ayarları</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Sekme Hakkında Soru Sor</string>
     <string name="duckChatContextualAskAboutPage">Sayfa Hakkında Soru Sor</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -59,7 +59,6 @@
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Search or enter address</string>
     <string name="input_screen_search_only_hint">Search</string>
-    <string name="input_screen_chat_hint">Ask privately</string>
     <string name="input_screen_user_pref_without_ai">Search Only</string>
     <string name="input_screen_user_pref_with_ai">Search &amp; Duck.ai</string>
     <string name="input_screen_user_pref_description">Try the new option to ask Duck.ai directly from the Address Bar. <annotation type="share_feedback">Share Feedback</annotation></string>
@@ -120,7 +119,6 @@
     <string name="duckAIContextualPromptSummarize">Summarize This Page</string>
     <string name="duckAIContextualAutomaticContextTitle">Automatically Send Page Content</string>
     <string name="duckAIContextualAutomaticContextMessage">Automatically send page content to Duck.ai</string>
-    <string name="duckAIContextualAttachPageContent">Attach Page Content</string>
 
     <!-- Contextual sheet quick action -->
     <string name="duckAIContextualPromptAskAboutPage">Ask About Page</string>
@@ -205,7 +203,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person's background">Summarize their background</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person's background">Summarize the background and notable work of this person.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Ask anything privately</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Recent Chats</string>
 
@@ -343,6 +341,5 @@
     <string name="duckAiSettingsTitle">Duck.ai Settings</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Ask About Tab</string>
     <string name="duckChatContextualAskAboutPage">Ask About Page</string>
 </resources>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -553,13 +553,12 @@ class DuckChatContextualViewModelTest {
                 }
                 """.trimIndent()
 
-            testee.addPageContext(fromPlaceholderTap = true)
+            testee.addPageContext()
             coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
 
             val state = testee.viewState.value
             assertFalse(state.showContext)
             assertFalse(state.userRemovedContext)
-            verify(duckChatPixels).reportContextualPlaceholderContextTapped()
             verify(duckChatPixels).reportContextualPageContextInvalidNoContent()
         }
 
@@ -620,13 +619,12 @@ class DuckChatContextualViewModelTest {
                 }
                 """.trimIndent()
 
-            testee.addPageContext(fromPlaceholderTap = true)
+            testee.addPageContext()
             coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
 
             val state = testee.viewState.value
             assertTrue(state.showContext)
             assertFalse(state.userRemovedContext)
-            verify(duckChatPixels).reportContextualPlaceholderContextTapped()
             verify(duckChatPixels).reportContextualPageContextManuallyAttachedNative()
         }
 
@@ -2017,9 +2015,6 @@ class DuckChatContextualViewModelTest {
 
         testee.onQuickActionClicked("") // SUBMIT_SUMMARIZE click — should not re-attach
 
-        // ASK_ABOUT_PAGE attaches context internally; it is not a placeholder tap, so the
-        // placeholder-tapped pixel must not fire on this path.
-        verify(duckChatPixels, never()).reportContextualPlaceholderContextTapped()
         verify(duckChatPixels, times(1)).reportContextualPageContextManuallyAttachedNative()
     }
 
@@ -2174,34 +2169,26 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when fire confirmed then placeholder shown pixel is not fired`() = runTest {
-        testee.onContextualFireConfirmed()
-        verify(duckChatPixels, never()).reportContextualPlaceholderContextShown()
-    }
-
-    @Test
-    fun `when sheet opened in ASK_ABOUT_PAGE state then placeholder shown pixel is not fired`() = runTest {
+    fun `when sheet opened then quickActionState is ASK_ABOUT_PAGE`() = runTest {
         val testee = buildViewModel()
 
         testee.onSheetOpened("tab-1")
 
         assertEquals(DuckChatContextualViewModel.QuickActionState.ASK_ABOUT_PAGE, testee.viewState.value.quickActionState)
-        verify(duckChatPixels, never()).reportContextualPlaceholderContextShown()
     }
 
     @Test
-    fun `when new chat triggered in ASK_ABOUT_PAGE state then placeholder shown pixel is not fired`() = runTest {
+    fun `when new chat triggered from ASK_ABOUT_PAGE then quickActionState stays ASK_ABOUT_PAGE`() = runTest {
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
 
         testee.onNewChatRequested()
 
         assertEquals(DuckChatContextualViewModel.QuickActionState.ASK_ABOUT_PAGE, testee.viewState.value.quickActionState)
-        verify(duckChatPixels, never()).reportContextualPlaceholderContextShown()
     }
 
     @Test
-    fun `when removePageContext reverts to ASK_ABOUT_PAGE then placeholder shown pixel is not fired but removed pixel is`() = runTest {
+    fun `when removePageContext reverts to ASK_ABOUT_PAGE then removed pixel is fired`() = runTest {
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2213,7 +2200,6 @@ class DuckChatContextualViewModelTest {
 
         assertEquals(DuckChatContextualViewModel.QuickActionState.ASK_ABOUT_PAGE, testee.viewState.value.quickActionState)
         verify(duckChatPixels).reportContextualPageContextRemovedNative()
-        verify(duckChatPixels, never()).reportContextualPlaceholderContextShown()
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -76,7 +76,6 @@ class DuckChatContextualViewModelTest {
     private val duckChatPixels: DuckChatPixels = mock()
     private val duckChatFeature: DuckChatFeature = mock()
     private val contextualFireButtonToggle: Toggle = mock()
-    private val contextualSheetImprovementsToggle: Toggle = mock()
     private val contextualSuggestedPromptsToggle: Toggle = mock()
     private val modelManager: com.duckduckgo.duckchat.impl.models.DuckAiModelManager = mock()
     private val contextualNativeInputManager: ContextualNativeInputManager = mock()
@@ -88,8 +87,6 @@ class DuckChatContextualViewModelTest {
     fun setup() {
         whenever(duckChatFeature.contextualFireButton()).thenReturn(contextualFireButtonToggle)
         whenever(contextualFireButtonToggle.isEnabled()).thenReturn(false)
-        whenever(duckChatFeature.contextualSheetImprovements()).thenReturn(contextualSheetImprovementsToggle)
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
         whenever(duckChatFeature.contextualSuggestedPrompts()).thenReturn(contextualSuggestedPromptsToggle)
         whenever(contextualSuggestedPromptsToggle.isEnabled()).thenReturn(true)
         whenever(chatHistoryRepository.observeChats()).thenReturn(recentChatsFlow)
@@ -478,7 +475,6 @@ class DuckChatContextualViewModelTest {
             }
 
             assertEquals(DuckChatContextualViewModel.SheetMode.WEBVIEW, testee.viewState.value.sheetMode)
-            assertEquals("", testee.viewState.value.prompt)
         }
 
     @Test
@@ -957,94 +953,7 @@ class DuckChatContextualViewModelTest {
         }
 
     @Test
-    fun `when replace prompt without valid context then context remains hidden`() =
-        runTest {
-            testee.viewState.test {
-                // initial emission
-                awaitItem()
-
-                testee.currentPageContext =
-                    """
-                    {
-                        "title": "Ctx Title",
-                        "url": "https://ctx.com",
-                        "content": ""
-                    }
-                    """.trimIndent()
-                testee.replacePrompt("", "new prompt")
-                val state = expectMostRecentItem() as DuckChatContextualViewModel.ViewState
-                assertEquals("new prompt", state.prompt)
-                assertFalse(state.showContext)
-                assertFalse(state.userRemovedContext)
-
-                cancelAndIgnoreRemainingEvents()
-            }
-        }
-
-    @Test
-    fun `when replace prompt with valid context then context shown`() =
-        runTest {
-            val tabId = "tab-1"
-            val serializedPageData =
-                """
-            {
-                "title": "Ctx Title",
-                "url": "https://ctx.com",
-                "content": "content"
-            }
-                """.trimIndent()
-            testee.onPageContextReceived(tabId, serializedPageData)
-
-            testee.viewState.test {
-                // initial emission
-                awaitItem()
-
-                testee.replacePrompt("existing", "new prompt")
-                val state = expectMostRecentItem() as DuckChatContextualViewModel.ViewState
-                assertEquals("existing new prompt", state.prompt)
-                assertTrue(state.showContext)
-                assertFalse(state.userRemovedContext)
-
-                cancelAndIgnoreRemainingEvents()
-            }
-        }
-
-    @Test
-    fun `when replace prompt without previous input then prompt is replaced`() =
-        runTest {
-            testee.viewState.test {
-                awaitItem()
-
-                testee.replacePrompt("", "summarize this")
-
-                val state = expectMostRecentItem() as DuckChatContextualViewModel.ViewState
-                assertEquals("summarize this", state.prompt)
-
-                cancelAndIgnoreRemainingEvents()
-            }
-        }
-
-    @Test
-    fun `when replace prompt then summarize prompt selected pixel not fired`() = runTest {
-        testee.replacePrompt("", "summarize this")
-
-        verify(duckChatPixels, never()).reportContextualSummarizePromptSelected()
-    }
-
-    @Test
-    fun `when summarize quick action clicked in legacy mode then summarize prompt selected pixel fired`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
-        val testee = buildViewModel()
-
-        testee.onQuickActionClicked("")
-
-        assertEquals(DuckChatContextualViewModel.QuickActionState.LEGACY_SUMMARIZE, testee.viewState.value.quickActionState)
-        verify(duckChatPixels).reportContextualSummarizePromptSelected()
-    }
-
-    @Test
     fun `when summarize quick action clicked in submit mode then summarize prompt selected pixel fired`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -1059,7 +968,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when ask about page quick action clicked then summarize prompt selected pixel not fired`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -1073,7 +981,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when ask about page quick action clicked then focus input command emitted`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -1090,7 +997,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when sheet opened fresh with improvements enabled then ask about page shown pixel fired`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         val testee = buildViewModel()
 
         testee.onSheetOpened("tab-1")
@@ -1100,19 +1006,7 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when sheet opened in legacy mode then ask about page shown pixel not fired`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
-        val testee = buildViewModel()
-
-        testee.onSheetOpened("tab-1")
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
-        verify(duckChatPixels, never()).reportContextualAskAboutPageShown()
-    }
-
-    @Test
     fun `when sheet reopened in input mode with improvements enabled then ask about page shown pixel fired`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
@@ -1126,7 +1020,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when page context removed reverting to ask about page then shown pixel fired`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -1146,7 +1039,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when prompt sent then attached page context is cleared from input`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
@@ -1260,69 +1152,6 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when replace prompt with previous input then prompt is appended`() =
-        runTest {
-            testee.viewState.test {
-                awaitItem()
-
-                testee.replacePrompt("existing input", "summarize this")
-
-                val state = expectMostRecentItem() as DuckChatContextualViewModel.ViewState
-                assertEquals("existing input summarize this", state.prompt)
-
-                cancelAndIgnoreRemainingEvents()
-            }
-        }
-
-    @Test
-    fun `when prompt cleared then prompt is empty`() =
-        runTest {
-            testee.viewState.test {
-                awaitItem()
-
-                testee.replacePrompt("", "summarize this")
-                expectMostRecentItem()
-
-                testee.onPromptCleared()
-                val state = expectMostRecentItem() as DuckChatContextualViewModel.ViewState
-                assertEquals("", state.prompt)
-
-                cancelAndIgnoreRemainingEvents()
-            }
-        }
-
-    @Test
-    fun `when prompt cleared then context state unchanged`() =
-        runTest {
-            testee.currentPageContext =
-                """
-                {
-                    "title": "Ctx Title",
-                    "url": "https://ctx.com",
-                    "content": "content"
-                }
-                """.trimIndent()
-
-            testee.addPageContext()
-            coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
-            testee.viewState.test {
-                awaitItem()
-
-                testee.replacePrompt("", "summarize this")
-                expectMostRecentItem()
-
-                testee.onPromptCleared()
-                val state = expectMostRecentItem() as DuckChatContextualViewModel.ViewState
-                assertEquals("", state.prompt)
-                assertTrue(state.showContext)
-                assertFalse(state.userRemovedContext)
-
-                cancelAndIgnoreRemainingEvents()
-            }
-        }
-
-    @Test
     fun `when user removed context then page context remains hidden`() = runTest {
         val tabId = "tab-1"
         val serializedPageData =
@@ -1431,7 +1260,7 @@ class DuckChatContextualViewModelTest {
 
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
         assertNull(contextualDataStore.getTabChatUrl(tabId))
-        verify(duckChatPixels).reportContextualPlaceholderContextShown()
+        verify(duckChatPixels).reportContextualAskAboutPageShown()
     }
 
     @Test
@@ -1448,7 +1277,7 @@ class DuckChatContextualViewModelTest {
         }
 
         verify(duckChatPixels).reportContextualSheetNewChat()
-        verify(duckChatPixels, times(2)).reportContextualPlaceholderContextShown()
+        verify(duckChatPixels, times(2)).reportContextualAskAboutPageShown()
     }
 
     @Test
@@ -1577,13 +1406,11 @@ class DuckChatContextualViewModelTest {
         val url = "https://duck.ai/chat?chatID=123"
         testee.onSheetOpened(tabId)
         contextualDataStore.persistTabChatUrl(tabId, url)
-        testee.replacePrompt("", "new prompt")
 
         testee.onNewChatRequested()
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
 
         assertNull(contextualDataStore.getTabChatUrl(tabId))
-        assertEquals("", testee.viewState.value.prompt)
     }
 
     @Test
@@ -1660,6 +1487,7 @@ class DuckChatContextualViewModelTest {
         val tabId = "tab-1"
         val storedUrl = "https://duck.ai/chat?chatID=123"
         contextualDataStore.persistTabChatUrl(tabId, storedUrl)
+        recentChatsFlow.value = listOf(fakeChat("123", "Chat", 1L))
         sessionTimeoutProvider.timeoutMs = 10_000L
         timeProvider.nowMs = 100_000L
         contextualDataStore.persistTabClosedTimestamp(tabId, 95_000L)
@@ -1679,7 +1507,7 @@ class DuckChatContextualViewModelTest {
 
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
         assertNull(contextualDataStore.getTabChatUrl(tabId))
-        verify(duckChatPixels).reportContextualPlaceholderContextShown()
+        verify(duckChatPixels).reportContextualAskAboutPageShown()
     }
 
     @Test
@@ -1687,14 +1515,16 @@ class DuckChatContextualViewModelTest {
         val tabId = "tab-1"
         val storedUrl = "https://duck.ai/chat?chatID=123"
         contextualDataStore.persistTabChatUrl(tabId, storedUrl)
+        recentChatsFlow.value = listOf(fakeChat("123", "Chat", 1L))
         sessionTimeoutProvider.timeoutMs = 10_000L
         timeProvider.nowMs = 100_000L
-        contextualDataStore.persistTabClosedTimestamp(tabId, 80_000L)
+        contextualDataStore.persistTabClosedTimestamp(tabId, 95_000L)
 
         testee.onSheetOpened(tabId)
         contextualDataStore.clearTabChatUrl(tabId)
 
         testee.subscriptionEventDataFlow.test {
+            timeProvider.nowMs = 120_000L
             testee.onSheetReopened()
 
             val event = awaitItem()
@@ -1706,7 +1536,7 @@ class DuckChatContextualViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
 
-        verify(duckChatPixels).reportContextualPlaceholderContextShown()
+        verify(duckChatPixels).reportContextualAskAboutPageShown()
     }
 
     @Test
@@ -1729,7 +1559,7 @@ class DuckChatContextualViewModelTest {
     fun `when sheet opened then contextual opened pixel is fired`() = runTest {
         testee.onSheetOpened("tab-1")
         verify(duckChatPixels).reportContextualSheetOpened()
-        verify(duckChatPixels).reportContextualPlaceholderContextShown()
+        verify(duckChatPixels).reportContextualAskAboutPageShown()
     }
 
     @Test
@@ -1749,7 +1579,7 @@ class DuckChatContextualViewModelTest {
         runTest {
             testee.removePageContext()
             verify(duckChatPixels).reportContextualPageContextRemovedNative()
-            verify(duckChatPixels).reportContextualPlaceholderContextShown()
+            verify(duckChatPixels).reportContextualAskAboutPageShown()
         }
 
     @Test
@@ -2046,43 +1876,10 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when contextualSheetImprovements disabled then initial quickActionState is LEGACY_SUMMARIZE`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
-        val testee = buildViewModel()
-
-        assertEquals(DuckChatContextualViewModel.QuickActionState.LEGACY_SUMMARIZE, testee.viewState.value.quickActionState)
-    }
-
-    @Test
-    fun `when contextualSheetImprovements enabled then initial quickActionState is ASK_ABOUT_PAGE`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+    fun `initial quickActionState is ASK_ABOUT_PAGE`() = runTest {
         val testee = buildViewModel()
 
         assertEquals(DuckChatContextualViewModel.QuickActionState.ASK_ABOUT_PAGE, testee.viewState.value.quickActionState)
-    }
-
-    @Test
-    fun `when contextualSheetImprovements disabled then chatHintResId is legacy hint`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
-        val testee = buildViewModel()
-
-        assertEquals(R.string.input_screen_chat_hint, testee.viewState.value.chatHintResId)
-    }
-
-    @Test
-    fun `when contextualSheetImprovements enabled then chatHintResId is improved hint`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
-        val testee = buildViewModel()
-
-        assertEquals(R.string.contextualSheetImprovedHint, testee.viewState.value.chatHintResId)
-    }
-
-    @Test
-    fun `LEGACY_SUMMARIZE uses the legacy arrow icon`() {
-        assertEquals(
-            com.duckduckgo.mobile.android.R.drawable.ic_arrow_down_right_16,
-            DuckChatContextualViewModel.QuickActionState.LEGACY_SUMMARIZE.iconResId,
-        )
     }
 
     @Test
@@ -2102,20 +1899,7 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when quick action clicked in LEGACY_SUMMARIZE then prompt is inserted into viewState`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
-        val testee = buildViewModel()
-
-        testee.onQuickActionClicked("")
-
-        val expected = context.getString(R.string.duckAIContextualPromptSummarize)
-        assertEquals(expected, testee.viewState.value.prompt)
-        assertEquals(DuckChatContextualViewModel.QuickActionState.LEGACY_SUMMARIZE, testee.viewState.value.quickActionState)
-    }
-
-    @Test
     fun `when quick action clicked in ASK_ABOUT_PAGE with valid context then state transitions to SUBMIT_SUMMARIZE`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2129,7 +1913,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when quick action clicked in ASK_ABOUT_PAGE with no page context then state stays ASK_ABOUT_PAGE`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         // No onPageContextReceived call — updatedPageContext is empty/invalid.
@@ -2141,8 +1924,7 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when contextualSheetImprovements enabled and auto-attach enabled then context is auto-attached in SUBMIT_SUMMARIZE`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+    fun `when auto-attach enabled then context is auto-attached in SUBMIT_SUMMARIZE`() = runTest {
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2159,8 +1941,7 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when contextualSheetImprovements enabled and auto-attach disabled then page context is NOT auto-attached`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+    fun `when auto-attach disabled then page context is NOT auto-attached`() = runTest {
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2177,8 +1958,7 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when contextualSheetImprovements enabled then context only attaches after ASK_ABOUT_PAGE clicked`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+    fun `when ASK_ABOUT_PAGE clicked then context is attached`() = runTest {
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2193,7 +1973,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when quick action clicked in ASK_ABOUT_PAGE with valid page context then context is attached`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2207,7 +1986,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when quick action clicked in SUBMIT_SUMMARIZE then summarize prompt is auto-submitted`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2230,7 +2008,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when SUBMIT_SUMMARIZE clicked then context-attach pixel not re-fired`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2248,7 +2025,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when SUBMIT_SUMMARIZE clicked after user removed context then summarize is NOT submitted`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2269,8 +2045,7 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when new chat triggered with contextualSheetImprovements enabled then quickActionState resets to ASK_ABOUT_PAGE`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+    fun `when new chat triggered then quickActionState resets to ASK_ABOUT_PAGE`() = runTest {
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2284,19 +2059,7 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when new chat triggered with contextualSheetImprovements disabled then quickActionState stays LEGACY_SUMMARIZE`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
-        val testee = buildViewModel()
-        testee.onSheetOpened("tab-1")
-
-        testee.onNewChatRequested()
-
-        assertEquals(DuckChatContextualViewModel.QuickActionState.LEGACY_SUMMARIZE, testee.viewState.value.quickActionState)
-    }
-
-    @Test
     fun `when SUBMIT_SUMMARIZE clicked with typed input then web prefill event emitted after auto-submit`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2328,7 +2091,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when SUBMIT_SUMMARIZE clicked with typed input then ChangeSheetState carries prefill`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2378,7 +2140,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when removePageContext from SUBMIT_SUMMARIZE then quickActionState reverts to ASK_ABOUT_PAGE`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2420,7 +2181,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when sheet opened in ASK_ABOUT_PAGE state then placeholder shown pixel is not fired`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         val testee = buildViewModel()
 
         testee.onSheetOpened("tab-1")
@@ -2431,7 +2191,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when new chat triggered in ASK_ABOUT_PAGE state then placeholder shown pixel is not fired`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
 
@@ -2443,7 +2202,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when removePageContext reverts to ASK_ABOUT_PAGE then placeholder shown pixel is not fired but removed pixel is`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2472,19 +2230,7 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when chats icon clicked and improvements disabled then new chat is requested`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
-        val testee = buildViewModel()
-        testee.onSheetOpened("tab-1")
-
-        testee.onChatsIconClicked()
-
-        verify(duckChatPixels).reportContextualSheetNewChat()
-    }
-
-    @Test
     fun `when chats icon clicked with no recent chats then chat history is launched`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         recentChatsFlow.value = emptyList()
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2503,7 +2249,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when chats icon clicked with recent chats in INPUT mode then ShowChatsPopup command emitted without new chat header`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         recentChatsFlow.value = listOf(fakeChat("c1", "Chat 1", 100L))
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2524,7 +2269,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when chats icon clicked with recent chats in WEBVIEW mode then ShowChatsPopup command includes new chat header`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         recentChatsFlow.value = listOf(fakeChat("c1", "Chat 1", 100L))
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -2542,7 +2286,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when current chat is loaded then it is excluded from recent chats`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         recentChatsFlow.value = listOf(
             fakeChat("current", "Current chat", 10L),
             fakeChat("a", "A", 5L),
@@ -2560,7 +2303,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when recent chats updates then view state is capped at 5 sorted by lastEdit desc`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         recentChatsFlow.value = listOf(
             fakeChat("a", "A", 1L),
             fakeChat("b", "B", 5L),
@@ -2579,7 +2321,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when recent chat clicked then OpenChatUrl command emitted with built url`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.buildChatUrl("c1")).thenReturn("https://duckduckgo.com/?chat_id=c1")
         recentChatsFlow.value = listOf(fakeChat("c1", "Chat 1", 100L))
         val testee = buildViewModel()
@@ -2598,7 +2339,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when view all chats clicked then LaunchChatHistory command emitted`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         val testee = buildViewModel()
 
         testee.commands.test {
@@ -2609,26 +2349,7 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when improvements enabled then showChatsIcon is true`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
-        val testee = buildViewModel()
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
-        assertTrue(testee.viewState.value.showChatsIcon)
-    }
-
-    @Test
-    fun `when improvements disabled then showChatsIcon is false`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
-        val testee = buildViewModel()
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
-        assertFalse(testee.viewState.value.showChatsIcon)
-    }
-
-    @Test
     fun `when sheet opened and stored chat was deleted while away then sheet resets to input`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         recentChatsFlow.value = listOf(fakeChat("other", "Other", 5L))
         contextualDataStore.persistTabChatUrl("tab-1", "https://duckduckgo.com/?chatID=current")
         val testee = buildViewModel()
@@ -2643,7 +2364,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when sheet opened and stored chat still in history then session is restored to webview`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         recentChatsFlow.value = listOf(fakeChat("current", "Current", 10L))
         contextualDataStore.persistTabChatUrl("tab-1", "https://duckduckgo.com/?chatID=current")
         val testee = buildViewModel()
@@ -2653,21 +2373,6 @@ class DuckChatContextualViewModelTest {
 
         assertEquals(DuckChatContextualViewModel.SheetMode.WEBVIEW, testee.viewState.value.sheetMode)
         assertEquals("current", testee.chatId.value)
-    }
-
-    @Test
-    fun `when improvements disabled and stored chat was deleted while away then sheet still resets to input`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
-        recentChatsFlow.value = emptyList()
-        contextualDataStore.persistTabChatUrl("tab-1", "https://duckduckgo.com/?chatID=current")
-        val testee = buildViewModel()
-
-        testee.onSheetOpened("tab-1")
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
-        assertEquals(DuckChatContextualViewModel.SheetMode.INPUT, testee.viewState.value.sheetMode)
-        assertNull(testee.chatId.value)
-        assertNull(contextualDataStore.getTabChatUrl("tab-1"))
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -37,10 +37,6 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_MANUALLY_ATTACHED_FRONTEND_DAILY
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_MANUALLY_ATTACHED_NATIVE_COUNT
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_MANUALLY_ATTACHED_NATIVE_DAILY
-import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_COUNT
-import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_DAILY
-import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_TAPPED_COUNT
-import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_TAPPED_DAILY
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_REMOVED_FRONTEND_COUNT
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_REMOVED_FRONTEND_DAILY
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_REMOVED_NATIVE_COUNT
@@ -316,26 +312,6 @@ class RealDuckChatPixelsTest {
 
         verify(mockPixel).fire(DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_SUMMARISE_SELECTED_COUNT)
         verify(mockPixel).fire(DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_SUMMARISE_SELECTED_DAILY, type = Pixel.PixelType.Daily())
-    }
-
-    @Test
-    fun `when reportContextualPlaceholderContextTapped then fires count and daily`() = runTest {
-        testee.reportContextualPlaceholderContextTapped()
-
-        advanceUntilIdle()
-
-        verify(mockPixel).fire(DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_TAPPED_COUNT)
-        verify(mockPixel).fire(DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_TAPPED_DAILY, type = Pixel.PixelType.Daily())
-    }
-
-    @Test
-    fun `when reportContextualPlaceholderContextShown then fires count and daily`() = runTest {
-        testee.reportContextualPlaceholderContextShown()
-
-        advanceUntilIdle()
-
-        verify(mockPixel).fire(DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_COUNT)
-        verify(mockPixel).fire(DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_DAILY, type = Pixel.PixelType.Daily())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211654189969294/task/1217197936851854?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description
 - Removed the `contextualSheetImprovements` feature flag (now permanently on) and deleted the legacy OFF path: the `LEGACY_SUMMARIZE` quick action, the always-on chats icon, and the constant chatHintResId.
  - Removed the now-dead `replacePrompt` / `viewState.prompt `state and `onPromptCleared` (the input field is cleared directly). -> We used to replace the prompt when Summarize page action is clicked, we don’t do that anymore.
  - Removed the legacy "attach page content" placeholder (`duckAiAttachContextLayout`) — unreachable once `ASK_ABOUT_PAGE` is always the default — including its placeholder_shown / placeholder_tapped pixels and
  registry definitions. -> this has been replaced with the Ask About Page action and menu item
  - Removed unused contextual sheet strings and their translations:` input_screen_chat_hint`, `duckAIContextualAttachPageContent`, and `duckChatContextualAskAboutTab`.

### Steps to test this PR
Smoke test contextual sheet 

  1. Sheet opened fresh (native input OFF, auto-attach OFF)

  - [x] Input hint reads "Ask anything privately" (not "Ask privately")
  - [x] Ask About Page quick action IS visible
  - [x] The dashed "Attach Page Content" placeholder is NOT visible
  - [x] The chats icon IS visible (legacy "+" icon is NOT shown)
  - [x] Tapping Ask About Page attaches the page context and switches the quick action to the summarize state, focusing the input

  2. Ask About Page → summarize (native input OFF, auto-attach OFF)

  - [x] After tapping Ask About Page, the attached-context chip IS visible
  - [x] Tapping the summarize quick action submits the summarize prompt and moves the sheet into the chat (WEBVIEW)
  - [x] Removing the context chip reverts the quick action back to Ask About Page

  3. Sheet opened fresh (auto-attach ON)

  - [x] Page context is auto-attached on open (context chip visible), quick action is in the summarize state
  - [x] The "Attach Page Content" placeholder is NOT visible at any point
  
  4. Native input ON

  - [x] Contextual sheet shows the unified native input widget (legacy EditText composer hidden)
  - [x] Ask About Page behavior and context attach/remove work as in cases 1–2
  - [x] The "Attach Page Content" placeholder is NOT visible

  5. Clear input (native input OFF)
  
  - [x] Type text into the legacy input field, then tap the clear (X) control
  - [x] The input field is emptied

  6. New chat resets state
  
  - [x] From an attached/summarize state, trigger New chat
  - [x] Quick action resets to Ask About Page and no context is attached

  7. Chats icon
  
  - [x] With recent chats present, tapping the chats icon shows the recent-chats popup
  - [x] With no recent chats, tapping the chats icon opens chat history directly



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the contextual sheet’s primary input/quick-action flow across Fragment, ViewModel, layout, and analytics; behavior change only for users who were still on the removed OFF path, but the surface area is user-visible and moderately large.
> 
> **Overview**
> Removes the **`contextualSheetImprovements`** remote flag and makes the improved contextual Duck.ai sheet the only code path. Users always get **Ask About Page** as the default quick action (not legacy summarize-in-field), the **chats** icon in input mode, and the **`contextualSheetImprovedHint`** on the legacy composer.
> 
> **Removed legacy UX and state:** the dashed **attach page content** placeholder (`duckAiAttachContextLayout`), **`LEGACY_SUMMARIZE`** quick action, **`replacePrompt`** / **`viewState.prompt`**, and **`onPromptCleared`** (clear still wipes the `EditText` directly). Summarize now flows only through **Ask About Page → SUBMIT_SUMMARIZE** auto-submit, not prefilling the input.
> 
> **Analytics cleanup:** drops placeholder shown/tapped pixels and their pixel registry entries; tests and pixel helpers updated to expect **ask about page shown** where placeholders used to fire.
> 
> **Strings:** deletes unused **`input_screen_chat_hint`**, **`duckAIContextualAttachPageContent`**, and **`duckChatContextualAskAboutTab`** across locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d214d1885006dc1ef0e70ccda607097e14601f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->