### PR TITLE
Handle C-S-S passkeyUsed notifications by parsing and logging

### DIFF
--- a/autofill/autofill-impl/build.gradle
+++ b/autofill/autofill-impl/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation project(path: ':browser-api')
     implementation project(path: ':browser-mode-api')
     implementation project(path: ':statistics-api')
+    implementation project(path: ':content-scope-scripts-api')
+    implementation project(path: ':js-messaging-api')
     testImplementation project(path: ':autofill-test')
     implementation project(path: ':sync-api')
     implementation project(path: ':navigation-api')

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedContentScopeJsMessageHandler.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedContentScopeJsMessageHandler.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.passkey
+
+import com.duckduckgo.contentscopescripts.api.ContentScopeJsMessageHandlersPlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.js.messaging.api.JsMessage
+import com.duckduckgo.js.messaging.api.JsMessageCallback
+import com.duckduckgo.js.messaging.api.JsMessageHandler
+import com.duckduckgo.js.messaging.api.JsMessaging
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+/**
+ * Handles the `webCompat` / `passkeyUsed` notification from content-scope-scripts.
+ *
+ * This is a notification rather than a request, so it carries no `id` and needs no
+ * response - unlike the request/response methods registered by web-compat's own handler,
+ * which is why this is a separate plugin rather than an addition to that method list.
+ */
+@ContributesMultibinding(AppScope::class)
+class PasskeyUsedContentScopeJsMessageHandler @Inject constructor(
+    private val logger: PasskeyUsedMessageLogger,
+) : ContentScopeJsMessageHandlersPlugin {
+
+    override fun getJsMessageHandler(): JsMessageHandler = object : JsMessageHandler {
+        override fun process(
+            jsMessage: JsMessage,
+            jsMessaging: JsMessaging,
+            jsMessageCallback: JsMessageCallback?,
+        ) {
+            logger.log(jsMessage.params)
+        }
+
+        override val allowedDomains: List<String> = emptyList()
+        override val featureName: String = FEATURE_NAME
+        override val methods: List<String> = listOf(METHOD_PASSKEY_USED)
+    }
+
+    private companion object {
+        const val FEATURE_NAME = "webCompat"
+        const val METHOD_PASSKEY_USED = "passkeyUsed"
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedContentScopeJsMessageHandler.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedContentScopeJsMessageHandler.kt
@@ -43,6 +43,8 @@ class PasskeyUsedContentScopeJsMessageHandler @Inject constructor(
             jsMessaging: JsMessaging,
             jsMessageCallback: JsMessageCallback?,
         ) {
+            // TEMP diagnostic: proves the classic transport routed the message to this handler.
+            android.util.Log.i("PasskeyUsedDbg", "classic handler process() reached: ${jsMessage.featureName}/${jsMessage.method}")
             logger.log(jsMessage.params)
         }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedContentScopeJsMessageHandler.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedContentScopeJsMessageHandler.kt
@@ -26,9 +26,10 @@ import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 
 /**
- * Handles the `webCompat` / `passkeyUsed` notification from content-scope-scripts.
+ * Handles the `webCompat` / `passkeyUsed` and `passkeyFailed` notifications from
+ * content-scope-scripts.
  *
- * This is a notification rather than a request, so it carries no `id` and needs no
+ * These are notifications rather than requests, so they carry no `id` and need no
  * response - unlike the request/response methods registered by web-compat's own handler,
  * which is why this is a separate plugin rather than an addition to that method list.
  */
@@ -45,16 +46,20 @@ class PasskeyUsedContentScopeJsMessageHandler @Inject constructor(
         ) {
             // TEMP diagnostic: proves the classic transport routed the message to this handler.
             android.util.Log.i("PasskeyUsedDbg", "classic handler process() reached: ${jsMessage.featureName}/${jsMessage.method}")
-            logger.log(jsMessage.params)
+            when (jsMessage.method) {
+                METHOD_PASSKEY_USED -> logger.logUsed(jsMessage.params)
+                METHOD_PASSKEY_FAILED -> logger.logFailed(jsMessage.params)
+            }
         }
 
         override val allowedDomains: List<String> = emptyList()
         override val featureName: String = FEATURE_NAME
-        override val methods: List<String> = listOf(METHOD_PASSKEY_USED)
+        override val methods: List<String> = listOf(METHOD_PASSKEY_USED, METHOD_PASSKEY_FAILED)
     }
 
     private companion object {
         const val FEATURE_NAME = "webCompat"
         const val METHOD_PASSKEY_USED = "passkeyUsed"
+        const val METHOD_PASSKEY_FAILED = "passkeyFailed"
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedMessageLogger.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedMessageLogger.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.autofill.impl.passkey
 
+import android.util.Log
 import logcat.LogPriority.INFO
 import logcat.LogPriority.WARN
 import logcat.logcat
@@ -37,6 +38,10 @@ import javax.inject.Inject
 class PasskeyUsedMessageLogger @Inject constructor() {
 
     fun log(params: JSONObject) {
+        // TEMP diagnostic: android.util.Log writes regardless of the debuggable flag or the
+        // logcat{} logger being installed. Remove once the message flow is confirmed on device.
+        Log.i(DIAG_TAG, "log() reached with params=$params")
+
         val type = params.optString(PARAM_TYPE)
         if (type != TYPE_GET && type != TYPE_CREATE) {
             logcat(WARN) { "Passkey: ignoring message with unsupported type '$type'" }
@@ -58,6 +63,7 @@ class PasskeyUsedMessageLogger @Inject constructor() {
     }
 
     private companion object {
+        const val DIAG_TAG = "PasskeyUsedDbg"
         const val PARAM_TYPE = "type"
         const val PARAM_SUCCESS = "success"
         const val PARAM_ERROR = "error"

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedMessageLogger.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedMessageLogger.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.passkey
+
+import logcat.LogPriority.INFO
+import logcat.LogPriority.WARN
+import logcat.logcat
+import org.json.JSONObject
+import javax.inject.Inject
+
+/**
+ * Parses the `webCompat` / `passkeyUsed` notification sent by content-scope-scripts when a
+ * WebAuthn ceremony completes, and logs the outcome.
+ *
+ * Payload contract (see `injected/src/messages/web-compat/passkeyUsed.notify.json` in C-S-S):
+ * ```
+ * { "type": "get" | "create", "success": boolean, "error"?: string }
+ * ```
+ * `error` is a sanitized DOMException name and is only present when `success` is false.
+ *
+ * Pixel firing is intentionally not implemented here yet.
+ */
+class PasskeyUsedMessageLogger @Inject constructor() {
+
+    fun log(params: JSONObject) {
+        val type = params.optString(PARAM_TYPE)
+        if (type != TYPE_GET && type != TYPE_CREATE) {
+            logcat(WARN) { "Passkey: ignoring message with unsupported type '$type'" }
+            return
+        }
+
+        val success = params.opt(PARAM_SUCCESS) as? Boolean
+        if (success == null) {
+            logcat(WARN) { "Passkey: ignoring $type message without a boolean '$PARAM_SUCCESS'" }
+            return
+        }
+
+        if (success) {
+            logcat(INFO) { "Passkey: $type succeeded" }
+        } else {
+            val error = params.optString(PARAM_ERROR).ifEmpty { "unspecified" }
+            logcat(INFO) { "Passkey: $type failed with $error" }
+        }
+    }
+
+    private companion object {
+        const val PARAM_TYPE = "type"
+        const val PARAM_SUCCESS = "success"
+        const val PARAM_ERROR = "error"
+        const val TYPE_GET = "get"
+        const val TYPE_CREATE = "create"
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedMessageLogger.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedMessageLogger.kt
@@ -24,48 +24,42 @@ import org.json.JSONObject
 import javax.inject.Inject
 
 /**
- * Parses the `webCompat` / `passkeyUsed` notification sent by content-scope-scripts when a
- * WebAuthn ceremony completes, and logs the outcome.
+ * Logs `webCompat` / `passkeyUsed` and `webCompat` / `passkeyFailed` notifications
+ * from content-scope-scripts when a WebAuthn ceremony completes.
  *
- * Payload contract (see `injected/src/messages/web-compat/passkeyUsed.notify.json` in C-S-S):
- * ```
- * { "type": "get" | "create", "success": boolean, "error"?: string }
- * ```
- * `error` is a sanitized DOMException name and is only present when `success` is false.
+ * Payload contracts:
+ * - `passkeyUsed`: `{ "type": "get" | "create" }`
+ * - `passkeyFailed`: `{ "type": "get" | "create", "error": string }`
  *
  * Pixel firing is intentionally not implemented here yet.
  */
 class PasskeyUsedMessageLogger @Inject constructor() {
 
-    fun log(params: JSONObject) {
-        // TEMP diagnostic: android.util.Log writes regardless of the debuggable flag or the
-        // logcat{} logger being installed. Remove once the message flow is confirmed on device.
-        Log.i(DIAG_TAG, "log() reached with params=$params")
+    fun logUsed(params: JSONObject) {
+        Log.i(DIAG_TAG, "logUsed() reached with params=$params")
+        val type = ceremonyType(params) ?: return
+        logcat(INFO) { "Passkey: $type succeeded" }
+    }
 
+    fun logFailed(params: JSONObject) {
+        Log.i(DIAG_TAG, "logFailed() reached with params=$params")
+        val type = ceremonyType(params) ?: return
+        val error = params.optString(PARAM_ERROR).ifEmpty { "unspecified" }
+        logcat(INFO) { "Passkey: $type failed with $error" }
+    }
+
+    private fun ceremonyType(params: JSONObject): String? {
         val type = params.optString(PARAM_TYPE)
         if (type != TYPE_GET && type != TYPE_CREATE) {
             logcat(WARN) { "Passkey: ignoring message with unsupported type '$type'" }
-            return
+            return null
         }
-
-        val success = params.opt(PARAM_SUCCESS) as? Boolean
-        if (success == null) {
-            logcat(WARN) { "Passkey: ignoring $type message without a boolean '$PARAM_SUCCESS'" }
-            return
-        }
-
-        if (success) {
-            logcat(INFO) { "Passkey: $type succeeded" }
-        } else {
-            val error = params.optString(PARAM_ERROR).ifEmpty { "unspecified" }
-            logcat(INFO) { "Passkey: $type failed with $error" }
-        }
+        return type
     }
 
     private companion object {
         const val DIAG_TAG = "PasskeyUsedDbg"
         const val PARAM_TYPE = "type"
-        const val PARAM_SUCCESS = "success"
         const val PARAM_ERROR = "error"
         const val TYPE_GET = "get"
         const val TYPE_CREATE = "create"

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/WebViewCompatPasskeyUsedContentScopeJsMessageHandler.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/WebViewCompatPasskeyUsedContentScopeJsMessageHandler.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.passkey
+
+import com.duckduckgo.contentscopescripts.api.WebViewCompatContentScopeJsMessageHandlersPlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.js.messaging.api.JsMessage
+import com.duckduckgo.js.messaging.api.ProcessResult
+import com.duckduckgo.js.messaging.api.WebViewCompatMessageHandler
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+/**
+ * WebMessageListener counterpart of [PasskeyUsedContentScopeJsMessageHandler], so the
+ * notification is handled on whichever content-scope-scripts transport the build uses.
+ *
+ * Returns null: the message is fully handled here, with nothing to forward to a consumer
+ * and no response to send.
+ */
+@ContributesMultibinding(AppScope::class)
+class WebViewCompatPasskeyUsedContentScopeJsMessageHandler @Inject constructor(
+    private val logger: PasskeyUsedMessageLogger,
+) : WebViewCompatContentScopeJsMessageHandlersPlugin {
+
+    override fun getJsMessageHandler(): WebViewCompatMessageHandler = object : WebViewCompatMessageHandler {
+        override fun process(jsMessage: JsMessage): ProcessResult? {
+            logger.log(jsMessage.params)
+            return null
+        }
+
+        override val featureName: String = FEATURE_NAME
+        override val methods: List<String> = listOf(METHOD_PASSKEY_USED)
+    }
+
+    private companion object {
+        const val FEATURE_NAME = "webCompat"
+        const val METHOD_PASSKEY_USED = "passkeyUsed"
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/WebViewCompatPasskeyUsedContentScopeJsMessageHandler.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/WebViewCompatPasskeyUsedContentScopeJsMessageHandler.kt
@@ -38,6 +38,8 @@ class WebViewCompatPasskeyUsedContentScopeJsMessageHandler @Inject constructor(
 
     override fun getJsMessageHandler(): WebViewCompatMessageHandler = object : WebViewCompatMessageHandler {
         override fun process(jsMessage: JsMessage): ProcessResult? {
+            // TEMP diagnostic: proves the WebMessageListener transport routed to this handler.
+            android.util.Log.i("PasskeyUsedDbg", "webviewcompat handler process() reached: ${jsMessage.featureName}/${jsMessage.method}")
             logger.log(jsMessage.params)
             return null
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/WebViewCompatPasskeyUsedContentScopeJsMessageHandler.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/passkey/WebViewCompatPasskeyUsedContentScopeJsMessageHandler.kt
@@ -40,16 +40,20 @@ class WebViewCompatPasskeyUsedContentScopeJsMessageHandler @Inject constructor(
         override fun process(jsMessage: JsMessage): ProcessResult? {
             // TEMP diagnostic: proves the WebMessageListener transport routed to this handler.
             android.util.Log.i("PasskeyUsedDbg", "webviewcompat handler process() reached: ${jsMessage.featureName}/${jsMessage.method}")
-            logger.log(jsMessage.params)
+            when (jsMessage.method) {
+                METHOD_PASSKEY_USED -> logger.logUsed(jsMessage.params)
+                METHOD_PASSKEY_FAILED -> logger.logFailed(jsMessage.params)
+            }
             return null
         }
 
         override val featureName: String = FEATURE_NAME
-        override val methods: List<String> = listOf(METHOD_PASSKEY_USED)
+        override val methods: List<String> = listOf(METHOD_PASSKEY_USED, METHOD_PASSKEY_FAILED)
     }
 
     private companion object {
         const val FEATURE_NAME = "webCompat"
         const val METHOD_PASSKEY_USED = "passkeyUsed"
+        const val METHOD_PASSKEY_FAILED = "passkeyFailed"
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedContentScopeJsMessageHandlerTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedContentScopeJsMessageHandlerTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.passkey
+
+import com.duckduckgo.js.messaging.api.JsMessage
+import com.duckduckgo.js.messaging.api.JsMessaging
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class PasskeyUsedContentScopeJsMessageHandlerTest {
+
+    private val logger: PasskeyUsedMessageLogger = mock()
+    private val jsMessaging: JsMessaging = mock()
+
+    @Test
+    fun whenClassicHandlerThenRegistersWebCompatPasskeyUsedForAllDomains() {
+        val handler = PasskeyUsedContentScopeJsMessageHandler(logger).getJsMessageHandler()
+
+        assertEquals("webCompat", handler.featureName)
+        assertEquals(listOf("passkeyUsed"), handler.methods)
+        assertTrue(handler.allowedDomains.isEmpty())
+    }
+
+    @Test
+    fun whenClassicHandlerReceivesNotificationWithoutIdThenParamsAreLogged() {
+        val handler = PasskeyUsedContentScopeJsMessageHandler(logger).getJsMessageHandler()
+        val params = params()
+
+        handler.process(message(params), jsMessaging, null)
+
+        verify(logger).log(params)
+    }
+
+    @Test
+    fun whenWebViewCompatHandlerThenRegistersWebCompatPasskeyUsed() {
+        val handler = WebViewCompatPasskeyUsedContentScopeJsMessageHandler(logger).getJsMessageHandler()
+
+        assertEquals("webCompat", handler.featureName)
+        assertEquals(listOf("passkeyUsed"), handler.methods)
+    }
+
+    @Test
+    fun whenWebViewCompatHandlerReceivesNotificationThenParamsAreLoggedAndMessageConsumed() {
+        val handler = WebViewCompatPasskeyUsedContentScopeJsMessageHandler(logger).getJsMessageHandler()
+        val params = params()
+
+        val result = handler.process(message(params))
+
+        assertNull(result)
+        verify(logger).log(params)
+    }
+
+    private fun params(): JSONObject = JSONObject()
+        .put("type", "get")
+        .put("success", true)
+
+    private fun message(params: JSONObject) = JsMessage(
+        context = "contentScopeScripts",
+        featureName = "webCompat",
+        method = "passkeyUsed",
+        params = params,
+        id = null,
+    )
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedContentScopeJsMessageHandlerTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedContentScopeJsMessageHandlerTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.autofill.impl.passkey
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.js.messaging.api.JsMessage
 import com.duckduckgo.js.messaging.api.JsMessaging
 import org.json.JSONObject
@@ -23,9 +24,12 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
+// Robolectric so the temporary android.util.Log diagnostic in the handlers resolves.
+@RunWith(AndroidJUnit4::class)
 class PasskeyUsedContentScopeJsMessageHandlerTest {
 
     private val logger: PasskeyUsedMessageLogger = mock()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedContentScopeJsMessageHandlerTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedContentScopeJsMessageHandlerTest.kt
@@ -36,51 +36,77 @@ class PasskeyUsedContentScopeJsMessageHandlerTest {
     private val jsMessaging: JsMessaging = mock()
 
     @Test
-    fun whenClassicHandlerThenRegistersWebCompatPasskeyUsedForAllDomains() {
+    fun whenClassicHandlerThenRegistersWebCompatPasskeyMessagesForAllDomains() {
         val handler = PasskeyUsedContentScopeJsMessageHandler(logger).getJsMessageHandler()
 
         assertEquals("webCompat", handler.featureName)
-        assertEquals(listOf("passkeyUsed"), handler.methods)
+        assertEquals(listOf("passkeyUsed", "passkeyFailed"), handler.methods)
         assertTrue(handler.allowedDomains.isEmpty())
     }
 
     @Test
-    fun whenClassicHandlerReceivesNotificationWithoutIdThenParamsAreLogged() {
+    fun whenClassicHandlerReceivesPasskeyUsedThenLogUsedIsCalled() {
         val handler = PasskeyUsedContentScopeJsMessageHandler(logger).getJsMessageHandler()
-        val params = params()
+        val params = usedParams()
 
-        handler.process(message(params), jsMessaging, null)
+        handler.process(message("passkeyUsed", params), jsMessaging, null)
 
-        verify(logger).log(params)
+        verify(logger).logUsed(params)
     }
 
     @Test
-    fun whenWebViewCompatHandlerThenRegistersWebCompatPasskeyUsed() {
+    fun whenClassicHandlerReceivesPasskeyFailedThenLogFailedIsCalled() {
+        val handler = PasskeyUsedContentScopeJsMessageHandler(logger).getJsMessageHandler()
+        val params = failedParams()
+
+        handler.process(message("passkeyFailed", params), jsMessaging, null)
+
+        verify(logger).logFailed(params)
+    }
+
+    @Test
+    fun whenWebViewCompatHandlerThenRegistersWebCompatPasskeyMessages() {
         val handler = WebViewCompatPasskeyUsedContentScopeJsMessageHandler(logger).getJsMessageHandler()
 
         assertEquals("webCompat", handler.featureName)
-        assertEquals(listOf("passkeyUsed"), handler.methods)
+        assertEquals(listOf("passkeyUsed", "passkeyFailed"), handler.methods)
     }
 
     @Test
-    fun whenWebViewCompatHandlerReceivesNotificationThenParamsAreLoggedAndMessageConsumed() {
+    fun whenWebViewCompatHandlerReceivesPasskeyUsedThenLogUsedIsCalledAndMessageConsumed() {
         val handler = WebViewCompatPasskeyUsedContentScopeJsMessageHandler(logger).getJsMessageHandler()
-        val params = params()
+        val params = usedParams()
 
-        val result = handler.process(message(params))
+        val result = handler.process(message("passkeyUsed", params))
 
         assertNull(result)
-        verify(logger).log(params)
+        verify(logger).logUsed(params)
     }
 
-    private fun params(): JSONObject = JSONObject()
-        .put("type", "get")
-        .put("success", true)
+    @Test
+    fun whenWebViewCompatHandlerReceivesPasskeyFailedThenLogFailedIsCalledAndMessageConsumed() {
+        val handler = WebViewCompatPasskeyUsedContentScopeJsMessageHandler(logger).getJsMessageHandler()
+        val params = failedParams()
 
-    private fun message(params: JSONObject) = JsMessage(
+        val result = handler.process(message("passkeyFailed", params))
+
+        assertNull(result)
+        verify(logger).logFailed(params)
+    }
+
+    private fun usedParams(): JSONObject = JSONObject().put("type", "get")
+
+    private fun failedParams(): JSONObject = JSONObject()
+        .put("type", "get")
+        .put("error", "NotAllowedError")
+
+    private fun message(
+        method: String,
+        params: JSONObject,
+    ) = JsMessage(
         context = "contentScopeScripts",
         featureName = "webCompat",
-        method = "passkeyUsed",
+        method = method,
         params = params,
         id = null,
     )

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedMessageLoggerTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedMessageLoggerTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.passkey
+
+import logcat.LogPriority
+import logcat.LogcatLogger
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PasskeyUsedMessageLoggerTest {
+
+    private val logged = mutableListOf<String>()
+    private val testee = PasskeyUsedMessageLogger()
+
+    @Before
+    fun setup() {
+        LogcatLogger.install(
+            object : LogcatLogger {
+                override fun log(
+                    priority: LogPriority,
+                    tag: String,
+                    message: String,
+                ) {
+                    logged.add(message)
+                }
+            },
+        )
+    }
+
+    @After
+    fun tearDown() {
+        LogcatLogger.uninstall()
+    }
+
+    @Test
+    fun whenAuthenticationSucceedsThenOutcomeIsLogged() {
+        testee.log(params(type = "get", success = true))
+
+        assertEquals(listOf("Passkey: get succeeded"), logged)
+    }
+
+    @Test
+    fun whenRegistrationSucceedsThenOutcomeIsLogged() {
+        testee.log(params(type = "create", success = true))
+
+        assertEquals(listOf("Passkey: create succeeded"), logged)
+    }
+
+    @Test
+    fun whenCeremonyFailsWithErrorThenErrorNameIsLogged() {
+        testee.log(params(type = "create", success = false).put("error", "NotReadableError"))
+
+        assertEquals(listOf("Passkey: create failed with NotReadableError"), logged)
+    }
+
+    @Test
+    fun whenCeremonyFailsWithoutErrorThenFailureIsStillLogged() {
+        testee.log(params(type = "get", success = false))
+
+        assertEquals(listOf("Passkey: get failed with unspecified"), logged)
+    }
+
+    @Test
+    fun whenTypeIsUnsupportedThenNoOutcomeIsLogged() {
+        testee.log(params(type = "password", success = true))
+
+        assertTrue(logged.none { it.startsWith("Passkey: password") })
+    }
+
+    @Test
+    fun whenTypeIsMissingThenNoOutcomeIsLogged() {
+        testee.log(JSONObject().put("success", true))
+
+        assertTrue(logged.none { it.contains("succeeded") })
+    }
+
+    @Test
+    fun whenSuccessIsMissingThenNoOutcomeIsLogged() {
+        testee.log(JSONObject().put("type", "get"))
+
+        assertTrue(logged.none { it.contains("succeeded") || it.contains("failed") })
+    }
+
+    @Test
+    fun whenSuccessIsNotBooleanThenNoOutcomeIsLogged() {
+        testee.log(JSONObject().put("type", "get").put("success", "true"))
+
+        assertTrue(logged.none { it.contains("succeeded") || it.contains("failed") })
+    }
+
+    private fun params(
+        type: String,
+        success: Boolean,
+    ): JSONObject = JSONObject()
+        .put("type", type)
+        .put("success", success)
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedMessageLoggerTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedMessageLoggerTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.autofill.impl.passkey
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import logcat.LogPriority
 import logcat.LogcatLogger
 import org.json.JSONObject
@@ -24,7 +25,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+// Robolectric so the temporary android.util.Log diagnostic in PasskeyUsedMessageLogger resolves.
+@RunWith(AndroidJUnit4::class)
 class PasskeyUsedMessageLoggerTest {
 
     private val logged = mutableListOf<String>()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedMessageLoggerTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/passkey/PasskeyUsedMessageLoggerTest.kt
@@ -56,64 +56,43 @@ class PasskeyUsedMessageLoggerTest {
 
     @Test
     fun whenAuthenticationSucceedsThenOutcomeIsLogged() {
-        testee.log(params(type = "get", success = true))
+        testee.logUsed(JSONObject().put("type", "get"))
 
         assertEquals(listOf("Passkey: get succeeded"), logged)
     }
 
     @Test
     fun whenRegistrationSucceedsThenOutcomeIsLogged() {
-        testee.log(params(type = "create", success = true))
+        testee.logUsed(JSONObject().put("type", "create"))
 
         assertEquals(listOf("Passkey: create succeeded"), logged)
     }
 
     @Test
     fun whenCeremonyFailsWithErrorThenErrorNameIsLogged() {
-        testee.log(params(type = "create", success = false).put("error", "NotReadableError"))
+        testee.logFailed(JSONObject().put("type", "create").put("error", "NotReadableError"))
 
         assertEquals(listOf("Passkey: create failed with NotReadableError"), logged)
     }
 
     @Test
     fun whenCeremonyFailsWithoutErrorThenFailureIsStillLogged() {
-        testee.log(params(type = "get", success = false))
+        testee.logFailed(JSONObject().put("type", "get"))
 
         assertEquals(listOf("Passkey: get failed with unspecified"), logged)
     }
 
     @Test
     fun whenTypeIsUnsupportedThenNoOutcomeIsLogged() {
-        testee.log(params(type = "password", success = true))
+        testee.logUsed(JSONObject().put("type", "password"))
 
         assertTrue(logged.none { it.startsWith("Passkey: password") })
     }
 
     @Test
     fun whenTypeIsMissingThenNoOutcomeIsLogged() {
-        testee.log(JSONObject().put("success", true))
+        testee.logUsed(JSONObject())
 
         assertTrue(logged.none { it.contains("succeeded") })
     }
-
-    @Test
-    fun whenSuccessIsMissingThenNoOutcomeIsLogged() {
-        testee.log(JSONObject().put("type", "get"))
-
-        assertTrue(logged.none { it.contains("succeeded") || it.contains("failed") })
-    }
-
-    @Test
-    fun whenSuccessIsNotBooleanThenNoOutcomeIsLogged() {
-        testee.log(JSONObject().put("type", "get").put("success", "true"))
-
-        assertTrue(logged.none { it.contains("succeeded") || it.contains("failed") })
-    }
-
-    private fun params(
-        type: String,
-        success: Boolean,
-    ): JSONObject = JSONObject()
-        .put("type", type)
-        .put("success", success)
 }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -878,6 +878,24 @@
     });
     return origDescriptor;
   }
+  function maskMethodIdentity(object, propertyName, origDescriptor) {
+    try {
+      const origFn = (
+        /** @type {{ value?: unknown } | undefined} */
+        origDescriptor?.value
+      );
+      const wrappedFn = (
+        /** @type {{ value?: unknown } | undefined} */
+        getOwnPropertyDescriptor(object, propertyName)?.value
+      );
+      if (typeof origFn !== "function" || typeof wrappedFn !== "function") {
+        return;
+      }
+      objectDefineProperty(wrappedFn, "name", { value: origFn.name, configurable: true });
+      objectDefineProperty(wrappedFn, "length", { value: origFn.length, configurable: true });
+    } catch {
+    }
+  }
   function shimInterface(interfaceName, ImplClass, options, definePropertyFn, injectName) {
     const g = globalThis;
     if (injectName === "integration") {
@@ -4333,6 +4351,9 @@
   var MSG_SCREEN_LOCK = "screenLock";
   var MSG_SCREEN_UNLOCK = "screenUnlock";
   var MSG_DEVICE_ENUMERATION = "deviceEnumeration";
+  var MSG_PASSKEY_USED = "passkeyUsed";
+  var CREDENTIAL_TYPE_PUBLIC_KEY = "public-key";
+  var PASSKEY_ERROR_OTHER = "Other";
   function canShare(data) {
     if (typeof data !== "object") return false;
     data = Object.assign({}, data);
@@ -4415,6 +4436,9 @@
       }
       if (this.getFeatureSettingEnabled("navigatorCredentials")) {
         this.navigatorCredentialsFix();
+      }
+      if (this.getFeatureSettingEnabled("passkeyDetection")) {
+        this.passkeyDetectionFix();
       }
       if (this.getFeatureSettingEnabled("safariObject")) {
         this.safariObjectFix();
@@ -4969,6 +4993,110 @@
           writable: true
         });
       } catch {
+      }
+    }
+    /**
+     * Detects usage of WebAuthn passkeys (`navigator.credentials.get`/`.create` called
+     * with a `publicKey` option) and notifies the native layer, purely for pixelling
+     * purposes. This never mediates, delays, or alters the credential ceremony itself:
+     * the original method is always invoked with the original arguments and its return
+     * value (a promise) is returned to the page completely unmodified. We only attach a
+     * side-channel observer to that promise to detect a successful outcome.
+     *
+     * This is intentionally a much lighter touch than `AutofillPasskeys`
+     * (autofill-passkeys.js), which fully mediates conditional requests to drive a
+     * custom credential-picker UI. Here there is no UI to replace (the platform already
+     * shows its own native passkey prompt), so we only need to observe, not intercept.
+     */
+    passkeyDetectionFix() {
+      try {
+        if (typeof CredentialsContainer === "undefined" || !navigator.credentials || !(navigator.credentials instanceof CredentialsContainer) || typeof navigator.credentials.get !== "function") {
+          return;
+        }
+        const proto = CredentialsContainer.prototype;
+        this.wrapPasskeyMethod(proto, "get");
+        this.wrapPasskeyMethod(proto, "create");
+      } catch {
+      }
+    }
+    /**
+     * Wraps a single CredentialsContainer method (`get` or `create`) so that WebAuthn
+     * (`publicKey`) calls are observed without changing behaviour.
+     * @param {object} proto
+     * @param {'get'|'create'} methodName
+     */
+    wrapPasskeyMethod(proto, methodName) {
+      const feature = this;
+      const origDescriptor = this.wrapMethod(proto, methodName, function(originalFn, ...args) {
+        const result = originalFn.apply(this, args);
+        try {
+          const options = args[0];
+          if (options && typeof options === "object" && options.publicKey && result && typeof result.then === "function") {
+            void feature.observePasskeyResult(result, methodName);
+          }
+        } catch {
+        }
+        return result;
+      });
+      maskMethodIdentity(proto, methodName, origDescriptor);
+    }
+    /**
+     * Observes (without consuming or altering) the outcome of a passkey ceremony and
+     * notifies native of success when it resolves with a public-key credential, or of
+     * failure when it rejects. Runs as a fire-and-forget derived promise chain - it
+     * never affects the promise/value returned to the page.
+     * @param {Promise<Credential | null>} resultPromise
+     * @param {'get'|'create'} type
+     */
+    async observePasskeyResult(resultPromise, type) {
+      let credential;
+      try {
+        credential = await resultPromise;
+      } catch (e) {
+        const error = this.sanitizePasskeyErrorName(e);
+        try {
+          this.notify(MSG_PASSKEY_USED, { type, success: false, error });
+        } catch {
+        }
+        return;
+      }
+      try {
+        if (credential && credential.type === CREDENTIAL_TYPE_PUBLIC_KEY) {
+          this.notify(MSG_PASSKEY_USED, { type, success: true });
+        }
+      } catch {
+      }
+    }
+    /**
+     * Reduces a rejected passkey ceremony error to a bounded, non-identifying name.
+     * Only a known DOMException name is forwarded; anything else (including non-Error
+     * rejections) becomes 'Other'. The error message is intentionally never used.
+     * @param {unknown} error
+     * @returns {NonNullable<import('../types/web-compat.js').PasskeyUsedParams['error']>}
+     */
+    sanitizePasskeyErrorName(error) {
+      try {
+        const name = (
+          /** @type {{ name?: unknown }} */
+          error?.name
+        );
+        switch (name) {
+          case "NotAllowedError":
+          case "SecurityError":
+          case "NotSupportedError":
+          case "InvalidStateError":
+          case "ConstraintError":
+          case "AbortError":
+          case "UnknownError":
+          case "EncodingError":
+          case "NotReadableError":
+          case "TypeError":
+            return name;
+          default:
+            return PASSKEY_ERROR_OTHER;
+        }
+      } catch {
+        return PASSKEY_ERROR_OTHER;
       }
     }
     safariObjectFix() {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -2291,6 +2291,24 @@
     });
     return origDescriptor;
   }
+  function maskMethodIdentity(object, propertyName, origDescriptor) {
+    try {
+      const origFn = (
+        /** @type {{ value?: unknown } | undefined} */
+        origDescriptor?.value
+      );
+      const wrappedFn = (
+        /** @type {{ value?: unknown } | undefined} */
+        getOwnPropertyDescriptor(object, propertyName)?.value
+      );
+      if (typeof origFn !== "function" || typeof wrappedFn !== "function") {
+        return;
+      }
+      objectDefineProperty(wrappedFn, "name", { value: origFn.name, configurable: true });
+      objectDefineProperty(wrappedFn, "length", { value: origFn.length, configurable: true });
+    } catch {
+    }
+  }
   function shimInterface(interfaceName, ImplClass, options, definePropertyFn, injectName) {
     const g = globalThis;
     if (injectName === "integration") {
@@ -7169,6 +7187,9 @@
   var MSG_SCREEN_LOCK = "screenLock";
   var MSG_SCREEN_UNLOCK = "screenUnlock";
   var MSG_DEVICE_ENUMERATION = "deviceEnumeration";
+  var MSG_PASSKEY_USED = "passkeyUsed";
+  var CREDENTIAL_TYPE_PUBLIC_KEY = "public-key";
+  var PASSKEY_ERROR_OTHER = "Other";
   function canShare(data) {
     if (typeof data !== "object") return false;
     data = Object.assign({}, data);
@@ -7251,6 +7272,9 @@
       }
       if (this.getFeatureSettingEnabled("navigatorCredentials")) {
         this.navigatorCredentialsFix();
+      }
+      if (this.getFeatureSettingEnabled("passkeyDetection")) {
+        this.passkeyDetectionFix();
       }
       if (this.getFeatureSettingEnabled("safariObject")) {
         this.safariObjectFix();
@@ -7805,6 +7829,110 @@
           writable: true
         });
       } catch {
+      }
+    }
+    /**
+     * Detects usage of WebAuthn passkeys (`navigator.credentials.get`/`.create` called
+     * with a `publicKey` option) and notifies the native layer, purely for pixelling
+     * purposes. This never mediates, delays, or alters the credential ceremony itself:
+     * the original method is always invoked with the original arguments and its return
+     * value (a promise) is returned to the page completely unmodified. We only attach a
+     * side-channel observer to that promise to detect a successful outcome.
+     *
+     * This is intentionally a much lighter touch than `AutofillPasskeys`
+     * (autofill-passkeys.js), which fully mediates conditional requests to drive a
+     * custom credential-picker UI. Here there is no UI to replace (the platform already
+     * shows its own native passkey prompt), so we only need to observe, not intercept.
+     */
+    passkeyDetectionFix() {
+      try {
+        if (typeof CredentialsContainer === "undefined" || !navigator.credentials || !(navigator.credentials instanceof CredentialsContainer) || typeof navigator.credentials.get !== "function") {
+          return;
+        }
+        const proto = CredentialsContainer.prototype;
+        this.wrapPasskeyMethod(proto, "get");
+        this.wrapPasskeyMethod(proto, "create");
+      } catch {
+      }
+    }
+    /**
+     * Wraps a single CredentialsContainer method (`get` or `create`) so that WebAuthn
+     * (`publicKey`) calls are observed without changing behaviour.
+     * @param {object} proto
+     * @param {'get'|'create'} methodName
+     */
+    wrapPasskeyMethod(proto, methodName) {
+      const feature = this;
+      const origDescriptor = this.wrapMethod(proto, methodName, function(originalFn, ...args) {
+        const result = originalFn.apply(this, args);
+        try {
+          const options = args[0];
+          if (options && typeof options === "object" && options.publicKey && result && typeof result.then === "function") {
+            void feature.observePasskeyResult(result, methodName);
+          }
+        } catch {
+        }
+        return result;
+      });
+      maskMethodIdentity(proto, methodName, origDescriptor);
+    }
+    /**
+     * Observes (without consuming or altering) the outcome of a passkey ceremony and
+     * notifies native of success when it resolves with a public-key credential, or of
+     * failure when it rejects. Runs as a fire-and-forget derived promise chain - it
+     * never affects the promise/value returned to the page.
+     * @param {Promise<Credential | null>} resultPromise
+     * @param {'get'|'create'} type
+     */
+    async observePasskeyResult(resultPromise, type) {
+      let credential;
+      try {
+        credential = await resultPromise;
+      } catch (e) {
+        const error = this.sanitizePasskeyErrorName(e);
+        try {
+          this.notify(MSG_PASSKEY_USED, { type, success: false, error });
+        } catch {
+        }
+        return;
+      }
+      try {
+        if (credential && credential.type === CREDENTIAL_TYPE_PUBLIC_KEY) {
+          this.notify(MSG_PASSKEY_USED, { type, success: true });
+        }
+      } catch {
+      }
+    }
+    /**
+     * Reduces a rejected passkey ceremony error to a bounded, non-identifying name.
+     * Only a known DOMException name is forwarded; anything else (including non-Error
+     * rejections) becomes 'Other'. The error message is intentionally never used.
+     * @param {unknown} error
+     * @returns {NonNullable<import('../types/web-compat.js').PasskeyUsedParams['error']>}
+     */
+    sanitizePasskeyErrorName(error) {
+      try {
+        const name = (
+          /** @type {{ name?: unknown }} */
+          error?.name
+        );
+        switch (name) {
+          case "NotAllowedError":
+          case "SecurityError":
+          case "NotSupportedError":
+          case "InvalidStateError":
+          case "ConstraintError":
+          case "AbortError":
+          case "UnknownError":
+          case "EncodingError":
+          case "NotReadableError":
+          case "TypeError":
+            return name;
+          default:
+            return PASSKEY_ERROR_OTHER;
+        }
+      } catch {
+        return PASSKEY_ERROR_OTHER;
       }
     }
     safariObjectFix() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^16.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#cursor/passkey-usage-detection-e6be",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#pr-releases/cursor/passkey-usage-detection-e6be",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -61,7 +61,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1d01d1b383534613f4e214fb1c760c1de7cce0b4",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#72cc2f8fc4b807869f351c7221570256991461aa",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^16.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.7.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#cursor/passkey-usage-detection-e6be",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -61,7 +61,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c13193705a8a5ab8a28d457a4849f27ba6d23676",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1d01d1b383534613f4e214fb1c760c1de7cce0b4",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^16.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#cursor/passkey-usage-detection-e6be",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#pr-releases/cursor/passkey-usage-detection-e6be",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^16.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.7.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#cursor/passkey-usage-detection-e6be",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Adds a dedicated handler pair for the webCompat/passkeyUsed notification that content-scope-scripts sends when a WebAuthn passkey ceremony completes ({ type: get|create, success: boolean, error? }).

Follows the ContentScopeJsMessageHandlersPlugin pattern (e.g. DecryptWithSyncMasterKeyHandler), with a WebViewCompat twin so the message is handled on either C-S-S transport. Unlike the existing webCompat request/response handlers there is intentionally no id guard: this is a notify() message and carries no id.

For now the payload is only parsed and logged; pixel firing is a follow-up (definitions in PR #7183).

Task/Issue URL: 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
