### PR TITLE
Contextual/DuckAi: Add new chat / ask about page menu

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -223,39 +223,6 @@
 
     <issue
         id="NoImplImportsInAppModule"
-        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.contextual.DuckChatContextualFragment&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
-        errorLine1="import com.duckduckgo.duckchat.impl.contextual.DuckChatContextualFragment"
-        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt"
-            line="343"
-            column="1"/>
-    </issue>
-
-    <issue
-        id="NoImplImportsInAppModule"
-        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.contextual.DuckChatContextualFragment.Companion.KEY_DUCK_AI_CONTEXTUAL_RESULT&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
-        errorLine1="import com.duckduckgo.duckchat.impl.contextual.DuckChatContextualFragment.Companion.KEY_DUCK_AI_CONTEXTUAL_RESULT"
-        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt"
-            line="344"
-            column="1"/>
-    </issue>
-
-    <issue
-        id="NoImplImportsInAppModule"
-        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.contextual.DuckChatContextualFragment.Companion.KEY_DUCK_AI_URL&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
-        errorLine1="import com.duckduckgo.duckchat.impl.contextual.DuckChatContextualFragment.Companion.KEY_DUCK_AI_URL"
-        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt"
-            line="345"
-            column="1"/>
-    </issue>
-
-    <issue
-        id="NoImplImportsInAppModule"
         message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.contextual.DuckChatContextualSharedViewModel&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
         errorLine1="import com.duckduckgo.duckchat.impl.contextual.DuckChatContextualSharedViewModel"
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -337,12 +337,10 @@ import com.duckduckgo.downloads.api.DownloadsFileActions
 import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatContextual
 import com.duckduckgo.duckchat.api.DuckChatHistoryNoParams
 import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InteractionLock
-import com.duckduckgo.duckchat.impl.contextual.DuckChatContextualFragment
-import com.duckduckgo.duckchat.impl.contextual.DuckChatContextualFragment.Companion.KEY_DUCK_AI_CONTEXTUAL_RESULT
-import com.duckduckgo.duckchat.impl.contextual.DuckChatContextualFragment.Companion.KEY_DUCK_AI_URL
 import com.duckduckgo.duckchat.impl.contextual.DuckChatContextualSharedViewModel
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.js.messaging.api.JsCallbackData
@@ -427,7 +425,8 @@ class BrowserTabFragment :
     EmailProtectionUserPromptListener {
     private val supervisorJob = SupervisorJob()
 
-    private var duckAiContextualFragment: DuckChatContextualFragment? = null
+    private var duckAiContextualFragment: Fragment? = null
+    private var duckChatButtonAnchor: View? = null
     private var contextualSheetLayoutChangeListener: View.OnLayoutChangeListener? = null
     private var contextualSheetBottomSheetCallback: BottomSheetBehavior.BottomSheetCallback? = null
 
@@ -649,6 +648,9 @@ class BrowserTabFragment :
 
     @Inject
     lateinit var duckChat: DuckChat
+
+    @Inject
+    lateinit var duckChatContextual: DuckChatContextual
 
     @Inject
     lateinit var newAddressBarPickerManager: NewAddressBarPickerManager
@@ -1476,9 +1478,6 @@ class BrowserTabFragment :
                     launchFilePicker(callback, mimeTypes)
                 },
                 restoreOmnibarAutocomplete = { forQuery -> restoreOmnibarAutocomplete(forQuery) },
-                onContextualSheetRequested = {
-                    viewModel.openDuckAIContextualMode()
-                },
             ),
         )
     }
@@ -2063,6 +2062,7 @@ class BrowserTabFragment :
             BottomSheetBehavior.from(binding.duckAiContextualFragmentContainer).removeBottomSheetCallback(it)
         }
         contextualSheetBottomSheetCallback = null
+        duckChatButtonAnchor = null
         browserNavigationBarIntegration.onDestroyView()
         renderer.removeBrandDesignFitListener()
         super.onDestroyView()
@@ -3052,7 +3052,14 @@ class BrowserTabFragment :
                 sharedContextualViewModel.onMainBrowserPageFinished(it.url, androidBrowserConfigFeature.storePageContext().isEnabled())
             }
 
-            is Command.ShowDuckAIContextualMode -> showDuckChatContextualSheet(it.tabId)
+            is Command.ShowDuckAIContextualMode -> {
+                val tabId = it.tabId
+                val anchor = duckChatButtonAnchor
+                duckChatButtonAnchor = null
+                viewLifecycleOwner.lifecycleScope.launch(dispatchers.main()) {
+                    duckChatContextual.launch(tabId, anchor) { showDuckChatContextualSheet(tabId) }
+                }
+            }
             is Command.StartAddressBarTrackersAnimation -> {
                 omnibar.startTrackersAnimation(it.trackerEntities)
             }
@@ -3906,7 +3913,8 @@ class BrowserTabFragment :
                     onOmnibarVoiceSearchPressed()
                 }
 
-                override fun onDuckChatButtonPressed() {
+                override fun onDuckChatButtonPressed(anchor: View) {
+                    duckChatButtonAnchor = anchor
                     val hasFocus = omnibar.omnibarTextInput.hasFocus()
                     val isNtp = omnibar.viewMode == ViewMode.NewTab
                     onOmnibarDuckChatPressed(query = omnibar.getText(), hasFocus = hasFocus, isNtp = isNtp)
@@ -3947,10 +3955,7 @@ class BrowserTabFragment :
 
     private fun createNewContextualFragment(tabId: String) {
         logcat { "Duck.ai Contextual: createNewContextualFragment" }
-        val fragment = DuckChatContextualFragment()
-        val args = Bundle()
-        args.putString(DuckChatContextualFragment.KEY_DUCK_AI_CONTEXTUAL_TAB_ID, tabId)
-        fragment.arguments = args
+        val fragment = duckChatContextual.createSheet(tabId)
 
         duckAiContextualFragment = fragment
         val transaction = childFragmentManager.beginTransaction()
@@ -3961,7 +3966,7 @@ class BrowserTabFragment :
         bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
     }
 
-    private fun openExistingContextualFragment(fragment: DuckChatContextualFragment) {
+    private fun openExistingContextualFragment(fragment: Fragment) {
         logcat { "Duck.ai Contextual: openExistingContextualFragment" }
         val transaction = childFragmentManager.beginTransaction()
         transaction.show(fragment)
@@ -3971,8 +3976,8 @@ class BrowserTabFragment :
     }
 
     private fun reactToDuckChatContextualSheetResult() {
-        childFragmentManager.setFragmentResultListener(KEY_DUCK_AI_CONTEXTUAL_RESULT, viewLifecycleOwner) { _, bundle ->
-            val contextualChatUrl = bundle.getString(KEY_DUCK_AI_URL)
+        childFragmentManager.setFragmentResultListener(DuckChatContextual.RESULT_KEY, viewLifecycleOwner) { _, bundle ->
+            val contextualChatUrl = bundle.getString(DuckChatContextual.RESULT_URL)
             contextualChatUrl?.let {
                 viewModel.openLinkInNewTab(contextualChatUrl.toUri())
                 removeDuckChatContextualSheet()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -5638,10 +5638,6 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    fun openDuckAIContextualMode() {
-        command.value = Command.ShowDuckAIContextualMode(tabId)
-    }
-
     fun onDuckChatOmnibarButtonClicked(
         query: String?,
         hasFocus: Boolean,

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -109,7 +109,6 @@ class NativeInputCallbacks(
      * the caller uses the return value to decide whether to re-show the suggestions list.
      */
     val restoreOmnibarAutocomplete: (forQuery: String) -> Boolean = { _ -> false },
-    val onContextualSheetRequested: () -> Unit = {},
 )
 
 interface NativeInputManager {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -81,7 +81,7 @@ class Omnibar(
 
         fun onVoiceSearchPressed()
 
-        fun onDuckChatButtonPressed()
+        fun onDuckChatButtonPressed(anchor: View)
 
         fun onBackButtonPressed()
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -592,7 +592,7 @@ class OmnibarLayout @JvmOverloads constructor(
         }
         aiChatMenu?.setOnClickListener {
             viewModel.onDuckChatButtonPressed()
-            omnibarItemPressedListener?.onDuckChatButtonPressed()
+            omnibarItemPressedListener?.onDuckChatButtonPressed(it)
         }
         shieldIcon.setOnClickListener {
             if (isAttachedToWindow) {

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -10778,14 +10778,6 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenOpenDuckAIContextualModeThenShowDuckAIContextualModeCommandSent() = runTest {
-        testee.openDuckAIContextualMode()
-
-        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
-        assertTrue(commandCaptor.lastValue is Command.ShowDuckAIContextualMode)
-    }
-
-    @Test
     fun whenOnDuckChatOmnibarButtonClickedAndContextualModeEnabledAndNTPThenContextualNotCalled() = runTest {
         val duckAIUrl = "https://duckduckgo.com/?q=test"
 

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatContextual.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatContextual.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.api
+
+import android.view.View
+import androidx.fragment.app.Fragment
+
+/**
+ * The browser's contextual Duck.ai surface. The host reports the entry-point tap and embeds the
+ * sheet fragment it is handed; everything else (the entry menu, the redesign decision, opening a new
+ * chat tab, and the sheet implementation) lives in the Duck.ai feature module.
+ */
+interface DuckChatContextual {
+
+    /**
+     * Launches the contextual Duck.ai flow. Depending on config this either shows the entry menu
+     * (anchored to [anchor]) or opens the contextual sheet directly.
+     * [sourceTabId] is the host tab the flow was launched from; a new chat tab is anchored to it so
+     * closing that tab returns here rather than leaving an orphan tab.
+     * [onAskAboutPage] is invoked (on the launching host) when the embedded contextual
+     * sheet should be shown. A null [anchor] (no entry-point view, e.g. from native input) always
+     * opens the sheet directly.
+     */
+    suspend fun launch(
+        sourceTabId: String,
+        anchor: View?,
+        onAskAboutPage: () -> Unit,
+    )
+
+    /**
+     * Creates the contextual sheet fragment for [tabId]. The host embeds it in its own bottom-sheet
+     * container and drives its visibility.
+     *
+     * The fragment reports the "open in full-screen Duck.ai" outcome back to the host via the Fragment
+     * Result API, keyed by [RESULT_KEY] with the URL under [RESULT_URL].
+     */
+    fun createSheet(tabId: String): Fragment
+
+    companion object {
+        const val RESULT_KEY: String = "KEY_DUCK_AI_CONTEXTUAL_RESULT"
+        const val RESULT_URL: String = "KEY_DUCK_AI_URL"
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -252,6 +252,12 @@ interface DuckChatInternal : DuckChat {
     fun isDuckChatContextualModeEnabled(): Boolean
 
     /**
+     * Returns whether the redesigned Duck.ai contextual entry (anchored menu) is enabled. Only
+     * meaningful when contextual mode is also enabled.
+     */
+    fun isContextualSheetRedesignEnabled(): Boolean
+
+    /**
      * Checks whether DuckChat is enabled based on remote config flag.
      */
     fun isDuckChatFeatureEnabled(): Boolean
@@ -486,6 +492,7 @@ class RealDuckChat @Inject constructor(
     private var keepSessionAliveInMinutes: Int = DEFAULT_SESSION_ALIVE
     private var clearChatHistory: Boolean = true
     private var isContextualModeEnabled: Boolean = false
+    private var contextualSheetRedesignEnabled: Boolean = false
     private var isAutomaticContextAttachmentEnabled: Boolean = false
     private var duckAiNativeStorage: Boolean = false
     private var areMultipleContentAttachmentsEnabled: Boolean = false
@@ -564,6 +571,8 @@ class RealDuckChat @Inject constructor(
     override fun isDuckChatFullScreenModeEnabled(): Boolean = isDuckChatFeatureEnabled
 
     override fun isDuckChatContextualModeEnabled(): Boolean = isContextualModeEnabled
+
+    override fun isContextualSheetRedesignEnabled(): Boolean = contextualSheetRedesignEnabled
 
     override fun isAutomaticContextAttachmentEnabled(): Boolean = isAutomaticContextAttachmentEnabled
     override fun isNativeStorageEnabled(): Boolean = duckAiNativeStorage
@@ -1026,6 +1035,8 @@ class RealDuckChat @Inject constructor(
 
             isContextualModeEnabled = showContextualMode && isContextualModeKillSwitch
             _showContextualMode.emit(isContextualModeEnabled)
+
+            contextualSheetRedesignEnabled = isContextualModeEnabled && duckChatFeature.contextualSheetRedesign().isEnabled()
 
             isAutomaticContextAttachmentEnabled = isContextualModeEnabled &&
                 duckChatFeature.automaticContextAttachment()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -85,6 +85,7 @@ import com.duckduckgo.downloads.api.DownloadConfirmationDialogListener
 import com.duckduckgo.downloads.api.DownloadStateListener
 import com.duckduckgo.downloads.api.DownloadsFileActions
 import com.duckduckgo.downloads.api.FileDownloader
+import com.duckduckgo.duckchat.api.DuckChatContextual
 import com.duckduckgo.duckchat.api.DuckChatHistoryNoParams
 import com.duckduckgo.duckchat.api.viewmodel.DuckChatSharedViewModel
 import com.duckduckgo.duckchat.impl.DuckChatInternal
@@ -740,10 +741,10 @@ class DuckChatContextualFragment :
                     is DuckChatContextualViewModel.Command.OpenFullscreenMode -> {
                         binding.root.viewTreeObserver.removeOnGlobalLayoutListener(keyboardVisibilityListener)
                         val result = Bundle().apply {
-                            putString(KEY_DUCK_AI_URL, command.url)
+                            putString(DuckChatContextual.RESULT_URL, command.url)
                         }
 
-                        setFragmentResult(KEY_DUCK_AI_CONTEXTUAL_RESULT, result)
+                        setFragmentResult(DuckChatContextual.RESULT_KEY, result)
                     }
 
                     is DuckChatContextualViewModel.Command.ChangeSheetState -> {
@@ -1319,8 +1320,6 @@ class DuckChatContextualFragment :
             "Mozilla/5.0 (Linux; Android 16) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/124.0.0.0 Mobile DuckDuckGo/5 Safari/537.36"
         const val REQUEST_CODE_CHOOSE_FILE = 100
 
-        const val KEY_DUCK_AI_URL: String = "KEY_DUCK_AI_URL"
-        const val KEY_DUCK_AI_CONTEXTUAL_RESULT: String = "KEY_DUCK_AI_CONTEXTUAL_RESULT"
         const val KEY_DUCK_AI_CONTEXTUAL_TAB_ID: String = "KEY_DUCK_AI_CONTEXTUAL_TAB_ID"
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual
+
+import android.app.Activity
+import android.content.ContextWrapper
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import androidx.fragment.app.Fragment
+import com.duckduckgo.app.tabs.BrowserNav
+import com.duckduckgo.common.ui.menu.PopupMenu
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckChatContextual
+import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+class RealDuckChatContextual @Inject constructor(
+    private val duckChatInternal: DuckChatInternal,
+    private val browserNav: BrowserNav,
+    private val contextualDataStore: DuckChatContextualDataStore,
+    private val sessionTimeoutProvider: DuckChatContextualSessionTimeoutProvider,
+    private val timeProvider: DuckChatContextualTimeProvider,
+) : DuckChatContextual {
+
+    override suspend fun launch(
+        sourceTabId: String,
+        anchor: View?,
+        onAskAboutPage: () -> Unit,
+    ) {
+        if (anchor == null || !duckChatInternal.isContextualSheetRedesignEnabled()) {
+            onAskAboutPage()
+            return
+        }
+        if (hasChatInProgress(sourceTabId)) {
+            // The sheet would reopen the existing chat for this tab, so skip the entry menu and open it directly.
+            onAskAboutPage()
+        } else {
+            showMenu(sourceTabId, anchor, onAskAboutPage)
+        }
+    }
+
+    private suspend fun hasChatInProgress(tabId: String): Boolean {
+        if (contextualDataStore.getTabChatUrl(tabId).isNullOrBlank()) return false
+        return shouldReuseStoredChatUrl(tabId)
+    }
+
+    private suspend fun shouldReuseStoredChatUrl(tabId: String): Boolean {
+        val lastClosedTimestamp = contextualDataStore.getTabClosedTimestamp(tabId) ?: return true
+        val timeoutMs = sessionTimeoutProvider.sessionTimeoutMillis()
+        if (timeoutMs <= 0) return false
+        return timeProvider.currentTimeMillis() - lastClosedTimestamp <= timeoutMs
+    }
+
+    override fun createSheet(tabId: String): Fragment {
+        return DuckChatContextualFragment().apply {
+            arguments = Bundle().apply {
+                putString(DuckChatContextualFragment.KEY_DUCK_AI_CONTEXTUAL_TAB_ID, tabId)
+            }
+        }
+    }
+
+    private fun showMenu(
+        sourceTabId: String,
+        anchor: View,
+        onAskAboutPage: () -> Unit,
+    ) {
+        val activity = anchor.activity() ?: return
+        val popup = PopupMenu(LayoutInflater.from(activity), R.layout.popup_contextual_chat_menu)
+        val content = popup.contentView
+        popup.onMenuItemClicked(content.findViewById(R.id.contextualChatMenuNewChat)) { openNewChatTab(activity, sourceTabId) }
+        popup.onMenuItemClicked(content.findViewById(R.id.contextualChatMenuAskAboutPage)) { onAskAboutPage() }
+        popup.showAnchoredView(activity, anchor.rootView, anchor)
+    }
+
+    private fun openNewChatTab(activity: Activity, sourceTabId: String) {
+        val url = duckChatInternal.getDuckChatUrl(query = "", autoPrompt = false)
+        browserNav.openInNewTab(activity, url, sourceTabId).also { activity.startActivity(it) }
+    }
+
+    private fun View.activity(): Activity? {
+        var context = context
+        while (context is ContextWrapper) {
+            if (context is Activity) return context
+            context = context.baseContext
+        }
+        return null
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -297,4 +297,11 @@ interface DuckChatFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun nativeInputAttachmentChanges(): Toggle
+
+    /**
+     * @return `true` when the redesigned Duck.ai contextual sheet UI and flow are enabled.
+     * If the remote feature is not present defaults to `false`.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun contextualSheetRedesign(): Toggle
 }

--- a/duckchat/duckchat-impl/src/main/res/drawable/ic_chevron_circle_down_24.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/ic_chevron_circle_down_24.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M7.22202,11.2827C6.92784,10.9911 6.92573,10.5162 7.21733,10.222C7.50892,9.92784 7.98379,9.92573 8.27798,10.2173L11.296,13.2088C11.6858,13.5951 12.3142,13.5951 12.704,13.2088L15.722,10.2173C16.0162,9.92573 16.4911,9.92784 16.7827,10.222C17.0743,10.5162 17.0722,10.9911 16.778,11.2827L13.7599,14.2741C12.7854,15.24 11.2146,15.24 10.2401,14.2741L7.22202,11.2827Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M12,2C6.47715,2 2,6.47715 2,12C2,17.5228 6.47715,22 12,22C17.5228,22 22,17.5228 22,12C22,6.47715 17.5228,2 12,2ZM3.5,12C3.5,7.30558 7.30558,3.5 12,3.5C16.6944,3.5 20.5,7.30558 20.5,12C20.5,16.6944 16.6944,20.5 12,20.5C7.30558,20.5 3.5,16.6944 3.5,12Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+</vector>

--- a/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chat_menu.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chat_menu.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/popup_menu_bg"
+    android:orientation="vertical">
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/contextualChatMenuNewChat"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_compose_24"
+        app:primaryText="@string/chatMenuPopupNewChat" />
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/contextualChatMenuAskAboutPage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_chevron_circle_down_24"
+        app:primaryText="@string/duckChatContextualAskAboutPage" />
+
+</LinearLayout>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextualTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextualTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual
+
+import android.view.View
+import com.duckduckgo.app.tabs.BrowserNav
+import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+class RealDuckChatContextualTest {
+
+    private val duckChatInternal: DuckChatInternal = mock()
+    private val browserNav: BrowserNav = mock()
+    private val contextualDataStore: DuckChatContextualDataStore = mock()
+    private val sessionTimeoutProvider: DuckChatContextualSessionTimeoutProvider = mock()
+    private val timeProvider: DuckChatContextualTimeProvider = mock()
+    private val anchor: View = mock()
+
+    private val testee = RealDuckChatContextual(
+        duckChatInternal,
+        browserNav,
+        contextualDataStore,
+        sessionTimeoutProvider,
+        timeProvider,
+    )
+
+    @Test
+    fun whenRedesignDisabledThenLaunchedAndDoesNotOpenNewTab() = runTest {
+        whenever(duckChatInternal.isContextualSheetRedesignEnabled()).thenReturn(false)
+        var askAboutPageCount = 0
+
+        testee.launch("tabId", anchor) { askAboutPageCount++ }
+
+        assertEquals(1, askAboutPageCount)
+        verifyNoInteractions(browserNav)
+    }
+
+    @Test
+    fun whenAnchorNullThenAskAboutPageInvokedDirectly() = runTest {
+        whenever(duckChatInternal.isContextualSheetRedesignEnabled()).thenReturn(true)
+        var askAboutPageCount = 0
+
+        testee.launch("tabId", anchor = null) { askAboutPageCount++ }
+
+        assertEquals(1, askAboutPageCount)
+        verifyNoInteractions(browserNav)
+    }
+
+    @Test
+    fun whenChatInProgressThenAskAboutPageInvokedWithoutShowingMenu() = runTest {
+        whenever(duckChatInternal.isContextualSheetRedesignEnabled()).thenReturn(true)
+        whenever(contextualDataStore.getTabChatUrl("tabId")).thenReturn("https://duckduckgo.com/?chatId=123")
+        whenever(contextualDataStore.getTabClosedTimestamp("tabId")).thenReturn(null)
+        var askAboutPageCount = 0
+
+        testee.launch("tabId", anchor) { askAboutPageCount++ }
+
+        assertEquals(1, askAboutPageCount)
+    }
+
+    @Test
+    fun whenStoredChatSessionExpiredThenTreatedAsNoChatInProgress() = runTest {
+        whenever(duckChatInternal.isContextualSheetRedesignEnabled()).thenReturn(true)
+        whenever(contextualDataStore.getTabChatUrl("tabId")).thenReturn("https://duckduckgo.com/?chatId=123")
+        whenever(contextualDataStore.getTabClosedTimestamp("tabId")).thenReturn(0L)
+        whenever(sessionTimeoutProvider.sessionTimeoutMillis()).thenReturn(1L)
+        whenever(timeProvider.currentTimeMillis()).thenReturn(1_000L)
+        var askAboutPageCount = 0
+
+        testee.launch("tabId", anchor) { askAboutPageCount++ }
+
+        // Session expired: the menu path is taken instead of opening the chat directly.
+        assertEquals(0, askAboutPageCount)
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -189,6 +189,8 @@ class FakeDuckChatInternal(
 
     override fun isDuckChatContextualModeEnabled(): Boolean = false
 
+    override fun isContextualSheetRedesignEnabled(): Boolean = false
+
     override fun isDuckChatFeatureEnabled(): Boolean = true
 
     override fun isChatSyncFeatureEnabled(): Boolean = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215757703816628?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1217412347880089
API Proposals URL(s) (if applicable): https://app.asana.com/1/137249556945/project/1212087397361015/task/1217417214101845

### Description
 - Adds the FF for the redesign `contextualSheetRedesign` that is OFF by default for now.
 - See: https://github.com/duckduckgo/Android/pull/9473
 - See: https://github.com/duckduckgo/Android/pull/9474

### Steps to test this PR
Testing to done on top most stack



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Duck Chat entry UX and tab navigation for contextual mode behind a new flag, but defaults off and keeps sheet behavior on the existing path when redesign is disabled.
> 
> **Overview**
> Introduces a **`DuckChatContextual`** API so the browser no longer depends on duckchat-impl for the contextual sheet and entry flow. **`BrowserTabFragment`** now injects that API, passes the omnibar Duck Chat **anchor view** on button press, and on **`ShowDuckAIContextualMode`** calls **`launch(tabId, anchor)`** before embedding a sheet from **`createSheet`**. Fragment results use **`DuckChatContextual.RESULT_KEY` / `RESULT_URL`** instead of impl constants.
> 
> **`RealDuckChatContextual`** implements the redesign: when **`contextualSheetRedesign`** is on and an anchor exists, it shows a popup (**New chat** / **Ask about page**); otherwise it invokes **`onAskAboutPage`** directly (including null anchor). An in-progress tab chat within the session timeout skips the menu and opens the sheet. New chat opens via **`BrowserNav`** anchored to the source tab.
> 
> Adds remote flag **`contextualSheetRedesign`** (default **false**), **`isContextualSheetRedesignEnabled()`** on **`DuckChatInternal`**, menu layout and icon, and unit tests for **`launch`** branching. Removes **`openDuckAIContextualMode`** and the native-input **`onContextualSheetRequested`** callback; lint baseline drops related impl-import violations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0263ae2a804a4d6024f62e7aca1fe14f9e19eb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->