### PR TITLE
Update content scope scripts to version 16.7.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -7850,6 +7850,26 @@
     const day = dob.getDate().toString().padStart(2, "0");
     return `${dob.getFullYear()}-${month}-${day}`;
   }
+  var DEFAULT_DATE_OF_BIRTH_FORMAT = "YYYY-MM-DD";
+  var DATE_OF_BIRTH_TOKENS = {
+    YYYY: { year: "numeric" },
+    YY: { year: "2-digit" },
+    MMMM: { month: "long" },
+    MMM: { month: "short" },
+    MM: { month: "2-digit" },
+    M: { month: "numeric" },
+    DD: { day: "2-digit" },
+    D: { day: "numeric" }
+  };
+  var DATE_OF_BIRTH_TOKEN = new RegExp(
+    Object.keys(DATE_OF_BIRTH_TOKENS).sort((a2, b2) => b2.length - a2.length).join("|"),
+    "g"
+  );
+  function formatDateOfBirth(dateOfBirth, format = DEFAULT_DATE_OF_BIRTH_FORMAT) {
+    const [year, month, day] = dateOfBirth.split("-");
+    const date = new Date(Number(year), Number(month) - 1, Number(day));
+    return format.replace(DATE_OF_BIRTH_TOKEN, (token) => new Intl.DateTimeFormat("en-US", DATE_OF_BIRTH_TOKENS[token]).format(date));
+  }
   function generateStreetAddress() {
     const streetDigits = generateRandomInt(1, 5);
     const streetNumber = generateRandomInt(2, streetDigits * 1e3);
@@ -7898,6 +7918,7 @@
     const results = [];
     const address = selectAddress(data2.addresses, userProfile?.addresses);
     const extras = { ...data2.extras, ...address?.extras };
+    let dateOfBirth = null;
     for (const element of elements) {
       const inputElem = getElement(root, element.selector);
       if (!inputElem) {
@@ -7911,22 +7932,25 @@
       } else if (element.type === "$generated_zip_code$") {
         results.push(setValueForInput(inputElem, generateZipCode()));
       } else if (element.type === "$generated_dob$") {
-        if (!Object.prototype.hasOwnProperty.call(data2, "age")) {
-          results.push({
-            result: false,
-            error: `element found with selector '${element.selector}', but data didn't contain an 'age' to generate a date of birth from`
-          });
-          continue;
+        if (dateOfBirth === null) {
+          if (!Object.prototype.hasOwnProperty.call(data2, "age")) {
+            results.push({
+              result: false,
+              error: `element found with selector '${element.selector}', but data didn't contain an 'age' to generate a date of birth from`
+            });
+            continue;
+          }
+          const age = parseInt(data2.age, 10);
+          if (!Number.isFinite(age) || age < 0) {
+            results.push({
+              result: false,
+              error: `element found with selector '${element.selector}', but data contained an 'age' that wasn't a non-negative number`
+            });
+            continue;
+          }
+          dateOfBirth = generateDateOfBirth(age);
         }
-        const age = parseInt(data2.age, 10);
-        if (!Number.isFinite(age) || age < 0) {
-          results.push({
-            result: false,
-            error: `element found with selector '${element.selector}', but data contained an 'age' that wasn't a non-negative number`
-          });
-          continue;
-        }
-        results.push(setValueForInput(inputElem, generateDateOfBirth(age)));
+        results.push(setValueForInput(inputElem, formatDateOfBirth(dateOfBirth, element.format)));
       } else if (element.type === "$generated_random_number$") {
         if (!element.min || !element.max) {
           results.push({

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -7819,6 +7819,26 @@
     const day = dob.getDate().toString().padStart(2, "0");
     return `${dob.getFullYear()}-${month}-${day}`;
   }
+  var DEFAULT_DATE_OF_BIRTH_FORMAT = "YYYY-MM-DD";
+  var DATE_OF_BIRTH_TOKENS = {
+    YYYY: { year: "numeric" },
+    YY: { year: "2-digit" },
+    MMMM: { month: "long" },
+    MMM: { month: "short" },
+    MM: { month: "2-digit" },
+    M: { month: "numeric" },
+    DD: { day: "2-digit" },
+    D: { day: "numeric" }
+  };
+  var DATE_OF_BIRTH_TOKEN = new RegExp(
+    Object.keys(DATE_OF_BIRTH_TOKENS).sort((a2, b2) => b2.length - a2.length).join("|"),
+    "g"
+  );
+  function formatDateOfBirth(dateOfBirth, format = DEFAULT_DATE_OF_BIRTH_FORMAT) {
+    const [year, month, day] = dateOfBirth.split("-");
+    const date = new Date(Number(year), Number(month) - 1, Number(day));
+    return format.replace(DATE_OF_BIRTH_TOKEN, (token) => new Intl.DateTimeFormat("en-US", DATE_OF_BIRTH_TOKENS[token]).format(date));
+  }
   function generateStreetAddress() {
     const streetDigits = generateRandomInt(1, 5);
     const streetNumber = generateRandomInt(2, streetDigits * 1e3);
@@ -7867,6 +7887,7 @@
     const results = [];
     const address = selectAddress(data2.addresses, userProfile?.addresses);
     const extras = { ...data2.extras, ...address?.extras };
+    let dateOfBirth = null;
     for (const element of elements) {
       const inputElem = getElement(root, element.selector);
       if (!inputElem) {
@@ -7880,22 +7901,25 @@
       } else if (element.type === "$generated_zip_code$") {
         results.push(setValueForInput(inputElem, generateZipCode()));
       } else if (element.type === "$generated_dob$") {
-        if (!Object.prototype.hasOwnProperty.call(data2, "age")) {
-          results.push({
-            result: false,
-            error: `element found with selector '${element.selector}', but data didn't contain an 'age' to generate a date of birth from`
-          });
-          continue;
+        if (dateOfBirth === null) {
+          if (!Object.prototype.hasOwnProperty.call(data2, "age")) {
+            results.push({
+              result: false,
+              error: `element found with selector '${element.selector}', but data didn't contain an 'age' to generate a date of birth from`
+            });
+            continue;
+          }
+          const age = parseInt(data2.age, 10);
+          if (!Number.isFinite(age) || age < 0) {
+            results.push({
+              result: false,
+              error: `element found with selector '${element.selector}', but data contained an 'age' that wasn't a non-negative number`
+            });
+            continue;
+          }
+          dateOfBirth = generateDateOfBirth(age);
         }
-        const age = parseInt(data2.age, 10);
-        if (!Number.isFinite(age) || age < 0) {
-          results.push({
-            result: false,
-            error: `element found with selector '${element.selector}', but data contained an 'age' that wasn't a non-negative number`
-          });
-          continue;
-        }
-        results.push(setValueForInput(inputElem, generateDateOfBirth(age)));
+        results.push(setValueForInput(inputElem, formatDateOfBirth(dateOfBirth, element.format)));
       } else if (element.type === "$generated_random_number$") {
         if (!element.min || !element.max) {
           results.push({

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^16.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.5.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.7.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -61,7 +61,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#8fdfbc706ff6280a66a112201780be126e5ac6a8",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c13193705a8a5ab8a28d457a4849f27ba6d23676",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -196,9 +196,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^16.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.5.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.7.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217309735856193

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [x] All tests must pass
- [x] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to vendored autofill/broker form-fill logic; improves DOB field formatting without touching auth, networking, or persistence.
> 
> **Overview**
> Bumps `@duckduckgo/content-scope-scripts` from **16.6.0** to **16.7.0** in `package.json` and `package-lock.json`, with matching updates to the vendored Android build outputs (`autofillImport.js`, `brokerProtection.js`).
> 
> For **`$generated_dob$`** handling in `fillMany`, the scripts now generate a single date of birth per fill pass (shared across multiple DOB fields) and format it per field via a new **`formatDateOfBirth`** helper. That helper supports token strings like `YYYY`, `MM`, `DD`, etc. (default `YYYY-MM-DD`) using `Intl.DateTimeFormat`, driven by an optional **`element.format`** on each element instead of always writing the raw generated string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f59ffd41c9bb6d21a9b2a118639044b8a137f492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->