### PR TITLE
Add nativePromptEditing feature flag and capability signalling

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -285,6 +285,11 @@ interface DuckChatInternal : DuckChat {
     fun isContextualNativeInputEnabled(): Boolean
 
     /**
+     * True when editing a sent prompt is handled by the native input. Requires the native chat input.
+     */
+    fun isNativePromptEditingEnabled(): Boolean
+
+    /**
      * Returns whether Duck.ai in contextual mode should attach more than one content
      */
     fun areMultipleContentAttachmentsEnabled(): Boolean
@@ -447,6 +452,7 @@ class RealDuckChat @Inject constructor(
     private var isNativeInputFieldEnabled: Boolean = false
     private var isNativeChatInputEnabled: Boolean = false
     private var isContextualNativeInputEnabled: Boolean = false
+    private var isNativePromptEditingEnabled: Boolean = false
 
     init {
         if (isMainProcess) {
@@ -525,6 +531,8 @@ class RealDuckChat @Inject constructor(
     override fun isNativeChatInputEnabled(): Boolean = isNativeChatInputEnabled
 
     override fun isContextualNativeInputEnabled(): Boolean = isContextualNativeInputEnabled
+
+    override fun isNativePromptEditingEnabled(): Boolean = isNativePromptEditingEnabled
 
     override fun areMultipleContentAttachmentsEnabled(): Boolean = areMultipleContentAttachmentsEnabled
 
@@ -939,6 +947,7 @@ class RealDuckChat @Inject constructor(
             // Contextual native INPUT mode is gated by nativeChatInput AND the contextualNativeInput flag.
             // Read synchronously via isContextualNativeInputEnabled() — no flow needed (static per session).
             isContextualNativeInputEnabled = isNativeChatInputEnabled && duckChatFeature.contextualNativeInput().isEnabled()
+            isNativePromptEditingEnabled = isNativeChatInputEnabled && duckChatFeature.nativePromptEditing().isEnabled()
             _nativeInputNavBarEnabled.value = duckChatFeature.nativeInputNavBar().isEnabled()
             val inputScreenUserSettingEnabled = duckChatFeatureRepository.isInputScreenUserSettingEnabled()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -149,6 +149,12 @@ interface DuckChatFeature {
     fun nativeChatInput(): Toggle
 
     /**
+     * Delegates editing an already-sent prompt to the native input instead of the Duck.ai inline editor.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun nativePromptEditing(): Toggle
+
+    /**
      * @return `true` when the native input top nav bar (fire / tabs / menu) may be shown. This is a
      * guardrail on top of the input mode: the bar shows only when this is enabled AND the address bar
      * is in Search & Duck.ai mode. Search-only users, or users with this disabled, never see it.

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -425,6 +425,7 @@ class RealDuckChatJSHelper @Inject constructor(
                 put(SUPPORTS_OPENING_SETTINGS, true)
                 put(SUPPORTS_NATIVE_CHAT_INPUT, duckChat.isNativeChatInputEnabled())
                 put(SUPPORTS_NATIVE_PROMPT, duckChat.isNativeChatInputEnabled())
+                put(SUPPORTS_NATIVE_PROMPT_EDITING, duckChat.isNativePromptEditingEnabled())
                 put(SUPPORTS_CHAT_ID_RESTORATION, duckChat.isDuckChatFullScreenModeEnabled())
                 put(SUPPORTS_IMAGE_UPLOAD, duckChat.isImageUploadEnabled())
                 put(SUPPORTS_STANDALONE_MIGRATION, duckChat.isStandaloneMigrationEnabled())
@@ -617,6 +618,7 @@ class RealDuckChatJSHelper @Inject constructor(
         private const val SUPPORTS_OPENING_SETTINGS = "supportsOpeningSettings"
         private const val SUPPORTS_NATIVE_CHAT_INPUT = "supportsNativeChatInput"
         private const val SUPPORTS_NATIVE_PROMPT = "supportsNativePrompt"
+        private const val SUPPORTS_NATIVE_PROMPT_EDITING = "supportsNativePromptEditing"
         private const val SUPPORTS_IMAGE_UPLOAD = "supportsImageUpload"
         private const val SUPPORTS_CHAT_ID_RESTORATION = "supportsURLChatIDRestoration"
         private const val SUPPORTS_STANDALONE_MIGRATION = "supportsStandaloneMigration"

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -493,6 +493,30 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun whenNativePromptEditingToggleEnabledAndNativeChatInputEnabledThenNativePromptEditingEnabled() = runTest {
+        duckChatFeature.nativeInputField().setRawStoredState(State(enable = true))
+        duckChatFeature.nativeChatInput().setRawStoredState(State(enable = true))
+        duckChatFeature.nativePromptEditing().setRawStoredState(State(enable = true))
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertTrue(testee.isNativePromptEditingEnabled())
+    }
+
+    @Test
+    fun whenNativeChatInputDisabledThenNativePromptEditingDisabled() = runTest {
+        duckChatFeature.nativeInputField().setRawStoredState(State(enable = false))
+        duckChatFeature.nativeChatInput().setRawStoredState(State(enable = false))
+        duckChatFeature.nativePromptEditing().setRawStoredState(State(enable = true))
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertFalse(testee.isNativePromptEditingEnabled())
+    }
+
+    @Test
     fun whenDuckChatUserDisabledThenShowVoiceChatEntryIsFalse() = runTest {
         duckChatFeature.self().setRawStoredState(State(enable = true))
         whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(true)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -303,6 +303,7 @@ class RealDuckChatJSHelperTest {
             put("supportsOpeningSettings", true)
             put("supportsNativeChatInput", false)
             put("supportsNativePrompt", false)
+            put("supportsNativePromptEditing", false)
             put("supportsURLChatIDRestoration", false)
             put("supportsImageUpload", false)
             put("supportsStandaloneMigration", false)
@@ -324,6 +325,36 @@ class RealDuckChatJSHelperTest {
         assertEquals(expected.method, result.method)
         assertEquals(expected.featureName, result.featureName)
         assertEquals(expected.params.toString(), result.params.toString())
+    }
+
+    @Test
+    fun whenGetAIChatNativeConfigValuesAndNativePromptEditingEnabledThenCapabilityIsTrue() = runTest {
+        whenever(mockDuckChat.isNativePromptEditingEnabled()).thenReturn(true)
+
+        val result = testee.processJsCallbackMessage(
+            "aiChat",
+            "getAIChatNativeConfigValues",
+            "123",
+            null,
+            pageContext = viewModel.updatedPageContext,
+        )
+
+        assertTrue(result!!.params.getBoolean("supportsNativePromptEditing"))
+    }
+
+    @Test
+    fun whenGetAIChatNativeConfigValuesAndNativePromptEditingDisabledThenCapabilityIsFalse() = runTest {
+        whenever(mockDuckChat.isNativePromptEditingEnabled()).thenReturn(false)
+
+        val result = testee.processJsCallbackMessage(
+            "aiChat",
+            "getAIChatNativeConfigValues",
+            "123",
+            null,
+            pageContext = viewModel.updatedPageContext,
+        )
+
+        assertFalse(result!!.params.getBoolean("supportsNativePromptEditing"))
     }
 
     @Test
@@ -645,6 +676,7 @@ class RealDuckChatJSHelperTest {
             put("supportsOpeningSettings", true)
             put("supportsNativeChatInput", false)
             put("supportsNativePrompt", false)
+            put("supportsNativePromptEditing", false)
             put("supportsURLChatIDRestoration", false)
             put("supportsImageUpload", false)
             put("supportsStandaloneMigration", false)
@@ -743,6 +775,7 @@ class RealDuckChatJSHelperTest {
             put("supportsOpeningSettings", true)
             put("supportsNativeChatInput", false)
             put("supportsNativePrompt", false)
+            put("supportsNativePromptEditing", false)
             put("supportsURLChatIDRestoration", true)
             put("supportsImageUpload", false)
             put("supportsStandaloneMigration", false)
@@ -903,6 +936,7 @@ class RealDuckChatJSHelperTest {
             put("supportsOpeningSettings", true)
             put("supportsNativeChatInput", false)
             put("supportsNativePrompt", false)
+            put("supportsNativePromptEditing", false)
             put("supportsURLChatIDRestoration", false)
             put("supportsImageUpload", false)
             put("supportsStandaloneMigration", false)
@@ -1006,6 +1040,7 @@ class RealDuckChatJSHelperTest {
             put("supportsOpeningSettings", true)
             put("supportsNativeChatInput", false)
             put("supportsNativePrompt", false)
+            put("supportsNativePromptEditing", false)
             put("supportsURLChatIDRestoration", false)
             put("supportsImageUpload", false)
             put("supportsStandaloneMigration", false)
@@ -1052,6 +1087,7 @@ class RealDuckChatJSHelperTest {
             put("supportsOpeningSettings", true)
             put("supportsNativeChatInput", false)
             put("supportsNativePrompt", false)
+            put("supportsNativePromptEditing", false)
             put("supportsURLChatIDRestoration", false)
             put("supportsImageUpload", false)
             put("supportsStandaloneMigration", true)
@@ -1098,6 +1134,7 @@ class RealDuckChatJSHelperTest {
             put("supportsOpeningSettings", true)
             put("supportsNativeChatInput", false)
             put("supportsNativePrompt", false)
+            put("supportsNativePromptEditing", false)
             put("supportsURLChatIDRestoration", false)
             put("supportsImageUpload", false)
             put("supportsStandaloneMigration", false)
@@ -1411,6 +1448,7 @@ class RealDuckChatJSHelperTest {
             put("supportsOpeningSettings", true)
             put("supportsNativeChatInput", false)
             put("supportsNativePrompt", false)
+            put("supportsNativePromptEditing", false)
             put("supportsURLChatIDRestoration", false)
             put("supportsImageUpload", true)
             put("supportsStandaloneMigration", false)
@@ -1454,6 +1492,7 @@ class RealDuckChatJSHelperTest {
             put("supportsOpeningSettings", true)
             put("supportsNativeChatInput", true)
             put("supportsNativePrompt", true)
+            put("supportsNativePromptEditing", false)
             put("supportsURLChatIDRestoration", false)
             put("supportsImageUpload", false)
             put("supportsStandaloneMigration", false)
@@ -1497,6 +1536,7 @@ class RealDuckChatJSHelperTest {
             put("supportsOpeningSettings", true)
             put("supportsNativeChatInput", false)
             put("supportsNativePrompt", false)
+            put("supportsNativePromptEditing", false)
             put("supportsURLChatIDRestoration", false)
             put("supportsImageUpload", false)
             put("supportsStandaloneMigration", false)
@@ -1541,6 +1581,7 @@ class RealDuckChatJSHelperTest {
             put("supportsOpeningSettings", true)
             put("supportsNativeChatInput", false)
             put("supportsNativePrompt", false)
+            put("supportsNativePromptEditing", false)
             put("supportsURLChatIDRestoration", false)
             put("supportsImageUpload", false)
             put("supportsStandaloneMigration", false)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -181,6 +181,8 @@ class FakeDuckChatInternal(
 
     override fun isContextualNativeInputEnabled(): Boolean = false
 
+    override fun isNativePromptEditingEnabled(): Boolean = false
+
     override fun keepSessionIntervalInMinutes(): Int = 30
 
     override fun isInputScreenFeatureAvailable(): Boolean = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217249853240175
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1216352541975427
API Proposals URL(s) (if applicable): N/A — no `-api` module change

### Description

First PR of the native message-editing series (editing a sent Duck.ai message will use the
native input instead of the frontend's inline editor). This PR adds only the feature flag and
capability signalling — no behaviour change yet.

- `DuckChatFeature.nativePromptEditing()` — new remote flag, `DefaultFeatureValue.INTERNAL`.
- `DuckChatInternal.isNativePromptEditingEnabled()` — true only when both `nativeChatInput` and
  `nativePromptEditing` are enabled.
- `supportsNativePromptEditing` added to the `getAIChatNativeConfigValues` JS handshake payload,
  next to `supportsNativeChatInput`/`supportsNativePrompt`.

The frontend reads this capability once at chat init and falls back to its own inline editor
when it's off, so production behaviour is unaffected until the flag is enabled and a later PR
in this series wires the actual editing flow.

### Steps to test this PR

_Feature flag_
- [x] Internal build, `nativeChatInput` + `nativePromptEditing` both enabled → `getAIChatNativeConfigValues` response includes `supportsNativePromptEditing: true`
- [x] Either flag disabled → `supportsNativePromptEditing: false`
- [x] Unit tests: `RealDuckChatTest`, `RealDuckChatJSHelperTest`

### UI changes
None — no user-visible surface in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag and JS capability only; no new user flows or changes to auth/data handling until a later PR enables the toggle and implements editing.
> 
> **Overview**
> Introduces **native prompt editing** as a gated capability for a later PR: editing a sent Duck.ai message would use the native input instead of the web inline editor. **No editing flow is wired here**—production behavior stays the same until the flag is turned on remotely and follow-up work lands.
> 
> Adds `DuckChatFeature.nativePromptEditing()` (defaults to **internal**) and `isNativePromptEditingEnabled()`, which is **true only when** native chat input is already enabled **and** this toggle is on—mirroring how `contextualNativeInput` is gated.
> 
> The Duck.ai JS handshake (`getAIChatNativeConfigValues`) now includes **`supportsNativePromptEditing`** so the frontend can read it at init and keep using its inline editor when the capability is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a016d856f17c174ee4dce02cd5aeaa81ca1ed61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->