### PR TITLE
Add surface param to Duck.ai chat prompt pixel

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1258,14 +1258,14 @@
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_sent_prompt_in_chat_daily": {
         "description": "(Daily Pixel) User submitted a prompt from the Unified Input while in a Duck.ai chat context. Fires alongside m_aichat_unified_input_prompt_submitted_daily.",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_stop_generation_tapped": {
         "description": "User tapped the stop generation button in the Unified Input",

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -194,7 +194,7 @@ interface DuckChatPixels {
     )
 
     /** Prompt submitted while the unified input is in a Duck.ai chat context. Fires alongside [firePromptSubmitted]. */
-    fun fireSentPromptInChat()
+    fun fireSentPromptInChat(surface: DuckChatPixelSurface)
     fun fireModelSelected(modelId: String, surface: DuckChatPixelSurface)
     fun fireReasoningEffortSelected(effortLevel: String, surface: DuckChatPixelSurface)
 
@@ -630,9 +630,10 @@ class RealDuckChatPixels @Inject constructor(
         )
     }
 
-    override fun fireSentPromptInChat() = fireCountAndDaily(
+    override fun fireSentPromptInChat(surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SENT_PROMPT_IN_CHAT_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SENT_PROMPT_IN_CHAT_DAILY,
+        surfaceParams(surface),
     )
 
     override fun fireModelSelected(modelId: String, surface: DuckChatPixelSurface) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -256,7 +256,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         }
     }
 
-    fun fireSentPromptInChat() = duckChatPixels.fireSentPromptInChat()
+    fun fireSentPromptInChat() = duckChatPixels.fireSentPromptInChat(currentSurface())
 
     fun fireVoiceTapped() = duckChatPixels.fireVoiceTapped(currentSurface())
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -463,13 +463,18 @@ class RealDuckChatPixelsTest {
     }
 
     @Test
-    fun whenFireSentPromptInChatThenCountAndDailyFired() = runTest {
-        testee.fireSentPromptInChat()
+    fun whenFireSentPromptInChatThenCountAndDailyFiredWithSurface() = runTest {
+        testee.fireSentPromptInChat(DuckChatPixelSurface.CONTEXTUAL_CHAT)
 
         advanceUntilIdle()
 
-        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SENT_PROMPT_IN_CHAT_COUNT)
-        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SENT_PROMPT_IN_CHAT_DAILY, type = Pixel.PixelType.Daily())
+        val params = mapOf(DuckChatPixelParameters.SURFACE to "contextual_chat")
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SENT_PROMPT_IN_CHAT_COUNT, parameters = params)
+        verify(mockPixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SENT_PROMPT_IN_CHAT_DAILY,
+            parameters = params,
+            type = Pixel.PixelType.Daily(),
+        )
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -1624,6 +1624,28 @@ class NativeInputModeWidgetViewModelTest {
         verify(duckChatPixels, never()).fireImageGenerationSubmitted(any())
     }
 
+    @Test
+    fun whenSentPromptInChatFromDuckAiTabThenDuckAiSurface() = runTest {
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        advanceUntilIdle()
+
+        viewModel.fireSentPromptInChat()
+
+        verify(duckChatPixels).fireSentPromptInChat(DuckChatPixelSurface.DUCK_AI)
+    }
+
+    @Test
+    fun whenSentPromptInChatFromContextualSheetThenContextualSurface() = runTest {
+        val viewModel = createViewModel()
+        viewModel.configureContextual(tabId = "tab-A")
+        advanceUntilIdle()
+
+        viewModel.fireSentPromptInChat()
+
+        verify(duckChatPixels).fireSentPromptInChat(DuckChatPixelSurface.CONTEXTUAL_CHAT)
+    }
+
     // endregion
 
     // region voice / stop pixels


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211654189969294/task/1217105288089801
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

`m_aichat_unified_input_sent_prompt_in_chat_count` / `_daily` fire whenever a prompt is submitted from the unified input while it is in a Duck.ai chat context, which covers both the Duck.ai tab and the contextual sheet. Until now there was no way to tell those two surfaces apart in the data.

This adds the existing `unifiedInputSurface` param (enum `address_bar | duck_ai | contextual_chat`) to both pixels, derived from the active tab's published input context via the `currentSurface()` helper that already feeds the rest of the unified-input family (`prompt_submitted`, tools, model/reasoning pickers, attachments, voice, stop).

In practice only `duck_ai` and `contextual_chat` are emitted, since the pixel only fires when the input is in a Duck.ai page context.

This mirrors the iOS change in https://github.com/duckduckgo/apple-browsers/pull/5779.

Pixel definitions updated for both pixels; `privacy review required` label applied.

### Steps to test this PR

_Prompt sent from the Duck.ai tab_
- [ ] Install an internal build with the unified input enabled
- [ ] Open the Duck.ai tab and send a prompt, then send a second prompt in the same chat
- [ ] In the pixel debug output (or a proxy), confirm `m_aichat_unified_input_sent_prompt_in_chat_count` and `_daily` carry `surface=duck_ai`

_Prompt sent from the contextual sheet_
- [ ] Load any web page and open the Duck.ai contextual sheet from the omnibar
- [ ] Send a prompt from the sheet
- [ ] Confirm `m_aichat_unified_input_sent_prompt_in_chat_count` and `_daily` carry `surface=contextual_chat`

_No pixel for search submissions_
- [ ] From the browser omnibar, submit a search (search tab of the unified input)
- [ ] Confirm `m_aichat_unified_input_sent_prompt_in_chat_*` does not fire

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes|No UI changes|
