### PR TITLE
Make the new voice/mic permission strings translatable - Translations

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
@@ -22,7 +22,7 @@
     <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blockiert Video-Werbung auf YouTube, sodass du Videos ohne Unterbrechungen ansehen kannst. \n\nWenn diese Funktion aktiviert ist, erkennt DuckDuckGo anonym, ob Werbeblocker stören oder YouTube-Fehler auftreten, um das Erlebnis für alle zu verbessern. DuckDuckGo sieht niemals, welche Videos du dir ansiehst, und erhält auch keine personenbezogenen Daten. <annotation type="learn_more_link">Mehr erfahren</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo blockiert Video-Werbung auf YouTube, sodass du Videos ohne Unterbrechungen ansehen kannst. <annotation type="learn_more_link">Mehr erfahren</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Öffnet Videos in einem ablenkungsfreien Theatermodus, der verhindert, dass das, was du ansiehst, deinen YouTube-Feed beeinflusst.</string>
+    <string name="ad_blocking_settings_duck_player_description">Öffnet Videos in einem ablenkungsfreien Kino-Modus, der verhindert, dass das, was du ansiehst, deinen YouTube-Feed beeinflusst.</string>
     <string name="ad_blocking_settings_title_v2">Werbeblockierung</string>
     <string name="ad_blocking_settings_header_description">Blockiert invasive Tracker, bevor sie geladen werden, und eliminiert so effektiv Werbung, die auf Tracking basiert.</string>
     <string name="contingencyMessageTitle">YouTube-Werbeblocker nicht verfügbar</string>

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -557,7 +557,7 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                         askForMicPermissions(rememberChoice)
                     }
                     if (isDuckAiAudioCapture) {
-                        R.string.duckAiMicDeniedSnackBarMessage
+                        R.string.duckAiMicPermissionDeniedSnackBarMessage
                     } else {
                         R.string.sitePermissionsMicDeniedSnackBarMessage
                     }

--- a/site-permissions/site-permissions-impl/src/main/res/values-bg/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-bg/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Сайтовете могат да използват камерата и микрофона, само ако разрешите на DuckDuckGo да поиска достъп.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Отвори Настройки</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Отмени</string>
+    <string name="duckAiMicDeniedSnackBarMessage">За гласовите функции е необходимо разрешение за достъп до микрофона</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo има нужда от достъп до микрофона</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Ако искате да използвате гласов чат в Duck.ai, трябва да разрешите достъп до микрофона.</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Промяна на разрешенията</string>
 
     <string name="sitePermissionsSettingsDescription">Сайтовете, които посещавате, може да поискат достъп до местоположението, камерата, микрофона или софтуера за управление на цифровите права (DRM) на устройството. Те няма да имат достъп до тях, освен ако не им дадете изрично разрешение.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Разрешаване на всички сайтове да искат:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-bg/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-bg/strings-site-permissions.xml
@@ -57,6 +57,7 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Сайтовете могат да използват камерата и микрофона, само ако разрешите на DuckDuckGo да поиска достъп.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Отвори Настройки</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Отмени</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">За гласовите функции е необходимо разрешение за достъп до микрофона</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo има нужда от достъп до микрофона</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Ако искате да използвате гласов чат в Duck.ai, трябва да разрешите достъп до микрофона.</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Промяна на разрешенията</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-bg/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-bg/strings-site-permissions.xml
@@ -57,7 +57,6 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Сайтовете могат да използват камерата и микрофона, само ако разрешите на DuckDuckGo да поиска достъп.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Отвори Настройки</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Отмени</string>
-    <string name="duckAiMicDeniedSnackBarMessage">За гласовите функции е необходимо разрешение за достъп до микрофона</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo има нужда от достъп до микрофона</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Ако искате да използвате гласов чат в Duck.ai, трябва да разрешите достъп до микрофона.</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Промяна на разрешенията</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-cs/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-cs/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Weby můžou používat tvůj fotoaparát a mikrofon, jen když službě DuckDuckGo povolíš žádat o přístup.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Otevřít nastavení</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Zrušit</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Pro hlasové funkce je potřeba povolit přístup k mikrofonu</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potřebuje přístup k mikrofonu</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Pokud chceš v Duck.ai používat hlasový chat, je potřeba povolit přístup k mikrofonu.</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Změnit oprávnění</string>
 
     <string name="sitePermissionsSettingsDescription">Stránky, které navštívíš, můžou žádat o přístup k fotoaparátu, mikrofonu, softwaru DRM (Digital Rights Management) nebo k poloze tvého zařízení. Přístup mít nebudou, pokud jim ho výslovně nepovolíš.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Povolit všem webům, aby žádaly o:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-da/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-da/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Websteder kan kun bruge dit kamera og din mikrofon, hvis du giver DuckDuckGo tilladelse til at bede om adgang.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Åbn indstillinger</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Afbestil</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Mikrofontilladelse er nødvendig for stemmefunktioner</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo skal have adgang til din mikrofon</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Mikrofontilladelser er nødvendige, hvis du vil bruge stemmechat i Duck.ai</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Skift tilladelser</string>
 
     <string name="sitePermissionsSettingsDescription">Websteder, du besøger, kan bede om adgang til din enheds placering, kamera, mikrofon eller DRM-software (Digital Rights Management). De vil ikke kunne få adgang til disse, medmindre du udtrykkeligt giver dem tilladelse.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Tillad, at alle websteder beder om:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-de/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-de/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Websites können deine Kamera und dein Mikrofon nur verwenden, wenn du DuckDuckGo erlaubst, um Zugriff zu bitten.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Einstellungen öffnen</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Abbrechen</string>
+    <string name="duckAiMicDeniedSnackBarMessage">Mikrofonberechtigung für Sprachfunktionen erforderlich</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo benötigt Zugriff auf dein Mikrofon.</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Mikrofonberechtigungen werden benötigt, wenn du den Sprachchat in Duck.ai nutzen möchtest.</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Berechtigungen ändern</string>
 
     <string name="sitePermissionsSettingsDescription">Von dir besuchte Websites bitten möglicherweise um Zugriff auf den Standort, die Kamera, das Mikrofon oder die DRM-Software (Digital Rights Management) deines Geräts. Sie können darauf nicht zugreifen, es sei denn, du erteilst ihnen ausdrücklich die Erlaubnis.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Allen Websites erlauben, um Folgendes zu bitten:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-de/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-de/strings-site-permissions.xml
@@ -57,7 +57,6 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Websites können deine Kamera und dein Mikrofon nur verwenden, wenn du DuckDuckGo erlaubst, um Zugriff zu bitten.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Einstellungen öffnen</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Abbrechen</string>
-    <string name="duckAiMicDeniedSnackBarMessage">Mikrofonberechtigung für Sprachfunktionen erforderlich</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo benötigt Zugriff auf dein Mikrofon.</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofonberechtigungen werden benötigt, wenn du den Sprachchat in Duck.ai nutzen möchtest.</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Berechtigungen ändern</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-de/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-de/strings-site-permissions.xml
@@ -57,6 +57,7 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Websites können deine Kamera und dein Mikrofon nur verwenden, wenn du DuckDuckGo erlaubst, um Zugriff zu bitten.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Einstellungen öffnen</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Abbrechen</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Mikrofonberechtigung für Sprachfunktionen erforderlich</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo benötigt Zugriff auf dein Mikrofon.</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofonberechtigungen werden benötigt, wenn du den Sprachchat in Duck.ai nutzen möchtest.</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Berechtigungen ändern</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-el/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-el/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Οι ιστότοποι μπορούν να χρησιμοποιούν την κάμερα και το μικρόφωνό σας μόνο εάν επιτρέψετε στο DuckDuckGo να αιτηθεί πρόσβαση.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Άνοιγμα ρυθμίσεων</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Ακύρωση</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Απαιτείται δικαίωμα πρόσβασης στο μικρόφωνο για τις φωνητικές λειτουργίες</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">Το DuckDuckGo χρειάζεται πρόσβαση στο μικρόφωνό σου</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Απαιτούνται δικαιώματα πρόσβασης στο μικρόφωνο αν θέλεις να χρησιμοποιήσεις τη φωνητική συνομιλία στο Duck.ai</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Αλλαγή δικαιωμάτων</string>
 
     <string name="sitePermissionsSettingsDescription">Οι ιστότοποι που επισκέπτεστε ενδέχεται να ζητήσουν πρόσβαση στην τοποθεσία, την κάμερα, το μικρόφωνο ή το λογισμικό DRM (Διαχείριση ψηφιακών δικαιωμάτων) της συσκευής σας. Δεν θα μπορούν να έχουν πρόσβαση σε αυτά εάν δεν τους παρέχετε ρητά την άδειά σας.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Να επιτρέπεται σε όλους τους ιστότοπους να αιτούνται:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-es/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-es/strings-site-permissions.xml
@@ -57,7 +57,6 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Los sitios solo pueden usar tu cámara y tu micrófono si permites que DuckDuckGo solicite acceso.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Abrir configuración</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Cancelar</string>
-    <string name="duckAiMicDeniedSnackBarMessage">Se necesita permiso de micrófono para las funciones de voz</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo necesita acceder a tu micrófono</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Se necesitan permisos de micrófono si quieres usar el chat de voz en Duck.ai</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Cambiar permisos</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-es/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-es/strings-site-permissions.xml
@@ -57,6 +57,7 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Los sitios solo pueden usar tu cámara y tu micrófono si permites que DuckDuckGo solicite acceso.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Abrir configuración</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Cancelar</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Se necesita permiso de micrófono para las funciones de voz</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo necesita acceder a tu micrófono</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Se necesitan permisos de micrófono si quieres usar el chat de voz en Duck.ai</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Cambiar permisos</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-es/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-es/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Los sitios solo pueden usar tu cámara y tu micrófono si permites que DuckDuckGo solicite acceso.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Abrir configuración</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Cancelar</string>
+    <string name="duckAiMicDeniedSnackBarMessage">Se necesita permiso de micrófono para las funciones de voz</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo necesita acceder a tu micrófono</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Se necesitan permisos de micrófono si quieres usar el chat de voz en Duck.ai</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Cambiar permisos</string>
 
     <string name="sitePermissionsSettingsDescription">Los sitios que visites pueden pedirte acceso a la ubicación de tu dispositivo, a la cámara, al micrófono o al software DRM (Gestión de Derechos Digitales). No podrán acceder a ellos a menos que les des permiso explícitamente.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Permitir que todos los sitios soliciten:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-et/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-et/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Saidid saavad sinu kaamerat ja mikrofoni kasutada ainult siis, kui lubad DuckDuckGo’l küsida sellele juurdepääsu.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Ava sätted</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Tühista</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Häälfunktsioonide jaoks on tarvis mikrofoni luba</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo vajab juurdepääsu teie mikrofonile</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Mikrofoni juurdepääsu on tarvis, kui soovite Duck.ai-s häälvestlust kasutada.</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Muuda load</string>
 
     <string name="sitePermissionsSettingsDescription">Külastatavad veebisaidid võivad küsida juurdepääsu sinu seadme asukohale, kaamerale, mikrofonile või DRM-i (Digital Rights Management) tarkvarale. Need ei saa juurdepääsu enne, kui oled selleks andnud selgesõnalise loa.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Luba kõigil saitidel küsida järgmist.</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-fi/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-fi/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Sivustot voivat käyttää kameraa ja mikrofonia vain, jos annat DuckDuckGon pyytää niiden käyttöoikeutta.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Avaa asetukset</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Peruuta</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Mikrofonin käyttöoikeus tarvitaan äänitoimintoja varten</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo tarvitsee mikrofonisi käyttöoikeuden</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Mikrofonin käyttöoikeudet tarvitaan, jos haluat käyttää äänikeskustelua Duck.ai:ssa</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Muuta käyttöoikeuksia</string>
 
     <string name="sitePermissionsSettingsDescription">Käyttämäsi sivustot saattavat pyytää pääsyä laitteesi sijaintiin, kameraan, mikrofoniin tai DRM-ohjelmistoon (Digital Rights Management). Ne eivät voi käyttää tietoja, ellet myönnä niille erillistä käyttöoikeutta.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Salli kaikkien sivustojen pyytää:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-fr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-fr/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Les sites ne peuvent utiliser votre appareil photo et votre micro que si vous autorisez DuckDuckGo à demander l\'accès.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Ouvrir les paramètres</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Annuler</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Autorisation d’accès au micro requise pour les fonctionnalités vocales</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo a besoin d’accéder à votre micro</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Les autorisations d’accès au micro sont nécessaires si vous souhaitez utiliser le chat vocal dans Duck.ai</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Modifier les autorisations</string>
 
     <string name="sitePermissionsSettingsDescription">Les sites que vous visitez sont susceptibles de demander l\'accès à la localisation, à l\'appareil photo, au micro ou au logiciel DRM (gestion des droits numériques) de votre appareil. Ils ne pourront y accéder que si vous leur en donnez explicitement la permission.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Autoriser tous les sites à demander :</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-hr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-hr/strings-site-permissions.xml
@@ -57,7 +57,6 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Stranice mogu koristiti tvoju kameru i mikrofon samo ako dopustiš DuckDuckGou da zatraži pristup.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Otvori postavke</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Otkaži</string>
-    <string name="duckAiMicDeniedSnackBarMessage">Za glasovne funkcije potrebno je dopuštenje za mikrofon</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo treba pristupiti tvom mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Dozvole za mikrofon potrebne su ako želiš koristiti Glasovno čavrljanje u Duck.ai</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Promijeni dozvole</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-hr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-hr/strings-site-permissions.xml
@@ -57,6 +57,7 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Stranice mogu koristiti tvoju kameru i mikrofon samo ako dopustiš DuckDuckGou da zatraži pristup.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Otvori postavke</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Otkaži</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Za glasovne funkcije potrebno je dopuštenje za mikrofon</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo treba pristupiti tvom mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Dozvole za mikrofon potrebne su ako želiš koristiti Glasovno čavrljanje u Duck.ai</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Promijeni dozvole</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-hr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-hr/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Stranice mogu koristiti tvoju kameru i mikrofon samo ako dopustiš DuckDuckGou da zatraži pristup.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Otvori postavke</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Otkaži</string>
+    <string name="duckAiMicDeniedSnackBarMessage">Za glasovne funkcije potrebno je dopuštenje za mikrofon</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo treba pristupiti tvom mikrofonu</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Dozvole za mikrofon potrebne su ako želiš koristiti Glasovno čavrljanje u Duck.ai</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Promijeni dozvole</string>
 
     <string name="sitePermissionsSettingsDescription">Stranice koje posjećuješ mogu tražiti pristup lokaciji tvog uređaja, fotoaparatu, mikrofonu ili DRM (Digital Rights Management) softveru. Neće im moći pristupiti osim ako im za to izričito ne daš dopuštenje.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Dopusti svim web-lokacijama da zatraže:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-hu/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-hu/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">A webhelyek csak akkor használhatják a kamerát és a mikrofont, ha engedélyezed, hogy a DuckDuckGo hozzáférést kérjen.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Beállítások megnyitása</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Mégsem</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">A beszédhangfunkciókhoz mikrofonengedély szükséges</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">A DuckDuckGónak hozzá kell férnie a mikrofonhoz</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Mikrofonengedélyre van szükség, ha a Duck.ai-ban szeretnél hangcsevegést használni</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Engedélyek módosítása</string>
 
     <string name="sitePermissionsSettingsDescription">A meglátogatott webhelyek hozzáférést kérhetnek az eszköz helyéhez, kamerájához, mikrofonjához vagy a digitális jogosultságokat kezelő (DRM) szoftveréhez. Ezekhez nem férhetnek hozzá, hacsak nem adsz rá kifejezett engedélyt.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Minden webhely kérheti a következőket:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-it/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-it/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">I siti possono utilizzare la fotocamera e il microfono solo se consenti a DuckDuckGo di richiederne l\'accesso.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Apri Impostazioni</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Annulla</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Autorizzazione del microfono necessaria per le funzioni vocali</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo deve accedere al microfono</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">I permessi del microfono sono necessari se vuoi usare la chat vocale su Duck.ai</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Modifica autorizzazioni</string>
 
     <string name="sitePermissionsSettingsDescription">I siti che visiti potrebbero richiedere l\'accesso al software di localizzazione, videocamera, microfono o DRM (Digital Rights Management) del tuo dispositivo. Non potranno accedervi finché non darai il consenso esplicito.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Consenti a tutti i siti di richiedere:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-lt/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-lt/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Svetainės gali naudoti jūsų kamerą ir mikrofoną tik tada, jei leisite „DuckDuckGo“ prašyti prieigos.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Atidaryti nustatymus</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Atšaukti</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Balso funkcijoms reikia leidimo naudoti mikrofoną</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">„DuckDuckGo“ reikia prieigos prie tavo mikrofono</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Jei nori naudotis „Duck.ai“ pokalbiais balsu, reikia leidimo naudoti mikrofoną</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Keisti leidimus</string>
 
     <string name="sitePermissionsSettingsDescription">Svetainėse, kuriose lankotės, gali būti prašoma prieigos prie jūsų įrenginio buvimo vietos, kameros, mikrofono arba DRM (skaitmeninių teisių valdymo) programinės įrangos. Jos negalės prie jų prisijungti, nebent aiškiai suteiksite joms leidimą.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Leisti visoms svetainėms prašyti:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-lv/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-lv/strings-site-permissions.xml
@@ -57,6 +57,7 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Vietnes var izmantot tavu kameru un mikrofonu tikai tad, ja tu atļauj DuckDuckGo prasīt piekļuvi.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Atvērt iestatījumus</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Atcelt</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Balss funkcijām nepieciešama mikrofona atļauja</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo ir nepieciešama piekļuve tavam mikrofonam</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Ja vēlies izmantot balss tērzēšanu vietnē Duck.ai, ir nepieciešamas mikrofona atļaujas</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Mainīt atļaujas</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-lv/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-lv/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Vietnes var izmantot tavu kameru un mikrofonu tikai tad, ja tu atļauj DuckDuckGo prasīt piekļuvi.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Atvērt iestatījumus</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Atcelt</string>
+    <string name="duckAiMicDeniedSnackBarMessage">Balss funkcijām nepieciešama mikrofona atļauja</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo ir nepieciešama piekļuve tavam mikrofonam</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Ja vēlies izmantot balss tērzēšanu vietnē Duck.ai, ir nepieciešamas mikrofona atļaujas</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Mainīt atļaujas</string>
 
     <string name="sitePermissionsSettingsDescription">Apmeklētās vietnes var pieprasīt piekļuvi tavas ierīces atrašanās vietai, kamerai, mikrofonam vai DRM (digitālā satura tiesību pārvaldības) programmatūrai. Tās nevarēs tiem piekļūt, ja vien īpaši nedosi attiecīgo atļauju.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Ļaut visām vietnēm prasīt:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-lv/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-lv/strings-site-permissions.xml
@@ -57,7 +57,6 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Vietnes var izmantot tavu kameru un mikrofonu tikai tad, ja tu atļauj DuckDuckGo prasīt piekļuvi.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Atvērt iestatījumus</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Atcelt</string>
-    <string name="duckAiMicDeniedSnackBarMessage">Balss funkcijām nepieciešama mikrofona atļauja</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo ir nepieciešama piekļuve tavam mikrofonam</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Ja vēlies izmantot balss tērzēšanu vietnē Duck.ai, ir nepieciešamas mikrofona atļaujas</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Mainīt atļaujas</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-nb/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-nb/strings-site-permissions.xml
@@ -57,6 +57,7 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Nettsteder kan bare bruke kameraet og mikrofonen din hvis du lar DuckDuckGo be om tilgang.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Åpne innstillinger</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Avbryt</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Mikrofontillatelse er nødvendig for talefunksjoner</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo trenger tilgang til mikrofonen</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofontillatelser er nødvendig hvis du vil bruke talefunksjoner i Duck.ai</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Endre tillatelser</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-nb/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-nb/strings-site-permissions.xml
@@ -57,7 +57,6 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Nettsteder kan bare bruke kameraet og mikrofonen din hvis du lar DuckDuckGo be om tilgang.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Åpne innstillinger</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Avbryt</string>
-    <string name="duckAiMicDeniedSnackBarMessage">Mikrofontillatelse er nødvendig for talefunksjoner</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo trenger tilgang til mikrofonen</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofontillatelser er nødvendig hvis du vil bruke talefunksjoner i Duck.ai</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Endre tillatelser</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-nb/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-nb/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Nettsteder kan bare bruke kameraet og mikrofonen din hvis du lar DuckDuckGo be om tilgang.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Åpne innstillinger</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Avbryt</string>
+    <string name="duckAiMicDeniedSnackBarMessage">Mikrofontillatelse er nødvendig for talefunksjoner</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo trenger tilgang til mikrofonen</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Mikrofontillatelser er nødvendig hvis du vil bruke talefunksjoner i Duck.ai</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Endre tillatelser</string>
 
     <string name="sitePermissionsSettingsDescription">Nettsteder du besøker, kan be om tilgang til enhetens posisjon, kamera, mikrofon eller DRA-programvare (digital rettighetsadministrasjon). De får ikke tilgang til disse med mindre du uttrykkelig gir dem tillatelse.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Tillat alle nettsteder å be om:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-nl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-nl/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Sites kunnen je camera en microfoon alleen gebruiken als je DuckDuckGo toestaat om toegang te vragen.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Open Instellingen</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Annuleren</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Microfoonmachtiging nodig voor spraakfuncties</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo heeft toegang tot je microfoon nodig</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Microfoonmachtigingen zijn vereist als je spraakchat wilt gebruiken in Duck.ai</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Toestemmingen wijzigen</string>
 
     <string name="sitePermissionsSettingsDescription">Sites die je bezoekt, kunnen toegang vragen tot de software, je camera, je microfoon of DRM (Digital Rights Management) op je apparaat. Ze krijgen die toegang alleen als je daar expliciet toestemming voor geeft.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Sta alle sites toe om het volgende vragen:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-pl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-pl/strings-site-permissions.xml
@@ -57,7 +57,6 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Witryny mogą korzystać z Twojej kamery i mikrofonu tylko wtedy, gdy pozwolisz DuckDuckGo poprosić o dostęp.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Otwórz ustawienia</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Anuluj</string>
-    <string name="duckAiMicDeniedSnackBarMessage">Do obsługi funkcji głosowych wymagane jest uprawnienie do korzystania z mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potrzebuje dostępu do Twojego mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Uprawnienia do mikrofonu są potrzebne, jeśli chcesz korzystać z czatu głosowego w Duck.ai</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Zmień uprawnienia</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-pl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-pl/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Witryny mogą korzystać z Twojej kamery i mikrofonu tylko wtedy, gdy pozwolisz DuckDuckGo poprosić o dostęp.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Otwórz ustawienia</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Anuluj</string>
+    <string name="duckAiMicDeniedSnackBarMessage">Do obsługi funkcji głosowych wymagane jest uprawnienie do korzystania z mikrofonu</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potrzebuje dostępu do Twojego mikrofonu</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Uprawnienia do mikrofonu są potrzebne, jeśli chcesz korzystać z czatu głosowego w Duck.ai</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Zmień uprawnienia</string>
 
     <string name="sitePermissionsSettingsDescription">Strony, które odwiedzasz, mogą prosić o dostęp do lokalizacji urządzenia, kamery, mikrofonu lub oprogramowania DRM (Digital Rights Management). Nie będą miały do nich dostępu, jeśli nie udzielisz im zgody.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Pozwól wszystkim stronom prosić o:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-pl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-pl/strings-site-permissions.xml
@@ -57,6 +57,7 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Witryny mogą korzystać z Twojej kamery i mikrofonu tylko wtedy, gdy pozwolisz DuckDuckGo poprosić o dostęp.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Otwórz ustawienia</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Anuluj</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Do obsługi funkcji głosowych wymagane jest uprawnienie do korzystania z mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potrzebuje dostępu do Twojego mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Uprawnienia do mikrofonu są potrzebne, jeśli chcesz korzystać z czatu głosowego w Duck.ai</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Zmień uprawnienia</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-pt/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-pt/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Os sites só podem utilizar a tua câmara e microfone se autorizares o DuckDuckGo a pedir acesso.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Abrir Definições</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Cancelar</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">É necessária permissão de microfone para as funcionalidades de voz</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">O DuckDuckGo precisa de aceder ao teu microfone</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Precisas de permissões de microfone se quiseres utilizar o chat de voz no Duck.ai</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Alterar permissões</string>
 
     <string name="sitePermissionsSettingsDescription">Os sites que visitas podem pedir acesso à localização, câmara, microfone ou DRM (Digital Rights Management) do teu dispositivo. Não poderão aceder a estas funcionalidades sem que concedas permissão explicitamente.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Permitir que todos os sites peçam:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-ro/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-ro/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Site-urile îți pot utiliza camera și microfonul numai dacă permiți ca DuckDuckGo să solicite accesul.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Deschide Setări</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Anulează</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Este necesară permisiunea pentru microfon în scopul de a utiliza funcțiile vocale</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo are nevoie de acces la microfon</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Sunt necesare permisiunile pentru microfon dacă vrei să folosești chatul vocal în Duck.ai</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Modifică permisiunile</string>
 
     <string name="sitePermissionsSettingsDescription">Site-urile pe care le accesezi îți pot solicita accesul la locația dispozitivului, la camera foto, la microfon sau la software-ul DRM (Digital Rights Management). Acestea nu vor putea accesa aceste date decât dacă le oferi în mod explicit permisiunea.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Permite tuturor site-urilor să solicite:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-ru/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-ru/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Если вы разрешите DuckDuckGo запрашивать доступ, сайты смогут использовать только камеру и микрофон.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Открыть Настройки</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Отменить</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Для работы голосовых функций требуется разрешение на доступ к микрофону</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo требуется доступ к вашему микрофону</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Для использования голосового чата в Duck.ai требуется доступ к микрофону</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Изменить разрешения</string>
 
     <string name="sitePermissionsSettingsDescription">Посещаемые вами сайты могут запрашивать доступ к геопозиции, камере, микрофону или программам DRM (защиты авторских прав) вашего устройства. Доступ предоставляется только с вашего разрешения.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Разрешить всем сайтам запрашивать:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-sk/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-sk/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Lokality môžu používať váš fotoaparát a mikrofón len vtedy, ak povolíte aplikácii DuckDuckGo žiadať o prístup.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Otvoriť nastavenia</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Zrušiť</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Na používanie hlasových funkcií potrebuješ povolenie pre mikrofón</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potrebuje prístup k tvojmu mikrofónu</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Ak chceš v Duck.ai používať hlasový čet, je potrebné povolenie pre mikrofón.</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Zmeniť oprávnenia</string>
 
     <string name="sitePermissionsSettingsDescription">Stránky, ktoré navštívite, môžu požiadať o prístup k polohe vášho zariadenia, fotoaparátu, mikrofónu alebo softvéru DRM (Digital Rights Management). Nebudú mať k nim prístup, pokiaľ im to výslovne nepovolíte.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Povoliť všetkým lokalitám žiadať o:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-sl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-sl/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Spletna mesta lahko uporabljajo vašo kamero in mikrofon le, če dovolite, da DuckDuckGo zaprosi za dostop.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Odpri nastavitve</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Preklic</string>
+    <string name="duckAiMicDeniedSnackBarMessage">Za glasovne funkcije je potrebno dovoljenje za mikrofon</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potrebuje dostop do mikrofona</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Dovoljenja za mikrofon so potrebna, če želite uporabljati glasovni klepet v Duck.ai</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Sprememba dovoljenj</string>
 
     <string name="sitePermissionsSettingsDescription">Spletna mesta, ki jih obiščete, lahko zahtevajo dostop do lokacije, kamere, mikrofona ali programske opreme DRM (Digital Rights Management) vaše naprave. Do njih ne bodo mogla dostopati, razen če jim to izrecno dovolite.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Dovoli vsem mestom, da zahtevajo:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-sl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-sl/strings-site-permissions.xml
@@ -57,7 +57,6 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Spletna mesta lahko uporabljajo vašo kamero in mikrofon le, če dovolite, da DuckDuckGo zaprosi za dostop.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Odpri nastavitve</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Preklic</string>
-    <string name="duckAiMicDeniedSnackBarMessage">Za glasovne funkcije je potrebno dovoljenje za mikrofon</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potrebuje dostop do mikrofona</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Dovoljenja za mikrofon so potrebna, če želite uporabljati glasovni klepet v Duck.ai</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Sprememba dovoljenj</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-sl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-sl/strings-site-permissions.xml
@@ -57,6 +57,7 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Spletna mesta lahko uporabljajo vašo kamero in mikrofon le, če dovolite, da DuckDuckGo zaprosi za dostop.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Odpri nastavitve</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Preklic</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Za glasovne funkcije je potrebno dovoljenje za mikrofon</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potrebuje dostop do mikrofona</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Dovoljenja za mikrofon so potrebna, če želite uporabljati glasovni klepet v Duck.ai</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Sprememba dovoljenj</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-sv/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-sv/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Webbplatser kan endast använda din kamera och mikrofon om du tillåter DuckDuckGo att be om åtkomst.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Öppna inställningar</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Avbryt</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Mikrofonbehörighet krävs för röstfunktioner</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo behöver komma åt din mikrofon</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Mikrofonbehörighet behövs om du vill använda röstchatt i Duck.ai</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Ändra behörigheter</string>
 
     <string name="sitePermissionsSettingsDescription">Webbplatser som du besöker kan begära åtkomst till din enhets plats, kamera, mikrofon eller DRM-programvara (Digital Rights Management). De kan inte komma åt dessa om du inte uttryckligen tillåter det.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Tillåt alla webbplatser att be om:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-tr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-tr/strings-site-permissions.xml
@@ -57,6 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Siteler kameranızı ve mikrofonunuzu yalnızca DuckDuckGo\'nun erişim istemesine izin verirseniz kullanabilir.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Ayarları Aç</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">İptal</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Ses özellikleri için mikrofon izni gerekiyor</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo\'nun mikrofonunuza erişmesi gerekiyor</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Duck.ai\'da Sesli Sohbet özelliğini kullanmak istiyorsanız mikrofon izinleri gereklidir</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">İzinleri Değiştir</string>
 
     <string name="sitePermissionsSettingsDescription">Ziyaret ettiğiniz siteler cihazınızın konumuna, kamerasına, mikrofonuna veya DRM (Dijital Haklar Yönetimi) yazılımına erişim isteyebilir. Siz açıkça izin vermediğiniz sürece bunlara erişemezler.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Tüm sitelerin şunları istemesine izin ver:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values/strings-site-permissions.xml
@@ -16,7 +16,7 @@
 
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <!-- DRM Permission -->
     <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" wants to open your Digital Rights Management (DRM) software</string>
     <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">If you pick \"Deny\" videos on the site may become unplayable, but %1$s will not have access to device identifiers provided by DRM software. You can manage permissions at any time in Settings. <annotation type="drm_learn_more_link">Learn More</annotation></string>
@@ -57,10 +57,10 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Sites can only use your camera and microphone if you allow DuckDuckGo to ask for access.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Open Settings</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Cancel</string>
-    <string name="duckAiMicDeniedSnackBarMessage" tools:ignore="MissingTranslation">Microphone permission needed for voice features</string>
-    <string name="duckAiMicPermissionDeniedDialogTitle" tools:ignore="MissingTranslation">DuckDuckGo needs to access your microphone</string>
-    <string name="duckAiMicPermissionDeniedDialogContent" tools:ignore="MissingTranslation">Microphone permissions are needed if you want to use Voice Chat in Duck.ai</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton" tools:ignore="MissingTranslation">Change Permissions</string>
+    <string name="duckAiMicDeniedSnackBarMessage">Microphone permission needed for voice features</string>
+    <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo needs to access your microphone</string>
+    <string name="duckAiMicPermissionDeniedDialogContent">Microphone permissions are needed if you want to use Voice Chat in Duck.ai</string>
+    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Change Permissions</string>
 
     <string name="sitePermissionsSettingsDescription">Sites you visit may ask for access to your device’s location, camera, microphone, or DRM (Digital Rights Management) software. They won’t be able to access these unless you explicitly give them permission.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Allow all sites to ask for:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values/strings-site-permissions.xml
@@ -57,7 +57,7 @@
     <string name="systemPermissionDialogCameraAndAudioDeniedContent">Sites can only use your camera and microphone if you allow DuckDuckGo to ask for access.</string>
     <string name="systemPermissionsDeniedDialogPositiveButton">Open Settings</string>
     <string name="systemPermissionsDeniedDialogNegativeButton">Cancel</string>
-    <string name="duckAiMicDeniedSnackBarMessage">Microphone permission needed for voice features</string>
+    <string name="duckAiMicPermissionDeniedSnackBarMessage">Microphone permission needed for voice features</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo needs to access your microphone</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Microphone permissions are needed if you want to use Voice Chat in Duck.ai</string>
     <string name="duckAiMicPermissionDeniedDialogPositiveButton">Change Permissions</string>

--- a/voice-search/voice-search-impl/src/main/res/values-bg/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-bg/strings-voice-search.xml
@@ -24,7 +24,6 @@
     <string name="voiceSearchNegativeAction">Отмени</string>
     <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo има нужда от достъп до микрофона</string>
     <string name="voiceSearchMicAccessDeniedDialogMessage">Ако искате да използвате нашето поверително гласово търсене, трябва да разрешите достъп до микрофона.</string>
-    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Ако искате да използвате гласов чат в Duck.ai, трябва да разрешите достъп до микрофона.</string>
     <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Промяна на разрешенията</string>
     <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Скриване на гласово търсене</string>
     <string name="voiceSearchMicPermissionDeniedSnackbarMessage">За гласовите функции е необходимо разрешение за достъп до микрофона</string>

--- a/voice-search/voice-search-impl/src/main/res/values-bg/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-bg/strings-voice-search.xml
@@ -24,6 +24,7 @@
     <string name="voiceSearchNegativeAction">Отмени</string>
     <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo има нужда от достъп до микрофона</string>
     <string name="voiceSearchMicAccessDeniedDialogMessage">Ако искате да използвате нашето поверително гласово търсене, трябва да разрешите достъп до микрофона.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Ако искате да използвате нашите поверителни гласови функции, трябва да разрешите достъп до микрофона.</string>
     <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Промяна на разрешенията</string>
     <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Скриване на гласово търсене</string>
     <string name="voiceSearchMicPermissionDeniedSnackbarMessage">За гласовите функции е необходимо разрешение за достъп до микрофона</string>

--- a/voice-search/voice-search-impl/src/main/res/values-bg/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-bg/strings-voice-search.xml
@@ -31,5 +31,12 @@
     <string name="voiceSearchRemovePositiveButton">Премахване</string>
     <string name="voiceSearchRemoveTitle">Премахване на опцията за поверително гласово търсене от адресната лента?</string>
     <string name="voiceSearchRemoveSubtitle">Винаги можете да управлявате тези и други предпочитания за достъпност в „Настройки“.</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo има нужда от достъп до микрофона</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Ако искате да използвате нашето поверително гласово търсене, трябва да разрешите достъп до микрофона.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Ако искате да използвате гласов чат в Duck.ai, трябва да разрешите достъп до микрофона.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Промяна на разрешенията</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Скриване на гласово търсене</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">За гласовите функции е необходимо разрешение за достъп до микрофона</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Разрешавам</string>
     <string name="voiceSearchTitle">Гласово търсене</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-bg/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-bg/strings-voice-search.xml
@@ -22,15 +22,6 @@
     <string name="voiceSearchListening">Говорете сега</string>
     <string name="voiceSearchListeningFooter">Аудиото се обработва на устройството. То не се съхранява или споделя с никого, включително DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Отмени</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo никога не слуша какво казвате. Аудиото се обработва на устройството. То не се съхранява или споделя с никого.</string>
-    <string name="voiceSearchPermissionRationaleTitle">За поверително гласово търсене се изисква достъп до микрофона</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">ОК</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">За да използвате гласовото търсене в DuckDuckGo, трябва да разрешите достъпа до микрофона в системните настройки.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Настройки</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Изисква се достъп до микрофона</string>
-    <string name="voiceSearchRemovePositiveButton">Премахване</string>
-    <string name="voiceSearchRemoveTitle">Премахване на опцията за поверително гласово търсене от адресната лента?</string>
-    <string name="voiceSearchRemoveSubtitle">Винаги можете да управлявате тези и други предпочитания за достъпност в „Настройки“.</string>
     <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo има нужда от достъп до микрофона</string>
     <string name="voiceSearchMicAccessDeniedDialogMessage">Ако искате да използвате нашето поверително гласово търсене, трябва да разрешите достъп до микрофона.</string>
     <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Ако искате да използвате гласов чат в Duck.ai, трябва да разрешите достъп до микрофона.</string>

--- a/voice-search/voice-search-impl/src/main/res/values-cs/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-cs/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Řekni něco</string>
     <string name="voiceSearchListeningFooter">Zvuk se zpracovává na zařízení. Nikde ho neukládáme a s nikým ho nesdílíme. Ani DuckDuckGo se k němu nedostane.</string>
     <string name="voiceSearchNegativeAction">Zrušit</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo potřebuje přístup k mikrofonu</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Pokud chceš používat naše soukromé hlasové vyhledávání, je potřeba povolit přístup k mikrofonu.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Pokud chceš používat naše soukromé hlasové funkce, je potřeba povolit přístup k mikrofonu.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Změnit oprávnění</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Skrýt hlasové vyhledávání</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Pro hlasové funkce je potřeba povolit přístup k mikrofonu</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Povolit</string>
     <string name="voiceSearchTitle">Hlasové vyhledávání</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-cs/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-cs/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Řekni něco</string>
     <string name="voiceSearchListeningFooter">Zvuk se zpracovává na zařízení. Nikde ho neukládáme a s nikým ho nesdílíme. Ani DuckDuckGo se k němu nedostane.</string>
     <string name="voiceSearchNegativeAction">Zrušit</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo nikdy neposlouchá, co říkáš. Zvuk se zpracovává na zařízení. Nikam se neukládá ani se s nikým nesdílí.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Pro soukromé hlasové vyhledávání je nutný přístup k mikrofonu</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">Dobře</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Jestli chceš v DuckDuckGo používat hlasové vyhledávání, musíš v nastavení systému povolit přístup k mikrofonu.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Nastavení</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Je nutný přístup k mikrofonu</string>
-    <string name="voiceSearchRemovePositiveButton">Odstranit</string>
-    <string name="voiceSearchRemoveTitle">Odebrat možnost soukromého hlasového vyhledávání z adresního řádku?</string>
-    <string name="voiceSearchRemoveSubtitle">Tyto a další předvolby usnadnění přístupu můžete kdykoli upravit v Nastavení.</string>
     <string name="voiceSearchTitle">Hlasové vyhledávání</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-da/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-da/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Tal nu</string>
     <string name="voiceSearchListeningFooter">Lyden behandles på enheden. Den hverken gemmes eller deles med nogen, inklusive DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Afbestil</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo skal have adgang til din mikrofon</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Mikrofontilladelser er påkrævet, hvis du vil bruge vores private stemmesøgning.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Mikrofontilladelser er nødvendige, hvis du vil bruge vores private stemmefunktioner.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Skift tilladelser</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Skjul stemmesøgning</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Mikrofontilladelse er nødvendig for stemmefunktioner</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Tillad</string>
     <string name="voiceSearchTitle">Stemmesøgning</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-da/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-da/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Tal nu</string>
     <string name="voiceSearchListeningFooter">Lyden behandles på enheden. Den hverken gemmes eller deles med nogen, inklusive DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Afbestil</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo lytter aldrig til det, du siger. Lyden behandles på enheden. Det gemmes ikke og deles ikke med nogen.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Mikrofonadgang påkrævet til privat stemmesøgning</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">Okay</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Hvis du vil bruge stemmesøgning i DuckDuckGo, skal du aktivere mikrofonadgang i systemindstillingerne.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Indstillinger</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Mikrofonadgang påkrævet</string>
-    <string name="voiceSearchRemovePositiveButton">Fjern</string>
-    <string name="voiceSearchRemoveTitle">Vil du fjerne privat stemmesøgningmuligheden fra adresselinjen?</string>
-    <string name="voiceSearchRemoveSubtitle">Du kan altid administrere dette og andre tilgængelighedspræferencer i Indstillinger.</string>
     <string name="voiceSearchTitle">Stemmesøgning</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-de/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-de/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Sprich jetzt</string>
     <string name="voiceSearchListeningFooter">Audio wird auf dem Gerät verarbeitet. Es wird weder gespeichert noch an Dritte weitergegeben, auch nicht an DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Abbrechen</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo muss auf dein Mikrofon zugreifen</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Mikrofonberechtigungen werden benötigt, wenn du unsere private Sprachsuche nutzen möchtest.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Mikrofonberechtigungen werden benötigt, wenn du unsere privaten Sprachfunktionen nutzen möchtest.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Berechtigungen ändern</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Sprachsuche ausblenden</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Mikrofonberechtigung für Sprachfunktionen erforderlich</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Zulassen</string>
     <string name="voiceSearchTitle">Sprachsuche</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-de/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-de/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Sprich jetzt</string>
     <string name="voiceSearchListeningFooter">Audio wird auf dem Gerät verarbeitet. Es wird weder gespeichert noch an Dritte weitergegeben, auch nicht an DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Abbrechen</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo hört nie das, was du sagst, mit. Audio wird auf dem Gerät verarbeitet. Es wird nicht gespeichert oder mit niemandem geteilt.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Mikrofonzugriff für private Sprachsuche erforderlich</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">OK</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Um die Sprachsuche in DuckDuckGo zu verwenden, musst du den Mikrofonzugriff in den Systemeinstellungen aktivieren.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Einstellungen</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Mikrofonzugriff erforderlich</string>
-    <string name="voiceSearchRemovePositiveButton">Entfernen</string>
-    <string name="voiceSearchRemoveTitle">Option „Private Sprachsuche“ aus der Adressleiste entfernen?</string>
-    <string name="voiceSearchRemoveSubtitle">Du kannst diese und andere Barrierefreiheitseinstellungen jederzeit in den Einstellungen verwalten.</string>
     <string name="voiceSearchTitle">Sprachsuche</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-el/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-el/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Μιλήστε τώρα</string>
     <string name="voiceSearchListeningFooter">Η επεξεργασία του ήχου πραγματοποιείται στη συσκευή. Δεν αποθηκεύεται ούτε κοινοποιείται σε οποιονδήποτε, συμπεριλαμβανομένου του DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Ακύρωση</string>
-    <string name="voiceSearchPermissionRationaleDescription">Το DuckDuckGo δεν ακούει ποτέ ό,τι λέτε. Η επεξεργασία του ήχου πραγματοποιείται στη συσκευή. Δεν αποθηκεύεται ούτε κοινοποιείται σε οποιονδήποτε.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Απαιτείται πρόσβαση στο μικρόφωνο για Ιδιωτική φωνητική αναζήτηση</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">Εντάξει</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Για να χρησιμοποιήσετε τη Φωνητική αναζήτηση στο DuckDuckGo, πρέπει να ενεργοποιήσετε την πρόσβαση στο μικρόφωνο από τις ρυθμίσεις του συστήματος.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Ρυθμίσεις</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Απαιτείται πρόσβαση στο μικρόφωνο</string>
-    <string name="voiceSearchRemovePositiveButton">Αφαίρεση</string>
-    <string name="voiceSearchRemoveTitle">Κατάργηση της επιλογής Ιδιωτική φωνητική αναζήτηση από τη γραμμή διευθύνσεων;</string>
-    <string name="voiceSearchRemoveSubtitle">Μπορείτε πάντα να διαχειρίζεστε αυτές και άλλες προτιμήσεις προσβασιμότητας από τις Ρυθμίσεις.</string>
     <string name="voiceSearchTitle">Φωνητική αναζήτηση</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-el/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-el/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Μιλήστε τώρα</string>
     <string name="voiceSearchListeningFooter">Η επεξεργασία του ήχου πραγματοποιείται στη συσκευή. Δεν αποθηκεύεται ούτε κοινοποιείται σε οποιονδήποτε, συμπεριλαμβανομένου του DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Ακύρωση</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">Το DuckDuckGo χρειάζεται πρόσβαση στο μικρόφωνό σου</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Απαιτούνται δικαιώματα πρόσβασης στο μικρόφωνο αν θέλεις να χρησιμοποιήσεις την Ιδιωτική Φωνητική Αναζήτησή μας.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Απαιτούνται δικαιώματα πρόσβασης στο μικρόφωνο αν θέλεις να χρησιμοποιήσεις τις ιδιωτικές φωνητικές λειτουργίες μας.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Αλλαγή δικαιωμάτων</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Απόκρυψη φωνητικής αναζήτησης</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Απαιτείται δικαίωμα πρόσβασης στο μικρόφωνο για τις φωνητικές λειτουργίες</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Αποδοχή</string>
     <string name="voiceSearchTitle">Φωνητική αναζήτηση</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-es/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-es/strings-voice-search.xml
@@ -22,15 +22,6 @@
     <string name="voiceSearchListening">Habla ahora</string>
     <string name="voiceSearchListeningFooter">El audio se procesa en el dispositivo. No se almacena ni comparte con nadie, incluyendo DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Cancelar</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo nunca escucha lo que dices. El audio se procesa en el dispositivo. No se almacena ni se comparte con nadie.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Se requiere acceso al micrófono para la búsqueda por voz privada</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">De acuerdo</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Para usar la búsqueda por voz en DuckDuckGo, debes habilitar el acceso al micrófono en la configuración del sistema.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Ajustes</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Se requiere acceso al micrófono</string>
-    <string name="voiceSearchRemovePositiveButton">Eliminar</string>
-    <string name="voiceSearchRemoveTitle">¿Eliminar la opción de búsqueda privada por voz de la barra de direcciones?</string>
-    <string name="voiceSearchRemoveSubtitle">Siempre puedes gestionar estas y otras preferencias de accesibilidad en Configuración.</string>
     <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo necesita acceder a tu micrófono</string>
     <string name="voiceSearchMicAccessDeniedDialogMessage">Se necesitan permisos de micrófono si quieres usar nuestra búsqueda por voz privada.</string>
     <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Se necesitan permisos de micrófono si quieres usar el chat de voz en Duck.ai.</string>

--- a/voice-search/voice-search-impl/src/main/res/values-es/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-es/strings-voice-search.xml
@@ -24,6 +24,7 @@
     <string name="voiceSearchNegativeAction">Cancelar</string>
     <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo necesita acceder a tu micrófono</string>
     <string name="voiceSearchMicAccessDeniedDialogMessage">Se necesitan permisos de micrófono si quieres usar nuestra búsqueda por voz privada.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Se necesitan permisos de micrófono si quieres usar nuestra búsqueda por voz privada.</string>
     <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Cambiar permisos</string>
     <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Ocultar búsqueda por voz</string>
     <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Se necesita permiso de micrófono para las funciones de voz</string>

--- a/voice-search/voice-search-impl/src/main/res/values-es/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-es/strings-voice-search.xml
@@ -24,7 +24,6 @@
     <string name="voiceSearchNegativeAction">Cancelar</string>
     <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo necesita acceder a tu micrófono</string>
     <string name="voiceSearchMicAccessDeniedDialogMessage">Se necesitan permisos de micrófono si quieres usar nuestra búsqueda por voz privada.</string>
-    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Se necesitan permisos de micrófono si quieres usar el chat de voz en Duck.ai.</string>
     <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Cambiar permisos</string>
     <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Ocultar búsqueda por voz</string>
     <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Se necesita permiso de micrófono para las funciones de voz</string>

--- a/voice-search/voice-search-impl/src/main/res/values-es/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-es/strings-voice-search.xml
@@ -31,5 +31,12 @@
     <string name="voiceSearchRemovePositiveButton">Eliminar</string>
     <string name="voiceSearchRemoveTitle">¿Eliminar la opción de búsqueda privada por voz de la barra de direcciones?</string>
     <string name="voiceSearchRemoveSubtitle">Siempre puedes gestionar estas y otras preferencias de accesibilidad en Configuración.</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo necesita acceder a tu micrófono</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Se necesitan permisos de micrófono si quieres usar nuestra búsqueda por voz privada.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Se necesitan permisos de micrófono si quieres usar el chat de voz en Duck.ai.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Cambiar permisos</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Ocultar búsqueda por voz</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Se necesita permiso de micrófono para las funciones de voz</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Permitir</string>
     <string name="voiceSearchTitle">Búsqueda por voz</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-et/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-et/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Räägi kohe</string>
     <string name="voiceSearchListeningFooter">Heli töödeldakse seadmes. Seda ei salvestata ega jagata kellegagi, sealhulgas DuckDuckGoga.</string>
     <string name="voiceSearchNegativeAction">Tühista</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo vajab juurdepääsu teie mikrofonile</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Mikrofoni õigused on vajalikud, kui soovite kasutada meie privaatset häälotsingut.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Mikrofoni õigused on vajalikud, kui soovid kasutada meie privaatseid häälfunktsioone.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Muuda load</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Peida häälotsing</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Häälfunktsioonide jaoks on tarvis mikrofoni luba</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Luba</string>
     <string name="voiceSearchTitle">Häälotsing</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-et/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-et/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Räägi kohe</string>
     <string name="voiceSearchListeningFooter">Heli töödeldakse seadmes. Seda ei salvestata ega jagata kellegagi, sealhulgas DuckDuckGoga.</string>
     <string name="voiceSearchNegativeAction">Tühista</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo ei kuula kunagi pealt, mida sa ütled. Heli töödeldakse seadmes kohapeal. Seda ei salvestata ega jagata kellegagi.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Privaatse häälotsingu jaoks on vajalik juurdepääs mikrofonile</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">OK</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">DuckDuckGo häälotsingu kasutamiseks pead süsteemiseadetes lubama mikrofonipääsu.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Sätted</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Vajalik juurdepääs mikrofonile</string>
-    <string name="voiceSearchRemovePositiveButton">Eemaldage</string>
-    <string name="voiceSearchRemoveTitle">Kas eemaldada privaatse häälotsingu valik aadressiribalt?</string>
-    <string name="voiceSearchRemoveSubtitle">Seda ja muid juurdepääsetavuse eelistusi saad alati muuta seadetes.</string>
     <string name="voiceSearchTitle">Häälotsing</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-fi/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-fi/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Puhu nyt</string>
     <string name="voiceSearchListeningFooter">Ääni käsitellään laitteella. Sitä ei tallenneta eikä jaeta kenellekään, edes DuckDuckGolle.</string>
     <string name="voiceSearchNegativeAction">Peruuta</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo ei koskaan kuuntele puhettasi. Ääni käsitellään laitteella. Sitä ei tallenneta eikä jaeta kenenkään kanssa.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Mikrofonin käyttöoikeus vaaditaan yksityiseen äänihakuun</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">OK</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Jotta voit käyttää äänihakua DuckDuckGossa, salli mikrofonin käyttö järjestelmäasetuksissa.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Asetukset</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Mikrofonin käyttöoikeus vaaditaan</string>
-    <string name="voiceSearchRemovePositiveButton">Poista</string>
-    <string name="voiceSearchRemoveTitle">Poistetaanko yksityinen äänihakuvaihtoehto osoitepalkista?</string>
-    <string name="voiceSearchRemoveSubtitle">Voit hallita tätä ja muita esteettömyysasetuksia Asetuksissa.</string>
     <string name="voiceSearchTitle">Äänihaku</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-fi/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-fi/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Puhu nyt</string>
     <string name="voiceSearchListeningFooter">Ääni käsitellään laitteella. Sitä ei tallenneta eikä jaeta kenellekään, edes DuckDuckGolle.</string>
     <string name="voiceSearchNegativeAction">Peruuta</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo tarvitsee mikrofonisi käyttöoikeuden</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Mikrofonin käyttöoikeudet tarvitaan, jos haluat käyttää yksityistä äänihakuamme.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Mikrofonin käyttöoikeudet tarvitaan, jos haluat käyttää yksityisiä äänitoimintojamme.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Muuta käyttöoikeuksia</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Piilota äänihaku</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Mikrofonin käyttöoikeus tarvitaan äänitoimintoja varten</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Salli</string>
     <string name="voiceSearchTitle">Äänihaku</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-fr/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-fr/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Parlez maintenant</string>
     <string name="voiceSearchListeningFooter">L\'audio est traité directement sur l\'appareil. Il n\'est ni stocké ni partagé avec qui que ce soit, y compris DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Annuler</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo n\'écoute jamais ce que vous dites. L\'audio est traité directement sur l\'appareil. Il n\'est ni stocké ni partagé avec qui que ce soit.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Accès au microphone requis pour la recherche vocale privée</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">Ok</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Pour utiliser la recherche vocale dans DuckDuckGo, vous devez activer l\'accès au microphone dans les paramètres système.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Paramètres</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Accès au microphone requis</string>
-    <string name="voiceSearchRemovePositiveButton">Supprimer</string>
-    <string name="voiceSearchRemoveTitle">Supprimer l\'option Recherche vocale privée de la barre d\'adresse ?</string>
-    <string name="voiceSearchRemoveSubtitle">Si vous souhaitez gérer cette option et d\'autres préférences d\'accessibilité, elles restent accessibles dans Paramètres.</string>
     <string name="voiceSearchTitle">Recherche vocale</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-fr/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-fr/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Parlez maintenant</string>
     <string name="voiceSearchListeningFooter">L\'audio est traité directement sur l\'appareil. Il n\'est ni stocké ni partagé avec qui que ce soit, y compris DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Annuler</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo a besoin d’accéder à votre micro</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Les autorisations d’accès au micro sont nécessaires si vous souhaitez utiliser notre fonction de recherche vocale privée.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Les autorisations d’accès au micro sont nécessaires si vous souhaitez utiliser nos fonctionnalités vocales privées.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Modifier les autorisations</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Masquer la recherche vocale</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Autorisation d’accès au micro requise pour les fonctionnalités vocales</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Autoriser</string>
     <string name="voiceSearchTitle">Recherche vocale</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-hr/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-hr/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Govori sad</string>
     <string name="voiceSearchListeningFooter">Zvuk se obrađuje na uređaju. Ne pohranjuje se i ne dijeli ni s kim, uključujući DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Odustani</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo nikad ne prisluškuje što govoriš. Zvuk se obrađuje na uređaju. Ne pohranjuje se i ne dijeli ni s kim.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Potreban je pristup mikrofonu za Privatno glasovno pretraživanje</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">U redu</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Za korištenje glasovnog pretraživanja u DuckDuckGou, moraš omogućiti pristup mikrofonu u postavkama sustava.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Postavke</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Potreban je pristup mikrofonu</string>
-    <string name="voiceSearchRemovePositiveButton">Ukloni</string>
-    <string name="voiceSearchRemoveTitle">Ukloniti opciju privatnog glasovnog pretraživanja iz adresne trake?</string>
-    <string name="voiceSearchRemoveSubtitle">Ovim i drugim postavkama pristupačnosti uvijek možeš upravljati putem Postavki.</string>
     <string name="voiceSearchTitle">Glasovno pretraživanje</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-hr/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-hr/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Govori sad</string>
     <string name="voiceSearchListeningFooter">Zvuk se obrađuje na uređaju. Ne pohranjuje se i ne dijeli ni s kim, uključujući DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Odustani</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo treba pristupiti tvom mikrofonu</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Ako želiš koristiti naše Privatno glasovno pretraživanje, potrebna su dopuštenja za mikrofon.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Dopuštenja za mikrofon potrebna su ako želiš koristiti naše privatne glasovne značajke.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Promijeni dozvole</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Sakrij glasovno pretraživanje</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Za glasovne funkcije potrebno je dopuštenje za mikrofon</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Dopusti</string>
     <string name="voiceSearchTitle">Glasovno pretraživanje</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-hu/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-hu/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Most beszélhetsz</string>
     <string name="voiceSearchListeningFooter">A hang feldolgozása az eszközön történik. Nem tároljuk és nem osztjuk meg senkivel, még a DuckDuckGóval sem.</string>
     <string name="voiceSearchNegativeAction">Mégsem</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">A DuckDuckGónak hozzá kell férnie a mikrofonhoz</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Mikrofonengedélyre van szükség, ha szeretnél privát beszédhangalapú keresést használni.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Mikrofonengedélyre van szükség, ha szeretnéd privát beszédhangfunkcióinkat használni.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Engedélyek módosítása</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Beszédhangalapú keresés elrejtése</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">A beszédhangfunkciókhoz mikrofonengedély szükséges</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Engedélyezés</string>
     <string name="voiceSearchTitle">Beszédhangalapú keresés</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-hu/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-hu/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Most beszélhetsz</string>
     <string name="voiceSearchListeningFooter">A hang feldolgozása az eszközön történik. Nem tároljuk és nem osztjuk meg senkivel, még a DuckDuckGóval sem.</string>
     <string name="voiceSearchNegativeAction">Mégsem</string>
-    <string name="voiceSearchPermissionRationaleDescription">A DuckDuckGo soha nem hallgatja azt, amit mondasz. A hang feldolgozása az eszközön történik. A hangot nem tároljuk és nem osztjuk meg senkivel.</string>
-    <string name="voiceSearchPermissionRationaleTitle">A Privát beszédhangalapú kereséshez Mikrofon-hozzáférés szükséges</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">OK</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">A DuckDuckGo beszédhangalapú keresésének használatához a rendszerbeállításokban engedélyezned kell a mikrofonhoz való hozzáférést.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Beállítások</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Mikrofon-hozzáférés szükséges</string>
-    <string name="voiceSearchRemovePositiveButton">Eltávolítás</string>
-    <string name="voiceSearchRemoveTitle">Eltávolítja a privát beszédhangalapú keresési opciót a címsorból?</string>
-    <string name="voiceSearchRemoveSubtitle">A beállításokban bármikor módosíthatod ezt és a többi kisegítő lehetőséget.</string>
     <string name="voiceSearchTitle">Beszédhangalapú keresés</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-it/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-it/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Parla ora</string>
     <string name="voiceSearchListeningFooter">L\'audio viene elaborato sul dispositivo e non viene memorizzato né condiviso con altri utenti, nemmeno con DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Annulla</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo deve accedere al microfono</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">I permessi per il microfono sono necessari per utilizzare la nostra Ricerca vocale privata.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">I permessi per il microfono sono necessari se vuoi usare le nostre funzionalità vocali private.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Modifica autorizzazioni</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Nascondi ricerca vocale</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Autorizzazione del microfono necessaria per le funzioni vocali</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Consenti</string>
     <string name="voiceSearchTitle">Ricerca vocale</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-it/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-it/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Parla ora</string>
     <string name="voiceSearchListeningFooter">L\'audio viene elaborato sul dispositivo e non viene memorizzato né condiviso con altri utenti, nemmeno con DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Annulla</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo non ascolta mai quello che dici. L\'audio viene elaborato sul dispositivo. Non viene archiviato né condiviso con altri.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Accesso al microfono necessario per la Ricerca vocale privata</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">OK</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Per utilizzare la ricerca vocale di DuckDuckGo, devi consentire l\'accesso al microfono nelle impostazioni di sistema.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Impostazioni</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Accesso al microfono obbligatorio</string>
-    <string name="voiceSearchRemovePositiveButton">Rimuovi</string>
-    <string name="voiceSearchRemoveTitle">Rimuovere l\'opzione di ricerca vocale privata dalla barra degli indirizzi?</string>
-    <string name="voiceSearchRemoveSubtitle">Puoi sempre gestire questa e altre preferenze di accessibilità nelle Impostazioni.</string>
     <string name="voiceSearchTitle">Ricerca vocale</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-lt/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-lt/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Kalbėkite dabar</string>
     <string name="voiceSearchListeningFooter">Garsas apdorojamas įrenginyje. Jis nesaugomas ir su niekuo, įskaitant „DuckDuckGo“, nebendrinamas.</string>
     <string name="voiceSearchNegativeAction">Atšaukti</string>
-    <string name="voiceSearchPermissionRationaleDescription">„DuckDuckGo“ niekada nesiklauso jūsų pokalbių. Garsas apdorojamas įrenginyje. Jis nesaugomas ir su niekuo nesidalijamas.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Privačiai balsu atliekamai paieškai reikalinga prieiga prie mikrofono</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">Gerai</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Jei norite naudoti „DuckDuckGo“ paiešką balsu, sistemos nustatymuose turite įjungti prieigą prie mikrofono.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Nustatymai</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Būtina prieiga prie mikrofono</string>
-    <string name="voiceSearchRemovePositiveButton">Pašalinti</string>
-    <string name="voiceSearchRemoveTitle">Pašalinti privačios paieškos balsu parinktį iš adreso juostos?</string>
-    <string name="voiceSearchRemoveSubtitle">Šias ir kitas pritaikymo neįgaliesiems nuostatas visada galite tvarkyti nustatymuose.</string>
     <string name="voiceSearchTitle">Paieška balsu</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-lt/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-lt/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Kalbėkite dabar</string>
     <string name="voiceSearchListeningFooter">Garsas apdorojamas įrenginyje. Jis nesaugomas ir su niekuo, įskaitant „DuckDuckGo“, nebendrinamas.</string>
     <string name="voiceSearchNegativeAction">Atšaukti</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">„DuckDuckGo“ reikia prieigos prie tavo mikrofono</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Jei nori naudotis mūsų privačia paieška balsu, reikia leidimo naudoti mikrofoną.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Norint naudotis mūsų privačiomis balso funkcijomis, reikia leidimo naudoti mikrofoną.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Keisti leidimus</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Slėpti paiešką balsu</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Balso funkcijoms reikia leidimo naudoti mikrofoną</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Leisti</string>
     <string name="voiceSearchTitle">Paieška balsu</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-lv/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-lv/strings-voice-search.xml
@@ -31,5 +31,12 @@
     <string name="voiceSearchRemovePositiveButton">Noņemt</string>
     <string name="voiceSearchRemoveTitle">Vai noņemt opciju \"Privātā meklēšana ar balsi\" no adreses joslas?</string>
     <string name="voiceSearchRemoveSubtitle">Šīs un citas pieejamības preferences vienmēr vari pārvaldīt sadaļā Iestatījumi.</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo ir nepieciešama piekļuve mikrofonam.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Ja vēlies izmantot mūsu privāto meklēšanu ar balsi, ir nepieciešamas mikrofona atļaujas.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Mikrofona atļaujas ir nepieciešamas, ja vēlies izmantot balss tērzēšanu vietnē Duck.ai.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Mainīt atļaujas</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Paslēpt meklēšanu ar balsi</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Balss funkcijām nepieciešama mikrofona atļauja</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Atļaut</string>
     <string name="voiceSearchTitle">Balss meklēšana</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-lv/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-lv/strings-voice-search.xml
@@ -22,15 +22,6 @@
     <string name="voiceSearchListening">Runā tagad</string>
     <string name="voiceSearchListeningFooter">Audio tiek apstrādāts ierīcē. Tas netiek glabāts, un tam nevar piekļūt neviens, pat ne DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Atcelt</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo nekad nenoklausās tevis teikto. Audio tiek apstrādāts ierīcē. Tas netiek glabāts vai koplietots ne ar vienu.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Privātajai meklēšanai ar balsi ir nepieciešama piekļuve mikrofonam</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">Labi</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Lai DuckDuckGo izmantotu balss meklēšanu, sistēmas iestatījumos ir jāiespējo piekļuve mikrofonam.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Iestatījumi</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Nepieciešama piekļuve mikrofonam</string>
-    <string name="voiceSearchRemovePositiveButton">Noņemt</string>
-    <string name="voiceSearchRemoveTitle">Vai noņemt opciju \"Privātā meklēšana ar balsi\" no adreses joslas?</string>
-    <string name="voiceSearchRemoveSubtitle">Šīs un citas pieejamības preferences vienmēr vari pārvaldīt sadaļā Iestatījumi.</string>
     <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo ir nepieciešama piekļuve mikrofonam.</string>
     <string name="voiceSearchMicAccessDeniedDialogMessage">Ja vēlies izmantot mūsu privāto meklēšanu ar balsi, ir nepieciešamas mikrofona atļaujas.</string>
     <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Mikrofona atļaujas ir nepieciešamas, ja vēlies izmantot balss tērzēšanu vietnē Duck.ai.</string>

--- a/voice-search/voice-search-impl/src/main/res/values-lv/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-lv/strings-voice-search.xml
@@ -24,6 +24,7 @@
     <string name="voiceSearchNegativeAction">Atcelt</string>
     <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo ir nepieciešama piekļuve mikrofonam.</string>
     <string name="voiceSearchMicAccessDeniedDialogMessage">Ja vēlies izmantot mūsu privāto meklēšanu ar balsi, ir nepieciešamas mikrofona atļaujas.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Ja vēlies izmantot mūsu privātās balss funkcijas, ir nepieciešamas mikrofona atļaujas.</string>
     <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Mainīt atļaujas</string>
     <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Paslēpt meklēšanu ar balsi</string>
     <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Balss funkcijām nepieciešama mikrofona atļauja</string>

--- a/voice-search/voice-search-impl/src/main/res/values-lv/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-lv/strings-voice-search.xml
@@ -24,7 +24,6 @@
     <string name="voiceSearchNegativeAction">Atcelt</string>
     <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo ir nepieciešama piekļuve mikrofonam.</string>
     <string name="voiceSearchMicAccessDeniedDialogMessage">Ja vēlies izmantot mūsu privāto meklēšanu ar balsi, ir nepieciešamas mikrofona atļaujas.</string>
-    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Mikrofona atļaujas ir nepieciešamas, ja vēlies izmantot balss tērzēšanu vietnē Duck.ai.</string>
     <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Mainīt atļaujas</string>
     <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Paslēpt meklēšanu ar balsi</string>
     <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Balss funkcijām nepieciešama mikrofona atļauja</string>

--- a/voice-search/voice-search-impl/src/main/res/values-nb/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-nb/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Snakk nå</string>
     <string name="voiceSearchListeningFooter">Lyd behandles på enheten. Den lagres ikke og deles ikke med noen, heller ikke med DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Avbryt</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo lytter aldri til det du sier. Lyd behandles på enheten. Den blir ikke lagret eller delt med noen.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Mikrofontilgang kreves for Privat talesøk</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">OK</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">For å bruke talesøk i DuckDuckGo må du aktivere mikrofontilgang i systeminnstillingene.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Innstillinger</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Mikrofontilgang kreves</string>
-    <string name="voiceSearchRemovePositiveButton">Fjern</string>
-    <string name="voiceSearchRemoveTitle">Vil du fjerne alternativet privat talesøk fra adressefeltet?</string>
-    <string name="voiceSearchRemoveSubtitle">Du kan alltid administrere dette og andre tilgjengelighetsinnstillinger i Innstillinger.</string>
     <string name="voiceSearchTitle">Talesøk</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-nb/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-nb/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Snakk nå</string>
     <string name="voiceSearchListeningFooter">Lyd behandles på enheten. Den lagres ikke og deles ikke med noen, heller ikke med DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Avbryt</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo trenger tilgang til mikrofonen</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Mikrofontillatelser er nødvendig hvis du vil bruke privat talesøk.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Mikrofontillatelser er nødvendig hvis du vil bruke private talefunksjoner.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Endre tillatelser</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Skjul talesøk</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Mikrofontillatelse er nødvendig for talefunksjoner</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Tillat</string>
     <string name="voiceSearchTitle">Talesøk</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-nl/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-nl/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Praat nu</string>
     <string name="voiceSearchListeningFooter">Audio wordt op het apparaat verwerkt. Het wordt niet opgeslagen of met iemand gedeeld, ook niet met DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Annuleren</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo heeft toegang tot je microfoon nodig</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Microfoontoegang is nodig als je onze Spraakgestuurd zoeken wilt gebruiken.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Microfoontoegang is nodig als je onze privé-spraakfuncties wilt gebruiken.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Toestemmingen wijzigen</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Zoeken via spraak verbergen</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Microfoonmachtiging nodig voor spraakfuncties</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Toestaan</string>
     <string name="voiceSearchTitle">Zoeken via spraak</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-nl/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-nl/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Praat nu</string>
     <string name="voiceSearchListeningFooter">Audio wordt op het apparaat verwerkt. Het wordt niet opgeslagen of met iemand gedeeld, ook niet met DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Annuleren</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo luistert nooit naar wat je zegt. Audio wordt op het apparaat verwerkt. Het wordt niet opgeslagen en met niemand gedeeld.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Microfoontoegang vereist voor Private Voice Search</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">OK</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Om te zoeken via spraak in DuckDuckGo, moet je toegang tot de microfoon inschakelen in de systeeminstellingen.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Instellingen</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Toegang tot microfoon vereist</string>
-    <string name="voiceSearchRemovePositiveButton">Verwijderen</string>
-    <string name="voiceSearchRemoveTitle">Wil je de optie \'Privé zoeken via spraak\' uit de adresbalk verwijderen?</string>
-    <string name="voiceSearchRemoveSubtitle">Je kunt deze en andere toegankelijkheidsvoorkeuren altijd beheren in \'Instellingen\'.</string>
     <string name="voiceSearchTitle">Zoeken via spraak</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-pl/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-pl/strings-voice-search.xml
@@ -31,5 +31,12 @@
     <string name="voiceSearchRemovePositiveButton">Usuń</string>
     <string name="voiceSearchRemoveTitle">Usunąć opcję prywatnego wyszukiwania głosowego z paska adresu?</string>
     <string name="voiceSearchRemoveSubtitle">Tymi i innymi preferencjami dostępności możesz zarządzać w Ustawieniach.</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo potrzebuje dostępu do Twojego mikrofonu</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Uprawnienia do mikrofonu są potrzebne, jeśli chcesz korzystać z naszego prywatnego wyszukiwania głosowego.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Uprawnienia do mikrofonu są potrzebne, jeśli chcesz korzystać z czatu głosowego w Duck.ai.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Zmień uprawnienia</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Ukryj wyszukiwanie głosowe</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Do obsługi funkcji głosowych wymagane jest uprawnienie do korzystania z mikrofonu</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Zezwól</string>
     <string name="voiceSearchTitle">Wyszukiwanie głosowe</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-pl/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-pl/strings-voice-search.xml
@@ -22,15 +22,6 @@
     <string name="voiceSearchListening">Mów teraz</string>
     <string name="voiceSearchListeningFooter">Dźwięk jest przetwarzany na urządzeniu. Dane nie są przechowywane ani udostępniane żadnym podmiotom, w tym DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Anuluj</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo nigdy nie rejestruje tego, co mówisz. Dźwięk jest przetwarzany na urządzeniu. Nie jest przechowywany ani nikomu udostępniany.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Wymagany dostęp do mikrofonu na potrzeby prywatnego wyszukiwania głosowego</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">OK</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Aby korzystać z wyszukiwania głosowego w DuckDuckGo, musisz włączyć dostęp do mikrofonu w ustawieniach systemu.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Ustawienia</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Wymagany dostęp do mikrofonu</string>
-    <string name="voiceSearchRemovePositiveButton">Usuń</string>
-    <string name="voiceSearchRemoveTitle">Usunąć opcję prywatnego wyszukiwania głosowego z paska adresu?</string>
-    <string name="voiceSearchRemoveSubtitle">Tymi i innymi preferencjami dostępności możesz zarządzać w Ustawieniach.</string>
     <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo potrzebuje dostępu do Twojego mikrofonu</string>
     <string name="voiceSearchMicAccessDeniedDialogMessage">Uprawnienia do mikrofonu są potrzebne, jeśli chcesz korzystać z naszego prywatnego wyszukiwania głosowego.</string>
     <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Uprawnienia do mikrofonu są potrzebne, jeśli chcesz korzystać z czatu głosowego w Duck.ai.</string>

--- a/voice-search/voice-search-impl/src/main/res/values-pl/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-pl/strings-voice-search.xml
@@ -24,7 +24,6 @@
     <string name="voiceSearchNegativeAction">Anuluj</string>
     <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo potrzebuje dostępu do Twojego mikrofonu</string>
     <string name="voiceSearchMicAccessDeniedDialogMessage">Uprawnienia do mikrofonu są potrzebne, jeśli chcesz korzystać z naszego prywatnego wyszukiwania głosowego.</string>
-    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Uprawnienia do mikrofonu są potrzebne, jeśli chcesz korzystać z czatu głosowego w Duck.ai.</string>
     <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Zmień uprawnienia</string>
     <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Ukryj wyszukiwanie głosowe</string>
     <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Do obsługi funkcji głosowych wymagane jest uprawnienie do korzystania z mikrofonu</string>

--- a/voice-search/voice-search-impl/src/main/res/values-pl/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-pl/strings-voice-search.xml
@@ -24,6 +24,7 @@
     <string name="voiceSearchNegativeAction">Anuluj</string>
     <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo potrzebuje dostępu do Twojego mikrofonu</string>
     <string name="voiceSearchMicAccessDeniedDialogMessage">Uprawnienia do mikrofonu są potrzebne, jeśli chcesz korzystać z naszego prywatnego wyszukiwania głosowego.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Uprawnienia do mikrofonu są potrzebne, jeśli chcesz korzystać z naszych prywatnych funkcji głosowych.</string>
     <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Zmień uprawnienia</string>
     <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Ukryj wyszukiwanie głosowe</string>
     <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Do obsługi funkcji głosowych wymagane jest uprawnienie do korzystania z mikrofonu</string>

--- a/voice-search/voice-search-impl/src/main/res/values-pt/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-pt/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Fala agora</string>
     <string name="voiceSearchListeningFooter">O áudio é processado no dispositivo. Não foi armazenado ou partilhado com ninguém, incluindo o DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Cancelar</string>
-    <string name="voiceSearchPermissionRationaleDescription">O DuckDuckGo nunca ouve o que dizes. O áudio é processado no dentro do teu dispositivo. Não é armazenado nem partilhado com ninguém.</string>
-    <string name="voiceSearchPermissionRationaleTitle">É necessário o acesso ao microfone para pesquisar por voz privada</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">OK</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Para usar a Pesquisa por voz no DuckDuckGo, tens de autorizar o acesso ao microfone nas definições do sistema.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Definições</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">É necessário o acesso ao microfone</string>
-    <string name="voiceSearchRemovePositiveButton">Remover</string>
-    <string name="voiceSearchRemoveTitle">Remover opção de pesquisa por voz privada da barra de endereços?</string>
-    <string name="voiceSearchRemoveSubtitle">Podes sempre gerir esta e outras preferências de acessibilidade nas Definições.</string>
     <string name="voiceSearchTitle">Pesquisa por voz</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-pt/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-pt/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Fala agora</string>
     <string name="voiceSearchListeningFooter">O áudio é processado no dispositivo. Não foi armazenado ou partilhado com ninguém, incluindo o DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Cancelar</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">O DuckDuckGo precisa de aceder ao teu microfone</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Precisas de permissões de microfone se quiseres usar a nossa pesquisa por voz privada.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Precisas de permissões de microfone se quiseres usar as nossas funcionalidades de voz privadas.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Alterar permissões</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Ocultar pesquisa por voz</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">É necessária permissão de microfone para as funcionalidades de voz</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Permitir</string>
     <string name="voiceSearchTitle">Pesquisa por voz</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-ro/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-ro/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Vorbește acum</string>
     <string name="voiceSearchListeningFooter">Componenta audio este prelucrată pe dispozitiv. Nu este stocată sau distribuită nimănui, nici DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Anulează</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo are nevoie de acces la microfon</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Sunt necesare permisiunile pentru microfon dacă vrei să folosești căutarea vocală privată.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Sunt necesare permisiunile pentru microfon dacă vrei să folosești funcțiile vocale private.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Modifică permisiunile</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Ascunde căutarea vocală</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Este necesară permisiunea pentru microfon în scopul de a utiliza funcțiile vocale</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Permite</string>
     <string name="voiceSearchTitle">Căutare vocală</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-ro/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-ro/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Vorbește acum</string>
     <string name="voiceSearchListeningFooter">Componenta audio este prelucrată pe dispozitiv. Nu este stocată sau distribuită nimănui, nici DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Anulează</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo nu ascultă niciodată ceea ce spui. Materialul audio este prelucrat pe dispozitiv. Nu este stocat sau partajat cu nimeni.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Este necesar accesul la microfon pentru Căutarea vocală privată</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">OK</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Pentru a utiliza căutarea vocală în DuckDuckGo, trebuie să activezi accesul la microfon din setările sistemului.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Setări</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Este necesar accesul la microfon</string>
-    <string name="voiceSearchRemovePositiveButton">Elimină</string>
-    <string name="voiceSearchRemoveTitle">Elimini opțiunea Căutare vocală privată din bara de adrese?</string>
-    <string name="voiceSearchRemoveSubtitle">Puteți gestiona oricând această preferință de accesibilitate și altele din Setări.</string>
     <string name="voiceSearchTitle">Căutare vocală</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-ru/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-ru/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Слушаем вас!</string>
     <string name="voiceSearchListeningFooter">Аудио обрабатывается непосредственно на устройстве, не хранится и не передается никому, даже DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Отменить</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo никогда не подслушивает ваши разговоры. Аудио обрабатывается на вашем устройстве, нигде не хранится и никому не передается.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Для приватного голосового поиска требуется доступ к микрофону</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">Хорошо</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Чтобы применить голосовой поиск в DuckDuckGo, включите доступ к микрофону в настройках системы.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Настройки</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Требуется доступ к микрофону</string>
-    <string name="voiceSearchRemovePositiveButton">Удалить</string>
-    <string name="voiceSearchRemoveTitle">Убрать частный голосовой поиск из адресной строки?</string>
-    <string name="voiceSearchRemoveSubtitle">Это и другие предпочтения можно всегда изменить в «Настройках».</string>
     <string name="voiceSearchTitle">Голосовой поиск</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-ru/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-ru/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Слушаем вас!</string>
     <string name="voiceSearchListeningFooter">Аудио обрабатывается непосредственно на устройстве, не хранится и не передается никому, даже DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Отменить</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo требуется доступ к вашему микрофону</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Для использования приватного голосового поиска требуется доступ к микрофону.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Для использования приватных голосовых функций требуется доступ к микрофону.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Изменить разрешения</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Скрыть голосовой поиск</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Для голосовых функций требуется разрешение на доступ к микрофону</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Разрешить</string>
     <string name="voiceSearchTitle">Голосовой поиск</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-sk/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-sk/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Hovorte teraz</string>
     <string name="voiceSearchListeningFooter">Zvuk sa spracováva v zariadení. Neukladá sa nikde a s nikým, vrátane DuckDuckGo, sa nezdieľa.</string>
     <string name="voiceSearchNegativeAction">Zrušiť</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo nikdy nepočúva, čo hovoríte. Zvuk sa spracováva v zariadení. Neukladá sa a nezdieľa sa s nikým.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Na používanie funkcie súkromného hlasového vyhľadávania sa vyžaduje prístup k mikrofónu.</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">OK</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Ak chcete používať hlasové vyhľadávanie v službe DuckDuckGo, musíte v nastaveniach systému povoliť prístup k mikrofónu.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Nastavenia</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Vyžaduje sa prístup k mikrofónu</string>
-    <string name="voiceSearchRemovePositiveButton">Odstrániť</string>
-    <string name="voiceSearchRemoveTitle">Odstrániť možnosť Súkromné hlasové vyhľadávanie z panela s adresou?</string>
-    <string name="voiceSearchRemoveSubtitle">Tieto a ďalšie nastavenia prístupnosti môžete vždy spravovať v Nastaveniach.</string>
     <string name="voiceSearchTitle">Hlasové vyhľadávanie</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-sk/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-sk/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Hovorte teraz</string>
     <string name="voiceSearchListeningFooter">Zvuk sa spracováva v zariadení. Neukladá sa nikde a s nikým, vrátane DuckDuckGo, sa nezdieľa.</string>
     <string name="voiceSearchNegativeAction">Zrušiť</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo potrebuje prístup k tvojmu mikrofónu</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Ak chceš používať naše súkromné hlasové vyhľadávanie, je potrebné povolenie pre mikrofón.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Ak chceš používať naše súkromné hlasové funkcie, je potrebné povolenie pre mikrofón.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Zmeniť oprávnenia</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Skryť hlasové vyhľadávanie</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Na používanie hlasových funkcií je potrebný prístup k mikrofónu</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Povoliť</string>
     <string name="voiceSearchTitle">Hlasové vyhľadávanie</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-sl/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-sl/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Govori zdaj</string>
     <string name="voiceSearchListeningFooter">Zvok bo obdelan v napravi. Zvok ne bo shranjen in ne bo deljen z drugimi, niti z brskalnikom DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Preklic</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo nikoli ne posluša vašega govora. Zvok bo obdelan v napravi. Nismo ga shranili ali delili z nikomer.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Za zasebno glasovno iskanje je potreben dostop do mikrofona</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">V redu</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">Če želite uporabljati glasovno iskanje v DuckDuckGo, morate v sistemskih nastavitvah omogočiti dostop do mikrofona.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Nastavitve</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Potreben je dostop do mikrofona</string>
-    <string name="voiceSearchRemovePositiveButton">Odstrani</string>
-    <string name="voiceSearchRemoveTitle">Želite odstraniti možnost zasebnega glasovnega iskanja iz naslovne vrstice?</string>
-    <string name="voiceSearchRemoveSubtitle">Te in druge nastavitve dostopnosti lahko vedno urejate v nastavitvah.</string>
     <string name="voiceSearchTitle">Glasovno iskanje</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-sl/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-sl/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Govori zdaj</string>
     <string name="voiceSearchListeningFooter">Zvok bo obdelan v napravi. Zvok ne bo shranjen in ne bo deljen z drugimi, niti z brskalnikom DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Preklic</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo potrebuje dostop do mikrofona</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Dovoljenja za mikrofon so potrebna, če želite uporabljati naše zasebno glasovno iskanje.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Če želite uporabljati naše zasebne glasovne funkcije, so potrebna dovoljenja za mikrofon.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Sprememba dovoljenj</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Skrij glasovno iskanje</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Za glasovne funkcije je potrebno dovoljenje za mikrofon</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Dovoli</string>
     <string name="voiceSearchTitle">Glasovno iskanje</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-sv/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-sv/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Tala nu</string>
     <string name="voiceSearchListeningFooter">Ljudet bearbetas på enheten. Det lagras inte och delas inte med någon, inte ens DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Avbryt</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo behöver komma åt din mikrofon</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Mikrofonbehörighet behövs om du vill använda vår privata röstsökning.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Mikrofonbehörighet behövs om du vill använda våra privata röstfunktioner.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Ändra behörigheter</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Dölj röstsökning</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Mikrofonbehörighet krävs för röstfunktioner</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Tillåt</string>
     <string name="voiceSearchTitle">Röstsökning</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-sv/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-sv/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Tala nu</string>
     <string name="voiceSearchListeningFooter">Ljudet bearbetas på enheten. Det lagras inte och delas inte med någon, inte ens DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Avbryt</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo lyssnar aldrig på det du säger. Ljudet bearbetas på enheten. Det lagras inte och delas inte med någon.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Mikrofonåtkomst krävs för privat röstsökning</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">OK</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">För att kunna använda röstsökning i DuckDuckGo måste du aktivera mikrofonåtkomst i systeminställningarna.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Inställningar</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Mikrofonåtkomst krävs</string>
-    <string name="voiceSearchRemovePositiveButton">Ta bort</string>
-    <string name="voiceSearchRemoveTitle">Ta bort alternativet privat röstsökning från adressfältet?</string>
-    <string name="voiceSearchRemoveSubtitle">Du kan alltid hantera den här och andra tillgänglighetsinställningar i inställningarna.</string>
     <string name="voiceSearchTitle">Röstsökning</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-tr/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-tr/strings-voice-search.xml
@@ -22,14 +22,5 @@
     <string name="voiceSearchListening">Şimdi Konuşun</string>
     <string name="voiceSearchListeningFooter">Ses cihazda işlenir. Saklanmaz ve DuckDuckGo da dâhil olmak üzere kimseyle paylaşılmaz.</string>
     <string name="voiceSearchNegativeAction">Vazgeç</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo söylediklerinizi asla dinlemez. Ses cihazda işlenir. Saklanmaz veya kimseyle paylaşılmaz.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Özel Sesli Arama için Mikrofon Erişimi Gerekli</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">Tamam</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">DuckDuckGo\'da Sesli Aramayı kullanmak için sistem ayarlarında Mikrofon erişimini etkinleştirmeniz gerekir.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Ayarlar</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Mikrofon Erişimi Gerekli</string>
-    <string name="voiceSearchRemovePositiveButton">Kaldır</string>
-    <string name="voiceSearchRemoveTitle">Gizli Sesli Arama seçeneği adres çubuğundan kaldırılsın mı?</string>
-    <string name="voiceSearchRemoveSubtitle">Bu ve diğer erişilebilirlik tercihlerini her zaman Ayarlar\'dan yönetebilirsiniz.</string>
     <string name="voiceSearchTitle">Sesli arama</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values-tr/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values-tr/strings-voice-search.xml
@@ -22,5 +22,12 @@
     <string name="voiceSearchListening">Şimdi Konuşun</string>
     <string name="voiceSearchListeningFooter">Ses cihazda işlenir. Saklanmaz ve DuckDuckGo da dâhil olmak üzere kimseyle paylaşılmaz.</string>
     <string name="voiceSearchNegativeAction">Vazgeç</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo\'nun mikrofonunuza erişmesi gerekiyor</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Gizli Sesli Arama özelliğimizi kullanmak istiyorsanız mikrofon izinleri gereklidir.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Gizli sesli arama özelliğimizi kullanmak istiyorsanız mikrofon izinleri gereklidir.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">İzinleri Değiştir</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Sesli Aramayı Gizle</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Ses özellikleri için mikrofon izni gerekiyor</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">İzin ver</string>
     <string name="voiceSearchTitle">Sesli arama</string>
 </resources>

--- a/voice-search/voice-search-impl/src/main/res/values/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values/strings-voice-search.xml
@@ -16,7 +16,7 @@
 
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <string name="voiceSearchError">Something went wrong. Please try again later.</string>
     <string name="voiceSearchIconContentDescription">Voice search</string>
     <string name="voiceSearchListening">Speak Now</string>
@@ -28,13 +28,13 @@
     <string name="voiceSearchPermissionRejectedDialogMessage">To use Voice Search in DuckDuckGo you need to enable Microphone access in the system settings.</string>
     <string name="voiceSearchPermissionRejectedDialogPositiveAction">Settings</string>
     <string name="voiceSearchPermissionRejectedDialogTitle">Microphone Access Required</string>
-    <string name="voiceSearchMicAccessDeniedDialogTitle" tools:ignore="MissingTranslation">DuckDuckGo needs to access your microphone</string>
-    <string name="voiceSearchMicAccessDeniedDialogMessage" tools:ignore="MissingTranslation">Microphone permissions are needed if you want to use our Private Voice Search.</string>
-    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi" tools:ignore="MissingTranslation">Microphone permissions are needed if you want to use Voice Chat in Duck.ai.</string>
-    <string name="voiceSearchMicAccessDeniedDialogChangePermissions" tools:ignore="MissingTranslation">Change Permissions</string>
-    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch" tools:ignore="MissingTranslation">Hide Voice Search</string>
-    <string name="voiceSearchMicPermissionDeniedSnackbarMessage" tools:ignore="MissingTranslation">Microphone permission needed for voice features</string>
-    <string name="voiceSearchMicPermissionDeniedSnackbarAction" tools:ignore="MissingTranslation">Allow</string>
+    <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo needs to access your microphone</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessage">Microphone permissions are needed if you want to use our Private Voice Search.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Microphone permissions are needed if you want to use Voice Chat in Duck.ai.</string>
+    <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Change Permissions</string>
+    <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Hide Voice Search</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Microphone permission needed for voice features</string>
+    <string name="voiceSearchMicPermissionDeniedSnackbarAction">Allow</string>
     <string name="voiceSearchRemovePositiveButton">Remove</string>
     <string name="voiceSearchRemoveTitle">Remove Private Voice Search option from the address bar?</string>
     <string name="voiceSearchRemoveSubtitle">You can always manage this and other accessibility preferences in Settings.</string>

--- a/voice-search/voice-search-impl/src/main/res/values/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values/strings-voice-search.xml
@@ -24,7 +24,7 @@
     <string name="voiceSearchNegativeAction">Cancel</string>
     <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo needs to access your microphone</string>
     <string name="voiceSearchMicAccessDeniedDialogMessage">Microphone permissions are needed if you want to use our Private Voice Search.</string>
-    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Microphone permissions are needed if you want to use Voice Chat in Duck.ai.</string>
+    <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Microphone permissions are needed if you want to use our private voice features.</string>
     <string name="voiceSearchMicAccessDeniedDialogChangePermissions">Change Permissions</string>
     <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Hide Voice Search</string>
     <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Microphone permission needed for voice features</string>

--- a/voice-search/voice-search-impl/src/main/res/values/strings-voice-search.xml
+++ b/voice-search/voice-search-impl/src/main/res/values/strings-voice-search.xml
@@ -22,12 +22,6 @@
     <string name="voiceSearchListening">Speak Now</string>
     <string name="voiceSearchListeningFooter">Audio is processed on-device. It\'s not stored or shared with anyone, including DuckDuckGo.</string>
     <string name="voiceSearchNegativeAction">Cancel</string>
-    <string name="voiceSearchPermissionRationaleDescription">DuckDuckGo never listens to what you say. Audio is processed on-device. It isn’t stored or shared with anyone.</string>
-    <string name="voiceSearchPermissionRationaleTitle">Microphone Access Required for Private Voice Search</string>
-    <string name="voiceSearchPermissionRationalePositiveAction">OK</string>
-    <string name="voiceSearchPermissionRejectedDialogMessage">To use Voice Search in DuckDuckGo you need to enable Microphone access in the system settings.</string>
-    <string name="voiceSearchPermissionRejectedDialogPositiveAction">Settings</string>
-    <string name="voiceSearchPermissionRejectedDialogTitle">Microphone Access Required</string>
     <string name="voiceSearchMicAccessDeniedDialogTitle">DuckDuckGo needs to access your microphone</string>
     <string name="voiceSearchMicAccessDeniedDialogMessage">Microphone permissions are needed if you want to use our Private Voice Search.</string>
     <string name="voiceSearchMicAccessDeniedDialogMessageDuckAi">Microphone permissions are needed if you want to use Voice Chat in Duck.ai.</string>
@@ -35,8 +29,5 @@
     <string name="voiceSearchMicAccessDeniedDialogHideVoiceSearch">Hide Voice Search</string>
     <string name="voiceSearchMicPermissionDeniedSnackbarMessage">Microphone permission needed for voice features</string>
     <string name="voiceSearchMicPermissionDeniedSnackbarAction">Allow</string>
-    <string name="voiceSearchRemovePositiveButton">Remove</string>
-    <string name="voiceSearchRemoveTitle">Remove Private Voice Search option from the address bar?</string>
-    <string name="voiceSearchRemoveSubtitle">You can always manage this and other accessibility preferences in Settings.</string>
     <string name="voiceSearchTitle">Voice search</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/task/1217449008251055?focus=true


### Description
Transltions


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String and translation updates only; one Kotlin resource ID rename with no permission logic changes.
> 
> **Overview**
> This PR lands **Smartling translations** for microphone-permission messaging used by **voice search** and **Duck.ai** site permissions, plus a small string-resource cleanup in the base English files.
> 
> **Site permissions:** Duck.ai mic-denied snackbar, dialog, and button strings are added across locales, and `SitePermissionsDialogActivityLauncher` now references `duckAiMicPermissionDeniedSnackBarMessage` (renamed from `duckAiMicDeniedSnackBarMessage`). Base `strings-site-permissions.xml` drops `tools:ignore` so those strings are fully translatable.
> 
> **Voice search:** Locale files replace the older rationale / rejected-permission / “remove from address bar” strings with the newer **mic access denied** dialog, snackbar, and actions (`voiceSearchMicAccessDenied*`), including a separate Duck.ai-oriented message variant. English base strings are aligned the same way.
> 
> **Ad blocking (de):** German Duck Player copy updates “Theatermodus” to **“Kino-Modus”** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9587c1fb51dd68f245886e343ef5057b8854cfa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->