### PR TITLE
Enabling NativeInputSearchOnly for internal users and fixing tests

### DIFF
--- a/.maestro/onboarding/preonboarding_returning_user_quick_setup_customize.yaml
+++ b/.maestro/onboarding/preonboarding_returning_user_quick_setup_customize.yaml
@@ -57,6 +57,6 @@ tags:
       - assertVisible:
           id: "newTabPage"
       - assertVisible:
-          id: "toolbarContainer"
+          id: "toolbarContainer|inputModeBottomRoot"
           below:
             id: "newTabPage"

--- a/.maestro/privacy_tests_internal/1_-_Api_manipulation.yaml
+++ b/.maestro/privacy_tests_internal/1_-_Api_manipulation.yaml
@@ -43,10 +43,10 @@ tags:
       - pressKey: Back
       - pressKey: Back
       - pressKey: Back
-      # In search-only mode (the default) the NTP uses the legacy omnibar, not
-      # the native input overlay — tap the text input directly to enter the URL.
+      # Tap whichever field is live: the legacy omnibar (native input search-only off)
+      # or the native input widget's field (native input search-only on).
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://privacy-test-pages.site/content-scope-scripts/infra/pages/conditional-matching-experiments.html?automation=1"
       - pressKey: Enter
       - tapOn:

--- a/.maestro/serp/open_ai_features_from_serp.yaml
+++ b/.maestro/serp/open_ai_features_from_serp.yaml
@@ -15,8 +15,10 @@ tags:
 
       - assertVisible:
           text: "Search"
+      # Tap whichever field is live: the legacy omnibar (native input search-only off)
+      # or the native input widget's field (native input search-only on).
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://duckduckgo.com"
       - pressKey: Enter
 

--- a/.maestro/unified_input_screen/unified_input_open_duckai_back_to_ntp.yaml
+++ b/.maestro/unified_input_screen/unified_input_open_duckai_back_to_ntp.yaml
@@ -1,7 +1,7 @@
 appId: com.duckduckgo.mobile.android
 name: "UnifiedInput: open duck.ai via icon (AI off) and back to NTP × omnibar positions"
-# DISABLED: untagged so it is excluded from the tagged (unifiedInputTest) CI suite.
-tags: []
+tags:
+  - unifiedInputTest
 ---
 # 1/3 — omnibar top
 - retry:

--- a/.maestro/unified_input_screen/unified_input_with_seeded_favorites.yaml
+++ b/.maestro/unified_input_screen/unified_input_with_seeded_favorites.yaml
@@ -51,52 +51,50 @@ tags:
       - runFlow: shared/launch_and_skip_onboarding.yaml
       - runFlow: shared/assert_seeded_favorites_visible.yaml
 
-# DISABLED: combos with nativeInputToggle=true, inputWithAiToggle=false (AI off) are commented out below.
-#
-# # 4/6 — AI off, omnibar top
-# - retry:
-#     maxRetries: 3
-#     commands:
-#       - launchApp:
-#           clearState: true
-#           stopApp: true
-#           arguments:
-#             isMaestro: "true"
-#             nativeInputToggle: "true"
-#             inputWithAiToggle: "false"
-#             omnibarPosition: "top"
-#             addFavorites: "example.com;duckduckgo.com;privacytest.com"
-#       - runFlow: shared/launch_and_skip_onboarding.yaml
-#       - runFlow: shared/assert_seeded_favorites_visible.yaml
-#
-# # 5/6 — AI off, omnibar bottom
-# - retry:
-#     maxRetries: 3
-#     commands:
-#       - launchApp:
-#           clearState: true
-#           stopApp: true
-#           arguments:
-#             isMaestro: "true"
-#             nativeInputToggle: "true"
-#             inputWithAiToggle: "false"
-#             omnibarPosition: "bottom"
-#             addFavorites: "example.com;duckduckgo.com;privacytest.com"
-#       - runFlow: shared/launch_and_skip_onboarding.yaml
-#       - runFlow: shared/assert_seeded_favorites_visible.yaml
-#
-# # 6/6 — AI off, omnibar split
-# - retry:
-#     maxRetries: 3
-#     commands:
-#       - launchApp:
-#           clearState: true
-#           stopApp: true
-#           arguments:
-#             isMaestro: "true"
-#             nativeInputToggle: "true"
-#             inputWithAiToggle: "false"
-#             omnibarPosition: "split"
-#             addFavorites: "example.com;duckduckgo.com;privacytest.com"
-#       - runFlow: shared/launch_and_skip_onboarding.yaml
-#       - runFlow: shared/assert_seeded_favorites_visible.yaml
+# 4/6 — AI off, omnibar top
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
+          arguments:
+            isMaestro: "true"
+            nativeInputToggle: "true"
+            inputWithAiToggle: "false"
+            omnibarPosition: "top"
+            addFavorites: "example.com;duckduckgo.com;privacytest.com"
+      - runFlow: shared/launch_and_skip_onboarding.yaml
+      - runFlow: shared/assert_seeded_favorites_visible.yaml
+
+# 5/6 — AI off, omnibar bottom
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
+          arguments:
+            isMaestro: "true"
+            nativeInputToggle: "true"
+            inputWithAiToggle: "false"
+            omnibarPosition: "bottom"
+            addFavorites: "example.com;duckduckgo.com;privacytest.com"
+      - runFlow: shared/launch_and_skip_onboarding.yaml
+      - runFlow: shared/assert_seeded_favorites_visible.yaml
+
+# 6/6 — AI off, omnibar split
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
+          arguments:
+            isMaestro: "true"
+            nativeInputToggle: "true"
+            inputWithAiToggle: "false"
+            omnibarPosition: "split"
+            addFavorites: "example.com;duckduckgo.com;privacytest.com"
+      - runFlow: shared/launch_and_skip_onboarding.yaml
+      - runFlow: shared/assert_seeded_favorites_visible.yaml

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputSearchOnlyFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputSearchOnlyFeature.kt
@@ -31,6 +31,6 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 )
 interface NativeInputSearchOnlyFeature {
 
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun self(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1217449871624356?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

Switch the `nativeInputSearchOnly` feature flag to internal, and add e2e tests for it. Also modify some existing tests to support this.

### Steps to test this PR
You can run maestro tests locally or on maestro against the branch. But I already did it. You can find the runs below.

Ran e2e tests full suite: https://github.com/duckduckgo/Android/actions/runs/31785709449
Also ran e2e tests "Full Suite of non release blocker tests”: https://github.com/duckduckgo/Android/actions/runs/31785737367

All successful.



### UI changes
No UI Changes - e2e tests only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The flag change alters omnibar/native-input behavior for internal users in search-only mode (core browser UI), though general release users stay on the previous default until remote config rolls out.
> 
> **Overview**
> Turns on **native input in search-only address-bar mode** for internal users by changing the `nativeInputSearchOnly` remote feature default from `FALSE` to `INTERNAL` in `NativeInputSearchOnlyFeature`.
> 
> Maestro flows are updated so automation works whether search-only uses the legacy omnibar or the native input widget: **alternate view IDs** (`omnibarTextInput|inputField`, `toolbarContainer|inputModeBottomRoot`) and comments explaining the dual paths.
> 
> Unified-input coverage is **restored**: `unified_input_open_duckai_back_to_ntp.yaml` is tagged `unifiedInputTest` again, and the three **AI-off × omnibar position** seeded-favorites scenarios in `unified_input_with_seeded_favorites.yaml` are uncommented.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5b5ffbb9710e09158734935f80e1aa918b847aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->