### PR TITLE
feature/cris/cpm prompt/prompt logic

### DIFF
--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInEvaluator.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInEvaluator.kt
@@ -55,11 +55,15 @@ class CookiePopupOptInEvaluator @Inject constructor(
         val eligible = autoconsentFeature.self().isEnabled() &&
             autoconsentFeature.cookiePopUpPreferenceSetting().isEnabled() &&
             autoconsentFeature.cookiePopUpOptInPrompt().isEnabled() &&
-            !settingsRepository.clickAcceptEnabled
+            !settingsRepository.clickAcceptEnabled &&
+            !settingsRepository.optInPromptChoiceMade &&
+            settingsRepository.optInPromptShownCount < MAX_PROMPT_DISPLAYS
 
         if (!eligible) {
             return@withContext ModalEvaluator.EvaluationResult.Skipped
         }
+
+        settingsRepository.optInPromptShownCount++
 
         delay(MODAL_DISPLAY_DELAY)
         appCoroutineScope.launch(dispatchers.main()) {
@@ -75,5 +79,6 @@ class CookiePopupOptInEvaluator @Inject constructor(
 
     companion object {
         private const val MODAL_DISPLAY_DELAY = 250L
+        private const val MAX_PROMPT_DISPLAYS = 3
     }
 }

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInEvaluator.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInEvaluator.kt
@@ -22,6 +22,7 @@ import android.content.Intent
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.autoconsent.impl.R
 import com.duckduckgo.autoconsent.impl.remoteconfig.AutoconsentFeature
+import com.duckduckgo.autoconsent.impl.store.AutoconsentSettingsRepository
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.promptscoordinator.api.ModalEvaluator
@@ -43,6 +44,7 @@ class CookiePopupOptInEvaluator @Inject constructor(
     private val applicationContext: Context,
     private val autoconsentFeature: AutoconsentFeature,
     private val dispatchers: DispatcherProvider,
+    private val settingsRepository: AutoconsentSettingsRepository,
 ) : ModalEvaluator {
 
     override val priority: Int = 6
@@ -50,7 +52,12 @@ class CookiePopupOptInEvaluator @Inject constructor(
     override val evaluatorId: String = "cookie_popup_opt_in"
 
     override suspend fun evaluate(): ModalEvaluator.EvaluationResult = withContext(dispatchers.io()) {
-        if (!autoconsentFeature.cookiePopUpOptInPrompt().isEnabled()) {
+        val eligible = autoconsentFeature.self().isEnabled() &&
+            autoconsentFeature.cookiePopUpPreferenceSetting().isEnabled() &&
+            autoconsentFeature.cookiePopUpOptInPrompt().isEnabled() &&
+            !settingsRepository.clickAcceptEnabled
+
+        if (!eligible) {
             return@withContext ModalEvaluator.EvaluationResult.Skipped
         }
 

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInViewModel.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInViewModel.kt
@@ -20,6 +20,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.autoconsent.api.Autoconsent
+import com.duckduckgo.autoconsent.impl.store.AutoconsentSettingsRepository
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
@@ -28,11 +30,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @ContributesViewModel(ActivityScope::class)
 class CookiePopupOptInViewModel @Inject constructor(
     private val autoconsent: Autoconsent,
+    private val settingsRepository: AutoconsentSettingsRepository,
+    private val dispatchers: DispatcherProvider,
 ) : ViewModel() {
 
     enum class Choice { MAX, KEEP_CURRENT }
@@ -68,6 +73,11 @@ class CookiePopupOptInViewModel @Inject constructor(
     }
 
     fun onConfirmClicked() {
-        viewModelScope.launch { command.send(Command.Close) }
+        viewModelScope.launch {
+            withContext(dispatchers.io()) {
+                settingsRepository.optInPromptChoiceMade = true
+            }
+            command.send(Command.Close)
+        }
     }
 }

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/store/AutoconsentSettingsDataStore.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/store/AutoconsentSettingsDataStore.kt
@@ -28,6 +28,8 @@ interface AutoconsentSettingsDataStore {
     var userSetting: Boolean
     var clickAcceptEnabled: Boolean
     var firstPopupHandled: Boolean
+    var optInPromptChoiceMade: Boolean
+    var optInPromptShownCount: Int
     fun invalidateCache()
 }
 
@@ -94,6 +96,22 @@ class RealAutoconsentSettingsDataStore constructor(
             }
         }
 
+    override var optInPromptChoiceMade: Boolean
+        get() = preferences.getBoolean(AUTOCONSENT_OPT_IN_PROMPT_CHOICE_MADE, false)
+        set(value) {
+            preferences.edit(commit = true) {
+                putBoolean(AUTOCONSENT_OPT_IN_PROMPT_CHOICE_MADE, value)
+            }
+        }
+
+    override var optInPromptShownCount: Int
+        get() = preferences.getInt(AUTOCONSENT_OPT_IN_PROMPT_SHOWN_COUNT, 0)
+        set(value) {
+            preferences.edit(commit = true) {
+                putInt(AUTOCONSENT_OPT_IN_PROMPT_SHOWN_COUNT, value)
+            }
+        }
+
     override fun invalidateCache() {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             _defaultValue = autoconsentFeature.onByDefault().isEnabled()
@@ -115,5 +133,7 @@ class RealAutoconsentSettingsDataStore constructor(
         private const val AUTOCONSENT_USER_SETTING = "AutoconsentUserSetting"
         private const val AUTOCONSENT_CLICK_ACCEPT_ENABLED = "AutoconsentClickAcceptEnabled"
         private const val AUTOCONSENT_FIRST_POPUP_HANDLED = "AutoconsentFirstPopupHandled"
+        private const val AUTOCONSENT_OPT_IN_PROMPT_CHOICE_MADE = "AutoconsentOptInPromptChoiceMade"
+        private const val AUTOCONSENT_OPT_IN_PROMPT_SHOWN_COUNT = "AutoconsentOptInPromptShownCount"
     }
 }

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/Fakes.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/Fakes.kt
@@ -55,6 +55,8 @@ class FakeSettingsRepository : AutoconsentSettingsRepository {
     override var userSetting: Boolean = false
     override var clickAcceptEnabled: Boolean = false
     override var firstPopupHandled: Boolean = false
+    override var optInPromptChoiceMade: Boolean = false
+    override var optInPromptShownCount: Int = 0
     override fun invalidateCache() {}
 }
 

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInEvaluatorTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInEvaluatorTest.kt
@@ -97,10 +97,35 @@ class CookiePopupOptInEvaluatorTest {
     }
 
     @Test
+    fun whenChoiceAlreadyMadeThenSkipped() = runTest {
+        settingsRepository.optInPromptChoiceMade = true
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+        assertNull(shadowOf(application).nextStartedActivity)
+    }
+
+    @Test
+    fun whenAlreadyShownMaxTimesThenSkipped() = runTest {
+        settingsRepository.optInPromptShownCount = 3
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+        assertNull(shadowOf(application).nextStartedActivity)
+    }
+
+    @Test
     fun whenAllConditionsMetThenModalShownAndActivityLaunched() = runTest {
         assertEquals(ModalEvaluator.EvaluationResult.ModalShown, testee.evaluate())
 
         val launched = shadowOf(application).nextStartedActivity
         assertEquals(CookiePopupOptInActivity::class.java.name, launched.component?.className)
+    }
+
+    @Test
+    fun whenModalShownThenShownCountIncremented() = runTest {
+        settingsRepository.optInPromptShownCount = 2
+
+        assertEquals(ModalEvaluator.EvaluationResult.ModalShown, testee.evaluate())
+        assertEquals(3, settingsRepository.optInPromptShownCount)
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
     }
 }

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInEvaluatorTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInEvaluatorTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autoconsent.impl.prompt
 
 import android.app.Application
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.autoconsent.impl.FakeSettingsRepository
 import com.duckduckgo.autoconsent.impl.remoteconfig.AutoconsentFeature
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
@@ -27,6 +28,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -42,6 +44,7 @@ class CookiePopupOptInEvaluatorTest {
 
     private val application: Application get() = RuntimeEnvironment.getApplication()
     private val feature = FakeFeatureToggleFactory.create(AutoconsentFeature::class.java)
+    private val settingsRepository = FakeSettingsRepository()
 
     private val testee by lazy {
         CookiePopupOptInEvaluator(
@@ -49,7 +52,16 @@ class CookiePopupOptInEvaluatorTest {
             applicationContext = application,
             autoconsentFeature = feature,
             dispatchers = coroutineRule.testDispatcherProvider,
+            settingsRepository = settingsRepository,
         )
+    }
+
+    @Before
+    fun setup() {
+        feature.self().setRawStoredState(Toggle.State(enable = true))
+        feature.cookiePopUpPreferenceSetting().setRawStoredState(Toggle.State(enable = true))
+        feature.cookiePopUpOptInPrompt().setRawStoredState(Toggle.State(enable = true))
+        settingsRepository.clickAcceptEnabled = false
     }
 
     @Test
@@ -61,9 +73,31 @@ class CookiePopupOptInEvaluatorTest {
     }
 
     @Test
-    fun whenPromptToggleEnabledThenModalShownAndActivityLaunched() = runTest {
-        feature.cookiePopUpOptInPrompt().setRawStoredState(Toggle.State(enable = true))
+    fun whenAutoconsentSelfDisabledThenSkipped() = runTest {
+        feature.self().setRawStoredState(Toggle.State(enable = false))
 
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+        assertNull(shadowOf(application).nextStartedActivity)
+    }
+
+    @Test
+    fun whenCookiePopUpPreferenceSettingDisabledThenSkipped() = runTest {
+        feature.cookiePopUpPreferenceSetting().setRawStoredState(Toggle.State(enable = false))
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+        assertNull(shadowOf(application).nextStartedActivity)
+    }
+
+    @Test
+    fun whenClickAcceptEnabledThenSkipped() = runTest {
+        settingsRepository.clickAcceptEnabled = true
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+        assertNull(shadowOf(application).nextStartedActivity)
+    }
+
+    @Test
+    fun whenAllConditionsMetThenModalShownAndActivityLaunched() = runTest {
         assertEquals(ModalEvaluator.EvaluationResult.ModalShown, testee.evaluate())
 
         val launched = shadowOf(application).nextStartedActivity

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInViewModelTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInViewModelTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autoconsent.impl.prompt
 
 import app.cash.turbine.test
 import com.duckduckgo.autoconsent.api.Autoconsent
+import com.duckduckgo.autoconsent.impl.FakeSettingsRepository
 import com.duckduckgo.autoconsent.impl.prompt.CookiePopupOptInViewModel.Choice
 import com.duckduckgo.autoconsent.impl.prompt.CookiePopupOptInViewModel.Command
 import com.duckduckgo.autoconsent.impl.prompt.CookiePopupOptInViewModel.Variant
@@ -25,6 +26,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
@@ -37,8 +39,9 @@ class CookiePopupOptInViewModelTest {
     val coroutineRule = CoroutineTestRule()
 
     private val autoconsent: Autoconsent = mock()
+    private val settingsRepository = FakeSettingsRepository()
 
-    private val testee by lazy { CookiePopupOptInViewModel(autoconsent) }
+    private val testee by lazy { CookiePopupOptInViewModel(autoconsent, settingsRepository, coroutineRule.testDispatcherProvider) }
 
     @Test
     fun whenCreatedThenMaxOptionIsSelected() {
@@ -83,5 +86,12 @@ class CookiePopupOptInViewModelTest {
             assertEquals(Command.Close, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun whenConfirmClickedThenChoiceStored() = runTest {
+        testee.onConfirmClicked()
+
+        assertTrue(settingsRepository.optInPromptChoiceMade)
     }
 }


### PR DESCRIPTION
Task/Issue URL: 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized autoconsent prompt UX and SharedPreferences settings; no auth or network changes.
> 
> **Overview**
> Adds **gating and persistence** for the cookie popup opt-in modal so it only appears when autoconsent, cookie popup preference, and opt-in prompt toggles are on, **click-accept is off**, the user has **not** already confirmed, and the prompt has been shown **fewer than three times**.
> 
> **`CookiePopupOptInEvaluator`** now reads `AutoconsentSettingsRepository` for those conditions and **increments** `optInPromptShownCount` each time it shows the activity. **`CookiePopupOptInViewModel`** sets **`optInPromptChoiceMade`** on confirm so the prompt does not return after the user completes the flow.
> 
> New persisted fields **`optInPromptChoiceMade`** and **`optInPromptShownCount`** are added on the settings datastore (and fakes), with expanded evaluator and view model tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b757a493c2e29a7d7575867a39817a6b6ea705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->