### PR TITLE
Test: verify CI Checks workflow triggers

### DIFF
--- a/.claude/hooks/android-gradle-quiet.sh
+++ b/.claude/hooks/android-gradle-quiet.sh
@@ -3,6 +3,7 @@
 # stays small enough for an agent to read. A deliberate log-level flag always wins.
 # No-ops silently if jq is missing, leaving the command untouched.
 set -uo pipefail
+# ci-trigger-test: jibberish, safe to ignore, will be removed
 
 input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,6 @@
+<!-- ci-trigger-test: jibberish line, safe to ignore, will be removed -->
+<!-- flibbertigibbet -->
+
 # CLAUDE.md — DuckDuckGo Android Browser
 
 DuckDuckGo Android is a privacy-focused browser built as a large multi-module Gradle project,


### PR DESCRIPTION
## Task/Issue URL
N/A — throwaway diagnostic PR

## Description
Adds a couple of jibberish comment lines to CLAUDE.md to check whether the `CI Checks` (ci.yml) workflow reliably fires a run on `pull_request` events. A prior PR (#9421) had a head commit with zero ci.yml runs against it. This PR isolates whether that was a one-off event-delivery miss or a repeatable issue.

Will be closed/reverted once confirmed either way.

## Steps to test
N/A

## UI changes
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only edits with no impact on app code, hooks logic, or CI configuration.
> 
> **Overview**
> Throwaway diagnostic change only: adds **temporary jibberish comments** (marked `ci-trigger-test`, intended to be removed) in `CLAUDE.md` and `.claude/hooks/android-gradle-quiet.sh`. No functional, build, or runtime behavior changes.
> 
> Purpose is to confirm whether the **CI Checks** (`ci.yml`) workflow runs on `pull_request` after a prior PR showed no run against its head commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e7a79afe01b4cfcf75a30acb0c859255dcce69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->