### PR TITLE
[Config-driven linear onboarding dialogs] Add E2E test coverage and enable internally

### DIFF
--- a/.claude/rules/maestro-ui-tests.md
+++ b/.claude/rules/maestro-ui-tests.md
@@ -128,20 +128,15 @@ patch in the repo and apply it when CI prepares the build.
   more than one). A patch that does not apply fails the build; it is never skipped.
 - Locally, `git apply <patch>` before building, and `git apply -R <patch>` after.
 - Never pass `source_patches` alongside `-PuseUploadSigning` in `gradle_flags` — that is the real
-  distribution signing path (`release_upload_play_store.yml`, `release_upload_internal.yml`), and
-  `checkout-and-assemble` hard-fails the build if it sees both, so a patched toggle default can
-  never ship to users even if a job gets copy-pasted into the wrong workflow.
+  distribution signing path, and `checkout-and-assemble` hard-fails the combination so a patched
+  toggle default can never ship.
 
-A source patch is written against the current default, so it stops applying the moment that default
-changes and CI fails. That is deliberate: whoever changes the default has to decide what coverage
-is now missing and either rewrite the patch or delete it together with the job that uses it. The
-`E2E Source Patches` job in `ci.yml` runs that check on every PR so the breakage surfaces there
-rather than in the next nightly.
+A source patch stops applying the moment the default it targets changes, and CI fails — the
+`E2E Source Patches` job in `ci.yml` checks every PR, so the breakage surfaces there rather than
+in the next nightly. That is deliberate: whoever changes the default decides what coverage is now
+missing and either rewrites the patch or deletes it together with the job that uses it.
 
-Work out what to patch from the coverage the flavors already give you, and patch only the gap.
-A `DefaultFeatureValue.INTERNAL` default resolves against the build flavour, so the play and
-internal binaries already cover both arms — but only for the flows each flavour runs.
-A `TRUE` or `FALSE` default is flavor-independent.
-
-Patching source is the heaviest option, reach for it only when the flag is genuinely read too early
-for a config patch, and only for the flows the unpatched builds leave uncovered.
+Patching source is the heaviest option: reach for it only when the flag is genuinely read too
+early for a config patch, and only for the flow/arm combinations the unpatched builds leave
+uncovered — a `DefaultFeatureValue.INTERNAL` default already covers both arms across the play and
+internal binaries, but only for the flows each flavour runs.

--- a/.claude/rules/maestro-ui-tests.md
+++ b/.claude/rules/maestro-ui-tests.md
@@ -105,38 +105,19 @@ Key points for Maestro tests:
 
 ## Source Patches
 
-Remote config patches and the test seeder both apply at runtime, so neither can set a flag that is
-read during app launch — config has not landed yet, and any `AppScope` class can read a toggle as
-soon as it is constructed. For those flags, change the default at compile time instead: keep a Git
-patch in the repo and apply it when CI prepares the build.
+A flag read during app launch (any `AppScope` class can read a toggle at construction) cannot be
+set by remote config patches or the test seeder — both apply at runtime. Flip its compile-time
+default with a Git patch instead. This is the heaviest option: use it only when a config patch is
+genuinely too late, and only for flow/arm combinations the unpatched builds leave uncovered.
 
-- Store patches under a `source_patches/` subdirectory next to the tests that need them:
-  ```
-  .maestro/
-    onboarding/
-      source_patches/
-        config_driven_dialogs_disabled.patch
-      onboarding.yaml
-  ```
-- Generate with minimal context so the hunk is pinned by the declaration it targets rather than by
-  its neighbours: `git diff -U1 -- <file>`. Drop the `index` line — it only enables `--3way`, and a
-  patch that needs a merge to apply should fail instead.
-- Start the file with a plain-text header explaining what it flips, which workflow job applies it,
-  and what to do when it stops applying. `git apply` ignores everything before the first
-  `diff --git` line.
-- Apply in CI through the `source_patches` input on `checkout-and-assemble` (newline-separated for
-  more than one). A patch that does not apply fails the build; it is never skipped.
-- Locally, `git apply <patch>` before building, and `git apply -R <patch>` after.
-- Never pass `source_patches` alongside `-PuseUploadSigning` in `gradle_flags` — that is the real
-  distribution signing path, and `checkout-and-assemble` hard-fails the combination so a patched
-  toggle default can never ship.
-
-A source patch stops applying the moment the default it targets changes, and CI fails — the
-`E2E Source Patches` job in `ci.yml` checks every PR, so the breakage surfaces there rather than
-in the next nightly. That is deliberate: whoever changes the default decides what coverage is now
-missing and either rewrites the patch or deletes it together with the job that uses it.
-
-Patching source is the heaviest option: reach for it only when the flag is genuinely read too
-early for a config patch, and only for the flow/arm combinations the unpatched builds leave
-uncovered — a `DefaultFeatureValue.INTERNAL` default already covers both arms across the play and
-internal binaries, but only for the flows each flavour runs.
+- Store patches under a `source_patches/` subdirectory next to the tests that need them.
+- Generate with `git diff -U1 -- <file>` and drop the `index` line, so the hunk is pinned to the
+  declaration it targets and fails instead of falling back to `--3way`.
+- Start the file with a plain-text header (ignored by `git apply`): what it flips, which workflow
+  job applies it, and what to do when it stops applying.
+- In CI, apply through the `source_patches` input on `checkout-and-assemble` (newline-separated for
+  more than one). Never pass it alongside `-PuseUploadSigning` in `gradle_flags` — the job
+  hard-fails that combination.
+- Locally, `git apply <patch>` before building and `git apply -R <patch>` after.
+- When the default a patch targets changes, the `E2E Source Patches` job in `ci.yml` fails the PR;
+  whoever changed the default rewrites the patch or deletes it together with the job that uses it.

--- a/.claude/rules/maestro-ui-tests.md
+++ b/.claude/rules/maestro-ui-tests.md
@@ -102,3 +102,46 @@ Key points for Maestro tests:
   maestro test .maestro/my-feature/my_test.yaml
   ```
 - In CI, pass the flag via `gradle_flags` on `checkout-and-assemble` with `flavours: 'internal'` — see the README for the full workflow snippet
+
+## Source Patches
+
+Remote config patches and the test seeder both apply at runtime, so neither can set a flag that is
+read during app launch — config has not landed yet, and any `AppScope` class can read a toggle as
+soon as it is constructed. For those flags, change the default at compile time instead: keep a Git
+patch in the repo and apply it when CI prepares the build.
+
+- Store patches under a `source_patches/` subdirectory next to the tests that need them:
+  ```
+  .maestro/
+    onboarding/
+      source_patches/
+        config_driven_dialogs_disabled.patch
+      onboarding.yaml
+  ```
+- Generate with minimal context so the hunk is pinned by the declaration it targets rather than by
+  its neighbours: `git diff -U1 -- <file>`. Drop the `index` line — it only enables `--3way`, and a
+  patch that needs a merge to apply should fail instead.
+- Start the file with a plain-text header explaining what it flips, which workflow job applies it,
+  and what to do when it stops applying. `git apply` ignores everything before the first
+  `diff --git` line.
+- Apply in CI through the `source_patches` input on `checkout-and-assemble` (newline-separated for
+  more than one). A patch that does not apply fails the build; it is never skipped.
+- Locally, `git apply <patch>` before building, and `git apply -R <patch>` after.
+- Never pass `source_patches` alongside `-PuseUploadSigning` in `gradle_flags` — that is the real
+  distribution signing path (`release_upload_play_store.yml`, `release_upload_internal.yml`), and
+  `checkout-and-assemble` hard-fails the build if it sees both, so a patched toggle default can
+  never ship to users even if a job gets copy-pasted into the wrong workflow.
+
+A source patch is written against the current default, so it stops applying the moment that default
+changes and CI fails. That is deliberate: whoever changes the default has to decide what coverage
+is now missing and either rewrite the patch or delete it together with the job that uses it. The
+`E2E Source Patches` job in `ci.yml` runs that check on every PR so the breakage surfaces there
+rather than in the next nightly.
+
+Work out what to patch from the coverage the flavors already give you, and patch only the gap.
+A `DefaultFeatureValue.INTERNAL` default resolves against the build flavour, so the play and
+internal binaries already cover both arms — but only for the flows each flavour runs.
+A `TRUE` or `FALSE` default is flavor-independent.
+
+Patching source is the heaviest option, reach for it only when the flag is genuinely read too early
+for a config patch, and only for the flows the unpatched builds leave uncovered.

--- a/.github/actions/checkout-and-assemble/action.yml
+++ b/.github/actions/checkout-and-assemble/action.yml
@@ -25,12 +25,9 @@ inputs:
     default: ''
   source_patches:
     description: >
-      Newline-separated Git patch files applied to the checkout before assembling, for test builds
-      that need a source change the app cannot make at runtime. A patch that does not apply fails
-      the build rather than being skipped, so a build never silently ships the unpatched behaviour.
-      For E2E test builds only — never combine with -PuseUploadSigning in gradle_flags. Real store
-      uploads (release_upload_play_store.yml, release_upload_internal.yml) don't call this action;
-      if that ever changes, this input must not reach that path.
+      Newline-separated Git patch files applied to the checkout before assembling, for E2E test
+      builds that need a compile-time change. A patch that does not apply fails the build. Never
+      combine with -PuseUploadSigning in gradle_flags — enforced below.
     required: false
     default: ''
   develocity_access_key:
@@ -64,10 +61,7 @@ runs:
         submodules: recursive
 
     - name: Refuse source patches on a signed shipping build
-      # useUploadSigning is what release_upload_play_store.yml and release_upload_internal.yml pass
-      # to sign a build for real distribution. This action isn't currently used by either, but a
-      # copy-paste of a source_patches snippet into a shipping job would silently ship a patched
-      # toggle default to users — this stops that regardless of how the two inputs got combined.
+      # A patched compile-time default must never reach a build signed for real distribution.
       if: ${{ inputs.source_patches != '' }}
       shell: bash
       env:

--- a/.github/actions/checkout-and-assemble/action.yml
+++ b/.github/actions/checkout-and-assemble/action.yml
@@ -23,6 +23,16 @@ inputs:
     description: 'Additional flags to pass to the gradlew command'
     required: false
     default: ''
+  source_patches:
+    description: >
+      Newline-separated Git patch files applied to the checkout before assembling, for test builds
+      that need a source change the app cannot make at runtime. A patch that does not apply fails
+      the build rather than being skipped, so a build never silently ships the unpatched behaviour.
+      For E2E test builds only — never combine with -PuseUploadSigning in gradle_flags. Real store
+      uploads (release_upload_play_store.yml, release_upload_internal.yml) don't call this action;
+      if that ever changes, this input must not reach that path.
+    required: false
+    default: ''
   develocity_access_key:
     description: 'Develocity access key for Gradle remote caching'
     required: false
@@ -52,6 +62,43 @@ runs:
       with:
         ref: ${{ inputs.commit }}
         submodules: recursive
+
+    - name: Refuse source patches on a signed shipping build
+      # useUploadSigning is what release_upload_play_store.yml and release_upload_internal.yml pass
+      # to sign a build for real distribution. This action isn't currently used by either, but a
+      # copy-paste of a source_patches snippet into a shipping job would silently ship a patched
+      # toggle default to users — this stops that regardless of how the two inputs got combined.
+      if: ${{ inputs.source_patches != '' }}
+      shell: bash
+      env:
+        GRADLE_FLAGS: ${{ inputs.gradle_flags }}
+      run: |
+        set -euo pipefail
+        if [[ "$GRADLE_FLAGS" == *"useUploadSigning"* ]]; then
+          echo "::error::source_patches is set together with -PuseUploadSigning. source_patches changes a compile-time default and must never be applied to a build signed for real distribution."
+          exit 1
+        fi
+
+    - name: Apply source patches
+      if: ${{ inputs.source_patches != '' }}
+      shell: bash
+      env:
+        SOURCE_PATCHES: ${{ inputs.source_patches }}
+      run: |
+        set -euo pipefail
+        while IFS= read -r patch; do
+          if [ -z "$patch" ]; then continue; fi
+          if [ ! -f "$patch" ]; then
+            echo "::error::Source patch not found: $patch"
+            exit 1
+          fi
+          if ! git apply --check "$patch"; then
+            echo "::error file=$patch::Source patch does not apply. The code it targets changed — update the patch, or delete it if the behaviour it covers has been retired."
+            exit 1
+          fi
+          git apply "$patch"
+          echo "Applied source patch: $patch"
+        done <<< "$SOURCE_PATCHES"
 
     - name: Set up JDK version
       uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,38 @@ jobs:
       - name: Run Code Formatting Checks
         run: ./gradlew spotlessCheck
 
+  # Verify that source patches used for tests still apply.
+  # If the PR introduces a patch breakage, it might otherwise only surface in nightly test suites.
+  source_patches:
+    name: E2E Source Patches
+    needs: [check_changes]
+    if: needs.check_changes.outputs.should_run == 'true'
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check E2E source patches still apply
+        run: |
+          set -euo pipefail
+          shopt -s nullglob globstar
+          patches=(.maestro/**/source_patches/*.patch)
+          if [ ${#patches[@]} -eq 0 ]; then
+            echo "No E2E source patches to check."
+            exit 0
+          fi
+          failed=0
+          for patch in "${patches[@]}"; do
+            if git apply --check "$patch"; then
+              echo "OK: $patch"
+            else
+              echo "::error file=$patch::Source patch no longer applies. The code it targets changed — update the patch, or delete it along with the workflow job that uses it if the behaviour it covers has been retired."
+              failed=1
+            fi
+          done
+          exit "$failed"
+
   unit_tests:
     name: ${{ matrix.di == 'AnvilDagger' && 'Unit tests' || format('Unit tests ({0})', matrix.di) }}
     needs: [check_changes]

--- a/.github/workflows/e2e-nightly-non-blockers-suite.yml
+++ b/.github/workflows/e2e-nightly-non-blockers-suite.yml
@@ -173,6 +173,29 @@ jobs:
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           test_suite_name: Onboarding${{ env.DI_PAREN_SUFFIX }}
 
+      # onboardingBrandDesignUpdate.configDrivenDialogs defaults to INTERNAL, so this internal
+      # binary already renders the config-driven dialogs while the release-blocking nightly runs
+      # these same flows on the play binary, where the flag resolves to false. Running them here
+      # too covers the config-driven renderer for no extra build.
+      - name: Onboarding, config-driven renderer
+        id: maestro-onboarding-config-driven-renderer
+        # Run regardless of earlier suite failures, but only if the internal binary uploaded.
+        if: ${{ !cancelled() && steps.maestro-upload-internal-binary.outcome == 'success' }}
+        uses: ./.github/actions/maestro-cloud-asana-reporter
+        timeout-minutes: 120
+        with:
+          maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
+          maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          maestro_test_name: onboardingConfigDrivenRenderer${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
+          maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
+          maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
+          maestro_api_level: 34
+          maestro_include_tags: onboardingTest
+          asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
+          asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          test_suite_name: Onboarding, config-driven renderer${{ env.DI_PAREN_SUFFIX }}
+
       - name: SERP Flows
         id: maestro-serp-flows
         # Run regardless of earlier suite failures, but only if the internal binary uploaded.
@@ -202,4 +225,87 @@ jobs:
           asana-section: ${{ secrets.GH_ASANA_INCOMING_ID }}
           asana-task-name: GH Workflow Failure - End to End tests${{ env.DDG_DI == 'AnvilDagger' && ' (Non Release Blockers)' || format(' ({0})', env.DDG_DI) }}
           asana-task-description: The end to end workflow${{ env.DI_PAREN_SUFFIX }} has failed. These are non release blocking tests, follow the steps in [Maintenance Playbook](https://app.asana.com/1/137249556945/project/1210669871036405/task/1210684104726187?focus=true). See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
+          action: 'create-asana-task'
+
+  # onboardingBrandDesignUpdate.configDrivenDialogs defaults to INTERNAL, so the flavour decides the
+  # renderer: play gets the legacy one, internal gets the config-driven one. The internal-only and
+  # preonboarding flows therefore only ever run against the config-driven renderer, leaving the
+  # legacy renderer — which is what production ships while the flag sits on INTERNAL — untested for
+  # those flows. The flag is read during app launch, so the only way to pin it is at compile time.
+  # This job builds the internal flavour from a checkout patched back to FALSE and runs those flows
+  # against it. The play flavour is not built: it already resolves to FALSE unpatched.
+  onboarding_legacy_renderer_on_internal:
+    runs-on: ubuntu-latest
+    name: Onboarding, legacy renderer on internal
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Assemble internal APK with configDrivenDialogs pinned to FALSE
+        id: assemble
+        uses: ./.github/actions/checkout-and-assemble
+        with:
+          commit: ${{ inputs.commit }}
+          flavours: 'internal'
+          release_properties: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
+          release_key: ${{ secrets.FAKE_RELEASE_KEY }}
+          gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          gradle_flags: '-Pddg.di=${{ env.DDG_DI }}'
+          source_patches: .maestro/onboarding/source_patches/config_driven_dialogs_disabled.patch
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          ducksans_package_auth_user: ${{ secrets.DAXMOBILE_GITHUB_PACKAGES_AUTOMATION_USER }}
+          ducksans_package_auth_token: ${{ secrets.DAXMOBILE_GITHUB_PACKAGES_AUTOMATION }}
+
+      - name: Upload Internal Binary to Maestro
+        id: maestro-upload-internal-binary
+        uses: ./.github/actions/maestro-cloud-asana-reporter
+        timeout-minutes: 120
+        with:
+          maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
+          maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          maestro_test_name: binary_internal_upload_legacy_renderer${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
+          maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
+          maestro_app_file: ${{ steps.assemble.outputs.internal_apk_path }}
+          maestro_api_level: 34
+          maestro_include_tags: binaryUpload
+          asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
+          asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          test_suite_name: Internal Binary Upload, legacy renderer${{ env.DI_PAREN_SUFFIX }}
+
+      # The internal-only onboarding flows and the preonboarding flows, which the blocking and
+      # non-blocking nightlies run separately, are covered in one run here — a single API level is
+      # enough for a suite that only has to prove the legacy renderer still works.
+      - name: Internal Onboarding Flows
+        id: maestro-internal-onboarding-legacy-renderer
+        # Run regardless of earlier suite failures, but only if the internal binary uploaded.
+        if: ${{ !cancelled() && steps.maestro-upload-internal-binary.outcome == 'success' }}
+        uses: ./.github/actions/maestro-cloud-asana-reporter
+        timeout-minutes: 120
+        with:
+          maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
+          maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          maestro_test_name: internalOnboardingLegacyRenderer${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
+          maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
+          maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
+          maestro_api_level: 36
+          maestro_include_tags: onboardingInternalTest,onboardingNonReleaseBlockingTest
+          asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
+          asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          test_suite_name: Internal Onboarding, legacy renderer${{ env.DI_PAREN_SUFFIX }}
+
+      - name: Create Asana task when workflow failed
+        if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
+        id: create-failure-task
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
+          asana-section: ${{ secrets.GH_ASANA_INCOMING_ID }}
+          asana-task-name: GH Workflow Failure - End to End tests, legacy onboarding renderer${{ env.DDG_DI == 'AnvilDagger' && ' (Non Release Blockers)' || format(' ({0})', env.DDG_DI) }}
+          asana-task-description: The end to end workflow${{ env.DI_PAREN_SUFFIX }} for the legacy onboarding renderer has failed. These are non release blocking tests, follow the steps in [Maintenance Playbook](https://app.asana.com/1/137249556945/project/1210669871036405/task/1210684104726187?focus=true). If the failure is `Source patch does not apply`, the flag's compile-time default changed — see the header of `.maestro/onboarding/source_patches/config_driven_dialogs_disabled.patch` for what to do. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
           action: 'create-asana-task'

--- a/.github/workflows/e2e-nightly-non-blockers-suite.yml
+++ b/.github/workflows/e2e-nightly-non-blockers-suite.yml
@@ -173,10 +173,8 @@ jobs:
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           test_suite_name: Onboarding${{ env.DI_PAREN_SUFFIX }}
 
-      # onboardingBrandDesignUpdate.configDrivenDialogs defaults to INTERNAL, so this internal
-      # binary already renders the config-driven dialogs while the release-blocking nightly runs
-      # these same flows on the play binary, where the flag resolves to false. Running them here
-      # too covers the config-driven renderer for no extra build.
+      # The internal binary resolves configDrivenDialogs (INTERNAL default) to true, so rerunning
+      # the onboarding flows here covers the config-driven renderer without an extra build.
       - name: Onboarding, config-driven renderer
         id: maestro-onboarding-config-driven-renderer
         # Run regardless of earlier suite failures, but only if the internal binary uploaded.
@@ -227,13 +225,9 @@ jobs:
           asana-task-description: The end to end workflow${{ env.DI_PAREN_SUFFIX }} has failed. These are non release blocking tests, follow the steps in [Maintenance Playbook](https://app.asana.com/1/137249556945/project/1210669871036405/task/1210684104726187?focus=true). See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
           action: 'create-asana-task'
 
-  # onboardingBrandDesignUpdate.configDrivenDialogs defaults to INTERNAL, so the flavour decides the
-  # renderer: play gets the legacy one, internal gets the config-driven one. The internal-only and
-  # preonboarding flows therefore only ever run against the config-driven renderer, leaving the
-  # legacy renderer — which is what production ships while the flag sits on INTERNAL — untested for
-  # those flows. The flag is read during app launch, so the only way to pin it is at compile time.
-  # This job builds the internal flavour from a checkout patched back to FALSE and runs those flows
-  # against it. The play flavour is not built: it already resolves to FALSE unpatched.
+  # Internal-only and preonboarding flows only run on internal builds, where configDrivenDialogs
+  # resolves to true — so the legacy renderer production ships is untested for them. The flag is
+  # read at launch, so a source patch pins it to FALSE at compile time (see the patch header).
   onboarding_legacy_renderer_on_internal:
     runs-on: ubuntu-latest
     name: Onboarding, legacy renderer on internal
@@ -276,9 +270,7 @@ jobs:
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           test_suite_name: Internal Binary Upload, legacy renderer${{ env.DI_PAREN_SUFFIX }}
 
-      # The internal-only onboarding flows and the preonboarding flows, which the blocking and
-      # non-blocking nightlies run separately, are covered in one run here — a single API level is
-      # enough for a suite that only has to prove the legacy renderer still works.
+      # API level 36 because the custom AI flows require it.
       - name: Internal Onboarding Flows
         id: maestro-internal-onboarding-legacy-renderer
         # Run regardless of earlier suite failures, but only if the internal binary uploaded.

--- a/.maestro/onboarding/source_patches/config_driven_dialogs_disabled.patch
+++ b/.maestro/onboarding/source_patches/config_driven_dialogs_disabled.patch
@@ -1,25 +1,16 @@
 Pins onboardingBrandDesignUpdate.configDrivenDialogs to FALSE so the nightly E2E suite can run
-the internal-flavour onboarding flows against the legacy renderer.
-
-The flag defaults to INTERNAL, which resolves to the build flavour: the play build ships FALSE
-and the internal build gets TRUE (FeatureToggles.kt, loadToggleMethod). That gives every
-onboarding flow one arm for free — the play flows cover FALSE, the internal flows cover TRUE —
-but it leaves the internal-only and preonboarding flows with no FALSE coverage at all, and FALSE
-is what production ships for as long as the flag stays on INTERNAL.
-
-The flag is read during app launch, before any config — bundled or remote — has landed, so
-nothing applied at runtime can pin it. Changing the default at compile time is the only
-mechanism that does not race normal startup.
+the internal-flavour onboarding flows against the legacy renderer — the renderer production
+ships while the flag sits on INTERNAL. The flag is read during app launch, so only a
+compile-time change can pin it.
 
 Applied only by the "Onboarding, legacy renderer on internal" job in
-.github/workflows/e2e-nightly-non-blockers-suite.yml, through the source_patches input on
-.github/actions/checkout-and-assemble. Never applied to a build that ships.
+.github/workflows/e2e-nightly-non-blockers-suite.yml.
 
 This patch is meant to stop applying once the default moves off INTERNAL. CI fails loudly at
 that point, and whoever changes the default decides what coverage is still missing:
 
-  - default becomes TRUE: every flavour renders config-driven, so this patch should be rewritten
-    to pin FALSE against TRUE and run on the play binary, until the legacy renderer is deleted.
+  - default becomes TRUE: rewrite this patch to pin FALSE against TRUE and run on the play
+    binary, until the legacy renderer is deleted.
   - legacy renderer deleted: delete this patch and the job that applies it.
 
 See .claude/rules/maestro-ui-tests.md for the full mechanism.

--- a/.maestro/onboarding/source_patches/config_driven_dialogs_disabled.patch
+++ b/.maestro/onboarding/source_patches/config_driven_dialogs_disabled.patch
@@ -1,0 +1,34 @@
+Pins onboardingBrandDesignUpdate.configDrivenDialogs to FALSE so the nightly E2E suite can run
+the internal-flavour onboarding flows against the legacy renderer.
+
+The flag defaults to INTERNAL, which resolves to the build flavour: the play build ships FALSE
+and the internal build gets TRUE (FeatureToggles.kt, loadToggleMethod). That gives every
+onboarding flow one arm for free — the play flows cover FALSE, the internal flows cover TRUE —
+but it leaves the internal-only and preonboarding flows with no FALSE coverage at all, and FALSE
+is what production ships for as long as the flag stays on INTERNAL.
+
+The flag is read during app launch, before any config — bundled or remote — has landed, so
+nothing applied at runtime can pin it. Changing the default at compile time is the only
+mechanism that does not race normal startup.
+
+Applied only by the "Onboarding, legacy renderer on internal" job in
+.github/workflows/e2e-nightly-non-blockers-suite.yml, through the source_patches input on
+.github/actions/checkout-and-assemble. Never applied to a build that ships.
+
+This patch is meant to stop applying once the default moves off INTERNAL. CI fails loudly at
+that point, and whoever changes the default decides what coverage is still missing:
+
+  - default becomes TRUE: every flavour renders config-driven, so this patch should be rewritten
+    to pin FALSE against TRUE and run on the play binary, until the legacy renderer is deleted.
+  - legacy renderer deleted: delete this patch and the job that applies it.
+
+See .claude/rules/maestro-ui-tests.md for the full mechanism.
+
+diff --git a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
+--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
++++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
+@@ -60,3 +60,3 @@ interface OnboardingBrandDesignUpdateToggles {
+      */
+-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
++    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+     fun configDrivenDialogs(): Toggle

--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
@@ -58,6 +58,6 @@ interface OnboardingBrandDesignUpdateToggles {
     /**
      * Selects the config-driven renderer for the brand-design onboarding dialogs.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun configDrivenDialogs(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1216981414381704?focus=true
Tech Design URL (if applicable):
- https://app.asana.com/1/137249556945/project/481882893211075/task/1216854264994244
- https://app.asana.com/1/137249556945/project/1212087397361015/task/1217272662963461

API Proposals URL(s) (if applicable): N/A

### Description

Defaults `onboardingBrandDesignUpdate.configDrivenDialogs` to `INTERNAL` and extends the
nightly E2E suites so both onboarding renderers stay covered for every flow.

The flag is read during app launch, before remote config or the Test Seeder can act, so the
only way to pin it for a test build is at compile time. This PR adds that mechanism and uses
it:

1. **Flag default**: `configDrivenDialogs` moves from `FALSE` to `INTERNAL` — internal builds
   render the config-driven dialogs, play keeps the legacy renderer.

2. **Source patches**: a new `source_patches` input on `checkout-and-assemble` applies Git
   patches to the checkout before assembling, for E2E builds that need a compile-time change.
   A patch that does not apply fails the build, and the action refuses to combine patches with
   `-PuseUploadSigning`, so a patched default can never reach a build signed for distribution.
   A new `E2E Source Patches` job in `ci.yml` verifies on every PR that the patches still
   apply, so a default change surfaces there instead of in the next nightly. Conventions are
   documented in `.claude/rules/maestro-ui-tests.md`.

3. **Nightly coverage**: the non-blockers suite gains a step rerunning the `onboardingTest`
   flows on the internal binary (config-driven renderer — the blocking nightly already runs
   them on play, i.e. legacy), and a job that builds the internal flavour with the flag
   patched back to `FALSE` and runs the internal-only and preonboarding flows against the
   legacy renderer, which is what production ships while the flag sits on `INTERNAL`.

Resulting coverage:

| Flows | Legacy renderer | Config-driven renderer |
| ----- | --------------- | ---------------------- |
| `onboardingTest` | blocking nightly, play | non-blockers nightly, internal (new) |
| `onboardingInternalTest` | non-blockers nightly, patched internal (new) | blocking nightly, internal |
| `onboardingNonReleaseBlockingTest` | non-blockers nightly, patched internal (new) | non-blockers nightly, internal |

### Steps to test this PR

_Source patch_
- [x] Check the `E2E Source Patches` job passes on this PR.
- [x] Locally, `git apply --check .maestro/onboarding/source_patches/config_driven_dialogs_disabled.patch` succeeds.

_Config-driven renderer (internal default)_
- [x] Install an internal build and go through onboarding — the config-driven dialogs render.
- [x] `maestro test .maestro/onboarding --include-tags onboardingTest` passes.

_Legacy renderer (patched internal)_
- [ ] `git apply .maestro/onboarding/source_patches/config_driven_dialogs_disabled.patch`,
      install an internal build — the legacy dialogs render.
- [ ] `maestro test .maestro/onboarding --include-tags onboardingInternalTest,onboardingNonReleaseBlockingTest` passes.
- [ ] `git apply -R` the patch afterwards.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes an onboarding feature-flag default and shared assemble CI infrastructure. Play/production stays on the legacy renderer, and patches are blocked from signed shipping builds.
> 
> **Overview**
> Defaults `configDrivenDialogs` to **INTERNAL** so internal builds use the config-driven onboarding renderer while play keeps the legacy one, and extends nightly E2E coverage so both renderers stay tested for every onboarding flow.
> 
> Adds a **source patches** mechanism for compile-time flag flips (needed because this toggle is read at app launch): a `source_patches` input on `checkout-and-assemble`, a hard refuse when combined with `-PuseUploadSigning`, a CI job that verifies patches still apply, and docs in `maestro-ui-tests.md`.
> 
> Nightly non-blockers now rerun `onboardingTest` on the internal binary (config-driven), and a new job builds internal with the flag patched back to `FALSE` to cover internal-only/preonboarding flows against the legacy renderer production still ships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f71aabcef9db23bf67718a25f2f637804f354dd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->