### PR TITLE
Skip CI checks for Claude tooling-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,12 @@ jobs:
             exit 0
           fi
           echo "Changed files:"; echo "$CHANGED"
-          if ([ -n "$CHANGED" ] && echo "$CHANGED" | grep -qvE '(\.md$|^\.github/)') || \
+          if ([ -n "$CHANGED" ] && echo "$CHANGED" | grep -qvE '(\.md$|^\.github/|^\.claude/)') || \
              echo "$CHANGED" | grep -qF '.github/workflows/ci.yml'; then
             echo "Code or required CI workflow changes detected — running checks"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Only docs or optional workflow changes detected — skipping checks"
+            echo "Only docs, Claude tooling, or optional workflow changes detected — skipping checks"
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214901934989258/task/1217285557727578?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

`check_changes` in `ci.yml` already skips the heavy check suite for `.md`-only and `.github/`-only diffs. Extends the same treatment to `.claude/` — agent config, docs, and hooks with no effect on the app build — so PRs that only touch Claude tooling don't run the full lint/unit-test/instrumentation suite.

### Steps to test this PR

_Diff detection_
- [ ] Push a commit touching only files under `.claude/` on a branch → `Check Changed Files` job logs "skipping checks", `Code Formatting`/`Android CI tests` report `skipped`, `Unit tests`/`Lint` (both DI matrix legs) still report `success`
- [ ] Push a commit touching both a `.claude/` file and a real source file → `should_run=true`, full suite runs

### UI changes
N/A — CI workflow change only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to path-based CI gating; no app code, auth, or data handling. Misclassification would only skip or run checks incorrectly for PRs touching `.claude/` paths.
> 
> **Overview**
> Extends the **`check_changes`** job in `ci.yml` so pull requests that only modify paths under **`.claude/`** are treated like markdown-only or `.github/` workflow-only changes: **`should_run=false`**, and the heavy jobs (formatting, unit tests, lint, Android CI) are skipped while matrix jobs still report success for required checks.
> 
> The diff filter regex gains **`^\.claude/`** alongside existing **`\.md$`** and **`^\.github/`** exclusions. Changes to **`ci.yml` itself** still force a full run. The skip log line now mentions Claude tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d43bbaebd826f049a6d70de6e0d76b07f5c2ef0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->