### PR TITLE
Lift floating return button above the keyboard

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -51,6 +51,9 @@ import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.toPx
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
@@ -188,6 +191,8 @@ class RealNativeInputManager @Inject constructor(
     private val nativeInputStateBugKillSwitch: NativeInputStateBugKillSwitch,
     private val nativeInputSearchOnlyFeature: NativeInputSearchOnlyFeature,
     private val nativeInputEventListener: NativeInputEventListener,
+    private val edgeToEdgeProvider: EdgeToEdgeProvider,
+    private val edgeToEdgeHandler: EdgeToEdgeHandler,
 ) : NativeInputManager {
     private lateinit var omnibarController: NativeInputOmnibarController
     private lateinit var rootView: ViewGroup
@@ -1415,6 +1420,11 @@ class RealNativeInputManager @Inject constructor(
             elevation = WIDGET_ELEVATION_DP.toPx()
         }.also {
             contentView.addView(it)
+            // The container hangs off android.R.id.content, which no longer resizes for the keyboard now that
+            // the browser is edge-to-edge, so it needs the IME (and nav bar) inset applied as bottom margin.
+            if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BROWSER)) {
+                edgeToEdgeHandler.applyNavigationBarInsetsAsMargin(it)
+            }
             floatingSubmitContainer = it
         }
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
@@ -35,6 +35,8 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
@@ -77,6 +79,8 @@ class RealNativeInputManagerTest {
     private val duckChatInputModeState: DuckChatInputModeState = mock()
     private val pixel: Pixel = mock()
     private val nativeInputEventListener: NativeInputEventListener = mock()
+    private val edgeToEdgeProvider: EdgeToEdgeProvider = mock()
+    private val edgeToEdgeHandler = EdgeToEdgeHandler()
     private val nativeInputStateBugKillSwitch = FakeFeatureToggleFactory.create(NativeInputStateBugKillSwitch::class.java)
     private val nativeInputSearchOnlyFeature = FakeFeatureToggleFactory.create(NativeInputSearchOnlyFeature::class.java)
 
@@ -106,6 +110,8 @@ class RealNativeInputManagerTest {
             nativeInputStateBugKillSwitch,
             nativeInputSearchOnlyFeature,
             nativeInputEventListener,
+            edgeToEdgeProvider,
+            edgeToEdgeHandler,
         )
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/InputScreenButtons.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/InputScreenButtons.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.duckchat.impl.ui.nativeinput.views
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.ImageView
@@ -25,6 +26,7 @@ import androidx.annotation.LayoutRes
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
+import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.duckchat.impl.R
@@ -151,13 +153,13 @@ class InputScreenButtons @JvmOverloads constructor(
         // because it needs the styling in both top-bar and bottom modes. The other
         // three buttons only need it when floating, so we apply it here.
         val backgroundRes = R.drawable.background_input_screen_button
-        actionNewLine.setBackgroundResource(backgroundRes)
-        actionVoiceChat?.setBackgroundResource(backgroundRes)
-        actionVoiceSearch?.setBackgroundResource(backgroundRes)
+        val backgroundTint = ColorStateList.valueOf(context.getColorFromAttr(CommonR.attr.daxColorControlFillPrimary))
         val circularRippleDrawable = ContextCompat.getDrawable(context, CommonR.drawable.selectable_circular_ripple)
-        actionNewLine.foreground = circularRippleDrawable
-        actionVoiceSearch?.foreground = circularRippleDrawable
-        actionVoiceChat?.foreground = circularRippleDrawable
+        listOfNotNull(actionNewLine, actionVoiceChat, actionVoiceSearch).forEach { button ->
+            button.setBackgroundResource(backgroundRes)
+            button.backgroundTintList = backgroundTint
+            button.foreground = circularRippleDrawable
+        }
     }
 
     companion object {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211654189969294/task/1216113336421408
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

The floating new-line/return button was rendering behind the keyboard.

`RealNativeInputManager.createFloatingSubmitContainer()` attaches the floating submit row to `android.R.id.content` with `Gravity.BOTTOM or Gravity.END` and a fixed 4dp bottom margin. That used to clear the keyboard for free: `BrowserActivity` declares `windowSoftInputMode="adjustResize"`, so the content view shrank when the IME appeared. Now that the browser is edge-to-edge on API 35+, `adjustResize` no longer resizes the window, so the row stays pinned to the window bottom and the keyboard covers it.

The fix applies the IME (and navigation bar + cutout) inset as the container's bottom margin through `EdgeToEdgeHandler.applyNavigationBarInsetsAsMargin()`, the same helper `BrowserTabFragment` already uses for the tab root. It's gated on the `BROWSER` edge-to-edge bucket, since without edge-to-edge the window reserves the bars itself and no offset should be added.

Handling this as an inset rather than reacting to `onKeyboardVisibilityChanged` also covers landscape, the gesture pill and the IME animation, none of which the keyboard-visibility path handles (it early-returns in split and Duck.ai mode). Side benefit: when the keyboard is dismissed with text still in the field, the button now clears the gesture navigation pill instead of sitting behind it.

### Steps to test this PR

_Floating return clears the keyboard_
- [x] Internal build, top address bar, native input + Duck.ai input enabled
- [x] Load any page, tap the omnibar, select the Duck.ai tab and type some text
- [x] Verify the floating return button (bottom right) is fully visible above the keyboard
- [x] Dismiss the keyboard with the text still in the field, verify the button sits above the gesture navigation pill
- [x] Rotate to landscape with the keyboard open, verify the button is still above the keyboard
- [x] Repeat with the bottom address bar: there is no floating return in that mode (Enter inserts the newline), nothing should change

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI inset wiring for an overlay container, gated on the existing browser edge-to-edge flag, with no auth, data, or payment changes.
> 
> **Overview**
> Fixes the **floating return/new-line button** (bottom-right in top-omnibar Duck.ai native input) sitting **behind the keyboard** after browser **edge-to-edge** on API 35+, where `adjustResize` no longer shrinks `android.R.id.content`.
> 
> When the floating submit row is attached to `android.R.id.content`, the change gates on **`EdgeToEdgeBucket.BROWSER`** and calls **`EdgeToEdgeHandler.applyNavigationBarInsetsAsMargin()`** on that container—the same approach **`BrowserTabFragment`** uses for tab root insets—so bottom margin tracks IME, navigation bar, and cutout instead of a fixed 4dp.
> 
> **`RealNativeInputManager`** now takes **`EdgeToEdgeProvider`** and **`EdgeToEdgeHandler`**; tests wire a mocked provider and a real handler. No new user-facing API; behavior is unchanged when edge-to-edge is off for the browser bucket.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42a1c84830de961683ca97eebb72984c93fc4428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->