### PR TITLE
Android: Enable by default Contextual/NativeInput in internal

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -287,6 +287,7 @@ interface DuckChatFeature {
      * the legacy input for INPUT mode while still using the native widget in WEBVIEW (in-chat) mode.
      * When native chat input is off, this has no effect (everything falls back to legacy/web input).
      */
+    @InternalAlwaysEnabled
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun contextualNativeInput(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217364525824563?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single annotation on a feature flag; affects internal-only default behavior for contextual Duck.ai input UI, not auth or data handling.
> 
> **Overview**
> Marks the **`contextualNativeInput`** Duck.ai feature toggle with **`@InternalAlwaysEnabled`**, matching toggles like **`nativeInputField`**.
> 
> Internal builds will always treat contextual native input as on (subject to **`nativeChatInput`** / **`nativeInputField`**), so the contextual sheet’s INPUT state uses the native unified composer instead of the legacy EditText path. Remote config can still gate external users via the existing **`INTERNAL`** default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83cd6510ff9a3a2c3f40b6884d2e916db05e36e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->