### PR TITLE
UnifiedInput: Attachment UI improvements

### DIFF
--- a/android-design-system/design-system/src/main/res/values/design-system-colors.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-colors.xml
@@ -46,6 +46,7 @@
     <attr name="daxColorBackground" format="color"/>
     <attr name="daxColorBackgroundInverted" format="color"/>
     <attr name="daxColorSurface" format="color"/>
+    <attr name="daxColorSurfaceTertiary" format="color"/>
     <attr name="daxColorContainer" format="color"/>
     <attr name="daxColorWindow" format="color"/>
     <attr name="daxColorDuckAiBackground" format="color"/>
@@ -281,6 +282,7 @@
     <!-- Backgrounds -->
     <color name="background_background_dark">#282828</color>
     <color name="background_surface_dark">#373737</color>
+    <color name="background_surface_tertiary_dark">@color/gray85</color>
     <color name="background_window_dark">#3D3D3D</color>
     <color name="background_duck_ai_dark">#111111</color>
     <color name="background_canvas_dark">#1F1F1F</color>
@@ -316,6 +318,7 @@
     <!-- Backgrounds -->
     <color name="background_background_light">#F2F2F2</color>
     <color name="background_surface_light">#F9F9F9</color>
+    <color name="background_surface_tertiary_light">@color/white</color>
     <color name="background_window_light">#FFFFFF</color>
     <color name="background_duck_ai_light">#FFFFFF</color>
     <color name="background_canvas_light">#FFFFFF</color>

--- a/android-design-system/design-system/src/main/res/values/design-system-theming.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-theming.xml
@@ -194,6 +194,7 @@
         <item name="daxColorBackground">@color/background_background_dark</item>
         <item name="daxColorBackgroundInverted">@color/gray0</item>
         <item name="daxColorSurface">@color/background_surface_dark</item>
+        <item name="daxColorSurfaceTertiary">@color/background_surface_tertiary_dark</item>
         <item name="daxColorContainer">@color/white12</item>
         <item name="daxColorWindow">@color/background_window_dark</item>
         <item name="daxColorDuckAiBackground">@color/background_duck_ai_dark</item>
@@ -335,6 +336,7 @@
         <item name="daxColorBackground">@color/background_background_light</item>
         <item name="daxColorBackgroundInverted">@color/gray100</item>
         <item name="daxColorSurface">@color/background_surface_light</item>
+        <item name="daxColorSurfaceTertiary">@color/background_surface_tertiary_light</item>
         <item name="daxColorContainer">@color/black6</item>
         <item name="daxColorWindow">@color/background_window_light</item>
         <item name="daxColorDuckAiBackground">@color/background_duck_ai_light</item>

--- a/duckchat/duckchat-impl/src/main/res/drawable/background_image_attachment_remove.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/background_image_attachment_remove.xml
@@ -17,5 +17,5 @@
 
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
-    <solid android:color="?attr/daxColorWindow" />
+    <solid android:color="?attr/daxColorSurfaceTertiary" />
 </shape>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_file_attachment_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_file_attachment_item.xml
@@ -45,7 +45,7 @@
         android:maxWidth="120dp"
         android:maxLines="1"
         app:textType="primary"
-        app:typography="body2_bold" />
+        app:typography="body2" />
 
     <ImageView
         android:id="@+id/fileRemove"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_file_attachment_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_file_attachment_item.xml
@@ -19,6 +19,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:layout_marginEnd="@dimen/keyline_1"
     android:background="@drawable/background_image_attachment_chip"
     android:clickable="true"
     android:focusable="true"
@@ -49,12 +50,13 @@
 
     <ImageView
         android:id="@+id/fileRemove"
-        android:layout_width="@dimen/keyline_4"
-        android:layout_height="@dimen/keyline_4"
+        android:layout_width="@dimen/keyline_5"
+        android:layout_height="@dimen/keyline_5"
         android:layout_marginStart="@dimen/keyline_2"
+        android:background="@drawable/background_image_attachment_remove"
         android:contentDescription="@string/duckChatFileAttachmentRemoveContentDescription"
-        android:scaleType="center"
-        app:srcCompat="@drawable/ic_close_16"
-        app:tint="?attr/daxColorSecondaryIcon" />
+        android:padding="@dimen/keyline_1"
+        android:scaleType="fitCenter"
+        app:srcCompat="@drawable/ic_close_16" />
 
 </LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_file_attachment_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_file_attachment_item.xml
@@ -19,7 +19,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/keyline_1"
     android:background="@drawable/background_image_attachment_chip"
     android:clickable="true"
     android:focusable="true"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_image_attachment_thumbnail.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_image_attachment_thumbnail.xml
@@ -19,6 +19,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:layout_marginEnd="@dimen/keyline_1"
     android:background="@drawable/background_image_attachment_chip"
     android:clickable="true"
     android:focusable="true"
@@ -47,12 +48,13 @@
 
     <ImageView
         android:id="@+id/thumbnailRemove"
-        android:layout_width="@dimen/keyline_4"
-        android:layout_height="@dimen/keyline_4"
+        android:layout_width="@dimen/keyline_5"
+        android:layout_height="@dimen/keyline_5"
         android:layout_marginStart="@dimen/keyline_2"
+        android:background="@drawable/background_image_attachment_remove"
         android:contentDescription="@string/duckChatImageAttachmentRemoveContentDescription"
-        android:scaleType="center"
-        app:srcCompat="@drawable/ic_close_16"
-        app:tint="?attr/daxColorSecondaryIcon" />
+        android:padding="@dimen/keyline_1"
+        android:scaleType="fitCenter"
+        app:srcCompat="@drawable/ic_close_16" />
 
 </LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_image_attachment_thumbnail.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_image_attachment_thumbnail.xml
@@ -19,7 +19,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/keyline_1"
     android:background="@drawable/background_image_attachment_chip"
     android:clickable="true"
     android:focusable="true"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_page_context_attachment_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_page_context_attachment_item.xml
@@ -19,7 +19,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/keyline_1"
     android:background="@drawable/background_image_attachment_chip"
     android:clickable="true"
     android:focusable="true"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_page_context_attachment_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_page_context_attachment_item.xml
@@ -19,6 +19,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:layout_marginEnd="@dimen/keyline_1"
     android:background="@drawable/background_image_attachment_chip"
     android:clickable="true"
     android:focusable="true"
@@ -49,12 +50,13 @@
 
     <ImageView
         android:id="@+id/pageContextRemove"
-        android:layout_width="@dimen/keyline_4"
-        android:layout_height="@dimen/keyline_4"
+        android:layout_width="@dimen/keyline_5"
+        android:layout_height="@dimen/keyline_5"
         android:layout_marginStart="@dimen/keyline_2"
+        android:background="@drawable/background_image_attachment_remove"
         android:contentDescription="@string/duckChatPageContextRemoveContentDescription"
-        android:scaleType="center"
-        app:srcCompat="@drawable/ic_close_16"
-        app:tint="?attr/daxColorSecondaryIcon" />
+        android:padding="@dimen/keyline_1"
+        android:scaleType="fitCenter"
+        app:srcCompat="@drawable/ic_close_16" />
 
 </LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_page_context_attachment_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_page_context_attachment_item.xml
@@ -45,7 +45,7 @@
         android:maxWidth="120dp"
         android:maxLines="1"
         app:textType="primary"
-        app:typography="body2_bold" />
+        app:typography="body2" />
 
     <ImageView
         android:id="@+id/pageContextRemove"

--- a/duckchat/duckchat-impl/src/main/res/values/dimens.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/dimens.xml
@@ -37,7 +37,7 @@
     <dimen name="reasoningModePickerMenuWidth">220dp</dimen>
 
     <!-- Chip-->
-    <dimen name="chipCornerRadius">16dp</dimen>
+    <dimen name="chipCornerRadius">20dp</dimen>
     <dimen name="chipStrokeWidth">1dp</dimen>
     <dimen name="chipImageCornerRadius">6dp</dimen>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462763415876/task/1217146291865570?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
NOTE: The changes in this PR are not behind a flag.
 - Contextual sheet padding — the duck.ai contextual sheet now keeps its expanded (8dp) vertical padding regardless of focus, rather than collapsing when unfocused.
 - Attachment chips — left-aligned with the toggle/input text, chip typography changed to regular, and the chip corner radius bumped from 16dp to 20dp.
 - Remove icon — the attachment remove (X) icon now sits in a 24dp circular background (16dp glyph centred inside), backed by a new daxColorSurfaceTertiary design-system color (white in light, gray85 in dark). Applies to file, page-context, and image attachment chips.

### Steps to test this PR
Before running, you could also add @InternalAlwaysEnabled for `contextualNativeInput` to test attachments.

_nativeInputAttachmentChanges OFF_
- [x] Disable `nativeInputAttachmentChanges` via FF inventory
- [x] Open a new tab
- [x] Click on the Unified input > Duck.Ai tab
- [x] Add a file attachment
- [x] Verify it looks correct (attachment padding, roundness, x background)
- [x] Add an image attachment
- [x] Verify it looks correct (attachment padding, roundness, x background)
- [x] Go to a website (imdb)
- [x] Attach context (Ask about page)
- [x] Verify it looks correct (attachment padding, roundness, x background)

### UI changes
Figma reference: https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?node-id=24132-34885&m=dev
<img width="414" height="206" alt="Screenshot 2026-08-11 at 18 23 16" src="https://github.com/user-attachments/assets/cb8d99ec-b0e5-41ff-9cb3-1645e406a85d" />


| Before  | After |
| ------ | ----- |
<img width="335" height="177" alt="Screenshot 2026-08-11 at 18 17 44" src="https://github.com/user-attachments/assets/def3e516-2457-472e-94a8-178ea1cafcaf" /> |<img width="341" height="176" alt="Screenshot 2026-08-11 at 18 13 04" src="https://github.com/user-attachments/assets/e92f28a0-d8c1-44bb-a56a-68a24def2dc3" /> | 
<img width="341" height="177" alt="Screenshot 2026-08-11 at 18 17 33" src="https://github.com/user-attachments/assets/b139184f-0e02-4c8c-87d2-8ee6b4357e32" /> | <img width="338" height="179" alt="Screenshot 2026-08-11 at 18 13 21" src="https://github.com/user-attachments/assets/77f77c00-a457-4e1c-a0a9-64e567105ddb" />|
<img width="338" height="172" alt="Screenshot 2026-08-11 at 18 16 28" src="https://github.com/user-attachments/assets/a1f1acd5-24f6-40e0-9d91-239590d8a890" /> | <img width="338" height="172" alt="Screenshot 2026-08-11 at 18 13 41" src="https://github.com/user-attachments/assets/1e40fa09-cf1b-4bf1-991d-ffc1215c8f3e" />|
<img width="340" height="170" alt="Screenshot 2026-08-11 at 18 17 21" src="https://github.com/user-attachments/assets/397bbd6c-e489-4226-8ed5-0df3208a8238" />|<img width="339" height="179" alt="Screenshot 2026-08-11 at 18 14 02" src="https://github.com/user-attachments/assets/d3531e97-8acd-4865-885f-87f25f4e19d1" />|
<img width="336" height="133" alt="Screenshot 2026-08-11 at 18 31 17" src="https://github.com/user-attachments/assets/021853b2-fa97-4c7f-9af1-59faae645988" />|<img width="343" height="135" alt="Screenshot 2026-08-11 at 18 29 48" src="https://github.com/user-attachments/assets/9d44b576-af04-4486-88cb-1064f6be040c" />

---


> [!NOTE]
> **Low Risk**
> Visual and design-token changes only in Duck Chat attachment layouts and shared color resources; no logic or data-path changes.
> 
> **Overview**
> Introduces **`daxColorSurfaceTertiary`** in the design system (light/dark palette + theme mapping) and uses it for the oval **remove** control background on Duck Chat attachment chips, replacing **`daxColorWindow`**.
> 
> **File, image, and page-context** attachment row layouts are aligned: chip label typography moves from **`body2_bold`** to **`body2`**, per-chip **`layout_marginStart`** is removed, and the remove **`ImageView`** is larger with **`background_image_attachment_remove`**, padding, and default close icon styling (secondary icon tint removed). **`chipCornerRadius`** increases from **16dp** to **20dp**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f7dc0979ed2d58ccd6eae8f58f1850f243202e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->