### PR TITLE
Sync: write device_info + account_info key atomically during signup for the unified device list

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoKeyManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoKeyManager.kt
@@ -50,6 +50,11 @@ interface AccountInfoKeyManager {
      * The winning public key is returned in [AccountInfoKeyResult] and cached in [SyncStore.accountInfoPublicKey].
      */
     suspend fun ensureKeyRegistered(): Result<AccountInfoKeyResult>
+
+    /**
+     * Mint a new `account_info` keypair wrapped for `ddg` only (a brand-new account has no scoped password yet) without registering it on the server
+     */
+    fun mintUnregistered(accountSecretKey: String): Result<MintedProtectedKey>
 }
 
 data class AccountInfoKeyResult(
@@ -76,7 +81,7 @@ class RealAccountInfoKeyManager @Inject constructor(
         val accountSecretKey = syncStore.secretKey
             ?: return@withContext Error(reason = "CreateAccountInfoKey: no account secret key")
 
-        val minted = when (val result = mintKeypair(accountSecretKey)) {
+        val minted = when (val result = mintUnregistered(accountSecretKey)) {
             is Success -> result.data
             is Error -> return@withContext result
         }
@@ -101,7 +106,7 @@ class RealAccountInfoKeyManager @Inject constructor(
         registration
     }
 
-    private fun mintKeypair(accountSecretKey: String): Result<MintedProtectedKey> =
+    override fun mintUnregistered(accountSecretKey: String): Result<MintedProtectedKey> =
         mintDdgWrappedProtectedKey(
             purpose = SYNC_PURPOSE_ACCOUNT_INFO,
             accountSecretKey = accountSecretKey,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoEncryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoEncryptor.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.store.AccountInfoPublicKey
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.Json
@@ -35,7 +36,15 @@ import javax.inject.Inject
  */
 @WorkerThread
 interface DeviceInfoEncryptor {
+    /**
+     * Encrypt against the account's cached `account_info` public key.
+     * */
     fun encrypt(name: String, type: String): Result<String>
+
+    /**
+     * Encrypt against an explicitly-provided `account_info` public key
+     */
+    fun encrypt(name: String, type: String, publicKey: AccountInfoPublicKey): Result<String>
 }
 
 /**
@@ -65,7 +74,10 @@ class RealDeviceInfoEncryptor @Inject constructor(
     override fun encrypt(name: String, type: String): Result<String> {
         val publicKey = syncStore.accountInfoPublicKey
             ?: return Error(reason = "DeviceInfoEncryptor: no cached account_info key")
+        return encrypt(name, type, publicKey)
+    }
 
+    override fun encrypt(name: String, type: String, publicKey: AccountInfoPublicKey): Result<String> {
         return runCatching {
             val plaintext = DeviceInfoPayload.toJson(DeviceInfoPayload(name = name, type = type)).toByteArray(Charsets.UTF_8)
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SignupAccountInfoBuilder.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SignupAccountInfoBuilder.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.annotation.WorkerThread
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.store.AccountInfoPublicKey
+import com.squareup.anvil.annotations.ContributesBinding
+import logcat.LogPriority.ERROR
+import logcat.logcat
+import javax.inject.Inject
+
+/** The unified-device-list additions to send in a signup request, plus the public key the caller caches once signup succeeds. */
+data class SignupAccountInfo(
+    val deviceInfo: String,
+    val keys: List<ProtectedKeyEntry>,
+    val publicKey: AccountInfoPublicKey,
+)
+
+/**
+ * Prepares the `account_info` key + encrypted `device_info` to embed in a signup request, so the account, its key and this device's
+ * device_info are created atomically. Signup can do this one-shot (unlike login) because it mints the keypair locally and therefore holds
+ * the public key up front.
+ */
+@WorkerThread
+interface SignupAccountInfoBuilder {
+    /**
+     * Returns the additions to include in the signup body, or null when they should be omitted — the write feature is off, or minting /
+     * encryption failed. Null is not an error: the caller signs up without them (best-effort) and migration/login backfills later.
+     * [accountSecretKey] is the freshly-generated account secret key (not yet in the store).
+     */
+    fun build(accountSecretKey: String, deviceName: String, deviceType: String): SignupAccountInfo?
+}
+
+@ContributesBinding(AppScope::class)
+class RealSignupAccountInfoBuilder @Inject constructor(
+    private val syncFeature: SyncFeature,
+    private val accountInfoKeyManager: AccountInfoKeyManager,
+    private val deviceInfoEncryptor: DeviceInfoEncryptor,
+) : SignupAccountInfoBuilder {
+
+    override fun build(accountSecretKey: String, deviceName: String, deviceType: String): SignupAccountInfo? {
+        if (!syncFeature.canWriteUnifiedDeviceList().isEnabled()) return null
+
+        val minkedKey = when (val result = accountInfoKeyManager.mintUnregistered(accountSecretKey)) {
+            is Success -> result.data
+            is Error -> {
+                logcat(ERROR) { "Sync-UnifiedDevices: signup account_info mint failed, signing up without it: ${result.reason}" }
+                return null
+            }
+        }
+        val publicJwk = minkedKey.entry.publicKey ?: run {
+            logcat(ERROR) { "Sync-UnifiedDevices: signup minted account_info key has no public key; signing up without it" }
+            return null
+        }
+        val publicKey = AccountInfoPublicKey(keyId = minkedKey.entry.kid, modulus = publicJwk.n, exponent = publicJwk.e)
+
+        val deviceInfo = when (val result = deviceInfoEncryptor.encrypt(deviceName, deviceType, publicKey)) {
+            is Success -> result.data
+            is Error -> {
+                logcat(ERROR) { "Sync-UnifiedDevices: signup device_info encryption failed, signing up without it: ${result.reason}" }
+                return null
+            }
+        }
+        return SignupAccountInfo(deviceInfo = deviceInfo, keys = listOf(minkedKey.entry), publicKey = publicKey)
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -171,6 +171,7 @@ class AppSyncAccountRepository @Inject constructor(
     private val thirdPartyCredentialManager: ThirdPartyCredentialManager,
     private val thirdPartyDeviceListDecryptor: ThirdPartyDeviceListDecryptor,
     private val loginDeviceInfoWriter: LoginDeviceInfoWriter,
+    private val signupAccountInfoBuilder: SignupAccountInfoBuilder,
 ) : SyncAccountRepository {
 
     // Bounded backoff for the 3party→ddg upgrade network calls.
@@ -1111,6 +1112,14 @@ class AppSyncAccountRepository @Inject constructor(
 
         val credentialId = if (syncFeature.canUseV2ConnectFlow().isEnabled()) CREDENTIAL_ID_DDG else null
 
+        // Unified device list: mint the account_info key locally and encrypt device_info so both are included in the signup request.
+        // Best-effort — null means we sign up without them (if feature flag is off, or mint/encrypt failed) and migration/login backfills later.
+        val unifiedDeviceInfo = if (credentialId == CREDENTIAL_ID_DDG) {
+            signupAccountInfoBuilder.build(account.secretKey, deviceName, deviceType.deviceFactor)
+        } else {
+            null
+        }
+
         val result = try {
             runBlocking { syncSetupWideEvent.onAccountCreationApiStarted() }
             syncApi.createAccount(
@@ -1121,6 +1130,8 @@ class AppSyncAccountRepository @Inject constructor(
                 encryptedDeviceName,
                 encryptedDeviceType,
                 credentialId,
+                deviceInfo = unifiedDeviceInfo?.deviceInfo,
+                keys = unifiedDeviceInfo?.keys,
             )
         } finally {
             runBlocking { syncSetupWideEvent.onAccountCreationApiFinished() }
@@ -1136,6 +1147,12 @@ class AppSyncAccountRepository @Inject constructor(
                 if (syncFeature.canUseV2ConnectFlow().isEnabled()) {
                     logcat { "Sync-ScopedToken: setting credentialId=ddg after account creation" }
                     syncStore.credentialId = CREDENTIAL_ID_DDG
+                }
+                unifiedDeviceInfo?.let {
+                    // cache the pubkey and mark migration done
+                    syncStore.accountInfoPublicKey = it.publicKey
+                    syncStore.unifiedDeviceListMigratedForUserId = account.userId
+                    logcat { "Sync-UnifiedDevices: signup wrote device_info + account_info key (kid=${it.publicKey.keyId})" }
                 }
                 try {
                     runBlocking { syncSetupWideEvent.onInitialSyncStarted() }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
@@ -210,6 +210,8 @@ data class Signup(
     @field:Json(name = "device_name") val deviceName: String,
     @field:Json(name = "device_type") val deviceType: String,
     @field:Json(name = "credential_id") val credentialId: String? = null,
+    @field:Json(name = "device_info") val deviceInfo: String? = null,
+    @field:Json(name = "keys") val keys: List<ProtectedKeyEntry>? = null,
 )
 
 data class Logout(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -39,6 +39,8 @@ interface SyncApi {
         deviceName: String,
         deviceType: String,
         credentialId: String? = null,
+        deviceInfo: String? = null,
+        keys: List<ProtectedKeyEntry>? = null,
     ): Result<AccountCreatedResponse>
 
     fun login(
@@ -202,6 +204,8 @@ class SyncServiceRemote @Inject constructor(
         deviceName: String,
         deviceType: String,
         credentialId: String?,
+        deviceInfo: String?,
+        keys: List<ProtectedKeyEntry>?,
     ): Result<AccountCreatedResponse> {
         val response = runCatching {
             val call = syncService.signup(
@@ -213,6 +217,8 @@ class SyncServiceRemote @Inject constructor(
                     deviceName = deviceName,
                     deviceType = deviceType,
                     credentialId = credentialId,
+                    deviceInfo = deviceInfo,
+                    keys = keys,
                 ),
             )
             call.execute()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -80,6 +80,7 @@ import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl
 import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrlWrapper
 import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
+import com.duckduckgo.sync.store.AccountInfoPublicKey
 import com.duckduckgo.sync.store.ScopedPassword
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.moshi.Moshi
@@ -95,6 +96,7 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.check
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -132,6 +134,7 @@ class AppSyncAccountRepositoryTest {
     private val thirdPartyCredentialManager: ThirdPartyCredentialManager = mock()
     private val thirdPartyDeviceListDecryptor: ThirdPartyDeviceListDecryptor = mock()
     private val loginDeviceInfoWriter: LoginDeviceInfoWriter = mock()
+    private val signupAccountInfoBuilder: SignupAccountInfoBuilder = mock()
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
@@ -156,6 +159,7 @@ class AppSyncAccountRepositoryTest {
             thirdPartyCredentialManager = thirdPartyCredentialManager,
             thirdPartyDeviceListDecryptor = thirdPartyDeviceListDecryptor,
             loginDeviceInfoWriter = loginDeviceInfoWriter,
+            signupAccountInfoBuilder = signupAccountInfoBuilder,
         )
         (syncRepo as AppSyncAccountRepository).upgradeRetryDelayMillis = 0L // keep retry-path tests instant
 
@@ -195,7 +199,7 @@ class AppSyncAccountRepositoryTest {
         prepareToProvideDeviceIds()
         prepareForEncryption()
         whenever(nativeLib.generateAccountKeys(userId = anyString(), password = anyString())).thenReturn(accountKeys)
-        whenever(syncApi.createAccount(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull()))
+        whenever(anyCreateAccountCall())
             .thenReturn(accountCreatedFailDupUser)
 
         val result = syncRepo.createAccount() as Error
@@ -207,7 +211,7 @@ class AppSyncAccountRepositoryTest {
     fun whenCreateAccountGenerateKeysFailsThenReturnCreateAccountError() {
         prepareToProvideDeviceIds()
         whenever(nativeLib.generateAccountKeys(userId = anyString(), password = anyString())).thenReturn(accountKeysFailed)
-        whenever(syncApi.createAccount(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull()))
+        whenever(anyCreateAccountCall())
             .thenReturn(accountCreatedSuccess)
 
         val result = syncRepo.createAccount() as Error
@@ -1122,12 +1126,24 @@ class AppSyncAccountRepositoryTest {
         whenever(syncDeviceIds.deviceType()).thenReturn(deviceType)
     }
 
+    private fun anyCreateAccountCall() = syncApi.createAccount(
+        anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull(), anyOrNull(), anyOrNull(),
+    )
+
     private fun prepareForCreateAccountSuccess() {
         prepareForEncryption()
         whenever(nativeLib.generateAccountKeys(userId = anyString(), password = anyString())).thenReturn(accountKeys)
-        whenever(syncApi.createAccount(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull()))
+        whenever(anyCreateAccountCall())
             .thenReturn(Success(AccountCreatedResponse(userId, token)))
     }
+
+    private fun unifiedAccountInfoEntry() = ProtectedKeyEntry(
+        kid = "kid-1",
+        purpose = SYNC_PURPOSE_ACCOUNT_INFO,
+        encryptedWith = CREDENTIAL_ID_DDG,
+        encryptedPrivateKey = "ddg-wrapped-private-key",
+        publicKey = RsaJwk(n = "n", e = "AQAB"),
+    )
 
     private fun prepareForEncryption() {
         whenever(nativeLib.decrypt(encryptedData = protectedEncryptionKey, secretKey = stretchedPrimaryKey)).thenReturn(decryptedSecretKey)
@@ -1259,7 +1275,9 @@ class AppSyncAccountRepositoryTest {
 
         syncRepo.createAccount()
 
-        verify(syncApi).createAccount(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), eq("ddg"))
+        verify(syncApi).createAccount(
+            anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), eq("ddg"), anyOrNull(), anyOrNull(),
+        )
     }
 
     @Test
@@ -1270,7 +1288,51 @@ class AppSyncAccountRepositoryTest {
 
         syncRepo.createAccount()
 
-        verify(syncApi).createAccount(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), eq(null))
+        verify(syncApi).createAccount(
+            anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), eq(null), anyOrNull(), anyOrNull(),
+        )
+        // Unified device_info is only built on the v2/ddg signup path.
+        verify(signupAccountInfoBuilder, never()).build(any(), any(), any())
+    }
+
+    @Test
+    fun whenSignupAccountInfoBuilderReturnsAdditionsThenIncludedInSignupAndCached() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        prepareToProvideDeviceIds()
+        prepareForCreateAccountSuccess()
+        val publicKey = AccountInfoPublicKey(keyId = "kid-1", modulus = "n", exponent = "AQAB")
+        whenever(signupAccountInfoBuilder.build(any(), any(), any()))
+            .thenReturn(SignupAccountInfo(deviceInfo = "deviceInfoJwe", keys = listOf(unifiedAccountInfoEntry()), publicKey = publicKey))
+
+        syncRepo.createAccount()
+
+        verify(syncApi).createAccount(
+            anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), eq("ddg"),
+            eq("deviceInfoJwe"),
+            check { keys ->
+                assertEquals(1, keys?.size)
+                assertEquals(CREDENTIAL_ID_DDG, keys?.first()?.encryptedWith)
+                assertEquals(SYNC_PURPOSE_ACCOUNT_INFO, keys?.first()?.purpose)
+            },
+        )
+        verify(syncStore).accountInfoPublicKey = publicKey
+        verify(syncStore).unifiedDeviceListMigratedForUserId = userId
+    }
+
+    @Test
+    fun whenSignupAccountInfoBuilderReturnsNullThenNoDeviceInfoOrKeysAndSignupStillSucceeds() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        prepareToProvideDeviceIds()
+        prepareForCreateAccountSuccess()
+        whenever(signupAccountInfoBuilder.build(any(), any(), any())).thenReturn(null)
+
+        val result = syncRepo.createAccount()
+
+        assertEquals(Success(true), result)
+        verify(syncApi).createAccount(
+            anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), eq("ddg"), eq(null), eq(null),
+        )
+        verify(syncStore, never()).unifiedDeviceListMigratedForUserId = any()
     }
 
     // ---- Delegation to ThirdPartyCredentialManager ----

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SignupAccountInfoBuilderTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SignupAccountInfoBuilderTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.store.AccountInfoPublicKey
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class SignupAccountInfoBuilderTest {
+
+    private val accountInfoKeyManager: AccountInfoKeyManager = mock()
+    private val deviceInfoEncryptor: DeviceInfoEncryptor = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+
+    private lateinit var builder: SignupAccountInfoBuilder
+
+    private val secretKey = "accountSecretKey"
+
+    @Before
+    fun before() {
+        builder = RealSignupAccountInfoBuilder(syncFeature, accountInfoKeyManager, deviceInfoEncryptor)
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
+    }
+
+    @Test
+    fun whenWriteFeatureOffThenNullAndNoMint() {
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = false))
+
+        assertNull(builder.build(secretKey, "My Phone", "phone"))
+        verify(accountInfoKeyManager, never()).mintUnregistered(any())
+    }
+
+    @Test
+    fun whenMintFailsThenNullAndNoEncrypt() {
+        whenever(accountInfoKeyManager.mintUnregistered(secretKey)).thenReturn(Error(reason = "mint boom"))
+
+        assertNull(builder.build(secretKey, "My Phone", "phone"))
+        verify(deviceInfoEncryptor, never()).encrypt(any(), any(), any())
+    }
+
+    @Test
+    fun whenEncryptFailsThenNull() {
+        whenever(accountInfoKeyManager.mintUnregistered(secretKey)).thenReturn(Success(mintedKey()))
+        whenever(deviceInfoEncryptor.encrypt(any(), any(), any())).thenReturn(Error(reason = "encrypt boom"))
+
+        assertNull(builder.build(secretKey, "My Phone", "phone"))
+    }
+
+    @Test
+    fun whenMintedAndEncryptedThenReturnsAdditionsWithMatchingKid() {
+        whenever(accountInfoKeyManager.mintUnregistered(secretKey)).thenReturn(Success(mintedKey()))
+        whenever(deviceInfoEncryptor.encrypt(any(), any(), any())).thenReturn(Success("deviceInfoJwe"))
+
+        val result = builder.build(secretKey, "My Phone", "phone")
+
+        val expectedPublicKey = AccountInfoPublicKey(keyId = "kid-1", modulus = "n", exponent = "AQAB")
+        assertEquals("deviceInfoJwe", result?.deviceInfo)
+        assertEquals(1, result?.keys?.size)
+        assertEquals("kid-1", result?.keys?.first()?.kid)
+        assertEquals(CREDENTIAL_ID_DDG, result?.keys?.first()?.encryptedWith)
+        assertEquals(expectedPublicKey, result?.publicKey)
+        // device_info must be encrypted under the minted key so its kid matches the registered key entry.
+        verify(deviceInfoEncryptor).encrypt(eq("My Phone"), eq("phone"), eq(expectedPublicKey))
+    }
+
+    private fun mintedKey() = MintedProtectedKey(
+        entry = ProtectedKeyEntry(
+            kid = "kid-1",
+            purpose = SYNC_PURPOSE_ACCOUNT_INFO,
+            encryptedWith = CREDENTIAL_ID_DDG,
+            encryptedPrivateKey = "ddg-wrapped-private-key",
+            publicKey = RsaJwk(n = "n", e = "AQAB"),
+        ),
+        rawPrivateKeyBytes = "raw".toByteArray(),
+    )
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
@@ -111,6 +111,39 @@ class SyncServiceRemoteTest {
     }
 
     @Test
+    fun whenCreateAccountWithDeviceInfoAndKeysThenSentInSignupBody() {
+        val call: Call<AccountCreatedResponse> = mock()
+        val keys = listOf(
+            ProtectedKeyEntry(
+                kid = "kid-1",
+                purpose = "account_info",
+                encryptedWith = "ddg",
+                encryptedPrivateKey = "wrapped",
+                publicKey = RsaJwk(n = "n", e = "AQAB"),
+            ),
+        )
+        val expected = signUpRequest.copy(deviceInfo = "device_info_jwe", keys = keys)
+        whenever(syncService.signup(expected)).thenReturn(call)
+        whenever(call.execute()).thenReturn(signupSuccess)
+
+        val result = with(accountKeys) {
+            syncRemote.createAccount(
+                userId,
+                passwordHash,
+                protectedSecretKey,
+                deviceId,
+                deviceName,
+                deviceFactor,
+                deviceInfo = "device_info_jwe",
+                keys = keys,
+            )
+        }
+
+        assertEquals(accountCreatedSuccess, result)
+        verify(syncService).signup(expected)
+    }
+
+    @Test
     fun whenCreateAccountIsInvalidThenReturnError() {
         val call: Call<AccountCreatedResponse> = mock()
         whenever(syncService.signup(signUpRequest)).thenReturn(call)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217243927034013?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Extends signup to bring the new device into the unified device list in the same request. On the v2/ddg signup path, when `canWriteUnifiedDeviceList` is enabled, creating an account now includes the `account_info` key and this device's encrypted `device_info` in the signup body, so account + key + `device_info` are created atomically.

Unlike login, which can't include `device_info` in its request (the `account_info` public key only arrives in the login response, so it writes via a follow-up `PATCH`), signup mints the key locally and has the public key up front, so it's a genuine one-shot.

### Steps to test this PR

**Pre-requisites**
- [ ] fresh install `internal` variant

**FF enabled: Creating account writes device_info**
- [ ] enable `canReadUnifiedDeviceList`
- [ ] enable `canWriteUnifiedDeviceList`
- [ ] Visit `Sync Dev Settings` and tap `Create account`
- [ ] Verify in logs (in order):

```
     Sync-ScopedToken: generating RSA-3072 keypair
     Sync-UnifiedDevices: encrypted device_info (… chars, kid=…)
     Sync-ScopedToken: setting credentialId=ddg after account creation
     Sync-UnifiedDevices: signup wrote device_info + account_info key (kid=…)
```

**Production device list**
- [ ] Open production sync screen to see list of devices
- [ ] Verify in logs `1 via device_info`

**FF disabled: Creating account writes device_info**
- [ ] Clear app data
- [ ] Visit `Sync Dev Settings`
- [ ] enable `canReadUnifiedDeviceList`
- [ ] ensure `canWriteUnifiedDeviceList` remains disabled
- [ ] Tap `Create account`
- [ ] Verify in logs you do NOT see `signup wrote device_info`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the signup wire format and local key minting for new accounts on a crypto-sensitive path, though behavior is feature-flagged and degrades gracefully when mint/encrypt fails.
> 
> **Overview**
> On the **v2/ddg** account-creation path, signup can now send the unified device list in a **single** request when `canWriteUnifiedDeviceList` is enabled: a locally minted `account_info` protected key and a JWE `device_info` blob encrypted under that key’s public half.
> 
> **`SignupAccountInfoBuilder`** orchestrates mint + encrypt (best-effort; failures omit the fields and signup still succeeds). **`AccountInfoKeyManager.mintUnregistered`** exposes ddg-only minting without `set-if-absent`; **`DeviceInfoEncryptor`** can encrypt against an explicit public key for signup before anything is cached.
> 
> After a successful signup that included those fields, the client caches **`accountInfoPublicKey`** and marks unified-device-list migration for the user. Signup API models and **`createAccount`** wire through optional `device_info` and `keys`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3136fb9e7990114f28ed7f31f253fb076694ebb6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->