### PR TITLE
Add voice search mic-icon and denied-dialog pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/voice_search.json5
+++ b/PixelDefinitions/pixels/definitions/voice_search.json5
@@ -19,5 +19,48 @@
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion", "source"]
+    },
+    "m_voice_search_icon_clicked": {
+        "description": "User tapped the voice search mic icon (entry point), fired before any permission check regardless of the outcome.",
+        "owners": ["aibrahim-"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "source"]
+    },
+    "m_voice_search_mic_denied_dialog_shown": {
+        "description": "The mic-access-denied dialog was shown after the microphone permission was permanently denied.",
+        "owners": ["aibrahim-"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "mode",
+                "type": "string",
+                "description": "Voice search mode",
+                "enum": ["search", "duckai"]
+            }
+        ]
+    },
+    "m_voice_search_mic_denied_dialog_click": {
+        "description": "User clicked a button on the mic-access-denied dialog.",
+        "owners": ["aibrahim-"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "mode",
+                "type": "string",
+                "description": "Voice search mode",
+                "enum": ["search", "duckai"]
+            },
+            {
+                "key": "action",
+                "type": "string",
+                "description": "Which dialog button was clicked.",
+                "enum": ["change_permissions", "hide_voice_search", "cancel"]
+            }
+        ]
     }
 }

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/PermissionAwareVoiceSearchLauncher.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/PermissionAwareVoiceSearchLauncher.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.voice.impl
 
 import android.app.Activity
 import androidx.activity.result.ActivityResultCaller
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.api.VoiceSearchLauncher
@@ -35,9 +36,15 @@ class PermissionAwareVoiceSearchLauncher @Inject constructor(
     private val voiceSearchActivityLauncher: VoiceSearchActivityLauncher,
     private val voiceSearchPermissionCheck: VoiceSearchPermissionCheck,
     private val voiceSearchAvailability: VoiceSearchAvailability,
+    private val pixel: Pixel,
 ) : VoiceSearchLauncher {
 
+    companion object {
+        private const val KEY_PARAM_SOURCE = "source"
+    }
+
     private var pendingInitialMode: VoiceSearchMode? = null
+    private var source: Source? = null
 
     override fun registerResultsCallback(
         caller: ActivityResultCaller,
@@ -45,6 +52,7 @@ class PermissionAwareVoiceSearchLauncher @Inject constructor(
         source: Source,
         onEvent: (Event) -> Unit,
     ) {
+        this.source = source
         voiceSearchActivityLauncher.registerResultsCallback(caller, activity, source) {
             onEvent(it)
         }
@@ -59,6 +67,11 @@ class PermissionAwareVoiceSearchLauncher @Inject constructor(
 
     override fun launch(activity: Activity, mode: VoiceSearchMode?) {
         if (!voiceSearchAvailability.isVoiceSearchAvailable) return
+
+        pixel.fire(
+            pixel = VoiceSearchPixelNames.VOICE_SEARCH_ICON_CLICKED,
+            parameters = mapOf(KEY_PARAM_SOURCE to source?.paramValueName.orEmpty()),
+        )
 
         pendingInitialMode = mode
         if (voiceSearchPermissionCheck.hasRequiredPermissionsGranted()) {

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/VoiceSearchPermissionDialogsLauncher.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/VoiceSearchPermissionDialogsLauncher.kt
@@ -20,6 +20,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.res.Configuration
 import android.view.ViewGroup
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.ui.view.dialog.StackedAlertDialogBuilder
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.di.scopes.ActivityScope
@@ -45,11 +46,21 @@ interface VoiceSearchPermissionDialogsLauncher {
 }
 
 @ContributesBinding(ActivityScope::class)
-class RealVoiceSearchPermissionDialogsLauncher @Inject constructor() : VoiceSearchPermissionDialogsLauncher {
+class RealVoiceSearchPermissionDialogsLauncher @Inject constructor(
+    private val pixel: Pixel,
+) : VoiceSearchPermissionDialogsLauncher {
 
     companion object {
         private const val CHANGE_PERMISSIONS_BUTTON = 0
         private const val HIDE_VOICE_SEARCH_BUTTON = 1
+
+        private const val KEY_PARAM_ACTION = "action"
+        private const val KEY_PARAM_MODE = "mode"
+        private const val ACTION_CHANGE_PERMISSIONS = "change_permissions"
+        private const val ACTION_HIDE_VOICE_SEARCH = "hide_voice_search"
+        private const val ACTION_CANCEL = "cancel"
+        private const val MODE_SEARCH = "search"
+        private const val MODE_DUCK_AI = "duckai"
     }
 
     override fun showMicAccessDeniedDialog(
@@ -60,6 +71,7 @@ class RealVoiceSearchPermissionDialogsLauncher @Inject constructor() : VoiceSear
         onCancelled: () -> Unit,
     ) {
         val isDuckAiMode = mode == VoiceSearchMode.DUCK_AI
+        val modeParam = if (isDuckAiMode) MODE_DUCK_AI else MODE_SEARCH
         val message = if (isDuckAiMode) {
             R.string.voiceSearchMicAccessDeniedDialogMessageDuckAi
         } else {
@@ -73,6 +85,11 @@ class RealVoiceSearchPermissionDialogsLauncher @Inject constructor() : VoiceSear
             add(R.string.voiceSearchNegativeAction)
         }
 
+        pixel.fire(
+            pixel = VoiceSearchPixelNames.VOICE_SEARCH_MIC_DENIED_DIALOG_SHOWN,
+            parameters = mapOf(KEY_PARAM_MODE to modeParam),
+        )
+
         StackedAlertDialogBuilder(context)
             .setHeaderImageResource(CommonR.drawable.ic_microphone_24)
             .setTitle(R.string.voiceSearchMicAccessDeniedDialogTitle)
@@ -82,14 +99,33 @@ class RealVoiceSearchPermissionDialogsLauncher @Inject constructor() : VoiceSear
                 object : StackedAlertDialogBuilder.EventListener() {
                     override fun onButtonClicked(position: Int) {
                         when (position) {
-                            CHANGE_PERMISSIONS_BUTTON -> onChangePermissionsSelected()
-                            HIDE_VOICE_SEARCH_BUTTON -> if (isDuckAiMode) onCancelled() else onHideVoiceSearchSelected()
-                            else -> onCancelled()
+                            CHANGE_PERMISSIONS_BUTTON -> {
+                                fireDialogClick(ACTION_CHANGE_PERMISSIONS, modeParam)
+                                onChangePermissionsSelected()
+                            }
+                            HIDE_VOICE_SEARCH_BUTTON -> if (isDuckAiMode) {
+                                fireDialogClick(ACTION_CANCEL, modeParam)
+                                onCancelled()
+                            } else {
+                                fireDialogClick(ACTION_HIDE_VOICE_SEARCH, modeParam)
+                                onHideVoiceSearchSelected()
+                            }
+                            else -> {
+                                fireDialogClick(ACTION_CANCEL, modeParam)
+                                onCancelled()
+                            }
                         }
                     }
                 },
             )
             .show()
+    }
+
+    private fun fireDialogClick(action: String, mode: String) {
+        pixel.fire(
+            pixel = VoiceSearchPixelNames.VOICE_SEARCH_MIC_DENIED_DIALOG_CLICK,
+            parameters = mapOf(KEY_PARAM_ACTION to action, KEY_PARAM_MODE to mode),
+        )
     }
 
     override fun showMicPermissionDeniedSnackbar(

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/VoiceSearchPixelNames.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/VoiceSearchPixelNames.kt
@@ -30,4 +30,7 @@ enum class VoiceSearchPixelNames(override val pixelName: String) : Pixel.PixelNa
     VOICE_SEARCH_GENERAL_SETTINGS_OFF("m_settings_general_voice_search_off"),
     VOICE_SEARCH_ERROR("m_voice_search_error"),
     VOICE_SEARCH_CANCELLED("m_voice_search_cancelled"),
+    VOICE_SEARCH_ICON_CLICKED("m_voice_search_icon_clicked"),
+    VOICE_SEARCH_MIC_DENIED_DIALOG_SHOWN("m_voice_search_mic_denied_dialog_shown"),
+    VOICE_SEARCH_MIC_DENIED_DIALOG_CLICK("m_voice_search_mic_denied_dialog_click"),
 }

--- a/voice-search/voice-search-impl/src/test/java/com/duckduckgo/voice/impl/PermissionAwareVoiceSearchLauncherTest.kt
+++ b/voice-search/voice-search-impl/src/test/java/com/duckduckgo/voice/impl/PermissionAwareVoiceSearchLauncherTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.voice.impl
 
 import android.app.Activity
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.api.VoiceSearchLauncher.Source
 import com.duckduckgo.voice.api.VoiceSearchLauncher.VoiceSearchMode
@@ -45,13 +46,21 @@ class PermissionAwareVoiceSearchLauncherTest {
     @Mock
     private lateinit var voiceSearchAvailability: VoiceSearchAvailability
 
+    @Mock
+    private lateinit var pixel: Pixel
+
     private lateinit var testee: PermissionAwareVoiceSearchLauncher
 
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)
-        testee =
-            PermissionAwareVoiceSearchLauncher(permissionRequest, voiceSearchActivityLauncher, voiceSearchPermissionCheck, voiceSearchAvailability)
+        testee = PermissionAwareVoiceSearchLauncher(
+            permissionRequest,
+            voiceSearchActivityLauncher,
+            voiceSearchPermissionCheck,
+            voiceSearchAvailability,
+            pixel,
+        )
     }
 
     @Test
@@ -180,5 +189,26 @@ class PermissionAwareVoiceSearchLauncherTest {
         onPermissionsGrantedCaptor.firstValue.invoke()
 
         verify(voiceSearchActivityLauncher).launch(activity, null)
+    }
+
+    @Test
+    fun whenLaunchAndVoiceSearchAvailableThenFireIconClickedPixelWithSource() {
+        val activity = mock<Activity>()
+        whenever(voiceSearchPermissionCheck.hasRequiredPermissionsGranted()).thenReturn(true)
+        whenever(voiceSearchAvailability.isVoiceSearchAvailable).thenReturn(true)
+
+        testee.registerResultsCallback(mock(), activity, Source.WIDGET) {}
+        testee.launch(activity, null)
+
+        verify(pixel).fire(VoiceSearchPixelNames.VOICE_SEARCH_ICON_CLICKED, mapOf("source" to "widget"))
+    }
+
+    @Test
+    fun whenLaunchAndVoiceSearchNotAvailableThenDoNotFireIconClickedPixel() {
+        whenever(voiceSearchAvailability.isVoiceSearchAvailable).thenReturn(false)
+
+        testee.launch(mock(), null)
+
+        verify(pixel, never()).fire(VoiceSearchPixelNames.VOICE_SEARCH_ICON_CLICKED, mapOf("source" to ""))
     }
 }


### PR DESCRIPTION


Task/Issue URL:  https://app.asana.com/1/137249556945/task/1217451439735408?focus=true

### Description
Instrument the voice search entry point and the mic-access-denied dialog:

- m_voice_search_icon_clicked: fired when the mic icon is tapped, before the permission check, so it captures intent regardless of the permission outcome.
- m_voice_search_mic_denied_dialog_shown: impression for the denied dialog, as a denominator for the click pixel.
- m_voice_search_mic_denied_dialog_click: which dialog button was clicked (change_permissions / hide_voice_search / cancel).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes on voice search UI paths; no changes to permission logic beyond firing pixels before existing behavior.
> 
> **Overview**
> Adds **three new voice search analytics pixels** and wires them into the permission/entry-point flow.
> 
> **`m_voice_search_icon_clicked`** fires when the user taps the mic entry point in `PermissionAwareVoiceSearchLauncher`, **before** the mic permission check (only when voice search is available), with a **`source`** parameter from the registered launcher callback.
> 
> **`m_voice_search_mic_denied_dialog_shown`** and **`m_voice_search_mic_denied_dialog_click`** fire when the permanent mic-denied dialog is shown and when a button is tapped, with **`mode`** (`search` / `duckai`) and **`action`** (`change_permissions`, `hide_voice_search`, `cancel`) on clicks.
> 
> Pixel definitions are added in `voice_search.json5` and mapped in `VoiceSearchPixelNames`. Unit tests cover icon-click firing (with source) and the case where voice search is unavailable (no pixel).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d92e46ac7c32fd0568ed0fb859595b76d78499cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->