### PR TITLE
UnifiedInput: Move attachment row placement

### DIFF
--- a/android-design-system/design-system/src/main/res/values/design-system-colors.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-colors.xml
@@ -46,6 +46,7 @@
     <attr name="daxColorBackground" format="color"/>
     <attr name="daxColorBackgroundInverted" format="color"/>
     <attr name="daxColorSurface" format="color"/>
+    <attr name="daxColorSurfaceTertiary" format="color"/>
     <attr name="daxColorContainer" format="color"/>
     <attr name="daxColorWindow" format="color"/>
     <attr name="daxColorDuckAiBackground" format="color"/>
@@ -281,6 +282,7 @@
     <!-- Backgrounds -->
     <color name="background_background_dark">#282828</color>
     <color name="background_surface_dark">#373737</color>
+    <color name="background_surface_tertiary_dark">@color/gray85</color>
     <color name="background_window_dark">#3D3D3D</color>
     <color name="background_duck_ai_dark">#111111</color>
     <color name="background_canvas_dark">#1F1F1F</color>
@@ -316,6 +318,7 @@
     <!-- Backgrounds -->
     <color name="background_background_light">#F2F2F2</color>
     <color name="background_surface_light">#F9F9F9</color>
+    <color name="background_surface_tertiary_light">@color/white</color>
     <color name="background_window_light">#FFFFFF</color>
     <color name="background_duck_ai_light">#FFFFFF</color>
     <color name="background_canvas_light">#FFFFFF</color>

--- a/android-design-system/design-system/src/main/res/values/design-system-theming.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-theming.xml
@@ -194,6 +194,7 @@
         <item name="daxColorBackground">@color/background_background_dark</item>
         <item name="daxColorBackgroundInverted">@color/gray0</item>
         <item name="daxColorSurface">@color/background_surface_dark</item>
+        <item name="daxColorSurfaceTertiary">@color/background_surface_tertiary_dark</item>
         <item name="daxColorContainer">@color/white12</item>
         <item name="daxColorWindow">@color/background_window_dark</item>
         <item name="daxColorDuckAiBackground">@color/background_duck_ai_dark</item>
@@ -335,6 +336,7 @@
         <item name="daxColorBackground">@color/background_background_light</item>
         <item name="daxColorBackgroundInverted">@color/gray100</item>
         <item name="daxColorSurface">@color/background_surface_light</item>
+        <item name="daxColorSurfaceTertiary">@color/background_surface_tertiary_light</item>
         <item name="daxColorContainer">@color/black6</item>
         <item name="daxColorWindow">@color/background_window_light</item>
         <item name="daxColorDuckAiBackground">@color/background_duck_ai_light</item>

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -289,4 +289,12 @@ interface DuckChatFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun contextualNativeInput(): Toggle
+
+    /**
+     * @return `true` when the native input attachment layout changes are enabled: the attachment row is
+     * placed above the text input, and the contextual sheet keeps its expanded padding regardless of focus.
+     * If the remote feature is not present defaults to `internal`.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun nativeInputAttachmentChanges(): Toggle
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.feature.maxUrlSuggestions
 import com.duckduckgo.duckchat.impl.helper.PendingNativeFile
 import com.duckduckgo.duckchat.impl.helper.PendingNativeImage
@@ -104,6 +105,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private val browserMode: BrowserMode,
     private val autoCompleteSettings: AutoCompleteSettings,
     private val duckAiChatHistoryFeature: DuckAiChatHistoryFeature,
+    private val duckChatFeature: DuckChatFeature,
     private val dispatchers: DispatcherProvider,
     private val pixel: Pixel,
     private val duckChatPixels: DuckChatPixels,
@@ -145,6 +147,9 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private val _isHistoryAvailable = MutableStateFlow(false)
     val isHistoryAvailable: StateFlow<Boolean> = _isHistoryAvailable.asStateFlow()
 
+    private val _attachmentChangesEnabled = MutableStateFlow(false)
+    val attachmentChangesEnabled: StateFlow<Boolean> = _attachmentChangesEnabled.asStateFlow()
+
     private val currentChat = MutableStateFlow<DuckAiChat?>(null)
     private var currentChatJob: Job? = null
 
@@ -161,6 +166,11 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         }
         viewModelScope.launch {
             _isHistoryAvailable.value = duckChatInternal.isChatHistoryAvailable()
+        }
+        viewModelScope.launch {
+            _attachmentChangesEnabled.value = withContext(dispatchers.io()) {
+                duckChatFeature.nativeInputAttachmentChanges().isEnabled()
+            }
         }
         viewModelScope.launch {
             // FE recovery "Switch Model": enter the model-change mode, but only when the event

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -77,6 +77,7 @@ import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.helper.PendingNativeFile
 import com.duckduckgo.duckchat.impl.helper.PendingNativeImage
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
@@ -101,6 +102,7 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import logcat.logcat
 import org.json.JSONArray
 import javax.inject.Inject
@@ -269,6 +271,11 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     @Inject
     lateinit var faviconManager: FaviconManager
+
+    @Inject
+    lateinit var duckChatFeature: DuckChatFeature
+
+    private var attachmentChangesEnabled: Boolean = false
 
     private var activeTabId: String? = null
 
@@ -639,6 +646,13 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun onAttachedToWindow() {
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
+        findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
+            attachmentChangesEnabled = withContext(dispatchers.io()) {
+                duckChatFeature.nativeInputAttachmentChanges().isEnabled()
+            }
+            applyAttachmentPlacement()
+            applyVerticalPaddingForFocus()
+        }
         inputModeSwitch.addOnTabSelectedListener(duckChatTabSelectedListener)
         val mode = if (inputModeSwitch.selectedTabPosition == 0) InputMode.SEARCH else InputMode.DUCK_AI
         duckChatInternal.setSelectedMode(mode)
@@ -954,14 +968,27 @@ class NativeInputModeWidget @JvmOverloads constructor(
         findViewById<View?>(R.id.inputModeSwitchRow)?.visibility = if (effective) VISIBLE else GONE
     }
 
+    private fun applyAttachmentPlacement() {
+        // When enabled, the attachment row sits above the text input instead of below it.
+        if (!attachmentChangesEnabled) return
+        val container = findViewById<ViewGroup>(R.id.inputModeWidgetContentContainer) ?: return
+        val attachments = findViewById<View>(R.id.attachmentsContainer) ?: return
+        val inputRow = findViewById<View>(R.id.inputModeWidgetCardContent) ?: return
+        if (container.indexOfChild(attachments) == container.indexOfChild(inputRow) - 1) return
+        container.removeView(attachments)
+        container.addView(attachments, container.indexOfChild(inputRow))
+    }
+
     private fun applyVerticalPaddingForFocus() {
         // 4dp when minimized, 8dp when expanded. The browser omnibar with the toggle disabled stays
         // minimized regardless of focus; the duck.ai omnibar and browser omnibar with toggle enabled
-        // expand on focus; the duck.ai contextual sheet is always expanded.
+        // expand on focus; the duck.ai contextual sheet is always expanded when the attachment changes
+        // are enabled.
         val isBrowserOmnibarMinimized = nativeInputState?.let {
             it.inputContext == NativeInputState.InputContext.BROWSER && !it.toggleVisible
         } ?: true
-        val expanded = isContextualWidget || (!isBrowserOmnibarMinimized && (inputField.hasFocus() || previewEnterFocus))
+        val expanded = (attachmentChangesEnabled && isContextualWidget) ||
+            (!isBrowserOmnibarMinimized && (inputField.hasFocus() || previewEnterFocus))
         val verticalPadAttr = if (expanded) {
             com.duckduckgo.mobile.android.R.dimen.keyline_2
         } else {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -77,7 +77,6 @@ import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
-import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.helper.PendingNativeFile
 import com.duckduckgo.duckchat.impl.helper.PendingNativeImage
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
@@ -102,7 +101,6 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import logcat.logcat
 import org.json.JSONArray
 import javax.inject.Inject
@@ -272,9 +270,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
     @Inject
     lateinit var faviconManager: FaviconManager
 
-    @Inject
-    lateinit var duckChatFeature: DuckChatFeature
-
     private var attachmentChangesEnabled: Boolean = false
 
     private var activeTabId: String? = null
@@ -286,6 +281,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var floatingSubmitContainer: ViewGroup? = null
     private var chatStateJob: Job? = null
     private var chatSuggestionsSettingJob: Job? = null
+    private var attachmentChangesJob: Job? = null
     private var chatSuggestionsJob: Job? = null
     private var tierJob: Job? = null
     private var nativeInputStateJob: Job? = null
@@ -646,13 +642,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun onAttachedToWindow() {
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
-        findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
-            attachmentChangesEnabled = withContext(dispatchers.io()) {
-                duckChatFeature.nativeInputAttachmentChanges().isEnabled()
-            }
-            applyAttachmentPlacement()
-            applyVerticalPaddingForFocus()
-        }
+        observeAttachmentChangesEnabled()
         inputModeSwitch.addOnTabSelectedListener(duckChatTabSelectedListener)
         val mode = if (inputModeSwitch.selectedTabPosition == 0) InputMode.SEARCH else InputMode.DUCK_AI
         duckChatInternal.setSelectedMode(mode)
@@ -786,6 +776,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
         chatStateJob = null
         chatSuggestionsSettingJob?.cancel()
         chatSuggestionsSettingJob = null
+        attachmentChangesJob?.cancel()
+        attachmentChangesJob = null
         tierJob?.cancel()
         tierJob = null
         nativeInputStateJob?.cancel()
@@ -1804,6 +1796,17 @@ class NativeInputModeWidget @JvmOverloads constructor(
         chatSuggestionsSettingJob?.cancel()
         chatSuggestionsSettingJob = viewModel.chatSuggestionsUserEnabled
             .onEach { enabled -> chatSuggestionsUserEnabled = enabled }
+            .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope ?: return)
+    }
+
+    private fun observeAttachmentChangesEnabled() {
+        attachmentChangesJob?.cancel()
+        attachmentChangesJob = viewModel.attachmentChangesEnabled
+            .onEach { enabled ->
+                attachmentChangesEnabled = enabled
+                applyAttachmentPlacement()
+                applyVerticalPaddingForFocus()
+            }
             .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope ?: return)
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -955,13 +955,13 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun applyVerticalPaddingForFocus() {
-        // 4dp when minimized, 8dp when expanded on focus. The browser omnibar with the toggle
-        // disabled stays minimized regardless of focus; everywhere else (duck.ai omnibar,
-        // duck.ai contextual, browser omnibar with toggle enabled) expands on focus.
+        // 4dp when minimized, 8dp when expanded. The browser omnibar with the toggle disabled stays
+        // minimized regardless of focus; the duck.ai omnibar and browser omnibar with toggle enabled
+        // expand on focus; the duck.ai contextual sheet is always expanded.
         val isBrowserOmnibarMinimized = nativeInputState?.let {
             it.inputContext == NativeInputState.InputContext.BROWSER && !it.toggleVisible
         } ?: true
-        val expanded = !isBrowserOmnibarMinimized && (inputField.hasFocus() || previewEnterFocus)
+        val expanded = isContextualWidget || (!isBrowserOmnibarMinimized && (inputField.hasFocus() || previewEnterFocus))
         val verticalPadAttr = if (expanded) {
             com.duckduckgo.mobile.android.R.dimen.keyline_2
         } else {

--- a/duckchat/duckchat-impl/src/main/res/drawable/background_image_attachment_remove.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/background_image_attachment_remove.xml
@@ -17,5 +17,5 @@
 
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
-    <solid android:color="?attr/daxColorWindow" />
+    <solid android:color="?attr/daxColorSurfaceTertiary" />
 </shape>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_file_attachment_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_file_attachment_item.xml
@@ -19,7 +19,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/keyline_1"
+    android:layout_marginEnd="@dimen/keyline_1"
     android:background="@drawable/background_image_attachment_chip"
     android:clickable="true"
     android:focusable="true"
@@ -46,16 +46,17 @@
         android:maxWidth="120dp"
         android:maxLines="1"
         app:textType="primary"
-        app:typography="body2_bold" />
+        app:typography="body2" />
 
     <ImageView
         android:id="@+id/fileRemove"
-        android:layout_width="@dimen/keyline_4"
-        android:layout_height="@dimen/keyline_4"
+        android:layout_width="@dimen/keyline_5"
+        android:layout_height="@dimen/keyline_5"
         android:layout_marginStart="@dimen/keyline_2"
+        android:background="@drawable/background_image_attachment_remove"
         android:contentDescription="@string/duckChatFileAttachmentRemoveContentDescription"
-        android:scaleType="center"
-        app:srcCompat="@drawable/ic_close_16"
-        app:tint="?attr/daxColorSecondaryIcon" />
+        android:padding="@dimen/keyline_1"
+        android:scaleType="fitCenter"
+        app:srcCompat="@drawable/ic_close_16" />
 
 </LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_image_attachment_thumbnail.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_image_attachment_thumbnail.xml
@@ -19,7 +19,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/keyline_1"
+    android:layout_marginEnd="@dimen/keyline_1"
     android:background="@drawable/background_image_attachment_chip"
     android:clickable="true"
     android:focusable="true"
@@ -48,12 +48,13 @@
 
     <ImageView
         android:id="@+id/thumbnailRemove"
-        android:layout_width="@dimen/keyline_4"
-        android:layout_height="@dimen/keyline_4"
+        android:layout_width="@dimen/keyline_5"
+        android:layout_height="@dimen/keyline_5"
         android:layout_marginStart="@dimen/keyline_2"
+        android:background="@drawable/background_image_attachment_remove"
         android:contentDescription="@string/duckChatImageAttachmentRemoveContentDescription"
-        android:scaleType="center"
-        app:srcCompat="@drawable/ic_close_16"
-        app:tint="?attr/daxColorSecondaryIcon" />
+        android:padding="@dimen/keyline_1"
+        android:scaleType="fitCenter"
+        app:srcCompat="@drawable/ic_close_16" />
 
 </LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
@@ -53,6 +53,7 @@
             app:layout_goneMarginEnd="@dimen/keyline_empty">
 
             <LinearLayout
+                android:id="@+id/inputModeWidgetContentContainer"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:clipChildren="false"
@@ -102,6 +103,12 @@
                     </com.duckduckgo.browser.ui.inputmode.NativeInputModeTabLayout>
 
                 </LinearLayout>
+
+                <FrameLayout
+                    android:id="@id/attachmentsContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone" />
 
                 <LinearLayout
                     android:id="@+id/inputModeWidgetCardContent"
@@ -177,11 +184,6 @@
                         android:visibility="gone" />
 
                 </LinearLayout>
-                <FrameLayout
-                    android:id="@id/attachmentsContainer"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone" />
 
                 <FrameLayout
                     android:id="@+id/inputModeWidgetBottomRow"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
@@ -104,12 +104,6 @@
 
                 </LinearLayout>
 
-                <FrameLayout
-                    android:id="@id/attachmentsContainer"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone" />
-
                 <LinearLayout
                     android:id="@+id/inputModeWidgetCardContent"
                     android:layout_width="match_parent"
@@ -184,6 +178,12 @@
                         android:visibility="gone" />
 
                 </LinearLayout>
+
+                <FrameLayout
+                    android:id="@id/attachmentsContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone" />
 
                 <FrameLayout
                     android:id="@+id/inputModeWidgetBottomRow"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_page_context_attachment_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_page_context_attachment_item.xml
@@ -19,7 +19,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/keyline_1"
+    android:layout_marginEnd="@dimen/keyline_1"
     android:background="@drawable/background_image_attachment_chip"
     android:clickable="true"
     android:focusable="true"
@@ -46,16 +46,17 @@
         android:maxWidth="120dp"
         android:maxLines="1"
         app:textType="primary"
-        app:typography="body2_bold" />
+        app:typography="body2" />
 
     <ImageView
         android:id="@+id/pageContextRemove"
-        android:layout_width="@dimen/keyline_4"
-        android:layout_height="@dimen/keyline_4"
+        android:layout_width="@dimen/keyline_5"
+        android:layout_height="@dimen/keyline_5"
         android:layout_marginStart="@dimen/keyline_2"
+        android:background="@drawable/background_image_attachment_remove"
         android:contentDescription="@string/duckChatPageContextRemoveContentDescription"
-        android:scaleType="center"
-        app:srcCompat="@drawable/ic_close_16"
-        app:tint="?attr/daxColorSecondaryIcon" />
+        android:padding="@dimen/keyline_1"
+        android:scaleType="fitCenter"
+        app:srcCompat="@drawable/ic_close_16" />
 
 </LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/values/dimens.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/dimens.xml
@@ -37,7 +37,7 @@
     <dimen name="reasoningModePickerMenuWidth">220dp</dimen>
 
     <!-- Chip-->
-    <dimen name="chipCornerRadius">16dp</dimen>
+    <dimen name="chipCornerRadius">20dp</dimen>
     <dimen name="chipStrokeWidth">1dp</dimen>
     <dimen name="chipImageCornerRadius">6dp</dimen>
 </resources>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
 import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
@@ -62,6 +63,7 @@ import com.duckduckgo.duckchat.impl.ui.nativeinput.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.ui.nativeinput.suggestions.reader.ChatSuggestionsReader
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.Subscriptions
@@ -113,6 +115,7 @@ class NativeInputModeWidgetViewModelTest {
     private val autoComplete: AutoComplete = mock()
     private val autoCompleteSettings: AutoCompleteSettings = mock()
     private val duckAiChatHistoryFeature: DuckAiChatHistoryFeature = mock()
+    private val duckChatFeature = FakeFeatureToggleFactory.create(DuckChatFeature::class.java)
     private val pixel: Pixel = mock()
     private val duckChatPixels: DuckChatPixels = mock()
     private val modelManager: DuckAiModelManager = mock()
@@ -182,6 +185,7 @@ class NativeInputModeWidgetViewModelTest {
             browserMode = BrowserMode.REGULAR,
             autoCompleteSettings = autoCompleteSettings,
             duckAiChatHistoryFeature = duckAiChatHistoryFeature,
+            duckChatFeature = duckChatFeature,
             dispatchers = coroutineRule.testDispatcherProvider,
             pixel = pixel,
             duckChatPixels = duckChatPixels,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462763415876/task/1215757703816624?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
 - Attachment row placement — when enabled, the attachment row is placed above the text input instead of below it.
- Contextual sheet padding — the duck.ai contextual sheet now keeps its expanded (8dp) vertical padding regardless of focus, rather than collapsing when unfocused.
- Introduced `nativeInputAttachmentChanges` to gate the attachment placement changes

### Steps to test this PR
Before running, you could also add @InternalAlwaysEnabled for contextualNativeInput to test attachments. (Can’t do it via FF inventory)

nativeInputAttachmentChanges (ON by default in internal)
- [x] Open new tab
- [x] Attach a file
- [x] Verify attachment is placed above the input
- [x] Attach an image
- [x] Verify attachment is placed above the input
- [x] Open a website on the tab
- [x] Open contextual sheet
- [x] Click on “Ask About Page"
- [ ] Verify attachment is placed above the input

nativeInputAttachmentChanges (OFF)
- [x] Open new tab
- [x] Attach a file
- [x] Verify attachment is placed below the input
- [x] Attach an image
- [x] Verify attachment is placed below the input
- [x] Open a website on the tab
- [x] Open contextual sheet
- [x] Click on “Ask About Page"
- [x] Verify attachment is placed below the input

### UI changes
See screenshots in https://app.asana.com/1/137249556945/project/1201462763415876/task/1217270181764114?focus=true


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and styling changes gated behind an internal feature flag, with no auth, data, or security impact.
> 
> **Overview**
> **Moves the native input attachment row above the text field**, gated by a new `nativeInputAttachmentChanges` feature flag (defaults to internal).
> 
> When enabled, `NativeInputModeWidget` reorders `attachmentsContainer` above the input and keeps the duck.ai contextual sheet at expanded (8dp) vertical padding regardless of focus.
> 
> Also refreshes attachment chip visuals: larger remove buttons with a new `daxColorSurfaceTertiary` background, non-bold chip text, end margins, and a slightly rounder chip corner radius.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 833dba1356dd850721eeeed587650d4c707ab083. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->