### PR TITLE
Stop pinning the inferred Duck.ai default model

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
@@ -97,6 +97,12 @@ class RealDuckAiModelManager @Inject constructor(
     init {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             try {
+                // Separate from the restore below so a failed migration cannot cost the user their selection.
+                stateMutex.withLock { clearPinnedDefaultModel() }
+            } catch (e: Exception) {
+                logcat { "Duck.ai Model Manager: failed to clear pinned default model: ${e.message}" }
+            }
+            try {
                 stateMutex.withLock { restoreCachedSelection() }
             } catch (e: Exception) {
                 logcat { "Duck.ai Model Manager: failed to restore cached selection: ${e.message}" }
@@ -108,6 +114,21 @@ class RealDuckAiModelManager @Inject constructor(
                     fetchModels()
                 }
         }
+    }
+
+    /**
+     * Earlier versions persisted the inferred default as if the user had picked it, which pinned most
+     * of the install base to [PINNED_DEFAULT_MODEL_ID] and stopped later server-side default changes
+     * from reaching them. Clearing that one id lets [resolveSelection] derive the current default
+     * again. Users who deliberately picked it are reset too, as the stored value records no intent.
+     */
+    private suspend fun clearPinnedDefaultModel() {
+        if (dataStore.hasClearedPinnedDefaultModel()) return
+        if (dataStore.getSelectedModel()?.id == PINNED_DEFAULT_MODEL_ID) {
+            dataStore.setSelectedModel(null)
+            logcat { "Duck.ai Model Manager: cleared pinned default model" }
+        }
+        dataStore.setClearedPinnedDefaultModel()
     }
 
     private suspend fun restoreCachedSelection() {
@@ -149,7 +170,7 @@ class RealDuckAiModelManager @Inject constructor(
                     }
                 val attachmentLimits = resolveAttachmentLimits(response.attachmentLimits, userTier)
                 stateMutex.withLock {
-                    val selectedModelId = validateAndPersistSelection(models)
+                    val selectedModelId = resolveSelection(models)
                     val selectedModel = models.find { it.id == selectedModelId }
                     val available = ReasoningResolver.availableModes(
                         supported = selectedModel?.supportedReasoningEfforts.orEmpty(),
@@ -181,19 +202,24 @@ class RealDuckAiModelManager @Inject constructor(
         return modelsService.getModels(url)
     }
 
-    private suspend fun validateAndPersistSelection(models: List<AIChatModel>): String? {
-        val currentSelectedId = dataStore.getSelectedModel()?.id
-        val validatedSelectedId = validateSelection(currentSelectedId, models)
-
-        if (validatedSelectedId != currentSelectedId) {
-            val validatedModel = models.find { it.id == validatedSelectedId }
-            if (validatedModel != null) {
-                dataStore.setSelectedModel(SelectedModel(validatedModel.id, validatedModel.shortName))
-            } else {
-                dataStore.setSelectedModel(null)
-            }
+    /**
+     * Only an explicit pick in [selectModel] is persisted. The default is re-derived from every
+     * response so that reordering the list, or promoting a new default, reaches users who never
+     * picked a model. A persisted pick that is gone from the response, or no longer accessible, is
+     * dropped rather than replaced, so we don't turn our fallback into a pick the user never made.
+     */
+    private suspend fun resolveSelection(models: List<AIChatModel>): String? {
+        val persistedId = dataStore.getSelectedModel()?.id
+        if (persistedId != null) {
+            val persisted = models.find { it.id == persistedId }
+            if (persisted != null && persisted.isAccessible) return persistedId
+            dataStore.setSelectedModel(null)
         }
-        return validatedSelectedId
+        return models.firstOrNull { it.isAccessible }?.id
+    }
+
+    private companion object {
+        const val PINNED_DEFAULT_MODEL_ID = "gpt-5.4-mini"
     }
 
     override suspend fun selectModel(model: AIChatModel) {
@@ -326,19 +352,6 @@ class RealDuckAiModelManager @Inject constructor(
             },
             supportedTools = remote.supportedTools.orEmpty().mapNotNull(Tool::from),
         )
-    }
-
-    private fun validateSelection(
-        currentSelectedId: String?,
-        models: List<AIChatModel>,
-    ): String? {
-        if (currentSelectedId == null) return models.firstOrNull { it.isAccessible }?.id
-
-        val selectedModel = models.find { it.id == currentSelectedId }
-        if (selectedModel == null || !selectedModel.isAccessible) {
-            return models.firstOrNull { it.isAccessible }?.id
-        }
-        return currentSelectedId
     }
 }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatDataStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatDataStore.kt
@@ -158,6 +158,10 @@ interface DuckChatDataStore {
 
     suspend fun setSelectedReasoningMode(rawValue: String?)
 
+    suspend fun hasClearedPinnedDefaultModel(): Boolean
+
+    suspend fun setClearedPinnedDefaultModel()
+
     suspend fun storeAddressBarPickerSelectedAt(timestampMillis: Long)
 
     suspend fun getAddressBarPickerSelectedAt(): Long?
@@ -201,6 +205,7 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
         val DUCK_AI_SELECTED_MODEL_ID = stringPreferencesKey(name = "DUCK_AI_SELECTED_MODEL_ID")
         val DUCK_AI_SELECTED_MODEL_SHORT_NAME = stringPreferencesKey(name = "DUCK_AI_SELECTED_MODEL_SHORT_NAME")
         val DUCK_AI_SELECTED_MODEL_REASONING_MODE = stringPreferencesKey(name = "DUCK_AI_SELECTED_MODEL_REASONING_MODE")
+        val DUCK_AI_CLEARED_PINNED_DEFAULT_MODEL = booleanPreferencesKey(name = "DUCK_AI_CLEARED_PINNED_DEFAULT_MODEL")
         val DUCK_AI_ADDRESS_BAR_PICKER_SELECTED_AT = longPreferencesKey(name = "DUCK_AI_ADDRESS_BAR_PICKER_SELECTED_AT")
     }
 
@@ -486,6 +491,13 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
                 prefs[Keys.DUCK_AI_SELECTED_MODEL_REASONING_MODE] = rawValue
             }
         }
+    }
+
+    override suspend fun hasClearedPinnedDefaultModel(): Boolean =
+        store.data.firstOrNull()?.get(Keys.DUCK_AI_CLEARED_PINNED_DEFAULT_MODEL) ?: false
+
+    override suspend fun setClearedPinnedDefaultModel() {
+        store.edit { prefs -> prefs[Keys.DUCK_AI_CLEARED_PINNED_DEFAULT_MODEL] = true }
     }
 
     override suspend fun storeAddressBarPickerSelectedAt(timestampMillis: Long) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
@@ -62,6 +62,7 @@ class RealDuckAiModelManagerTest {
         whenever(subscriptions.getEntitlements()).thenReturn(entitlementFlow)
         whenever(duckAiHostProvider.getHost()).thenReturn("duck.ai")
         subscriptions.stub { onBlocking { isEligible() }.thenReturn(true) }
+        dataStore.stub { onBlocking { hasClearedPinnedDefaultModel() }.thenReturn(true) }
     }
 
     private fun createManager(): RealDuckAiModelManager {
@@ -93,6 +94,42 @@ class RealDuckAiModelManagerTest {
 
         assertNull(testee.modelState.value.selectedModelId)
         assertNull(testee.modelState.value.selectedModelShortName)
+    }
+
+    @Test
+    fun whenPinnedDefaultModelPersistedThenClearedOnceAndNotRestored() = runTest {
+        whenever(dataStore.hasClearedPinnedDefaultModel()).thenReturn(false)
+        // Second value stands in for the store having been cleared by the migration.
+        whenever(dataStore.getSelectedModel()).thenReturn(SelectedModel("gpt-5.4-mini", "5.4-mini"), null)
+
+        testee = createManager()
+
+        verify(dataStore).setSelectedModel(null)
+        verify(dataStore).setClearedPinnedDefaultModel()
+        assertNull(testee.modelState.value.selectedModelId)
+    }
+
+    @Test
+    fun whenPersistedModelIsNotThePinnedDefaultThenSelectionKept() = runTest {
+        whenever(dataStore.hasClearedPinnedDefaultModel()).thenReturn(false)
+        whenever(dataStore.getSelectedModel()).thenReturn(SelectedModel("claude-haiku-4-5", "Haiku 4.5"))
+
+        testee = createManager()
+
+        verify(dataStore, never()).setSelectedModel(null)
+        verify(dataStore).setClearedPinnedDefaultModel()
+        assertEquals("claude-haiku-4-5", testee.modelState.value.selectedModelId)
+    }
+
+    @Test
+    fun whenPinnedDefaultAlreadyClearedThenLaterPickOfThatModelSurvives() = runTest {
+        whenever(dataStore.hasClearedPinnedDefaultModel()).thenReturn(true)
+        whenever(dataStore.getSelectedModel()).thenReturn(SelectedModel("gpt-5.4-mini", "5.4-mini"))
+
+        testee = createManager()
+
+        verify(dataStore, never()).setSelectedModel(any())
+        assertEquals("gpt-5.4-mini", testee.modelState.value.selectedModelId)
     }
 
     @Test
@@ -202,6 +239,60 @@ class RealDuckAiModelManagerTest {
         testee.fetchModels()
 
         assertEquals("id2", testee.modelState.value.selectedModelId)
+        verify(dataStore, never()).setSelectedModel(any())
+    }
+
+    @Test
+    fun whenNoSelectionPersistedAndListReorderedThenDefaultFollowsNewFirstAccessible() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel("id1", accessTier = listOf("free"), entityHasAccess = true),
+                    remoteModel("id2", accessTier = listOf("free"), entityHasAccess = true),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        assertEquals("id1", testee.modelState.value.selectedModelId)
+
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel("id2", accessTier = listOf("free"), entityHasAccess = true),
+                    remoteModel("id1", accessTier = listOf("free"), entityHasAccess = true),
+                ),
+            ),
+        )
+
+        testee.fetchModels()
+
+        assertEquals("id2", testee.modelState.value.selectedModelId)
+        verify(dataStore, never()).setSelectedModel(any())
+    }
+
+    @Test
+    fun whenUserPickedModelAndListReorderedThenPickPreserved() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(SelectedModel("id2", "model2"))
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel("id1", accessTier = listOf("free"), entityHasAccess = true),
+                    remoteModel("id2", accessTier = listOf("free"), entityHasAccess = true),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        assertEquals("id2", testee.modelState.value.selectedModelId)
+        verify(dataStore, never()).setSelectedModel(any())
     }
 
     @Test
@@ -239,7 +330,7 @@ class RealDuckAiModelManagerTest {
         testee.fetchModels()
 
         assertEquals("id2", testee.modelState.value.selectedModelId)
-        verify(dataStore).setSelectedModel(SelectedModel("id2", "id2"))
+        verify(dataStore).setSelectedModel(null)
     }
 
     @Test
@@ -256,7 +347,7 @@ class RealDuckAiModelManagerTest {
         testee.fetchModels()
 
         assertEquals("id", testee.modelState.value.selectedModelId)
-        verify(dataStore).setSelectedModel(SelectedModel("id", "id"))
+        verify(dataStore).setSelectedModel(null)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1216424634539240?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

`/duckchat/v1/models` exposes no default marker, so we infer the default by taking the first model the user's tier can access. The problem was that we then saved that inferred value to disk as if the user had picked it, on the first successful fetch. Later fetches only re-resolved when the saved model disappeared from the response or stopped being accessible, so reordering the list, or promoting a new default, never reached an install that already had one.

That write also fired on the first fetch after *upgrading* to a build containing the model picker, not just on new installs, so the pre-existing install base had its default snapshotted in one go shortly after #8157 shipped. The saved id is sent with every prompt, so it also overrides whatever default the backend would have applied. Net effect: most Android users are pinned to `gpt-5.4-mini` and no server-side default change can move them, while iOS follows the current default (see the investigation notes and Pete's confirmation of the iOS behaviour on the Asana task).

Changes:

- Persist a model only when the user explicitly picks one, and re-derive the default from every response. This matches iOS.
- Drop a saved pick that is gone from the response or no longer accessible, rather than replacing it with our fallback, so we never turn a fallback into a choice the user did not make.
- One-off migration clearing a saved `gpt-5.4-mini` so the affected cohort picks up the current default. A flag means it runs once, so a later deliberate pick of that model survives.

Wire behaviour is unchanged: we still send the resolved model id with the prompt. Existing chats are unaffected, they already resolve their own stored model and never read the global preference.

Two things worth knowing while reviewing:

- The migration hardcodes `gpt-5.4-mini`, deliberately, as a dated one-off repair for a known bad write. It rests on mini being the wrongly pinned value, which is still being confirmed against pixel data (`m_aichat_unified_input_prompt_submitted_count` carries `model_id`, `m_aichat_unified_input_model_selected` fires only on an explicit pick). Users who genuinely chose mini are reset too, since the stored value records no intent.
- Clearing the model preference orphans the saved reasoning mode, which then gets dropped by the existing orphan handling. Those users get the new default's first accessible reasoning mode.

### Steps to test this PR

_Default follows the server_
- [x] Fresh install, open the omnibar and switch to Duck.ai, confirm the picker chip shows `5.4-nano`, the first free model in the current list
- [x] Submit a prompt without touching the picker, confirm the chat runs on nano

_Explicit picks still stick_
- [x] Tap the chip, pick a different free model, submit a prompt, confirm that model is used
- [x] Kill and relaunch the app, confirm the picked model is still selected

_Migration_
- [x] On a build from `develop`, select `5.4-mini` so it is written to disk, then install this branch over it
- [x] Confirm the chip now shows `5.4-nano` rather than `5.4-mini`
- [x] Pick `5.4-mini` again, kill and relaunch, confirm it is still selected, the migration does not run twice

### UI changes
No UI changes. The picker renders the same, it just resolves the default from the current response instead of a value frozen on first run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global Duck.ai model resolution and prefs for all users, including a hardcoded one-time migration that may reset users who truly chose mini; prompt wiring still sends the resolved id.
> 
> **Overview**
> Fixes Android Duck.ai installs that were **pinned to `gpt-5.4-mini`** because the inferred default (first accessible model from `/duckchat/v1/models`) was written to prefs on fetch, as if the user had chosen it.
> 
> **Selection logic:** `fetchModels` now uses **`resolveSelection`** instead of validating and re-persisting the default. Only an explicit **`selectModel`** call saves a model id. On each fetch, users with no valid persisted pick get the **first accessible model** from the current response, so list reordering and new server defaults can land without a stored override.
> 
> **Invalid picks:** If a saved id is missing from the response or no longer accessible, prefs are **cleared** (`setSelectedModel(null)`); the UI still falls back to the first accessible model in memory, but that fallback is **not** written back as a user choice.
> 
> **One-off migration:** On startup, **`clearPinnedDefaultModel`** runs once (flag `DUCK_AI_CLEARED_PINNED_DEFAULT_MODEL`) and removes a stored **`gpt-5.4-mini`** selection so the affected cohort picks up the current default. Deliberate picks of that model after migration are kept.
> 
> Tests cover migration edge cases, reorder behavior, and that fetch no longer calls `setSelectedModel` for inferred defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e11935337f4fa7b4f48595436463d69ed3172d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->