### PR TITLE
Contextual/DuckAi: Integrate the new menu 

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -252,6 +252,12 @@ interface DuckChatInternal : DuckChat {
     fun isDuckChatContextualModeEnabled(): Boolean
 
     /**
+     * Returns whether the redesigned Duck.ai contextual entry (anchored menu) is enabled. Only
+     * meaningful when contextual mode is also enabled.
+     */
+    fun isContextualSheetRedesignEnabled(): Boolean
+
+    /**
      * Checks whether DuckChat is enabled based on remote config flag.
      */
     fun isDuckChatFeatureEnabled(): Boolean
@@ -486,6 +492,7 @@ class RealDuckChat @Inject constructor(
     private var keepSessionAliveInMinutes: Int = DEFAULT_SESSION_ALIVE
     private var clearChatHistory: Boolean = true
     private var isContextualModeEnabled: Boolean = false
+    private var contextualSheetRedesignEnabled: Boolean = false
     private var isAutomaticContextAttachmentEnabled: Boolean = false
     private var duckAiNativeStorage: Boolean = false
     private var areMultipleContentAttachmentsEnabled: Boolean = false
@@ -564,6 +571,8 @@ class RealDuckChat @Inject constructor(
     override fun isDuckChatFullScreenModeEnabled(): Boolean = isDuckChatFeatureEnabled
 
     override fun isDuckChatContextualModeEnabled(): Boolean = isContextualModeEnabled
+
+    override fun isContextualSheetRedesignEnabled(): Boolean = contextualSheetRedesignEnabled
 
     override fun isAutomaticContextAttachmentEnabled(): Boolean = isAutomaticContextAttachmentEnabled
     override fun isNativeStorageEnabled(): Boolean = duckAiNativeStorage
@@ -1026,6 +1035,8 @@ class RealDuckChat @Inject constructor(
 
             isContextualModeEnabled = showContextualMode && isContextualModeKillSwitch
             _showContextualMode.emit(isContextualModeEnabled)
+
+            contextualSheetRedesignEnabled = isContextualModeEnabled && duckChatFeature.contextualSheetRedesign().isEnabled()
 
             isAutomaticContextAttachmentEnabled = isContextualModeEnabled &&
                 duckChatFeature.automaticContextAttachment()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckChatContextual
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
@@ -35,6 +36,9 @@ import javax.inject.Inject
 class RealDuckChatContextual @Inject constructor(
     private val duckChatInternal: DuckChatInternal,
     private val browserNav: BrowserNav,
+    private val contextualDataStore: DuckChatContextualDataStore,
+    private val sessionTimeoutProvider: DuckChatContextualSessionTimeoutProvider,
+    private val timeProvider: DuckChatContextualTimeProvider,
 ) : DuckChatContextual {
 
     override suspend fun launch(
@@ -42,11 +46,28 @@ class RealDuckChatContextual @Inject constructor(
         anchor: View?,
         onAskAboutPage: () -> Unit,
     ) {
-        if (anchor != null && duckChatInternal.isContextualSheetRedesignEnabled()) {
-            showMenu(sourceTabId, anchor, onAskAboutPage)
-        } else {
+        if (anchor == null || !duckChatInternal.isContextualSheetRedesignEnabled()) {
             onAskAboutPage()
+            return
         }
+        if (hasChatInProgress(sourceTabId)) {
+            // The sheet would reopen the existing chat for this tab, so skip the entry menu and open it directly.
+            onAskAboutPage()
+        } else {
+            showMenu(sourceTabId, anchor, onAskAboutPage)
+        }
+    }
+
+    private suspend fun hasChatInProgress(tabId: String): Boolean {
+        if (contextualDataStore.getTabChatUrl(tabId).isNullOrBlank()) return false
+        return shouldReuseStoredChatUrl(tabId)
+    }
+
+    private suspend fun shouldReuseStoredChatUrl(tabId: String): Boolean {
+        val lastClosedTimestamp = contextualDataStore.getTabClosedTimestamp(tabId) ?: return true
+        val timeoutMs = sessionTimeoutProvider.sessionTimeoutMillis()
+        if (timeoutMs <= 0) return false
+        return timeProvider.currentTimeMillis() - lastClosedTimestamp <= timeoutMs
     }
 
     override fun createSheet(tabId: String): Fragment {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
@@ -16,23 +16,37 @@
 
 package com.duckduckgo.duckchat.impl.contextual
 
+import android.app.Activity
+import android.content.ContextWrapper
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
 import androidx.fragment.app.Fragment
+import com.duckduckgo.app.tabs.BrowserNav
+import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckChatContextual
+import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.R
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
-class RealDuckChatContextual @Inject constructor() : DuckChatContextual {
+class RealDuckChatContextual @Inject constructor(
+    private val duckChatInternal: DuckChatInternal,
+    private val browserNav: BrowserNav,
+) : DuckChatContextual {
 
     override suspend fun launch(
         sourceTabId: String,
         anchor: View?,
         onAskAboutPage: () -> Unit,
     ) {
-        onAskAboutPage()
+        if (anchor != null && duckChatInternal.isContextualSheetRedesignEnabled()) {
+            showMenu(sourceTabId, anchor, onAskAboutPage)
+        } else {
+            onAskAboutPage()
+        }
     }
 
     override fun createSheet(tabId: String): Fragment {
@@ -41,5 +55,32 @@ class RealDuckChatContextual @Inject constructor() : DuckChatContextual {
                 putString(DuckChatContextualFragment.KEY_DUCK_AI_CONTEXTUAL_TAB_ID, tabId)
             }
         }
+    }
+
+    private fun showMenu(
+        sourceTabId: String,
+        anchor: View,
+        onAskAboutPage: () -> Unit,
+    ) {
+        val activity = anchor.activity() ?: return
+        val popup = PopupMenu(LayoutInflater.from(activity), R.layout.popup_contextual_chat_menu)
+        val content = popup.contentView
+        popup.onMenuItemClicked(content.findViewById(R.id.contextualChatMenuNewChat)) { openNewChatTab(activity, sourceTabId) }
+        popup.onMenuItemClicked(content.findViewById(R.id.contextualChatMenuAskAboutPage)) { onAskAboutPage() }
+        popup.showAnchoredView(activity, anchor.rootView, anchor)
+    }
+
+    private fun openNewChatTab(activity: Activity, sourceTabId: String) {
+        val url = duckChatInternal.getDuckChatUrl(query = "", autoPrompt = false)
+        browserNav.openInNewTab(activity, url, sourceTabId).also { activity.startActivity(it) }
+    }
+
+    private fun View.activity(): Activity? {
+        var context = context
+        while (context is ContextWrapper) {
+            if (context is Activity) return context
+            context = context.baseContext
+        }
+        return null
     }
 }

--- a/duckchat/duckchat-impl/src/main/res/drawable/ic_chevron_circle_down_24.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/ic_chevron_circle_down_24.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M7.22202,11.2827C6.92784,10.9911 6.92573,10.5162 7.21733,10.222C7.50892,9.92784 7.98379,9.92573 8.27798,10.2173L11.296,13.2088C11.6858,13.5951 12.3142,13.5951 12.704,13.2088L15.722,10.2173C16.0162,9.92573 16.4911,9.92784 16.7827,10.222C17.0743,10.5162 17.0722,10.9911 16.778,11.2827L13.7599,14.2741C12.7854,15.24 11.2146,15.24 10.2401,14.2741L7.22202,11.2827Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M12,2C6.47715,2 2,6.47715 2,12C2,17.5228 6.47715,22 12,22C17.5228,22 22,17.5228 22,12C22,6.47715 17.5228,2 12,2ZM3.5,12C3.5,7.30558 7.30558,3.5 12,3.5C16.6944,3.5 20.5,7.30558 20.5,12C20.5,16.6944 16.6944,20.5 12,20.5C7.30558,20.5 3.5,16.6944 3.5,12Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+</vector>

--- a/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chat_menu.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chat_menu.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/popup_menu_bg"
+    android:orientation="vertical">
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/contextualChatMenuNewChat"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_compose_24"
+        app:primaryText="@string/chatMenuPopupNewChat" />
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/contextualChatMenuAskAboutPage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_chevron_circle_down_24"
+        app:primaryText="@string/duckChatContextualAskAboutPage" />
+
+</LinearLayout>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextualTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextualTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.contextual
 import android.view.View
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -30,9 +31,18 @@ class RealDuckChatContextualTest {
 
     private val duckChatInternal: DuckChatInternal = mock()
     private val browserNav: BrowserNav = mock()
+    private val contextualDataStore: DuckChatContextualDataStore = mock()
+    private val sessionTimeoutProvider: DuckChatContextualSessionTimeoutProvider = mock()
+    private val timeProvider: DuckChatContextualTimeProvider = mock()
     private val anchor: View = mock()
 
-    private val testee = RealDuckChatContextual(duckChatInternal, browserNav)
+    private val testee = RealDuckChatContextual(
+        duckChatInternal,
+        browserNav,
+        contextualDataStore,
+        sessionTimeoutProvider,
+        timeProvider,
+    )
 
     @Test
     fun whenRedesignDisabledThenLaunchedAndDoesNotOpenNewTab() = runTest {
@@ -43,5 +53,43 @@ class RealDuckChatContextualTest {
 
         assertEquals(1, askAboutPageCount)
         verifyNoInteractions(browserNav)
+    }
+
+    @Test
+    fun whenAnchorNullThenAskAboutPageInvokedDirectly() = runTest {
+        whenever(duckChatInternal.isContextualSheetRedesignEnabled()).thenReturn(true)
+        var askAboutPageCount = 0
+
+        testee.launch("tabId", anchor = null) { askAboutPageCount++ }
+
+        assertEquals(1, askAboutPageCount)
+        verifyNoInteractions(browserNav)
+    }
+
+    @Test
+    fun whenChatInProgressThenAskAboutPageInvokedWithoutShowingMenu() = runTest {
+        whenever(duckChatInternal.isContextualSheetRedesignEnabled()).thenReturn(true)
+        whenever(contextualDataStore.getTabChatUrl("tabId")).thenReturn("https://duckduckgo.com/?chatId=123")
+        whenever(contextualDataStore.getTabClosedTimestamp("tabId")).thenReturn(null)
+        var askAboutPageCount = 0
+
+        testee.launch("tabId", anchor) { askAboutPageCount++ }
+
+        assertEquals(1, askAboutPageCount)
+    }
+
+    @Test
+    fun whenStoredChatSessionExpiredThenTreatedAsNoChatInProgress() = runTest {
+        whenever(duckChatInternal.isContextualSheetRedesignEnabled()).thenReturn(true)
+        whenever(contextualDataStore.getTabChatUrl("tabId")).thenReturn("https://duckduckgo.com/?chatId=123")
+        whenever(contextualDataStore.getTabClosedTimestamp("tabId")).thenReturn(0L)
+        whenever(sessionTimeoutProvider.sessionTimeoutMillis()).thenReturn(1L)
+        whenever(timeProvider.currentTimeMillis()).thenReturn(1_000L)
+        var askAboutPageCount = 0
+
+        testee.launch("tabId", anchor) { askAboutPageCount++ }
+
+        // Session expired: the menu path is taken instead of opening the chat directly.
+        assertEquals(0, askAboutPageCount)
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextualTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextualTest.kt
@@ -17,23 +17,31 @@
 package com.duckduckgo.duckchat.impl.contextual
 
 import android.view.View
+import com.duckduckgo.app.tabs.BrowserNav
+import com.duckduckgo.duckchat.impl.DuckChatInternal
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 
 class RealDuckChatContextualTest {
 
+    private val duckChatInternal: DuckChatInternal = mock()
+    private val browserNav: BrowserNav = mock()
     private val anchor: View = mock()
 
-    private val testee = RealDuckChatContextual()
+    private val testee = RealDuckChatContextual(duckChatInternal, browserNav)
 
     @Test
-    fun whenLaunchedThenRequestsSheet() = runTest {
+    fun whenRedesignDisabledThenLaunchedAndDoesNotOpenNewTab() = runTest {
+        whenever(duckChatInternal.isContextualSheetRedesignEnabled()).thenReturn(false)
         var askAboutPageCount = 0
 
         testee.launch("tabId", anchor) { askAboutPageCount++ }
 
         assertEquals(1, askAboutPageCount)
+        verifyNoInteractions(browserNav)
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -189,6 +189,8 @@ class FakeDuckChatInternal(
 
     override fun isDuckChatContextualModeEnabled(): Boolean = false
 
+    override fun isContextualSheetRedesignEnabled(): Boolean = false
+
     override fun isDuckChatFeatureEnabled(): Boolean = true
 
     override fun isChatSyncFeatureEnabled(): Boolean = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462763415876/task/1217417214101840?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
  - Adds a redesigned Duck.ai contextual entry menu when `contextualSheetRedesign` is ON: tapping the Duck.ai omnibar button now opens an anchored popup menu with _New Chat_ and _Ask about this page_ actions, instead of jumping straight into the contextual sheet.
  - Ask about this page shows the existing contextual sheet; New Chat opens Duck.ai in a new browser tab. A null anchor (e.g. from native input) always opens the sheet directly.

### Steps to test this PR

_contextualSheetRedesign OFF (default)_
- [x] Open a new tab and load imdb.com 
- [x] Click on the contextual ai icon
- [x] Verify that sheet is launched (containing suggested prompts and native input)
- [x] Select any suggested prompt
- [x] Verify that sheet shows that chat
- [x] Close the sheet
- [x] Click on the contextual ai icon again
- [x] Verify that the sheet opens in the chat in progress state (WEBVIEW)
- [x] Full screen the chat
- [x] Verify that it opens on new tab
- [x] Close the tab and verify that it return to the tab with bbc loaded

_contextualSheetRedesign ON (via FF inventory)_
- [x] Open a new tab and load imdb.com 
- [x] Click on the contextual ai icon
- [x] Verify that menu is shown containing _New Chat_ and _Ask About Page_
- [x] Click on New Chat
- [x] Verify it open a new duck.ai chat tab
- [x] Close the tab and verify that it return to the tab with bbc loaded
- [x] Click on the contextual ai icon and open Ask About Page
- [x] Verify that sheet is launched (containing suggested prompts and native input)
- [x] Select any suggested prompt
- [x] Verify that sheet shows that chat
- [x] Close the sheet
- [x] Click on the contextual ai icon again
- [x] Verify that the sheet opens in the chat in progress state (WEBVIEW) and NOT the menu
- [x] Full screen the chat
- [x] Verify that it opens on new tab
- [x] Close the tab and verify that it return to the tab with bbc loaded
- [x] Click on the contextual ai icon again
- [x] Click on the chats icon and select new chat
- [x] Dismiss the dialog
- [x] Click on the contextual ai icon again
- [x] Verify menu is shown again

NOTE: This is just the basic integration more changes will come

### UI changes
<img width="345" height="210" alt="Screenshot 2026-08-13 at 13 49 12" src="https://github.com/user-attachments/assets/144a11c8-29ce-4522-894e-21cfc841fe1d" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing navigation change is behind a remote flag and preserves the old path when disabled or when anchor is null.
> 
> **Overview**
> When the **`contextualSheetRedesign`** remote flag is on (and contextual mode is active), tapping the Duck.ai omnibar entry with a valid anchor no longer opens the contextual sheet immediately. **`RealDuckChatContextual`** now shows an anchored popup with **New Chat** and **Ask about this page**.
> 
> **Ask about this page** keeps the existing behavior via `onAskAboutPage()`. **New Chat** opens Duck.ai in a new browser tab through `BrowserNav.openInNewTab` using `getDuckChatUrl`. If the anchor is null (e.g. native input) or the redesign flag is off, launch still calls `onAskAboutPage()` directly.
> 
> **`RealDuckChat`** exposes `isContextualSheetRedesignEnabled()` and sets it during config cache from `duckChatFeature.contextualSheetRedesign()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6f1c8c7e2e27470f9da64cb2e4d963bbc7badb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->