### PR TITLE
Fix: Favorites not functional on Search only

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -6545,6 +6545,8 @@ class BrowserTabFragment :
             addNewTabPageContent()
             newBrowserTab.newTabRootLayout.show()
             newBrowserTab.newTabLayout.show()
+            binding.browserLayout.gone()
+            webViewContainer.gone()
 
             omnibar.setViewMode(ViewMode.NewTab)
             omnibar.isScrollingEnabled = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1217320613314684?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
 - Fixed New Tab Page favorites becoming unresponsive to taps in search-only address bar mode. `showNewTab()` now hides` browserLayout/webViewContainer `when displaying the NTP, mirroring `showHome().`
- Previously the browser layer could stay z-ordered above the NTP after returning to a tab via `showNewTab();` being transparent, it let favorites render through while silently intercepting every tap, so they appeared dead until the view was recreated (e.g. switching to Duck.ai and back).
- Restores the NTP/browser layer mutual exclusivity, so favorite taps reliably reach the grid.

### Steps to test this PR
(Load favorites via Developer Settings > Tabs and Saved Sites)

- [x] Ensure you have Search Only enabled
- [x] Start with just one new tab
- [x] Tap a favorite -> verify it works and opens the site on the tab
- [x] Go to tab list and add a new tab 
- [x] Tap a favorite -> verify it works and opens the site on the tab
- [x] Go to tabs list and close the first tab
- [x] On the remaining tab, tap the back button until the browser exits
- [x] Open the browser again
- [x] Tap a favorite to load a site -> verify it works and opens the site on the tab [Previously fails]



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 049f569a78e7a247fe6aaebab585c3ea484a03e4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->