### PR TITLE
Fix broken site refresh detection timing

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3696,13 +3696,19 @@ class BrowserTabViewModel @Inject constructor(
             if (hasCtaBeenShownForCurrentPage.get() && isBrowserShowing) return null
             val detectedRefreshPatterns = brokenSitePrompt.getUserRefreshPatterns()
             handleBreakageRefreshPatterns(detectedRefreshPatterns)
+            val currentSite = siteLiveData.value
+            val currentNavigationUrl = webNavigationState?.currentUrl
+            val patternsForCurrentSite =
+                detectedRefreshPatterns.takeIf {
+                    currentNavigationUrl != null && currentSite?.url == currentNavigationUrl
+                } ?: emptySet()
             val cta =
                 withContext(dispatchers.io()) {
                     ctaViewModel.refreshCta(
                         dispatchers.io(),
                         isBrowserShowing && !isErrorShowing,
-                        siteLiveData.value,
-                        detectedRefreshPatterns,
+                        currentSite,
+                        patternsForCurrentSite,
                         suppressDuckAiOnboardingCta,
                     )
                 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1817,7 +1817,8 @@ class BrowserTabViewModel @Inject constructor(
 
         if (triggeredByUser) {
             site?.realBrokenSiteContext?.onUserTriggeredRefresh()
-            site?.uri?.let {
+            val refreshedUrl = webNavigationState?.currentUrl?.toUri() ?: site?.uri
+            refreshedUrl?.let {
                 brokenSitePrompt.pageRefreshed(it)
             }
         }
@@ -3698,18 +3699,15 @@ class BrowserTabViewModel @Inject constructor(
             handleBreakageRefreshPatterns(detectedRefreshPatterns)
             val currentSite = siteLiveData.value
             val currentNavigationUrl = webNavigationState?.currentUrl
-            val patternsForCurrentSite =
-                detectedRefreshPatterns.takeIf {
-                    currentNavigationUrl != null && currentSite?.url == currentNavigationUrl
-                } ?: emptySet()
             val cta =
                 withContext(dispatchers.io()) {
                     ctaViewModel.refreshCta(
                         dispatchers.io(),
                         isBrowserShowing && !isErrorShowing,
                         currentSite,
-                        patternsForCurrentSite,
+                        detectedRefreshPatterns,
                         suppressDuckAiOnboardingCta,
+                        brokenSitePromptUrl = currentNavigationUrl,
                     )
                 }
             val contextDaxDialogsShown =

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -337,7 +337,7 @@ class CtaViewModel @Inject constructor(
         site: Site? = null,
         detectedRefreshPatterns: Set<RefreshPattern>,
         suppressDuckAiOnboardingCta: Boolean = false,
-        brokenSitePromptUrl: String? = site?.url,
+        brokenSitePromptUrl: String?,
     ): Cta? {
         return withContext(dispatcher) {
             if (isBrowserShowing) {
@@ -567,6 +567,8 @@ class CtaViewModel @Inject constructor(
 
             if (areInContextDaxDialogsCompleted()) {
                 val promptUrl = brokenSitePromptUrl ?: return null
+                // Reports are built from Site, so reject stale state before showing the prompt.
+                if (nonNullSite.url != promptUrl) return null
                 return if (brokenSitePrompt.shouldShowBrokenSitePrompt(promptUrl, detectedRefreshPatterns)) {
                     BrokenSitePromptDialogCta()
                 } else {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -337,10 +337,11 @@ class CtaViewModel @Inject constructor(
         site: Site? = null,
         detectedRefreshPatterns: Set<RefreshPattern>,
         suppressDuckAiOnboardingCta: Boolean = false,
+        brokenSitePromptUrl: String? = site?.url,
     ): Cta? {
         return withContext(dispatcher) {
             if (isBrowserShowing) {
-                getBrowserCta(site, detectedRefreshPatterns, suppressDuckAiOnboardingCta)
+                getBrowserCta(site, detectedRefreshPatterns, suppressDuckAiOnboardingCta, brokenSitePromptUrl)
             } else {
                 getHomeCta()
             }
@@ -524,6 +525,7 @@ class CtaViewModel @Inject constructor(
         site: Site?,
         detectedRefreshPatterns: Set<RefreshPattern>,
         suppressDuckAiOnboardingCta: Boolean,
+        brokenSitePromptUrl: String?,
     ): Cta? {
         val nonNullSite = site ?: return null
 
@@ -564,7 +566,8 @@ class CtaViewModel @Inject constructor(
             }
 
             if (areInContextDaxDialogsCompleted()) {
-                return if (brokenSitePrompt.shouldShowBrokenSitePrompt(nonNullSite.url, detectedRefreshPatterns)) {
+                val promptUrl = brokenSitePromptUrl ?: return null
+                return if (brokenSitePrompt.shouldShowBrokenSitePrompt(promptUrl, detectedRefreshPatterns)) {
                     BrokenSitePromptDialogCta()
                 } else {
                     null

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3826,6 +3826,86 @@ class BrowserTabViewModelTest {
         }
 
     @Test
+    fun whenRefreshPatternsBelongToPreviousNavigationThenCtaReceivesNoPatterns() =
+        runTest {
+            val previousUrl = "https://previous.example"
+            val currentUrl = "https://current.example"
+            val refreshPatterns = setOf(RefreshPattern.THRICE_IN_20_SECONDS)
+            val staleSite = givenCurrentSite(previousUrl)
+            whenever(ctaViewModelMockSettingsStore.hideTips).thenReturn(true)
+            whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, Disabled))
+            whenever(mockBrokenSitePrompt.getUserRefreshPatterns()).thenReturn(refreshPatterns)
+            whenever(mockBrokenSitePrompt.shouldShowBrokenSitePrompt(any(), any())).thenReturn(false)
+            setBrowserShowing(true)
+
+            testee.navigationStateChanged(
+                buildWebNavigation(
+                    originalUrl = currentUrl,
+                    currentUrl = currentUrl,
+                ),
+            )
+            advanceUntilIdle()
+            testee.siteLiveData.value = staleSite
+
+            testee.refreshCta()
+
+            verify(refreshPixelSender).onRefreshPatternDetected(refreshPatterns)
+            verify(mockBrokenSitePrompt).shouldShowBrokenSitePrompt(
+                previousUrl,
+                emptySet(),
+            )
+        }
+
+    @Test
+    fun whenRefreshPatternsBelongToCurrentNavigationThenCtaReceivesPatterns() =
+        runTest {
+            val currentUrl = "https://current.example"
+            val refreshPatterns = setOf(RefreshPattern.THRICE_IN_20_SECONDS)
+            val currentSite = givenCurrentSite(currentUrl)
+            whenever(ctaViewModelMockSettingsStore.hideTips).thenReturn(true)
+            whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, Disabled))
+            whenever(mockBrokenSitePrompt.getUserRefreshPatterns()).thenReturn(refreshPatterns)
+            whenever(mockBrokenSitePrompt.shouldShowBrokenSitePrompt(any(), any())).thenReturn(false)
+            setBrowserShowing(true)
+
+            testee.navigationStateChanged(
+                buildWebNavigation(
+                    originalUrl = currentUrl,
+                    currentUrl = currentUrl,
+                ),
+            )
+            advanceUntilIdle()
+            testee.siteLiveData.value = currentSite
+
+            testee.refreshCta()
+
+            verify(mockBrokenSitePrompt).shouldShowBrokenSitePrompt(
+                currentUrl,
+                refreshPatterns,
+            )
+        }
+
+    @Test
+    fun whenCurrentNavigationUrlMissingThenCtaReceivesNoPatterns() =
+        runTest {
+            val siteUrl = "https://current.example"
+            val refreshPatterns = setOf(RefreshPattern.THRICE_IN_20_SECONDS)
+            givenCurrentSite(siteUrl)
+            whenever(ctaViewModelMockSettingsStore.hideTips).thenReturn(true)
+            whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, Disabled))
+            whenever(mockBrokenSitePrompt.getUserRefreshPatterns()).thenReturn(refreshPatterns)
+            whenever(mockBrokenSitePrompt.shouldShowBrokenSitePrompt(any(), any())).thenReturn(false)
+            setBrowserShowing(true)
+
+            testee.refreshCta()
+
+            verify(mockBrokenSitePrompt).shouldShowBrokenSitePrompt(
+                siteUrl,
+                emptySet(),
+            )
+        }
+
+    @Test
     fun whenCtaShownThenFirePixel() =
         runTest {
             val cta = HomePanelCta.AddWidgetAutoOnboarding

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3850,10 +3850,7 @@ class BrowserTabViewModelTest {
             testee.refreshCta()
 
             verify(refreshPixelSender).onRefreshPatternDetected(refreshPatterns)
-            verify(mockBrokenSitePrompt).shouldShowBrokenSitePrompt(
-                currentUrl,
-                refreshPatterns,
-            )
+            verify(mockBrokenSitePrompt, never()).shouldShowBrokenSitePrompt(any(), any())
         }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3851,8 +3851,8 @@ class BrowserTabViewModelTest {
 
             verify(refreshPixelSender).onRefreshPatternDetected(refreshPatterns)
             verify(mockBrokenSitePrompt).shouldShowBrokenSitePrompt(
-                previousUrl,
-                emptySet(),
+                currentUrl,
+                refreshPatterns,
             )
         }
 
@@ -3899,10 +3899,7 @@ class BrowserTabViewModelTest {
 
             testee.refreshCta()
 
-            verify(mockBrokenSitePrompt).shouldShowBrokenSitePrompt(
-                siteUrl,
-                emptySet(),
-            )
+            verify(mockBrokenSitePrompt, never()).shouldShowBrokenSitePrompt(any(), any())
         }
 
     @Test
@@ -7433,6 +7430,24 @@ class BrowserTabViewModelTest {
 
             testee.onRefreshRequested(triggeredByUser = true)
             verify(mockBrokenSitePrompt).pageRefreshed(url.toUri())
+        }
+
+    @Test
+    fun whenUserRefreshesAndNavigationUrlAvailableThenRecordNavigationUrl() =
+        runTest {
+            val siteUrl = "https://previous.example"
+            val currentUrl = "https://current.example"
+            givenCurrentSite(siteUrl)
+            testee.navigationStateChanged(
+                buildWebNavigation(
+                    originalUrl = currentUrl,
+                    currentUrl = currentUrl,
+                ),
+            )
+
+            testee.onRefreshRequested(triggeredByUser = true)
+
+            verify(mockBrokenSitePrompt).pageRefreshed(currentUrl.toUri())
         }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -417,6 +417,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = null,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
         assertNull(value)
     }
@@ -431,6 +432,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
         assertNull(value)
     }
@@ -447,6 +449,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = site.url,
         )
         assertTrue(value is BrokenSitePromptDialogCta)
     }
@@ -464,6 +467,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = site.url,
         )
         assertTrue(value is BrokenSitePromptDialogCta)
     }
@@ -479,6 +483,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
         assertNull(value)
     }
@@ -492,7 +497,8 @@ class CtaViewModelTest {
             coroutineRule.testDispatcher,
             isBrowserShowing = true,
             site = site,
-            detectedRefreshPatterns,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         ) as OnboardingDaxDialogCta
 
         assertTrue(value is OnboardingDaxDialogCta.DaxMainNetworkCta)
@@ -507,6 +513,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         ) as OnboardingDaxDialogCta
 
         assertTrue(value is OnboardingDaxDialogCta.DaxMainNetworkCta)
@@ -530,6 +537,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(value is OnboardingDaxDialogCta.DaxTrackersBlockedCta)
@@ -553,6 +561,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(value is OnboardingDaxDialogCta.DaxTrackersBlockedCta)
@@ -567,6 +576,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(value is OnboardingDaxDialogCta.DaxNoTrackersCta)
@@ -581,6 +591,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(value is OnboardingDaxDialogCta.DaxSerpCta)
@@ -595,6 +606,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(value is OnboardingDaxDialogCta.DaxNoTrackersCta)
@@ -609,6 +621,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(value is OnboardingDaxDialogCta.DaxNoTrackersCta)
@@ -623,6 +636,7 @@ class CtaViewModelTest {
             isBrowserShowing = false,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertFalse(value is OnboardingDaxDialogCta)
@@ -640,6 +654,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
         assertFalse(value is OnboardingDaxDialogCta.DaxEndCta)
     }
@@ -657,6 +672,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
         assertTrue(value is OnboardingDaxDialogCta.DaxEndCta)
     }
@@ -667,7 +683,12 @@ class CtaViewModelTest {
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(false)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)).thenReturn(true)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxBubbleCta.DaxIntroSearchOptionsCta)
     }
 
@@ -676,7 +697,12 @@ class CtaViewModelTest {
         givenDaxOnboardingActive()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxBubbleCta.DaxIntroVisitSiteOptionsCta)
     }
 
@@ -687,7 +713,12 @@ class CtaViewModelTest {
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)
         givenAtLeastOneDaxDialogCtaShown()
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxBubbleCta.DaxEndCta)
     }
 
@@ -696,7 +727,12 @@ class CtaViewModelTest {
         givenShownDaxOnboardingCtas(listOf(CtaId.DAX_INTRO))
         givenUserIsEstablished()
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertNull(value)
     }
 
@@ -709,6 +745,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
         assertNull(value)
     }
@@ -846,7 +883,12 @@ class CtaViewModelTest {
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(false)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)).thenReturn(true)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxBubbleCta.DaxIntroSearchOptionsCta)
     }
 
@@ -867,7 +909,12 @@ class CtaViewModelTest {
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_TRACKERS_FOUND)).thenReturn(false)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxBubbleCta.DaxIntroVisitSiteOptionsCta)
     }
 
@@ -877,7 +924,12 @@ class CtaViewModelTest {
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_TRACKERS_FOUND)).thenReturn(true)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertFalse(value is DaxBubbleCta.DaxIntroVisitSiteOptionsCta)
     }
 
@@ -907,7 +959,12 @@ class CtaViewModelTest {
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_END)).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxBubbleCta.DaxSubscriptionCta)
     }
 
@@ -924,7 +981,12 @@ class CtaViewModelTest {
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_END)).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxBubbleCta.DaxSubscriptionCta)
         assertTrue((value as DaxBubbleCta.DaxSubscriptionCta).isFreeTrialCopy)
     }
@@ -989,7 +1051,12 @@ class CtaViewModelTest {
         whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(mockDisabledToggle)
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxBubbleCta.DaxSubscriptionCta)
     }
 
@@ -1003,7 +1070,12 @@ class CtaViewModelTest {
         whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
         whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertNull(value)
     }
 
@@ -1018,7 +1090,12 @@ class CtaViewModelTest {
         whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
         whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertFalse(value is DaxBubbleCta.DaxSubscriptionCta)
         assertFalse(value is DaxSubscriptionBrandDesignUpdateBubbleCta)
     }
@@ -1047,7 +1124,12 @@ class CtaViewModelTest {
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_END)).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertFalse(value is DaxBubbleCta.DaxSubscriptionCta)
     }
 
@@ -1063,6 +1145,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
         assertNull(value)
     }
@@ -1083,6 +1166,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
         assertNull(value)
     }
@@ -1098,6 +1182,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
         assertNull(value)
     }
@@ -1113,6 +1198,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         ) as OnboardingDaxDialogCta
 
         assertTrue(value is OnboardingDaxDialogCta.DaxMainNetworkCta)
@@ -1129,6 +1215,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
         assertNull(value)
     }
@@ -1202,7 +1289,12 @@ class CtaViewModelTest {
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)).thenReturn(true)
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxTryASearchBrandDesignUpdateBubbleCta)
     }
 
@@ -1213,7 +1305,12 @@ class CtaViewModelTest {
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)).thenReturn(true)
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxBubbleCta.DaxIntroSearchOptionsCta)
     }
 
@@ -1223,7 +1320,12 @@ class CtaViewModelTest {
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxVisitSiteOptionsBrandDesignUpdateBubbleCta)
     }
 
@@ -1234,7 +1336,12 @@ class CtaViewModelTest {
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
         whenever(mockOnboardingBrandDesignUpdateToggles.onboardingImprovements()).thenReturn(mockDisabledToggle)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxVisitSiteOptionsBrandDesignUpdateBubbleCta)
         assertFalse((value as DaxVisitSiteOptionsBrandDesignUpdateBubbleCta).onboardingImprovementsEnabled)
     }
@@ -1246,7 +1353,12 @@ class CtaViewModelTest {
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
         whenever(mockOnboardingBrandDesignUpdateToggles.onboardingImprovements()).thenReturn(mockEnabledToggle)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxVisitSiteOptionsBrandDesignUpdateBubbleCta)
         assertTrue((value as DaxVisitSiteOptionsBrandDesignUpdateBubbleCta).onboardingImprovementsEnabled)
     }
@@ -1258,7 +1370,12 @@ class CtaViewModelTest {
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
         whenever(mockOnboardingBrandDesignUpdateToggles.onboardingImprovementsV2()).thenReturn(mockDisabledToggle)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxVisitSiteOptionsBrandDesignUpdateBubbleCta)
         assertFalse((value as DaxVisitSiteOptionsBrandDesignUpdateBubbleCta).onboardingImprovementsV2Enabled)
     }
@@ -1270,7 +1387,12 @@ class CtaViewModelTest {
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
         whenever(mockOnboardingBrandDesignUpdateToggles.onboardingImprovementsV2()).thenReturn(mockEnabledToggle)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxVisitSiteOptionsBrandDesignUpdateBubbleCta)
         assertTrue((value as DaxVisitSiteOptionsBrandDesignUpdateBubbleCta).onboardingImprovementsV2Enabled)
     }
@@ -1281,7 +1403,12 @@ class CtaViewModelTest {
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxBubbleCta.DaxIntroVisitSiteOptionsCta)
     }
 
@@ -1293,7 +1420,12 @@ class CtaViewModelTest {
         givenAtLeastOneDaxDialogCtaShown()
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxEndBrandDesignUpdateBubbleCta)
     }
 
@@ -1305,7 +1437,12 @@ class CtaViewModelTest {
         givenAtLeastOneDaxDialogCtaShown()
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxBubbleCta.DaxEndCta)
     }
 
@@ -1322,7 +1459,12 @@ class CtaViewModelTest {
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxSubscriptionBrandDesignUpdateBubbleCta)
     }
 
@@ -1339,7 +1481,12 @@ class CtaViewModelTest {
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
 
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertTrue(value is DaxBubbleCta.DaxSubscriptionCta)
     }
 
@@ -1368,6 +1515,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
         assertFalse(value is SubscriptionPromoModalCta)
     }
@@ -1385,6 +1533,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
         assertFalse(value is SubscriptionPromoModalCta)
     }
@@ -1404,6 +1553,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
         assertFalse(value is SubscriptionPromoModalCta)
     }
@@ -1419,6 +1569,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
         assertFalse(value is SubscriptionPromoModalCta)
     }
@@ -1436,6 +1587,7 @@ class CtaViewModelTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
         assertFalse(value is SubscriptionPromoModalCta)
     }
@@ -1451,7 +1603,12 @@ class CtaViewModelTest {
 
         // After modal is shown, DAX_INTRO_PRIVACY_PRO is in dismissed_cta, so bubble must not show
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)).thenReturn(true)
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
         assertFalse(value is DaxBubbleCta.DaxSubscriptionCta)
     }
 
@@ -1561,7 +1718,12 @@ class CtaViewModelTest {
         givenCanShowDuckAiEndCta()
         showInputScreenFlow.value = false
 
-        val cta = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val cta = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
 
         assertTrue(cta is DaxDuckAiEndBubbleCta)
     }
@@ -1573,7 +1735,12 @@ class CtaViewModelTest {
         showInputScreenFlow.value = false
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
 
-        val cta = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val cta = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
 
         assertTrue(cta is DaxDuckAiEndBrandDesignUpdateBubbleCta)
     }
@@ -1584,7 +1751,12 @@ class CtaViewModelTest {
         givenCanShowDuckAiEndCta()
         showInputScreenFlow.value = true
 
-        val cta = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        val cta = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
 
         assertNull(cta)
     }
@@ -1595,7 +1767,12 @@ class CtaViewModelTest {
         givenCanShowDuckAiEndCta()
         showInputScreenFlow.value = false
 
-        testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
 
         verify(mockDuckChat).setInputScreenUserSetting(true)
     }
@@ -1606,7 +1783,12 @@ class CtaViewModelTest {
         givenCanShowDuckAiEndCta()
         showInputScreenFlow.value = true
 
-        testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = false,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
+        )
 
         // The legacy input-screen path applies the toggle in prepareAndMarkDuckAiEndCtaForInputScreen, not here.
         verify(mockDuckChat, never()).setInputScreenUserSetting(any())

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest.kt
@@ -197,6 +197,7 @@ class DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest {
             isBrowserShowing = true,
             site = duckAiSite(),
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(cta is DaxDuckAiFireButtonBrandDesignUpdateContextualCta)
@@ -209,6 +210,7 @@ class DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest {
             isBrowserShowing = true,
             site = duckAiSite(),
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(cta is OnboardingDaxDialogCta.DaxDuckAiFireButtonCta)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
@@ -208,6 +208,7 @@ class DaxEndBrandDesignUpdateContextualCtaTest {
             isBrowserShowing = true,
             site = siteStub(),
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(value is DaxEndBrandDesignUpdateContextualCta)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
@@ -212,6 +212,7 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(value is DaxMainNetworkBrandDesignUpdateContextualCta)
@@ -271,6 +272,7 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(value is OnboardingDaxDialogCta.DaxMainNetworkCta)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCtaTest.kt
@@ -201,6 +201,7 @@ class DaxNoTrackersBrandDesignUpdateContextualCtaTest {
             isBrowserShowing = true,
             site = site(url = "http://www.wikipedia.com"),
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(value is DaxNoTrackersBrandDesignUpdateContextualCta)
@@ -216,6 +217,7 @@ class DaxNoTrackersBrandDesignUpdateContextualCtaTest {
             isBrowserShowing = true,
             site = site(url = "http://www.wikipedia.com"),
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(value is OnboardingDaxDialogCta.DaxNoTrackersCta)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCtaTest.kt
@@ -204,6 +204,7 @@ class DaxSerpBrandDesignUpdateContextualCtaTest {
             isBrowserShowing = true,
             site = site(url = "http://www.duckduckgo.com"),
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(value is DaxSerpBrandDesignUpdateContextualCta)
@@ -219,6 +220,7 @@ class DaxSerpBrandDesignUpdateContextualCtaTest {
             isBrowserShowing = true,
             site = site(url = "http://www.duckduckgo.com"),
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(value is OnboardingDaxDialogCta.DaxSerpCta)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
@@ -188,6 +188,7 @@ class DaxTrackersBlockedBrandDesignUpdateContextualCtaTest {
             isBrowserShowing = true,
             site = siteWithBlockedTrackers(),
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(value is DaxTrackersBlockedBrandDesignUpdateContextualCta)
@@ -203,6 +204,7 @@ class DaxTrackersBlockedBrandDesignUpdateContextualCtaTest {
             isBrowserShowing = true,
             site = siteWithBlockedTrackers(),
             detectedRefreshPatterns = detectedRefreshPatterns,
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(value is OnboardingDaxDialogCta.DaxTrackersBlockedCta)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
@@ -314,6 +314,7 @@ class OnboardingDaxDialogTests {
             isBrowserShowing = false,
             site = null,
             detectedRefreshPatterns = emptySet(),
+            brokenSitePromptUrl = null,
         )
 
         assertFalse(result is SubscriptionPromoModalCta)
@@ -332,6 +333,7 @@ class OnboardingDaxDialogTests {
             isBrowserShowing = false,
             site = null,
             detectedRefreshPatterns = emptySet(),
+            brokenSitePromptUrl = null,
         )
 
         assertFalse(result is SubscriptionPromoModalCta)
@@ -351,6 +353,7 @@ class OnboardingDaxDialogTests {
             isBrowserShowing = false,
             site = null,
             detectedRefreshPatterns = emptySet(),
+            brokenSitePromptUrl = null,
         )
 
         assertFalse(result is SubscriptionPromoModalCta)
@@ -367,6 +370,7 @@ class OnboardingDaxDialogTests {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = emptySet(),
+            brokenSitePromptUrl = null,
         )
 
         assertNull(result)
@@ -383,6 +387,7 @@ class OnboardingDaxDialogTests {
             isBrowserShowing = true,
             site = site,
             detectedRefreshPatterns = emptySet(),
+            brokenSitePromptUrl = null,
         )
 
         assertTrue(result is OnboardingDaxDialogCta.DaxMainNetworkCta)

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStore.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStore.kt
@@ -22,7 +22,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import java.time.LocalDateTime
-import java.util.WeakHashMap
 import javax.inject.Inject
 
 interface BrokenSiteRefreshesInMemoryStore {
@@ -37,7 +36,11 @@ class RefreshPatternOwner
 @SingleInstanceIn(AppScope::class)
 class RealBrokenSiteRefreshesInMemoryStore @Inject constructor() : BrokenSiteRefreshesInMemoryStore {
 
-    private val refreshStates = WeakHashMap<RefreshPatternOwner, RefreshPatternState>()
+    private var lastRefreshOwner: RefreshPatternOwner? = null
+    private var lastRefreshedUrl: Uri? = null
+    private var doubleRefreshTimes = emptyList<LocalDateTime>()
+    private var tripleRefreshTimes = emptyList<LocalDateTime>()
+    private var pendingDetection: RefreshPatternDetection? = null
 
     @Synchronized
     override fun addRefresh(
@@ -45,18 +48,17 @@ class RealBrokenSiteRefreshesInMemoryStore @Inject constructor() : BrokenSiteRef
         url: Uri,
         localDateTime: LocalDateTime,
     ) {
-        val state = refreshStates.getOrPut(owner, ::RefreshPatternState)
-        resetIfUrlChanged(state, url)
-        state.doubleRefreshTimes = state.doubleRefreshTimes.plus(localDateTime)
-        state.tripleRefreshTimes = state.tripleRefreshTimes.plus(localDateTime)
-        detectPatterns(state, url, localDateTime)
+        resetIfOwnerOrUrlChanged(owner, url)
+        doubleRefreshTimes = doubleRefreshTimes.plus(localDateTime)
+        tripleRefreshTimes = tripleRefreshTimes.plus(localDateTime)
+        detectPatterns(owner, url, localDateTime)
     }
 
     @Synchronized
     override fun getRefreshPatterns(owner: RefreshPatternOwner): Set<RefreshPattern> {
-        val state = refreshStates[owner] ?: return emptySet()
-        val detection = state.pendingDetection ?: return emptySet()
-        state.pendingDetection = detection.copy(patterns = emptySet())
+        val detection = pendingDetection ?: return emptySet()
+        if (detection.owner !== owner) return emptySet()
+        pendingDetection = detection.copy(patterns = emptySet())
         return detection.patterns
     }
 
@@ -65,59 +67,53 @@ class RealBrokenSiteRefreshesInMemoryStore @Inject constructor() : BrokenSiteRef
         url: Uri,
         currentDateTime: LocalDateTime,
     ): Boolean {
-        return refreshStates.values.any { state ->
-            state.pendingDetection?.let { detection ->
-                detection.url == url && !detection.detectedAt.isBefore(currentDateTime.minusSeconds(DETECTION_STALENESS_IN_SECS))
-            } == true
-        }
+        val detection = pendingDetection ?: return false
+        return detection.url == url && !detection.detectedAt.isBefore(currentDateTime.minusSeconds(DETECTION_STALENESS_IN_SECS))
     }
 
-    private fun resetIfUrlChanged(
-        state: RefreshPatternState,
+    private fun resetIfOwnerOrUrlChanged(
+        owner: RefreshPatternOwner,
         url: Uri,
     ) {
-        if (state.lastRefreshedUrl != url) {
-            state.lastRefreshedUrl = url
-            state.doubleRefreshTimes = emptyList()
-            state.tripleRefreshTimes = emptyList()
-            state.pendingDetection = null
+        if (lastRefreshOwner !== owner || lastRefreshedUrl != url) {
+            lastRefreshOwner = owner
+            lastRefreshedUrl = url
+            doubleRefreshTimes = emptyList()
+            tripleRefreshTimes = emptyList()
+            pendingDetection = null
         }
     }
 
     private fun detectPatterns(
-        state: RefreshPatternState,
+        owner: RefreshPatternOwner,
         url: Uri,
         currentDateTime: LocalDateTime,
     ) {
-        pruneOldRefreshes(state, currentDateTime)
+        pruneOldRefreshes(currentDateTime)
         val detectedPatterns = buildSet {
-            if (state.doubleRefreshTimes.size >= TWICE_REFRESH_THRESHOLD) {
+            if (doubleRefreshTimes.size >= TWICE_REFRESH_THRESHOLD) {
                 add(RefreshPattern.TWICE_IN_12_SECONDS)
-                state.doubleRefreshTimes = emptyList()
+                doubleRefreshTimes = emptyList()
             }
-            if (state.tripleRefreshTimes.size >= THRICE_REFRESH_THRESHOLD) {
+            if (tripleRefreshTimes.size >= THRICE_REFRESH_THRESHOLD) {
                 add(RefreshPattern.THRICE_IN_20_SECONDS)
-                state.tripleRefreshTimes = emptyList()
+                tripleRefreshTimes = emptyList()
             }
         }
 
         if (detectedPatterns.isNotEmpty()) {
-            state.pendingDetection = RefreshPatternDetection(
-                patterns = state.pendingDetection?.patterns.orEmpty() + detectedPatterns,
+            pendingDetection = RefreshPatternDetection(
+                patterns = pendingDetection?.patterns.orEmpty() + detectedPatterns,
+                owner = owner,
                 url = url,
                 detectedAt = currentDateTime,
             )
         }
     }
 
-    private fun pruneOldRefreshes(
-        state: RefreshPatternState,
-        currentDateTime: LocalDateTime,
-    ) {
-        state.doubleRefreshTimes =
-            state.doubleRefreshTimes.filter { it.isAfter(currentDateTime.minusSeconds(TWICE_REFRESH_WINDOW_IN_SECS)) }
-        state.tripleRefreshTimes =
-            state.tripleRefreshTimes.filter { it.isAfter(currentDateTime.minusSeconds(THRICE_REFRESH_WINDOW_IN_SECS)) }
+    private fun pruneOldRefreshes(currentDateTime: LocalDateTime) {
+        doubleRefreshTimes = doubleRefreshTimes.filter { it.isAfter(currentDateTime.minusSeconds(TWICE_REFRESH_WINDOW_IN_SECS)) }
+        tripleRefreshTimes = tripleRefreshTimes.filter { it.isAfter(currentDateTime.minusSeconds(THRICE_REFRESH_WINDOW_IN_SECS)) }
     }
 
     companion object {
@@ -129,15 +125,9 @@ class RealBrokenSiteRefreshesInMemoryStore @Inject constructor() : BrokenSiteRef
     }
 }
 
-private class RefreshPatternState(
-    var lastRefreshedUrl: Uri? = null,
-    var doubleRefreshTimes: List<LocalDateTime> = emptyList(),
-    var tripleRefreshTimes: List<LocalDateTime> = emptyList(),
-    var pendingDetection: RefreshPatternDetection? = null,
-)
-
 private data class RefreshPatternDetection(
     val patterns: Set<RefreshPattern>,
+    val owner: RefreshPatternOwner,
     val url: Uri,
     val detectedAt: LocalDateTime,
 )

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStore.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStore.kt
@@ -30,6 +30,10 @@ interface BrokenSiteRefreshesInMemoryStore {
     fun isRefreshPatternDetectionValid(url: Uri, currentDateTime: LocalDateTime): Boolean
 }
 
+/**
+ * Ties refresh patterns to the BrowserTabViewModel's prompt instance.
+ * Recording and consumption must use the same instance, which must not be shared across tabs.
+ */
 class RefreshPatternOwner
 
 @ContributesBinding(AppScope::class)

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStore.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStore.kt
@@ -26,7 +26,7 @@ import javax.inject.Inject
 
 interface BrokenSiteRefreshesInMemoryStore {
     fun addRefresh(owner: RefreshPatternOwner, url: Uri, localDateTime: LocalDateTime)
-    fun getRefreshPatterns(owner: RefreshPatternOwner): Set<RefreshPattern>
+    fun getRefreshPatterns(owner: RefreshPatternOwner, currentDateTime: LocalDateTime): Set<RefreshPattern>
     fun isRefreshPatternDetectionValid(url: Uri, currentDateTime: LocalDateTime): Boolean
 }
 
@@ -49,13 +49,18 @@ class RealBrokenSiteRefreshesInMemoryStore @Inject constructor() : BrokenSiteRef
         localDateTime: LocalDateTime,
     ) {
         resetIfOwnerOrUrlChanged(owner, url)
+        discardStalePendingDetection(localDateTime)
         doubleRefreshTimes = doubleRefreshTimes.plus(localDateTime)
         tripleRefreshTimes = tripleRefreshTimes.plus(localDateTime)
         detectPatterns(owner, url, localDateTime)
     }
 
     @Synchronized
-    override fun getRefreshPatterns(owner: RefreshPatternOwner): Set<RefreshPattern> {
+    override fun getRefreshPatterns(
+        owner: RefreshPatternOwner,
+        currentDateTime: LocalDateTime,
+    ): Set<RefreshPattern> {
+        discardStalePendingDetection(currentDateTime)
         val detection = pendingDetection ?: return emptySet()
         if (detection.owner !== owner) return emptySet()
         pendingDetection = detection.copy(patterns = emptySet())
@@ -67,9 +72,19 @@ class RealBrokenSiteRefreshesInMemoryStore @Inject constructor() : BrokenSiteRef
         url: Uri,
         currentDateTime: LocalDateTime,
     ): Boolean {
+        discardStalePendingDetection(currentDateTime)
         val detection = pendingDetection ?: return false
-        return detection.url == url && !detection.detectedAt.isBefore(currentDateTime.minusSeconds(DETECTION_STALENESS_IN_SECS))
+        return detection.url == url
     }
+
+    private fun discardStalePendingDetection(currentDateTime: LocalDateTime) {
+        if (pendingDetection?.isStale(currentDateTime) == true) {
+            pendingDetection = null
+        }
+    }
+
+    private fun RefreshPatternDetection.isStale(currentDateTime: LocalDateTime): Boolean =
+        detectedAt.isBefore(currentDateTime.minusSeconds(DETECTION_STALENESS_IN_SECS))
 
     private fun resetIfOwnerOrUrlChanged(
         owner: RefreshPatternOwner,

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStore.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStore.kt
@@ -25,106 +25,97 @@ import java.time.LocalDateTime
 import javax.inject.Inject
 
 interface BrokenSiteRefreshesInMemoryStore {
-    fun resetRefreshCount(pattern: RefreshPattern)
     fun addRefresh(url: Uri, localDateTime: LocalDateTime)
-    fun getRefreshPatterns(currentDateTime: LocalDateTime): Set<RefreshPattern>
+    fun getRefreshPatterns(): Set<RefreshPattern>
+    fun isRefreshPatternDetectionValid(url: Uri, currentDateTime: LocalDateTime): Boolean
 }
 
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
 class RealBrokenSiteRefreshesInMemoryStore @Inject constructor() : BrokenSiteRefreshesInMemoryStore {
 
-    private var doubleRefreshes: LastRefreshedUrl? = null
-    private var tripleRefreshes: LastRefreshedUrl? = null
+    private var lastRefreshedUrl: Uri? = null
+    private var doubleRefreshTimes = emptyList<LocalDateTime>()
+    private var tripleRefreshTimes = emptyList<LocalDateTime>()
+    private var pendingDetection: RefreshPatternDetection? = null
 
-    override fun resetRefreshCount(pattern: RefreshPattern) {
-        when (pattern) {
-            RefreshPattern.TWICE_IN_12_SECONDS -> this.doubleRefreshes = null
-            RefreshPattern.THRICE_IN_20_SECONDS -> this.tripleRefreshes = null
-        }
-    }
-
+    @Synchronized
     override fun addRefresh(
         url: Uri,
         localDateTime: LocalDateTime,
     ) {
-        doubleRefreshes = updateRefreshes(doubleRefreshes, url, localDateTime)
-        tripleRefreshes = updateRefreshes(tripleRefreshes, url, localDateTime)
+        resetIfUrlChanged(url)
+        doubleRefreshTimes = doubleRefreshTimes.plus(localDateTime)
+        tripleRefreshTimes = tripleRefreshTimes.plus(localDateTime)
+        detectPatterns(url, localDateTime)
     }
 
-    override fun getRefreshPatterns(currentDateTime: LocalDateTime): Set<RefreshPattern> {
-        pruneOldRefreshes(currentDateTime)
-
-        if (doubleRefreshes == null && tripleRefreshes == null) {
-            return emptySet()
-        }
-        val thriceRefreshCount = tripleRefreshes?.time?.count {
-            it.isAfter(currentDateTime.minusSeconds(THRICE_REFRESH_WINDOW_IN_SECS))
-        } ?: 0
-
-        val twiceRefreshCount = doubleRefreshes?.time?.count {
-            it.isAfter(currentDateTime.minusSeconds(TWICE_REFRESH_WINDOW_IN_SECS))
-        } ?: 0
-
-        val detectedPatterns = mutableSetOf<RefreshPattern>()
-        addPatternsAndResetCount(detectedPatterns, twiceRefreshCount, TWICE_REFRESH_THRESHOLD, RefreshPattern.TWICE_IN_12_SECONDS)
-        addPatternsAndResetCount(detectedPatterns, thriceRefreshCount, THRICE_REFRESH_THRESHOLD, RefreshPattern.THRICE_IN_20_SECONDS)
-
-        return detectedPatterns
+    @Synchronized
+    override fun getRefreshPatterns(): Set<RefreshPattern> {
+        val detection = pendingDetection ?: return emptySet()
+        pendingDetection = detection.copy(patterns = emptySet())
+        return detection.patterns
     }
 
-    private fun addPatternsAndResetCount(
-        detectedPatterns: MutableSet<RefreshPattern>,
-        refreshCount: Int,
-        threshold: Int,
-        pattern: RefreshPattern,
-    ) {
-        if (refreshCount >= threshold) {
-            detectedPatterns.add(pattern)
-            resetRefreshCount(pattern)
-        }
-    }
-
-    private fun pruneOldRefreshes(
-        currentTime: LocalDateTime,
-    ) {
-        val doubleTimes = doubleRefreshes?.time
-        val tripleTimes = tripleRefreshes?.time
-
-        if (doubleTimes != null) {
-            val cutoffTime = currentTime.minusSeconds(TWICE_REFRESH_WINDOW_IN_SECS)
-            val newDoubleTimes = doubleTimes.filter { it.isAfter(cutoffTime) }
-            this.doubleRefreshes = this.doubleRefreshes?.copy(time = newDoubleTimes)
-        }
-
-        if (tripleTimes != null) {
-            val cutoffTime = currentTime.minusSeconds(THRICE_REFRESH_WINDOW_IN_SECS)
-            val newTripleTimes = tripleTimes.filter { it.isAfter(cutoffTime) }
-            this.tripleRefreshes = this.tripleRefreshes?.copy(time = newTripleTimes)
-        }
-    }
-
-    private fun updateRefreshes(
-        currentRefreshes: LastRefreshedUrl?,
+    @Synchronized
+    override fun isRefreshPatternDetectionValid(
         url: Uri,
-        localDateTime: LocalDateTime,
-    ): LastRefreshedUrl {
-        return if (currentRefreshes == null || currentRefreshes.url != url) {
-            LastRefreshedUrl(url, mutableListOf(localDateTime))
-        } else {
-            currentRefreshes.copy(time = currentRefreshes.time.plus(localDateTime))
+        currentDateTime: LocalDateTime,
+    ): Boolean {
+        val detection = pendingDetection ?: return false
+        return detection.url == url && !detection.detectedAt.isBefore(currentDateTime.minusSeconds(DETECTION_STALENESS_IN_SECS))
+    }
+
+    private fun resetIfUrlChanged(url: Uri) {
+        if (lastRefreshedUrl != url) {
+            lastRefreshedUrl = url
+            doubleRefreshTimes = emptyList()
+            tripleRefreshTimes = emptyList()
+            pendingDetection = null
         }
+    }
+
+    private fun detectPatterns(
+        url: Uri,
+        currentDateTime: LocalDateTime,
+    ) {
+        pruneOldRefreshes(currentDateTime)
+        val detectedPatterns = buildSet {
+            if (doubleRefreshTimes.size >= TWICE_REFRESH_THRESHOLD) {
+                add(RefreshPattern.TWICE_IN_12_SECONDS)
+                doubleRefreshTimes = emptyList()
+            }
+            if (tripleRefreshTimes.size >= THRICE_REFRESH_THRESHOLD) {
+                add(RefreshPattern.THRICE_IN_20_SECONDS)
+                tripleRefreshTimes = emptyList()
+            }
+        }
+
+        if (detectedPatterns.isNotEmpty()) {
+            pendingDetection = RefreshPatternDetection(
+                patterns = pendingDetection?.patterns.orEmpty() + detectedPatterns,
+                url = url,
+                detectedAt = currentDateTime,
+            )
+        }
+    }
+
+    private fun pruneOldRefreshes(currentDateTime: LocalDateTime) {
+        doubleRefreshTimes = doubleRefreshTimes.filter { it.isAfter(currentDateTime.minusSeconds(TWICE_REFRESH_WINDOW_IN_SECS)) }
+        tripleRefreshTimes = tripleRefreshTimes.filter { it.isAfter(currentDateTime.minusSeconds(THRICE_REFRESH_WINDOW_IN_SECS)) }
     }
 
     companion object {
         private const val TWICE_REFRESH_WINDOW_IN_SECS = 12L
         private const val THRICE_REFRESH_WINDOW_IN_SECS = 20L
+        private const val DETECTION_STALENESS_IN_SECS = 60L
         private const val TWICE_REFRESH_THRESHOLD = 2
         private const val THRICE_REFRESH_THRESHOLD = 3
     }
 }
 
-data class LastRefreshedUrl(
+private data class RefreshPatternDetection(
+    val patterns: Set<RefreshPattern>,
     val url: Uri,
-    val time: List<LocalDateTime>,
+    val detectedAt: LocalDateTime,
 )

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStore.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStore.kt
@@ -22,38 +22,41 @@ import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import java.time.LocalDateTime
+import java.util.WeakHashMap
 import javax.inject.Inject
 
 interface BrokenSiteRefreshesInMemoryStore {
-    fun addRefresh(url: Uri, localDateTime: LocalDateTime)
-    fun getRefreshPatterns(): Set<RefreshPattern>
+    fun addRefresh(owner: RefreshPatternOwner, url: Uri, localDateTime: LocalDateTime)
+    fun getRefreshPatterns(owner: RefreshPatternOwner): Set<RefreshPattern>
     fun isRefreshPatternDetectionValid(url: Uri, currentDateTime: LocalDateTime): Boolean
 }
+
+class RefreshPatternOwner
 
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
 class RealBrokenSiteRefreshesInMemoryStore @Inject constructor() : BrokenSiteRefreshesInMemoryStore {
 
-    private var lastRefreshedUrl: Uri? = null
-    private var doubleRefreshTimes = emptyList<LocalDateTime>()
-    private var tripleRefreshTimes = emptyList<LocalDateTime>()
-    private var pendingDetection: RefreshPatternDetection? = null
+    private val refreshStates = WeakHashMap<RefreshPatternOwner, RefreshPatternState>()
 
     @Synchronized
     override fun addRefresh(
+        owner: RefreshPatternOwner,
         url: Uri,
         localDateTime: LocalDateTime,
     ) {
-        resetIfUrlChanged(url)
-        doubleRefreshTimes = doubleRefreshTimes.plus(localDateTime)
-        tripleRefreshTimes = tripleRefreshTimes.plus(localDateTime)
-        detectPatterns(url, localDateTime)
+        val state = refreshStates.getOrPut(owner, ::RefreshPatternState)
+        resetIfUrlChanged(state, url)
+        state.doubleRefreshTimes = state.doubleRefreshTimes.plus(localDateTime)
+        state.tripleRefreshTimes = state.tripleRefreshTimes.plus(localDateTime)
+        detectPatterns(state, url, localDateTime)
     }
 
     @Synchronized
-    override fun getRefreshPatterns(): Set<RefreshPattern> {
-        val detection = pendingDetection ?: return emptySet()
-        pendingDetection = detection.copy(patterns = emptySet())
+    override fun getRefreshPatterns(owner: RefreshPatternOwner): Set<RefreshPattern> {
+        val state = refreshStates[owner] ?: return emptySet()
+        val detection = state.pendingDetection ?: return emptySet()
+        state.pendingDetection = detection.copy(patterns = emptySet())
         return detection.patterns
     }
 
@@ -62,47 +65,59 @@ class RealBrokenSiteRefreshesInMemoryStore @Inject constructor() : BrokenSiteRef
         url: Uri,
         currentDateTime: LocalDateTime,
     ): Boolean {
-        val detection = pendingDetection ?: return false
-        return detection.url == url && !detection.detectedAt.isBefore(currentDateTime.minusSeconds(DETECTION_STALENESS_IN_SECS))
+        return refreshStates.values.any { state ->
+            state.pendingDetection?.let { detection ->
+                detection.url == url && !detection.detectedAt.isBefore(currentDateTime.minusSeconds(DETECTION_STALENESS_IN_SECS))
+            } == true
+        }
     }
 
-    private fun resetIfUrlChanged(url: Uri) {
-        if (lastRefreshedUrl != url) {
-            lastRefreshedUrl = url
-            doubleRefreshTimes = emptyList()
-            tripleRefreshTimes = emptyList()
-            pendingDetection = null
+    private fun resetIfUrlChanged(
+        state: RefreshPatternState,
+        url: Uri,
+    ) {
+        if (state.lastRefreshedUrl != url) {
+            state.lastRefreshedUrl = url
+            state.doubleRefreshTimes = emptyList()
+            state.tripleRefreshTimes = emptyList()
+            state.pendingDetection = null
         }
     }
 
     private fun detectPatterns(
+        state: RefreshPatternState,
         url: Uri,
         currentDateTime: LocalDateTime,
     ) {
-        pruneOldRefreshes(currentDateTime)
+        pruneOldRefreshes(state, currentDateTime)
         val detectedPatterns = buildSet {
-            if (doubleRefreshTimes.size >= TWICE_REFRESH_THRESHOLD) {
+            if (state.doubleRefreshTimes.size >= TWICE_REFRESH_THRESHOLD) {
                 add(RefreshPattern.TWICE_IN_12_SECONDS)
-                doubleRefreshTimes = emptyList()
+                state.doubleRefreshTimes = emptyList()
             }
-            if (tripleRefreshTimes.size >= THRICE_REFRESH_THRESHOLD) {
+            if (state.tripleRefreshTimes.size >= THRICE_REFRESH_THRESHOLD) {
                 add(RefreshPattern.THRICE_IN_20_SECONDS)
-                tripleRefreshTimes = emptyList()
+                state.tripleRefreshTimes = emptyList()
             }
         }
 
         if (detectedPatterns.isNotEmpty()) {
-            pendingDetection = RefreshPatternDetection(
-                patterns = pendingDetection?.patterns.orEmpty() + detectedPatterns,
+            state.pendingDetection = RefreshPatternDetection(
+                patterns = state.pendingDetection?.patterns.orEmpty() + detectedPatterns,
                 url = url,
                 detectedAt = currentDateTime,
             )
         }
     }
 
-    private fun pruneOldRefreshes(currentDateTime: LocalDateTime) {
-        doubleRefreshTimes = doubleRefreshTimes.filter { it.isAfter(currentDateTime.minusSeconds(TWICE_REFRESH_WINDOW_IN_SECS)) }
-        tripleRefreshTimes = tripleRefreshTimes.filter { it.isAfter(currentDateTime.minusSeconds(THRICE_REFRESH_WINDOW_IN_SECS)) }
+    private fun pruneOldRefreshes(
+        state: RefreshPatternState,
+        currentDateTime: LocalDateTime,
+    ) {
+        state.doubleRefreshTimes =
+            state.doubleRefreshTimes.filter { it.isAfter(currentDateTime.minusSeconds(TWICE_REFRESH_WINDOW_IN_SECS)) }
+        state.tripleRefreshTimes =
+            state.tripleRefreshTimes.filter { it.isAfter(currentDateTime.minusSeconds(THRICE_REFRESH_WINDOW_IN_SECS)) }
     }
 
     companion object {
@@ -113,6 +128,13 @@ class RealBrokenSiteRefreshesInMemoryStore @Inject constructor() : BrokenSiteRef
         private const val THRICE_REFRESH_THRESHOLD = 3
     }
 }
+
+private class RefreshPatternState(
+    var lastRefreshedUrl: Uri? = null,
+    var doubleRefreshTimes: List<LocalDateTime> = emptyList(),
+    var tripleRefreshTimes: List<LocalDateTime> = emptyList(),
+    var pendingDetection: RefreshPatternDetection? = null,
+)
 
 private data class RefreshPatternDetection(
     val patterns: Set<RefreshPattern>,

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteReportRepository.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteReportRepository.kt
@@ -58,8 +58,8 @@ interface BrokenSiteReportRepository {
     suspend fun clearAllDismissals()
     suspend fun getDismissalCountBetween(t1: LocalDateTime, t2: LocalDateTime): Int
 
-    fun addRefresh(url: Uri, localDateTime: LocalDateTime)
-    fun getRefreshPatterns(): Set<RefreshPattern>
+    fun addRefresh(owner: RefreshPatternOwner, url: Uri, localDateTime: LocalDateTime)
+    fun getRefreshPatterns(owner: RefreshPatternOwner): Set<RefreshPattern>
     fun isRefreshPatternDetectionValid(url: Uri, currentDateTime: LocalDateTime): Boolean
 }
 
@@ -153,12 +153,16 @@ class RealBrokenSiteReportRepository(
         return brokenSitePromptDataStore.getDismissalCountBetween(t1, t2)
     }
 
-    override fun addRefresh(url: Uri, localDateTime: LocalDateTime) {
-        brokenSiteRefreshesInMemoryStore.addRefresh(url, localDateTime)
+    override fun addRefresh(
+        owner: RefreshPatternOwner,
+        url: Uri,
+        localDateTime: LocalDateTime,
+    ) {
+        brokenSiteRefreshesInMemoryStore.addRefresh(owner, url, localDateTime)
     }
 
-    override fun getRefreshPatterns(): Set<RefreshPattern> {
-        return brokenSiteRefreshesInMemoryStore.getRefreshPatterns()
+    override fun getRefreshPatterns(owner: RefreshPatternOwner): Set<RefreshPattern> {
+        return brokenSiteRefreshesInMemoryStore.getRefreshPatterns(owner)
     }
 
     override fun isRefreshPatternDetectionValid(

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteReportRepository.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteReportRepository.kt
@@ -59,7 +59,8 @@ interface BrokenSiteReportRepository {
     suspend fun getDismissalCountBetween(t1: LocalDateTime, t2: LocalDateTime): Int
 
     fun addRefresh(url: Uri, localDateTime: LocalDateTime)
-    fun getRefreshPatterns(currentDateTime: LocalDateTime): Set<RefreshPattern>
+    fun getRefreshPatterns(): Set<RefreshPattern>
+    fun isRefreshPatternDetectionValid(url: Uri, currentDateTime: LocalDateTime): Boolean
 }
 
 class RealBrokenSiteReportRepository(
@@ -156,8 +157,15 @@ class RealBrokenSiteReportRepository(
         brokenSiteRefreshesInMemoryStore.addRefresh(url, localDateTime)
     }
 
-    override fun getRefreshPatterns(currentDateTime: LocalDateTime): Set<RefreshPattern> {
-        return brokenSiteRefreshesInMemoryStore.getRefreshPatterns(currentDateTime)
+    override fun getRefreshPatterns(): Set<RefreshPattern> {
+        return brokenSiteRefreshesInMemoryStore.getRefreshPatterns()
+    }
+
+    override fun isRefreshPatternDetectionValid(
+        url: Uri,
+        currentDateTime: LocalDateTime,
+    ): Boolean {
+        return brokenSiteRefreshesInMemoryStore.isRefreshPatternDetectionValid(url, currentDateTime)
     }
 
     private fun convertToShortDate(dateString: String): String {

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteReportRepository.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteReportRepository.kt
@@ -59,7 +59,7 @@ interface BrokenSiteReportRepository {
     suspend fun getDismissalCountBetween(t1: LocalDateTime, t2: LocalDateTime): Int
 
     fun addRefresh(owner: RefreshPatternOwner, url: Uri, localDateTime: LocalDateTime)
-    fun getRefreshPatterns(owner: RefreshPatternOwner): Set<RefreshPattern>
+    fun getRefreshPatterns(owner: RefreshPatternOwner, currentDateTime: LocalDateTime): Set<RefreshPattern>
     fun isRefreshPatternDetectionValid(url: Uri, currentDateTime: LocalDateTime): Boolean
 }
 
@@ -161,8 +161,11 @@ class RealBrokenSiteReportRepository(
         brokenSiteRefreshesInMemoryStore.addRefresh(owner, url, localDateTime)
     }
 
-    override fun getRefreshPatterns(owner: RefreshPatternOwner): Set<RefreshPattern> {
-        return brokenSiteRefreshesInMemoryStore.getRefreshPatterns(owner)
+    override fun getRefreshPatterns(
+        owner: RefreshPatternOwner,
+        currentDateTime: LocalDateTime,
+    ): Set<RefreshPattern> {
+        return brokenSiteRefreshesInMemoryStore.getRefreshPatterns(owner, currentDateTime)
     }
 
     override fun isRefreshPatternDetectionValid(

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/RealBrokenSitePrompt.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/RealBrokenSitePrompt.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.brokensite.impl
 
 import android.net.Uri
+import androidx.core.net.toUri
 import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.brokensite.api.RefreshPattern
@@ -61,7 +62,7 @@ class RealBrokenSitePrompt @Inject constructor(
     }
 
     override fun getUserRefreshPatterns(): Set<RefreshPattern> {
-        return brokenSiteReportRepository.getRefreshPatterns(currentTimeProvider.localDateTimeNow())
+        return brokenSiteReportRepository.getRefreshPatterns()
     }
 
     override suspend fun shouldShowBrokenSitePrompt(url: String, refreshPatterns: Set<RefreshPattern>): Boolean {
@@ -74,6 +75,9 @@ class RealBrokenSitePrompt @Inject constructor(
         }
 
         val currentTimestamp = currentTimeProvider.localDateTimeNow()
+        if (!brokenSiteReportRepository.isRefreshPatternDetectionValid(url.toUri(), currentTimestamp)) {
+            return false
+        }
 
         // Check if we're still in a cooldown period
         brokenSiteReportRepository.getNextShownDate()?.let { nextDate ->

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/RealBrokenSitePrompt.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/RealBrokenSitePrompt.kt
@@ -36,6 +36,7 @@ class RealBrokenSitePrompt @Inject constructor(
 ) : BrokenSitePrompt {
 
     private val _featureEnabled by lazy { brokenSitePromptRCFeature.self().isEnabled() }
+    private val refreshPatternOwner = RefreshPatternOwner()
 
     override suspend fun userDismissedPrompt() {
         if (!_featureEnabled) return
@@ -58,11 +59,11 @@ class RealBrokenSitePrompt @Inject constructor(
     override fun pageRefreshed(
         url: Uri,
     ) {
-        brokenSiteReportRepository.addRefresh(url, currentTimeProvider.localDateTimeNow())
+        brokenSiteReportRepository.addRefresh(refreshPatternOwner, url, currentTimeProvider.localDateTimeNow())
     }
 
     override fun getUserRefreshPatterns(): Set<RefreshPattern> {
-        return brokenSiteReportRepository.getRefreshPatterns()
+        return brokenSiteReportRepository.getRefreshPatterns(refreshPatternOwner)
     }
 
     override suspend fun shouldShowBrokenSitePrompt(url: String, refreshPatterns: Set<RefreshPattern>): Boolean {

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/RealBrokenSitePrompt.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/RealBrokenSitePrompt.kt
@@ -63,7 +63,7 @@ class RealBrokenSitePrompt @Inject constructor(
     }
 
     override fun getUserRefreshPatterns(): Set<RefreshPattern> {
-        return brokenSiteReportRepository.getRefreshPatterns(refreshPatternOwner)
+        return brokenSiteReportRepository.getRefreshPatterns(refreshPatternOwner, currentTimeProvider.localDateTimeNow())
     }
 
     override suspend fun shouldShowBrokenSitePrompt(url: String, refreshPatterns: Set<RefreshPattern>): Boolean {

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStoreTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStoreTest.kt
@@ -116,7 +116,7 @@ class BrokenSiteRefreshesInMemoryStoreTest {
     }
 
     @Test
-    fun whenOwnerChangesThenPreviousOwnersPatternsAreNotMerged() {
+    fun whenDifferentOwnerAddsRefreshThenPreviousOwnersPatternsReset() {
         store.addRefresh(testUrl, baseTime)
         store.addRefresh(testUrl, baseTime.plusSeconds(6))
         store.addRefresh(testUrl, baseTime.plusSeconds(12))
@@ -126,7 +126,7 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         store.addRefresh(otherOwner, testUrl, baseTime.plusSeconds(19))
 
         assertEquals(setOf(TWICE_IN_12_SECONDS), store.getRefreshPatterns(otherOwner))
-        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns())
+        assertTrue(store.getRefreshPatterns().isEmpty())
     }
 
     @Test

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStoreTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStoreTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.brokensite.impl
 
 import android.net.Uri
+import com.duckduckgo.brokensite.api.RefreshPattern
 import com.duckduckgo.brokensite.api.RefreshPattern.THRICE_IN_20_SECONDS
 import com.duckduckgo.brokensite.api.RefreshPattern.TWICE_IN_12_SECONDS
 import org.junit.Assert.assertEquals
@@ -49,7 +50,7 @@ class BrokenSiteRefreshesInMemoryStoreTest {
 
     @Test
     fun whenStoreInitializedThenNoRefreshPatternsFound() {
-        assertTrue(store.getRefreshPatterns().isEmpty())
+        assertTrue(store.getRefreshPatterns(baseTime).isEmpty())
     }
 
     @Test
@@ -57,7 +58,7 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         store.addRefresh(testUrl, baseTime)
         store.addRefresh(testUrl, baseTime.plusSeconds(11))
 
-        assertEquals(setOf(TWICE_IN_12_SECONDS), store.getRefreshPatterns())
+        assertEquals(setOf(TWICE_IN_12_SECONDS), store.getRefreshPatterns(baseTime.plusSeconds(11)))
     }
 
     @Test
@@ -65,7 +66,7 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         store.addRefresh(testUrl, baseTime)
         store.addRefresh(testUrl, baseTime.plusSeconds(12))
 
-        assertTrue(store.getRefreshPatterns().isEmpty())
+        assertTrue(store.getRefreshPatterns(baseTime.plusSeconds(12)).isEmpty())
     }
 
     @Test
@@ -74,7 +75,7 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         store.addRefresh(testUrl, baseTime.plusSeconds(12))
         store.addRefresh(testUrl, baseTime.plusSeconds(19))
 
-        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns())
+        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns(baseTime.plusSeconds(19)))
     }
 
     @Test
@@ -83,7 +84,7 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         store.addRefresh(testUrl, baseTime.plusSeconds(5))
         store.addRefresh(testUrl, baseTime.plusSeconds(20))
 
-        assertEquals(setOf(TWICE_IN_12_SECONDS), store.getRefreshPatterns())
+        assertEquals(setOf(TWICE_IN_12_SECONDS), store.getRefreshPatterns(baseTime.plusSeconds(20)))
     }
 
     @Test
@@ -92,7 +93,7 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         store.addRefresh(testUrl, baseTime.plusSeconds(6))
         store.addRefresh(testUrl, baseTime.plusSeconds(12))
 
-        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns())
+        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns(baseTime.plusSeconds(40)))
     }
 
     @Test
@@ -101,8 +102,8 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         store.addRefresh(testUrl, baseTime.plusSeconds(6))
         store.addRefresh(testUrl, baseTime.plusSeconds(12))
 
-        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns())
-        assertTrue(store.getRefreshPatterns().isEmpty())
+        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns(baseTime.plusSeconds(12)))
+        assertTrue(store.getRefreshPatterns(baseTime.plusSeconds(12)).isEmpty())
     }
 
     @Test
@@ -111,8 +112,8 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         store.addRefresh(testUrl, baseTime.plusSeconds(6))
         store.addRefresh(testUrl, baseTime.plusSeconds(12))
 
-        assertTrue(store.getRefreshPatterns(RefreshPatternOwner()).isEmpty())
-        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns())
+        assertTrue(store.getRefreshPatterns(RefreshPatternOwner(), baseTime.plusSeconds(12)).isEmpty())
+        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns(baseTime.plusSeconds(12)))
     }
 
     @Test
@@ -125,8 +126,8 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         store.addRefresh(otherOwner, testUrl, baseTime.plusSeconds(13))
         store.addRefresh(otherOwner, testUrl, baseTime.plusSeconds(19))
 
-        assertEquals(setOf(TWICE_IN_12_SECONDS), store.getRefreshPatterns(otherOwner))
-        assertTrue(store.getRefreshPatterns().isEmpty())
+        assertEquals(setOf(TWICE_IN_12_SECONDS), store.getRefreshPatterns(otherOwner, baseTime.plusSeconds(19)))
+        assertTrue(store.getRefreshPatterns(baseTime.plusSeconds(19)).isEmpty())
     }
 
     @Test
@@ -136,7 +137,7 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         store.addRefresh(testUrl, baseTime.plusSeconds(12))
         store.addRefresh(testUrl, baseTime.plusSeconds(18))
 
-        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns())
+        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns(baseTime.plusSeconds(18)))
     }
 
     @Test
@@ -147,7 +148,7 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         store.addRefresh(otherUrl, baseTime.plusSeconds(7))
         store.addRefresh(otherUrl, baseTime.plusSeconds(18))
 
-        assertEquals(setOf(TWICE_IN_12_SECONDS), store.getRefreshPatterns())
+        assertEquals(setOf(TWICE_IN_12_SECONDS), store.getRefreshPatterns(baseTime.plusSeconds(18)))
         assertTrue(store.isRefreshPatternDetectionValid(otherUrl, baseTime.plusSeconds(18)))
         assertFalse(store.isRefreshPatternDetectionValid(testUrl, baseTime.plusSeconds(18)))
     }
@@ -170,7 +171,7 @@ class BrokenSiteRefreshesInMemoryStoreTest {
     fun whenPatternsConsumedThenDetectionMetadataRemainsValid() {
         store.addRefresh(testUrl, baseTime)
         store.addRefresh(testUrl, baseTime.plusSeconds(6))
-        store.getRefreshPatterns()
+        store.getRefreshPatterns(baseTime.plusSeconds(6))
 
         assertTrue(store.isRefreshPatternDetectionValid(testUrl, baseTime.plusSeconds(6)))
     }
@@ -191,6 +192,48 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         assertFalse(store.isRefreshPatternDetectionValid(testUrl, baseTime.plusSeconds(67)))
     }
 
+    @Test
+    fun whenDetectionIsExactly60SecondsOldThenPatternsReported() {
+        store.addRefresh(testUrl, baseTime)
+        store.addRefresh(testUrl, baseTime.plusSeconds(6))
+        store.addRefresh(testUrl, baseTime.plusSeconds(12))
+
+        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns(baseTime.plusSeconds(72)))
+    }
+
+    @Test
+    fun whenDetectionIsOlderThan60SecondsThenPatternsNotReportedAndMetadataCleared() {
+        store.addRefresh(testUrl, baseTime)
+        store.addRefresh(testUrl, baseTime.plusSeconds(6))
+        store.addRefresh(testUrl, baseTime.plusSeconds(12))
+
+        assertTrue(store.getRefreshPatterns(baseTime.plusSeconds(73)).isEmpty())
+        assertFalse(store.isRefreshPatternDetectionValid(testUrl, baseTime.plusSeconds(73)))
+    }
+
+    @Test
+    fun whenForeignOwnerReadsStaleDetectionThenDetectionCleared() {
+        store.addRefresh(testUrl, baseTime)
+        store.addRefresh(testUrl, baseTime.plusSeconds(6))
+        store.addRefresh(testUrl, baseTime.plusSeconds(12))
+
+        assertTrue(store.getRefreshPatterns(RefreshPatternOwner(), baseTime.plusSeconds(73)).isEmpty())
+        assertTrue(store.getRefreshPatterns(baseTime.plusSeconds(73)).isEmpty())
+        assertFalse(store.isRefreshPatternDetectionValid(testUrl, baseTime.plusSeconds(73)))
+    }
+
+    @Test
+    fun whenStaleThricePatternFollowedByFreshTwicePatternThenOnlyTwicePatternReported() {
+        store.addRefresh(testUrl, baseTime)
+        store.addRefresh(testUrl, baseTime.plusSeconds(6))
+        store.addRefresh(testUrl, baseTime.plusSeconds(12))
+
+        store.addRefresh(testUrl, baseTime.plusSeconds(73))
+        store.addRefresh(testUrl, baseTime.plusSeconds(79))
+
+        assertEquals(setOf(TWICE_IN_12_SECONDS), store.getRefreshPatterns(baseTime.plusSeconds(79)))
+    }
+
     private fun RealBrokenSiteRefreshesInMemoryStore.addRefresh(
         url: Uri,
         localDateTime: LocalDateTime,
@@ -198,7 +241,7 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         addRefresh(refreshOwner, url, localDateTime)
     }
 
-    private fun RealBrokenSiteRefreshesInMemoryStore.getRefreshPatterns(): Set<com.duckduckgo.brokensite.api.RefreshPattern> {
-        return getRefreshPatterns(refreshOwner)
+    private fun RealBrokenSiteRefreshesInMemoryStore.getRefreshPatterns(currentDateTime: LocalDateTime): Set<RefreshPattern> {
+        return getRefreshPatterns(refreshOwner, currentDateTime)
     }
 }

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStoreTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStoreTest.kt
@@ -36,6 +36,7 @@ class BrokenSiteRefreshesInMemoryStoreTest {
     private lateinit var testUrl: Uri
     private lateinit var otherUrl: Uri
     private lateinit var baseTime: LocalDateTime
+    private lateinit var refreshOwner: RefreshPatternOwner
 
     @Before
     fun setup() {
@@ -43,6 +44,7 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         baseTime = LocalDateTime.of(2025, 1, 1, 12, 0, 0)
         testUrl = mock(Uri::class.java)
         otherUrl = mock(Uri::class.java)
+        refreshOwner = RefreshPatternOwner()
     }
 
     @Test
@@ -101,6 +103,30 @@ class BrokenSiteRefreshesInMemoryStoreTest {
 
         assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns())
         assertTrue(store.getRefreshPatterns().isEmpty())
+    }
+
+    @Test
+    fun whenDifferentOwnerReadsPatternsThenPatternsRemainForDetectionOwner() {
+        store.addRefresh(testUrl, baseTime)
+        store.addRefresh(testUrl, baseTime.plusSeconds(6))
+        store.addRefresh(testUrl, baseTime.plusSeconds(12))
+
+        assertTrue(store.getRefreshPatterns(RefreshPatternOwner()).isEmpty())
+        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns())
+    }
+
+    @Test
+    fun whenOwnerChangesThenPreviousOwnersPatternsAreNotMerged() {
+        store.addRefresh(testUrl, baseTime)
+        store.addRefresh(testUrl, baseTime.plusSeconds(6))
+        store.addRefresh(testUrl, baseTime.plusSeconds(12))
+
+        val otherOwner = RefreshPatternOwner()
+        store.addRefresh(otherOwner, testUrl, baseTime.plusSeconds(13))
+        store.addRefresh(otherOwner, testUrl, baseTime.plusSeconds(19))
+
+        assertEquals(setOf(TWICE_IN_12_SECONDS), store.getRefreshPatterns(otherOwner))
+        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns())
     }
 
     @Test
@@ -163,5 +189,16 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         store.addRefresh(testUrl, baseTime.plusSeconds(6))
 
         assertFalse(store.isRefreshPatternDetectionValid(testUrl, baseTime.plusSeconds(67)))
+    }
+
+    private fun RealBrokenSiteRefreshesInMemoryStore.addRefresh(
+        url: Uri,
+        localDateTime: LocalDateTime,
+    ) {
+        addRefresh(refreshOwner, url, localDateTime)
+    }
+
+    private fun RealBrokenSiteRefreshesInMemoryStore.getRefreshPatterns(): Set<com.duckduckgo.brokensite.api.RefreshPattern> {
+        return getRefreshPatterns(refreshOwner)
     }
 }

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStoreTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStoreTest.kt
@@ -17,19 +17,16 @@
 package com.duckduckgo.brokensite.impl
 
 import android.net.Uri
-import com.duckduckgo.brokensite.api.RefreshPattern
-import kotlinx.coroutines.test.runTest
+import com.duckduckgo.brokensite.api.RefreshPattern.THRICE_IN_20_SECONDS
+import com.duckduckgo.brokensite.api.RefreshPattern.TWICE_IN_12_SECONDS
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.Mockito.mock
-import org.mockito.kotlin.spy
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import java.time.LocalDateTime
 
 @RunWith(JUnit4::class)
@@ -37,127 +34,134 @@ class BrokenSiteRefreshesInMemoryStoreTest {
 
     private lateinit var store: RealBrokenSiteRefreshesInMemoryStore
     private lateinit var testUrl: Uri
+    private lateinit var otherUrl: Uri
     private lateinit var baseTime: LocalDateTime
 
     @Before
     fun setup() {
-        store = spy(RealBrokenSiteRefreshesInMemoryStore())
+        store = RealBrokenSiteRefreshesInMemoryStore()
         baseTime = LocalDateTime.of(2025, 1, 1, 12, 0, 0)
         testUrl = mock(Uri::class.java)
-        whenever(testUrl.toString()).thenReturn("https://example.com")
+        otherUrl = mock(Uri::class.java)
     }
 
     @Test
-    fun whenStoreInitializedThenNoRefreshPatternsFound() = runTest {
-        val patterns = store.getRefreshPatterns(baseTime)
-        assertTrue(patterns.isEmpty())
+    fun whenStoreInitializedThenNoRefreshPatternsFound() {
+        assertTrue(store.getRefreshPatterns().isEmpty())
     }
 
     @Test
-    fun whenResetCalledThenRefreshCountReset() = runTest {
+    fun whenTwoRefreshesOccurWithin12SecondsThenTwicePatternDetected() {
         store.addRefresh(testUrl, baseTime)
-        store.addRefresh(testUrl, baseTime.plusSeconds(5))
-        store.addRefresh(testUrl, baseTime.plusSeconds(10))
+        store.addRefresh(testUrl, baseTime.plusSeconds(11))
 
-        store.resetRefreshCount(RefreshPattern.TWICE_IN_12_SECONDS)
-        store.resetRefreshCount(RefreshPattern.THRICE_IN_20_SECONDS)
-
-        val patterns = store.getRefreshPatterns(baseTime.plusSeconds(11))
-        assertTrue(patterns.isEmpty())
+        assertEquals(setOf(TWICE_IN_12_SECONDS), store.getRefreshPatterns())
     }
 
     @Test
-    fun whenRefreshAddedForNewUrlThenPreviousDataReplaced() = runTest {
+    fun whenTwoRefreshesOccurAt12SecondBoundaryThenNoTwicePatternDetected() {
         store.addRefresh(testUrl, baseTime)
+        store.addRefresh(testUrl, baseTime.plusSeconds(12))
 
-        val newUrl = mock(Uri::class.java)
-        whenever(newUrl.toString()).thenReturn("https://newUrl.com")
-
-        store.addRefresh(newUrl, baseTime.plusSeconds(5))
-
-        val patterns = store.getRefreshPatterns(baseTime.plusSeconds(10))
-        assertTrue(patterns.isEmpty())
-
-        store.addRefresh(newUrl, baseTime.plusSeconds(10))
-
-        val updatedPatterns = store.getRefreshPatterns(baseTime.plusSeconds(15))
-        assertEquals(1, updatedPatterns.size)
-        assertEquals(updatedPatterns, setOf(RefreshPattern.TWICE_IN_12_SECONDS))
+        assertTrue(store.getRefreshPatterns().isEmpty())
     }
 
     @Test
-    fun whenRefreshAddedForSameUrlThenRefreshAddedToExistingList() = runTest {
+    fun whenThreeRefreshesOccurWithin20SecondsThenThricePatternDetected() {
         store.addRefresh(testUrl, baseTime)
-        store.addRefresh(testUrl, baseTime.plusSeconds(5))
+        store.addRefresh(testUrl, baseTime.plusSeconds(12))
+        store.addRefresh(testUrl, baseTime.plusSeconds(19))
 
-        val patterns = store.getRefreshPatterns(baseTime.plusSeconds(10))
-        assertEquals(1, patterns.size)
-        assertEquals(patterns, setOf(RefreshPattern.TWICE_IN_12_SECONDS))
+        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns())
     }
 
     @Test
-    fun whenTwoRefreshesOccurWithin12SecondsThenPatternDetected() = runTest {
-        store.addRefresh(testUrl, baseTime)
-        store.addRefresh(testUrl, baseTime.plusSeconds(5))
-
-        val patterns = store.getRefreshPatterns(baseTime.plusSeconds(10))
-        assertEquals(1, patterns.size)
-        assertEquals(patterns, setOf(RefreshPattern.TWICE_IN_12_SECONDS))
-    }
-
-    @Test
-    fun whenTwoRefreshesOccurAfter12SecondsThenNoTwicePatternDetected() = runTest {
-        store.addRefresh(testUrl, baseTime)
-        store.addRefresh(testUrl, baseTime.plusSeconds(15))
-
-        val patterns = store.getRefreshPatterns(baseTime.plusSeconds(20))
-        assertTrue(patterns.isEmpty())
-    }
-
-    @Test
-    fun whenThreeRefreshesOccurWithin10SecondsThenTwiceAndThricePatternDetected() = runTest {
-        store.addRefresh(testUrl, baseTime)
-        store.addRefresh(testUrl, baseTime.plusSeconds(5))
-        store.addRefresh(testUrl, baseTime.plusSeconds(10))
-
-        val patterns = store.getRefreshPatterns(baseTime.plusSeconds(15))
-        assertEquals(2, patterns.size)
-        assertEquals(patterns, (setOf(RefreshPattern.TWICE_IN_12_SECONDS, RefreshPattern.THRICE_IN_20_SECONDS)))
-    }
-
-    @Test
-    fun whenThreeRefreshesOccurAfter20SecondsThenNoThricePatternDetected() = runTest {
+    fun whenThreeRefreshesOccurAt20SecondBoundaryThenNoThricePatternDetected() {
         store.addRefresh(testUrl, baseTime)
         store.addRefresh(testUrl, baseTime.plusSeconds(5))
         store.addRefresh(testUrl, baseTime.plusSeconds(20))
 
-        val patterns = store.getRefreshPatterns(baseTime.plusSeconds(25))
-        assertTrue(patterns.isEmpty())
+        assertEquals(setOf(TWICE_IN_12_SECONDS), store.getRefreshPatterns())
     }
 
     @Test
-    fun whenRefreshesAreOlderThanRespectiveWindowThenTheyArePruned() = runTest {
+    fun whenThreeRefreshesDetectedThenLoadCompletionTimeDoesNotAffectPatterns() {
         store.addRefresh(testUrl, baseTime)
-        store.addRefresh(testUrl, baseTime.plusSeconds(3))
-        store.addRefresh(testUrl, baseTime.plusSeconds(5))
+        store.addRefresh(testUrl, baseTime.plusSeconds(6))
+        store.addRefresh(testUrl, baseTime.plusSeconds(12))
 
-        val patternsBeforePruning = store.getRefreshPatterns(baseTime.plusSeconds(7))
-        assertEquals(2, patternsBeforePruning.size)
-
-        val patterns = store.getRefreshPatterns(baseTime.plusSeconds(25))
-        assertTrue(patterns.isEmpty())
+        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns())
     }
 
     @Test
-    fun whenEachRefreshPatternIsRecordedThenItsMemoryListIsCleared() = runTest {
+    fun whenPatternsConsumedThenNextReadReturnsEmpty() {
         store.addRefresh(testUrl, baseTime)
-        store.addRefresh(testUrl, baseTime.plusSeconds(5))
-        store.addRefresh(testUrl, baseTime.plusSeconds(10))
+        store.addRefresh(testUrl, baseTime.plusSeconds(6))
+        store.addRefresh(testUrl, baseTime.plusSeconds(12))
 
-        val patterns = store.getRefreshPatterns(baseTime.plusSeconds(11))
-        assertEquals(2, patterns.size)
-        assertEquals(patterns, setOf(RefreshPattern.TWICE_IN_12_SECONDS, RefreshPattern.THRICE_IN_20_SECONDS))
-        verify(store, times(1)).resetRefreshCount(RefreshPattern.TWICE_IN_12_SECONDS)
-        verify(store, times(1)).resetRefreshCount(RefreshPattern.THRICE_IN_20_SECONDS)
+        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns())
+        assertTrue(store.getRefreshPatterns().isEmpty())
+    }
+
+    @Test
+    fun whenSamePatternDetectedAgainBeforeConsumptionThenPatternIsCollapsed() {
+        store.addRefresh(testUrl, baseTime)
+        store.addRefresh(testUrl, baseTime.plusSeconds(6))
+        store.addRefresh(testUrl, baseTime.plusSeconds(12))
+        store.addRefresh(testUrl, baseTime.plusSeconds(18))
+
+        assertEquals(setOf(TWICE_IN_12_SECONDS, THRICE_IN_20_SECONDS), store.getRefreshPatterns())
+    }
+
+    @Test
+    fun whenUrlChangesThenRefreshHistoryAndPendingPatternsReset() {
+        store.addRefresh(testUrl, baseTime)
+        store.addRefresh(testUrl, baseTime.plusSeconds(6))
+
+        store.addRefresh(otherUrl, baseTime.plusSeconds(7))
+        store.addRefresh(otherUrl, baseTime.plusSeconds(18))
+
+        assertEquals(setOf(TWICE_IN_12_SECONDS), store.getRefreshPatterns())
+        assertTrue(store.isRefreshPatternDetectionValid(otherUrl, baseTime.plusSeconds(18)))
+        assertFalse(store.isRefreshPatternDetectionValid(testUrl, baseTime.plusSeconds(18)))
+    }
+
+    @Test
+    fun whenNoPatternDetectedThenDetectionIsInvalid() {
+        assertFalse(store.isRefreshPatternDetectionValid(testUrl, baseTime))
+    }
+
+    @Test
+    fun whenDetectionUrlMatchesThenDetectionIsValid() {
+        store.addRefresh(testUrl, baseTime)
+        store.addRefresh(testUrl, baseTime.plusSeconds(6))
+
+        assertTrue(store.isRefreshPatternDetectionValid(testUrl, baseTime.plusSeconds(6)))
+        assertFalse(store.isRefreshPatternDetectionValid(otherUrl, baseTime.plusSeconds(6)))
+    }
+
+    @Test
+    fun whenPatternsConsumedThenDetectionMetadataRemainsValid() {
+        store.addRefresh(testUrl, baseTime)
+        store.addRefresh(testUrl, baseTime.plusSeconds(6))
+        store.getRefreshPatterns()
+
+        assertTrue(store.isRefreshPatternDetectionValid(testUrl, baseTime.plusSeconds(6)))
+    }
+
+    @Test
+    fun whenDetectionIs60SecondsOldThenDetectionIsValid() {
+        store.addRefresh(testUrl, baseTime)
+        store.addRefresh(testUrl, baseTime.plusSeconds(6))
+
+        assertTrue(store.isRefreshPatternDetectionValid(testUrl, baseTime.plusSeconds(66)))
+    }
+
+    @Test
+    fun whenDetectionIsOlderThan60SecondsThenDetectionIsInvalid() {
+        store.addRefresh(testUrl, baseTime)
+        store.addRefresh(testUrl, baseTime.plusSeconds(6))
+
+        assertFalse(store.isRefreshPatternDetectionValid(testUrl, baseTime.plusSeconds(67)))
     }
 }

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStoreTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/BrokenSiteRefreshesInMemoryStoreTest.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.brokensite.impl
 
 import android.net.Uri
-import com.duckduckgo.brokensite.api.RefreshPattern
 import com.duckduckgo.brokensite.api.RefreshPattern.THRICE_IN_20_SECONDS
 import com.duckduckgo.brokensite.api.RefreshPattern.TWICE_IN_12_SECONDS
 import org.junit.Assert.assertEquals
@@ -241,7 +240,6 @@ class BrokenSiteRefreshesInMemoryStoreTest {
         addRefresh(refreshOwner, url, localDateTime)
     }
 
-    private fun RealBrokenSiteRefreshesInMemoryStore.getRefreshPatterns(currentDateTime: LocalDateTime): Set<RefreshPattern> {
-        return getRefreshPatterns(refreshOwner, currentDateTime)
-    }
+    private fun RealBrokenSiteRefreshesInMemoryStore.getRefreshPatterns(currentDateTime: LocalDateTime) =
+        getRefreshPatterns(refreshOwner, currentDateTime)
 }

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSitePromptTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSitePromptTest.kt
@@ -18,6 +18,8 @@ import org.mockito.MockedStatic
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.mockStatic
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -97,15 +99,18 @@ class RealBrokenSitePromptTest {
 
         whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(now)
         testee.pageRefreshed(url)
+        testee.getUserRefreshPatterns()
 
-        verify(mockBrokenSiteReportRepository).addRefresh(url, now)
+        val ownerCaptor = argumentCaptor<RefreshPatternOwner>()
+        verify(mockBrokenSiteReportRepository).addRefresh(ownerCaptor.capture(), eq(url), eq(now))
+        verify(mockBrokenSiteReportRepository).getRefreshPatterns(ownerCaptor.firstValue)
         verify(mockCurrentTimeProvider).localDateTimeNow()
     }
 
     @Test
     fun whenGetUserRefreshPatternsThenStoredPatternsReturnedWithoutReadingClock() {
         val patterns = setOf(RefreshPattern.TWICE_IN_12_SECONDS, RefreshPattern.THRICE_IN_20_SECONDS)
-        whenever(mockBrokenSiteReportRepository.getRefreshPatterns()).thenReturn(patterns)
+        whenever(mockBrokenSiteReportRepository.getRefreshPatterns(any())).thenReturn(patterns)
 
         assertEquals(patterns, testee.getUserRefreshPatterns())
 

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSitePromptTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSitePromptTest.kt
@@ -21,6 +21,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.LocalDateTime
@@ -93,28 +94,31 @@ class RealBrokenSitePromptTest {
     }
 
     @Test
-    fun whenPageRefreshedThenTimestampCapturedOnceAndRefreshAdded() {
-        val now = LocalDateTime.now()
+    fun whenPageRefreshedAndPatternsReadThenSameOwnerAndCurrentTimestampsUsed() {
+        val refreshTime = LocalDateTime.now()
+        val evaluationTime = refreshTime.plusSeconds(12)
         val url: Uri = org.mockito.kotlin.mock()
 
-        whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(now)
+        whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(refreshTime, evaluationTime)
         testee.pageRefreshed(url)
         testee.getUserRefreshPatterns()
 
         val ownerCaptor = argumentCaptor<RefreshPatternOwner>()
-        verify(mockBrokenSiteReportRepository).addRefresh(ownerCaptor.capture(), eq(url), eq(now))
-        verify(mockBrokenSiteReportRepository).getRefreshPatterns(ownerCaptor.firstValue)
-        verify(mockCurrentTimeProvider).localDateTimeNow()
+        verify(mockBrokenSiteReportRepository).addRefresh(ownerCaptor.capture(), eq(url), eq(refreshTime))
+        verify(mockBrokenSiteReportRepository).getRefreshPatterns(ownerCaptor.firstValue, evaluationTime)
+        verify(mockCurrentTimeProvider, times(2)).localDateTimeNow()
     }
 
     @Test
-    fun whenGetUserRefreshPatternsThenStoredPatternsReturnedWithoutReadingClock() {
+    fun whenGetUserRefreshPatternsThenStoredPatternsReturnedAtCurrentTime() {
+        val now = LocalDateTime.now()
         val patterns = setOf(RefreshPattern.TWICE_IN_12_SECONDS, RefreshPattern.THRICE_IN_20_SECONDS)
-        whenever(mockBrokenSiteReportRepository.getRefreshPatterns(any())).thenReturn(patterns)
+        whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(now)
+        whenever(mockBrokenSiteReportRepository.getRefreshPatterns(any(), eq(now))).thenReturn(patterns)
 
         assertEquals(patterns, testee.getUserRefreshPatterns())
 
-        verify(mockCurrentTimeProvider, never()).localDateTimeNow()
+        verify(mockCurrentTimeProvider).localDateTimeNow()
     }
 
     @Test

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSitePromptTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSitePromptTest.kt
@@ -8,11 +8,15 @@ import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.mockito.MockedStatic
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
 import org.mockito.kotlin.any
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -26,6 +30,8 @@ class RealBrokenSitePromptTest {
     private val fakeBrokenSitePromptRCFeature: BrokenSitePromptRCFeature = FakeFeatureToggleFactory.create(BrokenSitePromptRCFeature::class.java)
     private val mockCurrentTimeProvider: CurrentTimeProvider = mock()
     private val mockDuckGoUrlDetector: DuckDuckGoUrlDetector = mock()
+    private val exampleUri: Uri = mock()
+    private lateinit var mockedUri: MockedStatic<Uri>
 
     private val testee = RealBrokenSitePrompt(
         brokenSiteReportRepository = mockBrokenSiteReportRepository,
@@ -36,10 +42,18 @@ class RealBrokenSitePromptTest {
 
     @Before
     fun setup() = runTest {
+        mockedUri = mockStatic(Uri::class.java)
+        mockedUri.`when`<Uri> { Uri.parse("https://example.com") }.thenReturn(exampleUri)
         whenever(mockBrokenSiteReportRepository.getCoolDownDays()).thenReturn(7)
         whenever(mockBrokenSiteReportRepository.getMaxDismissStreak()).thenReturn(3)
         whenever(mockBrokenSiteReportRepository.getDismissStreakResetDays()).thenReturn(30)
+        whenever(mockBrokenSiteReportRepository.isRefreshPatternDetectionValid(any(), any())).thenReturn(true)
         fakeBrokenSitePromptRCFeature.self().setRawStoredState(State(true))
+    }
+
+    @After
+    fun tearDown() {
+        mockedUri.close()
     }
 
     @Test
@@ -77,7 +91,7 @@ class RealBrokenSitePromptTest {
     }
 
     @Test
-    fun whenIncrementRefreshCountThenAddRefreshCalled() {
+    fun whenPageRefreshedThenTimestampCapturedOnceAndRefreshAdded() {
         val now = LocalDateTime.now()
         val url: Uri = org.mockito.kotlin.mock()
 
@@ -85,23 +99,25 @@ class RealBrokenSitePromptTest {
         testee.pageRefreshed(url)
 
         verify(mockBrokenSiteReportRepository).addRefresh(url, now)
+        verify(mockCurrentTimeProvider).localDateTimeNow()
     }
 
     @Test
-    fun whenGetUserRefreshPatternsThenGetRefreshPatternsCalled() {
-        val now = LocalDateTime.now()
-        whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(now)
+    fun whenGetUserRefreshPatternsThenStoredPatternsReturnedWithoutReadingClock() {
+        val patterns = setOf(RefreshPattern.TWICE_IN_12_SECONDS, RefreshPattern.THRICE_IN_20_SECONDS)
+        whenever(mockBrokenSiteReportRepository.getRefreshPatterns()).thenReturn(patterns)
 
-        testee.getUserRefreshPatterns()
+        assertEquals(patterns, testee.getUserRefreshPatterns())
 
-        verify(mockBrokenSiteReportRepository).getRefreshPatterns(now)
+        verify(mockCurrentTimeProvider, never()).localDateTimeNow()
     }
 
     @Test
     fun whenAllRequirementsMetThenShouldShowBrokenSitePromptReturnsTrue() = runTest {
         val detectedRefreshPatterns = setOf(RefreshPattern.TWICE_IN_12_SECONDS, RefreshPattern.THRICE_IN_20_SECONDS)
-        whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(LocalDateTime.now())
-        whenever(mockBrokenSiteReportRepository.getNextShownDate()).thenReturn(LocalDateTime.now().minusDays(3))
+        val now = LocalDateTime.now()
+        whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(now)
+        whenever(mockBrokenSiteReportRepository.getNextShownDate()).thenReturn(now.minusDays(3))
         whenever(mockBrokenSiteReportRepository.getDismissalCountBetween(any(), any())).thenReturn(2)
 
         val result = testee.shouldShowBrokenSitePrompt(
@@ -109,6 +125,41 @@ class RealBrokenSitePromptTest {
             detectedRefreshPatterns,
         )
         assertTrue(result)
+        verify(mockBrokenSiteReportRepository).isRefreshPatternDetectionValid(exampleUri, now)
+    }
+
+    @Test
+    fun whenRefreshPatternsEmptyThenDetectionMetadataNotChecked() = runTest {
+        val result = testee.shouldShowBrokenSitePrompt("https://example.com", emptySet())
+
+        assertFalse(result)
+        verify(mockBrokenSiteReportRepository, never()).isRefreshPatternDetectionValid(any(), any())
+    }
+
+    @Test
+    fun whenRefreshPatternsDoNotContainThricePatternThenDetectionMetadataNotChecked() = runTest {
+        val result = testee.shouldShowBrokenSitePrompt(
+            "https://example.com",
+            setOf(RefreshPattern.TWICE_IN_12_SECONDS),
+        )
+
+        assertFalse(result)
+        verify(mockBrokenSiteReportRepository, never()).isRefreshPatternDetectionValid(any(), any())
+    }
+
+    @Test
+    fun whenRefreshPatternDetectionMetadataInvalidThenShouldShowBrokenSitePromptReturnsFalse() = runTest {
+        val now = LocalDateTime.now()
+        whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(now)
+        whenever(mockBrokenSiteReportRepository.isRefreshPatternDetectionValid(any(), any())).thenReturn(false)
+
+        val result = testee.shouldShowBrokenSitePrompt(
+            "https://example.com",
+            setOf(RefreshPattern.THRICE_IN_20_SECONDS),
+        )
+
+        assertFalse(result)
+        verify(mockBrokenSiteReportRepository, never()).getNextShownDate()
     }
 
     @Test

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSiteReportRepositoryTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSiteReportRepositoryTest.kt
@@ -199,19 +199,21 @@ class RealBrokenSiteReportRepositoryTest {
     fun whenAddRefreshCalledThenAddRefreshIsCalled() = runTest {
         val localDateTime = LocalDateTime.now()
         val url: Uri = mock()
+        val owner = RefreshPatternOwner()
 
-        testee.addRefresh(url, localDateTime)
+        testee.addRefresh(owner, url, localDateTime)
 
-        verify(mockInMemoryStore).addRefresh(url, localDateTime)
+        verify(mockInMemoryStore).addRefresh(owner, url, localDateTime)
     }
 
     @Test
     fun whenGetRefreshPatternsCalledThenReturnStoredPatterns() {
         val patterns = setOf(RefreshPattern.THRICE_IN_20_SECONDS)
-        whenever(mockInMemoryStore.getRefreshPatterns()).thenReturn(patterns)
+        val owner = RefreshPatternOwner()
+        whenever(mockInMemoryStore.getRefreshPatterns(owner)).thenReturn(patterns)
 
-        assertEquals(patterns, testee.getRefreshPatterns())
-        verify(mockInMemoryStore).getRefreshPatterns()
+        assertEquals(patterns, testee.getRefreshPatterns(owner))
+        verify(mockInMemoryStore).getRefreshPatterns(owner)
     }
 
     @Test

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSiteReportRepositoryTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSiteReportRepositoryTest.kt
@@ -17,13 +17,16 @@
 package com.duckduckgo.brokensite.impl
 
 import android.net.Uri
+import com.duckduckgo.brokensite.api.RefreshPattern
 import com.duckduckgo.brokensite.store.BrokenSiteDao
 import com.duckduckgo.brokensite.store.BrokenSiteDatabase
 import com.duckduckgo.brokensite.store.BrokenSiteLastSentReportEntity
 import com.duckduckgo.common.test.CoroutineTestRule
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -200,5 +203,32 @@ class RealBrokenSiteReportRepositoryTest {
         testee.addRefresh(url, localDateTime)
 
         verify(mockInMemoryStore).addRefresh(url, localDateTime)
+    }
+
+    @Test
+    fun whenGetRefreshPatternsCalledThenReturnStoredPatterns() {
+        val patterns = setOf(RefreshPattern.THRICE_IN_20_SECONDS)
+        whenever(mockInMemoryStore.getRefreshPatterns()).thenReturn(patterns)
+
+        assertEquals(patterns, testee.getRefreshPatterns())
+        verify(mockInMemoryStore).getRefreshPatterns()
+    }
+
+    @Test
+    fun whenRefreshPatternDetectionIsValidThenReturnTrue() {
+        val url: Uri = mock()
+        val now = LocalDateTime.now()
+        whenever(mockInMemoryStore.isRefreshPatternDetectionValid(url, now)).thenReturn(true)
+
+        assertTrue(testee.isRefreshPatternDetectionValid(url, now))
+    }
+
+    @Test
+    fun whenRefreshPatternDetectionIsInvalidThenReturnFalse() {
+        val url: Uri = mock()
+        val now = LocalDateTime.now()
+        whenever(mockInMemoryStore.isRefreshPatternDetectionValid(url, now)).thenReturn(false)
+
+        assertFalse(testee.isRefreshPatternDetectionValid(url, now))
     }
 }

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSiteReportRepositoryTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSiteReportRepositoryTest.kt
@@ -210,10 +210,11 @@ class RealBrokenSiteReportRepositoryTest {
     fun whenGetRefreshPatternsCalledThenReturnStoredPatterns() {
         val patterns = setOf(RefreshPattern.THRICE_IN_20_SECONDS)
         val owner = RefreshPatternOwner()
-        whenever(mockInMemoryStore.getRefreshPatterns(owner)).thenReturn(patterns)
+        val now = LocalDateTime.now()
+        whenever(mockInMemoryStore.getRefreshPatterns(owner, now)).thenReturn(patterns)
 
-        assertEquals(patterns, testee.getRefreshPatterns(owner))
-        verify(mockInMemoryStore).getRefreshPatterns(owner)
+        assertEquals(patterns, testee.getRefreshPatterns(owner, now))
+        verify(mockInMemoryStore).getRefreshPatterns(owner, now)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1217360550002208?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

We show the 3x refresh prompt to report site breakage 2.5x less often on Android than iOS. To address that, we're starting with this change to evaluate refresh patterns when reload occurs rather than after page load completes to prevent slow page loads from shrinking our detection window.


### Steps to test this PR

1. Install the internal debug build and skip/complete onboarding:
     `./gradlew installInternalDebug`

2. Run:
     `adb reverse tcp:8765 tcp:8765`

3. Start the local slow server using a Python script:
```
python3 - <<'PY'
from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
from time import sleep
class Handler(BaseHTTPRequestHandler):
    def do_GET(self):
        if self.path.startswith("/slow"):
            sleep(15)
        self.send_response(200)
        self.send_header("Cache-Control", "no-store")
        self.end_headers()
        try:
            self.wfile.write(b"Reload detection test page")
        except BrokenPipeError:
            pass
    def log_message(self, *_):
        pass
ThreadingHTTPServer(("127.0.0.1", 8765), Handler).serve_forever()
PY
```

#### URL mismatch

  1. Open http://127.0.0.1:8765/slow.
  2. After loading, refresh 3x quickly.
  3. Immediately open http://127.0.0.1:8765/fast.
  4. Verify the broken-site prompt does not appear.

#### Slow load detection

  1. Open http://127.0.0.1:8765/slow again and wait for it to load.
  2. Refresh 3x quickly.
  3. Wait for the final load to finish.
  4. Verify “Site not working? Let us know” appears.

  Run the reset commands before repeating after the prompt has appeared.

```
 adb shell am force-stop com.duckduckgo.mobile.android.debug
 adb shell run-as com.duckduckgo.mobile.android.debug rm -f files/datastore/broken_site_prompt.preferences_pb
 adb shell monkey -p com.duckduckgo.mobile.android.debug 1
```

 That should clear only prompt cooldown/dismissal state, preserving onboarding.
