### PR TITLE
Update PIR broker bundle - 2026-08-10

### DIFF
--- a/pir/pir-impl/src/main/assets/brokers/advancedbackgroundchecks.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/advancedbackgroundchecks.com.json
@@ -1,10 +1,10 @@
 {
   "name": "AdvancedBackgroundChecks",
   "url": "advancedbackgroundchecks.com",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1678060800000,
-  "optOutUrl": "https://www.advancedbackgroundchecks.com/removal",
+  "optOutUrl": "https://www.advancedbackgroundchecks.com/opt-out",
   "steps": [
     {
       "stepType": "scan",

--- a/pir/pir-impl/src/main/assets/brokers/backgroundcheckers.net.json
+++ b/pir/pir-impl/src/main/assets/brokers/backgroundcheckers.net.json
@@ -1,7 +1,7 @@
 {
   "name": "BackgroundCheckers",
   "url": "backgroundcheckers.net",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.backgroundcheckers.net/optOut/name/landing",
   "steps": [
@@ -13,6 +13,17 @@
           "actionType": "navigate",
           "url": "https://www.backgroundcheckers.net/name/search-result",
           "id": "e117c04f-eee0-4b12-9570-b3df8e77c9d5"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(., '_cf_chl_opt')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'] or .//iframe[contains(@src,'challenges.cloudflare.com')] or .//div[@id='cf-error-details'])]"
+            }
+          ],
+          "id": "cfc-da85374d-22cd-4591-9600-7f028b1c466d"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/checksecrets.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/checksecrets.com.json
@@ -1,7 +1,7 @@
 {
   "name": "CheckSecrets",
   "url": "checksecrets.com",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.checksecrets.com/optOut/name/landing",
   "steps": [
@@ -13,6 +13,17 @@
           "actionType": "navigate",
           "url": "https://www.checksecrets.com/name/search-result",
           "id": "00fdf31f-03ef-4b6b-80d5-2996514a2bf4"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(., '_cf_chl_opt')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'] or .//iframe[contains(@src,'challenges.cloudflare.com')] or .//div[@id='cf-error-details'])]"
+            }
+          ],
+          "id": "cfc-2a55b2a5-7ba4-4352-8058-dfa4f364b058"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/inmatessearcher.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/inmatessearcher.com.json
@@ -1,7 +1,7 @@
 {
   "name": "InmatesSearcher",
   "url": "inmatessearcher.com",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.inmatessearcher.com/optOut/name/landing",
   "steps": [
@@ -13,6 +13,17 @@
           "actionType": "navigate",
           "url": "https://www.inmatessearcher.com/name/search-result",
           "id": "6465a3f6-3266-47a7-8372-dba02b768092"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(., '_cf_chl_opt')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'] or .//iframe[contains(@src,'challenges.cloudflare.com')] or .//div[@id='cf-error-details'])]"
+            }
+          ],
+          "id": "cfc-a274586f-bc2f-4176-889c-414c373f4235"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/peoplesearch123.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplesearch123.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PeopleSearch123",
   "url": "peoplesearch123.com",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.peoplesearch123.com/optOut/name/landing",
   "steps": [
@@ -13,6 +13,17 @@
           "actionType": "navigate",
           "url": "https://www.peoplesearch123.com/name/search-result",
           "id": "7cca9863-e32a-47a3-9c96-741b2240c1f6"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(., '_cf_chl_opt')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'] or .//iframe[contains(@src,'challenges.cloudflare.com')] or .//div[@id='cf-error-details'])]"
+            }
+          ],
+          "id": "cfc-b9770039-9e93-4047-b63b-4731b5acd402"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/peoplesearchusa.org.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplesearchusa.org.json
@@ -1,7 +1,7 @@
 {
   "name": "PeopleSearchUSA",
   "url": "peoplesearchusa.org",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.peoplesearchusa.org/optOut/name/landing",
   "steps": [
@@ -13,6 +13,17 @@
           "actionType": "navigate",
           "url": "https://www.peoplesearchusa.org/name/search-result",
           "id": "449fddc8-e5e7-405f-aecc-e87ee25500d5"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(., '_cf_chl_opt')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'] or .//iframe[contains(@src,'challenges.cloudflare.com')] or .//div[@id='cf-error-details'])]"
+            }
+          ],
+          "id": "cfc-9043b059-2e8b-480b-a73e-567861775f34"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/personsearchers.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/personsearchers.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PersonSearchers",
   "url": "personsearchers.com",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.personsearchers.com/optOut/name/landing",
   "steps": [
@@ -13,6 +13,17 @@
           "actionType": "navigate",
           "url": "https://www.personsearchers.com/name/search-result",
           "id": "ab2b7b28-4204-48a5-9366-2697382fdcfe"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(., '_cf_chl_opt')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'] or .//iframe[contains(@src,'challenges.cloudflare.com')] or .//div[@id='cf-error-details'])]"
+            }
+          ],
+          "id": "cfc-3b691469-ddc9-48fd-85a7-1ef165bb423e"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/privaterecords.net.json
+++ b/pir/pir-impl/src/main/assets/brokers/privaterecords.net.json
@@ -1,7 +1,7 @@
 {
   "name": "PrivateRecords",
   "url": "privaterecords.net",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.privaterecords.net/optOut/name/landing",
   "steps": [
@@ -13,6 +13,17 @@
           "actionType": "navigate",
           "url": "https://www.privaterecords.net/name/search-result",
           "id": "4ccf82e4-9cce-439a-8f37-7371cf762c2a"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(., '_cf_chl_opt')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'] or .//iframe[contains(@src,'challenges.cloudflare.com')] or .//div[@id='cf-error-details'])]"
+            }
+          ],
+          "id": "cfc-c1a79f04-38ed-43db-88c0-b3b49db6fea0"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/quickpeopletrace.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/quickpeopletrace.com.json
@@ -1,7 +1,7 @@
 {
   "name": "Quick People Trace",
   "url": "quickpeopletrace.com",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1674540000000,
   "optOutUrl": "https://www.quickpeopletrace.com/contact-us/",
@@ -18,7 +18,7 @@
         {
           "actionType": "extract",
           "id": "54cdba05-95bd-4142-b97c-4cafc59059df",
-          "selector": "//table/tbody/tr[position() > 1]",
+          "selector": "//table/tbody/tr[td[2]]",
           "noResultsSelector": "//div[contains(@class, 'alert') and contains(text(), 'no results')]",
           "profile": {
             "name": {

--- a/pir/pir-impl/src/main/assets/brokers/sealedrecords.net.json
+++ b/pir/pir-impl/src/main/assets/brokers/sealedrecords.net.json
@@ -1,7 +1,7 @@
 {
   "name": "SealedRecords",
   "url": "sealedrecords.net",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.sealedrecords.net/optOut/name/landing",
   "steps": [
@@ -13,6 +13,17 @@
           "actionType": "navigate",
           "url": "https://www.sealedrecords.net/name/search-result",
           "id": "c8a32ec6-d560-4ecb-92f6-e83033fd317a"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(., '_cf_chl_opt')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'] or .//iframe[contains(@src,'challenges.cloudflare.com')] or .//div[@id='cf-error-details'])]"
+            }
+          ],
+          "id": "cfc-da7a8927-1dfc-4c1c-82fe-90c2b0aba562"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/usphonebook.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/usphonebook.com.json
@@ -1,7 +1,7 @@
 {
   "name": "USPhoneBook",
   "url": "usphonebook.com",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1678082400000,
   "optOutUrl": "https://www.usphonebook.com/opt-out",
@@ -14,6 +14,17 @@
           "actionType": "navigate",
           "id": "98a804b2-115c-4c2c-8e97-3f3679cd3fbb",
           "url": "https://www.usphonebook.com/${firstName|hyphenated}-${lastName|hyphenated}/${state|upcase}/${city|hyphenated}"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(., '_cf_chl_opt')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'] or .//iframe[contains(@src,'challenges.cloudflare.com')] or .//div[@id='cf-error-details'])]"
+            }
+          ],
+          "id": "cfc-59f9967d-4254-40d2-965f-0ba9c905bdc5"
         },
         {
           "actionType": "extract",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217309859332896

## PIR Broker Bundle Update

Automated update of PIR broker JSON files from the remote bundle.

### Changes

**Updated (11):**
- advancedbackgroundchecks.com.json (0.9.0 → 0.10.0)
- backgroundcheckers.net.json (0.3.0 → 0.4.0)
- checksecrets.com.json (0.3.0 → 0.4.0)
- inmatessearcher.com.json (0.3.0 → 0.4.0)
- peoplesearch123.com.json (0.3.0 → 0.4.0)
- peoplesearchusa.org.json (0.3.0 → 0.4.0)
- personsearchers.com.json (0.3.0 → 0.4.0)
- privaterecords.net.json (0.3.0 → 0.4.0)
- quickpeopletrace.com.json (0.5.0 → 0.6.0)
- sealedrecords.net.json (0.3.0 → 0.4.0)
- usphonebook.com.json (0.6.0 → 0.7.0)

### Checklist

- [ ] Verify broker changes look correct
- [ ] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect live broker scan timing and DOM selectors; mis-tuned Cloudflare waits or row selectors could cause scan failures or missed profiles until corrected in a follow-up bundle.
> 
> **Overview**
> Automated bump of **11 PIR broker JSON** configs (version increments only in this bundle).
> 
> **Cloudflare gating:** Nine **privatereports.com**-family brokers and **usphonebook.com** now insert a post-`navigate` **expectation** that waits until Cloudflare challenge/Turnstile markers are absent (negative XPath covering challenge scripts, Turnstile iframe/input, and `cf-error-details`), before the existing form/UI waits continue.
> 
> **Scan / URL tweaks:** **quickpeopletrace.com** changes the result-row XPath from skipping the first row to rows with a second `td`, aligning extraction with the current table layout. **advancedbackgroundchecks.com** updates `optOutUrl` from `/removal` to `/opt-out` (0.10.0).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff738f04bc7054416225d5f3dfa290312ca621ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->