### PR TITLE
Store persisted favicons outside the OS-clearable cache directory

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/FileBasedFaviconPersisterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/FileBasedFaviconPersisterTest.kt
@@ -90,7 +90,26 @@ class FileBasedFaviconPersisterTest {
 
         assertNotNull(file)
         verifyDirectoryUse(file!!.absolutePath, testDirectory)
-        verifyCacheDirectoryUsed(file.absolutePath)
+        verifyExpectedBaseDirectoryUsed(file.absolutePath, testDirectory)
+    }
+
+    @Test
+    fun whenFaviconFileIsForTempDirectoryThenCacheDirUsed() = runTest {
+        createNewFile(FileBasedFaviconPersister.FAVICON_TEMP_DIR)
+        val file = testee.faviconFile(FileBasedFaviconPersister.FAVICON_TEMP_DIR, subFolder, domain)
+
+        assertNotNull(file)
+        assertTrue(file!!.absolutePath.startsWith(context.cacheDir.absolutePath))
+    }
+
+    @Test
+    fun whenFaviconFileIsForPersistedDirectoryThenNonCacheDirUsed() = runTest {
+        createNewFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR)
+        val file = testee.faviconFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, subFolder, domain)
+
+        assertNotNull(file)
+        assertTrue(file!!.absolutePath.startsWith(context.filesDir.absolutePath))
+        assertFalse(file.absolutePath.startsWith(context.cacheDir.absolutePath))
     }
 
     @Test
@@ -213,8 +232,11 @@ class FileBasedFaviconPersisterTest {
         assertTrue(path.parent!!.endsWith(subFolder))
     }
 
-    private fun verifyCacheDirectoryUsed(path: String) {
-        assertTrue(path.startsWith(context.cacheDir.absolutePath))
+    private fun verifyExpectedBaseDirectoryUsed(
+        path: String,
+        directory: String,
+    ) {
+        assertTrue(path.startsWith(expectedBaseDir(directory).absolutePath))
     }
 
     private fun verifyDirectoryUse(
@@ -224,15 +246,20 @@ class FileBasedFaviconPersisterTest {
         assertTrue(path.contains("/$directory"))
     }
 
-    private fun createNewFile() {
-        val previewFileDestination = File(File(context.cacheDir, testDirectory), subFolder)
+    // Mirrors FileBasedFaviconPersister's private faviconDirectory() base-dir decision.
+    private fun expectedBaseDir(directory: String): File {
+        return if (directory == FileBasedFaviconPersister.FAVICON_TEMP_DIR) context.cacheDir else context.filesDir
+    }
+
+    private fun createNewFile(directory: String = testDirectory) {
+        val previewFileDestination = File(File(expectedBaseDir(directory), directory), subFolder)
         previewFileDestination.mkdirs()
         val file = File(previewFileDestination, filename(domain))
         writeBytesToFile(file)
     }
 
     private fun getTestFile(): File {
-        val previewFileDestination = File(File(context.cacheDir, testDirectory), subFolder)
+        val previewFileDestination = File(File(expectedBaseDir(testDirectory), testDirectory), subFolder)
         return File(previewFileDestination, filename(domain))
     }
 
@@ -246,9 +273,13 @@ class FileBasedFaviconPersisterTest {
     private fun filename(name: String): String = "${name.sha256}.png"
 
     private fun deleteTestFolders() {
-        val dirToDelete = File(File(context.cacheDir, testDirectory), "")
-        dirToDelete.deleteRecursively()
-        val secondaryDirToDelete = File(File(context.cacheDir, secondaryTestDirectory), "")
-        secondaryDirToDelete.deleteRecursively()
+        listOf(
+            testDirectory,
+            secondaryTestDirectory,
+            FileBasedFaviconPersister.FAVICON_TEMP_DIR,
+            FileBasedFaviconPersister.FAVICON_PERSISTED_DIR,
+        ).forEach {
+            File(expectedBaseDir(it), it).deleteRecursively()
+        }
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/FileBasedFaviconPersisterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/FileBasedFaviconPersisterTest.kt
@@ -28,6 +28,9 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.sha256
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -110,6 +113,114 @@ class FileBasedFaviconPersisterTest {
         assertNotNull(file)
         assertTrue(file!!.absolutePath.startsWith(context.filesDir.absolutePath))
         assertFalse(file.absolutePath.startsWith(context.cacheDir.absolutePath))
+    }
+
+    @Test
+    fun whenLegacyCacheFaviconExistsThenItIsMovedToFilesDirOnFirstAccess() = runTest {
+        val legacyFile = createLegacyCacheFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, content = "legacy")
+
+        val file = testee.faviconFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, subFolder, domain)
+
+        assertNotNull(file)
+        assertTrue(file!!.absolutePath.startsWith(context.filesDir.absolutePath))
+        assertEquals("legacy", file.readText())
+        assertFalse(legacyFile.exists())
+        assertFalse(File(context.cacheDir, FileBasedFaviconPersister.FAVICON_PERSISTED_DIR).exists())
+    }
+
+    @Test
+    fun whenLegacyCacheFaviconAndNewFaviconBothExistThenNewOneIsKept() = runTest {
+        createLegacyCacheFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, content = "legacy")
+        createNewFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, content = "new")
+
+        val file = testee.faviconFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, subFolder, domain)
+
+        assertNotNull(file)
+        assertEquals("new", file!!.readText())
+        assertFalse(File(context.cacheDir, FileBasedFaviconPersister.FAVICON_PERSISTED_DIR).exists())
+    }
+
+    @Test
+    fun whenLegacyCacheWidgetPlaceholderExistsThenItIsMovedToFilesDirOnFirstAccess() = runTest {
+        createLegacyCacheFile(FileBasedFaviconPersister.FAVICON_WIDGET_PLACEHOLDERS_DIR, content = "legacy")
+
+        val file = testee.faviconFile(FileBasedFaviconPersister.FAVICON_WIDGET_PLACEHOLDERS_DIR, subFolder, domain)
+
+        assertNotNull(file)
+        assertTrue(file!!.absolutePath.startsWith(context.filesDir.absolutePath))
+        assertFalse(File(context.cacheDir, FileBasedFaviconPersister.FAVICON_WIDGET_PLACEHOLDERS_DIR).exists())
+    }
+
+    @Test
+    fun whenNoLegacyCacheDirectoryExistsThenNothingIsCreatedInCache() = runTest {
+        createNewFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR)
+
+        val file = testee.faviconFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, subFolder, domain)
+
+        assertNotNull(file)
+        assertFalse(File(context.cacheDir, FileBasedFaviconPersister.FAVICON_PERSISTED_DIR).exists())
+    }
+
+    @Test
+    fun whenLegacyCacheDirectoryIsEmptyThenItIsRemoved() = runTest {
+        val legacyDirectory = File(context.cacheDir, FileBasedFaviconPersister.FAVICON_PERSISTED_DIR)
+        legacyDirectory.mkdirs()
+
+        testee.faviconFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, subFolder, domain)
+
+        assertFalse(legacyDirectory.exists())
+    }
+
+    @Test
+    fun whenLegacyCacheContainsNestedFilesThenStructureIsPreserved() = runTest {
+        createLegacyCacheFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, content = "legacy")
+        val nested = File(File(File(context.cacheDir, FileBasedFaviconPersister.FAVICON_PERSISTED_DIR), "nested"), "inner.png")
+        nested.parentFile!!.mkdirs()
+        writeBytesToFile(nested, "nested")
+
+        testee.faviconFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, subFolder, domain)
+
+        val migratedNested = File(File(File(context.filesDir, FileBasedFaviconPersister.FAVICON_PERSISTED_DIR), "nested"), "inner.png")
+        assertEquals("nested", migratedNested.readText())
+        assertFalse(File(context.cacheDir, FileBasedFaviconPersister.FAVICON_PERSISTED_DIR).exists())
+    }
+
+    @Test
+    fun whenLegacyCacheContainsTmpFileThenItIsNotMigrated() = runTest {
+        createLegacyCacheFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, content = "legacy")
+        val legacyDirectory = File(File(context.cacheDir, FileBasedFaviconPersister.FAVICON_PERSISTED_DIR), subFolder)
+        writeBytesToFile(File(legacyDirectory, "${filename(domain)}.tmp"), "partial")
+
+        testee.faviconFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, subFolder, domain)
+
+        val migratedDirectory = File(File(context.filesDir, FileBasedFaviconPersister.FAVICON_PERSISTED_DIR), subFolder)
+        assertTrue(File(migratedDirectory, filename(domain)).exists())
+        assertFalse(File(migratedDirectory, "${filename(domain)}.tmp").exists())
+        assertFalse(File(context.cacheDir, FileBasedFaviconPersister.FAVICON_PERSISTED_DIR).exists())
+    }
+
+    @Test
+    fun whenLegacyCacheIsAccessedConcurrentlyThenMigrationHappensOnceWithoutErrors() = runTest {
+        createLegacyCacheFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, content = "legacy")
+
+        val results = (1..20).map {
+            async(Dispatchers.IO) {
+                testee.faviconFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, subFolder, domain)
+            }
+        }.awaitAll()
+
+        assertTrue(results.all { it != null && it.absolutePath.startsWith(context.filesDir.absolutePath) })
+        assertEquals("legacy", results.first()!!.readText())
+        assertFalse(File(context.cacheDir, FileBasedFaviconPersister.FAVICON_PERSISTED_DIR).exists())
+    }
+
+    @Test
+    fun whenTempDirectoryIsAccessedThenNothingIsMigrated() = runTest {
+        val legacyFile = createLegacyCacheFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, content = "legacy")
+
+        testee.faviconFile(FileBasedFaviconPersister.FAVICON_TEMP_DIR, subFolder, domain)
+
+        assertTrue(legacyFile.exists())
     }
 
     @Test
@@ -251,11 +362,24 @@ class FileBasedFaviconPersisterTest {
         return if (directory == FileBasedFaviconPersister.FAVICON_TEMP_DIR) context.cacheDir else context.filesDir
     }
 
-    private fun createNewFile(directory: String = testDirectory) {
+    private fun createNewFile(
+        directory: String = testDirectory,
+        content: String = "1",
+    ) {
         val previewFileDestination = File(File(expectedBaseDir(directory), directory), subFolder)
         previewFileDestination.mkdirs()
         val file = File(previewFileDestination, filename(domain))
-        writeBytesToFile(file)
+        writeBytesToFile(file, content)
+    }
+
+    // Where FileBasedFaviconPersister stored persisted favicons before they moved out of cacheDir.
+    private fun createLegacyCacheFile(
+        directory: String,
+        content: String,
+    ): File {
+        val legacyDirectory = File(File(context.cacheDir, directory), subFolder)
+        legacyDirectory.mkdirs()
+        return File(legacyDirectory, filename(domain)).also { writeBytesToFile(it, content) }
     }
 
     private fun getTestFile(): File {
@@ -263,9 +387,12 @@ class FileBasedFaviconPersisterTest {
         return File(previewFileDestination, filename(domain))
     }
 
-    private fun writeBytesToFile(previewFile: File) {
+    private fun writeBytesToFile(
+        previewFile: File,
+        content: String = "1",
+    ) {
         FileOutputStream(previewFile).use { outputStream ->
-            outputStream.write("1".toByteArray())
+            outputStream.write(content.toByteArray())
             outputStream.flush()
         }
     }
@@ -278,8 +405,10 @@ class FileBasedFaviconPersisterTest {
             secondaryTestDirectory,
             FileBasedFaviconPersister.FAVICON_TEMP_DIR,
             FileBasedFaviconPersister.FAVICON_PERSISTED_DIR,
+            FileBasedFaviconPersister.FAVICON_WIDGET_PLACEHOLDERS_DIR,
         ).forEach {
             File(expectedBaseDir(it), it).deleteRecursively()
+            File(context.cacheDir, it).deleteRecursively()
         }
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/FileBasedFaviconPersisterTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/FileBasedFaviconPersisterTest.kt
@@ -215,6 +215,34 @@ class FileBasedFaviconPersisterTest {
     }
 
     @Test
+    fun whenOneLegacyFileCannotBeMovedThenOthersMigrateAndLegacyDirectoryIsKeptForRetry() = runTest {
+        createLegacyCacheFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, content = "legacy")
+        val legacyRoot = File(context.cacheDir, FileBasedFaviconPersister.FAVICON_PERSISTED_DIR)
+        val blockedLegacyFile = File(File(legacyRoot, "blocked"), "inner.png")
+        blockedLegacyFile.parentFile!!.mkdirs()
+        writeBytesToFile(blockedLegacyFile, "blocked")
+        // A regular file where the destination sub-directory should be makes that one move fail.
+        val destinationRoot = File(context.filesDir, FileBasedFaviconPersister.FAVICON_PERSISTED_DIR)
+        destinationRoot.mkdirs()
+        val blocker = File(destinationRoot, "blocked")
+        writeBytesToFile(blocker, "not a directory")
+
+        val file = testee.faviconFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, subFolder, domain)
+
+        assertNotNull(file)
+        assertEquals("legacy", file!!.readText())
+        assertTrue(legacyRoot.exists())
+        assertTrue(blockedLegacyFile.exists())
+        assertFalse(File(File(legacyRoot, subFolder), filename(domain)).exists())
+
+        blocker.delete()
+        testee.faviconFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, subFolder, domain)
+
+        assertEquals("blocked", File(File(destinationRoot, "blocked"), "inner.png").readText())
+        assertFalse(legacyRoot.exists())
+    }
+
+    @Test
     fun whenTempDirectoryIsAccessedThenNothingIsMigrated() = runTest {
         val legacyFile = createLegacyCacheFile(FileBasedFaviconPersister.FAVICON_PERSISTED_DIR, content = "legacy")
 

--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconPersister.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconPersister.kt
@@ -281,7 +281,11 @@ class FileBasedFaviconPersister(
     }
 
     private fun faviconDirectory(directory: String): File {
-        return File(context.cacheDir, directory)
+        // FAVICON_TEMP_DIR holds per-tab favicons and is fine to live under cacheDir, which the OS
+        // may clear under storage pressure. FAVICON_PERSISTED_DIR (bookmarks/favorites) and
+        // FAVICON_WIDGET_PLACEHOLDERS_DIR must survive that, so they live in non-cache storage.
+        val baseDir = if (directory == FAVICON_TEMP_DIR) context.cacheDir else context.filesDir
+        return File(baseDir, directory)
     }
 
     private fun filename(name: String): String = "${name.sha256}.png"

--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconPersister.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconPersister.kt
@@ -307,22 +307,47 @@ class FileBasedFaviconPersister(
         synchronized(legacyMigrationLock) {
             if (!legacyDirectory.exists()) return
 
-            runCatching {
-                legacyDirectory.walkTopDown()
-                    .filter { it.isFile && !it.name.endsWith(TMP_FILE_SUFFIX) }
-                    .forEach { legacyFile ->
-                        val target = File(destination, legacyFile.relativeTo(legacyDirectory).path)
-                        target.parentFile?.mkdirs()
-                        // A file already written by this version is newer than the legacy one, keep it.
-                        if (!target.exists() && !legacyFile.renameTo(target)) {
-                            legacyFile.copyTo(target)
-                        }
-                    }
-            }.onFailure {
-                logcat(LogPriority.WARN) { "FaviconPersister: failed to migrate legacy $directory favicons: ${it.message}" }
+            val allMoved = legacyDirectory.walkTopDown()
+                .filter { it.isFile && !it.name.endsWith(TMP_FILE_SUFFIX) }
+                .map { legacyFile -> moveLegacyFile(legacyFile, File(destination, legacyFile.relativeTo(legacyDirectory).path)) }
+                .toList()
+                .all { it }
+
+            // Only drop the legacy directory once every file is safely in the new location. A partial
+            // failure (e.g. no space for the copy fallback) leaves the remaining files where they are so
+            // the next lookup can retry them instead of losing them.
+            if (allMoved) {
+                legacyDirectory.deleteRecursively()
+            } else {
+                logcat(LogPriority.WARN) { "FaviconPersister: some legacy $directory favicons could not be migrated, will retry on next access" }
             }
-            legacyDirectory.deleteRecursively()
         }
+    }
+
+    private fun moveLegacyFile(
+        source: File,
+        target: File,
+    ): Boolean = runCatching {
+        // A file already written by this version is newer than the legacy one, keep it.
+        if (target.exists()) return@runCatching true
+        target.parentFile?.mkdirs()
+        if (source.renameTo(target)) return@runCatching true
+
+        // Copy through a temp file so a failure part-way never leaves a truncated favicon behind.
+        val tmp = File(target.parent, "${target.name}$TMP_FILE_SUFFIX")
+        val copied = runCatching {
+            source.copyTo(tmp, overwrite = true)
+            tmp.renameTo(target)
+        }.getOrDefault(false)
+        if (!copied) {
+            tmp.delete()
+            return@runCatching false
+        }
+        source.delete()
+        true
+    }.getOrElse {
+        logcat(LogPriority.WARN) { "FaviconPersister: failed to migrate ${source.name}: ${it.message}" }
+        false
     }
 
     private fun filename(name: String): String = "${name.sha256}.png"

--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconPersister.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconPersister.kt
@@ -71,6 +71,7 @@ class FileBasedFaviconPersister(
 ) : FaviconPersister {
 
     val mutex = Mutex()
+    private val legacyMigrationLock = Any()
 
     override suspend fun deleteAll(directory: String) {
         fileDeleter.deleteDirectory(faviconDirectory(directory))
@@ -98,7 +99,7 @@ class FileBasedFaviconPersister(
         withContext(dispatcherProvider.io()) {
             val persistedFile = fileForFavicon(directory, newSubfolder, newFilename)
             if (androidBrowserConfigFeature.atomicFaviconWrites().isEnabled()) {
-                val tmp = File(persistedFile.parent, "${persistedFile.name}.tmp")
+                val tmp = File(persistedFile.parent, "${persistedFile.name}$TMP_FILE_SUFFIX")
                 runCatching {
                     file.copyTo(tmp, overwrite = true)
                     if (!tmp.renameTo(persistedFile)) {
@@ -268,7 +269,7 @@ class FileBasedFaviconPersister(
     }
 
     private fun writeBitmapAtomically(file: File, bitmap: Bitmap) {
-        val tmp = File(file.parent, "${file.name}.tmp")
+        val tmp = File(file.parent, "${file.name}$TMP_FILE_SUFFIX")
         FileOutputStream(tmp).use { outputStream ->
             bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
             outputStream.flush()
@@ -284,8 +285,44 @@ class FileBasedFaviconPersister(
         // FAVICON_TEMP_DIR holds per-tab favicons and is fine to live under cacheDir, which the OS
         // may clear under storage pressure. FAVICON_PERSISTED_DIR (bookmarks/favorites) and
         // FAVICON_WIDGET_PLACEHOLDERS_DIR must survive that, so they live in non-cache storage.
-        val baseDir = if (directory == FAVICON_TEMP_DIR) context.cacheDir else context.filesDir
-        return File(baseDir, directory)
+        if (directory == FAVICON_TEMP_DIR) {
+            return File(context.cacheDir, directory)
+        }
+        return File(context.filesDir, directory).also { migrateLegacyCacheDirectory(directory, it) }
+    }
+
+    /**
+     * Persisted favicons used to live under cacheDir. Moving them on first access keeps existing
+     * bookmark and favorite icons after an upgrade instead of showing placeholders until each site
+     * is visited again. The legacy directory is removed afterwards, so this is a single exists()
+     * check on every later call.
+     */
+    private fun migrateLegacyCacheDirectory(
+        directory: String,
+        destination: File,
+    ) {
+        val legacyDirectory = File(context.cacheDir, directory)
+        if (!legacyDirectory.exists()) return
+
+        synchronized(legacyMigrationLock) {
+            if (!legacyDirectory.exists()) return
+
+            runCatching {
+                legacyDirectory.walkTopDown()
+                    .filter { it.isFile && !it.name.endsWith(TMP_FILE_SUFFIX) }
+                    .forEach { legacyFile ->
+                        val target = File(destination, legacyFile.relativeTo(legacyDirectory).path)
+                        target.parentFile?.mkdirs()
+                        // A file already written by this version is newer than the legacy one, keep it.
+                        if (!target.exists() && !legacyFile.renameTo(target)) {
+                            legacyFile.copyTo(target)
+                        }
+                    }
+            }.onFailure {
+                logcat(LogPriority.WARN) { "FaviconPersister: failed to migrate legacy $directory favicons: ${it.message}" }
+            }
+            legacyDirectory.deleteRecursively()
+        }
     }
 
     private fun filename(name: String): String = "${name.sha256}.png"
@@ -295,5 +332,6 @@ class FileBasedFaviconPersister(
         const val FAVICON_PERSISTED_DIR = "favicons"
         const val FAVICON_WIDGET_PLACEHOLDERS_DIR = "faviconsWidgetPlaceholders"
         const val NO_SUBFOLDER = ""
+        private const val TMP_FILE_SUFFIX = ".tmp"
     }
 }

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -20,6 +20,6 @@
         name="external_files"
         path="." />
     <cache-path name="sync" path="sync" />
-    <cache-path name="favicons" path="favicons/" />
-    <cache-path name="favicons_widget_placeholders" path="faviconsWidgetPlaceholders/" />
+    <files-path name="favicons" path="favicons/" />
+    <files-path name="favicons_widget_placeholders" path="faviconsWidgetPlaceholders/" />
 </paths>


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/Android/issues/6374
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

Favicons for bookmarked and favorited sites were stored under `context.cacheDir` via `FileBasedFaviconPersister`. Android is permitted to automatically clear an app's cache directory under low storage conditions, so saved favicons would randomly disappear and fall back to a letter-avatar placeholder, even though the bookmark/favorite itself was untouched.

Per-tab temporary favicons (`FAVICON_TEMP_DIR`) are fine to lose and still use `cacheDir`. Persisted favicons for bookmarks/favorites (`FAVICON_PERSISTED_DIR`) and widget placeholders (`FAVICON_WIDGET_PLACEHOLDERS_DIR`) now use `context.filesDir`, which the OS does not automatically clear.

Favicons that existing installs already have under `cacheDir` are moved to `filesDir` the first time the persisted directory is accessed after the upgrade, so bookmark and favorite icons carry over without waiting for each site to be visited again. A file already written to the new location wins, leftover `.tmp` files from interrupted writes are skipped, and the legacy directory is deleted once moved, so later lookups only pay for a single `exists()` check. Re-fetching from the network on a miss only happens when the opt-in favicon fetching setting is enabled, so the migration is what keeps icons visible for most users.

### Steps to test this PR

_Existing favicons survive the upgrade_
- [x] On a build from `develop`, bookmark a site with a distinct favicon and confirm the file exists under `cache/favicons/`
- [x] Install this build over it and open Bookmarks
- [x] Confirm the favicon still displays, the file now lives under `files/favicons/`, and `cache/favicons/` is gone

_Favicon survives cache clearing_
- [x] Bookmark or favorite a site with a distinct favicon and confirm it displays correctly
- [x] Force-stop the app, then clear the app's cache via Android Settings > Apps > DuckDuckGo > Storage > Clear cache (or simulate OS-level cache eviction)
- [x] Relaunch the app and open Bookmarks/Favorites
- [x] Confirm the favicon still displays correctly instead of falling back to a letter avatar

### UI changes
No new UI. Screenshots below show the bug and the fix on a physical device (Vivo V2036, Android 13). Same steps on both builds: bookmark github.com, force-stop the app, delete the app's cache directory (what the OS does under storage pressure), relaunch.

| Before (develop) | After (this PR) |
| ------ | ----- |
| Bookmarks list falls back to the letter placeholder | Real favicon survives the cache clear |

![Bookmarks before/after](https://raw.githubusercontent.com/theabhishekchandra/Android/pr-9470-assets/pr-9470-bookmarks-before-after.png)

Search and Favorites widget, same steps (widget loads the favicon through the updated FileProvider paths):

![Widget before/after](https://raw.githubusercontent.com/theabhishekchandra/Android/pr-9470-assets/pr-9470-widget-before-after.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrade-time file migration and FileProvider path changes affect bookmark/favorite and widget icon loading; behavior is localized but storage failures could leave legacy cache until retry.
> 
> **Overview**
> **Persisted bookmark/favorite and widget placeholder favicons** no longer live under the OS-clearable `cacheDir`; only per-tab temp favicons stay in cache. `FileBasedFaviconPersister` routes `FAVICON_PERSISTED_DIR` and `FAVICON_WIDGET_PLACEHOLDERS_DIR` through `filesDir` and **migrates** any matching legacy tree from `cacheDir` on first access (synced, skips `.tmp`, keeps newer files in the new location, retries if a move fails).
> 
> **FileProvider** `provider_paths.xml` switches those favicon roots from `cache-path` to `files-path` so widgets and other URI consumers still resolve icons after the move.
> 
> Instrumented tests cover base-dir choice, migration edge cases (concurrency, partial failure, nested files), and updated test helpers to mirror the new layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e135c6779282fbe1219520041775002d45716a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

