### PR TITLE
Sync: update device_info when renaming this synced device

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoMigrator.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoMigrator.kt
@@ -32,8 +32,7 @@ import logcat.logcat
 import javax.inject.Inject
 
 /**
- * One-time, per-device backfill that brings an already signed-in user into the unified device list:
- * ensures the account's `account_info` key exists and writes this device's `device_info`.
+ * One-time, per-device backfill that brings an already signed-in user into the unified device list by writing this device's `device_info`.
  */
 @WorkerThread
 interface DeviceInfoMigrator {
@@ -54,7 +53,6 @@ class RealDeviceInfoMigrator @Inject constructor(
     private val syncApi: SyncApi,
     private val syncFeature: SyncFeature,
     private val syncDeviceIds: SyncDeviceIds,
-    private val accountInfoKeyManager: AccountInfoKeyManager,
     private val deviceInfoUpdater: DeviceInfoUpdater,
     private val dispatchers: DispatcherProvider,
 ) : DeviceInfoMigrator {
@@ -83,13 +81,7 @@ class RealDeviceInfoMigrator @Inject constructor(
             is Error -> return serverHasDeviceInfoResult
         }
 
-        logcat { "Sync-UnifiedDevices: no device_info on server for this device; ensuring account_info key" }
-        when (val keyResult = ensureAccountInfoKey()) {
-            is Success -> Unit
-            is Error -> return keyResult
-        }
-
-        logcat { "Sync-UnifiedDevices: writing device_info for this device" }
+        logcat { "Sync-UnifiedDevices: no device_info on server for this device; writing device_info" }
         return writeDeviceInfo(inputs.userId)
     }
 
@@ -133,29 +125,16 @@ class RealDeviceInfoMigrator @Inject constructor(
         }
     }
 
-    private suspend fun ensureAccountInfoKey(): Result<Unit> {
-        return when (val keyResult = accountInfoKeyManager.ensureKeyRegistered()) {
-            is Success -> {
-                logcat { "Sync-UnifiedDevices: account_info key ready (kid=${keyResult.data.kid})" }
-                Success(Unit)
-            }
-            is Error -> {
-                logcat(ERROR) { "Sync-UnifiedDevices: migration ensureKeyRegistered failed, will retry later: ${keyResult.reason}" }
-                keyResult
-            }
-        }
-    }
-
-    private fun writeDeviceInfo(userId: String): Result<Unit> {
-        return when (val patch = deviceInfoUpdater.updateThisDevice(syncDeviceIds.deviceName())) {
+    private suspend fun writeDeviceInfo(userId: String): Result<Unit> {
+        return when (val updateResult = deviceInfoUpdater.setThisDeviceName(syncDeviceIds.deviceName())) {
             is Success -> {
                 markMigrated(userId)
-                logcat { "Sync-UnifiedDevices: migration complete for this device (${patch.data.size} devices_v2 returned)" }
+                logcat { "Sync-UnifiedDevices: migration complete for this device (${updateResult.data.size} devices_v2 returned)" }
                 Success(Unit)
             }
             is Error -> {
-                logcat(ERROR) { "Sync-UnifiedDevices: migration PATCH failed, will retry later: ${patch.reason}" }
-                patch
+                logcat(ERROR) { "Sync-UnifiedDevices: migration PATCH failed, will retry later: ${updateResult.reason}" }
+                updateResult
             }
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoUpdater.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoUpdater.kt
@@ -16,23 +16,31 @@
 
 package com.duckduckgo.sync.impl
 
-import androidx.annotation.WorkerThread
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import logcat.LogPriority.ERROR
+import logcat.logcat
 import javax.inject.Inject
 
 /**
- * Publishes this device's name to the server. Writes the cross-credential `device_info` blob and
- * the per-credential `name`/`type` fields in the same request, so clients that don't read `device_info` yet still see the new name.
+ * The single writer of this device's name. Writes the cross-credential `device_info` blob and the per-credential `name`/`type` fields in the
+ * same request, so clients that don't read `device_info` yet still see the new name.
  */
-@WorkerThread
 interface DeviceInfoUpdater {
-    /** Returns the server's device list as it stands after the update. */
-    fun updateThisDevice(name: String): Result<List<DeviceV2>>
+    /**
+     * Sets this device's name to [name]
+     *
+     * @return the server's device list as it stands after the update
+     */
+    suspend fun setThisDeviceName(name: String): Result<List<DeviceV2>>
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -43,17 +51,44 @@ class RealDeviceInfoUpdater @Inject constructor(
     private val syncDeviceIds: SyncDeviceIds,
     private val deviceInfoEncryptor: DeviceInfoEncryptor,
     private val deviceFieldEncryptor: DeviceFieldEncryptor,
+    private val accountInfoKeyManager: AccountInfoKeyManager,
+    private val syncFeature: SyncFeature,
+    private val dispatchers: DispatcherProvider,
 ) : DeviceInfoUpdater {
 
-    override fun updateThisDevice(name: String): Result<List<DeviceV2>> {
+    private val mutex = Mutex()
+
+    override suspend fun setThisDeviceName(name: String): Result<List<DeviceV2>> = withContext(dispatchers.io()) {
+        mutex.withLock { setName(name, includeDeviceInfo = syncFeature.canWriteUnifiedDeviceList().isEnabled()) }
+    }
+
+    /**
+     * Sets this device's name
+     *
+     * @param name The new device name
+     * @param includeDeviceInfo Whether to attach `device_info` to the network request or not.
+     *   * If true, it will ensure the account's `account_info` key exists first since encrypting needs its public key
+     *   * If false, `device_info` will be omitted from the request
+     * @return the server's device list as it stands after the update
+     */
+    private suspend fun setName(name: String, includeDeviceInfo: Boolean): Result<List<DeviceV2>> {
         val token = syncStore.token.takeUnless { it.isNullOrEmpty() }
             ?: return Error(reason = "UpdateDeviceInfo: not signed in")
         val type = syncDeviceIds.deviceType().deviceFactor
 
-        val deviceInfo = when (val result = deviceInfoEncryptor.encrypt(name, type)) {
-            is Success -> result.data
-            is Error -> return result
+        val deviceInfo = if (includeDeviceInfo) {
+            when (val keyResult = ensureAccountInfoKey()) {
+                is Success -> Unit
+                is Error -> return keyResult
+            }
+            when (val result = deviceInfoEncryptor.encrypt(name, type)) {
+                is Success -> result.data
+                is Error -> return result
+            }
+        } else {
+            null
         }
+
         val legacyFields = when (val result = deviceFieldEncryptor.encrypt(name, type)) {
             is Success -> result.data
             is Error -> return result
@@ -67,8 +102,31 @@ class RealDeviceInfoUpdater @Inject constructor(
                 deviceInfo = deviceInfo,
             )
         ) {
-            is Success -> Success(result.data.devicesV2)
+            is Success -> {
+                syncStore.deviceName = name
+                Success(result.data.devicesV2)
+            }
             is Error -> result
+        }
+    }
+
+    /**
+     * The `account_info` key is immutable for the lifetime of the account, so a cached public key is always the right one to encrypt with and
+     * needs no network call. Otherwise, register one, which creates it or adopts the account's existing key.
+     */
+    private suspend fun ensureAccountInfoKey(): Result<Unit> {
+        if (syncStore.accountInfoPublicKey != null) return Success(Unit)
+
+        logcat { "Sync-UnifiedDevices: no cached account_info public key; registering one before writing device_info" }
+        return when (val result = accountInfoKeyManager.ensureKeyRegistered()) {
+            is Success -> {
+                logcat { "Sync-UnifiedDevices: account_info key ready (kid=${result.data.kid})" }
+                Success(Unit)
+            }
+            is Error -> {
+                logcat(ERROR) { "Sync-UnifiedDevices: cannot write device_info, account_info key unavailable: ${result.reason}" }
+                result
+            }
         }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoUpdater.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoUpdater.kt
@@ -59,19 +59,18 @@ class RealDeviceInfoUpdater @Inject constructor(
     private val mutex = Mutex()
 
     override suspend fun setThisDeviceName(name: String): Result<List<DeviceV2>> = withContext(dispatchers.io()) {
-        mutex.withLock { setName(name, includeDeviceInfo = syncFeature.canWriteUnifiedDeviceList().isEnabled()) }
+        mutex.withLock { setName(name) }
     }
 
     /**
      * Sets this device's name
      *
      * @param name The new device name
-     * @param includeDeviceInfo Whether to attach `device_info` to the network request or not.
-     *   * If true, it will ensure the account's `account_info` key exists first since encrypting needs its public key
-     *   * If false, `device_info` will be omitted from the request
      * @return the server's device list as it stands after the update
      */
-    private suspend fun setName(name: String, includeDeviceInfo: Boolean): Result<List<DeviceV2>> {
+    private suspend fun setName(name: String): Result<List<DeviceV2>> {
+        val includeDeviceInfo = syncFeature.canWriteUnifiedDeviceList().isEnabled()
+
         val token = syncStore.token.takeUnless { it.isNullOrEmpty() }
             ?: return Error(reason = "UpdateDeviceInfo: not signed in")
         val type = syncDeviceIds.deviceType().deviceFactor

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
 import logcat.LogPriority.INFO
 import logcat.LogPriority.VERBOSE
@@ -86,7 +87,11 @@ interface SyncAccountRepository {
     fun generateExchangeInvitationCode(): Result<AuthCode>
     fun pollSecondDeviceExchangeAcknowledgement(): Result<Boolean>
     fun pollForRecoveryCodeAndLogin(): Result<ExchangeResult>
-    fun renameDevice(device: ConnectedDevice): Result<Boolean>
+
+    /**
+     * Renames [device] to its current [ConnectedDevice.deviceName]. Only this device can be renamed: [Result.Error] for any other device.
+     */
+    suspend fun renameDevice(device: ConnectedDevice): Result<Boolean>
     fun logoutAndJoinNewAccount(stringCode: String): Result<Boolean>
 
     /**
@@ -172,6 +177,7 @@ class AppSyncAccountRepository @Inject constructor(
     private val thirdPartyDeviceListDecryptor: ThirdPartyDeviceListDecryptor,
     private val loginDeviceInfoWriter: LoginDeviceInfoWriter,
     private val signupAccountInfoBuilder: SignupAccountInfoBuilder,
+    private val deviceInfoUpdater: DeviceInfoUpdater,
 ) : SyncAccountRepository {
 
     // Bounded backoff for the 3party→ddg upgrade network calls.
@@ -406,12 +412,30 @@ class AppSyncAccountRepository @Inject constructor(
         }
     }
 
-    override fun renameDevice(device: ConnectedDevice): Result<Boolean> {
-        val userId = syncStore.userId ?: return Error(reason = "Rename Device: Not existing userId").alsoFireUpdateDeviceErrorPixel()
-        val primaryKey = syncStore.primaryKey ?: return Error(reason = "Rename Device: Not existing primaryKey").alsoFireUpdateDeviceErrorPixel()
-        return performLogin(userId, device.deviceId, device.deviceName, primaryKey).onFailure {
+    override suspend fun renameDevice(device: ConnectedDevice): Result<Boolean> = withContext(dispatcherProvider.io()) {
+        // A device can only rename itself
+        if (device.deviceId != syncStore.deviceId) {
+            return@withContext Error(reason = "Rename Device: only this device can be renamed").alsoFireUpdateDeviceErrorPixel()
+        }
+
+        val withDeviceInfo = syncFeature.canWriteUnifiedDeviceList().isEnabled()
+        val canPatchDevice = withDeviceInfo || syncFeature.canUsePatchEndpointForLegacyDeviceRename().isEnabled()
+        logcat { "Sync-UnifiedDevices: rename via ${if (canPatchDevice) "PATCH" else "login"}, withDeviceInfo=$withDeviceInfo" }
+        if (canPatchDevice) {
+            return@withContext when (val result = deviceInfoUpdater.setThisDeviceName(device.deviceName)) {
+                is Success -> Success(true)
+                is Error -> result.alsoFireUpdateDeviceErrorPixel()
+            }
+        }
+
+        // Legacy re-registration, which leaves device_info untouched
+        val userId = syncStore.userId
+            ?: return@withContext Error(reason = "Rename Device: Not existing userId").alsoFireUpdateDeviceErrorPixel()
+        val primaryKey = syncStore.primaryKey
+            ?: return@withContext Error(reason = "Rename Device: Not existing primaryKey").alsoFireUpdateDeviceErrorPixel()
+        performLogin(userId, device.deviceId, device.deviceName, primaryKey).onFailure {
             it.alsoFireUpdateDeviceErrorPixel()
-            return it.copy(code = LOGIN_FAILED.code)
+            return@withContext it.copy(code = LOGIN_FAILED.code)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -109,12 +109,22 @@ interface SyncFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun updateSyncActivityViewStateAtomically(): Toggle
 
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun preventStaleTokenLogout(): Toggle
+
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun canWriteUnifiedDeviceList(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun canReadUnifiedDeviceList(): Toggle
 
+    /**
+     * Whether to rename this device using new `PATCH /sync/devices` or legacy `login` endpoint
+     * Applies only when [canWriteUnifiedDeviceList] is disabled.
+     *
+     * If this flag is enabled, it will use the `PATCH /sync/devices` endpoint and omit `device_info`
+     * If this flag is disabled, it will fallback to the previous renaming endpoint using `POST /sync/login`
+     */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
-    fun preventStaleTokenLogout(): Toggle
+    fun canUsePatchEndpointForLegacyDeviceRename(): Toggle
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -79,7 +79,10 @@ interface SyncApi {
     fun getDevices(token: String): Result<DeviceEntries>
 
     /**
-     * Update this device's `name`, `type` and `info`. All three fields are sent every time — the server clears `info` when it is omitted.
+     * Update this device's `name`, `type` and `info`.
+     *
+     * A null [deviceInfo] is omitted from the request, which makes the server **clear** this device's stored `info` — the intended
+     * behaviour for a legacy-only rename, so nobody reads a name we've stopped keeping up to date.
      *
      * Returns the server's post-update device list.
      */
@@ -87,7 +90,7 @@ interface SyncApi {
         token: String,
         encryptedName: String,
         encryptedType: String,
-        deviceInfo: String,
+        deviceInfo: String?,
     ): Result<PatchDevicesResponse>
 
     fun getBookmarks(
@@ -276,7 +279,7 @@ class SyncServiceRemote @Inject constructor(
         token: String,
         encryptedName: String,
         encryptedType: String,
-        deviceInfo: String,
+        deviceInfo: String?,
     ): Result<PatchDevicesResponse> {
         val deviceId = syncStore.deviceId.takeUnless { it.isNullOrEmpty() }
             ?: return Result.Error(reason = "PatchDevices: no device id")

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -76,6 +76,7 @@ import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository.AuthCode
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.impl.metrics.ConnectedDevicesObserver
+import com.duckduckgo.sync.impl.pixels.SyncAccountOperation
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl
 import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrlWrapper
@@ -135,6 +136,7 @@ class AppSyncAccountRepositoryTest {
     private val thirdPartyDeviceListDecryptor: ThirdPartyDeviceListDecryptor = mock()
     private val loginDeviceInfoWriter: LoginDeviceInfoWriter = mock()
     private val signupAccountInfoBuilder: SignupAccountInfoBuilder = mock()
+    private val deviceInfoUpdater: DeviceInfoUpdater = mock()
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
@@ -160,6 +162,7 @@ class AppSyncAccountRepositoryTest {
             thirdPartyDeviceListDecryptor = thirdPartyDeviceListDecryptor,
             loginDeviceInfoWriter = loginDeviceInfoWriter,
             signupAccountInfoBuilder = signupAccountInfoBuilder,
+            deviceInfoUpdater = deviceInfoUpdater,
         )
         (syncRepo as AppSyncAccountRepository).upgradeRetryDelayMillis = 0L // keep retry-path tests instant
 
@@ -948,21 +951,93 @@ class AppSyncAccountRepositoryTest {
     }
 
     @Test
-    fun whenRenameDeviceUnAuthenticatedThenReturnError() {
+    fun whenRenameDeviceUnAuthenticatedThenReturnError() = runTest {
         val result = syncRepo.renameDevice(connectedDevice)
 
         assertTrue(result is Error)
     }
 
     @Test
-    fun whenRenameDeviceSuccessThenReturnSuccess() {
+    fun whenPatchEndpointForLegacyRenameIsKillSwitchedThenReRegisterViaLogin() = runTest {
         givenAuthenticatedDevice()
         prepareForLoginSuccess()
+        syncFeature.canUsePatchEndpointForLegacyDeviceRename().setRawStoredState(State(enable = false))
 
         val result = syncRepo.renameDevice(connectedDevice)
 
         verify(syncApi).login(anyString(), anyString(), eq(connectedDevice.deviceId), anyString(), anyString(), anyOrNull())
+        verifyNoInteractions(deviceInfoUpdater)
         assertTrue(result is Success)
+    }
+
+    @Test
+    fun whenRenameThisDeviceAndCanWriteUnifiedDeviceListThenRenamesViaUnifiedPath() = runTest {
+        givenAuthenticatedDevice()
+        prepareForLoginSuccess()
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
+        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Success(emptyList()))
+
+        val result = syncRepo.renameDevice(connectedDevice.copy(deviceName = "New Name"))
+
+        assertTrue(result is Success)
+        verify(deviceInfoUpdater).setThisDeviceName("New Name")
+        verify(syncApi, never()).login(anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull())
+    }
+
+    @Test
+    fun whenUnifiedRenameFailsThenReturnErrorAndFireUpdateDevicePixel() = runTest {
+        givenAuthenticatedDevice()
+        prepareForLoginSuccess()
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
+        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Error(reason = "patch failed"))
+
+        val result = syncRepo.renameDevice(connectedDevice)
+
+        assertTrue(result is Error)
+        verify(syncPixels).fireSyncAccountErrorPixel(any(), eq(SyncAccountOperation.UPDATE_DEVICE))
+        verify(syncApi, never()).login(anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull())
+    }
+
+    @Test
+    fun whenRenameAnotherDeviceThenReturnErrorWithoutWritingAnything() = runTest {
+        givenAuthenticatedDevice()
+        prepareForLoginSuccess()
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
+        val anotherDevice = connectedDevice.copy(thisDevice = false, deviceId = "anotherDeviceId")
+
+        val result = syncRepo.renameDevice(anotherDevice)
+
+        assertTrue(result is Error)
+        verifyNoInteractions(deviceInfoUpdater)
+        verify(syncApi, never()).login(anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull())
+    }
+
+    @Test
+    fun whenRenameThisDeviceAndCannotWriteUnifiedDeviceListThenStillPatchViaTheUpdater() = runTest {
+        givenAuthenticatedDevice()
+        prepareForLoginSuccess()
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = false))
+        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Success(emptyList()))
+
+        val result = syncRepo.renameDevice(connectedDevice.copy(deviceName = "New Name"))
+
+        assertTrue(result is Success)
+        verify(deviceInfoUpdater).setThisDeviceName("New Name")
+        verify(syncApi, never()).login(anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull())
+    }
+
+    @Test
+    fun whenLegacyOnlyRenameFailsThenReturnErrorAndFireUpdateDevicePixel() = runTest {
+        givenAuthenticatedDevice()
+        prepareForLoginSuccess()
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = false))
+        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Error(reason = "patch failed"))
+
+        val result = syncRepo.renameDevice(connectedDevice)
+
+        assertTrue(result is Error)
+        verify(syncPixels).fireSyncAccountErrorPixel(any(), eq(SyncAccountOperation.UPDATE_DEVICE))
+        verify(syncApi, never()).login(anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull())
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoMigratorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoMigratorTest.kt
@@ -41,7 +41,6 @@ class DeviceInfoMigratorTest {
     private val syncStore: SyncStore = mock()
     private val syncApi: SyncApi = mock()
     private val syncDeviceIds: SyncDeviceIds = mock()
-    private val accountInfoKeyManager: AccountInfoKeyManager = mock()
     private val deviceInfoUpdater: DeviceInfoUpdater = mock()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
 
@@ -50,8 +49,6 @@ class DeviceInfoMigratorTest {
 
     private lateinit var migrator: DeviceInfoMigrator
 
-    private val keyResult = AccountInfoKeyResult(kid = "kid-1", publicKey = RsaJwk(n = "n", e = "AQAB"), created = true, wrapsSent = 1)
-
     @Before
     fun before() {
         migrator = RealDeviceInfoMigrator(
@@ -59,7 +56,6 @@ class DeviceInfoMigratorTest {
             syncApi = syncApi,
             syncFeature = syncFeature,
             syncDeviceIds = syncDeviceIds,
-            accountInfoKeyManager = accountInfoKeyManager,
             deviceInfoUpdater = deviceInfoUpdater,
             dispatchers = coroutineTestRule.testDispatcherProvider,
         )
@@ -100,7 +96,7 @@ class DeviceInfoMigratorTest {
     }
 
     @Test
-    fun whenServerAlreadyHasDeviceInfoThenMarkDoneWithoutKeyOrPatch() = runTest {
+    fun whenServerAlreadyHasDeviceInfoThenMarkDoneWithoutWriting() = runTest {
         whenever(syncApi.getDevices(token)).thenReturn(
             Result.Success(deviceEntries(deviceInfo = "existing.device.info.jwe")),
         )
@@ -109,20 +105,18 @@ class DeviceInfoMigratorTest {
 
         assertTrue(result is Result.Success)
         verify(syncStore).unifiedDeviceListMigratedForUserId = userId
-        verify(accountInfoKeyManager, never()).ensureKeyRegistered()
-        verify(deviceInfoUpdater, never()).updateThisDevice(any())
+        verify(deviceInfoUpdater, never()).setThisDeviceName(any())
     }
 
     @Test
-    fun whenKeyEnsuredAndPatchSucceedsThenMarkDone() = runTest {
+    fun whenDeviceInfoWrittenThenMarkDone() = runTest {
         whenever(syncApi.getDevices(token)).thenReturn(Result.Success(deviceEntries(deviceInfo = null)))
-        whenever(accountInfoKeyManager.ensureKeyRegistered()).thenReturn(Result.Success(keyResult))
-        whenever(deviceInfoUpdater.updateThisDevice("deviceName")).thenReturn(Result.Success(emptyList()))
+        whenever(deviceInfoUpdater.setThisDeviceName("deviceName")).thenReturn(Result.Success(emptyList()))
 
         val result = migrator.ensureMigrated()
 
         assertTrue(result is Result.Success)
-        verify(deviceInfoUpdater).updateThisDevice("deviceName")
+        verify(deviceInfoUpdater).setThisDeviceName("deviceName")
         verify(syncStore).unifiedDeviceListMigratedForUserId = userId
     }
 
@@ -131,25 +125,14 @@ class DeviceInfoMigratorTest {
         whenever(syncApi.getDevices(token)).thenReturn(Result.Error(reason = "network"))
 
         assertTrue(migrator.ensureMigrated() is Result.Error)
-        verify(accountInfoKeyManager, never()).ensureKeyRegistered()
+        verify(deviceInfoUpdater, never()).setThisDeviceName(any())
         verify(syncStore, never()).unifiedDeviceListMigratedForUserId = any()
     }
 
     @Test
-    fun whenEnsureKeyFailsThenErrorAndNotMarked() = runTest {
+    fun whenWriteFailsThenErrorAndNotMarked() = runTest {
         whenever(syncApi.getDevices(token)).thenReturn(Result.Success(deviceEntries(deviceInfo = null)))
-        whenever(accountInfoKeyManager.ensureKeyRegistered()).thenReturn(Result.Error(reason = "no secret key"))
-
-        assertTrue(migrator.ensureMigrated() is Result.Error)
-        verify(deviceInfoUpdater, never()).updateThisDevice(any())
-        verify(syncStore, never()).unifiedDeviceListMigratedForUserId = any()
-    }
-
-    @Test
-    fun whenPatchFailsThenErrorAndNotMarked() = runTest {
-        whenever(syncApi.getDevices(token)).thenReturn(Result.Success(deviceEntries(deviceInfo = null)))
-        whenever(accountInfoKeyManager.ensureKeyRegistered()).thenReturn(Result.Success(keyResult))
-        whenever(deviceInfoUpdater.updateThisDevice("deviceName")).thenReturn(Result.Error(reason = "patch failed"))
+        whenever(deviceInfoUpdater.setThisDeviceName("deviceName")).thenReturn(Result.Error(reason = "patch failed"))
 
         assertTrue(migrator.ensureMigrated() is Result.Error)
         verify(syncStore, never()).unifiedDeviceListMigratedForUserId = any()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoUpdaterTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoUpdaterTest.kt
@@ -16,21 +16,30 @@
 
 package com.duckduckgo.sync.impl
 
+import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.TestSyncFixtures.token
+import com.duckduckgo.sync.store.AccountInfoPublicKey
 import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@SuppressLint("DenyListedApi")
 @RunWith(AndroidJUnit4::class)
 class DeviceInfoUpdaterTest {
 
@@ -39,77 +48,188 @@ class DeviceInfoUpdaterTest {
     private val syncDeviceIds: SyncDeviceIds = mock()
     private val deviceInfoEncryptor: DeviceInfoEncryptor = mock()
     private val deviceFieldEncryptor: DeviceFieldEncryptor = mock()
-    private val updater = RealDeviceInfoUpdater(syncStore, syncApi, syncDeviceIds, deviceInfoEncryptor, deviceFieldEncryptor)
+    private val accountInfoKeyManager: AccountInfoKeyManager = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    private lateinit var updater: RealDeviceInfoUpdater
 
     private val updatedDevices = listOf(DeviceV2(deviceId = "device-1", deviceInfo = "device.info.jwe", credentialId = "ddg"))
+    private val cachedPublicKey = AccountInfoPublicKey(keyId = "kid-1", modulus = "n", exponent = "AQAB")
+    private val keyRegistered = AccountInfoKeyResult(kid = "kid-1", publicKey = RsaJwk(n = "n", e = "AQAB"), created = true, wrapsSent = 1)
 
     @Before
     fun before() {
+        updater = RealDeviceInfoUpdater(
+            syncStore = syncStore,
+            syncApi = syncApi,
+            syncDeviceIds = syncDeviceIds,
+            deviceInfoEncryptor = deviceInfoEncryptor,
+            deviceFieldEncryptor = deviceFieldEncryptor,
+            accountInfoKeyManager = accountInfoKeyManager,
+            syncFeature = syncFeature,
+            dispatchers = coroutineTestRule.testDispatcherProvider,
+        )
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
         whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.accountInfoPublicKey).thenReturn(cachedPublicKey)
         whenever(syncDeviceIds.deviceType()).thenReturn(DeviceType("phone"))
     }
 
     @Test
-    fun whenAllStepsSucceedThenSendBothEncryptedFormsAndReturnUpdatedDevices() {
+    fun whenAllStepsSucceedThenSendBothEncryptedFormsAndReturnUpdatedDevices() = runTest {
         whenever(deviceInfoEncryptor.encrypt("My Phone", "phone")).thenReturn(Result.Success("device.info.jwe"))
         whenever(deviceFieldEncryptor.encrypt("My Phone", "phone"))
             .thenReturn(Result.Success(EncryptedDeviceFields(name = "encName", type = "encType")))
         whenever(syncApi.patchThisDevice(token, "encName", "encType", "device.info.jwe"))
             .thenReturn(Result.Success(PatchDevicesResponse(devicesV2 = updatedDevices)))
 
-        val result = updater.updateThisDevice("My Phone")
+        val result = updater.setThisDeviceName("My Phone")
 
         assertEquals(Result.Success(updatedDevices), result)
     }
 
     @Test
-    fun whenNotSignedInThenErrorWithoutEncrypting() {
+    fun whenUpdateSucceedsThenStoreTheNewNameLocally() = runTest {
+        givenEncryptionAndPatchSucceed()
+
+        updater.setThisDeviceName("My Phone")
+
+        verify(syncStore).deviceName = "My Phone"
+    }
+
+    @Test
+    fun whenNotSignedInThenErrorWithoutEncrypting() = runTest {
         whenever(syncStore.token).thenReturn(null)
 
-        assertTrue(updater.updateThisDevice("My Phone") is Result.Error)
+        assertTrue(updater.setThisDeviceName("My Phone") is Result.Error)
         verify(deviceInfoEncryptor, never()).encrypt(any(), any())
     }
 
     @Test
-    fun whenDeviceInfoEncryptionFailsThenErrorWithoutPatching() {
-        whenever(deviceInfoEncryptor.encrypt(any(), any())).thenReturn(Result.Error(reason = "no cached account_info key"))
+    fun whenAccountInfoPublicKeyIsCachedThenNoKeyRegistration() = runTest {
+        givenEncryptionAndPatchSucceed()
 
-        assertTrue(updater.updateThisDevice("My Phone") is Result.Error)
+        updater.setThisDeviceName("My Phone")
+
+        verify(accountInfoKeyManager, never()).ensureKeyRegistered()
+    }
+
+    @Test
+    fun whenAccountInfoPublicKeyIsMissingThenRegisterKeyBeforePatching() = runTest {
+        whenever(syncStore.accountInfoPublicKey).thenReturn(null)
+        whenever(accountInfoKeyManager.ensureKeyRegistered()).thenReturn(Result.Success(keyRegistered))
+        givenEncryptionAndPatchSucceed()
+
+        val result = updater.setThisDeviceName("My Phone")
+
+        assertTrue(result is Result.Success)
+        verify(accountInfoKeyManager).ensureKeyRegistered()
+        verify(syncApi).patchThisDevice(any(), any(), any(), any())
+    }
+
+    @Test
+    fun whenKeyRegistrationFailsThenErrorWithoutEncryptingOrPatching() = runTest {
+        whenever(syncStore.accountInfoPublicKey).thenReturn(null)
+        whenever(accountInfoKeyManager.ensureKeyRegistered()).thenReturn(Result.Error(reason = "no account secret key"))
+
+        assertTrue(updater.setThisDeviceName("My Phone") is Result.Error)
+        verify(deviceInfoEncryptor, never()).encrypt(any(), any())
         verify(syncApi, never()).patchThisDevice(any(), any(), any(), any())
     }
 
     @Test
-    fun whenLegacyFieldEncryptionFailsThenErrorWithoutPatching() {
+    fun whenDeviceInfoEncryptionFailsThenErrorWithoutPatching() = runTest {
+        whenever(deviceInfoEncryptor.encrypt(any(), any())).thenReturn(Result.Error(reason = "no cached account_info key"))
+
+        assertTrue(updater.setThisDeviceName("My Phone") is Result.Error)
+        verify(syncApi, never()).patchThisDevice(any(), any(), any(), any())
+    }
+
+    @Test
+    fun whenLegacyFieldEncryptionFailsThenErrorWithoutPatching() = runTest {
         whenever(deviceInfoEncryptor.encrypt(any(), any())).thenReturn(Result.Success("device.info.jwe"))
         whenever(deviceFieldEncryptor.encrypt(any(), any())).thenReturn(Result.Error(reason = "primaryKey missing"))
 
-        assertTrue(updater.updateThisDevice("My Phone") is Result.Error)
+        assertTrue(updater.setThisDeviceName("My Phone") is Result.Error)
         verify(syncApi, never()).patchThisDevice(any(), any(), any(), any())
     }
 
     @Test
-    fun whenPatchFailsThenReturnItsError() {
+    fun whenPatchFailsThenReturnItsErrorAndLeaveTheStoredNameAlone() = runTest {
         whenever(deviceInfoEncryptor.encrypt(any(), any())).thenReturn(Result.Success("device.info.jwe"))
         whenever(deviceFieldEncryptor.encrypt(any(), any()))
             .thenReturn(Result.Success(EncryptedDeviceFields(name = "encName", type = "encType")))
         whenever(syncApi.patchThisDevice(any(), any(), any(), any()))
             .thenReturn(Result.Error(code = 500, reason = "unexpected status code"))
 
-        assertEquals(Result.Error(code = 500, reason = "unexpected status code"), updater.updateThisDevice("My Phone"))
+        assertEquals(Result.Error(code = 500, reason = "unexpected status code"), updater.setThisDeviceName("My Phone"))
+        verify(syncStore, never()).deviceName = any()
     }
 
     @Test
-    fun whenDeviceTypeIsTakenFromThisDeviceThenCallerCannotOverrideIt() {
-        whenever(syncDeviceIds.deviceType()).thenReturn(DeviceType("desktop"))
-        whenever(deviceInfoEncryptor.encrypt(any(), any())).thenReturn(Result.Success("device.info.jwe"))
+    fun whenWriteFeatureDisabledThenOmitDeviceInfoSoTheServerClearsItAndStoreTheNewNameLocally() = runTest {
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = false))
+        givenEncryptionAndPatchSucceed()
+
+        val result = updater.setThisDeviceName("My Phone")
+
+        assertTrue(result is Result.Success)
+        verify(syncApi).patchThisDevice(token, "encName", "encType", null)
+        verify(syncStore).deviceName = "My Phone"
+    }
+
+    @Test
+    fun whenWriteFeatureDisabledThenNoDeviceInfoEncryptionOrKeyRegistration() = runTest {
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = false))
+        whenever(syncStore.accountInfoPublicKey).thenReturn(null)
+        givenEncryptionAndPatchSucceed()
+
+        updater.setThisDeviceName("My Phone")
+
+        verify(accountInfoKeyManager, never()).ensureKeyRegistered()
+        verify(deviceInfoEncryptor, never()).encrypt(any(), any())
+    }
+
+    @Test
+    fun whenWriteFeatureDisabledAndPatchFailsThenReturnItsErrorAndLeaveTheStoredNameAlone() = runTest {
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = false))
         whenever(deviceFieldEncryptor.encrypt(any(), any()))
             .thenReturn(Result.Success(EncryptedDeviceFields(name = "encName", type = "encType")))
-        whenever(syncApi.patchThisDevice(any(), any(), any(), any()))
-            .thenReturn(Result.Success(PatchDevicesResponse(devicesV2 = updatedDevices)))
+        whenever(syncApi.patchThisDevice(any(), any(), any(), anyOrNull()))
+            .thenReturn(Result.Error(code = 500, reason = "unexpected status code"))
 
-        updater.updateThisDevice("My Laptop")
+        assertTrue(updater.setThisDeviceName("My Phone") is Result.Error)
+        verify(syncStore, never()).deviceName = any()
+    }
+
+    @Test
+    fun whenWriteFeatureEnabledThenSendDeviceInfoAlongsideTheLegacyFields() = runTest {
+        givenEncryptionAndPatchSucceed()
+
+        updater.setThisDeviceName("My Phone")
+
+        verify(syncApi).patchThisDevice(token, "encName", "encType", "device.info.jwe")
+    }
+
+    @Test
+    fun whenDeviceTypeIsTakenFromThisDeviceThenCallerCannotOverrideIt() = runTest {
+        whenever(syncDeviceIds.deviceType()).thenReturn(DeviceType("desktop"))
+        givenEncryptionAndPatchSucceed()
+
+        updater.setThisDeviceName("My Laptop")
 
         verify(deviceInfoEncryptor).encrypt(eq("My Laptop"), eq("desktop"))
         verify(deviceFieldEncryptor).encrypt(eq("My Laptop"), eq("desktop"))
+    }
+
+    private fun givenEncryptionAndPatchSucceed() {
+        whenever(deviceInfoEncryptor.encrypt(any(), any())).thenReturn(Result.Success("device.info.jwe"))
+        whenever(deviceFieldEncryptor.encrypt(any(), any()))
+            .thenReturn(Result.Success(EncryptedDeviceFields(name = "encName", type = "encType")))
+        whenever(syncApi.patchThisDevice(any(), any(), any(), anyOrNull()))
+            .thenReturn(Result.Success(PatchDevicesResponse(devicesV2 = updatedDevices)))
     }
 }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -382,6 +382,11 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.canReadUnifiedDeviceListToggle.quietlySetIsChecked(viewState.canReadUnifiedDeviceListEnabled) { _, enabled ->
             viewModel.onCanReadUnifiedDeviceListFlagChanged(enabled)
         }
+        binding.canUsePatchEndpointForLegacyDeviceRenameToggle.quietlySetIsChecked(
+            viewState.canUsePatchEndpointForLegacyDeviceRenameEnabled,
+        ) { _, enabled ->
+            viewModel.onCanUsePatchEndpointForLegacyDeviceRenameFlagChanged(enabled)
+        }
         binding.migrationStatusTextView.text = viewState.migrationStatusText
         binding.migrationResultTextView.text = viewState.migrationResult
         if (viewState.isSignedIn) {

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -142,6 +142,7 @@ constructor(
         val fetchDecryptDevicesResult: String = "",
         val canWriteUnifiedDeviceListEnabled: Boolean = false,
         val canReadUnifiedDeviceListEnabled: Boolean = false,
+        val canUsePatchEndpointForLegacyDeviceRenameEnabled: Boolean = false,
         val migrationStatusText: String = "",
         val migrationResult: String = "",
     )
@@ -336,6 +337,7 @@ constructor(
                 fetchDecryptDevicesResult = if (accountInfo.isSignedIn) viewState.value.fetchDecryptDevicesResult else "",
                 canWriteUnifiedDeviceListEnabled = syncFeature.canWriteUnifiedDeviceList().isEnabled(),
                 canReadUnifiedDeviceListEnabled = syncFeature.canReadUnifiedDeviceList().isEnabled(),
+                canUsePatchEndpointForLegacyDeviceRenameEnabled = syncFeature.canUsePatchEndpointForLegacyDeviceRename().isEnabled(),
                 migrationStatusText = buildMigrationStatusText(),
                 migrationResult = if (accountInfo.isSignedIn) viewState.value.migrationResult else "",
             ),
@@ -695,10 +697,6 @@ constructor(
                 command.send(ShowMessage("Not signed in"))
                 return@launch
             }
-            if (syncStore.accountInfoPublicKey == null) {
-                command.send(ShowMessage("No cached account_info key — tap 'Create & Register account_info Key' first"))
-                return@launch
-            }
             command.send(
                 Command.ShowRenameDeviceDialog(
                     currentName = syncDeviceIds.deviceName(),
@@ -710,7 +708,7 @@ constructor(
 
     fun onRenameDeviceConfirmed(newName: String) {
         viewModelScope.launch(dispatchers.io()) {
-            when (val result = deviceInfoUpdater.updateThisDevice(newName)) {
+            when (val result = deviceInfoUpdater.setThisDeviceName(newName)) {
                 is Success -> {
                     val text = "PATCH ok — ${result.data.size} devices_v2 returned; name set to \"$newName\""
                     logcat { "Sync-UnifiedDevices: $text" }
@@ -800,6 +798,14 @@ constructor(
         viewModelScope.launch(dispatchers.io()) {
             logcat { "Sync-UnifiedDevices: setting canReadUnifiedDeviceList flag = $enabled" }
             setRawToggleState(syncFeature.canReadUnifiedDeviceList(), enabled)
+            updateViewState()
+        }
+    }
+
+    fun onCanUsePatchEndpointForLegacyDeviceRenameFlagChanged(enabled: Boolean) {
+        viewModelScope.launch(dispatchers.io()) {
+            logcat { "Sync-UnifiedDevices: setting canUsePatchEndpointForLegacyDeviceRename flag = $enabled" }
+            setRawToggleState(syncFeature.canUsePatchEndpointForLegacyDeviceRename(), enabled)
             updateViewState()
         }
     }

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -267,6 +267,15 @@
             app:showSwitch="true"
             app:primaryText="canReadUnifiedDeviceList" />
 
+        <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+            android:id="@+id/canUsePatchEndpointForLegacyDeviceRenameToggle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:showSwitch="true"
+            app:primaryText="canUsePatchEndpointFor\nLegacyDeviceRename"
+            app:primaryTextTruncated="false"
+        />
+
         <com.duckduckgo.common.ui.view.text.DaxTextView
             android:id="@+id/migrationStatusTextView"
             android:layout_width="match_parent"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216792641477216?focus=true
Tech Design URL (if applicable): [Specification](https://app.asana.com/1/137249556945/project/72649045549333/task/1215838110052947?focus=true)
API Proposals URL(s) (if applicable):

### Description
Renaming a synced device used to re-register it with `POST /sync/login`, which doesn't touch `device_info` and only writes the legacy name/type. With this PR, we start using the new `PATCH /sync/devices` endpoint to rename devices which is `device_info` aware. 

#### Feature flags
- `canWriteUnifiedDeviceList` dictates whether we can write the full update including `device_info` to the new endpoint. If this is **disabled** we might still use the new endpoint but with `device_info` omitted (depending on the value of kill-switch `canUsePatchEndpointForLegacyDeviceRename`.

### Steps to test this PR

_Pre-requisite setup_
- [ ] Fresh install `internal` variant on two devices / emulators

_Rename with the unified write enabled_
  - [ ] On Device A, open Sync internal settings and enable `canWriteUnifiedDeviceList` and `canReadUnifiedDeviceList`
- [ ] On Device A, start syncing
- [ ] Rename this device (e.g. `test 1`) from the real, prod Sync settings device list (not the dev screen button)
- [ ] Logcat shows `rename via PATCH, withDeviceInfo=true` and `patchDevices ok`
- [ ] Verify this new name appears on this device 
- [ ] Sync with Device B, and ensure Device B sees the device name you entered (e.g., `test 1`)

_Rename with the unified write disabled (default state)_
- [ ] On Device A, turn `canWriteUnifiedDeviceList` off, leaving `canUsePatchEndpointForLegacyDeviceRename` on
- [ ] Rename this device (e.g., `test 2`); 
- [ ] Verify logcat shows `rename via PATCH, withDeviceInfo=false`
- [ ] Verified the new `test 2` name appears here and on the other synced device
- [ ] Open Sync Dev screen and tap "Fetch & decrypt devices; verify `device_info: (no device_info)` for this device
  
_Kill-switch restores the old behaviour_
- [ ] Turn `canUsePatchEndpointForLegacyDeviceRename` off and rename again (e.g. `test 3`)
- [ ] Verify logcat shows `rename via login, withDeviceInfo=false` and the rename works
 
_The account_info key is created on demand_
- [ ] Open sync dev settings
- [ ] Enable `canWriteUnifiedDeviceList` again
- [ ] Tap "Delete cached account_info Key"
- [ ] Rename device (e.g., `test 4`) from Sync prod settings
- [ ] Logcat shows `no cached account_info public key; registering one`, and the rename succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync account device rename and migration paths and token/login side effects when the login fallback is used; rollout is gated by remote toggles but affects production sync settings UX.
> 
> **Overview**
> **Renaming this synced device** no longer goes through `POST /sync/login` by default. `renameDevice` is now `suspend`, only allows renaming **this** device, and routes through `DeviceInfoUpdater.setThisDeviceName`, which PATCHes `/sync/devices` with encrypted legacy name/type and optionally `device_info`.
> 
> `DeviceInfoUpdater` becomes the single writer for this device’s name: async with IO + mutex, persists `syncStore.deviceName` on success, and when unified write is on ensures `account_info` key registration before encrypting `device_info`. When unified write is off, `device_info` is omitted (server clears stale `info`); legacy rename can still PATCH via new flag `canUsePatchEndpointForLegacyDeviceRename`, or fall back to login when that kill-switch is off.
> 
> `DeviceInfoMigrator` drops its own `account_info` key step and delegates migration writes to `setThisDeviceName`. `patchThisDevice` accepts nullable `device_info`. Internal sync settings add a toggle for the legacy PATCH flag; dev rename uses `setThisDeviceName` without requiring a cached key upfront.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9f44f731c1662b89321de99aec491caf95bd042. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->