### PR TITLE
Hide Report Broken Site in the menu on Duck.ai

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2181,7 +2181,8 @@ class BrowserTabViewModel @Inject constructor(
                 addToHomeEnabled = domain != null,
                 canSharePage = domain != null,
                 showPrivacyShield = HighlightableButton.Visible(enabled = true),
-                canReportSite = domain != null && !duckPlayer.isDuckPlayerUri(url),
+                // Duck.ai issues aren't site breakage, they go through the feedback flow instead
+                canReportSite = domain != null && !duckPlayer.isDuckPlayerUri(url) && !duckChat.isDuckChatUrl(url.toUri()),
                 canChangePrivacyProtection = domain != null && !duckPlayer.isDuckPlayerUri(url),
                 isPrivacyProtectionDisabled = false,
                 canFindInPage = true,

--- a/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuViewStateFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuViewStateFactory.kt
@@ -120,7 +120,6 @@ class RealBrowserMenuViewStateFactory @Inject constructor(
     ): BrowserMenuViewState.DuckAi {
         return BrowserMenuViewState.DuckAi(
             canPrintPage = browserViewState.canPrintPage,
-            canReportSite = browserViewState.canReportSite,
             showAutofill = browserViewState.showAutofill,
             showDownloadDot = newDownloadState.hasNewDownload(),
             showDuckChatHistoryOption = browserViewState.showDuckChatHistoryOption,

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -4461,6 +4461,16 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenUserInDuckAiThenCannotReportSite() {
+        val duckAiUrl = "https://duck.ai/"
+        whenever(mockDuckChat.isDuckChatUrl(duckAiUrl.toUri())).thenReturn(true)
+
+        loadUrl(duckAiUrl)
+
+        assertFalse(browserViewState().canReportSite)
+    }
+
+    @Test
     fun whenUserInDuckPlayerThenCannotAllowList() {
         setupNavigation(skipHome = false, isBrowsing = true)
         whenever(mockDuckPlayer.isDuckPlayerUri(anyString())).thenReturn(true)

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheet.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheet.kt
@@ -454,7 +454,8 @@ class BrowserMenuBottomSheet(
         settingsMenuItem.isEnabled = true
 
         refreshMenuItem.isVisible = true
-        brokenSiteMenuItem.isVisible = viewState.canReportSite
+        // Duck.ai issues aren't site breakage, they go through the feedback flow instead
+        brokenSiteMenuItem.isVisible = false
         printPageMenuItem.isVisible = viewState.canPrintPage
         autofillMenuItem.isVisible = viewState.showAutofill
         downloadsMenuItem.isVisible = true

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuViewState.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuViewState.kt
@@ -77,7 +77,6 @@ sealed class BrowserMenuViewState {
 
     data class DuckAi(
         val canPrintPage: Boolean = false,
-        val canReportSite: Boolean = false,
         val showAutofill: Boolean = false,
         val showDownloadDot: Boolean = false,
         val showDuckChatHistoryOption: Boolean = false,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217302708360937
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

Duck.ai bugs are feature/browser issues, not site breakage, so the Report Broken Site entry in the browser menu sends them into the broken site reports pipeline where duck.ai is muted and nothing gets triaged. It also pulls people away from the feedback flow that actually reaches the team. iOS already doesn't offer the option on Duck.ai.

The Duck.ai menu state no longer carries `canReportSite` at all, and the item is hidden in the Duck.ai render. `canReportSite` in `BrowserTabViewModel` now also excludes Duck.ai URLs, so the regular browser menu can't show the item in the window before the page is recognised as Duck.ai.

### Steps to test this PR

_Report Broken Site is gone on Duck.ai_
- [x] Open Duck.ai (omnibar, Duck.ai shortcut, or a duck.ai link)
- [x] Open the browser menu and scroll through it
- [x] There is no Report Broken Site entry

_Report Broken Site still works everywhere else_
- [x] Load any regular website, e.g. https://example.com
- [x] Open the browser menu, tap Report Broken Site, confirm the report flow opens
- [x] Load a DuckDuckGo SERP and confirm the entry stays hidden there, as before

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="1080" height="2424" alt="androidReporting" src="https://github.com/user-attachments/assets/d67d9299-8e1f-42d7-89ff-a0b156cbb874" />|<img width="1080" height="2424" alt="image-1786380434078" src="https://github.com/user-attachments/assets/2560f5fe-715a-40a9-9c77-709f7d0a17a0" />|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Menu visibility and view-state wiring only; no changes to reporting backends, auth, or data handling.
> 
> **Overview**
> **Report Broken Site** is removed from the browser menu on Duck.ai so users aren’t sent into the broken-site pipeline (where Duck.ai is muted); behavior aligns with iOS.
> 
> `canReportSite` in `BrowserTabViewModel` now treats Duck.ai URLs like Duck Player—disabled when `duckChat.isDuckChatUrl` is true. The Duck.ai menu path no longer carries `canReportSite`; `renderDuckAiMenu` always hides the broken-site item. Regular sites still use `canReportSite` from the browser menu state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 344811cdf540842079d5218d9fc40ce078929901. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->