### PR TITLE
Skip CI checks for .maestro and scripts-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,12 @@ jobs:
             exit 0
           fi
           echo "Changed files:"; echo "$CHANGED"
-          if ([ -n "$CHANGED" ] && echo "$CHANGED" | grep -qvE '(\.md$|^\.github/|^\.claude/)') || \
+          if ([ -n "$CHANGED" ] && echo "$CHANGED" | grep -qvE '(\.md$|^\.github/|^\.claude/|^\.maestro/|^scripts/)') || \
              echo "$CHANGED" | grep -qF '.github/workflows/ci.yml'; then
             echo "Code or required CI workflow changes detected — running checks"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Only docs, Claude tooling, or optional workflow changes detected — skipping checks"
+            echo "Only docs, tooling, or optional workflow changes detected — skipping checks"
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217317704404722

### Description
`check_changes` in `ci.yml` already skips the heavy check suite for `.md`-only, `.github/`-only, and `.claude/`-only diffs (#9438). Extends the same treatment to `.maestro/` and `scripts/`, per the follow-up agreed during that review.

### Steps to test this PR
- [ ] Push a commit touching only files under `.maestro/` or `scripts/` on a branch → `Check Changed Files` job logs "skipping checks", `Code Formatting`/`Android CI tests` report `skipped`, `Unit tests`/`Lint` (both DI matrix legs) still report `success`
- [ ] Push a commit touching both a `.maestro/`/`scripts/` file and a real source file → `should_run=true`, full suite runs

### UI changes
N/A — CI workflow change only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to PR diff filtering; no app runtime or security impact, with full checks still enforced when real source or `ci.yml` changes.
> 
> **Overview**
> Extends the **`check_changes`** gate in **`ci.yml`** so PRs that only touch **`.maestro/`** or **`scripts/`** skip the heavy suite (formatting, Android CI tests, etc.), matching the existing treatment for markdown, **`.github/`**, and **`.claude/`** changes.
> 
> The path filter regex adds **`^\.maestro/`** and **`^scripts/`**; edits confined to **`ci.yml`** still force a full run. The skip log line is generalized from “Claude tooling” to “tooling.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e185eeb7bbbe2b2182dd86e4cb9a8c09520fb303. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->