### PR TITLE
[Brand design updates - Core App Components] Update accent blue colour

### DIFF
--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/DuckDuckGoActivity.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/DuckDuckGoActivity.kt
@@ -82,7 +82,7 @@ abstract class DuckDuckGoActivity : DaggerActivity() {
         themeChangeReceiver = applyTheme(
             themingDataStore.theme,
             applyFireTheme,
-            appBrandDesignUpdateToggles.feature().isEnabled(),
+            appBrandDesignUpdateToggles.theme().isEnabled(),
         )
         super.onCreate(savedInstanceState)
     }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/store/AppBrandDesignUpdatePreWarmObserver.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/store/AppBrandDesignUpdatePreWarmObserver.kt
@@ -44,7 +44,7 @@ class AppBrandDesignUpdatePreWarmObserver @Inject constructor(
 
     override fun onCreate(owner: LifecycleOwner) {
         appCoroutineScope.launch(dispatcherProvider.io()) {
-            toggles.feature().isEnabled()
+            toggles.theme().isEnabled()
         }
     }
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/store/AppBrandDesignUpdateToggles.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/store/AppBrandDesignUpdateToggles.kt
@@ -22,11 +22,8 @@ import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 /**
- * App-wide brand design update (rebrand) feature flag, excluding onboarding which is gated via
+ * App-wide, theme-related design changes feature flag, excluding onboarding which is gated via
  * `OnboardingBrandDesignUpdateToggles`.
- *
- * Gate rebrand changes on [feature] via `feature().isEnabled()`, never on [self]:
- * self() cannot use the incremental rollout mechanism.
  */
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -37,10 +34,16 @@ interface AppBrandDesignUpdateToggles {
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun self(): Toggle
 
-    /** Off leaves Change app icon below the theme and night mode settings on the Appearance screen. */
+    /**
+     * Off leaves Change app icon below the theme and night mode settings on the Appearance screen.
+     * */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun appIcon(): Toggle
 
+    /**
+     * Gates theme-level design changes. This currently includes the rebrand button styling and
+     * theme-specific accent blue; future theme-controlled changes should use this sub-toggle.
+     */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
-    fun feature(): Toggle
+    fun theme(): Toggle
 }

--- a/android-design-system/design-system/src/main/res/values/design-system-rebrand.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-rebrand.xml
@@ -41,6 +41,7 @@
     <attr name="daxColorRebrandButtonDestructiveSecondaryText" format="color" />
     <attr name="daxColorRebrandButtonDestructiveGhostContainerPressed" format="color" />
     <attr name="daxColorRebrandButtonDestructiveGhostText" format="color" />
+    <attr name="daxColorRebrandAccentBlue" format="color" />
 
     <dimen name="rebrandButtonSmallHeight">48dp</dimen>
     <dimen name="rebrandButtonLargeHeight">56dp</dimen>
@@ -135,6 +136,7 @@
     </style>
 
     <style name="ThemeOverlay.Rebrand" parent="">
+        <item name="daxColorAccentBlue">?attr/daxColorRebrandAccentBlue</item>
         <item name="daxButtonPrimary">@style/Widget.DuckDuckGo.DaxButton.Rebrand.Primary</item>
         <item name="daxButtonSecondary">@style/Widget.DuckDuckGo.DaxButton.Rebrand.SecondaryFill</item>
         <item name="daxButtonGhost">@style/Widget.DuckDuckGo.DaxButton.Rebrand.Ghost</item>

--- a/android-design-system/design-system/src/main/res/values/design-system-theming.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-theming.xml
@@ -270,6 +270,7 @@
         <item name="daxColorButtonBrandContainer">@color/pollen40</item>
         <item name="daxColorButtonBrandContainerPressed">@color/pollen60</item>
         <item name="daxColorButtonBrandText">@color/pollen100</item>
+        <item name="daxColorRebrandAccentBlue">@color/pondwater40</item>
         <item name="daxColorRebrandButtonPrimaryContainer">@color/pondwater40</item>
         <item name="daxColorRebrandButtonPrimaryContainerPressed">@color/pondwater60</item>
         <item name="daxColorRebrandButtonPrimaryText">@color/eggshell90</item>
@@ -430,6 +431,7 @@
         <item name="daxColorButtonBrandContainer">@color/mandarin50</item>
         <item name="daxColorButtonBrandContainerPressed">@color/mandarin70</item>
         <item name="daxColorButtonBrandText">@color/white</item>
+        <item name="daxColorRebrandAccentBlue">@color/pondwater60</item>
         <item name="daxColorRebrandButtonPrimaryContainer">@color/pondwater60</item>
         <item name="daxColorRebrandButtonPrimaryContainerPressed">@color/pondwater80</item>
         <item name="daxColorRebrandButtonPrimaryText">@color/white</item>

--- a/android-design-system/design-system/src/test/java/com/duckduckgo/common/ui/ThemingRebrandOverlayTest.kt
+++ b/android-design-system/design-system/src/test/java/com/duckduckgo/common/ui/ThemingRebrandOverlayTest.kt
@@ -62,6 +62,21 @@ class ThemingRebrandOverlayTest {
             setTheme(themeResId)
         }
 
+    private fun resolveColor(
+        activity: AppCompatActivity,
+        attr: Int,
+    ): Int {
+        val value = TypedValue()
+        activity.theme.resolveAttribute(attr, value, true)
+        return value.data
+    }
+
+    private fun colorOf(colorRes: Int): Int =
+        RuntimeEnvironment.getApplication().resources.getColor(colorRes, null)
+
+    private fun themedActivity(): AppCompatActivity =
+        Robolectric.buildActivity(AppCompatActivity::class.java).get()
+
     @Test
     fun whenFixedThemeActivityWithBrandDesignUpdateThenRebrandStyleResolves() {
         val activity = fixedThemeActivity()
@@ -117,5 +132,43 @@ class ThemingRebrandOverlayTest {
     @Test
     fun whenThemeIsAppCompatTransparentThenRebrandOverlayIsNotSupported() {
         assertFalse(themeFor(R.style.Theme_AppCompat_Transparent_NoActionBar).supportsRebrandOverlay())
+    }
+
+    @Test
+    fun whenLightThemeWithBrandDesignUpdateThenAccentBlueIsPondwater60() {
+        val activity = themedActivity()
+        activity.applyTheme(DuckDuckGoTheme.LIGHT, applyBrandDesignUpdate = true)
+        assertEquals(colorOf(R.color.pondwater60), resolveColor(activity, R.attr.daxColorAccentBlue))
+    }
+
+    @Test
+    fun whenDarkThemeWithBrandDesignUpdateThenAccentBlueIsPondwater40() {
+        val activity = themedActivity()
+        activity.applyTheme(DuckDuckGoTheme.DARK, applyBrandDesignUpdate = true)
+        assertEquals(colorOf(R.color.pondwater40), resolveColor(activity, R.attr.daxColorAccentBlue))
+    }
+
+    @Test
+    fun whenLightThemeWithoutBrandDesignUpdateThenAccentBlueIsUnchanged() {
+        val activity = themedActivity()
+        activity.applyTheme(DuckDuckGoTheme.LIGHT)
+        assertEquals(colorOf(R.color.blue50), resolveColor(activity, R.attr.daxColorAccentBlue))
+    }
+
+    @Test
+    fun whenDarkThemeWithoutBrandDesignUpdateThenAccentBlueIsUnchanged() {
+        val activity = themedActivity()
+        activity.applyTheme(DuckDuckGoTheme.DARK)
+        assertEquals(colorOf(R.color.blue30), resolveColor(activity, R.attr.daxColorAccentBlue))
+    }
+
+    @Test
+    fun whenBrandDesignUpdateThenSwitchTrackFollowsAccentBlue() {
+        val activity = themedActivity()
+        activity.applyTheme(DuckDuckGoTheme.LIGHT, applyBrandDesignUpdate = true)
+        assertEquals(
+            resolveColor(activity, R.attr.daxColorAccentBlue),
+            resolveColor(activity, R.attr.daxColorSwitchTrackOn),
+        )
     }
 }

--- a/android-design-system/design-system/src/test/java/com/duckduckgo/common/ui/store/AppBrandDesignUpdatePreWarmObserverTest.kt
+++ b/android-design-system/design-system/src/test/java/com/duckduckgo/common/ui/store/AppBrandDesignUpdatePreWarmObserverTest.kt
@@ -47,7 +47,7 @@ class AppBrandDesignUpdatePreWarmObserverTest {
     @Before
     fun setup() {
         whenever(dispatcherProvider.io()).thenReturn(coroutineRule.testDispatcher)
-        whenever(toggles.feature()).thenReturn(feature)
+        whenever(toggles.theme()).thenReturn(feature)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216907145452928
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

Updates the rebrand accent blue to the new brand colour (`#1074CC` light / `#75B6EB` dark) and resolves it per-theme under the rebrand overlay.

### Steps to test this PR

[Designs](https://www.figma.com/design/6tcKR2xDTfq80O2FqU6Qsi/%F0%9F%93%90-Mobile--New-Design-Language?node-id=1448-22646&m=dev)

_Rebrand accent blue_

**Light mode**
- [x] Open the App Components design system screen and ensure the brand design toggle is enabled
- [x] Go to the colour palette and check the accent blue colour
- [x] Confirm the accent blue colour for the View version is different to the Compose version (the Compose version is still on the old colour — useful as a point of comparison)
- [x] Go to the Interactive tab and compare the View switch against the Compose switch — the colours should be slightly different, and the switch thumb/track colours should differ too
- [x] Compare the View checkbox against the Compose checkbox — colours should differ
- [x] Compare the View radio button against the Compose radio button — colours should differ

**Dark mode**
- [x] Repeat all of the above steps in dark mode

**Optional**
- [x] Smoke test through the app looking at various Switches, Checkboxes, Toggles. Settings is a good area to see usages. As well as Onboarding when selecting Address Bar etc. Checkboexs are used in VPN Settings -> Excluded Apps dialog

### UI changes

Before is under "Compose"

| Light | Dark |
|--------|--------|
| <img width="1344" height="2992" alt="Screenshot_20260812_112435" src="https://github.com/user-attachments/assets/29576fe0-15a1-44d9-a123-715c5ab24518" /> | <img width="1344" height="2992" alt="Screenshot_20260812_112412" src="https://github.com/user-attachments/assets/d2ada76c-1adb-40f0-b837-e22f81e9a491" /> |
| <img width="1344" height="2992" alt="Screenshot_20260812_112358" src="https://github.com/user-attachments/assets/c93aba84-9afc-4605-b156-ab21fe6abd84" /> | <img width="1344" height="2992" alt="Screenshot_20260812_112421" src="https://github.com/user-attachments/assets/2e0814f2-9a2a-411c-a1b5-6036e89d5727" /> | 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Theming and feature-flag naming only; legacy accent colors remain when the toggle is off, with added test coverage.
> 
> **Overview**
> When the brand design **theme** sub-toggle is on, the rebrand overlay now maps `daxColorAccentBlue` to new pondwater values (light `pondwater60`, dark `pondwater40`), so View-based controls that already use that attribute—switches, checkboxes, radio buttons, sliders, and Material accents—pick up the updated blue without per-widget changes.
> 
> The remote flag API renames `feature()` to **`theme()`** for gating theme-level rebrand work (buttons plus accent blue); `DuckDuckGoActivity` and the pre-warm observer read `theme().isEnabled()` instead of `feature()`.
> 
> Tests assert accent blue and switch track-on colors with and without the brand overlay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bb0fe3945201b5165ff312bc41c68aea567d051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->