### PR TITLE
Serialize auth token refresh

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -240,6 +240,13 @@ interface SubscriptionsFeature {
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun sendAuthTokenRefreshWideEvent(): Toggle
 
+    /**
+     * Kill switch for serializing auth token refresh with a cross-process lock.
+     * When disabled, concurrent refreshes are possible (previous behavior).
+     */
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.INTERNAL)
+    fun serializeTokenRefresh(): Toggle
+
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun sendSubscriptionSwitchWideEvent(): Toggle
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -762,7 +762,7 @@ class RealSubscriptionsManager @Inject constructor(
 
     override suspend fun refreshAccessToken() {
         try {
-            tokenRefreshWideEvent.onStart(subscriptionStatus())
+            tokenRefreshWideEvent.onStart(subscriptionStatus(), serializationEnabled = false)
             doRefreshAccessToken()
             tokenRefreshWideEvent.onSuccess()
         } catch (e: Exception) {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -47,6 +47,7 @@ import com.duckduckgo.subscriptions.impl.auth2.AccessTokenClaims
 import com.duckduckgo.subscriptions.impl.auth2.AuthClient
 import com.duckduckgo.subscriptions.impl.auth2.AuthJwtValidator
 import com.duckduckgo.subscriptions.impl.auth2.BackgroundTokenRefresh
+import com.duckduckgo.subscriptions.impl.auth2.CrossProcessLock
 import com.duckduckgo.subscriptions.impl.auth2.PkceGenerator
 import com.duckduckgo.subscriptions.impl.auth2.RefreshTokenClaims
 import com.duckduckgo.subscriptions.impl.auth2.TokenPair
@@ -88,6 +89,7 @@ import dagger.Lazy
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -96,6 +98,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
 import logcat.asLog
@@ -292,6 +296,7 @@ class RealSubscriptionsManager @Inject constructor(
     private val pkceGenerator: PkceGenerator,
     private val timeProvider: CurrentTimeProvider,
     private val backgroundTokenRefresh: BackgroundTokenRefresh,
+    private val crossProcessLock: CrossProcessLock,
     private val subscriptionPurchaseWideEvent: SubscriptionPurchaseWideEvent,
     private val tokenRefreshWideEvent: AuthTokenRefreshWideEvent,
     private val subscriptionSwitchWideEvent: SubscriptionSwitchWideEvent,
@@ -328,6 +333,8 @@ class RealSubscriptionsManager @Inject constructor(
     override val entitlementSet = _entitlementSet.onSubscription { emitEntitlementsValues() }
 
     private var purchaseStateJob: Job? = null
+
+    private val tokenRefreshMutex = Mutex()
 
     private var removeExpiredSubscriptionOnCancelledPurchase: Boolean = false
 
@@ -761,14 +768,46 @@ class RealSubscriptionsManager @Inject constructor(
     }
 
     override suspend fun refreshAccessToken() {
-        try {
-            tokenRefreshWideEvent.onStart(subscriptionStatus(), serializationEnabled = false)
-            doRefreshAccessToken()
-            tokenRefreshWideEvent.onSuccess()
-        } catch (e: Exception) {
-            tokenRefreshWideEvent.onFailure(e)
-            throw e
+        val serializeRefresh = withContext(dispatcherProvider.io()) {
+            subscriptionsFeature.get().serializeTokenRefresh().isEnabled()
         }
+
+        if (!serializeRefresh) {
+            try {
+                tokenRefreshWideEvent.onStart(subscriptionStatus(), serializationEnabled = false)
+                doRefreshAccessToken()
+                tokenRefreshWideEvent.onSuccess()
+            } catch (e: Exception) {
+                tokenRefreshWideEvent.onFailure(e)
+                throw e
+            }
+            return
+        }
+
+        // Moving token refresh to app-scoped coroutine to ensure it's not interrupted by caller cancellation.
+        coroutineScope.async {
+            tokenRefreshMutex.withLock {
+                try {
+                    tokenRefreshWideEvent.onStart(subscriptionStatus(), serializationEnabled = true)
+
+                    val lockResult = crossProcessLock.acquire(TOKEN_REFRESH_LOCK_KEY)
+                    tokenRefreshWideEvent.onCrossProcessLockAcquired(lockResult)
+
+                    try {
+                        doRefreshAccessToken()
+                    } finally {
+                        lockResult.getOrNull()?.let { lockHandle ->
+                            withContext(dispatcherProvider.io()) { lockHandle.close() }
+                        }
+                    }
+
+                    tokenRefreshWideEvent.onSuccess()
+                } catch (e: Exception) {
+                    tokenRefreshWideEvent.onFailure(e)
+                    throw e
+                }
+            }
+        }.await()
     }
 
     private suspend fun doRefreshAccessToken() {
@@ -1350,6 +1389,7 @@ class RealSubscriptionsManager @Inject constructor(
 
     companion object {
         const val SUBSCRIPTION_NOT_FOUND_ERROR = "SubscriptionNotFound"
+        private const val TOKEN_REFRESH_LOCK_KEY = "auth_token_refresh"
     }
 }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -763,89 +763,93 @@ class RealSubscriptionsManager @Inject constructor(
     override suspend fun refreshAccessToken() {
         try {
             tokenRefreshWideEvent.onStart(subscriptionStatus())
-            val refreshToken = checkNotNull(authRepository.getRefreshTokenV2())
-            tokenRefreshWideEvent.onTokenRead()
-
-            /*
-                Get jwks before refreshing the token, just in case getting jwks fails. We don't want to end up in a situation where
-                a new token has been fetched (potentially invalidating the old one), but we can't validate and store it.
-             */
-            val jwks = authClient.getJwks()
-            tokenRefreshWideEvent.onJwksFetched()
-
-            val newTokens = try {
-                val tokens = authClient.getTokens(refreshToken.jwt)
-                tokenRefreshWideEvent.onTokensFetched()
-                validateTokens(tokens, jwks)
-                    .also { tokenRefreshWideEvent.onTokensValidated() }
-            } catch (e: HttpException) {
-                val backendErrorResponse = parseError(e)?.error
-                    ?.also { tokenRefreshWideEvent.onBackendErrorResponse(backendErrorResponse = it) }
-
-                if (e.code() == 400) {
-                    if (backendErrorResponse == "unknown_account") {
-                        /*
-                        Refresh token appears to be valid, but the related account doesn't exist in BE.
-                        After the subscription expires, BE eventually deletes the account, so this is expected.
-                         */
-                        tokenRefreshWideEvent.onUnknownAccountError()
-                        signOut()
-                        throw e
-                    }
-
-                    // refresh token is invalid / expired -> try to get a new pair of tokens using store login
-                    pixelSender.reportAuthV2InvalidRefreshTokenDetected()
-                    val account = checkNotNull(authRepository.getAccount()) { "Missing account info when refreshing access token" }
-
-                    when (val storeLoginResult = storeLogin(account.externalId)) {
-                        is StoreLoginResult.Success -> {
-                            tokenRefreshWideEvent.onPlayLoginSuccess()
-                            pixelSender.reportAuthV2InvalidRefreshTokenRecovered()
-                            storeLoginResult.tokens
-                        }
-
-                        StoreLoginResult.Failure.AccountExternalIdMismatch,
-                        StoreLoginResult.Failure.AuthenticationError,
-                        StoreLoginResult.Failure.NoActivePurchase,
-                        -> {
-                            tokenRefreshWideEvent.onPlayLoginFailure(
-                                signedOut = true,
-                                refreshException = e,
-                                loginError = storeLoginResult.javaClass.simpleName,
-                            )
-                            pixelSender.reportAuthV2InvalidRefreshTokenSignedOut()
-                            signOut()
-                            throw e
-                        }
-
-                        is StoreLoginResult.Failure.TokenValidationFailed,
-                        is StoreLoginResult.Failure.PurchaseInfoNotAvailable,
-                        is StoreLoginResult.Failure.UnknownError,
-                        -> {
-                            val loginError = when (storeLoginResult) {
-                                is StoreLoginResult.Failure.PurchaseInfoNotAvailable ->
-                                    "${storeLoginResult.javaClass.simpleName} - ${storeLoginResult.cause}"
-                                else -> storeLoginResult.javaClass.simpleName
-                            }
-                            tokenRefreshWideEvent.onPlayLoginFailure(
-                                signedOut = false,
-                                refreshException = e,
-                                loginError = loginError,
-                            )
-                            throw e
-                        }
-                    }
-                } else {
-                    throw e
-                }
-            }
-
-            saveTokens(newTokens)
+            doRefreshAccessToken()
             tokenRefreshWideEvent.onSuccess()
         } catch (e: Exception) {
             tokenRefreshWideEvent.onFailure(e)
             throw e
         }
+    }
+
+    private suspend fun doRefreshAccessToken() {
+        val refreshToken = checkNotNull(authRepository.getRefreshTokenV2())
+        tokenRefreshWideEvent.onTokenRead()
+
+        /*
+            Get jwks before refreshing the token, just in case getting jwks fails. We don't want to end up in a situation where
+            a new token has been fetched (potentially invalidating the old one), but we can't validate and store it.
+         */
+        val jwks = authClient.getJwks()
+        tokenRefreshWideEvent.onJwksFetched()
+
+        val newTokens = try {
+            val tokens = authClient.getTokens(refreshToken.jwt)
+            tokenRefreshWideEvent.onTokensFetched()
+            validateTokens(tokens, jwks)
+                .also { tokenRefreshWideEvent.onTokensValidated() }
+        } catch (e: HttpException) {
+            val backendErrorResponse = parseError(e)?.error
+                ?.also { tokenRefreshWideEvent.onBackendErrorResponse(backendErrorResponse = it) }
+
+            if (e.code() == 400) {
+                if (backendErrorResponse == "unknown_account") {
+                    /*
+                    Refresh token appears to be valid, but the related account doesn't exist in BE.
+                    After the subscription expires, BE eventually deletes the account, so this is expected.
+                     */
+                    tokenRefreshWideEvent.onUnknownAccountError()
+                    signOut()
+                    throw e
+                }
+
+                // refresh token is invalid / expired -> try to get a new pair of tokens using store login
+                pixelSender.reportAuthV2InvalidRefreshTokenDetected()
+                val account = checkNotNull(authRepository.getAccount()) { "Missing account info when refreshing access token" }
+
+                when (val storeLoginResult = storeLogin(account.externalId)) {
+                    is StoreLoginResult.Success -> {
+                        tokenRefreshWideEvent.onPlayLoginSuccess()
+                        pixelSender.reportAuthV2InvalidRefreshTokenRecovered()
+                        storeLoginResult.tokens
+                    }
+
+                    StoreLoginResult.Failure.AccountExternalIdMismatch,
+                    StoreLoginResult.Failure.AuthenticationError,
+                    StoreLoginResult.Failure.NoActivePurchase,
+                    -> {
+                        tokenRefreshWideEvent.onPlayLoginFailure(
+                            signedOut = true,
+                            refreshException = e,
+                            loginError = storeLoginResult.javaClass.simpleName,
+                        )
+                        pixelSender.reportAuthV2InvalidRefreshTokenSignedOut()
+                        signOut()
+                        throw e
+                    }
+
+                    is StoreLoginResult.Failure.TokenValidationFailed,
+                    is StoreLoginResult.Failure.PurchaseInfoNotAvailable,
+                    is StoreLoginResult.Failure.UnknownError,
+                    -> {
+                        val loginError = when (storeLoginResult) {
+                            is StoreLoginResult.Failure.PurchaseInfoNotAvailable ->
+                                "${storeLoginResult.javaClass.simpleName} - ${storeLoginResult.cause}"
+                            else -> storeLoginResult.javaClass.simpleName
+                        }
+                        tokenRefreshWideEvent.onPlayLoginFailure(
+                            signedOut = false,
+                            refreshException = e,
+                            loginError = loginError,
+                        )
+                        throw e
+                    }
+                }
+            } else {
+                throw e
+            }
+        }
+
+        saveTokens(newTokens)
     }
 
     override suspend fun refreshSubscriptionData() {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/auth2/CrossProcessLock.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/auth2/CrossProcessLock.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.auth2
+
+import android.content.Context
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import logcat.LogPriority.WARN
+import logcat.asLog
+import logcat.logcat
+import java.io.Closeable
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+interface CrossProcessLock {
+    /**
+     * Acquires an exclusive cross-process lock identified by [key], waiting up to [timeout].
+     * Returns a [Closeable] that releases the lock, or a failure if the lock could not be acquired
+     * ([TimeoutCancellationException] if [timeout] elapsed).
+     * Callers MUST serialize acquisitions of the same [key] in-process.
+     */
+    suspend fun acquire(key: String, timeout: Duration = 60.seconds): Result<Closeable>
+}
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealCrossProcessLock @Inject constructor(
+    private val context: Context,
+    private val dispatcherProvider: DispatcherProvider,
+) : CrossProcessLock {
+
+    override suspend fun acquire(key: String, timeout: Duration): Result<Closeable> = try {
+        withTimeout(timeout) {
+            withContext(dispatcherProvider.io()) {
+                val channel = RandomAccessFile(File(context.filesDir, "$key.lock"), "rw").channel
+                try {
+                    var lock = channel.tryLock()
+                    while (lock == null) {
+                        delay(POLL_INTERVAL)
+                        lock = channel.tryLock()
+                    }
+                    logcat(tag = LOG_TAG) { "Lock acquired: $key" }
+                    Result.success(FileLockHandle(key, channel, lock))
+                } catch (e: Throwable) {
+                    runCatching { channel.close() }
+                    throw e
+                }
+            }
+        }
+    } catch (e: TimeoutCancellationException) {
+        logcat(tag = LOG_TAG, priority = WARN) { "Timed out acquiring lock: $key" }
+        Result.failure(e)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        logcat(tag = LOG_TAG, priority = WARN) { "Lock acquisition failed: $key ${e.asLog()}" }
+        Result.failure(e)
+    }
+
+    private class FileLockHandle(
+        private val key: String,
+        private val channel: FileChannel,
+        private val lock: FileLock,
+    ) : Closeable {
+        override fun close() {
+            runCatching { lock.release() }
+            runCatching { channel.close() }
+            logcat(tag = LOG_TAG) { "Lock released: $key" }
+        }
+    }
+
+    private companion object {
+        val POLL_INTERVAL = 100.milliseconds
+        const val LOG_TAG = "CrossProcessLock"
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/auth2/CrossProcessLock.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/auth2/CrossProcessLock.kt
@@ -56,32 +56,38 @@ class RealCrossProcessLock @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
 ) : CrossProcessLock {
 
-    override suspend fun acquire(key: String, timeout: Duration): Result<Closeable> = try {
-        withTimeout(timeout) {
-            withContext(dispatcherProvider.io()) {
-                val channel = RandomAccessFile(File(context.filesDir, "$key.lock"), "rw").channel
-                try {
-                    var lock = channel.tryLock()
-                    while (lock == null) {
-                        delay(POLL_INTERVAL)
-                        lock = channel.tryLock()
+    override suspend fun acquire(key: String, timeout: Duration): Result<Closeable> {
+        var handle: FileLockHandle? = null
+        return try {
+            withTimeout(timeout) {
+                withContext(dispatcherProvider.io()) {
+                    val channel = RandomAccessFile(File(context.filesDir, "$key.lock"), "rw").channel
+                    try {
+                        var lock = channel.tryLock()
+                        while (lock == null) {
+                            delay(POLL_INTERVAL)
+                            lock = channel.tryLock()
+                        }
+                        logcat(tag = LOG_TAG) { "Lock acquired: $key" }
+                        Result.success(FileLockHandle(key, channel, lock).also { handle = it })
+                    } catch (e: Throwable) {
+                        runCatching { channel.close() }
+                        throw e
                     }
-                    logcat(tag = LOG_TAG) { "Lock acquired: $key" }
-                    Result.success(FileLockHandle(key, channel, lock))
-                } catch (e: Throwable) {
-                    runCatching { channel.close() }
-                    throw e
                 }
             }
+        } catch (e: TimeoutCancellationException) {
+            handle?.close()
+            logcat(tag = LOG_TAG, priority = WARN) { "Timed out acquiring lock: $key" }
+            Result.failure(e)
+        } catch (e: CancellationException) {
+            handle?.close()
+            throw e
+        } catch (e: Exception) {
+            handle?.close()
+            logcat(tag = LOG_TAG, priority = WARN) { "Lock acquisition failed: $key ${e.asLog()}" }
+            Result.failure(e)
         }
-    } catch (e: TimeoutCancellationException) {
-        logcat(tag = LOG_TAG, priority = WARN) { "Timed out acquiring lock: $key" }
-        Result.failure(e)
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Exception) {
-        logcat(tag = LOG_TAG, priority = WARN) { "Lock acquisition failed: $key ${e.asLog()}" }
-        Result.failure(e)
     }
 
     private class FileLockHandle(

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEvent.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEvent.kt
@@ -28,11 +28,20 @@ import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.Lazy
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withContext
+import java.io.Closeable
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 interface AuthTokenRefreshWideEvent {
-    suspend fun onStart(subscriptionStatus: SubscriptionStatus)
+    suspend fun onStart(
+        subscriptionStatus: SubscriptionStatus,
+        serializationEnabled: Boolean,
+    )
+
+    suspend fun onCrossProcessLockAcquired(result: Result<Closeable>)
     suspend fun onTokenRead()
     suspend fun onJwksFetched()
     suspend fun onTokensFetched()
@@ -62,7 +71,10 @@ class AuthTokenRefreshWideEventImpl @Inject constructor(
 
     private var ongoingTokenRefreshWideEventId: Long? = null
 
-    override suspend fun onStart(subscriptionStatus: SubscriptionStatus) {
+    override suspend fun onStart(
+        subscriptionStatus: SubscriptionStatus,
+        serializationEnabled: Boolean,
+    ) {
         if (!isFeatureEnabled()) return
 
         ongoingTokenRefreshWideEventId?.let { wideEventId ->
@@ -78,12 +90,35 @@ class AuthTokenRefreshWideEventImpl @Inject constructor(
                     KEY_NETP_IS_ENABLED to runCatching { networkProtectionState.get().isEnabled().toString() }.getOrDefault(""),
                     KEY_NETP_IS_RUNNING to runCatching { networkProtectionState.get().isRunning().toString() }.getOrDefault(""),
                     KEY_PROCESS_NAME to processName,
+                    KEY_SERIALIZATION_ENABLED to serializationEnabled.toString(),
                 ),
             )
             .getOrNull()
             ?.also { wideEventId ->
                 wideEventClient.intervalStart(wideEventId = wideEventId, key = INTERVAL_TOTAL_DURATION)
+                if (serializationEnabled) {
+                    wideEventClient.intervalStart(wideEventId = wideEventId, key = INTERVAL_LOCK_WAIT, buckets = LOCK_WAIT_BUCKETS)
+                }
             }
+    }
+
+    override suspend fun onCrossProcessLockAcquired(result: Result<Closeable>) {
+        if (!isFeatureEnabled()) return
+        ongoingTokenRefreshWideEventId?.let { wideEventId ->
+            wideEventClient.intervalEnd(wideEventId = wideEventId, key = INTERVAL_LOCK_WAIT)
+            wideEventClient.flowStep(
+                wideEventId = wideEventId,
+                stepName = STEP_LOCK_ACQUIRE,
+                success = result.isSuccess,
+                metadata = mapOf(KEY_LOCK_OUTCOME to result.toOutcomeValue()),
+            )
+        }
+    }
+
+    private fun Result<Closeable>.toOutcomeValue(): String = when {
+        isSuccess -> "acquired"
+        exceptionOrNull() is TimeoutCancellationException -> "timeout"
+        else -> "error"
     }
 
     override suspend fun onTokenRead() {
@@ -190,16 +225,22 @@ class AuthTokenRefreshWideEventImpl @Inject constructor(
     private companion object {
         const val AUTH_TOKEN_REFRESH_FEATURE_NAME = "auth-token-refresh"
 
+        const val STEP_LOCK_ACQUIRE = "lock_acquire"
         const val STEP_TOKEN_READ = "token_read"
         const val STEP_JWKS_FETCH = "jwks_fetch"
         const val STEP_TOKEN_REQUEST = "token_request"
         const val STEP_TOKEN_VALIDATION = "token_validation"
         const val STEP_PLAY_LOGIN = "play_login"
 
+        const val INTERVAL_LOCK_WAIT = "token_refresh_lock_wait_ms_bucketed"
         const val INTERVAL_GET_JWKS = "fetch_jwks_latency_ms_bucketed"
         const val INTERVAL_GET_TOKENS = "refresh_access_token_latency_ms_bucketed"
         const val INTERVAL_TOTAL_DURATION = "total_duration_ms_bucketed"
 
+        val LOCK_WAIT_BUCKETS = setOf(100.milliseconds, 500.milliseconds, 1.seconds, 3.seconds, 10.seconds, 30.seconds, 60.seconds)
+
+        const val KEY_LOCK_OUTCOME = "lock_outcome"
+        const val KEY_SERIALIZATION_ENABLED = "serialization_enabled"
         const val KEY_SUBSCRIPTION_STATUS = "subscription_status"
         const val KEY_BACKEND_ERROR_RESPONSE = "backend_error_response"
         const val KEY_PLAY_LOGIN_ERROR = "play_login_error"

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.subscriptions.impl.auth2.AccessTokenClaims
 import com.duckduckgo.subscriptions.impl.auth2.AuthClient
 import com.duckduckgo.subscriptions.impl.auth2.AuthJwtValidator
 import com.duckduckgo.subscriptions.impl.auth2.BackgroundTokenRefresh
+import com.duckduckgo.subscriptions.impl.auth2.CrossProcessLock
 import com.duckduckgo.subscriptions.impl.auth2.PkceGenerator
 import com.duckduckgo.subscriptions.impl.auth2.PkceGeneratorImpl
 import com.duckduckgo.subscriptions.impl.auth2.RefreshTokenClaims
@@ -76,12 +77,20 @@ import com.duckduckgo.subscriptions.impl.wideevents.FreeTrialConversionWideEvent
 import com.duckduckgo.subscriptions.impl.wideevents.SubscriptionPurchaseWideEvent
 import com.duckduckgo.subscriptions.impl.wideevents.SubscriptionRestoreWideEvent
 import com.duckduckgo.subscriptions.impl.wideevents.SubscriptionSwitchWideEvent
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
@@ -99,15 +108,19 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import retrofit2.HttpException
 import retrofit2.Response
+import java.io.Closeable
+import java.io.IOException
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDateTime
@@ -128,7 +141,10 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
 
     @SuppressLint("DenyListedApi")
     private val subscriptionsFeature: SubscriptionsFeature = FakeFeatureToggleFactory.create(SubscriptionsFeature::class.java)
-        .apply { authApiV2().setRawStoredState(State(authApiV2Enabled)) }
+        .apply {
+            authApiV2().setRawStoredState(State(authApiV2Enabled))
+            serializeTokenRefresh().setRawStoredState(State(true))
+        }
     private val authRepository = RealAuthRepository(authDataStore, coroutineRule.testDispatcherProvider, serpPromo, { subscriptionsFeature })
     private val emailManager: EmailManager = mock()
     private val playBillingManager: PlayBillingManager = mock()
@@ -146,6 +162,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     private val authJwtValidator: AuthJwtValidator = mock()
     private val timeProvider = FakeTimeProvider()
     private val backgroundTokenRefresh: BackgroundTokenRefresh = mock()
+    private val crossProcessLock: CrossProcessLock = mock()
     private lateinit var subscriptionsManager: RealSubscriptionsManager
 
     @Before
@@ -153,6 +170,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         whenever(emailManager.getToken()).thenReturn(null)
         whenever(context.packageName).thenReturn("packageName")
         whenever(playBillingManager.purchaseState).thenReturn(flowOf())
+        whenever(crossProcessLock.acquire(any(), any())).thenReturn(Result.success(FakeLockHandle()))
         subscriptionsManager = RealSubscriptionsManager(
             authService,
             subscriptionsService,
@@ -169,6 +187,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             pkceGenerator,
             timeProvider,
             backgroundTokenRefresh,
+            crossProcessLock,
             subscriptionPurchaseWideEvent,
             tokenRefreshWideEvent,
             subscriptionSwitchWideEvent,
@@ -718,6 +737,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             pkceGenerator,
             timeProvider,
             backgroundTokenRefresh,
+            crossProcessLock,
             subscriptionPurchaseWideEvent,
             tokenRefreshWideEvent,
             subscriptionSwitchWideEvent,
@@ -753,6 +773,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             pkceGenerator,
             timeProvider,
             backgroundTokenRefresh,
+            crossProcessLock,
             subscriptionPurchaseWideEvent,
             tokenRefreshWideEvent,
             subscriptionSwitchWideEvent,
@@ -792,6 +813,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             pkceGenerator,
             timeProvider,
             backgroundTokenRefresh,
+            crossProcessLock,
             subscriptionPurchaseWideEvent,
             tokenRefreshWideEvent,
             subscriptionSwitchWideEvent,
@@ -845,6 +867,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             pkceGenerator,
             timeProvider,
             backgroundTokenRefresh,
+            crossProcessLock,
             subscriptionPurchaseWideEvent,
             tokenRefreshWideEvent,
             subscriptionSwitchWideEvent,
@@ -894,6 +917,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             pkceGenerator,
             timeProvider,
             backgroundTokenRefresh,
+            crossProcessLock,
             subscriptionPurchaseWideEvent,
             tokenRefreshWideEvent,
             subscriptionSwitchWideEvent,
@@ -937,6 +961,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             pkceGenerator,
             timeProvider,
             backgroundTokenRefresh,
+            crossProcessLock,
             subscriptionPurchaseWideEvent,
             tokenRefreshWideEvent,
             subscriptionSwitchWideEvent,
@@ -973,6 +998,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             pkceGenerator,
             timeProvider,
             backgroundTokenRefresh,
+            crossProcessLock,
             subscriptionPurchaseWideEvent,
             tokenRefreshWideEvent,
             subscriptionSwitchWideEvent,
@@ -1112,6 +1138,143 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     }
 
     @Test
+    @SuppressLint("DenyListedApi")
+    fun whenSerializeTokenRefreshDisabledThenRefreshDoesNotUseCrossProcessLock() = runTest {
+        assumeTrue(authApiV2Enabled)
+
+        subscriptionsFeature.serializeTokenRefresh().setRawStoredState(State(false))
+        givenUserIsSignedIn()
+        givenAccessTokenIsExpired()
+        givenV2AccessTokenRefreshSucceeds(newAccessToken = "new access token")
+
+        val result = subscriptionsManager.getAccessToken()
+
+        assertTrue(result is AccessTokenResult.Success)
+        verifyNoInteractions(crossProcessLock)
+        verify(tokenRefreshWideEvent).onStart(any(), eq(false))
+        verify(tokenRefreshWideEvent, never()).onCrossProcessLockAcquired(any())
+    }
+
+    @Test
+    fun whenRefreshSucceedsThenCrossProcessLockIsReleased() = runTest {
+        assumeTrue(authApiV2Enabled)
+
+        val lockHandle = FakeLockHandle()
+        val acquireResult = Result.success(lockHandle)
+        whenever(crossProcessLock.acquire(any(), any())).thenReturn(acquireResult)
+        givenUserIsSignedIn()
+        givenAccessTokenIsExpired()
+        givenV2AccessTokenRefreshSucceeds(newAccessToken = "new access token")
+
+        val result = subscriptionsManager.getAccessToken()
+
+        assertTrue(result is AccessTokenResult.Success)
+        assertTrue(lockHandle.closed)
+        verify(tokenRefreshWideEvent).onCrossProcessLockAcquired(acquireResult)
+    }
+
+    @Test
+    fun whenRefreshFailsThenCrossProcessLockIsReleased() = runTest {
+        assumeTrue(authApiV2Enabled)
+
+        val lockHandle = FakeLockHandle()
+        whenever(crossProcessLock.acquire(any(), any())).thenReturn(Result.success(lockHandle))
+        givenUserIsSignedIn()
+        givenAccessTokenIsExpired()
+        givenV2AccessTokenRefreshFails()
+
+        val result = subscriptionsManager.getAccessToken()
+
+        assertTrue(result is AccessTokenResult.Failure)
+        assertTrue(lockHandle.closed)
+    }
+
+    @Test
+    fun whenCrossProcessLockAcquisitionTimesOutThenRefreshStillRuns() = runTest {
+        assumeTrue(authApiV2Enabled)
+
+        val acquireResult = Result.failure<Closeable>(timeoutCancellationException())
+        whenever(crossProcessLock.acquire(any(), any())).thenReturn(acquireResult)
+        givenUserIsSignedIn()
+        givenAccessTokenIsExpired()
+        givenV2AccessTokenRefreshSucceeds(newAccessToken = "new access token")
+
+        val result = subscriptionsManager.getAccessToken()
+
+        assertTrue(result is AccessTokenResult.Success)
+        verify(tokenRefreshWideEvent).onCrossProcessLockAcquired(acquireResult)
+    }
+
+    @Test
+    fun whenCrossProcessLockAcquisitionFailsThenRefreshStillRuns() = runTest {
+        assumeTrue(authApiV2Enabled)
+
+        val acquireResult = Result.failure<Closeable>(IOException())
+        whenever(crossProcessLock.acquire(any(), any())).thenReturn(acquireResult)
+        givenUserIsSignedIn()
+        givenAccessTokenIsExpired()
+        givenV2AccessTokenRefreshSucceeds(newAccessToken = "new access token")
+
+        val result = subscriptionsManager.getAccessToken()
+
+        assertTrue(result is AccessTokenResult.Success)
+        verify(tokenRefreshWideEvent).onCrossProcessLockAcquired(acquireResult)
+    }
+
+    @Test
+    fun whenTokenRefreshesRunConcurrentlyThenTheyDoNotOverlap() = runTest {
+        assumeTrue(authApiV2Enabled)
+
+        givenUserIsSignedIn()
+        givenValidateV2TokensSucceeds()
+        whenever(authClient.getJwks()).thenReturn("fake jwks")
+
+        var concurrentCalls = 0
+        var maxConcurrentCalls = 0
+        whenever(authClient.getTokens(any())).doSuspendableAnswer {
+            concurrentCalls++
+            maxConcurrentCalls = maxOf(maxConcurrentCalls, concurrentCalls)
+            yield()
+            concurrentCalls--
+            TokenPair(FAKE_ACCESS_TOKEN_V2, FAKE_REFRESH_TOKEN_V2)
+        }
+
+        listOf(
+            launch { subscriptionsManager.refreshAccessToken() },
+            launch { subscriptionsManager.refreshAccessToken() },
+        ).joinAll()
+
+        assertEquals(1, maxConcurrentCalls)
+    }
+
+    @Test
+    fun whenCallerIsCancelledMidRefreshThenRefreshCompletes() = runTest {
+        assumeTrue(authApiV2Enabled)
+
+        givenUserIsSignedIn()
+        givenValidateV2TokensSucceeds()
+        whenever(authClient.getJwks()).thenReturn("fake jwks")
+
+        val tokenRequestStarted = CompletableDeferred<Unit>()
+        val tokenRequestBlocker = CompletableDeferred<Unit>()
+        whenever(authClient.getTokens(any())).doSuspendableAnswer {
+            tokenRequestStarted.complete(Unit)
+            tokenRequestBlocker.await()
+            TokenPair("refreshed access token", "refreshed refresh token")
+        }
+
+        val job = launch { subscriptionsManager.refreshAccessToken() }
+        tokenRequestStarted.await()
+        job.cancel()
+        tokenRequestBlocker.complete(Unit)
+        job.join()
+        advanceUntilIdle() // the refresh continues in the app scope after the caller is cancelled
+
+        assertEquals("refreshed access token", authRepository.getAccessTokenV2()?.jwt)
+        verify(tokenRefreshWideEvent).onSuccess()
+    }
+
+    @Test
     fun whenGetAccessTokenIfSignedInWithV1ThenExchangesTokenForV2AndReturnsTrue() = runTest {
         assumeTrue(authApiV2Enabled)
 
@@ -1245,6 +1408,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             pkceGenerator,
             timeProvider,
             backgroundTokenRefresh,
+            crossProcessLock,
             subscriptionPurchaseWideEvent,
             tokenRefreshWideEvent,
             subscriptionSwitchWideEvent,
@@ -1297,6 +1461,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             pkceGenerator,
             timeProvider,
             backgroundTokenRefresh,
+            crossProcessLock,
             subscriptionPurchaseWideEvent,
             tokenRefreshWideEvent,
             subscriptionSwitchWideEvent,
@@ -1652,6 +1817,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             pkceGenerator,
             timeProvider,
             backgroundTokenRefresh,
+            crossProcessLock,
             subscriptionPurchaseWideEvent,
             tokenRefreshWideEvent,
             subscriptionSwitchWideEvent,
@@ -2543,6 +2709,13 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         override fun localDateTimeNow(): LocalDateTime = throw UnsupportedOperationException()
     }
 
+    // TimeoutCancellationException has an internal constructor, so a real instance is obtained via withTimeout
+    private suspend fun timeoutCancellationException(): TimeoutCancellationException = try {
+        withTimeout(1) { awaitCancellation() }
+    } catch (e: TimeoutCancellationException) {
+        e
+    }
+
     private companion object {
         @JvmStatic
         @Parameterized.Parameters(name = "authApiV2Enabled={0}")
@@ -2550,5 +2723,12 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
 
         const val FAKE_ACCESS_TOKEN_V2 = "fake access token"
         const val FAKE_REFRESH_TOKEN_V2 = "fake refresh token"
+    }
+}
+
+private class FakeLockHandle : Closeable {
+    var closed = false
+    override fun close() {
+        closed = true
     }
 }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/auth2/RealCrossProcessLockTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/auth2/RealCrossProcessLockTest.kt
@@ -18,7 +18,14 @@ package com.duckduckgo.subscriptions.impl.auth2
 
 import android.content.Context
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.DispatcherProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -26,6 +33,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.io.Closeable
 import java.io.File
 import java.io.RandomAccessFile
 
@@ -112,5 +120,38 @@ class RealCrossProcessLockTest {
 
         handle.close()
         handle.close()
+    }
+
+    @Test
+    fun `when cancellation races successful acquisition then lock is released`() = runTest {
+        val ioDispatcher = StandardTestDispatcher(testScheduler)
+        val lock = RealCrossProcessLock(
+            context,
+            object : DispatcherProvider {
+                override fun computation(): CoroutineDispatcher = ioDispatcher
+                override fun io(): CoroutineDispatcher = ioDispatcher
+                override fun main(): CoroutineDispatcher = ioDispatcher
+                override fun unconfined(): CoroutineDispatcher = ioDispatcher
+            },
+        )
+
+        // UNDISPATCHED runs acquire() up to the withContext(io) dispatch, queueing lock acquisition;
+        // the canceller is queued behind it, so cancellation lands after the lock is acquired but
+        // before the result crosses the withContext boundary, where prompt cancellation discards it.
+        var result: Result<Closeable>? = null
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            result = lock.acquire("test_key")
+        }
+        launch { job.cancel() }
+        testScheduler.runCurrent()
+
+        assertTrue(File(temporaryFolder.root, "test_key.lock").exists())
+        assertNull(result)
+        assertTrue(job.isCancelled)
+
+        // A leaked lock would make this same-JVM tryLock throw OverlappingFileLockException
+        RandomAccessFile(File(temporaryFolder.root, "test_key.lock"), "rw").channel.use { channel ->
+            assertNotNull(runCatching { channel.tryLock() }.getOrNull())
+        }
     }
 }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/auth2/RealCrossProcessLockTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/auth2/RealCrossProcessLockTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.auth2
+
+import android.content.Context
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.io.File
+import java.io.RandomAccessFile
+
+class RealCrossProcessLockTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val context: Context = mock()
+    private lateinit var crossProcessLock: RealCrossProcessLock
+
+    @Before
+    fun setup() {
+        whenever(context.filesDir).thenReturn(temporaryFolder.root)
+        crossProcessLock = RealCrossProcessLock(context, coroutineRule.testDispatcherProvider)
+    }
+
+    @Test
+    fun `when uncontended then lock is acquired and lock file is created`() = runTest {
+        val result = crossProcessLock.acquire("test_key")
+
+        assertTrue(result.isSuccess)
+        assertTrue(File(temporaryFolder.root, "test_key.lock").exists())
+
+        result.getOrThrow().close()
+    }
+
+    @Test
+    fun `when lock is released then it can be acquired again`() = runTest {
+        val first = crossProcessLock.acquire("test_key")
+        assertTrue(first.isSuccess)
+        first.getOrThrow().close()
+
+        val second = crossProcessLock.acquire("test_key")
+        assertTrue(second.isSuccess)
+        second.getOrThrow().close()
+    }
+
+    @Test
+    fun `when different keys then distinct lock files are used and both can be held`() = runTest {
+        val first = crossProcessLock.acquire("key_a")
+        val second = crossProcessLock.acquire("key_b")
+
+        assertTrue(first.isSuccess)
+        assertTrue(second.isSuccess)
+        assertTrue(File(temporaryFolder.root, "key_a.lock").exists())
+        assertTrue(File(temporaryFolder.root, "key_b.lock").exists())
+
+        first.getOrThrow().close()
+        second.getOrThrow().close()
+    }
+
+    @Test
+    fun `when lock file is already locked in the same JVM then returns error`() = runTest {
+        // Same-JVM overlap makes tryLock() throw OverlappingFileLockException, exercising the broad catch;
+        // the cross-process tryLock-returns-null path can't be simulated in a single JVM.
+        val externalChannel = RandomAccessFile(File(temporaryFolder.root, "test_key.lock"), "rw").channel
+        val externalLock = externalChannel.lock()
+        try {
+            val result = crossProcessLock.acquire("test_key")
+            assertTrue(result.isFailure)
+        } finally {
+            externalLock.release()
+            externalChannel.close()
+        }
+    }
+
+    @Test
+    fun `when lock file cannot be created then returns error`() = runTest {
+        whenever(context.filesDir).thenReturn(File(temporaryFolder.root, "does-not-exist"))
+
+        val result = crossProcessLock.acquire("test_key")
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `when handle is closed twice then second close is a no-op`() = runTest {
+        val result = crossProcessLock.acquire("test_key")
+        val handle = result.getOrThrow()
+
+        handle.close()
+        handle.close()
+    }
+}

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEventTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEventTest.kt
@@ -26,12 +26,18 @@ import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.*
+import java.io.Closeable
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class AuthTokenRefreshWideEventTest {
     @get:Rule
@@ -67,7 +73,7 @@ class AuthTokenRefreshWideEventTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(123L))
 
-        authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
 
         verify(wideEventClient).flowStart(
             name = "auth-token-refresh",
@@ -77,11 +83,42 @@ class AuthTokenRefreshWideEventTest {
                 "netp_is_enabled" to "false",
                 "netp_is_running" to "false",
                 "process_name" to "main",
+                "serialization_enabled" to "true",
             ),
             cleanupPolicy = CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
         )
 
         verify(wideEventClient).intervalStart(123L, "total_duration_ms_bucketed", null)
+        verify(wideEventClient).intervalStart(
+            wideEventId = 123L,
+            key = "token_refresh_lock_wait_ms_bucketed",
+            timeout = null,
+            buckets = setOf(100.milliseconds, 500.milliseconds, 1.seconds, 3.seconds, 10.seconds, 30.seconds, 60.seconds),
+        )
+    }
+
+    @Test
+    fun `onStart with serialization disabled does not start lock wait interval`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .thenReturn(Result.success(123L))
+
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = false)
+
+        verify(wideEventClient).flowStart(
+            name = "auth-token-refresh",
+            flowEntryPoint = null,
+            metadata = mapOf(
+                "subscription_status" to SubscriptionStatus.UNKNOWN.statusName,
+                "netp_is_enabled" to "false",
+                "netp_is_running" to "false",
+                "process_name" to "main",
+                "serialization_enabled" to "false",
+            ),
+            cleanupPolicy = CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
+        )
+
+        verify(wideEventClient).intervalStart(123L, "total_duration_ms_bucketed", null)
+        verify(wideEventClient, never()).intervalStart(any(), eq("token_refresh_lock_wait_ms_bucketed"), anyOrNull(), anyOrNull())
     }
 
     @Test
@@ -89,22 +126,56 @@ class AuthTokenRefreshWideEventTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(1L))
 
-        authWideEvent.onStart(SubscriptionStatus.WAITING)
+        authWideEvent.onStart(SubscriptionStatus.WAITING, serializationEnabled = true)
 
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(2L))
 
-        authWideEvent.onStart(SubscriptionStatus.AUTO_RENEWABLE)
+        authWideEvent.onStart(SubscriptionStatus.AUTO_RENEWABLE, serializationEnabled = true)
 
         verify(wideEventClient).intervalEnd(1L, "total_duration_ms_bucketed")
         verify(wideEventClient).flowFinish(1L, FlowStatus.Unknown, emptyMap())
     }
 
     @Test
+    fun `onCrossProcessLockAcquired ends lock wait interval and sends successful step with outcome`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .thenReturn(Result.success(21L))
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
+
+        authWideEvent.onCrossProcessLockAcquired(Result.success(Closeable {}))
+
+        verify(wideEventClient).intervalEnd(21L, "token_refresh_lock_wait_ms_bucketed")
+        verify(wideEventClient).flowStep(21L, "lock_acquire", true, mapOf("lock_outcome" to "acquired"))
+    }
+
+    @Test
+    fun `onCrossProcessLockAcquired with fallback timeout outcome sends failed step`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .thenReturn(Result.success(23L))
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
+
+        authWideEvent.onCrossProcessLockAcquired(Result.failure(timeoutCancellationException()))
+
+        verify(wideEventClient).flowStep(23L, "lock_acquire", false, mapOf("lock_outcome" to "timeout"))
+    }
+
+    @Test
+    fun `onCrossProcessLockAcquired with fallback error outcome sends failed step`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .thenReturn(Result.success(24L))
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
+
+        authWideEvent.onCrossProcessLockAcquired(Result.failure(RuntimeException()))
+
+        verify(wideEventClient).flowStep(24L, "lock_acquire", false, mapOf("lock_outcome" to "error"))
+    }
+
+    @Test
     fun `onTokenRead sends step and starts jwks interval`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(10L))
-        authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
 
         authWideEvent.onTokenRead()
 
@@ -116,7 +187,7 @@ class AuthTokenRefreshWideEventTest {
     fun `onJwksFetched ends jwks interval and starts tokens interval`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(11L))
-        authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
 
         authWideEvent.onJwksFetched()
 
@@ -129,7 +200,7 @@ class AuthTokenRefreshWideEventTest {
     fun `onTokensFetched ends tokens interval and sends step`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(12L))
-        authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
 
         authWideEvent.onTokensFetched()
 
@@ -141,7 +212,7 @@ class AuthTokenRefreshWideEventTest {
     fun `onTokensValidated sends validation step`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(13L))
-        authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
 
         authWideEvent.onTokensValidated()
 
@@ -152,7 +223,7 @@ class AuthTokenRefreshWideEventTest {
     fun `onBackendErrorResponse sends token_request failure with metadata`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(14L))
-        authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
 
         authWideEvent.onBackendErrorResponse("backend-err")
 
@@ -168,7 +239,7 @@ class AuthTokenRefreshWideEventTest {
     fun `onPlayLoginSuccess sends step`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(15L))
-        authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
 
         authWideEvent.onPlayLoginSuccess()
 
@@ -179,7 +250,7 @@ class AuthTokenRefreshWideEventTest {
     fun `onPlayLoginFailure sends failure step, finishes flow and clears id`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(16L))
-        authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
 
         val ex = IllegalStateException("boom")
         authWideEvent.onPlayLoginFailure(signedOut = true, refreshException = ex, loginError = "sign-in-required")
@@ -204,7 +275,7 @@ class AuthTokenRefreshWideEventTest {
     fun `onUnknownAccountError cancels flow and clears id`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(17L))
-        authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
 
         authWideEvent.onUnknownAccountError()
 
@@ -220,7 +291,7 @@ class AuthTokenRefreshWideEventTest {
     fun `onSuccess finishes with Success and clears id`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(18L))
-        authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
 
         authWideEvent.onSuccess()
 
@@ -236,7 +307,7 @@ class AuthTokenRefreshWideEventTest {
     fun `onFailure finishes with Failure and clears id`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(19L))
-        authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
 
         authWideEvent.onFailure(IllegalArgumentException("nope"))
 
@@ -244,12 +315,19 @@ class AuthTokenRefreshWideEventTest {
         verify(wideEventClient).flowFinish(19L, FlowStatus.Failure("IllegalArgumentException"), emptyMap())
     }
 
+    // TimeoutCancellationException has an internal constructor, so a real instance is obtained via withTimeout
+    private suspend fun timeoutCancellationException(): TimeoutCancellationException = try {
+        withTimeout(1) { awaitCancellation() }
+    } catch (e: TimeoutCancellationException) {
+        e
+    }
+
     @SuppressLint("DenyListedApi")
     @Test
     fun `feature disabled results in no interactions`() = runTest {
         subscriptionsFeature.sendAuthTokenRefreshWideEvent().setRawStoredState(Toggle.State(false))
 
-        authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
         authWideEvent.onTokensFetched()
 
         verifyNoInteractions(wideEventClient)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207679781959993/task/1217412552838675?focus=true 
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1202552961248957/task/1211659787702791?focus=true
API Proposals URL(s) (if applicable):

### Description

Auth token refresh can run concurrently from different processes (e.g. the main process refreshing subscription data while the :vpn process requests a token during connection setup), which can have negative impact on reliability. This PR serializes the token refresh operation so it never executes in parallel, including across processes.

### Steps to test this PR

_Subscriptions smoke test_
- [x] Build the app with this [patch](https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true)
- [x] Purchase test subscription
- [x] Enable VPN
- [x] Close the app
- [x] Wait 4 minutes (staging access token expires in 4 minutes)
- [x] Launch the app again
- [x] Turn VPN off / on
- [x] Add email to the subscription
- [x] Go to subscription settings
- [x] Switch to a different plan or billing cycle
- [x] Verify VPN still works

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth token refresh concurrency and cancellation semantics across main and VPN processes; incorrect locking or toggle rollout could affect VPN/subscription reliability, though failures fall back to running refresh without the lock.
> 
> **Overview**
> **Auth token refresh** is no longer allowed to run in parallel when the `serializeTokenRefresh` feature toggle is on (default **INTERNAL**). The refresh body moves into `doRefreshAccessToken()`, while `refreshAccessToken()` gates on the toggle and, when enabled, runs work on the app `coroutineScope` behind an in-process `Mutex` and a new **`CrossProcessLock`** (file lock on `auth_token_refresh.lock` in `filesDir`).
> 
> If lock acquisition times out or fails, refresh still proceeds (previous fallback behavior). Callers that cancel mid-refresh no longer abort the in-flight refresh; it continues in app scope until tokens are saved.
> 
> **Auth token refresh wide events** now record whether serialization was enabled, lock wait buckets, and a `lock_acquire` step with outcomes `acquired` / `timeout` / `error`.
> 
> Tests cover the lock implementation, manager serialization, lock release on success/failure, and cancellation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83a29d567bc1609f2e18309048b20937fc0e17e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->