### PR TITLE
Fix Android Design System Maestro flow after Navigation tab addition

### DIFF
--- a/.maestro/ads_preview_flows/1-_design-system-components.yaml
+++ b/.maestro/ads_preview_flows/1-_design-system-components.yaml
@@ -105,6 +105,8 @@ tags:
             id: "com.duckduckgo.mobile.android:id/primaryCta"
         - tapOn: "LAYOUTS"
         - assertVisible: "Dax Dialog Card"
+        - tapOn: "NAVIGATION"
+        - assertVisible: "Top bar"
         - tapOn: "INTERACTIVE"
         - tapOn:
             id: "com.duckduckgo.mobile.android:id/dax_switch_one"
@@ -175,6 +177,7 @@ tags:
         - tapOn: "TEXT INPUT"
         - tapOn: "DIALOGS"
         - tapOn: "LAYOUTS"
+        - tapOn: "NAVIGATION"
         - tapOn: "INTERACTIVE"
         - tapOn: "MESSAGING"
         - tapOn: "LIST ITEMS"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1217339255113902?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

The Android Design System nightly Maestro flow was failing with `Element not found: Text matching regex: INTERACTIVE`. The new NAVIGATION tab added for the Compose top app bar work shifted INTERACTIVE further along the scrollable tab strip, so the flow's direct tap on it after LAYOUTS could no longer find it on screen. Added a tap on NAVIGATION in between so the tab strip scrolls INTERACTIVE back into view.

### Steps to test this PR

_Android Design System Maestro flow_
- [x] Run `maestro test .maestro/ads_preview_flows/1-_design-system-components.yaml` and confirm it passes

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only YAML changes with no production code, security, or data impact.
> 
> **Overview**
> Updates the Android Design System Maestro flow so it still passes after a **NAVIGATION** tab was added to the preview’s scrollable tab strip.
> 
> After **LAYOUTS**, the flow now taps **NAVIGATION** and asserts **Top bar** is visible before continuing to **INTERACTIVE**, so the strip scrolls **INTERACTIVE** back on screen (the direct tap was failing with “Element not found: INTERACTIVE”). The same **NAVIGATION** tap is added in the later tab-walk sequence between **LAYOUTS** and **INTERACTIVE**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48b6d394d644e7b7ee3794bbc587912202e270f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->