### PR TITLE
Add toggle_visible to the native omnibar-shown pixel

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -491,14 +491,28 @@
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "toggle_visible",
+                "type": "boolean",
+                "description": "Whether the Search+Duck.ai toggle was shown."
+            }
+        ]
     },
     "m_aichat_experimental_omnibar_shown_count": {
         "description": "Native input field shown to the user",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "toggle_visible",
+                "type": "boolean",
+                "description": "Whether the Search+Duck.ai toggle was shown."
+            }
+        ]
     },
     "m_aichat_experimental_omnibar_query_submitted_count": {
         "description": "User submitted a search query from the native input field",

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelPa
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
+import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.ModelTier
 import com.duckduckgo.duckchat.impl.ReportMetric
 import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_CREATE_NEW_CHAT
@@ -258,6 +259,7 @@ interface DuckChatPixels {
 class RealDuckChatPixels @Inject constructor(
     private val pixel: Pixel,
     private val duckChatFeatureRepository: DuckChatFeatureRepository,
+    private val duckChatInternal: DuckChatInternal,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val statisticsUpdater: StatisticsUpdater,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -955,6 +955,7 @@ class RealDuckChatPixels @Inject constructor(
     override fun fireOmnibarShown() = fireCountAndDaily(
         DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_COUNT,
         DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_DAILY,
+        mapOf(DuckChatPixelParameters.TOGGLE_VISIBLE to (duckChatInternal.resolvedTogglePosition() != null).toString()),
     )
 
     override fun fireOmnibarTextAreaFocused(landscape: Boolean) {

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
@@ -42,6 +42,7 @@ class RealDuckChatPixelsAttachmentsTest {
     private val testee = RealDuckChatPixels(
         pixel = pixel,
         duckChatFeatureRepository = duckChatFeatureRepository,
+        duckChatInternal = mock(),
         appCoroutineScope = coroutineTestRule.testScope,
         dispatcherProvider = coroutineTestRule.testDispatcherProvider,
         statisticsUpdater = statisticsUpdater,

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
@@ -42,6 +42,7 @@ class RealDuckChatPixelsPickerTest {
     private val testee = RealDuckChatPixels(
         pixel = pixel,
         duckChatFeatureRepository = duckChatFeatureRepository,
+        duckChatInternal = mock(),
         appCoroutineScope = coroutineTestRule.testScope,
         dispatcherProvider = coroutineTestRule.testDispatcherProvider,
         statisticsUpdater = statisticsUpdater,

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
@@ -43,6 +43,7 @@ class RealDuckChatPixelsToolsTest {
     private val testee = RealDuckChatPixels(
         pixel = pixel,
         duckChatFeatureRepository = duckChatFeatureRepository,
+        duckChatInternal = mock(),
         appCoroutineScope = coroutineTestRule.testScope,
         dispatcherProvider = coroutineTestRule.testDispatcherProvider,
         statisticsUpdater = statisticsUpdater,

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -454,13 +454,37 @@ class RealDuckChatPixelsTest {
     }
 
     @Test
-    fun whenFireOmnibarShownThenCountAndDailyFired() = runTest {
+    fun whenFireOmnibarShownWithToggleVisibleThenParamsReflectIt() = runTest {
+        whenever(mockDuckChatInternal.resolvedTogglePosition()).thenReturn(ToggleSelection.SEARCH)
+
         testee.fireOmnibarShown()
 
         advanceUntilIdle()
 
-        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_COUNT)
-        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_DAILY, type = Pixel.PixelType.Daily())
+        val params = mapOf(DuckChatPixelParameters.TOGGLE_VISIBLE to "true")
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_COUNT, parameters = params)
+        verify(mockPixel).fire(
+            DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_DAILY,
+            parameters = params,
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenFireOmnibarShownWithNoToggleThenParamsReflectIt() = runTest {
+        whenever(mockDuckChatInternal.resolvedTogglePosition()).thenReturn(null)
+
+        testee.fireOmnibarShown()
+
+        advanceUntilIdle()
+
+        val params = mapOf(DuckChatPixelParameters.TOGGLE_VISIBLE to "false")
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_COUNT, parameters = params)
+        verify(mockPixel).fire(
+            DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_DAILY,
+            parameters = params,
+            type = Pixel.PixelType.Daily(),
+        )
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
+import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.ReportMetric
 import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_ACCEPT_TERMS_AND_CONDITIONS
 import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_CREATE_NEW_CHAT
@@ -87,6 +88,7 @@ class RealDuckChatPixelsTest {
     private val statisticsUpdater: StatisticsUpdater = mock()
     private val duckAiMetricCollector: DuckAiMetricCollector = mock()
     private val mockTermsOfServiceHandler: DuckChatTermsOfServiceHandler = mock()
+    private val mockDuckChatInternal: DuckChatInternal = mock()
 
     private lateinit var testee: RealDuckChatPixels
 
@@ -97,6 +99,7 @@ class RealDuckChatPixelsTest {
         testee = RealDuckChatPixels(
             pixel = mockPixel,
             duckChatFeatureRepository = mockDuckChatFeatureRepository,
+            duckChatInternal = mockDuckChatInternal,
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             statisticsUpdater = statisticsUpdater,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217295011063286?focus=true 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

### Description
Adds a toggle_visible parameter to `m_aichat_experimental_omnibar_shown` 
We fire a pixel whenever the native Input Screen is shown, but can't yet tell what fraction of those
impressions actually offered the Search/Duck.ai toggle. This adds one param:

| Pixel | Added |
| --- | --- |
| `m_aichat_experimental_omnibar_shown` / `_count` | `toggle_visible` |

`toggle_visible` is a boolean, reusing the same `DuckChatInternal.resolvedTogglePosition() != null`
check used in other pixels pixel.

### Steps to test this PR

Enable the `nativeInputField` and `nativeInputSearchOnly` feature flag, attach logcat, filter for `Pixel sent:`.

_toggle_visible on the native Input Screen_
- [x] With Search + Duck.ai enabled (toggle offered), open the Input Screen —
      `m_aichat_experimental_omnibar_shown_count` carries `toggle_visible=true`
- [x] Turn Search + Duck.ai off so no toggle is offered, open the Input Screen again ->
      `toggle_visible=false`

### UI changes
No UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only pixel parameter and wiring; no user-facing behavior or security-sensitive paths.
> 
> **Overview**
> Adds **`toggle_visible`** to the pixel definitions for **`m_aichat_experimental_omnibar_shown`** and **`m_aichat_experimental_omnibar_shown_count`**, so analytics can split native input impressions by whether the Search/Duck.ai toggle was on screen.
> 
> **`fireOmnibarShown()`** now passes **`toggle_visible`** on both count and daily fires, derived from **`DuckChatInternal.resolvedTogglePosition() != null`**. **`RealDuckChatPixels`** takes **`DuckChatInternal`** as a new constructor dependency.
> 
> Tests were updated to supply the mock internal API, and **`RealDuckChatPixelsTest`** now asserts **`toggle_visible=true`** vs **`false`** for the two toggle cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bd21d6fda8d840c9dd73784a75f0dc6790ed58d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->