### PR TITLE
Unable to open DigiD app

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
@@ -48,6 +48,9 @@ class DuckDuckGoAppLinksHandler @Inject constructor(
     var previousUrl: String? = null
     var isAUserQuery = false
     var hasTriggeredForDomain = false
+
+    // Domains exempt from every suppression rule below  as they launch on repeat navigations to the same
+    // domain, and without a user gesture.
     private val alwaysTriggerList = listOf("app.digid.nl")
 
     override fun handleAppLink(
@@ -63,10 +66,13 @@ class DuckDuckGoAppLinksHandler @Inject constructor(
             return false
         }
 
+        val urlString = appLink.uriString
+        val isAlwaysTriggerDomain = alwaysTriggerList.contains(urlString.extractDomain())
+
         // HTTP navigations shouldn't launch apps unless started with a user gesture. That is unless
         // the "trusted-caller" carve-out applies - if an app opens a Custom Tab, App Links that
         // point back to that same app should be allowed even without user interaction.
-        if (androidBrowserConfigFeature.customTabEndlessLoopFix().isEnabled()) {
+        if (!isAlwaysTriggerDomain && androidBrowserConfigFeature.customTabEndlessLoopFix().isEnabled()) {
             val targetPackage = appLink.appIntent?.component?.packageName ?: appLink.appIntent?.`package`
             val isTrustedCaller = targetPackage != null && clientPackage == targetPackage
             if (!hasGesture && !isTrustedCaller) {
@@ -74,15 +80,13 @@ class DuckDuckGoAppLinksHandler @Inject constructor(
             }
         }
 
-        val urlString = appLink.uriString
         previousUrl?.let {
             if (isSameOrSubdomain(it, urlString)) {
-                val shouldTrigger = alwaysTriggerList.contains(urlString.extractDomain())
-                if (isAUserQuery || !hasTriggeredForDomain || shouldTrigger) {
+                if (isAUserQuery || !hasTriggeredForDomain || isAlwaysTriggerDomain) {
                     previousUrl = urlString
                     launchAppLink()
                     hasTriggeredForDomain = true
-                    if (shouldTrigger) return true
+                    if (isAlwaysTriggerDomain) return true
                 }
                 return false
             }

--- a/app/src/test/java/com/duckduckgo/app/browser/applinks/DuckDuckGoAppLinksHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/applinks/DuckDuckGoAppLinksHandlerTest.kt
@@ -427,6 +427,63 @@ class DuckDuckGoAppLinksHandlerTest {
     }
 
     @Test
+    fun whenNoGestureAndNotTrustedCallerButIsInAlwaysTriggerListThenLaunchAppLink() {
+        testee.isAUserQuery = false
+        testee.previousUrl = "foo.com"
+        assertTrue(
+            testee.handleAppLink(
+                isForMainFrame = true,
+                appLink = AppLink(uriString = "app.digid.nl/something"),
+                hasGesture = false,
+                clientPackage = null,
+                launchAppLink = mockCallback,
+                shouldHaltWebNavigation = true,
+                appLinksEnabled = true,
+            ),
+        )
+        assertEquals("app.digid.nl/something", testee.previousUrl)
+        verify(mockCallback).invoke()
+    }
+
+    @Test
+    fun whenNoGestureAndSameDomainAndHasTriggeredButIsInAlwaysTriggerListThenLaunchAppLink() {
+        testee.isAUserQuery = false
+        testee.hasTriggeredForDomain = true
+        testee.previousUrl = "digid.nl/something"
+        assertTrue(
+            testee.handleAppLink(
+                isForMainFrame = true,
+                appLink = AppLink(uriString = "app.digid.nl/something"),
+                hasGesture = false,
+                clientPackage = null,
+                launchAppLink = mockCallback,
+                shouldHaltWebNavigation = true,
+                appLinksEnabled = true,
+            ),
+        )
+        assertEquals("app.digid.nl/something", testee.previousUrl)
+        verify(mockCallback).invoke()
+    }
+
+    @Test
+    fun whenNoGestureAndNotTrustedCallerAndParentOfAlwaysTriggerDomainThenReturnFalseAndDoNotLaunch() {
+        testee.isAUserQuery = false
+        testee.previousUrl = "foo.com"
+        assertFalse(
+            testee.handleAppLink(
+                isForMainFrame = true,
+                appLink = AppLink(uriString = "digid.nl/something"),
+                hasGesture = false,
+                clientPackage = null,
+                launchAppLink = mockCallback,
+                shouldHaltWebNavigation = true,
+                appLinksEnabled = true,
+            ),
+        )
+        verifyNoInteractions(mockCallback)
+    }
+
+    @Test
     fun whenFixDisabledThenNoGestureAndNotTrustedCallerStillLaunchesAppLink() {
         androidBrowserConfigFeature.customTabEndlessLoopFix().setRawStoredState(State(false))
         testee.isAUserQuery = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1217144802956732?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

App Links on always-trigger domains (currently `app.digid.nl`) stopped launching. The `customTabEndlessLoopFix` gesture requirement applies to every navigation, so a DigiD hand-back that arrives without a user gesture was suppressed and the user
never reached the DigiD app.

Always-trigger domains are now exempt from the gesture and trusted-caller check, as they already were from the repeat-trigger rule. Every other domain keeps the gesture requirement exactly as before.

### Steps to test this PR

See https://app.asana.com/1/137249556945/task/1217144802956732/comment/1217189956011755?focus=true

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow carve-out for a single allowlisted domain in app-link handling; other domains keep existing gesture and loop-prevention behavior.
> 
> **Overview**
> Fixes DigiD app hand-backs failing when `customTabEndlessLoopFix` blocks app links without a user gesture.
> 
> **Always-trigger domains** (`app.digid.nl`) are now exempt from the gesture/trusted-caller gate introduced by that fix, matching how they already bypass repeat-trigger suppression. Other domains still require a gesture or trusted Custom Tab caller when the fix is enabled.
> 
> The handler computes `isAlwaysTriggerDomain` once up front and reuses it in both code paths; tests cover no-gesture launch, repeat same-domain launch, and that parent domains like `digid.nl` remain blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62c6b642211591a181d50afbe14f6d99d4031d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->