### PR TITLE
Add duck.ai FE event pixels and origins

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1341,6 +1341,55 @@
             }
         ]
     },
+    "m_aichat_subscription-funnel_subscribe-modal_impression": {
+        "description": "Subscription-funnel impression: the subscribe modal was shown. Origin is the FE-supplied entry point (source).",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "duckAiSubscriptionFunnelOrigin"]
+    },
+    "m_aichat_subscription-funnel_subscribe-modal_subscribe_click": {
+        "description": "Subscription-funnel click: the user tapped Subscribe on the subscribe modal. Origin is the FE-supplied entry point (source).",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "duckAiSubscriptionFunnelOrigin"]
+    },
+    "m_aichat_subscription-funnel_subscribe-modal_activate_click": {
+        "description": "Subscription-funnel click: the user tapped Activate on the subscribe modal. Origin is the FE-supplied entry point (source).",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "duckAiSubscriptionFunnelOrigin"]
+    },
+    "m_aichat_subscription-funnel_upgrade-to-pro-modal_impression": {
+        "description": "Subscription-funnel impression: the upgrade-to-Pro modal was shown. Origin is the FE-supplied entry point (source).",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "duckAiSubscriptionFunnelOrigin"]
+    },
+    "m_aichat_subscription-funnel_upgrade-to-pro-modal_upgrade_click": {
+        "description": "Subscription-funnel click: the user tapped Upgrade on the upgrade-to-Pro modal. Origin is the FE-supplied entry point (source).",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "duckAiSubscriptionFunnelOrigin"]
+    },
+    "m_aichat_subscription-funnel_impression": {
+        "description": "Subscription-funnel impression relayed from the Duck.ai website (FE reportMetric). Carries the funnel entry-point origin.",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "duckAiSubscriptionFunnelOrigin"]
+    },
+    "m_aichat_subscription-funnel_click": {
+        "description": "Subscription-funnel click relayed from the Duck.ai website (FE reportMetric). Carries the funnel entry-point origin.",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "duckAiSubscriptionFunnelOrigin"]
+    },
     "m_aichat_unified_input_model_picker_shown": {
         "description": "Subscription-funnel impression: the Unified Input model picker was shown to the user",
         "owners": ["YoussefKeyrouz"],

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -172,5 +172,28 @@
             "foreground_start_failed",
             "work_stopped"
         ]
+    },
+    "duckAiSubscriptionFunnelOrigin": {
+        "key": "origin",
+        "type": "string",
+        "description": "Duck.ai Android subscription-funnel entry-point origin. Bounded set; unknown or unrecognised sources collapse to funnel_duckai_android__unknown.",
+        "enum": [
+            "funnel_duckai_android__modelpicker",
+            "funnel_duckai_android__reasoningpicker",
+            "funnel_duckai_android__reasoningdropdown",
+            "funnel_duckai_android__aisidebar",
+            "funnel_duckai_android__activatesubscription",
+            "funnel_duckai_android__freelabel",
+            "funnel_duckai_android__freelimit",
+            "funnel_duckai_android__imagegenerationlimit",
+            "funnel_duckai_android__pluslimit",
+            "funnel_duckai_android__promotioncard",
+            "funnel_duckai_android__settings",
+            "funnel_duckai_android__switchmodel",
+            "funnel_duckai_android__voicechatdurationlimit",
+            "funnel_duckai_android__voicechatlimit",
+            "funnel_duckai_android__disclaimerbanner",
+            "funnel_duckai_android__unknown"
+        ]
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -335,6 +335,37 @@ enum class ReportMetric(
     USER_DID_CREATE_NEW_CHAT("userDidCreateNewChat"),
     USER_DID_TAP_KEYBOARD_RETURN_KEY("userDidTapKeyboardReturnKey"),
     USER_DID_ACCEPT_TERMS_AND_CONDITIONS("userDidAcceptTermsAndConditions"),
+
+    // Subscription-funnel impression/click events from the Duck.ai website (FE).
+    USER_DID_VIEW_AI_SIDEBAR_UPGRADE_BUTTON("userDidViewAiSidebarUpgradeButton"),
+    USER_DID_CLICK_AI_SIDEBAR_UPGRADE_BUTTON("userDidClickAiSidebarUpgradeButton"),
+    USER_DID_VIEW_ACTIVATE_SUBSCRIPTION_BANNER("userDidViewActivateSubscriptionBanner"),
+    USER_DID_CLICK_ACTIVATE_SUBSCRIPTION_BUTTON("userDidClickActivateSubscriptionButton"),
+    USER_DID_VIEW_FREE_PLAN_BADGE("userDidViewFreePlanBadge"),
+    USER_DID_CLICK_FREE_PLAN_UPGRADE_BUTTON("userDidClickFreePlanUpgradeButton"),
+    USER_DID_VIEW_FREE_LIMIT_MESSAGE("userDidViewFreeLimitMessage"),
+    USER_DID_CLICK_FREE_LIMIT_SUBSCRIBE_LINK("userDidClickFreeLimitSubscribeLink"),
+    USER_DID_VIEW_IMAGE_GENERATION_LIMIT_MESSAGE("userDidViewImageGenerationLimitMessage"),
+    USER_DID_CLICK_IMAGE_GENERATION_LIMIT_SUBSCRIBE_BUTTON("userDidClickImageGenerationLimitSubscribeButton"),
+    USER_DID_VIEW_PLUS_LIMIT_MESSAGE("userDidViewPlusLimitMessage"),
+    USER_DID_CLICK_PLUS_LIMIT_UPGRADE_LINK("userDidClickPlusLimitUpgradeLink"),
+    USER_DID_VIEW_PROMOTION_CARD("userDidViewPromotionCard"),
+    USER_DID_CLICK_PROMOTION_CARD_BUTTON("userDidClickPromotionCardButton"),
+    USER_DID_VIEW_SETTINGS_SUBSCRIBE_BUTTON("userDidViewSettingsSubscribeButton"),
+    USER_DID_CLICK_SETTINGS_SUBSCRIBE_BUTTON("userDidClickSettingsSubscribeButton"),
+    USER_DID_VIEW_VOICE_CHAT_DURATION_LIMIT_MODAL("userDidViewVoiceChatDurationLimitModal"),
+    USER_DID_CLICK_VOICE_CHAT_DURATION_LIMIT_MODAL_SUBSCRIBE_BUTTON("userDidClickVoiceChatDurationLimitModalSubscribeButton"),
+    USER_DID_VIEW_VOICE_CHAT_LIMIT_MODAL("userDidViewVoiceChatLimitModal"),
+    USER_DID_CLICK_VOICE_CHAT_LIMIT_MODAL_SUBSCRIBE_BUTTON("userDidClickVoiceChatLimitModalSubscribeButton"),
+    USER_DID_VIEW_PRO_UPGRADE_DISCLAIMER_BANNER("userDidViewProUpgradeDisclaimerBanner"),
+    USER_DID_CLICK_PRO_UPGRADE_DISCLAIMER_BANNER_BUTTON("userDidClickProUpgradeDisclaimerBannerButton"),
+
+    // Subscribe / upgrade modal events. FE sends the funnel entry point as `source`, which forms the origin.
+    USER_DID_OPEN_SUBSCRIBE_MODAL("userDidOpenSubscribeModal"),
+    USER_DID_CLICK_SUBSCRIBE_ON_SUBSCRIBE_MODAL("userDidClickSubscribeOnSubscribeModal"),
+    USER_DID_CLICK_ACTIVATE_ON_SUBSCRIBE_MODAL("userDidClickActivateOnSubscribeModal"),
+    USER_DID_OPEN_UPGRADE_TO_PRO_MODAL("userDidOpenUpgradeToProModal"),
+    USER_DID_CLICK_UPGRADE_ON_UPGRADE_TO_PRO_MODAL("userDidClickUpgradeOnUpgradeToProModal"),
     ;
 
     companion object {
@@ -352,6 +383,34 @@ enum class ModelTier(val model: String) {
 
     companion object {
         fun fromValue(v: String?): ModelTier? = entries.firstOrNull { it.model.equals(v, ignoreCase = true) }
+    }
+}
+
+// Funnel entry point supplied by the FE as `source` on the subscribe/upgrade modal events. Parsed from
+// the raw value and falls back to [UNKNOWN].
+enum class SubscriptionFunnelSource(val value: String) {
+    MODEL_PICKER("modelpicker"),
+    REASONING_PICKER("reasoningpicker"),
+    REASONING_DROPDOWN("reasoningdropdown"),
+    AI_SIDEBAR("aisidebar"),
+    ACTIVATE_SUBSCRIPTION("activatesubscription"),
+    FREE_LABEL("freelabel"),
+    FREE_LIMIT("freelimit"),
+    IMAGE_GENERATION_LIMIT("imagegenerationlimit"),
+    PLUS_LIMIT("pluslimit"),
+    PROMOTION_CARD("promotioncard"),
+    SETTINGS("settings"),
+    SWITCH_MODEL("switchmodel"),
+    VOICE_CHAT_DURATION_LIMIT("voicechatdurationlimit"),
+    VOICE_CHAT_LIMIT("voicechatlimit"),
+    DISCLAIMER_BANNER("disclaimerbanner"),
+    UNKNOWN("unknown"),
+    ;
+
+    val origin: String get() = "funnel_duckai_android__$value"
+
+    companion object {
+        fun fromValue(v: String?): SubscriptionFunnelSource = entries.firstOrNull { it.value == v } ?: UNKNOWN
     }
 }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -233,9 +233,10 @@ class RealDuckChatJSHelper @Inject constructor(
             REPORT_METRIC -> {
                 val reportMetric = ReportMetric.fromValue(data?.optString("metricName"))
                 val modelTier = ModelTier.fromValue(data?.optString("modelTier"))
+                val source = data?.optString("source")?.takeIf { it.isNotBlank() }
 
                 reportMetric?.let {
-                    duckChatPixels.sendReportMetricPixel(it, modelTier)
+                    duckChatPixels.sendReportMetricPixel(it, modelTier, source)
                 }
                 null
             }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_SELECT_FIRST_HISTORY_I
 import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_SUBMIT_FIRST_PROMPT
 import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_SUBMIT_PROMPT
 import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_TAP_KEYBOARD_RETURN_KEY
+import com.duckduckgo.duckchat.impl.SubscriptionFunnelSource
 import com.duckduckgo.duckchat.impl.helper.DuckChatTermsOfServiceHandler
 import com.duckduckgo.duckchat.impl.metric.DuckAiMetricCollector
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_ADDRESS_BAR_IS_ENABLED_DAILY
@@ -135,7 +136,7 @@ enum class DuckChatPixelSurface(val value: String) {
 }
 
 interface DuckChatPixels {
-    fun sendReportMetricPixel(reportMetric: ReportMetric, modelTier: ModelTier? = null)
+    fun sendReportMetricPixel(reportMetric: ReportMetric, modelTier: ModelTier? = null, source: String? = null)
     fun reportOpen()
     fun reportContextualSheetOpened()
     fun reportContextualSheetDismissed()
@@ -267,7 +268,7 @@ class RealDuckChatPixels @Inject constructor(
     private fun surfaceParams(surface: DuckChatPixelSurface): Map<String, String> =
         mapOf(DuckChatPixelParameters.SURFACE to surface.value)
 
-    override fun sendReportMetricPixel(reportMetric: ReportMetric, modelTier: ModelTier?) {
+    override fun sendReportMetricPixel(reportMetric: ReportMetric, modelTier: ModelTier?, source: String?) {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             var refreshAtb = false
             val sessionParams = mapOf(
@@ -299,6 +300,52 @@ class RealDuckChatPixels @Inject constructor(
                     }
                     DuckChatPixelName.DUCK_CHAT_USER_ACCEPTED_TERMS_AND_CONDITIONS to emptyMap()
                 }
+
+                // Subscription-funnel events from the Duck.ai website (FE): impression/click pixel + origin.
+                ReportMetric.USER_DID_VIEW_AI_SIDEBAR_UPGRADE_BUTTON -> subscriptionFunnelImpression("funnel_duckai_android__aisidebar")
+                ReportMetric.USER_DID_CLICK_AI_SIDEBAR_UPGRADE_BUTTON -> subscriptionFunnelClick("funnel_duckai_android__aisidebar")
+                ReportMetric.USER_DID_VIEW_ACTIVATE_SUBSCRIPTION_BANNER -> subscriptionFunnelImpression("funnel_duckai_android__activatesubscription")
+                ReportMetric.USER_DID_CLICK_ACTIVATE_SUBSCRIPTION_BUTTON -> subscriptionFunnelClick("funnel_duckai_android__activatesubscription")
+                ReportMetric.USER_DID_VIEW_FREE_PLAN_BADGE -> subscriptionFunnelImpression("funnel_duckai_android__freelabel")
+                ReportMetric.USER_DID_CLICK_FREE_PLAN_UPGRADE_BUTTON -> subscriptionFunnelClick("funnel_duckai_android__freelabel")
+                ReportMetric.USER_DID_VIEW_FREE_LIMIT_MESSAGE -> subscriptionFunnelImpression("funnel_duckai_android__freelimit")
+                ReportMetric.USER_DID_CLICK_FREE_LIMIT_SUBSCRIBE_LINK -> subscriptionFunnelClick("funnel_duckai_android__freelimit")
+                ReportMetric.USER_DID_VIEW_IMAGE_GENERATION_LIMIT_MESSAGE -> subscriptionFunnelImpression(
+                    "funnel_duckai_android__imagegenerationlimit",
+                )
+                ReportMetric.USER_DID_CLICK_IMAGE_GENERATION_LIMIT_SUBSCRIBE_BUTTON -> subscriptionFunnelClick(
+                    "funnel_duckai_android__imagegenerationlimit",
+                )
+                ReportMetric.USER_DID_VIEW_PLUS_LIMIT_MESSAGE -> subscriptionFunnelImpression("funnel_duckai_android__pluslimit")
+                ReportMetric.USER_DID_CLICK_PLUS_LIMIT_UPGRADE_LINK -> subscriptionFunnelClick("funnel_duckai_android__pluslimit")
+                ReportMetric.USER_DID_VIEW_PROMOTION_CARD -> subscriptionFunnelImpression("funnel_duckai_android__promotioncard")
+                ReportMetric.USER_DID_CLICK_PROMOTION_CARD_BUTTON -> subscriptionFunnelClick("funnel_duckai_android__promotioncard")
+                ReportMetric.USER_DID_VIEW_SETTINGS_SUBSCRIBE_BUTTON -> subscriptionFunnelImpression("funnel_duckai_android__settings")
+                ReportMetric.USER_DID_CLICK_SETTINGS_SUBSCRIBE_BUTTON -> subscriptionFunnelClick("funnel_duckai_android__settings")
+                ReportMetric.USER_DID_VIEW_VOICE_CHAT_DURATION_LIMIT_MODAL -> subscriptionFunnelImpression(
+                    "funnel_duckai_android__voicechatdurationlimit",
+                )
+                ReportMetric.USER_DID_CLICK_VOICE_CHAT_DURATION_LIMIT_MODAL_SUBSCRIBE_BUTTON -> subscriptionFunnelClick(
+                    "funnel_duckai_android__voicechatdurationlimit",
+                )
+                ReportMetric.USER_DID_VIEW_VOICE_CHAT_LIMIT_MODAL -> subscriptionFunnelImpression("funnel_duckai_android__voicechatlimit")
+                ReportMetric.USER_DID_CLICK_VOICE_CHAT_LIMIT_MODAL_SUBSCRIBE_BUTTON -> subscriptionFunnelClick(
+                    "funnel_duckai_android__voicechatlimit",
+                )
+                ReportMetric.USER_DID_VIEW_PRO_UPGRADE_DISCLAIMER_BANNER -> subscriptionFunnelImpression("funnel_duckai_android__disclaimerbanner")
+                ReportMetric.USER_DID_CLICK_PRO_UPGRADE_DISCLAIMER_BANNER_BUTTON -> subscriptionFunnelClick("funnel_duckai_android__disclaimerbanner")
+
+                // Subscribe/upgrade modal events: distinct pixels (mirroring Windows), origin from the FE source.
+                ReportMetric.USER_DID_OPEN_SUBSCRIBE_MODAL ->
+                    DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_SUBSCRIBE_MODAL_IMPRESSION to subscriptionModalOrigin(source)
+                ReportMetric.USER_DID_CLICK_SUBSCRIBE_ON_SUBSCRIBE_MODAL ->
+                    DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_SUBSCRIBE_MODAL_SUBSCRIBE_CLICK to subscriptionModalOrigin(source)
+                ReportMetric.USER_DID_CLICK_ACTIVATE_ON_SUBSCRIBE_MODAL ->
+                    DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_SUBSCRIBE_MODAL_ACTIVATE_CLICK to subscriptionModalOrigin(source)
+                ReportMetric.USER_DID_OPEN_UPGRADE_TO_PRO_MODAL ->
+                    DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_UPGRADE_TO_PRO_MODAL_IMPRESSION to subscriptionModalOrigin(source)
+                ReportMetric.USER_DID_CLICK_UPGRADE_ON_UPGRADE_TO_PRO_MODAL ->
+                    DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_UPGRADE_TO_PRO_MODAL_UPGRADE_CLICK to subscriptionModalOrigin(source)
             }
 
             withContext(dispatcherProvider.main()) {
@@ -310,6 +357,16 @@ class RealDuckChatPixels @Inject constructor(
             }
         }
     }
+
+    private fun subscriptionFunnelImpression(origin: String) =
+        DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_IMPRESSION to mapOf(DuckChatPixelParameters.ORIGIN to origin)
+
+    private fun subscriptionFunnelClick(origin: String) =
+        DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_CLICK to mapOf(DuckChatPixelParameters.ORIGIN to origin)
+
+    // Origin param for the subscribe/upgrade modal pixels, parsed from the FE `source`.
+    private fun subscriptionModalOrigin(source: String?) =
+        mapOf(DuckChatPixelParameters.ORIGIN to SubscriptionFunnelSource.fromValue(source).origin)
 
     override fun reportOpen() {
         appCoroutineScope.launch(dispatcherProvider.io()) {
@@ -935,6 +992,13 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_OPEN_HISTORY("aichat_open_history"),
     DUCK_CHAT_OPEN_MOST_RECENT_HISTORY_CHAT("aichat_open_most_recent_history_chat"),
     DUCK_CHAT_SEND_PROMPT_ONGOING_CHAT("aichat_sent_prompt_ongoing_chat"),
+    DUCK_CHAT_SUBSCRIPTION_FUNNEL_IMPRESSION("m_aichat_subscription-funnel_impression"),
+    DUCK_CHAT_SUBSCRIPTION_FUNNEL_CLICK("m_aichat_subscription-funnel_click"),
+    DUCK_CHAT_SUBSCRIPTION_FUNNEL_SUBSCRIBE_MODAL_IMPRESSION("m_aichat_subscription-funnel_subscribe-modal_impression"),
+    DUCK_CHAT_SUBSCRIPTION_FUNNEL_SUBSCRIBE_MODAL_SUBSCRIBE_CLICK("m_aichat_subscription-funnel_subscribe-modal_subscribe_click"),
+    DUCK_CHAT_SUBSCRIPTION_FUNNEL_SUBSCRIBE_MODAL_ACTIVATE_CLICK("m_aichat_subscription-funnel_subscribe-modal_activate_click"),
+    DUCK_CHAT_SUBSCRIPTION_FUNNEL_UPGRADE_TO_PRO_MODAL_IMPRESSION("m_aichat_subscription-funnel_upgrade-to-pro-modal_impression"),
+    DUCK_CHAT_SUBSCRIPTION_FUNNEL_UPGRADE_TO_PRO_MODAL_UPGRADE_CLICK("m_aichat_subscription-funnel_upgrade-to-pro-modal_upgrade_click"),
     DUCK_CHAT_PAID_OPEN_DUCK_AI_CLICKED("m_privacy-pro_settings_paid-ai-chat_click"),
     DUCK_CHAT_PAID_SETTINGS_OPENED("m_privacy-pro_settings_paid-ai-chat_impression"),
     DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_DAILY("m_aichat_experimental_omnibar_shown"),

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.pixel
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.impl.ReportMetric
 import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_ACCEPT_TERMS_AND_CONDITIONS
 import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_CREATE_NEW_CHAT
 import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_OPEN_HISTORY
@@ -511,6 +512,114 @@ class RealDuckChatPixelsTest {
         verify(mockPixel).fire(
             pixel = DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_BACK_BUTTON_PRESSED,
             parameters = mapOf(DuckChatPixelParameters.INPUT_SCREEN_MODE to "search"),
+        )
+    }
+
+    @Test
+    fun `when sendReportMetricPixel with website impression event then fires funnel impression pixel with android origin`() = runTest {
+        testee.sendReportMetricPixel(ReportMetric.USER_DID_VIEW_FREE_LIMIT_MESSAGE)
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(
+            DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_IMPRESSION,
+            parameters = mapOf(DuckChatPixelParameters.ORIGIN to "funnel_duckai_android__freelimit"),
+        )
+    }
+
+    @Test
+    fun `when sendReportMetricPixel with website click event then fires funnel click pixel with android origin`() = runTest {
+        testee.sendReportMetricPixel(ReportMetric.USER_DID_CLICK_FREE_LIMIT_SUBSCRIBE_LINK)
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(
+            DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_CLICK,
+            parameters = mapOf(DuckChatPixelParameters.ORIGIN to "funnel_duckai_android__freelimit"),
+        )
+    }
+
+    @Test
+    fun `when open subscribe modal with source then fires subscribe-modal impression with source origin`() = runTest {
+        testee.sendReportMetricPixel(ReportMetric.USER_DID_OPEN_SUBSCRIBE_MODAL, source = "disclaimerbanner")
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(
+            DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_SUBSCRIBE_MODAL_IMPRESSION,
+            parameters = mapOf(DuckChatPixelParameters.ORIGIN to "funnel_duckai_android__disclaimerbanner"),
+        )
+    }
+
+    @Test
+    fun `when subscribe click on subscribe modal with source then fires subscribe-modal subscribe click`() = runTest {
+        testee.sendReportMetricPixel(ReportMetric.USER_DID_CLICK_SUBSCRIBE_ON_SUBSCRIBE_MODAL, source = "freelimit")
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(
+            DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_SUBSCRIBE_MODAL_SUBSCRIBE_CLICK,
+            parameters = mapOf(DuckChatPixelParameters.ORIGIN to "funnel_duckai_android__freelimit"),
+        )
+    }
+
+    @Test
+    fun `when activate click on subscribe modal with source then fires subscribe-modal activate click`() = runTest {
+        testee.sendReportMetricPixel(ReportMetric.USER_DID_CLICK_ACTIVATE_ON_SUBSCRIBE_MODAL, source = "aisidebar")
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(
+            DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_SUBSCRIBE_MODAL_ACTIVATE_CLICK,
+            parameters = mapOf(DuckChatPixelParameters.ORIGIN to "funnel_duckai_android__aisidebar"),
+        )
+    }
+
+    @Test
+    fun `when open upgrade modal with source then fires upgrade-to-pro-modal impression with source origin`() = runTest {
+        testee.sendReportMetricPixel(ReportMetric.USER_DID_OPEN_UPGRADE_TO_PRO_MODAL, source = "pluslimit")
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(
+            DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_UPGRADE_TO_PRO_MODAL_IMPRESSION,
+            parameters = mapOf(DuckChatPixelParameters.ORIGIN to "funnel_duckai_android__pluslimit"),
+        )
+    }
+
+    @Test
+    fun `when upgrade click on upgrade modal with source then fires upgrade-to-pro-modal upgrade click`() = runTest {
+        testee.sendReportMetricPixel(ReportMetric.USER_DID_CLICK_UPGRADE_ON_UPGRADE_TO_PRO_MODAL, source = "disclaimerbanner")
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(
+            DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_UPGRADE_TO_PRO_MODAL_UPGRADE_CLICK,
+            parameters = mapOf(DuckChatPixelParameters.ORIGIN to "funnel_duckai_android__disclaimerbanner"),
+        )
+    }
+
+    @Test
+    fun `when modal event with unrecognised source then origin falls back to unknown`() = runTest {
+        testee.sendReportMetricPixel(ReportMetric.USER_DID_OPEN_SUBSCRIBE_MODAL, source = "somethingnotinthelist")
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(
+            DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_SUBSCRIBE_MODAL_IMPRESSION,
+            parameters = mapOf(DuckChatPixelParameters.ORIGIN to "funnel_duckai_android__unknown"),
+        )
+    }
+
+    @Test
+    fun `when modal event with no source then origin falls back to unknown`() = runTest {
+        testee.sendReportMetricPixel(ReportMetric.USER_DID_OPEN_SUBSCRIBE_MODAL)
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(
+            DuckChatPixelName.DUCK_CHAT_SUBSCRIPTION_FUNNEL_SUBSCRIBE_MODAL_IMPRESSION,
+            parameters = mapOf(DuckChatPixelParameters.ORIGIN to "funnel_duckai_android__unknown"),
         )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217287648325827?focus=true 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

Relays Duck.ai front-end `reportMetric` events (sent over the JS bridge with `metricName`, and for the modal events a `source`) to native subscription-funnel pixels, each carrying the funnel entry point as an `origin` param.

Two groups:

New generic funnel pixels for the website-relayed events (fixed origin per event):
- `m_aichat_subscription-funnel_impression` (all "user did view" events)
- `m_aichat_subscription-funnel_click` (all "user did click" events)
- origins: `funnel_duckai_android__{aisidebar, activatesubscription, freelabel, freelimit, imagegenerationlimit, pluslimit, promotioncard, settings, voicechatdurationlimit, voicechatlimit, disclaimerbanner}`

New modal pixels , origin taken from the FE `source` field:
- `m_aichat_subscription-funnel_subscribe-modal_impression` (userDidOpenSubscribeModal)
- `m_aichat_subscription-funnel_subscribe-modal_subscribe_click` (userDidClickSubscribeOnSubscribeModal)
- `m_aichat_subscription-funnel_subscribe-modal_activate_click` (userDidClickActivateOnSubscribeModal)
- `m_aichat_subscription-funnel_upgrade-to-pro-modal_impression` (userDidOpenUpgradeToProModal)
- `m_aichat_subscription-funnel_upgrade-to-pro-modal_upgrade_click` (userDidClickUpgradeOnUpgradeToProModal)

- origin: `funnel_duckai_android__{source}`; an unrecognised or missing source collapses to `funnel_duckai_android__unknown`

Notes:
- `origin` is bounded: the modal source is parsed into the `SubscriptionFunnelSource` enum (fallback `UNKNOWN`), and all funnel pixels share the `duckAiSubscriptionFunnelOrigin` dictionary param, so a web-supplied value can never reach telemetry as an arbitrary origin.
- These pixels do not carry ATB (Duck.ai pixels are opt-in for ATB and these are not registered).

### Steps to test this PR

Setup:
- Internal build.
- Point Duck.ai at the FE test build that emits these events: in the app dev settings, set the Duck.ai URL to `https://use-serp-dev-testing21.duck.ai/`.
- Open Duck.ai and navigate to `https://use-serp-dev-testing21.duck.ai/` instead of the normal duck.ai so the funnel surfaces/events are available.
- Watch pixels with: `adb logcat | grep -iE “pixel sent”` or just filter adb in android studio

These fire in response to FE `reportMetric` events. Trigger the Duck.ai website surface, then confirm the native pixel + origin.

_Website-relayed funnel events_
- [ ] In duck.ai open the side panel and tap on “Upgrade” so the modal shows. 2 pixels should be fired:
  - `m_aichat_subscription-funnel_click` (origin = `funnel_duckai_android__aisidebar`)
  - `m_aichat_subscription-funnel_subscribe-modal_impression` (origin = `funnel_duckai_android__aisidebar`)
- [ ] Spot-check another surface you have access to (promotion card, disclaimer banner, ai sidebar, settings subscribe) and confirm the matching `funnel_duckai_android__<surface>` origin

_Subscribe / upgrade modal events_
- [ ] Open the subscribe modal from a surface. Expect `..._subscribe-modal_impression` with `origin=funnel_duckai_android__<source>`
- [ ] Tap Subscribe in that modal. Expect `..._subscribe-modal_subscribe_click`, same origin
- [ ] Tap Activate (I have a subscritpion) in that modal. Expect `..._subscribe-modal_activate_click`, same origin
- [ ] As a Plus user, open the upgrade-to-Pro modal and tap Upgrade. Expect `..._upgrade-to-pro-modal_impression` then `..._upgrade-to-pro-modal_upgrade_click`, `origin=funnel_duckai_android__<source>`

_Some harder to test events, only test if you are ok reaching the limit_
- [ ] (Harder to test) Hit the free chat limit so the free-limit message shows, then tap its subscribe link. Expect `..._funnel_impression` then `..._funnel_click`, both `origin=funnel_duckai_android__freelimit`
- [ ] (Harder to test)  As a Plus user, hit the plus limit and tap the upgrade link. Expect impression + click with `origin=funnel_duckai_android__pluslimit`

### UI changes

None, telemetry only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes to pixel mapping and definitions; no auth, billing, or user-setting logic. Unknown FE `source` values are bounded to a safe default origin.
> 
> **Overview**
> Adds **telemetry for the Duck.ai subscription funnel** when the web layer calls `reportMetric` through the JS bridge.
> 
> **New `ReportMetric` values** cover website impressions/clicks (sidebar upgrade, activate banner, free limits, voice limits, settings subscribe, etc.) and subscribe / upgrade-to-Pro modal show and button taps. **Subscribe and upgrade modal events** fire dedicated pixels (`subscribe-modal_*`, `upgrade-to-pro-modal_*`) with an **`origin`** derived from the FE’s optional `source` field via **`SubscriptionFunnelSource`** (`funnel_duckai_android__*`), falling back to **`unknown`** when missing or invalid. Other funnel UI events map to the generic **`m_aichat_subscription-funnel_impression`** / **`click`** pixels with fixed Android origins per surface.
> 
> **Pixel definitions** register seven new `m_aichat_subscription-funnel_*` events and a shared **`duckAiSubscriptionFunnelOrigin`** parameter dictionary entry. **`DuckChatJSHelper`** forwards `source` from the metric payload into **`sendReportMetricPixel`**. Unit tests assert pixel names and origin params for representative funnel and modal metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26f98ea1b28fab5f6c6d829755dd39510dc090b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->