### PR TITLE
Update content scope scripts to version 16.5.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -6352,11 +6352,64 @@
       return !frame.hidden && frame.src !== "" && frame.src !== "about:blank";
     });
   }
+  var ORDERED_NODE_SNAPSHOT_TYPE = 7;
+  var compiledXPaths = /* @__PURE__ */ new WeakMap();
+  function compileXPath(expression) {
+    let cache = compiledXPaths.get(document);
+    if (!cache) {
+      cache = /* @__PURE__ */ new Map();
+      compiledXPaths.set(document, cache);
+    }
+    let compiled = cache.get(expression);
+    if (!compiled) {
+      compiled = document.createExpression(expression, null);
+      cache.set(expression, compiled);
+    }
+    return compiled;
+  }
+  var DEFAULT_CHUNK_SIZE = 8192;
+  var CHUNK_TAIL_RATIO = 16;
+  var MAX_WORD_LENGTH = 64;
+  function isWordCode(code) {
+    return code >= 97 && code <= 122 || // a-z
+    code >= 65 && code <= 90 || // A-Z
+    code >= 48 && code <= 57 || // 0-9
+    code === 95;
+  }
+  function resolveXPathConfig(config) {
+    const chunkSize = config?.chunkSize ?? DEFAULT_CHUNK_SIZE;
+    const chunkTail = config?.chunkTail ?? Math.floor(chunkSize / CHUNK_TAIL_RATIO);
+    return { chunkSize, chunkTail };
+  }
+  function retainTail(buffer, chunkTail) {
+    let cut = buffer.length - chunkTail;
+    if (cut <= 0) return buffer;
+    const limit = Math.max(0, cut - Math.min(chunkTail, MAX_WORD_LENGTH));
+    while (cut > limit && isWordCode(buffer.charCodeAt(cut - 1))) cut--;
+    return buffer.slice(cut);
+  }
+  function xpathMatches(pattern, expression, { chunkSize, chunkTail }) {
+    const snapshot = compileXPath(expression).evaluate(document, ORDERED_NODE_SNAPSHOT_TYPE, null);
+    let buffer = "";
+    let pending = 0;
+    for (let i = 0; i < snapshot.snapshotLength; i++) {
+      const text = snapshot.snapshotItem(i)?.textContent || "";
+      buffer += text;
+      pending += text.length;
+      if (chunkSize > 0 && pending >= chunkSize) {
+        if (pattern.test(buffer)) return true;
+        buffer = retainTail(buffer, chunkTail);
+        pending = 0;
+      }
+    }
+    return pattern.test(buffer);
+  }
   function evaluateSingleTextCondition(condition) {
     const patterns = asArray(condition.pattern);
-    const selectors = asArray(condition.selector, ["body"]);
+    const xpaths = asArray(condition.xpath);
+    const selectors = asArray(condition.selector, xpaths.length > 0 ? [] : ["body"]);
     const patternComb = new RegExp(patterns.join("|"), "i");
-    return selectors.some((selector) => {
+    const selectorMatch = selectors.some((selector) => {
       const elements = document.querySelectorAll(selector);
       for (const element of elements) {
         if (patternComb.test(element.textContent || "")) {
@@ -6365,6 +6418,14 @@
       }
       return false;
     });
+    if (selectorMatch) {
+      return true;
+    }
+    if (xpaths.length === 0) {
+      return false;
+    }
+    const chunking = resolveXPathConfig(condition.xpathConfig);
+    return xpaths.some((expression) => xpathMatches(patternComb, expression, chunking));
   }
   function evaluateSingleElementCondition(config) {
     const visibility = config.visibility ?? "any";

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -5749,6 +5749,11 @@
     if (typeof input !== "string") return false;
     return input.trim().length > 0;
   }
+  function capitalize(s) {
+    const words = s.split(" ");
+    const capitalizedWords = words.map((word) => word.charAt(0).toUpperCase() + word.slice(1));
+    return capitalizedWords.join(" ");
+  }
   function matchingPair(a2, b2) {
     if (!nonEmptyString(a2)) return false;
     if (!nonEmptyString(b2)) return false;
@@ -5764,6 +5769,26 @@
       }
       return a2.city.localeCompare(b2.city);
     });
+  }
+  function dedupeAddresses(addresses) {
+    const cityStatesWithExtras = new Set(addresses.filter(hasExtras).map(cityStateKey));
+    const unique = /* @__PURE__ */ new Map();
+    for (const address of addresses) {
+      if (!hasExtras(address) && cityStatesWithExtras.has(cityStateKey(address))) continue;
+      unique.set(addressDedupKey(address), address);
+    }
+    return [...unique.values()];
+  }
+  function hasExtras(obj) {
+    return Object.keys(obj.extras ?? {}).length > 0;
+  }
+  function cityStateKey(addr) {
+    return `${addr.city},${addr.state}`.toLowerCase();
+  }
+  function addressDedupKey(addr) {
+    const extras = addr.extras ?? {};
+    const extrasKey = Object.keys(extras).sort().map((key) => `${key}=${extras[key]}`).join("&");
+    return `${cityStateKey(addr)}|${extrasKey}`;
   }
   async function hashObject(profile) {
     const msgUint8 = new TextEncoder().encode(JSON.stringify(profile));
@@ -7335,11 +7360,10 @@
   // src/features/broker-protection/comparisons/address.js
   init_define_import_meta_trackerLookup();
   function addressMatch(userAddresses, foundAddresses) {
-    return userAddresses.some((user) => {
-      return foundAddresses.some((found) => {
-        return matchingPair(user.city, found.city) && matchingPair(user.state, found.state);
-      });
-    });
+    return userAddresses.some((user) => foundAddresses.some((found) => sameCityState(user, found)));
+  }
+  function sameCityState(a2, b2) {
+    return matchingPair(a2.city, b2.city) && matchingPair(a2.state, b2.state);
   }
   function getStateFromAbbreviation(stateAbbreviation) {
     if (stateAbbreviation == null || stateAbbreviation.trim() === "") {
@@ -7398,10 +7422,36 @@
     const normalized = normalizeState(trimmedState);
     return normalized ? [{ city: trimmedCity, state: normalized }] : [];
   }
+  var STREET_PARTS = ["number", "prefix", "street", "type", "suffix", "sec_unit_type", "sec_unit_num"];
+  function deslugParsedAddress(parsed) {
+    return Object.fromEntries(
+      Object.entries(parsed).map(([key, value]) => [
+        key,
+        key === "number" || key === "sec_unit_num" || key === "zip" ? value : value.replace(/-/g, " ")
+      ])
+    );
+  }
   function extractAddressFull(select2, root, spec) {
-    return selectStrings(select2, root, spec).map((str) => str.replace("\n", " ")).flatMap((str) => stringToList(str, spec.separator)).map((str) => import_parse_address.default.parseLocation(str) || {}).filter((parsed) => Boolean(parsed?.city)).map((addr) => {
-      return { city: addr.city, state: addr.state || null };
+    return selectStrings(select2, root, spec).map((str) => str.replace("\n", " ")).flatMap((str) => stringToList(str, spec.separator)).map((str) => {
+      const parsed = import_parse_address.default.parseLocation(str) || {};
+      const isHref = spec.attribute === "href";
+      const isSlug = !/\s/.test(str);
+      return isHref && isSlug ? deslugParsedAddress(parsed) : parsed;
+    }).filter((parsed) => Boolean(parsed?.city)).map((addr) => {
+      const address = { city: capitalize(addr.city), state: addr.state ? normalizeState(addr.state) : null };
+      const extras = addressExtras(addr);
+      if (Object.keys(extras).length > 0) address.extras = extras;
+      return address;
     });
+  }
+  function addressExtras(addr) {
+    const extras = {};
+    const street = capitalize(
+      STREET_PARTS.map((part) => (addr[part] || "").replace(/[^a-z0-9]+$/i, "")).filter(Boolean).join(" ")
+    );
+    if (street) extras.street = street;
+    if (addr.zip) extras.zip = addr.zip;
+    return extras;
   }
   function getCityStateCombos(inputList) {
     const output = [];
@@ -7521,10 +7571,27 @@
       }
       return {
         ...profile,
-        identifier: await hashObject(profile)
+        identifier: await hashObject(omitExtrasForHash(profile))
       };
     }
   };
+  function omitExtrasForHash({ extras, ...profile }) {
+    if (!Array.isArray(profile.addresses)) return profile;
+    const seen = /* @__PURE__ */ new Set();
+    const addresses = profile.addresses.map(({ extras: extras2, ...address }) => address).filter((address) => {
+      const cityState = `${address.city},${address.state}`;
+      if (seen.has(cityState)) return false;
+      seen.add(cityState);
+      return true;
+    });
+    return { ...profile, addresses };
+  }
+
+  // src/features/broker-protection/extractors/extra.js
+  init_define_import_meta_trackerLookup();
+  function extractExtra(select2, root, spec) {
+    return firstString(selectStrings(select2, root, spec)) || null;
+  }
 
   // src/features/broker-protection/actions/extract.js
   async function extract(action, userData, root = document) {
@@ -7593,11 +7660,18 @@
   };
   function createProfile(select2, root, profileSpec) {
     const output = {};
+    const extras = {};
     for (const [field, fieldSpec] of Object.entries(profileSpec)) {
-      const extractField = extractors[field];
-      if (!extractField) continue;
-      output[field] = extractField(select2, root, fieldSpec ?? {}) || null;
+      const extractField = Object.prototype.hasOwnProperty.call(extractors, field) ? extractors[field] : void 0;
+      if (extractField) {
+        output[field] = extractField(select2, root, fieldSpec ?? {}) || null;
+        continue;
+      }
+      if (field === "extras" || fieldSpec === null || typeof fieldSpec !== "object") continue;
+      const value = extractExtra(select2, root, fieldSpec);
+      if (value) extras[field] = value;
     }
+    if (Object.keys(extras).length > 0) output.extras = extras;
     return output;
   }
   function selectStrings(select2, root, spec) {
@@ -7672,14 +7746,13 @@
       ...profile.addressFullList || [],
       ...profile.addressFull || []
     ];
-    const addressMap = new Map(combinedAddresses.map((addr) => [`${addr.city},${addr.state}`, addr]));
-    const addresses = sortAddressesByStateAndCity([...addressMap.values()]);
+    const addresses = sortAddressesByStateAndCity(dedupeAddresses(combinedAddresses));
     const phoneArray = profile.phone || [];
     const phoneListArray = profile.phoneList || [];
     const phoneNumbers = [.../* @__PURE__ */ new Set([...phoneArray, ...phoneListArray])].sort((a2, b2) => parseInt(a2) - parseInt(b2));
     const relatives = [...new Set(profile.relativesList)].sort();
     const alternativeNames = [...new Set(profile.alternativeNamesList)].sort();
-    return {
+    const output = {
       name: profile.name,
       alternativeNames,
       age: profile.age,
@@ -7688,6 +7761,8 @@
       relatives,
       ...profile.profileUrl
     };
+    if (hasExtras(profile)) output.extras = profile.extras;
+    return output;
   }
   async function applyPostTransforms(profile, profileSpec) {
     const transforms = [
@@ -7804,12 +7879,12 @@
   }
 
   // src/features/broker-protection/actions/fill-form.js
-  function fillForm(action, userData, root = document) {
+  function fillForm(action, userData, root = document, userProfile = null) {
     const form = getElement(root, action.selector);
     if (!form) return new ErrorResponse({ actionID: action.id, message: "missing form" });
     if (!userData) return new ErrorResponse({ actionID: action.id, message: "user data was absent" });
     form.scrollIntoView?.();
-    const results = fillMany(form, action.elements, userData);
+    const results = fillMany(form, action.elements, userData, userProfile);
     const errors = results.filter((x2) => x2.result === false).map((x2) => {
       if ("error" in x2) return x2.error;
       return "unknown error";
@@ -7819,8 +7894,10 @@
     }
     return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: null });
   }
-  function fillMany(root, elements, data2) {
+  function fillMany(root, elements, data2, userProfile = null) {
     const results = [];
+    const address = selectAddress(data2.addresses, userProfile?.addresses);
+    const extras = { ...data2.extras, ...address?.extras };
     for (const element of elements) {
       const inputElem = getElement(root, element.selector);
       if (!inputElem) {
@@ -7871,23 +7948,25 @@
       } else if (element.type === "$generated_street_address$") {
         results.push(setValueForInput(inputElem, generateStreetAddress()));
       } else if (element.type === "cityState") {
-        if (!Object.prototype.hasOwnProperty.call(data2, "city") || !Object.prototype.hasOwnProperty.call(data2, "state")) {
+        const city = Object.prototype.hasOwnProperty.call(data2, "city") ? data2.city : address?.city;
+        const state = Object.prototype.hasOwnProperty.call(data2, "state") ? data2.state : address?.state;
+        if (!city || !state) {
           results.push({
             result: false,
             error: `element found with selector '${element.selector}', but data didn't contain the keys 'city' and 'state'`
           });
           continue;
         }
-        results.push(setValueForInput(inputElem, data2.city + ", " + data2.state));
+        results.push(setValueForInput(inputElem, city + ", " + state));
       } else if (element.type === "fullState") {
-        if (!Object.prototype.hasOwnProperty.call(data2, "state")) {
+        const state = Object.prototype.hasOwnProperty.call(data2, "state") ? data2.state : address?.state;
+        if (!state) {
           results.push({
             result: false,
             error: `element found with selector '${element.selector}', but data didn't contain the key 'state'`
           });
           continue;
         }
-        const state = data2.state;
         if (!Object.prototype.hasOwnProperty.call(states, state)) {
           results.push({
             result: false,
@@ -7898,27 +7977,32 @@
         const stateFull = states[state];
         results.push(setValueForInput(inputElem, stateFull));
       } else {
-        if (isElementTypeOptional(element.type)) {
-          continue;
-        }
-        if (!Object.prototype.hasOwnProperty.call(data2, element.type)) {
+        const value = lookupValue(element.type, data2, address, extras);
+        if (!value) {
+          if (isElementTypeOptional(element.type)) {
+            continue;
+          }
           results.push({
             result: false,
-            error: `element found with selector '${element.selector}', but data didn't contain the key '${element.type}'`
+            error: value === void 0 ? `element found with selector '${element.selector}', but data didn't contain the key '${element.type}'` : `data contained the key '${element.type}', but it wasn't something we can fill: ${value}`
           });
           continue;
         }
-        if (!data2[element.type]) {
-          results.push({
-            result: false,
-            error: `data contained the key '${element.type}', but it wasn't something we can fill: ${data2[element.type]}`
-          });
-          continue;
-        }
-        results.push(setValueForInput(inputElem, data2[element.type]));
+        results.push(setValueForInput(inputElem, value));
       }
     }
     return results;
+  }
+  function lookupValue(type, data2, address, extras) {
+    if (Object.prototype.hasOwnProperty.call(data2, type)) return data2[type];
+    if ((type === "city" || type === "state") && address?.[type]) return address[type];
+    if (Object.prototype.hasOwnProperty.call(extras, type)) return extras[type];
+    return void 0;
+  }
+  function selectAddress(profileAddresses, userAddresses) {
+    if (!profileAddresses || profileAddresses.length === 0) return null;
+    const matched = profileAddresses.find((address) => userAddresses?.some((user) => sameCityState(user, address)));
+    return matched ?? profileAddresses[0];
   }
   function isElementTypeOptional(type) {
     if (type === "middleName") {
@@ -8067,11 +8151,6 @@
       }
     }
     return outputString;
-  }
-  function capitalize(s) {
-    const words = s.split(" ");
-    const capitalizedWords = words.map((word) => word.charAt(0).toUpperCase() + word.slice(1));
-    return capitalizedWords.join(" ");
   }
 
   // src/features/broker-protection/actions/click.js
@@ -9184,8 +9263,10 @@
           return click(action, data(action, inputData, "userProfile"), root);
         case "expectation":
           return expectation(action, root);
-        case "fillForm":
-          return fillForm(action, data(action, inputData, "extractedProfile"), root);
+        case "fillForm": {
+          const userProfile = inputData?.userProfile ?? null;
+          return fillForm(action, data(action, inputData, "extractedProfile"), root, userProfile);
+        }
         case "getCaptchaInfo":
           return await getCaptchaInfo2(action, root);
         case "solveCaptcha":

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -5718,6 +5718,11 @@
     if (typeof input !== "string") return false;
     return input.trim().length > 0;
   }
+  function capitalize(s) {
+    const words = s.split(" ");
+    const capitalizedWords = words.map((word) => word.charAt(0).toUpperCase() + word.slice(1));
+    return capitalizedWords.join(" ");
+  }
   function matchingPair(a2, b2) {
     if (!nonEmptyString(a2)) return false;
     if (!nonEmptyString(b2)) return false;
@@ -5733,6 +5738,26 @@
       }
       return a2.city.localeCompare(b2.city);
     });
+  }
+  function dedupeAddresses(addresses) {
+    const cityStatesWithExtras = new Set(addresses.filter(hasExtras).map(cityStateKey));
+    const unique = /* @__PURE__ */ new Map();
+    for (const address of addresses) {
+      if (!hasExtras(address) && cityStatesWithExtras.has(cityStateKey(address))) continue;
+      unique.set(addressDedupKey(address), address);
+    }
+    return [...unique.values()];
+  }
+  function hasExtras(obj) {
+    return Object.keys(obj.extras ?? {}).length > 0;
+  }
+  function cityStateKey(addr) {
+    return `${addr.city},${addr.state}`.toLowerCase();
+  }
+  function addressDedupKey(addr) {
+    const extras = addr.extras ?? {};
+    const extrasKey = Object.keys(extras).sort().map((key) => `${key}=${extras[key]}`).join("&");
+    return `${cityStateKey(addr)}|${extrasKey}`;
   }
   async function hashObject(profile) {
     const msgUint8 = new TextEncoder().encode(JSON.stringify(profile));
@@ -7304,11 +7329,10 @@
   // src/features/broker-protection/comparisons/address.js
   init_define_import_meta_trackerLookup();
   function addressMatch(userAddresses, foundAddresses) {
-    return userAddresses.some((user) => {
-      return foundAddresses.some((found) => {
-        return matchingPair(user.city, found.city) && matchingPair(user.state, found.state);
-      });
-    });
+    return userAddresses.some((user) => foundAddresses.some((found) => sameCityState(user, found)));
+  }
+  function sameCityState(a2, b2) {
+    return matchingPair(a2.city, b2.city) && matchingPair(a2.state, b2.state);
   }
   function getStateFromAbbreviation(stateAbbreviation) {
     if (stateAbbreviation == null || stateAbbreviation.trim() === "") {
@@ -7367,10 +7391,36 @@
     const normalized = normalizeState(trimmedState);
     return normalized ? [{ city: trimmedCity, state: normalized }] : [];
   }
+  var STREET_PARTS = ["number", "prefix", "street", "type", "suffix", "sec_unit_type", "sec_unit_num"];
+  function deslugParsedAddress(parsed) {
+    return Object.fromEntries(
+      Object.entries(parsed).map(([key, value]) => [
+        key,
+        key === "number" || key === "sec_unit_num" || key === "zip" ? value : value.replace(/-/g, " ")
+      ])
+    );
+  }
   function extractAddressFull(select2, root, spec) {
-    return selectStrings(select2, root, spec).map((str) => str.replace("\n", " ")).flatMap((str) => stringToList(str, spec.separator)).map((str) => import_parse_address.default.parseLocation(str) || {}).filter((parsed) => Boolean(parsed?.city)).map((addr) => {
-      return { city: addr.city, state: addr.state || null };
+    return selectStrings(select2, root, spec).map((str) => str.replace("\n", " ")).flatMap((str) => stringToList(str, spec.separator)).map((str) => {
+      const parsed = import_parse_address.default.parseLocation(str) || {};
+      const isHref = spec.attribute === "href";
+      const isSlug = !/\s/.test(str);
+      return isHref && isSlug ? deslugParsedAddress(parsed) : parsed;
+    }).filter((parsed) => Boolean(parsed?.city)).map((addr) => {
+      const address = { city: capitalize(addr.city), state: addr.state ? normalizeState(addr.state) : null };
+      const extras = addressExtras(addr);
+      if (Object.keys(extras).length > 0) address.extras = extras;
+      return address;
     });
+  }
+  function addressExtras(addr) {
+    const extras = {};
+    const street = capitalize(
+      STREET_PARTS.map((part) => (addr[part] || "").replace(/[^a-z0-9]+$/i, "")).filter(Boolean).join(" ")
+    );
+    if (street) extras.street = street;
+    if (addr.zip) extras.zip = addr.zip;
+    return extras;
   }
   function getCityStateCombos(inputList) {
     const output = [];
@@ -7490,10 +7540,27 @@
       }
       return {
         ...profile,
-        identifier: await hashObject(profile)
+        identifier: await hashObject(omitExtrasForHash(profile))
       };
     }
   };
+  function omitExtrasForHash({ extras, ...profile }) {
+    if (!Array.isArray(profile.addresses)) return profile;
+    const seen = /* @__PURE__ */ new Set();
+    const addresses = profile.addresses.map(({ extras: extras2, ...address }) => address).filter((address) => {
+      const cityState = `${address.city},${address.state}`;
+      if (seen.has(cityState)) return false;
+      seen.add(cityState);
+      return true;
+    });
+    return { ...profile, addresses };
+  }
+
+  // src/features/broker-protection/extractors/extra.js
+  init_define_import_meta_trackerLookup();
+  function extractExtra(select2, root, spec) {
+    return firstString(selectStrings(select2, root, spec)) || null;
+  }
 
   // src/features/broker-protection/actions/extract.js
   async function extract(action, userData, root = document) {
@@ -7562,11 +7629,18 @@
   };
   function createProfile(select2, root, profileSpec) {
     const output = {};
+    const extras = {};
     for (const [field, fieldSpec] of Object.entries(profileSpec)) {
-      const extractField = extractors[field];
-      if (!extractField) continue;
-      output[field] = extractField(select2, root, fieldSpec ?? {}) || null;
+      const extractField = Object.prototype.hasOwnProperty.call(extractors, field) ? extractors[field] : void 0;
+      if (extractField) {
+        output[field] = extractField(select2, root, fieldSpec ?? {}) || null;
+        continue;
+      }
+      if (field === "extras" || fieldSpec === null || typeof fieldSpec !== "object") continue;
+      const value = extractExtra(select2, root, fieldSpec);
+      if (value) extras[field] = value;
     }
+    if (Object.keys(extras).length > 0) output.extras = extras;
     return output;
   }
   function selectStrings(select2, root, spec) {
@@ -7641,14 +7715,13 @@
       ...profile.addressFullList || [],
       ...profile.addressFull || []
     ];
-    const addressMap = new Map(combinedAddresses.map((addr) => [`${addr.city},${addr.state}`, addr]));
-    const addresses = sortAddressesByStateAndCity([...addressMap.values()]);
+    const addresses = sortAddressesByStateAndCity(dedupeAddresses(combinedAddresses));
     const phoneArray = profile.phone || [];
     const phoneListArray = profile.phoneList || [];
     const phoneNumbers = [.../* @__PURE__ */ new Set([...phoneArray, ...phoneListArray])].sort((a2, b2) => parseInt(a2) - parseInt(b2));
     const relatives = [...new Set(profile.relativesList)].sort();
     const alternativeNames = [...new Set(profile.alternativeNamesList)].sort();
-    return {
+    const output = {
       name: profile.name,
       alternativeNames,
       age: profile.age,
@@ -7657,6 +7730,8 @@
       relatives,
       ...profile.profileUrl
     };
+    if (hasExtras(profile)) output.extras = profile.extras;
+    return output;
   }
   async function applyPostTransforms(profile, profileSpec) {
     const transforms = [
@@ -7773,12 +7848,12 @@
   }
 
   // src/features/broker-protection/actions/fill-form.js
-  function fillForm(action, userData, root = document) {
+  function fillForm(action, userData, root = document, userProfile = null) {
     const form = getElement(root, action.selector);
     if (!form) return new ErrorResponse({ actionID: action.id, message: "missing form" });
     if (!userData) return new ErrorResponse({ actionID: action.id, message: "user data was absent" });
     form.scrollIntoView?.();
-    const results = fillMany(form, action.elements, userData);
+    const results = fillMany(form, action.elements, userData, userProfile);
     const errors = results.filter((x2) => x2.result === false).map((x2) => {
       if ("error" in x2) return x2.error;
       return "unknown error";
@@ -7788,8 +7863,10 @@
     }
     return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: null });
   }
-  function fillMany(root, elements, data2) {
+  function fillMany(root, elements, data2, userProfile = null) {
     const results = [];
+    const address = selectAddress(data2.addresses, userProfile?.addresses);
+    const extras = { ...data2.extras, ...address?.extras };
     for (const element of elements) {
       const inputElem = getElement(root, element.selector);
       if (!inputElem) {
@@ -7840,23 +7917,25 @@
       } else if (element.type === "$generated_street_address$") {
         results.push(setValueForInput(inputElem, generateStreetAddress()));
       } else if (element.type === "cityState") {
-        if (!Object.prototype.hasOwnProperty.call(data2, "city") || !Object.prototype.hasOwnProperty.call(data2, "state")) {
+        const city = Object.prototype.hasOwnProperty.call(data2, "city") ? data2.city : address?.city;
+        const state = Object.prototype.hasOwnProperty.call(data2, "state") ? data2.state : address?.state;
+        if (!city || !state) {
           results.push({
             result: false,
             error: `element found with selector '${element.selector}', but data didn't contain the keys 'city' and 'state'`
           });
           continue;
         }
-        results.push(setValueForInput(inputElem, data2.city + ", " + data2.state));
+        results.push(setValueForInput(inputElem, city + ", " + state));
       } else if (element.type === "fullState") {
-        if (!Object.prototype.hasOwnProperty.call(data2, "state")) {
+        const state = Object.prototype.hasOwnProperty.call(data2, "state") ? data2.state : address?.state;
+        if (!state) {
           results.push({
             result: false,
             error: `element found with selector '${element.selector}', but data didn't contain the key 'state'`
           });
           continue;
         }
-        const state = data2.state;
         if (!Object.prototype.hasOwnProperty.call(states, state)) {
           results.push({
             result: false,
@@ -7867,27 +7946,32 @@
         const stateFull = states[state];
         results.push(setValueForInput(inputElem, stateFull));
       } else {
-        if (isElementTypeOptional(element.type)) {
-          continue;
-        }
-        if (!Object.prototype.hasOwnProperty.call(data2, element.type)) {
+        const value = lookupValue(element.type, data2, address, extras);
+        if (!value) {
+          if (isElementTypeOptional(element.type)) {
+            continue;
+          }
           results.push({
             result: false,
-            error: `element found with selector '${element.selector}', but data didn't contain the key '${element.type}'`
+            error: value === void 0 ? `element found with selector '${element.selector}', but data didn't contain the key '${element.type}'` : `data contained the key '${element.type}', but it wasn't something we can fill: ${value}`
           });
           continue;
         }
-        if (!data2[element.type]) {
-          results.push({
-            result: false,
-            error: `data contained the key '${element.type}', but it wasn't something we can fill: ${data2[element.type]}`
-          });
-          continue;
-        }
-        results.push(setValueForInput(inputElem, data2[element.type]));
+        results.push(setValueForInput(inputElem, value));
       }
     }
     return results;
+  }
+  function lookupValue(type, data2, address, extras) {
+    if (Object.prototype.hasOwnProperty.call(data2, type)) return data2[type];
+    if ((type === "city" || type === "state") && address?.[type]) return address[type];
+    if (Object.prototype.hasOwnProperty.call(extras, type)) return extras[type];
+    return void 0;
+  }
+  function selectAddress(profileAddresses, userAddresses) {
+    if (!profileAddresses || profileAddresses.length === 0) return null;
+    const matched = profileAddresses.find((address) => userAddresses?.some((user) => sameCityState(user, address)));
+    return matched ?? profileAddresses[0];
   }
   function isElementTypeOptional(type) {
     if (type === "middleName") {
@@ -8036,11 +8120,6 @@
       }
     }
     return outputString;
-  }
-  function capitalize(s) {
-    const words = s.split(" ");
-    const capitalizedWords = words.map((word) => word.charAt(0).toUpperCase() + word.slice(1));
-    return capitalizedWords.join(" ");
   }
 
   // src/features/broker-protection/actions/click.js
@@ -9153,8 +9232,10 @@
           return click(action, data(action, inputData, "userProfile"), root);
         case "expectation":
           return expectation(action, root);
-        case "fillForm":
-          return fillForm(action, data(action, inputData, "extractedProfile"), root);
+        case "fillForm": {
+          const userProfile = inputData?.userProfile ?? null;
+          return fillForm(action, data(action, inputData, "extractedProfile"), root, userProfile);
+        }
         case "getCaptchaInfo":
           return await getCaptchaInfo2(action, root);
         case "solveCaptcha":

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -8355,11 +8355,64 @@
       return !frame.hidden && frame.src !== "" && frame.src !== "about:blank";
     });
   }
+  var ORDERED_NODE_SNAPSHOT_TYPE = 7;
+  var compiledXPaths = /* @__PURE__ */ new WeakMap();
+  function compileXPath(expression) {
+    let cache = compiledXPaths.get(document);
+    if (!cache) {
+      cache = /* @__PURE__ */ new Map();
+      compiledXPaths.set(document, cache);
+    }
+    let compiled = cache.get(expression);
+    if (!compiled) {
+      compiled = document.createExpression(expression, null);
+      cache.set(expression, compiled);
+    }
+    return compiled;
+  }
+  var DEFAULT_CHUNK_SIZE = 8192;
+  var CHUNK_TAIL_RATIO = 16;
+  var MAX_WORD_LENGTH = 64;
+  function isWordCode(code) {
+    return code >= 97 && code <= 122 || // a-z
+    code >= 65 && code <= 90 || // A-Z
+    code >= 48 && code <= 57 || // 0-9
+    code === 95;
+  }
+  function resolveXPathConfig(config) {
+    const chunkSize = config?.chunkSize ?? DEFAULT_CHUNK_SIZE;
+    const chunkTail = config?.chunkTail ?? Math.floor(chunkSize / CHUNK_TAIL_RATIO);
+    return { chunkSize, chunkTail };
+  }
+  function retainTail(buffer, chunkTail) {
+    let cut = buffer.length - chunkTail;
+    if (cut <= 0) return buffer;
+    const limit = Math.max(0, cut - Math.min(chunkTail, MAX_WORD_LENGTH));
+    while (cut > limit && isWordCode(buffer.charCodeAt(cut - 1))) cut--;
+    return buffer.slice(cut);
+  }
+  function xpathMatches(pattern, expression, { chunkSize, chunkTail }) {
+    const snapshot = compileXPath(expression).evaluate(document, ORDERED_NODE_SNAPSHOT_TYPE, null);
+    let buffer = "";
+    let pending = 0;
+    for (let i = 0; i < snapshot.snapshotLength; i++) {
+      const text2 = snapshot.snapshotItem(i)?.textContent || "";
+      buffer += text2;
+      pending += text2.length;
+      if (chunkSize > 0 && pending >= chunkSize) {
+        if (pattern.test(buffer)) return true;
+        buffer = retainTail(buffer, chunkTail);
+        pending = 0;
+      }
+    }
+    return pattern.test(buffer);
+  }
   function evaluateSingleTextCondition(condition) {
     const patterns = asArray(condition.pattern);
-    const selectors = asArray(condition.selector, ["body"]);
+    const xpaths = asArray(condition.xpath);
+    const selectors = asArray(condition.selector, xpaths.length > 0 ? [] : ["body"]);
     const patternComb = new RegExp(patterns.join("|"), "i");
-    return selectors.some((selector) => {
+    const selectorMatch = selectors.some((selector) => {
       const elements = document.querySelectorAll(selector);
       for (const element of elements) {
         if (patternComb.test(element.textContent || "")) {
@@ -8368,6 +8421,14 @@
       }
       return false;
     });
+    if (selectorMatch) {
+      return true;
+    }
+    if (xpaths.length === 0) {
+      return false;
+    }
+    const chunking = resolveXPathConfig(condition.xpathConfig);
+    return xpaths.some((expression) => xpathMatches(patternComb, expression, chunking));
   }
   function evaluateSingleElementCondition(config) {
     const visibility = config.visibility ?? "any";

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^16.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.3.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.5.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -61,7 +61,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#133d556df3d5e4280b5950f461b8c1ca9c519703",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#8fdfbc706ff6280a66a112201780be126e5ac6a8",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^16.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.3.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.5.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217273906765935

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [x] All tests must pass
- [x] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect in-page privacy/broker automation (form fill, profile matching, and content expectations), not just a version string; regressions could break broker flows or page-condition detection on specific sites.
> 
> **Overview**
> Bumps `@duckduckgo/content-scope-scripts` from **16.3.0** to **16.5.0** and refreshes the vendored Android bundles under `node_modules/@duckduckgo/content-scope-scripts/build/android/`.
> 
> **Content / expectation matching:** Text conditions can now use `xpath` (with optional `xpathConfig` chunking) in addition to CSS selectors, so large-page pattern checks don’t rely only on `body`/`selector` text scans.
> 
> **Broker protection:** Address extraction is richer—capitalized cities, normalized states, street/zip in per-address `extras`, slug-style `href` parsing, and smarter dedupe when extras exist. Profile hashing strips address extras and duplicate city/state pairs. `fillForm` receives `userProfile` so city/state and extra fields (e.g. street) can come from the matched scraped address, not only flat extracted data. Unknown profile spec keys can be scraped via a generic extra extractor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8f9ff6257a1e9978d2b75ac7e325badc79674a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->