### PR TITLE
Sample post_idle_session wide event at 5%

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/postidle/RealPostIdleSessionWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/postidle/RealPostIdleSessionWideEvent.kt
@@ -95,6 +95,7 @@ class RealPostIdleSessionWideEvent @Inject constructor(
                         flowStatus = FlowStatus.Unknown,
                     ),
                     metadata = mapOf(KEY_SURFACE to surface.value),
+                    samplingProbability = SAMPLING_PROBABILITY,
                 )
 
                 result.onSuccess { flowId ->
@@ -222,6 +223,7 @@ class RealPostIdleSessionWideEvent @Inject constructor(
     private companion object {
         const val TAG = "RealPostIdleSessionWideEvent"
         const val FEATURE_NAME = "post_idle_session"
+        const val SAMPLING_PROBABILITY = 0.05f
 
         const val REASON_BAR_USED = "bar_used"
         const val REASON_CHAT_SELECTED = "chat_selected"

--- a/app/src/test/java/com/duckduckgo/app/browser/postidle/RealPostIdleSessionWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/postidle/RealPostIdleSessionWideEventTest.kt
@@ -96,7 +96,7 @@ class RealPostIdleSessionWideEventTest {
                     flowStatus = FlowStatus.Unknown,
                 ),
             ),
-            samplingProbability = any(),
+            samplingProbability = eq(0.05f),
             definition = any(),
         )
         verify(wideEventClient).intervalStart(eq(123L), eq("session_duration_ms_bucketed"), anyOrNull(), anyOrNull())
@@ -121,7 +121,7 @@ class RealPostIdleSessionWideEventTest {
             flowEntryPoint = isNull(),
             metadata = eq(mapOf("surface" to "lut")),
             cleanupPolicy = any(),
-            samplingProbability = any(),
+            samplingProbability = eq(0.05f),
             definition = any(),
         )
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211850753229323/task/1217014953183502?focus=true 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

Samples the `post_idle_session` wide event at 5% instead of sending every occurrence. At 15M events/day it's the largest wide event by volume.

### Steps to test this PR

_Sampling is applied_

- [ ] Change inactivity timer to Always (General > After Inactivity > Choose an inactivity timer)
- [ ] Browse to any website.
- [ ] Background the app, then reopen it — this triggers a `post_idle_session` flow start. (log filter: `RealPostIdleSessionWideEvent`)
- [ ] Repeat a few times.
- [ ] Confirm the `wide_post_idle_session_c` pixel is either not sent at all or sent with `global.sample_rate=0.05` param. (you can change the sampling rate `RealPostIdleSessionWideEvent#SAMPLING_PROBABILITY` to have a higher probability to sent the wide event if necessary)

### UI changes

No user-facing UI changes — internal telemetry sampling rate only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only sampling change for a single high-volume wide event; no user-facing or security behavior changes.
> 
> **Overview**
> Reduces volume of the **`post_idle_session`** wide event by passing **`samplingProbability = 0.05f`** into `wideEventClient.flowStart` when a post-idle session starts (NTP/LUT after idle). Previously sampling was not set explicitly on this flow.
> 
> Unit tests now assert **`eq(0.05f)`** instead of **`any()`** for that parameter on `flowStart` verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c1268575a4608194c20e8fd5ec6fdc758128281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->