### PR TITLE
Add pixels for the Edit Message screen

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1246,74 +1246,39 @@
         "suffixes": ["form_factor"],
         "parameters": ["appVersion", "unifiedInputSurface"]
     },
-    "m_aichat_edit_prompt_opened_count": {
+    "m_aichat_edit_prompt_opened": {
         "description": "User opened the fullscreen Edit Message screen for a sent prompt",
         "owners": ["malmstein"],
         "triggers": ["other"],
-        "suffixes": ["form_factor"],
+        "suffixes": ["first_daily_count", "form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_aichat_edit_prompt_opened_daily": {
-        "description": "(Daily Pixel) User opened the fullscreen Edit Message screen for a sent prompt",
-        "owners": ["malmstein"],
-        "triggers": ["other"],
-        "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
-    },
-    "m_aichat_edit_prompt_cancelled_count": {
+    "m_aichat_edit_prompt_cancelled": {
         "description": "User left the Edit Message screen without submitting (toolbar close, system or predictive back)",
         "owners": ["malmstein"],
         "triggers": ["other"],
-        "suffixes": ["form_factor"],
+        "suffixes": ["first_daily_count", "form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_aichat_edit_prompt_cancelled_daily": {
-        "description": "(Daily Pixel) User left the Edit Message screen without submitting (toolbar close, system or predictive back)",
-        "owners": ["malmstein"],
-        "triggers": ["other"],
-        "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
-    },
-    "m_aichat_edit_prompt_submitted_count": {
+    "m_aichat_edit_prompt_submitted": {
         "description": "User submitted the edited prompt from the Edit Message screen, replacing the original message",
         "owners": ["malmstein"],
         "triggers": ["other"],
-        "suffixes": ["form_factor"],
+        "suffixes": ["first_daily_count", "form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_aichat_edit_prompt_submitted_daily": {
-        "description": "(Daily Pixel) User submitted the edited prompt from the Edit Message screen, replacing the original message",
-        "owners": ["malmstein"],
-        "triggers": ["other"],
-        "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
-    },
-    "m_aichat_edit_prompt_image_removed_count": {
+    "m_aichat_edit_prompt_image_removed": {
         "description": "User removed an attached image while on the Edit Message screen",
         "owners": ["malmstein"],
         "triggers": ["other"],
-        "suffixes": ["form_factor"],
+        "suffixes": ["first_daily_count", "form_factor"],
         "parameters": ["appVersion", "unifiedInputSurface"]
     },
-    "m_aichat_edit_prompt_image_removed_daily": {
-        "description": "(Daily Pixel) User removed an attached image while on the Edit Message screen",
-        "owners": ["malmstein"],
-        "triggers": ["other"],
-        "suffixes": ["form_factor"],
-        "parameters": ["appVersion", "unifiedInputSurface"]
-    },
-    "m_aichat_edit_prompt_file_removed_count": {
+    "m_aichat_edit_prompt_file_removed": {
         "description": "User removed an attached file while on the Edit Message screen",
         "owners": ["malmstein"],
         "triggers": ["other"],
-        "suffixes": ["form_factor"],
-        "parameters": ["appVersion", "unifiedInputSurface"]
-    },
-    "m_aichat_edit_prompt_file_removed_daily": {
-        "description": "(Daily Pixel) User removed an attached file while on the Edit Message screen",
-        "owners": ["malmstein"],
-        "triggers": ["other"],
-        "suffixes": ["form_factor"],
+        "suffixes": ["first_daily_count", "form_factor"],
         "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_model_selected": {

--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1246,6 +1246,76 @@
         "suffixes": ["form_factor"],
         "parameters": ["appVersion", "unifiedInputSurface"]
     },
+    "m_aichat_edit_prompt_opened_count": {
+        "description": "User opened the fullscreen Edit Message screen for a sent prompt",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_edit_prompt_opened_daily": {
+        "description": "(Daily Pixel) User opened the fullscreen Edit Message screen for a sent prompt",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_edit_prompt_cancelled_count": {
+        "description": "User left the Edit Message screen without submitting (toolbar close, system or predictive back)",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_edit_prompt_cancelled_daily": {
+        "description": "(Daily Pixel) User left the Edit Message screen without submitting (toolbar close, system or predictive back)",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_edit_prompt_submitted_count": {
+        "description": "User submitted the edited prompt from the Edit Message screen, replacing the original message",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_edit_prompt_submitted_daily": {
+        "description": "(Daily Pixel) User submitted the edited prompt from the Edit Message screen, replacing the original message",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_edit_prompt_image_removed_count": {
+        "description": "User removed an attached image while on the Edit Message screen",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "unifiedInputSurface"]
+    },
+    "m_aichat_edit_prompt_image_removed_daily": {
+        "description": "(Daily Pixel) User removed an attached image while on the Edit Message screen",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "unifiedInputSurface"]
+    },
+    "m_aichat_edit_prompt_file_removed_count": {
+        "description": "User removed an attached file while on the Edit Message screen",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "unifiedInputSurface"]
+    },
+    "m_aichat_edit_prompt_file_removed_daily": {
+        "description": "(Daily Pixel) User removed an attached file while on the Edit Message screen",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "unifiedInputSurface"]
+    },
     "m_aichat_unified_input_model_selected": {
         "description": "User selected a model in the Unified Input model picker",
         "owners": ["malmstein"],

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -229,14 +229,8 @@ interface DuckChatPixels {
     fun fireVoiceTapped(surface: DuckChatPixelSurface)
     fun fireVoiceSearchTapped(surface: DuckChatPixelSurface)
     fun fireStopGenerationTapped(surface: DuckChatPixelSurface)
-
-    /** The fullscreen Edit Message screen was opened for a sent prompt. */
     fun fireEditPromptOpened()
-
-    /** The Edit Message screen was left without submitting (toolbar close, system/predictive back). */
     fun fireEditPromptCancelled()
-
-    /** The edited prompt was submitted, replacing the original message. */
     fun fireEditPromptSubmitted()
     fun fireEditPromptImageRemoved(surface: DuckChatPixelSurface)
     fun fireEditPromptFileRemoved(surface: DuckChatPixelSurface)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -229,6 +229,17 @@ interface DuckChatPixels {
     fun fireVoiceTapped(surface: DuckChatPixelSurface)
     fun fireVoiceSearchTapped(surface: DuckChatPixelSurface)
     fun fireStopGenerationTapped(surface: DuckChatPixelSurface)
+
+    /** The fullscreen Edit Message screen was opened for a sent prompt. */
+    fun fireEditPromptOpened()
+
+    /** The Edit Message screen was left without submitting (toolbar close, system/predictive back). */
+    fun fireEditPromptCancelled()
+
+    /** The edited prompt was submitted, replacing the original message. */
+    fun fireEditPromptSubmitted()
+    fun fireEditPromptImageRemoved(surface: DuckChatPixelSurface)
+    fun fireEditPromptFileRemoved(surface: DuckChatPixelSurface)
     fun fireDuckAiChatHistorySuggestionClicked()
     fun fireDuckAiSearchDuckDuckGoSuggestionClicked()
     fun fireRecentChatDeleteButtonTapped()
@@ -857,6 +868,33 @@ class RealDuckChatPixels @Inject constructor(
         surfaceParams(surface),
     )
 
+    override fun fireEditPromptOpened() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_EDIT_PROMPT_OPENED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_EDIT_PROMPT_OPENED_DAILY,
+    )
+
+    override fun fireEditPromptCancelled() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_EDIT_PROMPT_CANCELLED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_EDIT_PROMPT_CANCELLED_DAILY,
+    )
+
+    override fun fireEditPromptSubmitted() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_EDIT_PROMPT_SUBMITTED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_EDIT_PROMPT_SUBMITTED_DAILY,
+    )
+
+    override fun fireEditPromptImageRemoved(surface: DuckChatPixelSurface) = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_EDIT_PROMPT_IMAGE_REMOVED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_EDIT_PROMPT_IMAGE_REMOVED_DAILY,
+        surfaceParams(surface),
+    )
+
+    override fun fireEditPromptFileRemoved(surface: DuckChatPixelSurface) = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_EDIT_PROMPT_FILE_REMOVED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_EDIT_PROMPT_FILE_REMOVED_DAILY,
+        surfaceParams(surface),
+    )
+
     override fun fireFileValidationFailed(reason: String, surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_VALIDATION_FAILED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_VALIDATION_FAILED_DAILY,
@@ -1260,6 +1298,18 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_UNIFIED_INPUT_VOICE_SEARCH_TAPPED_COUNT("m_aichat_unified_input_voice_search_tapped_count"),
     DUCK_CHAT_UNIFIED_INPUT_VOICE_SEARCH_TAPPED_DAILY("m_aichat_unified_input_voice_search_tapped_daily"),
     DUCK_CHAT_UNIFIED_INPUT_STOP_GENERATION_TAPPED("m_aichat_unified_input_stop_generation_tapped"),
+
+    // Edit Message screen (fullscreen prompt editor)
+    DUCK_CHAT_EDIT_PROMPT_OPENED_COUNT("m_aichat_edit_prompt_opened_count"),
+    DUCK_CHAT_EDIT_PROMPT_OPENED_DAILY("m_aichat_edit_prompt_opened_daily"),
+    DUCK_CHAT_EDIT_PROMPT_CANCELLED_COUNT("m_aichat_edit_prompt_cancelled_count"),
+    DUCK_CHAT_EDIT_PROMPT_CANCELLED_DAILY("m_aichat_edit_prompt_cancelled_daily"),
+    DUCK_CHAT_EDIT_PROMPT_SUBMITTED_COUNT("m_aichat_edit_prompt_submitted_count"),
+    DUCK_CHAT_EDIT_PROMPT_SUBMITTED_DAILY("m_aichat_edit_prompt_submitted_daily"),
+    DUCK_CHAT_EDIT_PROMPT_IMAGE_REMOVED_COUNT("m_aichat_edit_prompt_image_removed_count"),
+    DUCK_CHAT_EDIT_PROMPT_IMAGE_REMOVED_DAILY("m_aichat_edit_prompt_image_removed_daily"),
+    DUCK_CHAT_EDIT_PROMPT_FILE_REMOVED_COUNT("m_aichat_edit_prompt_file_removed_count"),
+    DUCK_CHAT_EDIT_PROMPT_FILE_REMOVED_DAILY("m_aichat_edit_prompt_file_removed_daily"),
 
     // Subscription-funnel impressions. The matching "click" is DUCK_CHAT_UNIFIED_INPUT_SUBSCRIPTION_UPSELL_TRIGGERED.
     DUCK_CHAT_UNIFIED_INPUT_MODEL_PICKER_SHOWN("m_aichat_unified_input_model_picker_shown"),

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
@@ -310,7 +310,7 @@ class AttachmentViewModel @Inject constructor(
         }
     }
 
-    fun removeImageAttachment(id: String) {
+    fun removeImageAttachment(id: String, isEditMode: Boolean = false) {
         var toRecycle: Bitmap? = null
         var removed = false
         imageAttachments.update { list ->
@@ -319,17 +319,23 @@ class AttachmentViewModel @Inject constructor(
             removed = match != null
             list.filter { it.id != id }
         }
-        if (removed) duckChatPixels.fireImageRemoved(surface.value)
+        if (removed) {
+            duckChatPixels.fireImageRemoved(surface.value)
+            if (isEditMode) duckChatPixels.fireEditPromptImageRemoved(surface.value)
+        }
         viewModelScope.launch { toRecycle?.recycle() }
     }
 
-    fun removeFileAttachment(id: String) {
+    fun removeFileAttachment(id: String, isEditMode: Boolean = false) {
         var removed = false
         _fileAttachments.update { list ->
             removed = list.any { it.id == id }
             list.filter { it.id != id }
         }
-        if (removed) duckChatPixels.fireFileRemoved(surface.value)
+        if (removed) {
+            duckChatPixels.fireFileRemoved(surface.value)
+            if (isEditMode) duckChatPixels.fireEditPromptFileRemoved(surface.value)
+        }
     }
 
     fun setPageContext(attachment: PageContextAttachment) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/edit/EditPromptActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/edit/EditPromptActivity.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.databinding.ActivityEditPromptBinding
 import com.duckduckgo.duckchat.impl.helper.EditPromptResult
 import com.duckduckgo.duckchat.impl.helper.EditPromptSessionStore
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.NativeInputModeWidgetViewModel
 import com.duckduckgo.navigation.api.getActivityParams
 import kotlinx.coroutines.launch
@@ -54,11 +55,15 @@ class EditPromptActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
+    @Inject
+    lateinit var duckChatPixels: DuckChatPixels
+
     private val binding: ActivityEditPromptBinding by viewBinding()
 
     private val params by lazy { intent.getActivityParams(EditPromptScreenParams::class.java) }
 
     private var submitted = false
+    private var opened = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -99,6 +104,8 @@ class EditPromptActivity : DuckDuckGoActivity() {
             // field not yet focusable. Queuing after it (registered later, so it runs after) fixes it.
             asView().doOnAttach { focusInput(this@EditPromptActivity) }
         }
+        opened = true
+        duckChatPixels.fireEditPromptOpened()
 
         // The store's CompletableDeferred fans out to any number of awaiters, so this doesn't race
         // submit()/onDestroy()'s own resolve() calls — it just closes the screen if the session gets
@@ -128,6 +135,7 @@ class EditPromptActivity : DuckDuckGoActivity() {
                 files = binding.editPromptInput.getFileAttachmentsJson().toSubmittedFiles(),
             ),
         )
+        duckChatPixels.fireEditPromptSubmitted()
         finish()
     }
 
@@ -139,6 +147,9 @@ class EditPromptActivity : DuckDuckGoActivity() {
      */
     override fun finish() {
         params?.sessionId?.let { editPromptSessionStore.resolve(it, EditPromptResult.Cancelled) }
+        // Only a real cancel from an already-shown screen, not the early bail-out for a dead/stale
+        // session (params/payload missing) or the tail end of submit()'s own finish() call.
+        if (opened && !submitted) duckChatPixels.fireEditPromptCancelled()
         super.finish()
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/edit/EditPromptActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/edit/EditPromptActivity.kt
@@ -64,6 +64,7 @@ class EditPromptActivity : DuckDuckGoActivity() {
 
     private var submitted = false
     private var opened = false
+    private var finishHandled = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -144,12 +145,19 @@ class EditPromptActivity : DuckDuckGoActivity() {
      * finish(), so resolving here gets the cancel across the JS bridge while the edit screen still
      * covers the web view. Waiting for onDestroy() would land the reply after the exit animation,
      * making the frontend's leave-edit re-render visible on the transcript the user is back on.
+     *
+     * resolve()'s CompletableDeferred resumes the onCreate() awaiter synchronously (Main.immediate,
+     * already on the main thread), which itself calls finish() again before isFinishing flips —
+     * finishHandled guards that re-entrant call so the cancel only resolves/fires once.
      */
     override fun finish() {
-        params?.sessionId?.let { editPromptSessionStore.resolve(it, EditPromptResult.Cancelled) }
-        // Only a real cancel from an already-shown screen, not the early bail-out for a dead/stale
-        // session (params/payload missing) or the tail end of submit()'s own finish() call.
-        if (opened && !submitted) duckChatPixels.fireEditPromptCancelled()
+        if (!finishHandled) {
+            finishHandled = true
+            params?.sessionId?.let { editPromptSessionStore.resolve(it, EditPromptResult.Cancelled) }
+            // Only a real cancel from an already-shown screen, not the early bail-out for a dead/stale
+            // session (params/payload missing) or the tail end of submit()'s own finish() call.
+            if (opened && !submitted) duckChatPixels.fireEditPromptCancelled()
+        }
         super.finish()
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
@@ -196,13 +196,13 @@ class AttachmentView(
         pageContextContainer = pageContext
 
         val imagesContainer = ImageAttachmentsContainerView(context).also {
-            it.onAttachmentRemoved = { id -> vm.removeImageAttachment(id) }
+            it.onAttachmentRemoved = { id -> vm.removeImageAttachment(id, isEditMode) }
         }
         row.addView(imagesContainer)
         imageAttachmentsContainer = imagesContainer
 
         val filesContainer = FileAttachmentsContainerView(context).also {
-            it.onAttachmentRemoved = { attachment -> vm.removeFileAttachment(attachment.id) }
+            it.onAttachmentRemoved = { attachment -> vm.removeFileAttachment(attachment.id, isEditMode) }
         }
         row.addView(filesContainer)
         fileAttachmentsContainer = filesContainer


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1217151440349295
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

Adds pixels for the fullscreen Edit Message screen: opened, cancelled (left without submitting), submitted, and attachment removed while editing.

- `m_aichat_edit_prompt_opened` — fired once `EditPromptActivity` has configured the widget for the session
- `m_aichat_edit_prompt_cancelled` — fired from the `finish()` override, only when the screen was actually shown and the exit wasn't a submit (toolbar close, system back, predictive back all route through `finish()`)
- `m_aichat_edit_prompt_submitted` — fired alongside resolving the session as `Submitted`
- `m_aichat_edit_prompt_image_removed` / `m_aichat_edit_prompt_file_removed` — fired from `AttachmentViewModel` when an attachment is removed while `isEditMode` is true, in addition to the existing generic removal pixels

All follow the existing `m_aichat_*` wire-name / `DUCK_CHAT_*` enum / `fireCountAndDaily` (count+daily pair) convention already used throughout `DuckChatPixels.kt`.

### Steps to test this PR

_Editing a message_
- [x] Open a Duck.ai chat, send a prompt, tap edit on it — confirm `m_aichat_edit_prompt_opened_count`/`_daily` fire
- [x] Tap the X (or back) without submitting — confirm `m_aichat_edit_prompt_cancelled_count`/`_daily` fire, and that submitting afterwards does not also fire a cancel
- [x] Edit the text and submit — confirm `m_aichat_edit_prompt_submitted_count`/`_daily` fire, and no cancel pixel fires
- [x] With an image/file attached, remove it from the Edit screen — confirm `m_aichat_edit_prompt_image_removed`/`m_aichat_edit_prompt_file_removed` fire (in addition to the existing unified-input removal pixels), and that removing an attachment outside the Edit screen does not fire these new pixels

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes with small lifecycle guards in EditPromptActivity.finish(); no auth, data, or chat submission logic changes.
> 
> **Overview**
> Adds **analytics coverage** for the fullscreen Edit Message flow so product can measure open, abandon, submit, and attachment edits.
> 
> New pixel definitions (`m_aichat_edit_prompt_*`) are registered in `duck_chat.json5` and wired through `DuckChatPixels` using the existing count + daily `fireCountAndDaily` pattern. **Opened** fires after `EditPromptActivity` configures the input; **submitted** fires on successful send; **cancelled** fires from `finish()` only when the screen was shown and the user did not submit (toolbar close, back, predictive back), with a `finishHandled` guard so re-entrant `finish()` from session resolution does not double-fire cancel or cancel after submit.
> 
> **Image/file removed** pixels fire from `AttachmentViewModel` when `isEditMode` is true, in addition to the existing unified-input removal pixels; `AttachmentView` passes `isEditMode` into the remove callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a92cda1d39d35d3f0b2c0fa2a3e34ca1ef9abc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->