### PR TITLE
Add an edit mode to the native input widget

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
@@ -41,6 +41,8 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ImageAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.LimitsHandler
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.PageContextAttachment
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedFile
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedImage
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachmentProcessor
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -161,6 +163,43 @@ class AttachmentViewModel @Inject constructor(
             }
         }
     }
+
+    /**
+     * Takes attachments that are already encoded (an edit of a sent message) straight into state:
+     * no validation or limit accounting, because an edit can only remove attachments.
+     */
+    fun adopt(
+        images: List<AdoptedImage>,
+        files: List<AdoptedFile>,
+    ) {
+        imageAttachments.value = images.map { image ->
+            val bytes = decodeBase64(image.data)
+            // The image stays in state even when it cannot be rendered, so submitting preserves it
+            // and the user can still remove it.
+            val bitmap = bytes?.let { BitmapFactory.decodeByteArray(it, 0, it.size) } ?: placeholderBitmap()
+            ImageAttachment(
+                id = UUID.randomUUID().toString(),
+                bitmap = bitmap,
+                base64Data = image.data,
+                format = image.format,
+            )
+        }
+        _fileAttachments.value = files.map { file ->
+            FileAttachment(
+                id = UUID.randomUUID().toString(),
+                uri = Uri.EMPTY,
+                fileName = file.fileName,
+                mimeType = file.mimeType,
+                sizeBytes = decodeBase64(file.data)?.size?.toLong() ?: 0L,
+                base64Data = file.data,
+            )
+        }
+    }
+
+    private fun decodeBase64(data: String): ByteArray? = runCatching { Base64.decode(data, Base64.DEFAULT) }.getOrNull()
+
+    private fun placeholderBitmap(): Bitmap =
+        Bitmap.createBitmap(PLACEHOLDER_BITMAP_SIZE_PX, PLACEHOLDER_BITMAP_SIZE_PX, Bitmap.Config.ARGB_8888)
 
     fun onFilesPicked(uris: List<Uri>) {
         viewModelScope.launch {
@@ -429,6 +468,7 @@ class AttachmentViewModel @Inject constructor(
     companion object {
         private const val COMPRESSION_QUALITY = 85
         private const val MAX_DIMENSION_PX = 512
+        private const val PLACEHOLDER_BITMAP_SIZE_PX = 96
         private const val FILE_VALIDATION_SIZE_EXCEEDED = "size_exceeded"
         private const val FILE_VALIDATION_COUNT_EXCEEDED = "count_exceeded"
         private const val FILE_VALIDATION_PAGE_COUNT_EXCEEDED = "page_count_exceeded"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
@@ -41,8 +41,8 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ImageAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.LimitsHandler
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.PageContextAttachment
-import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedFile
-import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedImage
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.SubmittedFile
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.SubmittedImage
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachmentProcessor
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -169,32 +169,42 @@ class AttachmentViewModel @Inject constructor(
      * no validation or limit accounting, because an edit can only remove attachments.
      */
     fun adopt(
-        images: List<AdoptedImage>,
-        files: List<AdoptedFile>,
+        images: List<SubmittedImage>,
+        files: List<SubmittedFile>,
     ) {
-        val toRecycle = imageAttachments.value
-        imageAttachments.value = images.map { image ->
-            val bytes = decodeBase64(image.data)
-            // The image stays in state even when it cannot be rendered, so submitting preserves it
-            // and the user can still remove it.
-            val bitmap = bytes?.let { BitmapFactory.decodeByteArray(it, 0, it.size) } ?: placeholderBitmap()
-            ImageAttachment(
-                id = UUID.randomUUID().toString(),
-                bitmap = bitmap,
-                base64Data = image.data,
-                format = image.format,
-            )
-        }
-        viewModelScope.launch { toRecycle.forEach { it.bitmap.recycle() } }
-        _fileAttachments.value = files.map { file ->
-            FileAttachment(
-                id = UUID.randomUUID().toString(),
-                uri = Uri.EMPTY,
-                fileName = file.fileName,
-                mimeType = file.mimeType,
-                sizeBytes = decodeBase64(file.data)?.size?.toLong() ?: 0L,
-                base64Data = file.data,
-            )
+        viewModelScope.launch {
+            // Base64 decode + bitmap decode of full attachment payloads is real work — off the
+            // calling thread (typically main, via EditPromptActivity.onCreate), same as onImagesPicked.
+            val adoptedImages = withContext(dispatchers.io()) {
+                images.map { image ->
+                    val bytes = decodeBase64(image.data)
+                    // The image stays in state even when it cannot be rendered, so submitting preserves it
+                    // and the user can still remove it.
+                    val bitmap = bytes?.let { BitmapFactory.decodeByteArray(it, 0, it.size) } ?: placeholderBitmap()
+                    ImageAttachment(
+                        id = UUID.randomUUID().toString(),
+                        bitmap = bitmap,
+                        base64Data = image.data,
+                        format = image.format,
+                    )
+                }
+            }
+            val adoptedFiles = withContext(dispatchers.io()) {
+                files.map { file ->
+                    FileAttachment(
+                        id = UUID.randomUUID().toString(),
+                        uri = Uri.EMPTY,
+                        fileName = file.fileName,
+                        mimeType = file.mimeType,
+                        sizeBytes = decodeBase64(file.data)?.size?.toLong() ?: 0L,
+                        base64Data = file.data,
+                    )
+                }
+            }
+            val toRecycle = imageAttachments.value
+            imageAttachments.value = adoptedImages
+            _fileAttachments.value = adoptedFiles
+            viewModelScope.launch { toRecycle.forEach { it.bitmap.recycle() } }
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
@@ -172,6 +172,7 @@ class AttachmentViewModel @Inject constructor(
         images: List<AdoptedImage>,
         files: List<AdoptedFile>,
     ) {
+        val toRecycle = imageAttachments.value
         imageAttachments.value = images.map { image ->
             val bytes = decodeBase64(image.data)
             // The image stays in state even when it cannot be rendered, so submitting preserves it
@@ -184,6 +185,7 @@ class AttachmentViewModel @Inject constructor(
                 format = image.format,
             )
         }
+        viewModelScope.launch { toRecycle.forEach { it.bitmap.recycle() } }
         _fileAttachments.value = files.map { file ->
             FileAttachment(
                 id = UUID.randomUUID().toString(),

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -544,6 +544,20 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         replayPendingState(tabId)
     }
 
+    /**
+     * The edit screen hosts a second widget for a tab that already has one. Publishing under a
+     * synthetic key keeps it from overwriting the real tab's state, which nothing would repair:
+     * `state` only re-publishes when a value changes.
+     */
+    fun configureForEdit(sessionId: String) {
+        activeTabId.value = editStateKey(sessionId)
+        widgetConfig.value = WidgetConfig(
+            inputContext = NativeInputState.InputContext.DUCK_AI,
+            inputPosition = NativeInputState.InputPosition.TOP,
+            toggleSelection = NativeInputState.ToggleSelection.DUCK_AI,
+        )
+    }
+
     fun cancelChatSuggestions() {
         chatSuggestionsReader.tearDown()
         lastChatUrlSuggestions = emptyList()
@@ -661,4 +675,8 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         } else {
             NativeInputState.InputMode.SEARCH_ONLY
         }
+
+    companion object {
+        fun editStateKey(sessionId: String): String = "edit:$sessionId"
+    }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -344,25 +344,21 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         .map { it.duckAiFireButtonHighlighted }
         .distinctUntilChanged()
 
-    // chatState is a global signal, not scoped to any one tab — the edit widget has no chat of its
-    // own streaming, so it must never inherit whatever the real tab is doing.
-    private val isChatStreamingForThisWidget: Flow<Boolean> = combine(
-        duckChatInternal.chatState,
-        activeTabId,
-    ) { chatState, tabId ->
-        val isEditWidget = tabId?.startsWith(EDIT_STATE_KEY_PREFIX) == true
-        !isEditWidget && (chatState == ChatState.STREAMING || chatState == ChatState.LOADING)
-    }
-
     val state: SharedFlow<NativeInputState> = combine(
         baseState,
-        isChatStreamingForThisWidget,
+        duckChatInternal.chatState,
         activeChatId,
         interactionLock,
         duckAiFireButtonHighlighted,
-    ) { state, isStreaming, chatId, lock, fireHighlighted ->
+    ) { state, chatState, chatId, lock, fireHighlighted ->
+        // chatState is a global signal, not scoped to any one tab — the edit widget has no chat of
+        // its own streaming, so it must never inherit whatever the real tab is doing. Read
+        // synchronously rather than folded into the combine's inputs, so this Flow's shape is
+        // otherwise identical to the pre-edit-mode code (a prior version spliced a derived Flow in
+        // here instead and shipped a regression in the real, non-edit composer's toggle state).
+        val isEditWidget = activeTabId.value?.startsWith(EDIT_STATE_KEY_PREFIX) == true
         state.copy(
-            isChatStreaming = isStreaming,
+            isChatStreaming = !isEditWidget && (chatState == ChatState.STREAMING || chatState == ChatState.LOADING),
             chatId = chatId,
             interactionLock = lock,
             duckAiFireButtonHighlighted = fireHighlighted,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -344,15 +344,25 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         .map { it.duckAiFireButtonHighlighted }
         .distinctUntilChanged()
 
+    // chatState is a global signal, not scoped to any one tab — the edit widget has no chat of its
+    // own streaming, so it must never inherit whatever the real tab is doing.
+    private val isChatStreamingForThisWidget: Flow<Boolean> = combine(
+        duckChatInternal.chatState,
+        activeTabId,
+    ) { chatState, tabId ->
+        val isEditWidget = tabId?.startsWith(EDIT_STATE_KEY_PREFIX) == true
+        !isEditWidget && (chatState == ChatState.STREAMING || chatState == ChatState.LOADING)
+    }
+
     val state: SharedFlow<NativeInputState> = combine(
         baseState,
-        duckChatInternal.chatState,
+        isChatStreamingForThisWidget,
         activeChatId,
         interactionLock,
         duckAiFireButtonHighlighted,
-    ) { state, chatState, chatId, lock, fireHighlighted ->
+    ) { state, isStreaming, chatId, lock, fireHighlighted ->
         state.copy(
-            isChatStreaming = chatState == ChatState.STREAMING || chatState == ChatState.LOADING,
+            isChatStreaming = isStreaming,
             chatId = chatId,
             interactionLock = lock,
             duckAiFireButtonHighlighted = fireHighlighted,
@@ -677,6 +687,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         }
 
     companion object {
-        fun editStateKey(sessionId: String): String = "edit:$sessionId"
+        private const val EDIT_STATE_KEY_PREFIX = "edit:"
+        fun editStateKey(sessionId: String): String = "$EDIT_STATE_KEY_PREFIX$sessionId"
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/edit/AdoptedAttachment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/edit/AdoptedAttachment.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.edit
+
+/** An attachment already on a sent message, handed to the native input as base64 by the frontend. */
+data class AdoptedImage(
+    val data: String,
+    val format: String,
+)
+
+data class AdoptedFile(
+    val data: String,
+    val fileName: String,
+    val mimeType: String,
+)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/edit/SubmittedAttachment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/edit/SubmittedAttachment.kt
@@ -17,12 +17,12 @@
 package com.duckduckgo.duckchat.impl.ui.nativeinput.edit
 
 /** An attachment already on a sent message, handed to the native input as base64 by the frontend. */
-data class AdoptedImage(
+data class SubmittedImage(
     val data: String,
     val format: String,
 )
 
-data class AdoptedFile(
+data class SubmittedFile(
     val data: String,
     val fileName: String,
     val mimeType: String,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
@@ -46,8 +46,8 @@ import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.ui.AttachmentViewModel
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ImageAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.PageContextAttachment
-import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedFile
-import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedImage
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.SubmittedFile
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.SubmittedImage
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachmentsContainerView
 import kotlinx.coroutines.CoroutineScope
@@ -132,8 +132,8 @@ class AttachmentView(
     fun clearAttachments() = viewModel?.clearAttachments()
 
     fun adoptAttachments(
-        images: List<AdoptedImage>,
-        files: List<AdoptedFile>,
+        images: List<SubmittedImage>,
+        files: List<SubmittedFile>,
     ) = viewModel?.adopt(images, files)
 
     fun clearAttachmentsForNewChat() = viewModel?.clearAttachmentsForNewChat()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
@@ -46,6 +46,8 @@ import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.ui.AttachmentViewModel
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ImageAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.PageContextAttachment
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedFile
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedImage
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachmentsContainerView
 import kotlinx.coroutines.CoroutineScope
@@ -64,6 +66,7 @@ class AttachmentView(
     var onCameraCaptureRequested: ((ValueCallback<Array<Uri>>) -> Unit)? = null
     var onFilePickerRequested: ((ValueCallback<Array<Uri>>, List<String>) -> Unit)? = null
     var isContextual: Boolean = false
+    var isEditMode: Boolean = false
     var onAskAboutPage: (() -> Unit)? = null
     var onPageContextRemoved: (() -> Unit)? = null
 
@@ -108,7 +111,12 @@ class AttachmentView(
     }
 
     private fun updateButtonVisibility() {
-        val show = (supportsUpload || isContextual) && lastNativeInputState?.shouldShowPluginControls() == true
+        val show = shouldShowAttachButton(
+            supportsUpload = supportsUpload,
+            isContextual = isContextual,
+            isEditMode = isEditMode,
+            pluginControlsVisible = lastNativeInputState?.shouldShowPluginControls(isEditing = isEditMode) == true,
+        )
         isVisible = show
         (parent as? View)?.isVisible = show
     }
@@ -122,6 +130,11 @@ class AttachmentView(
     fun getFileAttachmentsJson(): JSONArray? = viewModel?.getFileAttachmentsJson()
 
     fun clearAttachments() = viewModel?.clearAttachments()
+
+    fun adoptAttachments(
+        images: List<AdoptedImage>,
+        files: List<AdoptedFile>,
+    ) = viewModel?.adopt(images, files)
 
     fun clearAttachmentsForNewChat() = viewModel?.clearAttachmentsForNewChat()
 
@@ -210,12 +223,14 @@ class AttachmentView(
         syncImages(imagesView, state)
         syncFiles(state)
         syncPageContext(state)
-        val errorMessage =
-            state.imageLimitError
+        val errorMessage = effectiveLimitError(
+            imageLimitError = state.imageLimitError
                 ?: state.fileLimitError
                 ?: state.fileSizeError
                 ?: state.filePageCountError
-                ?: state.fileTotalSizeError
+                ?: state.fileTotalSizeError,
+            isEditMode = isEditMode,
+        )
         val notStreaming = lastNativeInputState?.isChatStreaming != true
         container.isVisible = (state.hasAttachments || errorMessage != null) && notStreaming
         updateLimitError(errorMessage)
@@ -271,7 +286,7 @@ class AttachmentView(
         updateButtonVisibility()
         host?.attachmentChanged(
             hasAttachments = state.hasAttachments,
-            limitExceeded = (
+            limitExceeded = !isEditMode && (
                 state.imageLimitError != null ||
                     state.fileLimitError != null ||
                     state.fileSizeError != null ||
@@ -401,3 +416,19 @@ class AttachmentView(
         if (!list.isNullOrEmpty()) viewModel?.onFilesPicked(list)
     }
 }
+
+internal fun shouldShowAttachButton(
+    supportsUpload: Boolean,
+    isContextual: Boolean,
+    isEditMode: Boolean,
+    pluginControlsVisible: Boolean,
+): Boolean = !isEditMode && (supportsUpload || isContextual) && pluginControlsVisible
+
+/**
+ * Adopted attachments are counted against the conversation limits, so an edit of a message already at
+ * the limit would show an error the user cannot act on. Editing only ever removes, so drop the errors.
+ */
+internal fun effectiveLimitError(
+    imageLimitError: String?,
+    isEditMode: Boolean,
+): String? = if (isEditMode) null else imageLimitError

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -133,6 +133,8 @@ class ModelPickerView @JvmOverloads constructor(
 
     private var pickerEnabled = false
 
+    var isEditMode: Boolean = false
+
     override fun setPickerEnabled(enabled: Boolean) {
         this.pickerEnabled = enabled
         if (isAttachedToWindow) updateVisibility()
@@ -143,10 +145,12 @@ class ModelPickerView @JvmOverloads constructor(
     }
 
     private fun updateVisibility() {
-        val nativeState = lastNativeInputState
-        val show = pickerEnabled &&
-            viewModel.state.value.models.isNotEmpty() &&
-            nativeState?.shouldShowPluginControls() == true
+        val show = shouldShowModelPicker(
+            nativeInputState = lastNativeInputState,
+            pickerEnabled = pickerEnabled,
+            hasModels = viewModel.state.value.models.isNotEmpty(),
+            isEditMode = isEditMode,
+        )
         isVisible = show
         (parent as? View)?.isVisible = show
     }
@@ -373,3 +377,15 @@ class ModelPickerView @JvmOverloads constructor(
         addView(HorizontalDivider(context))
     }
 }
+
+/**
+ * The model picker follows the same visibility rule as the other plugin controls: derived purely
+ * from [NativeInputState] plus its own enabled/model-availability flags, so it is unit-testable
+ * without Robolectric.
+ */
+internal fun shouldShowModelPicker(
+    nativeInputState: NativeInputState?,
+    pickerEnabled: Boolean,
+    hasModels: Boolean,
+    isEditMode: Boolean,
+): Boolean = pickerEnabled && hasModels && nativeInputState?.shouldShowPluginControls(isEditing = isEditMode) == true

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -85,6 +85,8 @@ import com.duckduckgo.duckchat.impl.pixel.inputScreenPixelsModeParam
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.impl.ui.NativeInputModeWidgetViewModel
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.PageContextAttachment
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedFile
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedImage
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.tabs.TabLayout
 import dagger.android.support.AndroidSupportInjection
@@ -175,6 +177,8 @@ interface NativeInputWidget {
     fun storePendingPrompt(query: String)
     fun configure(tabId: String, isDuckAiMode: Boolean, isBottom: Boolean)
     fun configureContextual(tabId: String)
+    fun configureForEdit(sessionId: String)
+    fun adoptEditAttachments(images: List<AdoptedImage>, files: List<AdoptedFile>)
     fun isWidgetBottom(): Boolean
     fun setWidgetPosition(isBottom: Boolean)
     fun setWidgetRootView(view: View)
@@ -374,6 +378,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
     // with inputContext=BROWSER and toggleVisible=true/false that would otherwise show the
     // toggle row and reset the parent card's corners.
     private var isContextualWidget: Boolean = false
+
+    // True when this widget instance is hosting the fullscreen edit-message surface, configured
+    // via configureForEdit() against a synthetic per-tab state key rather than a real tab.
+    private var isEditWidget: Boolean = false
 
     // Held during the enter animation so padding/bottom-row compute as if focused; without
     // it they'd flip from 4dp→8dp after focusInput and look like a second step.
@@ -696,13 +704,13 @@ class NativeInputModeWidget @JvmOverloads constructor(
                         // The start-chat shortcut is a search-only address-bar affordance; it has no place
                         // in the contextual sheet's Duck.ai composer (and reads the shared per-tab state,
                         // which can be search-only), so skip it there.
-                        if (isContextualWidget && plugin.containerId == R.id.startChatContainer) continue
+                        if ((isContextualWidget || isEditWidget) && plugin.containerId == R.id.startChatContainer) continue
                         val container = findViewById<FrameLayout?>(plugin.containerId) ?: continue
                         val pluginView = plugin.createView(context, this@NativeInputModeWidget)
                         container.removeAllViews()
                         container.addView(pluginView)
                         if (plugin.containerId != R.id.startChatContainer) {
-                            container.isVisible = isChatTabSelected()
+                            container.isVisible = isChatTabSelected() && !isEditWidget
                         }
                         if (pluginView is ModelPicker) {
                             modelPickerView = pluginView
@@ -737,6 +745,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
             pluginView.onCameraCaptureRequested = pendingCameraCaptureCallback
             pluginView.onFilePickerRequested = pendingFilePickerCallback
             pluginView.isContextual = pendingIsContextual
+            pluginView.isEditMode = isEditWidget
             pluginView.onAskAboutPage = pendingAskAboutPage
             pluginView.onPageContextRemoved = pendingOnPageContextRemoved
             pluginView.bind(scope, viewModelFactory, nativeInputStateProvider, faviconManager)
@@ -927,7 +936,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val bottomRow = findViewById<View?>(R.id.inputModeWidgetBottomRow) ?: return
         val suppress = nativeInputState?.shouldSuppressBottomRow() == true
         val visible = isChatTabSelected() &&
-            (inputField.hasFocus() || previewEnterFocus || isContextualWidget) &&
+            (inputField.hasFocus() || previewEnterFocus || isContextualWidget || isEditWidget) &&
             !isStreaming &&
             !suppress
         bottomRow.visibility = if (visible) VISIBLE else GONE
@@ -956,7 +965,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private fun applyToggleVisibility(visible: Boolean) {
         // Contextual sheet always hides the toggle row, regardless of what state the per-tab
         // store emits — the main widget can publish toggleVisible=true for the same tabId.
-        val effective = visible && !isContextualWidget
+        // Edit mode has no mode switch at all.
+        val effective = visible && !isContextualWidget && !isEditWidget
         findViewById<View?>(R.id.inputModeSwitchRow)?.visibility = if (effective) VISIBLE else GONE
     }
 
@@ -1007,10 +1017,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun updateVoiceButtonVisibility() {
         val isBlank = inputField.text.isNullOrBlank() && !hasAttachments
-        setVoiceButtonVisible(voiceSearchAvailable && isBlank)
+        setVoiceButtonVisible(!isEditWidget && voiceSearchAvailable && isBlank)
         val host = voiceHostButtons()
         host?.setVoiceSearchVisible(false)
-        host?.setVoiceChatVisible(voiceChatAvailable && isBlank && !isStreaming)
+        host?.setVoiceChatVisible(!isEditWidget && voiceChatAvailable && isBlank && !isStreaming)
     }
 
     private fun updateSendButtonVisibility() {
@@ -1035,7 +1045,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private fun updateNewLineButtonVisibility() {
         val isBrowserContext = nativeInputState?.inputContext == NativeInputState.InputContext.BROWSER
         val hasText = inputField.text.isNotBlank()
-        val visible = isBrowserContext && isChatTabSelected() && hasText && !isStreaming
+        val visible = (isBrowserContext || isEditWidget) && isChatTabSelected() && hasText && !isStreaming
         // Only the top-bar floating row hosts the new-line button. Bottom-bar mode has no
         // on-screen new-line; carriage return there is the IME enter key while on a Duck.ai
         // page (see `applyChatInputType`: IME_ACTION_NONE + TYPE_TEXT_FLAG_MULTI_LINE).
@@ -1109,9 +1119,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun updateBackButtons(state: NativeInputState) {
         inputModeWidgetBack.visibility =
-            if (state.shouldShowToggleRowBack(navBarVisible)) VISIBLE else GONE
+            if (state.shouldShowToggleRowBack(navBarVisible, isEditing = isEditWidget)) VISIBLE else GONE
         inputModeWidgetUnifiedBack.visibility =
-            if (state.shouldShowCardRowBack()) VISIBLE else GONE
+            if (state.shouldShowCardRowBack(isEditing = isEditWidget)) VISIBLE else GONE
         inputModeWidgetBack.setBackgroundResource(
             com.duckduckgo.mobile.android.R.drawable.selectable_circular_container_ripple,
         )
@@ -1127,10 +1137,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
      * typing and the chrome around the input should yield space to the keyboard / input area.
      */
     private fun updateFireButtonVisibility(state: NativeInputState) {
-        val showLeading = state.shouldShowLeadingFireButton() && !inputField.hasFocus()
+        val showLeading = state.shouldShowLeadingFireButton(isEditing = isEditWidget) && !inputField.hasFocus()
         leadingFireButtonView()?.visibility = if (showLeading) VISIBLE else GONE
         fireButton.visibility =
-            if (state.shouldShowTrailingFireButton()) VISIBLE else GONE
+            if (state.shouldShowTrailingFireButton(isEditing = isEditWidget)) VISIBLE else GONE
     }
 
     // Onboarding rendering for the leading (Duck.ai) fire button. The lock/dim comes from interactionLock; the
@@ -1597,6 +1607,22 @@ class NativeInputModeWidget @JvmOverloads constructor(
             viewModel.configureContextual(tabId)
             selectChatTab()
         }
+    }
+
+    override fun configureForEdit(sessionId: String) {
+        isEditWidget = true
+        attachmentView?.isEditMode = true
+        doOnAttach {
+            viewModel.configureForEdit(sessionId)
+            selectChatTab()
+        }
+    }
+
+    override fun adoptEditAttachments(
+        images: List<AdoptedImage>,
+        files: List<AdoptedFile>,
+    ) {
+        attachmentView?.adoptAttachments(images, files)
     }
 
     override fun isWidgetBottom(): Boolean = nativeInputState?.isBottom ?: false

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -2056,11 +2056,13 @@ internal fun NativeInputState.chatHintRes(): Int =
 // The nav bar carries its own back arrow, so this one fills in as the back affordance only while the nav
 // bar is hidden — the two are never visible at once (browser only; this arrow never renders in Duck.ai /
 // contextual, where toggleVisible is false).
-internal fun NativeInputState.shouldShowToggleRowBack(isNavBarVisible: Boolean): Boolean =
-    toggleVisible && inputContext == NativeInputState.InputContext.BROWSER && !isNavBarVisible
+internal fun NativeInputState.shouldShowToggleRowBack(
+    isNavBarVisible: Boolean,
+    isEditing: Boolean = false,
+): Boolean = !isEditing && toggleVisible && inputContext == NativeInputState.InputContext.BROWSER && !isNavBarVisible
 
-internal fun NativeInputState.shouldShowCardRowBack(): Boolean =
-    !toggleVisible && inputContext == NativeInputState.InputContext.BROWSER
+internal fun NativeInputState.shouldShowCardRowBack(isEditing: Boolean = false): Boolean =
+    !isEditing && !toggleVisible && inputContext == NativeInputState.InputContext.BROWSER
 
 /**
  * Whether to synchronously show the chat-suggestions list (an opaque overlay) when the Duck.ai tab is
@@ -2078,12 +2080,12 @@ internal fun shouldShowChatSuggestionsCoverOnSelect(
 ): Boolean = inputText.isNotEmpty() || recentChatsExpected
 
 /** Fire button placed inside the input field card at the leading edge — only in a fullscreen Duck.ai chat. */
-internal fun NativeInputState.shouldShowLeadingFireButton(): Boolean =
-    inputContext == NativeInputState.InputContext.DUCK_AI
+internal fun NativeInputState.shouldShowLeadingFireButton(isEditing: Boolean = false): Boolean =
+    !isEditing && inputContext == NativeInputState.InputContext.DUCK_AI
 
 /** Trailing fire button (in the buttons row next to tabs/menu) — hidden in fullscreen Duck.ai chat, otherwise shown. */
-internal fun NativeInputState.shouldShowTrailingFireButton(): Boolean =
-    inputContext != NativeInputState.InputContext.DUCK_AI
+internal fun NativeInputState.shouldShowTrailingFireButton(isEditing: Boolean = false): Boolean =
+    !isEditing && inputContext != NativeInputState.InputContext.DUCK_AI
 
 /**
  * The bottom row hosts chat-mode tools (attachments, options, reasoning, model picker).
@@ -2109,5 +2111,5 @@ internal fun shouldShowInputControls(
  * the Duck.ai chat tab and only when no chat is streaming. Derived purely from [NativeInputState]
  * so it is unit-testable without Robolectric.
  */
-internal fun NativeInputState.shouldShowPluginControls(): Boolean =
-    toggleSelection == NativeInputState.ToggleSelection.DUCK_AI && !isChatStreaming
+internal fun NativeInputState.shouldShowPluginControls(isEditing: Boolean = false): Boolean =
+    !isEditing && toggleSelection == NativeInputState.ToggleSelection.DUCK_AI && !isChatStreaming

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -85,8 +85,8 @@ import com.duckduckgo.duckchat.impl.pixel.inputScreenPixelsModeParam
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.impl.ui.NativeInputModeWidgetViewModel
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.PageContextAttachment
-import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedFile
-import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedImage
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.SubmittedFile
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.SubmittedImage
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.tabs.TabLayout
 import dagger.android.support.AndroidSupportInjection
@@ -178,7 +178,7 @@ interface NativeInputWidget {
     fun configure(tabId: String, isDuckAiMode: Boolean, isBottom: Boolean)
     fun configureContextual(tabId: String)
     fun configureForEdit(sessionId: String)
-    fun adoptEditAttachments(images: List<AdoptedImage>, files: List<AdoptedFile>)
+    fun adoptEditAttachments(images: List<SubmittedImage>, files: List<SubmittedFile>)
     fun isWidgetBottom(): Boolean
     fun setWidgetPosition(isBottom: Boolean)
     fun setWidgetRootView(view: View)
@@ -1628,8 +1628,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     override fun adoptEditAttachments(
-        images: List<AdoptedImage>,
-        files: List<AdoptedFile>,
+        images: List<SubmittedImage>,
+        files: List<SubmittedFile>,
     ) {
         attachmentView?.adoptAttachments(images, files)
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -826,16 +826,19 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun observeChatState() {
-        // chatState is global, not scoped to a tab — the edit widget has no chat of its own to
-        // reflect, and reacting to it would hijack the submit button or hide the whole screen
-        // whenever an unrelated surface starts streaming or hides its input.
-        if (isEditWidget) return
         var isFocussed = false
 
         chatStateJob?.cancel()
         chatStateJob = viewModel.chatState
             .drop(1)
             .onEach { state ->
+                // chatState is global, not scoped to a tab — the edit widget has no chat of its own
+                // to reflect, and reacting to it would hijack the submit button or hide the whole
+                // screen whenever an unrelated surface starts streaming or hides its input. Checked
+                // per emission, not just at subscribe time: if this ever subscribes before
+                // configureForEdit() flips the flag (e.g. an addView-then-configure caller), the
+                // subscription must still stay inert rather than act once on a stale isEditWidget.
+                if (isEditWidget) return@onEach
                 setChatStreaming(state == ChatState.STREAMING || state == ChatState.LOADING)
                 when (state) {
                     ChatState.HIDE -> {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -751,6 +751,15 @@ class NativeInputModeWidget @JvmOverloads constructor(
             pluginView.bind(scope, viewModelFactory, nativeInputStateProvider, faviconManager)
             pendingPageContext?.let { pluginView.setPageContext(it) }
         }
+        if (pluginView is OptionsView) {
+            pluginView.isEditMode = isEditWidget
+        }
+        if (pluginView is ModelPickerView) {
+            pluginView.isEditMode = isEditWidget
+        }
+        if (pluginView is ReasoningModePickerView) {
+            pluginView.isEditMode = isEditWidget
+        }
         (pluginView as? ModelPicker)?.let { picker ->
             picker.onMenuShown = { isModelMenuVisible = true }
             picker.onMenuDismissed = {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -826,6 +826,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun observeChatState() {
+        // chatState is global, not scoped to a tab — the edit widget has no chat of its own to
+        // reflect, and reacting to it would hijack the submit button or hide the whole screen
+        // whenever an unrelated surface starts streaming or hides its input.
+        if (isEditWidget) return
         var isFocussed = false
 
         chatStateJob?.cancel()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -63,6 +63,8 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
     /** Whether the model / reasoning pickers are allowed for the current tool selection. */
     val pickersEnabled: Boolean get() = viewModel.shouldShowPickers
 
+    var isEditMode: Boolean = false
+
     private data class MenuItem(
         val iconRes: Int,
         val titleRes: Int,
@@ -135,7 +137,7 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
     }
 
     private fun updateContainerVisibility() {
-        val show = lastNativeInputState?.shouldShowPluginControls() == true
+        val show = shouldShowOptionsContainer(lastNativeInputState, isEditMode)
         isVisible = show
         (parent as? View)?.isVisible = show
         refreshOptionsButtonVisibility()
@@ -309,3 +311,12 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
         private const val MENU_DISMISS_DELAY_MS = 150L
     }
 }
+
+/**
+ * The options container follows the same visibility rule as the other plugin controls: derived
+ * purely from [NativeInputState] so it is unit-testable without Robolectric.
+ */
+internal fun shouldShowOptionsContainer(
+    nativeInputState: NativeInputState?,
+    isEditMode: Boolean,
+): Boolean = nativeInputState?.shouldShowPluginControls(isEditing = isEditMode) == true

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
@@ -78,6 +78,8 @@ class ReasoningModePickerView @JvmOverloads constructor(
     private var lastInputContext: InputContext = InputContext.BROWSER
     private var lastNativeInputState: NativeInputState? = null
 
+    var isEditMode: Boolean = false
+
     init {
         inflate(context, R.layout.view_reasoning_mode_picker, this)
     }
@@ -115,8 +117,7 @@ class ReasoningModePickerView @JvmOverloads constructor(
     }
 
     private fun applyVisibility(pickerVisible: Boolean) {
-        val nativeState = lastNativeInputState
-        val show = pickerVisible && nativeState?.shouldShowPluginControls() == true
+        val show = shouldShowReasoningPicker(lastNativeInputState, pickerVisible, isEditMode)
         isVisible = show
         (parent as? View)?.isVisible = show
         // Popup is positioned by screen coordinates, not parented to the button. Dismiss
@@ -221,3 +222,14 @@ class ReasoningModePickerView @JvmOverloads constructor(
         popupWindow = null
     }
 }
+
+/**
+ * The reasoning mode picker follows the same visibility rule as the other plugin controls:
+ * derived purely from [NativeInputState] plus its own visibility flag, so it is unit-testable
+ * without Robolectric.
+ */
+internal fun shouldShowReasoningPicker(
+    nativeInputState: NativeInputState?,
+    pickerVisible: Boolean,
+    isEditMode: Boolean,
+): Boolean = pickerVisible && nativeInputState?.shouldShowPluginControls(isEditing = isEditMode) == true

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.ui
 import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
+import android.util.Base64
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -41,6 +42,8 @@ import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ConversationFileUs
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ImageAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.LimitsHandler
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.PageContextAttachment
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedFile
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedImage
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachmentProcessor
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -63,6 +66,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.io.ByteArrayOutputStream
 import java.util.UUID
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -1016,5 +1020,60 @@ class AttachmentViewModelTest {
         viewModel.clearAttachments()
 
         assertNull(viewModel.attachmentState.value.pageContext)
+    }
+
+    @Test
+    fun whenAdoptingImagesThenTheyAppearInStateWithBase64Preserved() = runTest {
+        val png = validPngBase64()
+
+        viewModel.adopt(images = listOf(AdoptedImage(data = png, format = "png")), files = emptyList())
+
+        val adopted = viewModel.getImageAttachments()
+        assertEquals(1, adopted.size)
+        assertEquals(png, adopted.first().base64Data)
+        assertEquals("png", adopted.first().format)
+    }
+
+    @Test
+    fun whenAdoptingAnUndecodableImageThenItIsStillAdoptedWithAPlaceholderBitmap() = runTest {
+        viewModel.adopt(images = listOf(AdoptedImage(data = "not-base64-image-bytes", format = "png")), files = emptyList())
+
+        val adopted = viewModel.getImageAttachments()
+        assertEquals(1, adopted.size)
+        assertEquals("not-base64-image-bytes", adopted.first().base64Data)
+        assertFalse(adopted.first().bitmap.isRecycled)
+    }
+
+    @Test
+    fun whenAdoptingFilesThenSizeIsDerivedFromTheDecodedBytes() = runTest {
+        val base64 = Base64.encodeToString(ByteArray(1024), Base64.NO_WRAP)
+
+        viewModel.adopt(
+            images = emptyList(),
+            files = listOf(AdoptedFile(data = base64, fileName = "doc.pdf", mimeType = "application/pdf")),
+        )
+
+        val adopted = viewModel.getFileAttachments()
+        assertEquals(1, adopted.size)
+        assertEquals("doc.pdf", adopted.first().fileName)
+        assertEquals(1024L, adopted.first().sizeBytes)
+        assertNull(adopted.first().pageCount)
+    }
+
+    @Test
+    fun whenAdoptedAttachmentIsRemovedThenItLeavesTheReplyPayload() = runTest {
+        viewModel.adopt(images = listOf(AdoptedImage(data = validPngBase64(), format = "png")), files = emptyList())
+        val id = viewModel.getImageAttachments().first().id
+
+        viewModel.removeImageAttachment(id)
+
+        assertNull(viewModel.getImageAttachmentsJson())
+    }
+
+    private fun validPngBase64(): String {
+        val bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888)
+        val out = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+        return Base64.encodeToString(out.toByteArray(), Base64.NO_WRAP)
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
@@ -42,8 +42,8 @@ import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ConversationFileUs
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ImageAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.LimitsHandler
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.PageContextAttachment
-import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedFile
-import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.AdoptedImage
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.SubmittedFile
+import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.SubmittedImage
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachmentProcessor
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -1026,7 +1026,7 @@ class AttachmentViewModelTest {
     fun whenAdoptingImagesThenTheyAppearInStateWithBase64Preserved() = runTest {
         val png = validPngBase64()
 
-        viewModel.adopt(images = listOf(AdoptedImage(data = png, format = "png")), files = emptyList())
+        viewModel.adopt(images = listOf(SubmittedImage(data = png, format = "png")), files = emptyList())
 
         val adopted = viewModel.getImageAttachments()
         assertEquals(1, adopted.size)
@@ -1036,7 +1036,7 @@ class AttachmentViewModelTest {
 
     @Test
     fun whenAdoptingAnUndecodableImageThenItIsStillAdoptedWithAPlaceholderBitmap() = runTest {
-        viewModel.adopt(images = listOf(AdoptedImage(data = "not-base64-image-bytes", format = "png")), files = emptyList())
+        viewModel.adopt(images = listOf(SubmittedImage(data = "not-base64-image-bytes", format = "png")), files = emptyList())
 
         val adopted = viewModel.getImageAttachments()
         assertEquals(1, adopted.size)
@@ -1050,7 +1050,7 @@ class AttachmentViewModelTest {
 
         viewModel.adopt(
             images = emptyList(),
-            files = listOf(AdoptedFile(data = base64, fileName = "doc.pdf", mimeType = "application/pdf")),
+            files = listOf(SubmittedFile(data = base64, fileName = "doc.pdf", mimeType = "application/pdf")),
         )
 
         val adopted = viewModel.getFileAttachments()
@@ -1062,7 +1062,7 @@ class AttachmentViewModelTest {
 
     @Test
     fun whenAdoptedAttachmentIsRemovedThenItLeavesTheReplyPayload() = runTest {
-        viewModel.adopt(images = listOf(AdoptedImage(data = validPngBase64(), format = "png")), files = emptyList())
+        viewModel.adopt(images = listOf(SubmittedImage(data = validPngBase64(), format = "png")), files = emptyList())
         val id = viewModel.getImageAttachments().first().id
 
         viewModel.removeImageAttachment(id)
@@ -1071,11 +1071,11 @@ class AttachmentViewModelTest {
     }
 
     @Test
-    fun whenAdoptedFileAttachmentIsRemovedThenItLeavesTheReplyPayload() = runTest {
+    fun whenSubmittedFileAttachmentIsRemovedThenItLeavesTheReplyPayload() = runTest {
         val base64 = Base64.encodeToString(ByteArray(1024), Base64.NO_WRAP)
         viewModel.adopt(
             images = emptyList(),
-            files = listOf(AdoptedFile(data = base64, fileName = "doc.pdf", mimeType = "application/pdf")),
+            files = listOf(SubmittedFile(data = base64, fileName = "doc.pdf", mimeType = "application/pdf")),
         )
         val id = viewModel.getFileAttachments().first().id
 
@@ -1086,10 +1086,10 @@ class AttachmentViewModelTest {
 
     @Test
     fun whenAdoptCalledAgainThenPreviouslyAdoptedBitmapsAreRecycled() = runTest {
-        viewModel.adopt(images = listOf(AdoptedImage(data = validPngBase64(), format = "png")), files = emptyList())
+        viewModel.adopt(images = listOf(SubmittedImage(data = validPngBase64(), format = "png")), files = emptyList())
         val firstRoundBitmap = viewModel.getImageAttachments().first().bitmap
 
-        viewModel.adopt(images = listOf(AdoptedImage(data = validPngBase64(), format = "png")), files = emptyList())
+        viewModel.adopt(images = listOf(SubmittedImage(data = validPngBase64(), format = "png")), files = emptyList())
         advanceUntilIdle()
 
         assertTrue(firstRoundBitmap.isRecycled)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
@@ -1070,6 +1070,31 @@ class AttachmentViewModelTest {
         assertNull(viewModel.getImageAttachmentsJson())
     }
 
+    @Test
+    fun whenAdoptedFileAttachmentIsRemovedThenItLeavesTheReplyPayload() = runTest {
+        val base64 = Base64.encodeToString(ByteArray(1024), Base64.NO_WRAP)
+        viewModel.adopt(
+            images = emptyList(),
+            files = listOf(AdoptedFile(data = base64, fileName = "doc.pdf", mimeType = "application/pdf")),
+        )
+        val id = viewModel.getFileAttachments().first().id
+
+        viewModel.removeFileAttachment(id)
+
+        assertNull(viewModel.getFileAttachmentsJson())
+    }
+
+    @Test
+    fun whenAdoptCalledAgainThenPreviouslyAdoptedBitmapsAreRecycled() = runTest {
+        viewModel.adopt(images = listOf(AdoptedImage(data = validPngBase64(), format = "png")), files = emptyList())
+        val firstRoundBitmap = viewModel.getImageAttachments().first().bitmap
+
+        viewModel.adopt(images = listOf(AdoptedImage(data = validPngBase64(), format = "png")), files = emptyList())
+        advanceUntilIdle()
+
+        assertTrue(firstRoundBitmap.isRecycled)
+    }
+
     private fun validPngBase64(): String {
         val bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888)
         val out = ByteArrayOutputStream()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputControlsVisibilityTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputControlsVisibilityTest.kt
@@ -16,8 +16,12 @@
 
 package com.duckduckgo.duckchat.impl.ui
 
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.effectiveLimitError
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowAttachButton
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowInputControls
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -41,5 +45,25 @@ class NativeInputControlsVisibilityTest {
     @Test
     fun `controls hidden off chat tab while streaming`() {
         assertFalse(shouldShowInputControls(onChatTab = false, isStreaming = true))
+    }
+
+    @Test
+    fun `attach button hidden in edit mode even when uploads are supported`() {
+        assertFalse(shouldShowAttachButton(supportsUpload = true, isContextual = false, isEditMode = true, pluginControlsVisible = true))
+    }
+
+    @Test
+    fun `attach button shown outside edit mode when uploads are supported`() {
+        assertTrue(shouldShowAttachButton(supportsUpload = true, isContextual = false, isEditMode = false, pluginControlsVisible = true))
+    }
+
+    @Test
+    fun `limit errors suppressed in edit mode`() {
+        assertNull(effectiveLimitError(imageLimitError = "too many images", isEditMode = true))
+    }
+
+    @Test
+    fun `limit errors surfaced outside edit mode`() {
+        assertEquals("too many images", effectiveLimitError(imageLimitError = "too many images", isEditMode = false))
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
@@ -133,6 +133,13 @@ class NativeInputModeWidgetBackButtonsTest {
     fun `no back arrows in edit mode`() {
         val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.BROWSER)
         assertFalse(state.shouldShowToggleRowBack(isNavBarVisible = false, isEditing = true))
+    }
+
+    @Test
+    fun `card row back is hidden in edit mode even when otherwise shown`() {
+        val state = stateOf(InputMode.SEARCH_ONLY, InputContext.BROWSER)
+
+        assertTrue(state.shouldShowCardRowBack(isEditing = false))
         assertFalse(state.shouldShowCardRowBack(isEditing = true))
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
@@ -129,6 +129,13 @@ class NativeInputModeWidgetBackButtonsTest {
         assertFalse(state.shouldSuppressBottomRow())
     }
 
+    @Test
+    fun `no back arrows in edit mode`() {
+        val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.BROWSER)
+        assertFalse(state.shouldShowToggleRowBack(isNavBarVisible = false, isEditing = true))
+        assertFalse(state.shouldShowCardRowBack(isEditing = true))
+    }
+
     private fun stateOf(inputMode: InputMode, inputContext: InputContext): NativeInputState =
         NativeInputState(inputMode = inputMode, inputContext = inputContext)
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetFireButtonsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetFireButtonsTest.kt
@@ -63,6 +63,13 @@ class NativeInputModeWidgetFireButtonsTest {
         assertTrue(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI_CONTEXTUAL).shouldShowTrailingFireButton())
     }
 
+    @Test
+    fun `no fire buttons in edit mode`() {
+        val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI)
+        assertFalse(state.shouldShowLeadingFireButton(isEditing = true))
+        assertFalse(state.shouldShowTrailingFireButton(isEditing = true))
+    }
+
     private fun stateOf(inputMode: InputMode, inputContext: InputContext): NativeInputState =
         NativeInputState(inputMode = inputMode, inputContext = inputContext)
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetFireButtonsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetFireButtonsTest.kt
@@ -67,6 +67,13 @@ class NativeInputModeWidgetFireButtonsTest {
     fun `no fire buttons in edit mode`() {
         val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI)
         assertFalse(state.shouldShowLeadingFireButton(isEditing = true))
+    }
+
+    @Test
+    fun `trailing fire is hidden in edit mode even when otherwise shown`() {
+        val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.BROWSER)
+
+        assertTrue(state.shouldShowTrailingFireButton(isEditing = false))
         assertFalse(state.shouldShowTrailingFireButton(isEditing = true))
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -566,6 +566,16 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
+    fun `state isChatStreaming is false for the edit widget even when chatState is STREAMING`() = runTest {
+        // chatState is global, not scoped to a tab — a real chat streaming on another tab must not
+        // leak into the edit widget's own synthetic-key state.
+        chatStateFlow.value = ChatState.STREAMING
+        testee.configureForEdit(sessionId = "session-1")
+
+        assertFalse(testee.state.firstOrNull()!!.isChatStreaming)
+    }
+
+    @Test
     fun whenChatStateFlowEmitsThenViewModelChatStateMirrorsIt() = runTest {
         chatStateFlow.value = ChatState.STREAMING
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -403,6 +403,31 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
+    fun whenConfiguredForEditThenPublishesUnderTheSyntheticKeyOnly() = runTest {
+        testee.configureForEdit(sessionId = "session-1")
+        advanceUntilIdle()
+
+        val editKey = NativeInputModeWidgetViewModel.editStateKey("session-1")
+        assertEquals(
+            NativeInputState.InputContext.DUCK_AI,
+            nativeInputStateProvider.stateForTab(editKey).value.inputContext,
+        )
+        assertEquals(
+            NativeInputState.InputContext.BROWSER,
+            nativeInputStateProvider.stateForTab("test-tab").value.inputContext,
+        )
+    }
+
+    @Test
+    fun whenConfiguredForEditThenContextIsDuckAiAndToggleIsDuckAi() = runTest {
+        testee.configureForEdit(sessionId = "session-1")
+
+        val state = testee.state.first()
+        assertEquals(NativeInputState.InputContext.DUCK_AI, state.inputContext)
+        assertEquals(NativeInputState.ToggleSelection.DUCK_AI, state.toggleSelection)
+    }
+
+    @Test
     fun whenSetDuckAiModeThenInputModeUnchanged() = runTest {
         setIsEnabled(true)
         inputScreenUserSettingFlow.value = true

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputPluginVisibilityTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputPluginVisibilityTest.kt
@@ -20,7 +20,10 @@ import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputMode
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowModelPicker
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowOptionsContainer
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowPluginControls
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowReasoningPicker
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -61,6 +64,42 @@ class NativeInputPluginVisibilityTest {
     fun `plugin controls hidden in edit mode`() {
         val state = stateOf(ToggleSelection.DUCK_AI, isChatStreaming = false)
         assertFalse(state.shouldShowPluginControls(isEditing = true))
+    }
+
+    @Test
+    fun `options container suppressed in edit mode even when tab state would show it`() {
+        val state = stateOf(ToggleSelection.DUCK_AI, isChatStreaming = false)
+        assertFalse(shouldShowOptionsContainer(state, isEditMode = true))
+    }
+
+    @Test
+    fun `options container shown outside edit mode when tab state allows it`() {
+        val state = stateOf(ToggleSelection.DUCK_AI, isChatStreaming = false)
+        assertTrue(shouldShowOptionsContainer(state, isEditMode = false))
+    }
+
+    @Test
+    fun `model picker suppressed in edit mode even when enabled with models and tab state would show it`() {
+        val state = stateOf(ToggleSelection.DUCK_AI, isChatStreaming = false)
+        assertFalse(shouldShowModelPicker(state, pickerEnabled = true, hasModels = true, isEditMode = true))
+    }
+
+    @Test
+    fun `model picker shown outside edit mode when enabled with models and tab state allows it`() {
+        val state = stateOf(ToggleSelection.DUCK_AI, isChatStreaming = false)
+        assertTrue(shouldShowModelPicker(state, pickerEnabled = true, hasModels = true, isEditMode = false))
+    }
+
+    @Test
+    fun `reasoning picker suppressed in edit mode even when visible and tab state would show it`() {
+        val state = stateOf(ToggleSelection.DUCK_AI, isChatStreaming = false)
+        assertFalse(shouldShowReasoningPicker(state, pickerVisible = true, isEditMode = true))
+    }
+
+    @Test
+    fun `reasoning picker shown outside edit mode when visible and tab state allows it`() {
+        val state = stateOf(ToggleSelection.DUCK_AI, isChatStreaming = false)
+        assertTrue(shouldShowReasoningPicker(state, pickerVisible = true, isEditMode = false))
     }
 
     private fun stateOf(

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputPluginVisibilityTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputPluginVisibilityTest.kt
@@ -57,6 +57,12 @@ class NativeInputPluginVisibilityTest {
         assertTrue(state.shouldShowPluginControls())
     }
 
+    @Test
+    fun `plugin controls hidden in edit mode`() {
+        val state = stateOf(ToggleSelection.DUCK_AI, isChatStreaming = false)
+        assertFalse(state.shouldShowPluginControls(isEditing = true))
+    }
+
     private fun stateOf(
         toggleSelection: ToggleSelection,
         isChatStreaming: Boolean,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1157893581871903/task/1217368568249088?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1216352541975427
API Proposals URL(s) (if applicable): N/A — no `-api` module change

### Description

Re-submission of #9429, reverted in #9457 after it broke live Duck.ai
(https://app.asana.com/1/137249556945/project/488551667048375/task/1217357488141551
— submitting a prompt on the real Duck.ai tab flipped the UI back to the
Search tab, persisting across restart).

**Root cause:** `NativeInputModeWidgetViewModel.state`'s combine had
`duckChatInternal.chatState` replaced with a new derived `Flow`
(`isChatStreamingForThisWidget`, itself a nested `combine` of `chatState`
and the widget's raw, unfiltered `activeTabId`) so the edit widget could
ignore an unrelated tab's streaming state. That spliced a new node into
the `Flow` graph feeding a shared, `replay = 1` hot flow that every
widget instance publishes its `toggleSelection` from — exactly the kind
of change that can introduce a subtle recombination-timing bug.

**Fix in this PR:** the edit-widget check is now a synchronous
`activeTabId.value` read inside the existing 5-input combine lambda —
no new `Flow`, no change to the combine's shape or inputs. For every
non-edit widget the code path is now structurally identical to the
pre-#9429 original (the `!isEditWidget &&` guard is the only addition,
and `isEditWidget` is always `false` there). Manually verified on
device: submitting a prompt on the real Duck.ai tab no longer flips the
toggle, including across an app restart.

Otherwise unchanged from #9429 — adds an edit mode to
`NativeInputModeWidget` that reduces it to text field + attachments +
submit. Nothing calls it yet, so this PR has no other behaviour change;
a later PR wires the launch path.

- Edit mode is a **widget-local flag**, not a field on the shared
  `NativeInputState` — that type is per-tab state read by the app module
  and every `NativeInputPlugin`, and a second widget instance publishing
  to it would clobber the real tab. The five pure visibility helpers
  (`shouldShowPluginControls`, `shouldShowLeadingFireButton`,
  `shouldShowTrailingFireButton`, `shouldShowToggleRowBack`,
  `shouldShowCardRowBack`) take `isEditing` as a parameter instead.
- The edit widget publishes under a **synthetic `"edit:$sessionId"`
  state key**, never the real tabId, so it can share a
  `ViewModelStoreOwner` with the real widget without corrupting its
  published state.
- Model picker / reasoning picker / options / start-chat /
  stop-streaming / voice / both back arrows / the mode switch / the
  chat-suggestions overlay are all suppressed in edit mode. The
  attachment strip and new-line button are kept.
- `AttachmentViewModel.adopt(images, files)` ingests already-encoded
  base64 attachments (the FE hands over an already-sent message's
  attachments) straight into state, decoded off the main thread — no
  `Uri` decode, no format/size validation, no limit accounting, since
  an edit can only remove attachments.

### Steps to test this PR

_Regression check for the #9457 revert reason — the critical one_
- [x] On the real Duck.ai tab (not edit mode), submit a prompt →
  confirm the toggle stays on Duck.ai, does not flip to Search
- [x] Restart the app → confirm still on Duck.ai, no regression

_No user-facing edit entry point yet — unit tests only for the rest_
- [x] `./gradlew :duckchat-impl:testDebugUnitTest` green
- [x] Confirm no other behaviour change on the existing native input
  (browser omnibar, Duck.ai tab, contextual sheet) —
  `isEditing`/`isEditMode` default to `false` everywhere

### UI changes
None — the edit mode isn't reachable from any UI yet.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared `NativeInputModeWidgetViewModel` state publishing and global `chatState` handling where a prior change caused a production toggle regression; edit mode is unreachable but the streaming guard is on the main composer path.
> 
> **Overview**
> Adds an **edit mode** to `NativeInputModeWidget` (text, attachments, submit only). Edit is a **widget-local flag**; visibility helpers take `isEditing` so shared per-tab `NativeInputState` is not clobbered. The edit surface publishes under a synthetic **`edit:$sessionId`** key via `configureForEdit`, and `adopt` / `adoptEditAttachments` load already-sent base64 attachments without validation or limit accounting.
> 
> **Regression fix** for the reverted #9429 behavior: `isChatStreaming` for the edit widget is computed with a synchronous `activeTabId` check inside the existing five-input `combine` (no extra `Flow`), so global `chatState` does not flip the real Duck.ai tab’s toggle or streaming UI.
> 
> In edit mode, model/reasoning/options pickers, attach affordance, mode switch, fire/voice/back chrome, and attachment limit errors are suppressed; the attachment strip and new-line control remain. No launch path yet—behavior defaults keep `isEditMode` false everywhere else.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75b6ab5c29cab46aebda62c46c9ce113fffd2fa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->