### PR TITLE
Update content scope scripts to version 16.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^16.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.7.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.8.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -61,7 +61,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c13193705a8a5ab8a28d457a4849f27ba6d23676",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9bb13ba44c2e73f97ebe45c8ce77c238578f3ce5",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -575,9 +575,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.49.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.2.tgz",
-      "integrity": "sha512-rGbJiKeQ4WDe3EXlDAIaQcwftVfv2Q8o1awFNfvXolJYKkb1AuZY1RTOmqx4LJXZENbWZA7eIsYGHuEzHsi1nQ==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
+      "integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^16.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.7.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.8.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217448276705745

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [x] All tests must pass
- [x] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine dependency pin with no application code changes in the diff; risk depends on upstream 16.8.0 script behavior if/when bundled assets are synced.
> 
> **Overview**
> Bumps the `@duckduckgo/content-scope-scripts` Git dependency from **16.7.0** to **16.8.0** in `package.json` and `package-lock.json`, updating the resolved commit for the injected privacy/content scripts package used by the Android browser.
> 
> The lockfile also reflects a minor dev transitive update to **terser** (5.49.2 → 5.50.0) from the dependency tree refresh. There are **no** changes in this diff to copied `content-scope-scripts` assets under the repo—only the npm package pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d1dac426c651db56790632dd09f77ed5c6acc15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->