### PR TITLE
Add contextual suggestion pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1582,7 +1582,7 @@
         "parameters": ["appVersion"]
     },
     "aichat_contextual_suggestion_selected": {
-        "description": "User tapped a suggested prompt on the contextual Duck.ai sheet start surface. suggestionId=ask-about-page represents the Ask About Page quick action tap while contextual suggestions are enabled, which additionally fires the legacy m_aichat_contextual_quick_action_ask_about_page_selected pixel.",
+        "description": "User tapped a suggested prompt on the contextual Duck.ai sheet start surface. The Ask About Page quick action reports as suggestionId=ask-about-page and also fires m_aichat_contextual_quick_action_ask_about_page_selected.",
         "owners": ["joshliebe"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "form_factor"],
@@ -1620,7 +1620,7 @@
         ]
     },
     "aichat_contextual_suggestions_viewed": {
-        "description": "Suggested prompts became visible on the contextual Duck.ai sheet start surface. Fires once per continuous display; a fresh impression is counted when the start surface reloads (sheet reopened or New Chat). Loading or empty surfaces never fire.",
+        "description": "Suggested prompts became visible on the contextual Duck.ai sheet start surface. Fires once per display; only a reload (sheet reopened, or returning from an open chat) counts a fresh impression.",
         "owners": ["joshliebe"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "form_factor"],

--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1594,29 +1594,7 @@
                 "description": "Catalog key of the selected suggestion (e.g. summarize-page, translate-page, key-takeaways) or ask-about-page for the quick action. Bounded by the bundled PageSuggestionsCatalog ids.",
                 "examples": ["summarize-page", "translate-page", "key-takeaways", "ask-about-page"]
             },
-            {
-                "key": "pageType",
-                "type": "string",
-                "description": "Coarse page-type bucket computed natively from page-type signals. Never a URL, domain or page content.",
-                "enum": [
-                    "recipe",
-                    "product",
-                    "article",
-                    "video",
-                    "job",
-                    "book",
-                    "event",
-                    "place",
-                    "forum",
-                    "code",
-                    "course",
-                    "review",
-                    "person",
-                    "howto",
-                    "faq",
-                    "none"
-                ]
-            }
+            "contextualSuggestionsPageType"
         ]
     },
     "aichat_contextual_suggestions_viewed": {
@@ -1631,29 +1609,7 @@
                 "type": "boolean",
                 "description": "Whether the displayed suggestions were contextually matched to the page (JSON-LD, og:type or domain) rather than generic defaults."
             },
-            {
-                "key": "pageType",
-                "type": "string",
-                "description": "Coarse page-type bucket computed natively from page-type signals. Never a URL, domain or page content.",
-                "enum": [
-                    "recipe",
-                    "product",
-                    "article",
-                    "video",
-                    "job",
-                    "book",
-                    "event",
-                    "place",
-                    "forum",
-                    "code",
-                    "course",
-                    "review",
-                    "person",
-                    "howto",
-                    "faq",
-                    "none"
-                ]
-            }
+            "contextualSuggestionsPageType"
         ]
     },
     "debug_aichat_contextual_suggestions_catalog_load_failed": {

--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1580,5 +1580,94 @@
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "form_factor"],
         "parameters": ["appVersion"]
+    },
+    "aichat_contextual_suggestion_selected": {
+        "description": "User tapped a suggested prompt on the contextual Duck.ai sheet start surface. suggestionId=ask-about-page represents the Ask About Page quick action tap while contextual suggestions are enabled, which additionally fires the legacy m_aichat_contextual_quick_action_ask_about_page_selected pixel.",
+        "owners": ["joshliebe"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "suggestionId",
+                "type": "string",
+                "description": "Catalog key of the selected suggestion (e.g. summarize-page, translate-page, key-takeaways) or ask-about-page for the quick action. Bounded by the bundled PageSuggestionsCatalog ids.",
+                "examples": ["summarize-page", "translate-page", "key-takeaways", "ask-about-page"]
+            },
+            {
+                "key": "pageType",
+                "type": "string",
+                "description": "Coarse page-type bucket computed natively from page-type signals. Never a URL, domain or page content.",
+                "enum": [
+                    "recipe",
+                    "product",
+                    "article",
+                    "video",
+                    "job",
+                    "book",
+                    "event",
+                    "place",
+                    "forum",
+                    "code",
+                    "course",
+                    "review",
+                    "person",
+                    "howto",
+                    "faq",
+                    "none"
+                ]
+            }
+        ]
+    },
+    "aichat_contextual_suggestions_viewed": {
+        "description": "Suggested prompts became visible on the contextual Duck.ai sheet start surface. Fires once per continuous display; a fresh impression is counted when the start surface reloads (sheet reopened or New Chat). Loading or empty surfaces never fire.",
+        "owners": ["joshliebe"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "isSmart",
+                "type": "boolean",
+                "description": "Whether the displayed suggestions were contextually matched to the page (JSON-LD, og:type or domain) rather than generic defaults."
+            },
+            {
+                "key": "pageType",
+                "type": "string",
+                "description": "Coarse page-type bucket computed natively from page-type signals. Never a URL, domain or page content.",
+                "enum": [
+                    "recipe",
+                    "product",
+                    "article",
+                    "video",
+                    "job",
+                    "book",
+                    "event",
+                    "place",
+                    "forum",
+                    "code",
+                    "course",
+                    "review",
+                    "person",
+                    "howto",
+                    "faq",
+                    "none"
+                ]
+            }
+        ]
+    },
+    "debug_aichat_contextual_suggestions_catalog_load_failed": {
+        "description": "The bundled PageSuggestionsCatalog.json could not be loaded or decoded when resolving contextual suggestions; the start surface falls back to no suggestions.",
+        "owners": ["joshliebe"],
+        "triggers": ["exception"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "debug_aichat_contextual_suggestions_context_collection_timed_out": {
+        "description": "Page context collection did not complete within the timeout while contextual suggestions were loading; suggestions fall back to generic defaults.",
+        "owners": ["joshliebe"],
+        "triggers": ["exception"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -15,6 +15,29 @@
         "description": "The Unified Input surface the pixel was fired from, distinguishing the contextual chat sheet from the Duck.ai tab and the address bar",
         "enum": ["address_bar", "duck_ai", "contextual_chat"]
     },
+    "contextualSuggestionsPageType": {
+        "key": "pageType",
+        "type": "string",
+        "description": "Coarse page-type bucket computed natively from page-type signals. Never a URL, domain or page content.",
+        "enum": [
+            "recipe",
+            "product",
+            "article",
+            "video",
+            "job",
+            "book",
+            "event",
+            "place",
+            "forum",
+            "code",
+            "course",
+            "review",
+            "person",
+            "howto",
+            "faq",
+            "none"
+        ]
+    },
     "osVersion": {
         "key": "os_version",
         "type": "integer",

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -269,6 +269,7 @@ class DuckChatContextualFragment :
             ) {
                 if (newState == BottomSheetBehavior.STATE_HIDDEN) {
                     viewModel.onSheetClosed()
+                    binding.contextualSuggestionsView.clear()
                 }
                 if (newState == BottomSheetBehavior.STATE_HALF_EXPANDED) {
                     bottomSheet.requestLayout()
@@ -552,6 +553,8 @@ class DuckChatContextualFragment :
         }
     }
 
+    private fun isSheetVisible(): Boolean = bottomSheetBehavior.state != BottomSheetBehavior.STATE_HIDDEN
+
     private fun reserveSpaceForSuggestions() {
         if (!viewModel.viewState.value.contextualSuggestionsEnabled) return
         if (isKeyboardVisible) return
@@ -798,7 +801,7 @@ class DuckChatContextualFragment :
                 when (command) {
                     is DuckChatContextualSharedViewModel.Command.PageContextAttached -> {
                         viewModel.onPageContextReceived(command.tabId, command.pageContext, command.isStorePageContextEnabled)
-                        if (viewModel.viewState.value.sheetMode == DuckChatContextualViewModel.SheetMode.INPUT) {
+                        if (isSheetVisible() && viewModel.viewState.value.sheetMode == DuckChatContextualViewModel.SheetMode.INPUT) {
                             binding.contextualSuggestionsView.onPageContextUpdated(command.pageContext)
                         }
                     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -698,7 +698,7 @@ class DuckChatContextualFragment :
             } else {
                 binding.legacyInputField.text.toString()
             }
-            viewModel.onQuickActionClicked(currentInput)
+            viewModel.onQuickActionClicked(currentInput, binding.contextualSuggestionsView.pageTypePixelValue())
         }
     }
 
@@ -798,7 +798,9 @@ class DuckChatContextualFragment :
                 when (command) {
                     is DuckChatContextualSharedViewModel.Command.PageContextAttached -> {
                         viewModel.onPageContextReceived(command.tabId, command.pageContext, command.isStorePageContextEnabled)
-                        binding.contextualSuggestionsView.onPageContextUpdated(command.pageContext)
+                        if (viewModel.viewState.value.sheetMode == DuckChatContextualViewModel.SheetMode.INPUT) {
+                            binding.contextualSuggestionsView.onPageContextUpdated(command.pageContext)
+                        }
                     }
 
                     is DuckChatContextualSharedViewModel.Command.MainBrowserPageFinished -> {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -698,7 +698,7 @@ class DuckChatContextualFragment :
             } else {
                 binding.legacyInputField.text.toString()
             }
-            viewModel.onQuickActionClicked(currentInput, binding.contextualSuggestionsView.pageTypePixelValue())
+            viewModel.onQuickActionClicked(currentInput, binding.contextualSuggestionsView.currentPageType())
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -682,7 +682,10 @@ class DuckChatContextualViewModel @Inject constructor(
         sheetMode == SheetMode.INPUT &&
             quickActionState == QuickActionState.ASK_ABOUT_PAGE
 
-    fun onQuickActionClicked(currentInput: String) {
+    fun onQuickActionClicked(
+        currentInput: String,
+        suggestionsPageType: String = "none",
+    ) {
         when (_viewState.value.quickActionState) {
             QuickActionState.ASK_ABOUT_PAGE -> {
                 if (!isContextValid(currentPageContext)) {
@@ -690,6 +693,9 @@ class DuckChatContextualViewModel @Inject constructor(
                     return
                 }
                 duckChatPixels.reportContextualAskAboutPageSelected()
+                if (_viewState.value.contextualSuggestionsEnabled) {
+                    duckChatPixels.reportContextualAskAboutPageSuggestionSelected(suggestionsPageType)
+                }
                 addPageContext()
                 commandChannel.trySend(Command.FocusInput)
                 viewModelScope.launch {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.duckchat.api.toChatIdOrNull
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.contextual.suggestions.ContextualSuggestedPrompt
+import com.duckduckgo.duckchat.impl.contextual.suggestions.SuggestionsPageType
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.helper.NativeAction
@@ -684,7 +685,7 @@ class DuckChatContextualViewModel @Inject constructor(
 
     fun onQuickActionClicked(
         currentInput: String,
-        suggestionsPageType: String = "none",
+        suggestionsPageType: SuggestionsPageType = SuggestionsPageType.NONE,
     ) {
         when (_viewState.value.quickActionState) {
             QuickActionState.ASK_ABOUT_PAGE -> {
@@ -694,7 +695,7 @@ class DuckChatContextualViewModel @Inject constructor(
                 }
                 duckChatPixels.reportContextualAskAboutPageSelected()
                 if (_viewState.value.contextualSuggestionsEnabled) {
-                    duckChatPixels.reportContextualAskAboutPageSuggestionSelected(suggestionsPageType)
+                    duckChatPixels.reportContextualAskAboutPageSuggestionSelected(suggestionsPageType.pixelValue)
                 }
                 addPageContext()
                 commandChannel.trySend(Command.FocusInput)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestedPromptsProvider.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestedPromptsProvider.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
@@ -29,7 +30,7 @@ import logcat.logcat
 import javax.inject.Inject
 
 interface ContextualSuggestedPromptsProvider {
-    suspend fun resolveSuggestions(input: ResolvePageSuggestionsInput): List<ContextualSuggestedPrompt>
+    suspend fun resolveSuggestions(input: ResolvePageSuggestionsInput): ResolvedPageSuggestions
     suspend fun maxSuggestedPrompts(): Int
     suspend fun prioritySuggestionIds(): Set<String>
 }
@@ -38,6 +39,7 @@ interface ContextualSuggestedPromptsProvider {
 class RealContextualSuggestedPromptsProvider @Inject constructor(
     private val context: Context,
     private val dispatcherProvider: DispatcherProvider,
+    private val duckChatPixels: DuckChatPixels,
 ) : ContextualSuggestedPromptsProvider {
 
     internal var catalogAssetPath: String = CATALOG_ASSET_PATH
@@ -50,11 +52,22 @@ class RealContextualSuggestedPromptsProvider @Inject constructor(
 
     override suspend fun resolveSuggestions(
         input: ResolvePageSuggestionsInput,
-    ): List<ContextualSuggestedPrompt> = withContext(dispatcherProvider.io()) {
-        val catalog = bundledCatalog ?: return@withContext emptyList()
-        ContextualSuggestionsMatcher.resolve(input, catalog)
-            .filterNot { it.id == SUGGESTION_ID_SUMMARIZE_PAGE }
-            .map { localize(it, input) }
+    ): ResolvedPageSuggestions = withContext(dispatcherProvider.io()) {
+        val catalog = bundledCatalog
+        if (catalog == null) {
+            duckChatPixels.reportContextualSuggestionsCatalogLoadFailed()
+            return@withContext ResolvedPageSuggestions(
+                suggestions = emptyList(),
+                isSmart = false,
+                pageType = ContextualSuggestionsMatcher.classifyPageType(input.pageTypeSignals),
+            )
+        }
+        val resolved = ContextualSuggestionsMatcher.resolve(input, catalog)
+        resolved.copy(
+            suggestions = resolved.suggestions
+                .filterNot { it.id == SUGGESTION_ID_SUMMARIZE_PAGE }
+                .map { localize(it, input) },
+        )
     }
 
     private fun localize(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsMatcher.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsMatcher.kt
@@ -26,6 +26,17 @@ data class ContextualSuggestedPrompt(
     val icon: String?,
 )
 
+data class ResolvedPageSuggestions(
+    val suggestions: List<ContextualSuggestedPrompt>,
+    val isSmart: Boolean,
+    val pageType: SuggestionsPageType,
+)
+
+enum class SuggestionsPageType {
+    RECIPE, PRODUCT, ARTICLE, VIDEO, JOB, BOOK, EVENT, PLACE, FORUM, CODE, COURSE, REVIEW, PERSON, HOWTO, FAQ, NONE;
+    val pixelValue: String get() = name.lowercase()
+}
+
 data class PageTypeSignals(
     val jsonLdType: List<String> = emptyList(),
     val ogType: String? = null,
@@ -68,9 +79,9 @@ object ContextualSuggestionsMatcher {
     fun resolve(
         input: ResolvePageSuggestionsInput,
         catalog: SuggestionCatalog,
-    ): List<ContextualSuggestedPrompt> {
+    ): ResolvedPageSuggestions {
         val cap = maxOf(1, catalog.maxSuggestedPrompts)
-        val candidateIds = collectCandidateIds(input, catalog, cap)
+        val (candidateIds, isSmart) = collectCandidateIds(input, catalog, cap)
         val seen = mutableSetOf<String>()
         val resolved = mutableListOf<ContextualSuggestedPrompt>()
 
@@ -90,14 +101,29 @@ object ContextualSuggestionsMatcher {
                 ),
             )
         }
-        return resolved
+        return ResolvedPageSuggestions(
+            suggestions = resolved,
+            isSmart = isSmart,
+            pageType = classifyPageType(input.pageTypeSignals),
+        )
+    }
+
+    fun classifyPageType(signals: PageTypeSignals?): SuggestionsPageType {
+        if (signals == null) return SuggestionsPageType.NONE
+        for (type in signals.jsonLdType) {
+            jsonLdTypeToPageType[type.trim().lowercase()]?.let { return it }
+        }
+        signals.ogType?.trim()?.lowercase()?.let { ogType ->
+            ogTypeToPageType[ogType]?.let { return it }
+        }
+        return SuggestionsPageType.NONE
     }
 
     private fun collectCandidateIds(
         input: ResolvePageSuggestionsInput,
         catalog: SuggestionCatalog,
         cap: Int,
-    ): List<String> {
+    ): Pair<List<String>, Boolean> {
         var contextual: List<String>? = null
 
         input.pageTypeSignals?.let { signals ->
@@ -123,8 +149,50 @@ object ContextualSuggestionsMatcher {
 
         val body = contextual ?: floorDefaults
         val bodyBudget = (cap - priorityDefaults.size).coerceAtLeast(0)
-        return body.take(bodyBudget) + priorityDefaults
+        return body.take(bodyBudget) + priorityDefaults to (contextual != null)
     }
+
+    private val jsonLdTypeToPageType = mapOf(
+        "recipe" to SuggestionsPageType.RECIPE,
+        "product" to SuggestionsPageType.PRODUCT,
+        "article" to SuggestionsPageType.ARTICLE,
+        "newsarticle" to SuggestionsPageType.ARTICLE,
+        "reportagenewsarticle" to SuggestionsPageType.ARTICLE,
+        "liveblogposting" to SuggestionsPageType.ARTICLE,
+        "blogposting" to SuggestionsPageType.ARTICLE,
+        "scholarlyarticle" to SuggestionsPageType.ARTICLE,
+        "videoobject" to SuggestionsPageType.VIDEO,
+        "movie" to SuggestionsPageType.VIDEO,
+        "tvseries" to SuggestionsPageType.VIDEO,
+        "jobposting" to SuggestionsPageType.JOB,
+        "book" to SuggestionsPageType.BOOK,
+        "course" to SuggestionsPageType.COURSE,
+        "event" to SuggestionsPageType.EVENT,
+        "restaurant" to SuggestionsPageType.PLACE,
+        "foodestablishment" to SuggestionsPageType.PLACE,
+        "localbusiness" to SuggestionsPageType.PLACE,
+        "discussionforumposting" to SuggestionsPageType.FORUM,
+        "qapage" to SuggestionsPageType.FORUM,
+        "faqpage" to SuggestionsPageType.FAQ,
+        "softwaresourcecode" to SuggestionsPageType.CODE,
+        "review" to SuggestionsPageType.REVIEW,
+        "aggregaterating" to SuggestionsPageType.REVIEW,
+        "person" to SuggestionsPageType.PERSON,
+        "howto" to SuggestionsPageType.HOWTO,
+    )
+
+    private val ogTypeToPageType = mapOf(
+        "article" to SuggestionsPageType.ARTICLE,
+        "product" to SuggestionsPageType.PRODUCT,
+        "product.item" to SuggestionsPageType.PRODUCT,
+        "video" to SuggestionsPageType.VIDEO,
+        "video.other" to SuggestionsPageType.VIDEO,
+        "video.movie" to SuggestionsPageType.VIDEO,
+        "video.episode" to SuggestionsPageType.VIDEO,
+        "video.tv_show" to SuggestionsPageType.VIDEO,
+        "book" to SuggestionsPageType.BOOK,
+        "profile" to SuggestionsPageType.PERSON,
+    )
 
     private fun matchByJsonLdType(
         types: List<String>,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
@@ -113,6 +113,11 @@ class ContextualSuggestionsView @JvmOverloads constructor(
         }
     }
 
+    fun pageTypePixelValue(): String {
+        if (!isAttachedToWindow) return SuggestionsPageType.NONE.pixelValue
+        return viewModel.pageTypePixelValue()
+    }
+
     fun hasContent(): Boolean = loadingView.isVisible || cardsContainer.isNotEmpty()
 
     private fun render(viewState: ContextualSuggestionsViewModel.ViewState) {
@@ -125,7 +130,10 @@ class ContextualSuggestionsView @JvmOverloads constructor(
                 val itemBinding = ItemContextualSuggestionBinding.inflate(inflater, cardsContainer, false)
                 itemBinding.suggestionLabel.text = suggestion.label
                 itemBinding.suggestionLabel.setCompoundDrawablesRelativeWithIntrinsicBounds(iconResFor(suggestion.icon), 0, 0, 0)
-                itemBinding.root.setOnClickListener { onSuggestionSelected?.invoke(suggestion) }
+                itemBinding.root.setOnClickListener {
+                    viewModel.onSuggestionSelected(suggestion.id)
+                    onSuggestionSelected?.invoke(suggestion)
+                }
                 cardsContainer.addView(itemBinding.root)
             }
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
@@ -113,9 +113,9 @@ class ContextualSuggestionsView @JvmOverloads constructor(
         }
     }
 
-    fun pageTypePixelValue(): String {
-        if (!isAttachedToWindow) return SuggestionsPageType.NONE.pixelValue
-        return viewModel.pageTypePixelValue()
+    fun currentPageType(): SuggestionsPageType {
+        if (!isAttachedToWindow) return SuggestionsPageType.NONE
+        return viewModel.currentPageType()
     }
 
     fun hasContent(): Boolean = loadingView.isVisible || cardsContainer.isNotEmpty()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
@@ -62,7 +62,7 @@ class ContextualSuggestionsViewModel @Inject constructor(
 
     fun load() {
         loadJob?.cancel()
-        suggestionsVisible = false
+        resetResolvedState()
         loadJob = viewModelScope.launch {
             if (!suggestionsEnabled()) {
                 hideSuggestions()
@@ -160,8 +160,14 @@ class ContextualSuggestionsViewModel @Inject constructor(
     }
 
     private fun hideSuggestions() {
-        suggestionsVisible = false
+        resetResolvedState()
         _viewState.value = ViewState(suggestions = emptyList(), loading = false)
+    }
+
+    private fun resetResolvedState() {
+        suggestionsVisible = false
+        pageType = SuggestionsPageType.NONE
+        isSmart = false
     }
 
     private fun parsePageTypeSignals(pageContextJson: JSONObject): PageTypeSignals? {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
@@ -86,11 +86,13 @@ class ContextualSuggestionsViewModel @Inject constructor(
     fun onPageContextUpdated(serializedPageContext: String) {
         val json = runCatching { JSONObject(serializedPageContext) }.getOrNull() ?: return
         if (json.optString("title").isBlank() || json.optString("content").isBlank()) return
+        val pageTypeSignals = parsePageTypeSignals(json)
+        pageType = ContextualSuggestionsMatcher.classifyPageType(pageTypeSignals)
         loadJob?.cancel()
         loadJob = viewModelScope.launch {
             resolve(
                 url = json.optString("url").takeIf { it.isNotBlank() },
-                pageTypeSignals = parsePageTypeSignals(json),
+                pageTypeSignals = pageTypeSignals,
             )
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
@@ -81,7 +81,7 @@ class ContextualSuggestionsViewModel @Inject constructor(
         duckChatPixels.reportContextualSuggestionSelected(suggestionId, pageType.pixelValue)
     }
 
-    fun pageTypePixelValue(): String = pageType.pixelValue
+    fun currentPageType(): SuggestionsPageType = pageType
 
     fun onPageContextUpdated(serializedPageContext: String) {
         val json = runCatching { JSONObject(serializedPageContext) }.getOrNull() ?: return

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
@@ -62,12 +62,12 @@ class ContextualSuggestionsViewModel @Inject constructor(
 
     fun load() {
         loadJob?.cancel()
+        suggestionsVisible = false
         loadJob = viewModelScope.launch {
             if (!suggestionsEnabled()) {
                 hideSuggestions()
                 return@launch
             }
-            suggestionsVisible = false
             _viewState.value = ViewState(suggestions = emptyList(), loading = true)
             delay(TIMEOUT_MS)
             if (_viewState.value.loading) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModel.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,6 +40,7 @@ class ContextualSuggestionsViewModel @Inject constructor(
     private val suggestedPromptsProvider: ContextualSuggestedPromptsProvider,
     private val duckChatFeature: DuckChatFeature,
     private val dispatchers: DispatcherProvider,
+    private val duckChatPixels: DuckChatPixels,
 ) : ViewModel() {
 
     data class ViewState(
@@ -54,27 +56,38 @@ class ContextualSuggestionsViewModel @Inject constructor(
     private var maxSuggestedPrompts: Int = 1
     private var prioritySuggestionIds: Set<String> = emptySet()
     private var reservedQuickActionSlots: Int = 0
+    private var pageType: SuggestionsPageType = SuggestionsPageType.NONE
+    private var isSmart: Boolean = false
+    private var suggestionsVisible = false
 
     fun load() {
         loadJob?.cancel()
         loadJob = viewModelScope.launch {
-            val enabled = withContext(dispatchers.io()) { duckChatFeature.contextualSuggestedPrompts().isEnabled() }
-            if (!enabled) {
-                _viewState.value = ViewState(suggestions = emptyList(), loading = false)
+            if (!suggestionsEnabled()) {
+                hideSuggestions()
                 return@launch
             }
+            suggestionsVisible = false
             _viewState.value = ViewState(suggestions = emptyList(), loading = true)
             delay(TIMEOUT_MS)
             if (_viewState.value.loading) {
+                duckChatPixels.reportContextualSuggestionsContextCollectionTimedOut()
                 resolve(url = null, pageTypeSignals = null)
             }
         }
     }
 
+    fun onSuggestionSelected(suggestionId: String) {
+        duckChatPixels.reportContextualSuggestionSelected(suggestionId, pageType.pixelValue)
+    }
+
+    fun pageTypePixelValue(): String = pageType.pixelValue
+
     fun onPageContextUpdated(serializedPageContext: String) {
         val json = runCatching { JSONObject(serializedPageContext) }.getOrNull() ?: return
         if (json.optString("title").isBlank() || json.optString("content").isBlank()) return
-        viewModelScope.launch {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
             resolve(
                 url = json.optString("url").takeIf { it.isNotBlank() },
                 pageTypeSignals = parsePageTypeSignals(json),
@@ -85,7 +98,7 @@ class ContextualSuggestionsViewModel @Inject constructor(
     fun clear() {
         loadJob?.cancel()
         resolvedSuggestions = emptyList()
-        _viewState.value = ViewState(suggestions = emptyList(), loading = false)
+        hideSuggestions()
     }
 
     fun onReservedQuickActionSlotsChanged(count: Int) {
@@ -107,11 +120,21 @@ class ContextualSuggestionsViewModel @Inject constructor(
         url: String?,
         pageTypeSignals: PageTypeSignals?,
     ) {
-        val enabled = withContext(dispatchers.io()) { duckChatFeature.contextualSuggestedPrompts().isEnabled() }
-        if (!enabled) {
-            _viewState.value = ViewState(suggestions = emptyList(), loading = false)
+        if (!suggestionsEnabled()) {
+            hideSuggestions()
             return
         }
+        fetchSuggestions(url, pageTypeSignals)
+        showSuggestions()
+    }
+
+    private suspend fun suggestionsEnabled(): Boolean =
+        withContext(dispatchers.io()) { duckChatFeature.contextualSuggestedPrompts().isEnabled() }
+
+    private suspend fun fetchSuggestions(
+        url: String?,
+        pageTypeSignals: PageTypeSignals?,
+    ) {
         val input = ResolvePageSuggestionsInput(
             pageTypeSignals = pageTypeSignals,
             url = url,
@@ -120,8 +143,25 @@ class ContextualSuggestionsViewModel @Inject constructor(
         val resolved = suggestedPromptsProvider.resolveSuggestions(input)
         maxSuggestedPrompts = suggestedPromptsProvider.maxSuggestedPrompts()
         prioritySuggestionIds = suggestedPromptsProvider.prioritySuggestionIds()
-        resolvedSuggestions = resolved
-        _viewState.value = ViewState(suggestions = visibleSuggestions(), loading = false)
+        resolvedSuggestions = resolved.suggestions
+        pageType = resolved.pageType
+        isSmart = resolved.isSmart
+    }
+
+    private fun showSuggestions() {
+        val suggestions = visibleSuggestions()
+        _viewState.value = ViewState(suggestions = suggestions, loading = false)
+        if (suggestions.isEmpty()) {
+            suggestionsVisible = false
+        } else if (!suggestionsVisible) {
+            suggestionsVisible = true
+            duckChatPixels.reportContextualSuggestionsViewed(isSmart, pageType.pixelValue)
+        }
+    }
+
+    private fun hideSuggestions() {
+        suggestionsVisible = false
+        _viewState.value = ViewState(suggestions = emptyList(), loading = false)
     }
 
     private fun parsePageTypeSignals(pageContextJson: JSONObject): PageTypeSignals? {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -164,6 +164,11 @@ interface DuckChatPixels {
     fun reportContextualPageContextInvalidNoTitle()
     fun reportContextualPageContextInvalidNoContent()
 
+    fun reportContextualSuggestionSelected(suggestionId: String, pageType: String)
+    fun reportContextualSuggestionsViewed(isSmart: Boolean, pageType: String)
+    fun reportContextualSuggestionsContextCollectionTimedOut()
+    fun reportContextualSuggestionsCatalogLoadFailed()
+
     fun reportContextualFireButtonTapped()
     fun reportContextualFireButtonConfirmed()
 
@@ -265,6 +270,48 @@ class RealDuckChatPixels @Inject constructor(
 
     private fun surfaceParams(surface: DuckChatPixelSurface): Map<String, String> =
         mapOf(DuckChatPixelParameters.SURFACE to surface.value)
+
+    override fun reportContextualSuggestionSelected(
+        suggestionId: String,
+        pageType: String,
+    ) {
+        fireCountAndDaily(
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTION_SELECTED_COUNT,
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTION_SELECTED_DAILY,
+            mapOf(
+                DuckChatPixelParameters.SUGGESTION_ID to suggestionId,
+                DuckChatPixelParameters.PAGE_TYPE to pageType,
+            ),
+        )
+    }
+
+    override fun reportContextualSuggestionsViewed(
+        isSmart: Boolean,
+        pageType: String,
+    ) {
+        fireCountAndDaily(
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_VIEWED_COUNT,
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_VIEWED_DAILY,
+            mapOf(
+                DuckChatPixelParameters.IS_SMART to isSmart.toString(),
+                DuckChatPixelParameters.PAGE_TYPE to pageType,
+            ),
+        )
+    }
+
+    override fun reportContextualSuggestionsContextCollectionTimedOut() {
+        fireCountAndDaily(
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_TIMED_OUT_COUNT,
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_TIMED_OUT_DAILY,
+        )
+    }
+
+    override fun reportContextualSuggestionsCatalogLoadFailed() {
+        fireCountAndDaily(
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_CATALOG_LOAD_FAILED_COUNT,
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_CATALOG_LOAD_FAILED_DAILY,
+        )
+    }
 
     override fun sendReportMetricPixel(reportMetric: ReportMetric, modelTier: ModelTier?, source: String?) {
         appCoroutineScope.launch(dispatcherProvider.io()) {
@@ -1052,6 +1099,14 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SELECTED_DAILY("m_aichat_contextual_quick_action_ask_about_page_selected_daily"),
     DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SHOWN_COUNT("m_aichat_contextual_quick_action_ask_about_page_shown_count"),
     DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SHOWN_DAILY("m_aichat_contextual_quick_action_ask_about_page_shown_daily"),
+    DUCK_CHAT_CONTEXTUAL_SUGGESTION_SELECTED_COUNT("aichat_contextual_suggestion_selected_count"),
+    DUCK_CHAT_CONTEXTUAL_SUGGESTION_SELECTED_DAILY("aichat_contextual_suggestion_selected_daily"),
+    DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_VIEWED_COUNT("aichat_contextual_suggestions_viewed_count"),
+    DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_VIEWED_DAILY("aichat_contextual_suggestions_viewed_daily"),
+    DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_TIMED_OUT_COUNT("debug_aichat_contextual_suggestions_context_collection_timed_out_count"),
+    DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_TIMED_OUT_DAILY("debug_aichat_contextual_suggestions_context_collection_timed_out_daily"),
+    DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_CATALOG_LOAD_FAILED_COUNT("debug_aichat_contextual_suggestions_catalog_load_failed_count"),
+    DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_CATALOG_LOAD_FAILED_DAILY("debug_aichat_contextual_suggestions_catalog_load_failed_daily"),
     DUCK_CHAT_CONTEXTUAL_CHATS_BUTTON_TAPPED_COUNT("m_aichat_contextual_chats_button_tapped_count"),
     DUCK_CHAT_CONTEXTUAL_CHATS_BUTTON_TAPPED_DAILY("m_aichat_contextual_chats_button_tapped_daily"),
     DUCK_CHAT_CONTEXTUAL_RECENT_CHATS_POPUP_DISPLAYED_COUNT("m_aichat_contextual_recent_chats_popup_displayed_count"),
@@ -1208,6 +1263,9 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
 
 object DuckChatPixelParameters {
     const val WAS_USED_BEFORE = "was_used_before"
+    const val SUGGESTION_ID = "suggestionId"
+    const val PAGE_TYPE = "pageType"
+    const val IS_SMART = "isSmart"
     const val DELTA_TIMESTAMP_PARAMETERS = "delta-timestamp-minutes"
     const val INPUT_SCREEN_MODE = "mode"
     const val TEXT_LENGTH_BUCKET = "text_length_bucket"
@@ -1375,6 +1433,14 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PROMPT_SUBMITTED_WITHOUT_CONTEXT_NATIVE_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PROMPT_SUBMITTED_WITHOUT_CONTEXT_NATIVE_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_COLLECTION_EMPTY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTION_SELECTED_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTION_SELECTED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_VIEWED_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_VIEWED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_TIMED_OUT_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_TIMED_OUT_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_CATALOG_LOAD_FAILED_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_CATALOG_LOAD_FAILED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SETTING_AUTOMATIC_PAGE_CONTENT_ENABLED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SETTING_AUTOMATIC_PAGE_CONTENT_ENABLED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SETTING_AUTOMATIC_PAGE_CONTENT_DISABLED_COUNT.pixelName to PixelParameter.removeAtb(),

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -166,6 +166,7 @@ interface DuckChatPixels {
 
     fun reportContextualSuggestionSelected(suggestionId: String, pageType: String)
     fun reportContextualSuggestionsViewed(isSmart: Boolean, pageType: String)
+    fun reportContextualAskAboutPageSuggestionSelected(pageType: String)
     fun reportContextualSuggestionsContextCollectionTimedOut()
     fun reportContextualSuggestionsCatalogLoadFailed()
 
@@ -297,6 +298,10 @@ class RealDuckChatPixels @Inject constructor(
                 DuckChatPixelParameters.PAGE_TYPE to pageType,
             ),
         )
+    }
+
+    override fun reportContextualAskAboutPageSuggestionSelected(pageType: String) {
+        reportContextualSuggestionSelected("ask-about-page", pageType)
     }
 
     override fun reportContextualSuggestionsContextCollectionTimedOut() {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -52,6 +52,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -962,6 +963,53 @@ class DuckChatContextualViewModelTest {
         testee.onQuickActionClicked("") // SUBMIT_SUMMARIZE click -> fires summarize pixel
 
         verify(duckChatPixels).reportContextualSummarizePromptSelected()
+    }
+
+    @Test
+    fun `when ask about page quick action clicked with suggestions enabled then suggestion selected pixel fired alongside legacy pixel`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
+        testee.onPageContextReceived("tab-1", pageContext)
+
+        testee.onQuickActionClicked("", suggestionsPageType = "article")
+
+        verify(duckChatPixels).reportContextualAskAboutPageSelected()
+        verify(duckChatPixels).reportContextualAskAboutPageSuggestionSelected("article")
+    }
+
+    @Test
+    fun `when ask about page quick action clicked with suggestions disabled then suggestion selected pixel not fired`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(contextualSuggestedPromptsToggle.isEnabled()).thenReturn(false)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
+        testee.onPageContextReceived("tab-1", pageContext)
+
+        testee.onQuickActionClicked("")
+
+        verify(duckChatPixels).reportContextualAskAboutPageSelected()
+        verify(duckChatPixels, never()).reportContextualAskAboutPageSuggestionSelected(any())
+    }
+
+    @Test
+    fun `when ask about page quick action clicked without valid context then neither selected pixel fired`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onQuickActionClicked("")
+
+        verify(duckChatPixels, never()).reportContextualAskAboutPageSelected()
+        verify(duckChatPixels, never()).reportContextualAskAboutPageSuggestionSelected(any())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -968,7 +968,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when ask about page quick action clicked with suggestions enabled then suggestion selected pixel fired alongside legacy pixel`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
@@ -984,7 +983,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when ask about page quick action clicked with suggestions disabled then suggestion selected pixel not fired`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(contextualSuggestedPromptsToggle.isEnabled()).thenReturn(false)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
@@ -1001,7 +999,6 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when ask about page quick action clicked without valid context then neither selected pixel fired`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.contextual.suggestions.ContextualSuggestedPrompt
+import com.duckduckgo.duckchat.impl.contextual.suggestions.SuggestionsPageType
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.helper.NativeAction
@@ -975,7 +976,7 @@ class DuckChatContextualViewModelTest {
         val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
         testee.onPageContextReceived("tab-1", pageContext)
 
-        testee.onQuickActionClicked("", suggestionsPageType = "article")
+        testee.onQuickActionClicked("", suggestionsPageType = SuggestionsPageType.ARTICLE)
 
         verify(duckChatPixels).reportContextualAskAboutPageSelected()
         verify(duckChatPixels).reportContextualAskAboutPageSuggestionSelected("article")

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsMatcherTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsMatcherTest.kt
@@ -80,14 +80,14 @@ class ContextualSuggestionsMatcherTest {
 
     @Test
     fun whenJsonLdTypeMatchesThenReturnsThoseSuggestionsFirst() {
-        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), catalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), catalog).suggestions
 
         assertEquals(listOf("shopping-list", "recipe-nutrition", "scale-recipe"), result.map { it.id })
     }
 
     @Test
     fun whenPageSpecificMatchThenSummarizePageDroppedFromDefaults() {
-        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Product")), catalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Product")), catalog).suggestions
 
         assertEquals(listOf("product-pros-cons", "find-alternatives"), result.map { it.id })
         assertFalse(result.any { it.id == "summarize-page" })
@@ -95,28 +95,28 @@ class ContextualSuggestionsMatcherTest {
 
     @Test
     fun whenJsonLdTypeMatchIsCaseInsensitiveThenMatches() {
-        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("  rEcIpE ")), catalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("  rEcIpE ")), catalog).suggestions
 
         assertEquals(listOf("shopping-list", "recipe-nutrition", "scale-recipe"), result.map { it.id })
     }
 
     @Test
     fun whenMultipleJsonLdTypesPresentThenFirstCatalogMappingWins() {
-        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Product", "Recipe")), catalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Product", "Recipe")), catalog).suggestions
 
         assertEquals(listOf("shopping-list", "recipe-nutrition", "scale-recipe"), result.map { it.id })
     }
 
     @Test
     fun whenNoJsonLdMatchButOgTypeMatchesThenUsesOgType() {
-        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Unknown"), ogType = "product"), catalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Unknown"), ogType = "product"), catalog).suggestions
 
         assertEquals(listOf("product-pros-cons", "find-alternatives"), result.map { it.id })
     }
 
     @Test
     fun whenOgTypeHasWhitespaceAndCaseThenNormalisedBeforeLookup() {
-        val result = ContextualSuggestionsMatcher.resolve(input(ogType = " VIDEO "), catalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(ogType = " VIDEO "), catalog).suggestions
 
         assertEquals(listOf("summarize-video", "video-key-points"), result.map { it.id })
     }
@@ -126,14 +126,14 @@ class ContextualSuggestionsMatcherTest {
         val result = ContextualSuggestionsMatcher.resolve(
             input(noSignals = true, url = "https://www.youtube.com/watch?v=abc"),
             catalog,
-        )
+        ).suggestions
 
         assertEquals(listOf("summarize-video", "video-key-points"), result.map { it.id })
     }
 
     @Test
     fun whenDomainIsExactHostThenMatches() {
-        val result = ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = "https://github.com/duckduckgo"), catalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = "https://github.com/duckduckgo"), catalog).suggestions
 
         assertEquals(listOf("explain-repo"), result.map { it.id })
     }
@@ -143,7 +143,7 @@ class ContextualSuggestionsMatcherTest {
         val result = ContextualSuggestionsMatcher.resolve(
             input(jsonLdType = listOf("Recipe"), url = "https://www.youtube.com/watch?v=abc"),
             catalog,
-        )
+        ).suggestions
 
         assertEquals(listOf("shopping-list", "recipe-nutrition", "scale-recipe"), result.map { it.id })
     }
@@ -153,14 +153,14 @@ class ContextualSuggestionsMatcherTest {
         val result = ContextualSuggestionsMatcher.resolve(
             input(jsonLdType = listOf("Unknown"), url = "https://example.com"),
             catalog,
-        )
+        ).suggestions
 
         assertEquals(listOf("summarize-page"), result.map { it.id })
     }
 
     @Test
     fun whenNoSignalsAndNoUrlThenReturnsDefaults() {
-        val result = ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = null), catalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = null), catalog).suggestions
 
         assertEquals(listOf("summarize-page"), result.map { it.id })
     }
@@ -169,7 +169,7 @@ class ContextualSuggestionsMatcherTest {
     fun whenCandidateAlsoInDefaultsThenDeduplicated() {
         val recipeThenSummarizeCatalog = catalog.copy(defaults = listOf("shopping-list", "summarize-page"))
 
-        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), recipeThenSummarizeCatalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), recipeThenSummarizeCatalog).suggestions
 
         assertEquals(1, result.count { it.id == "shopping-list" })
     }
@@ -178,7 +178,7 @@ class ContextualSuggestionsMatcherTest {
     fun whenMoreCandidatesThanMaxThenCappedAtMax() {
         val cappedCatalog = catalog.copy(maxSuggestedPrompts = 2)
 
-        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), cappedCatalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), cappedCatalog).suggestions
 
         assertEquals(2, result.size)
         assertEquals(listOf("shopping-list", "recipe-nutrition"), result.map { it.id })
@@ -189,7 +189,7 @@ class ContextualSuggestionsMatcherTest {
         val result = ContextualSuggestionsMatcher.resolve(
             input(noSignals = false, jsonLdType = listOf("Unknown"), lang = "fr", uiLocale = "en-US"),
             catalog,
-        )
+        ).suggestions
 
         assertTrue(result.any { it.id == "translate-page" })
     }
@@ -199,7 +199,7 @@ class ContextualSuggestionsMatcherTest {
         val result = ContextualSuggestionsMatcher.resolve(
             input(jsonLdType = listOf("Unknown"), lang = "en", uiLocale = "en-US"),
             catalog,
-        )
+        ).suggestions
 
         assertFalse(result.any { it.id == "translate-page" })
     }
@@ -209,7 +209,7 @@ class ContextualSuggestionsMatcherTest {
         val result = ContextualSuggestionsMatcher.resolve(
             input(jsonLdType = listOf("Unknown"), lang = "en-GB", uiLocale = "en_US"),
             catalog,
-        )
+        ).suggestions
 
         assertFalse(result.any { it.id == "translate-page" })
     }
@@ -219,7 +219,7 @@ class ContextualSuggestionsMatcherTest {
         val result = ContextualSuggestionsMatcher.resolve(
             input(jsonLdType = listOf("Unknown"), lang = "", uiLocale = "en-US"),
             catalog,
-        )
+        ).suggestions
 
         assertFalse(result.any { it.id == "translate-page" })
     }
@@ -240,7 +240,7 @@ class ContextualSuggestionsMatcherTest {
         val result = ContextualSuggestionsMatcher.resolve(
             input(jsonLdType = listOf("Article"), lang = "fr", uiLocale = "en-US"),
             articleCatalog,
-        )
+        ).suggestions
 
         assertEquals(listOf("a1", "a2", "a3", "translate-page"), result.map { it.id })
     }
@@ -250,7 +250,7 @@ class ContextualSuggestionsMatcherTest {
         val result = ContextualSuggestionsMatcher.resolve(
             input(jsonLdType = listOf("Unknown"), lang = "de", uiLocale = "en-US"),
             catalog,
-        )
+        ).suggestions
 
         val translate = result.first { it.id == "translate-page" }
         assertEquals("Translate this page into English.", translate.prompt)
@@ -266,14 +266,14 @@ class ContextualSuggestionsMatcherTest {
 
     @Test
     fun whenPromptHasNoPlaceholderThenLeftUnchanged() {
-        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), catalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), catalog).suggestions
 
         assertEquals("Create a shopping list.", result.first { it.id == "shopping-list" }.prompt)
     }
 
     @Test
     fun whenEntryResolvedThenLabelAndIconCarriedThrough() {
-        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("VideoObject")), catalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("VideoObject")), catalog).suggestions
 
         val video = result.first { it.id == "summarize-video" }
         assertEquals("Summarize this video", video.label)
@@ -282,7 +282,7 @@ class ContextualSuggestionsMatcherTest {
 
     @Test
     fun whenHostnameMerelyEndsWithDomainTextThenDoesNotMatch() {
-        val result = ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = "https://notgithub.com/duckduckgo"), catalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = "https://notgithub.com/duckduckgo"), catalog).suggestions
 
         assertEquals(listOf("summarize-page"), result.map { it.id })
     }
@@ -294,7 +294,7 @@ class ContextualSuggestionsMatcherTest {
             byJsonLdType = listOf(SuggestionCatalog.JsonLdMapping("Recipe", listOf("future", "shopping-list"))),
         )
 
-        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), futureCatalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), futureCatalog).suggestions
 
         assertFalse(result.any { it.id == "future" })
         assertTrue(result.any { it.id == "shopping-list" })
@@ -306,7 +306,7 @@ class ContextualSuggestionsMatcherTest {
             byJsonLdType = listOf(SuggestionCatalog.JsonLdMapping("Recipe", listOf("missing-id", "shopping-list"))),
         )
 
-        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), danglingCatalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), danglingCatalog).suggestions
 
         assertFalse(result.any { it.id == "missing-id" })
         assertTrue(result.any { it.id == "shopping-list" })
@@ -314,7 +314,7 @@ class ContextualSuggestionsMatcherTest {
 
     @Test
     fun whenUrlIsMalformedThenFallsBackToDefaults() {
-        val result = ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = "not a url ://"), catalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = "not a url ://"), catalog).suggestions
 
         assertEquals(listOf("summarize-page"), result.map { it.id })
     }
@@ -324,7 +324,7 @@ class ContextualSuggestionsMatcherTest {
         val result = ContextualSuggestionsMatcher.resolve(
             input(jsonLdType = listOf("Unknown"), ogType = "", url = "https://github.com/duckduckgo"),
             catalog,
-        )
+        ).suggestions
 
         assertEquals(listOf("explain-repo"), result.map { it.id })
     }
@@ -333,7 +333,7 @@ class ContextualSuggestionsMatcherTest {
     fun whenMaxSuggestedPromptsIsZeroThenAtLeastOneSuggestionIsReturned() {
         val zeroCapCatalog = catalog.copy(maxSuggestedPrompts = 0)
 
-        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), zeroCapCatalog)
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), zeroCapCatalog).suggestions
 
         assertEquals(listOf("shopping-list"), result.map { it.id })
     }
@@ -343,7 +343,7 @@ class ContextualSuggestionsMatcherTest {
         val result = ContextualSuggestionsMatcher.resolve(
             input(jsonLdType = listOf("Unknown"), lang = "fr", uiLocale = "en-US"),
             catalog,
-        )
+        ).suggestions
 
         assertEquals(listOf("summarize-page", "translate-page"), result.map { it.id })
     }
@@ -353,9 +353,49 @@ class ContextualSuggestionsMatcherTest {
         val result = ContextualSuggestionsMatcher.resolve(
             input(jsonLdType = listOf("Unknown"), lang = "en", uiLocale = "de-DE"),
             catalog,
-        )
+        ).suggestions
 
         val translate = result.first { it.id == "translate-page" }
         assertEquals("Translate this page into Deutsch.", translate.prompt)
+    }
+
+    @Test
+    fun whenContextualMatchThenResultIsSmart() {
+        assertTrue(ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Recipe")), catalog).isSmart)
+        assertTrue(ContextualSuggestionsMatcher.resolve(input(ogType = "product"), catalog).isSmart)
+        assertTrue(ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = "https://github.com/duckduckgo"), catalog).isSmart)
+    }
+
+    @Test
+    fun whenOnlyDefaultsMatchThenResultIsNotSmart() {
+        assertFalse(ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Unknown"), url = "https://example.com"), catalog).isSmart)
+        assertFalse(ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = null), catalog).isSmart)
+    }
+
+    @Test
+    fun whenJsonLdTypeKnownThenPageTypeClassifiedInSignalOrder() {
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Unknown", " NewsArticle ", "Recipe")), catalog)
+
+        assertEquals(SuggestionsPageType.ARTICLE, result.pageType)
+    }
+
+    @Test
+    fun whenNoJsonLdMatchThenPageTypeFallsBackToOgType() {
+        val result = ContextualSuggestionsMatcher.resolve(input(jsonLdType = listOf("Unknown"), ogType = "video.movie"), catalog)
+
+        assertEquals(SuggestionsPageType.VIDEO, result.pageType)
+    }
+
+    @Test
+    fun whenDomainOnlyMatchThenPageTypeIsNone() {
+        val result = ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = "https://www.youtube.com/watch?v=abc"), catalog)
+
+        assertTrue(result.isSmart)
+        assertEquals(SuggestionsPageType.NONE, result.pageType)
+    }
+
+    @Test
+    fun whenNoSignalsThenPageTypeIsNone() {
+        assertEquals(SuggestionsPageType.NONE, ContextualSuggestionsMatcher.resolve(input(noSignals = true, url = null), catalog).pageType)
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
@@ -340,7 +340,7 @@ class ContextualSuggestionsViewModelTest {
         )
         coroutineRule.testDispatcher.scheduler.runCurrent()
 
-        assertEquals("recipe", viewModel.pageTypePixelValue())
+        assertEquals(SuggestionsPageType.RECIPE, viewModel.currentPageType())
         gate.complete(Unit)
     }
 
@@ -349,11 +349,11 @@ class ContextualSuggestionsViewModelTest {
         val tailored = ContextualSuggestedPrompt("shopping-list", "Generate a shopping list", "Create a shopping list.", null)
         stubProvider(listOf(tailored), isSmart = true, pageType = SuggestionsPageType.RECIPE)
         viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
-        assertEquals("recipe", viewModel.pageTypePixelValue())
+        assertEquals(SuggestionsPageType.RECIPE, viewModel.currentPageType())
 
         viewModel.clear()
 
-        assertEquals("none", viewModel.pageTypePixelValue())
+        assertEquals(SuggestionsPageType.NONE, viewModel.currentPageType())
     }
 
     @Test
@@ -361,12 +361,12 @@ class ContextualSuggestionsViewModelTest {
         val tailored = ContextualSuggestedPrompt("shopping-list", "Generate a shopping list", "Create a shopping list.", null)
         stubProvider(listOf(tailored), isSmart = true, pageType = SuggestionsPageType.RECIPE)
         viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
-        assertEquals("recipe", viewModel.pageTypePixelValue())
+        assertEquals(SuggestionsPageType.RECIPE, viewModel.currentPageType())
 
         viewModel.load()
         coroutineRule.testDispatcher.scheduler.runCurrent()
 
-        assertEquals("none", viewModel.pageTypePixelValue())
+        assertEquals(SuggestionsPageType.NONE, viewModel.currentPageType())
     }
 
     @Test
@@ -440,6 +440,6 @@ class ContextualSuggestionsViewModelTest {
 
         viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
 
-        assertEquals("recipe", viewModel.pageTypePixelValue())
+        assertEquals(SuggestionsPageType.RECIPE, viewModel.currentPageType())
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -32,6 +33,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -322,6 +324,24 @@ class ContextualSuggestionsViewModelTest {
         viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com/2","content":"c"}""")
 
         verify(duckChatPixels, times(1)).reportContextualSuggestionsViewed(true, "recipe")
+    }
+
+    @Test
+    fun `when page context arrives then page type is reported before suggestions finish resolving`() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        whenever(suggestedPromptsProvider.resolveSuggestions(any())).doSuspendableAnswer {
+            gate.await()
+            ResolvedPageSuggestions(emptyList(), isSmart = true, pageType = SuggestionsPageType.RECIPE)
+        }
+
+        viewModel.load()
+        viewModel.onPageContextUpdated(
+            """{"title":"T","url":"https://example.com","content":"c","pageTypeSignals":{"jsonLdType":["Recipe"],"lang":"en"}}""",
+        )
+        coroutineRule.testDispatcher.scheduler.runCurrent()
+
+        assertEquals("recipe", viewModel.pageTypePixelValue())
+        gate.complete(Unit)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
@@ -325,6 +325,20 @@ class ContextualSuggestionsViewModelTest {
     }
 
     @Test
+    fun `when sheet reopened then viewed pixel fires a fresh impression even if page context wins the race`() = runTest {
+        val tailored = ContextualSuggestedPrompt("shopping-list", "Generate a shopping list", "Create a shopping list.", null)
+        stubProvider(listOf(tailored), isSmart = true, pageType = SuggestionsPageType.RECIPE)
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.load()
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatPixels, times(2)).reportContextualSuggestionsViewed(true, "recipe")
+    }
+
+    @Test
     fun `when suggestions cleared and shown again then viewed pixel fires a fresh impression`() = runTest {
         val tailored = ContextualSuggestedPrompt("shopping-list", "Generate a shopping list", "Create a shopping list.", null)
         stubProvider(listOf(tailored), isSmart = true, pageType = SuggestionsPageType.RECIPE)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.duckchat.impl.contextual.suggestions
 
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -45,11 +46,13 @@ class ContextualSuggestionsViewModelTest {
     private val suggestedPromptsProvider: ContextualSuggestedPromptsProvider = mock()
     private val duckChatFeature: DuckChatFeature = mock()
     private val suggestedPromptsToggle: Toggle = mock()
+    private val duckChatPixels: DuckChatPixels = mock()
 
     private val viewModel = ContextualSuggestionsViewModel(
         suggestedPromptsProvider = suggestedPromptsProvider,
         duckChatFeature = duckChatFeature,
         dispatchers = coroutineRule.testDispatcherProvider,
+        duckChatPixels = duckChatPixels,
     )
 
     @Before
@@ -63,8 +66,13 @@ class ContextualSuggestionsViewModelTest {
         }
     }
 
-    private suspend fun stubProvider(result: List<ContextualSuggestedPrompt>) {
-        whenever(suggestedPromptsProvider.resolveSuggestions(any())).thenReturn(result)
+    private suspend fun stubProvider(
+        result: List<ContextualSuggestedPrompt>,
+        isSmart: Boolean = false,
+        pageType: SuggestionsPageType = SuggestionsPageType.NONE,
+    ) {
+        whenever(suggestedPromptsProvider.resolveSuggestions(any()))
+            .thenReturn(ResolvedPageSuggestions(suggestions = result, isSmart = isSmart, pageType = pageType))
     }
 
     @Test
@@ -290,5 +298,89 @@ class ContextualSuggestionsViewModelTest {
 
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
         assertFalse(viewModel.viewState.value.loading)
+    }
+
+    @Test
+    fun `when suggestions become visible then viewed pixel fired once with smartness and page type`() = runTest {
+        val tailored = ContextualSuggestedPrompt("shopping-list", "Generate a shopping list", "Create a shopping list.", null)
+        stubProvider(listOf(tailored), isSmart = true, pageType = SuggestionsPageType.RECIPE)
+
+        viewModel.load()
+        coroutineRule.testDispatcher.scheduler.runCurrent()
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatPixels).reportContextualSuggestionsViewed(true, "recipe")
+    }
+
+    @Test
+    fun `when suggestions stay visible across a re-resolve then viewed pixel not fired again`() = runTest {
+        val tailored = ContextualSuggestedPrompt("shopping-list", "Generate a shopping list", "Create a shopping list.", null)
+        stubProvider(listOf(tailored), isSmart = true, pageType = SuggestionsPageType.RECIPE)
+
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com/2","content":"c"}""")
+
+        verify(duckChatPixels, times(1)).reportContextualSuggestionsViewed(true, "recipe")
+    }
+
+    @Test
+    fun `when suggestions cleared and shown again then viewed pixel fires a fresh impression`() = runTest {
+        val tailored = ContextualSuggestedPrompt("shopping-list", "Generate a shopping list", "Create a shopping list.", null)
+        stubProvider(listOf(tailored), isSmart = true, pageType = SuggestionsPageType.RECIPE)
+
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+        viewModel.clear()
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+
+        verify(duckChatPixels, times(2)).reportContextualSuggestionsViewed(true, "recipe")
+    }
+
+    @Test
+    fun `when resolve returns no suggestions then viewed pixel not fired`() = runTest {
+        stubProvider(emptyList())
+
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+
+        verify(duckChatPixels, never()).reportContextualSuggestionsViewed(any(), any())
+    }
+
+    @Test
+    fun `when load times out without page context then timed out pixel fired`() = runTest {
+        viewModel.load()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatPixels).reportContextualSuggestionsContextCollectionTimedOut()
+    }
+
+    @Test
+    fun `when page context arrives before timeout then timed out pixel not fired`() = runTest {
+        viewModel.load()
+        coroutineRule.testDispatcher.scheduler.runCurrent()
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatPixels, never()).reportContextualSuggestionsContextCollectionTimedOut()
+    }
+
+    @Test
+    fun `when suggestion selected then selected pixel fired with suggestion id and page type`() = runTest {
+        val tailored = ContextualSuggestedPrompt("summarize-video", "Summarize this video", "Summarize this video.", "summary")
+        stubProvider(listOf(tailored), isSmart = true, pageType = SuggestionsPageType.VIDEO)
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+
+        viewModel.onSuggestionSelected("summarize-video")
+
+        verify(duckChatPixels).reportContextualSuggestionSelected("summarize-video", "video")
+    }
+
+    @Test
+    fun `when suggestions resolved then page type pixel value reflects the resolved page type`() = runTest {
+        val tailored = ContextualSuggestedPrompt("shopping-list", "Generate a shopping list", "Create a shopping list.", null)
+        stubProvider(listOf(tailored), isSmart = true, pageType = SuggestionsPageType.RECIPE)
+
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+
+        assertEquals("recipe", viewModel.pageTypePixelValue())
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsViewModelTest.kt
@@ -325,6 +325,31 @@ class ContextualSuggestionsViewModelTest {
     }
 
     @Test
+    fun `when suggestions cleared then page type no longer reports the previous page`() = runTest {
+        val tailored = ContextualSuggestedPrompt("shopping-list", "Generate a shopping list", "Create a shopping list.", null)
+        stubProvider(listOf(tailored), isSmart = true, pageType = SuggestionsPageType.RECIPE)
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+        assertEquals("recipe", viewModel.pageTypePixelValue())
+
+        viewModel.clear()
+
+        assertEquals("none", viewModel.pageTypePixelValue())
+    }
+
+    @Test
+    fun `when a new load starts then page type no longer reports the previous page`() = runTest {
+        val tailored = ContextualSuggestedPrompt("shopping-list", "Generate a shopping list", "Create a shopping list.", null)
+        stubProvider(listOf(tailored), isSmart = true, pageType = SuggestionsPageType.RECIPE)
+        viewModel.onPageContextUpdated("""{"title":"T","url":"https://example.com","content":"c"}""")
+        assertEquals("recipe", viewModel.pageTypePixelValue())
+
+        viewModel.load()
+        coroutineRule.testDispatcher.scheduler.runCurrent()
+
+        assertEquals("none", viewModel.pageTypePixelValue())
+    }
+
+    @Test
     fun `when sheet reopened then viewed pixel fires a fresh impression even if page context wins the race`() = runTest {
         val tailored = ContextualSuggestedPrompt("shopping-list", "Generate a shopping list", "Create a shopping list.", null)
         stubProvider(listOf(tailored), isSmart = true, pageType = SuggestionsPageType.RECIPE)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/RealContextualSuggestedPromptsProviderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/RealContextualSuggestedPromptsProviderTest.kt
@@ -125,7 +125,7 @@ class RealContextualSuggestedPromptsProviderTest {
             ),
         )
 
-        val translate = result.first { it.id == "translate-page" }
+        val translate = result.suggestions.first { it.id == "translate-page" }
         assertEquals(context.getString(R.string.duckAiSuggestionTranslatePageLabel), translate.label)
         assertEquals("Translate this page into English.", translate.prompt)
     }
@@ -142,7 +142,7 @@ class RealContextualSuggestedPromptsProviderTest {
             ),
         )
 
-        val unknown = result.first { it.id == "unknown-id" }
+        val unknown = result.suggestions.first { it.id == "unknown-id" }
         assertEquals("Unknown", unknown.label)
         assertEquals("Unknown.", unknown.prompt)
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/RealContextualSuggestedPromptsProviderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/suggestions/RealContextualSuggestedPromptsProviderTest.kt
@@ -21,12 +21,17 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
 class RealContextualSuggestedPromptsProviderTest {
@@ -36,7 +41,9 @@ class RealContextualSuggestedPromptsProviderTest {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
 
-    private val provider = RealContextualSuggestedPromptsProvider(context, coroutineRule.testDispatcherProvider)
+    private val duckChatPixels: DuckChatPixels = mock()
+
+    private val provider = RealContextualSuggestedPromptsProvider(context, coroutineRule.testDispatcherProvider, duckChatPixels)
 
     @Test
     fun whenRealCatalogAndDomainMatchesThenResolvesPageSpecificSuggestions() = runTest {
@@ -46,7 +53,7 @@ class RealContextualSuggestedPromptsProviderTest {
                 url = "https://www.youtube.com/watch?v=abc",
                 uiLocale = "en-US",
             ),
-        )
+        ).suggestions
 
         assertEquals(listOf("summarize-video", "video-key-points"), result.map { it.id })
     }
@@ -59,7 +66,7 @@ class RealContextualSuggestedPromptsProviderTest {
                 url = "https://example.com/recipe",
                 uiLocale = "en-US",
             ),
-        )
+        ).suggestions
 
         assertEquals(listOf("shopping-list", "recipe-nutrition", "scale-recipe"), result.map { it.id })
     }
@@ -72,7 +79,7 @@ class RealContextualSuggestedPromptsProviderTest {
                 url = "https://example.com",
                 uiLocale = "en-US",
             ),
-        )
+        ).suggestions
 
         assertTrue(result.none { it.id == "summarize-page" })
         assertTrue(result.size <= 4)
@@ -86,7 +93,7 @@ class RealContextualSuggestedPromptsProviderTest {
                 url = "https://example.com",
                 uiLocale = "en-US",
             ),
-        )
+        ).suggestions
 
         val translate = result.first { it.id == "translate-page" }
         assertEquals("Translate this page into English.", translate.prompt)
@@ -150,8 +157,80 @@ class RealContextualSuggestedPromptsProviderTest {
                 url = "https://www.youtube.com/watch?v=abc",
                 uiLocale = "en-US",
             ),
-        )
+        ).suggestions
 
         assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun whenCatalogAssetMissingThenCatalogLoadFailedPixelFiredAndPageTypeStillClassified() = runTest {
+        provider.catalogAssetPath = "DoesNotExist.json"
+
+        val result = provider.resolveSuggestions(
+            ResolvePageSuggestionsInput(
+                pageTypeSignals = PageTypeSignals(jsonLdType = listOf("Recipe"), ogType = null, lang = "en"),
+                url = "https://example.com",
+                uiLocale = "en-US",
+            ),
+        )
+
+        verify(duckChatPixels).reportContextualSuggestionsCatalogLoadFailed()
+        assertFalse(result.isSmart)
+        assertEquals(SuggestionsPageType.RECIPE, result.pageType)
+    }
+
+    @Test
+    fun whenRealCatalogResolvesThenNoCatalogLoadFailedPixelFired() = runTest {
+        provider.resolveSuggestions(
+            ResolvePageSuggestionsInput(
+                pageTypeSignals = null,
+                url = "https://example.com",
+                uiLocale = "en-US",
+            ),
+        )
+
+        verify(duckChatPixels, never()).reportContextualSuggestionsCatalogLoadFailed()
+    }
+
+    @Test
+    fun whenRealCatalogAndJsonLdTypeMatchesThenSmartWithClassifiedPageType() = runTest {
+        val result = provider.resolveSuggestions(
+            ResolvePageSuggestionsInput(
+                pageTypeSignals = PageTypeSignals(jsonLdType = listOf("Recipe"), ogType = null, lang = "en"),
+                url = "https://example.com/recipe",
+                uiLocale = "en-US",
+            ),
+        )
+
+        assertTrue(result.isSmart)
+        assertEquals(SuggestionsPageType.RECIPE, result.pageType)
+    }
+
+    @Test
+    fun whenRealCatalogAndOnlyDomainMatchesThenSmartWithNonePageType() = runTest {
+        val result = provider.resolveSuggestions(
+            ResolvePageSuggestionsInput(
+                pageTypeSignals = null,
+                url = "https://www.youtube.com/watch?v=abc",
+                uiLocale = "en-US",
+            ),
+        )
+
+        assertTrue(result.isSmart)
+        assertEquals(SuggestionsPageType.NONE, result.pageType)
+    }
+
+    @Test
+    fun whenRealCatalogAndNothingMatchesThenNotSmartWithNonePageType() = runTest {
+        val result = provider.resolveSuggestions(
+            ResolvePageSuggestionsInput(
+                pageTypeSignals = null,
+                url = "https://example.com",
+                uiLocale = "en-US",
+            ),
+        )
+
+        assertFalse(result.isSmart)
+        assertEquals(SuggestionsPageType.NONE, result.pageType)
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -325,6 +325,17 @@ class RealDuckChatPixelsTest {
     }
 
     @Test
+    fun `when reportContextualAskAboutPageSuggestionSelected then fires selected pixel with the reserved id`() = runTest {
+        testee.reportContextualAskAboutPageSuggestionSelected("article")
+
+        advanceUntilIdle()
+
+        val params = mapOf("suggestionId" to "ask-about-page", "pageType" to "article")
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTION_SELECTED_COUNT, params)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTION_SELECTED_DAILY, params, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
     fun `when reportContextualSuggestionSelected then fires count and daily with suggestion id and page type`() = runTest {
         testee.reportContextualSuggestionSelected("summarize-video", "video")
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -325,6 +325,48 @@ class RealDuckChatPixelsTest {
     }
 
     @Test
+    fun `when reportContextualSuggestionSelected then fires count and daily with suggestion id and page type`() = runTest {
+        testee.reportContextualSuggestionSelected("summarize-video", "video")
+
+        advanceUntilIdle()
+
+        val params = mapOf("suggestionId" to "summarize-video", "pageType" to "video")
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTION_SELECTED_COUNT, params)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTION_SELECTED_DAILY, params, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `when reportContextualSuggestionsViewed then fires count and daily with smartness and page type`() = runTest {
+        testee.reportContextualSuggestionsViewed(isSmart = true, pageType = "recipe")
+
+        advanceUntilIdle()
+
+        val params = mapOf("isSmart" to "true", "pageType" to "recipe")
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_VIEWED_COUNT, params)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_VIEWED_DAILY, params, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `when reportContextualSuggestionsContextCollectionTimedOut then fires count and daily`() = runTest {
+        testee.reportContextualSuggestionsContextCollectionTimedOut()
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_TIMED_OUT_COUNT)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_TIMED_OUT_DAILY, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `when reportContextualSuggestionsCatalogLoadFailed then fires count and daily`() = runTest {
+        testee.reportContextualSuggestionsCatalogLoadFailed()
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_CATALOG_LOAD_FAILED_COUNT)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SUGGESTIONS_CATALOG_LOAD_FAILED_DAILY, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
     fun `when reportChatSyncActive then fires daily pixel`() {
         testee.reportChatSyncActive()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1217279121853562?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Adds the follwoing pixels for contextual suggestions:

1. `aichat_contextual_suggestion_selected` - Fired when a suggestion is tapped

params:
- `suggestionId` - The catalog id of the suggestion (e.g. "translate-page")
- `pageType` - A course bucket for the kind of page (e.g. "recipe”)

---

2. `aichat_contextual_suggestions_viewed` - Fired once when the suggestions become visible

params:
- `isSmart` - Indicates whether suggestions were matched to the page or are defaults
- `pageType` - A course bucket for the kind of page (e.g. "recipe”)

---

3. `debug_aichat_contextual_suggestions_context_collection_timed_out` - Fired when the page context hasn't arrived in 5 seconds

---

5. `debug_aichat_contextual_suggestions_catalog_load_failed` - Fired when the catalog fails to load

### Steps to test this PR

- [x] Go to a news article, recipe etc.
- [x] Open contextual
- [x] Verify `aichat_contextual_suggestions_viewed_count with params: {isSmart, pageType}` is sent (count + daily)
- [x] Hide contextual and open it again
- [x] Verify `aichat_contextual_suggestions_viewed_count with params: {isSmart, pageType}` is sent (count)
- [x] Tap a suggestion
- [x] Verify `aichat_contextual_suggestion_selected_count with params: {suggestionId, pageType}` is sent (count + daily)
- [x] Go to different site and tap a suggestion
- [x] Verify `aichat_contextual_suggestion_selected_count with params: {suggestionId, pageType}` is sent (count)
<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Analytics-only changes in Duck.ai contextual UI with no auth, payment, or data-pipeline modifications; behavioral tweak limits suggestion refresh to INPUT mode.
> 
> **Overview**
> Adds **analytics pixels** for contextual Duck.ai suggested prompts on the sheet start surface, plus the wiring to fire them from the suggestions pipeline.
> 
> **Pixel definitions** in `duck_chat.json5` cover suggestion taps (`aichat_contextual_suggestion_selected` with `suggestionId` and coarse `pageType`), impressions (`aichat_contextual_suggestions_viewed` with `isSmart` and `pageType`), and two debug/exception pixels for catalog load failure and page-context collection timeout.
> 
> **Matcher and provider** now return `ResolvedPageSuggestions` (suggestions, whether matching was contextual vs defaults, and `SuggestionsPageType` from JSON-LD/og:type) instead of a plain list. Catalog failure reports the debug pixel and still classifies page type from signals.
> 
> **ViewModel and UI** fire viewed once per continuous display (reset on clear/reopen), selected on tap, timeout on load delay, and when Ask About Page is used with suggestions enabled an additional selected event with `ask-about-page` alongside the legacy quick-action pixel. Page context updates to suggestions run only in INPUT sheet mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd7a95d1fce43d5fc1ba58082ad3e463db09445f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes and a small UX guard (INPUT-only suggestion refresh, clear on hide); no auth, payments, or data pipeline changes.
> 
> **Overview**
> Adds **analytics** for contextual Duck.ai suggested prompts on the sheet start surface, plus wiring from the suggestions pipeline into `DuckChatPixels`.
> 
> **Pixel definitions** (`duck_chat.json5`, `params_dictionary.json`) cover suggestion taps (`aichat_contextual_suggestion_selected` with `suggestionId` and coarse `pageType`), impressions (`aichat_contextual_suggestions_viewed` with `isSmart` and `pageType`), and two debug pixels for catalog load failure and page-context collection timeout.
> 
> **Matcher/provider** now return `ResolvedPageSuggestions` (suggestions list, contextual-vs-default `isSmart`, and `SuggestionsPageType` from JSON-LD/og:type) instead of a plain list. Catalog failure fires the debug pixel and still classifies `pageType` from signals.
> 
> **ViewModel/UI** fire viewed once per display (reset on clear/reopen), selected on tap, timeout after 5s without page context, and when Ask About Page is used with suggestions enabled an extra selected event with `ask-about-page` alongside the legacy quick-action pixel. Page context updates to suggestions run only when the sheet is visible and in INPUT mode; suggestions clear when the sheet is hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80ab3341a60f2582453c51b92ab000dcd38d680f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->