### PR TITLE
Cover message editing from the contextual Duck.ai sheet

### DIFF
--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -478,6 +478,21 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
+    fun whenEditRequestTargetsThisTabAndSurfaceMatchesThenTheContextualWidgetEmitsIt() = runTest {
+        testee.configureContextual(tabId = "tab-1")
+
+        val emissions = mutableListOf<EditPromptRequest>()
+        val job = launch { testee.editPromptRequests.toList(emissions) }
+        advanceUntilIdle()
+        editPromptRequestsFlow.tryEmit(EditPromptRequest("session-1", "tab-1", contextual = true))
+        advanceUntilIdle()
+
+        assertEquals(1, emissions.size)
+        assertEquals("session-1", emissions.single().sessionId)
+        job.cancel()
+    }
+
+    @Test
     fun whenSetDuckAiModeThenInputModeUnchanged() = runTest {
         setIsEnabled(true)
         inputScreenUserSettingFlow.value = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217249853240176
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1216352541975427
API Proposals URL(s) (if applicable): N/A — no `-api` module change

**Stacked on #9430 — review and merge that one first. This PR targets its branch, so the diff
here is only the fourth step.**

### Description

Fourth and final PR of the native message-editing series. Both the Duck.ai browser tab and the
contextual bottom sheet route their JS messages through the same `RealDuckChatJSHelper`, and both
surfaces' native input widgets can be configured with the *same* tabId — so an `editPrompt`
request needs to reach only the widget instance matching its own surface, or both would try to
launch the edit screen.

- `EditPromptRequest` now carries `contextual`, and each widget's ViewModel filters
  `editPromptRequests` on both `tabId` and surface, so the contextual sheet's edit requests are
  never seen by the omnibar widget and vice versa.

### Steps to test this PR

Requires `nativeChatInput` + `nativePromptEditing` enabled (internal build), and an FE build that
sends `editPrompt`.

_Editing from the contextual sheet_
- [ ] Open the contextual sheet on a page, send a message, tap edit → edit screen opens **once**
  (not twice — the omnibar widget must not also react)
- [ ] Submitting/cancelling applies inside the sheet, same as the browser tab flow in #9430
- [ ] Unit tests: `NativeInputModeWidgetViewModelTest` (contextual vs browser filtering)

### UI changes
None beyond #9430 — same edit screen, reached from a second entry point.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The visible diff is test-only; no production logic changes in this PR’s patch.
> 
> **Overview**
> Adds a unit test so **contextual** native input widgets accept `editPrompt` events when `tabId` and `contextual = true` align—complementing existing tests that ignore browser-tab requests on the contextual surface.
> 
> This locks in the stacked behavior where `NativeInputModeWidgetViewModel` filters `editPromptRequests` on **tab** and **surface**, so omnibar and contextual sheet widgets sharing a tab do not both open the edit screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc27207409b6515691a82bf28694dcba80842378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->