### PR TITLE
Extract WebViewImeInsets helper and add unit coverage

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -33,11 +33,9 @@ import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.core.graphics.Insets
 import androidx.core.view.NestedScrollingChild3
 import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.webkit.JavaScriptReplyProxy
 import androidx.webkit.ScriptHandler
 import androidx.webkit.WebViewCompat
@@ -106,21 +104,10 @@ class DuckDuckGoWebView :
     }
 
     override fun onApplyWindowInsets(insets: WindowInsets): WindowInsets {
-        val adjustedInsets = if (stripImeInsetsEnabled) stripImeInsets(insets) else insets
+        // Zero IME insets when the surrounding layout already resizes for the keyboard, so WebView
+        // M139+ does not additionally shrink the visual viewport (double padding). See WebViewImeInsets.
+        val adjustedInsets = if (stripImeInsetsEnabled) WebViewImeInsets.strip(insets, this) else insets
         return super.onApplyWindowInsets(adjustedInsets)
-    }
-
-    // Zero any IME inset passed to the WebView to avoid double-padding if the IME padding is handled by the surrounding layout.
-    // Reference https://developer.android.com/develop/ui/views/layout/webapps/understand-window-insets
-    private fun stripImeInsets(insets: WindowInsets): WindowInsets {
-        val windowInsetsCompat = WindowInsetsCompat.toWindowInsetsCompat(insets, this)
-
-        if (windowInsetsCompat.getInsets(WindowInsetsCompat.Type.ime()) == Insets.NONE) return insets
-
-        return WindowInsetsCompat.Builder(windowInsetsCompat)
-            .setInsets(WindowInsetsCompat.Type.ime(), Insets.NONE)
-            .build()
-            .toWindowInsets() ?: insets
     }
 
     override fun destroy() {

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewImeInsets.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewImeInsets.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import android.view.View
+import android.view.WindowInsets
+import androidx.core.graphics.Insets
+import androidx.core.view.WindowInsetsCompat
+
+/**
+ * Zeroes IME insets before they reach WebView so an adjustResize host layout and WebView M139+
+ * IME visual-viewport resizing do not both shrink the page (double padding).
+ *
+ * @see <a href="https://developer.android.com/develop/ui/views/layout/webapps/understand-window-insets">
+ * Android WebView window insets guidance</a>
+ */
+internal object WebViewImeInsets {
+    fun strip(insets: WindowInsets, view: View): WindowInsets {
+        val compat = WindowInsetsCompat.toWindowInsetsCompat(insets, view)
+        val stripped = strip(compat)
+        return if (stripped === compat) insets else stripped.toWindowInsets() ?: insets
+    }
+
+    fun strip(compat: WindowInsetsCompat): WindowInsetsCompat {
+        if (compat.getInsets(WindowInsetsCompat.Type.ime()) == Insets.NONE) return compat
+
+        return WindowInsetsCompat.Builder(compat)
+            .setInsets(WindowInsetsCompat.Type.ime(), Insets.NONE)
+            .build()
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/WebViewImeInsetsTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/WebViewImeInsetsTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import androidx.core.graphics.Insets
+import androidx.core.view.WindowInsetsCompat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WebViewImeInsetsTest {
+
+    @Test
+    fun whenImeInsetsPresentThenStripZeroesImeAndPreservesSystemBars() {
+        val incoming = WindowInsetsCompat.Builder()
+            .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, 400))
+            .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(0, 48, 0, 24))
+            .build()
+
+        val outgoing = WebViewImeInsets.strip(incoming)
+
+        assertEquals(Insets.NONE, outgoing.getInsets(WindowInsetsCompat.Type.ime()))
+        assertEquals(Insets.of(0, 48, 0, 24), outgoing.getInsets(WindowInsetsCompat.Type.systemBars()))
+    }
+
+    @Test
+    fun whenImeInsetsAlreadyNoneThenReturnsSameInstance() {
+        val incoming = WindowInsetsCompat.Builder()
+            .setInsets(WindowInsetsCompat.Type.ime(), Insets.NONE)
+            .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(0, 48, 0, 24))
+            .build()
+
+        val outgoing = WebViewImeInsets.strip(incoming)
+
+        assertSame(incoming, outgoing)
+        assertEquals(Insets.of(0, 48, 0, 24), outgoing.getInsets(WindowInsetsCompat.Type.systemBars()))
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205617573940217/task/1217145253883158?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

Follow-up to #9396 (Gemini / WebView M139 IME double-padding keyboard dismiss).

Extracts the IME zeroing logic into `WebViewImeInsets` so it can be unit-tested via `WindowInsetsCompat` without Robolectric platform `WindowInsets` round-trip quirks. Behavior is unchanged: when `stripWebViewImeInsets` is enabled, IME insets are zeroed before they reach the browser WebView.

### Steps to test this PR

_Unit tests_
- [x] `./gradlew :app:testPlayDebugUnitTest --tests com.duckduckgo.app.browser.WebViewImeInsetsTest`

_Keyboard stays open on Gemini (existing #9396 coverage)_
- [ ] Navigate to https://gemini.google.com
- [ ] Tap the message composer
- [ ] Verify the keyboard opens and stays open

### No UI changes