### PR TITLE
Request translations for Duck.ai edit message screen

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/edit/EditPromptActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/edit/EditPromptActivity.kt
@@ -73,7 +73,7 @@ class EditPromptActivity : DuckDuckGoActivity() {
             setupToolbar(this)
             title = getString(R.string.duck_ai_edit_prompt_title)
             setNavigationIcon(com.duckduckgo.mobile.android.R.drawable.ic_close_24)
-            navigationContentDescription = getString(R.string.duck_ai_edit_prompt_cancel)
+            navigationContentDescription = getString(com.duckduckgo.mobile.android.R.string.cancel)
             setNavigationOnClickListener { finish() }
         }
 

--- a/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Обобщи биографията</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Обобщи биографията и значимите постижения на това лице.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Задайте въпрос поверително</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Последни чатове</string>
 
@@ -343,4 +343,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Попитайте за страницата</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Редактиране на съобщение</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Редактирането ще замени отговора с нов.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Shrň mi základní informace</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Shrň mi základní informace a významná díla této osoby.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Zeptej se soukromě na cokoli</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Nedávné chaty</string>
 
@@ -345,4 +345,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Zeptat se ohledně stránky</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Upravit zprávu</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Po úpravě se odpověď nahradí novou.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Sammenfat personens baggrund</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Sammenfat denne persons baggrund og bemærkelsesværdige arbejde.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Spørg om hvad som helst privat</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Seneste chats</string>
 
@@ -343,4 +343,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Spørg om siden</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Redigér besked</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Redigering vil erstatte svaret med et nyt.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Hintergrund zusammenfassen</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Fasse den Hintergrund und die wichtigsten Leistungen dieser Person zusammen.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Alles privat fragen</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Aktuelle Chats</string>
 
@@ -343,4 +343,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Frage zur Seite</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Nachricht bearbeiten</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Beim Bearbeiten wird die Antwort durch eine neue ersetzt.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Συνόψισε το ιστορικό τους</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Συνόψισε το ιστορικό αυτού του ατόμου και το σημαντικό του έργο.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Ρωτήστε οτιδήποτε ιδιωτικά</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Πρόσφατες συνομιλίες</string>
 
@@ -343,4 +343,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Ρώτα για τη σελίδα</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Επεξεργασία μηνύματος</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Η επεξεργασία θα αντικαταστήσει την απάντηση με μια νέα.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Resume sus antecedentes</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Resume la trayectoria y el trabajo notable de esta persona.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Pregunta cualquier cosa en privado</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Chats recientes</string>
 
@@ -343,4 +343,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Preguntar sobre la página</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Editar mensaje</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Al editar, se reemplazará la respuesta por una nueva.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Tee nende taustast kokkuvõte</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Tee kokkuvõte selle isiku taustast ja tähelepanuväärsest tööst.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Küsi ükskõik mida privaatselt</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Hiljutised vestlused</string>
 
@@ -343,4 +343,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Küsi lehe kohta</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Muuda sõnumit</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Muutmine asendab vastuse uuega.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Tee yhteenveto heidän taustastaan</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Tee yhteenveto tämän henkilön taustasta ja merkittävistä töistä.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Kysy mitä tahansa yksityisesti</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Viimeaikaiset keskustelut</string>
 
@@ -343,4 +343,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Kysy sivusta</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Muokkaa viestiä</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Muokkaaminen korvaa vastauksen uudella.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -59,7 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Rechercher ou saisir une adresse</string>
-    <string name="input_screen_search_only_hint">Rechercher</string>
+    <string name="input_screen_search_only_hint">Recherche</string>
     <string name="input_screen_user_pref_without_ai">Recherche uniquement</string>
     <string name="input_screen_user_pref_with_ai">Recherche et Duck.ai</string>
     <string name="input_screen_user_pref_description">Essayez la nouvelle option pour interroger Duck.ai directement à partir de la barre d\'adresse. <annotation type="share_feedback">Partagez vos commentaires</annotation></string>
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Résumer son parcours</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Résume le parcours et les travaux notables de cette personne.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Posez toutes vos questions en privé</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Discussions récentes</string>
 
@@ -343,4 +343,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Posez des questions sur la page</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Modifier le message</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">La modification remplacera la réponse existante par une nouvelle réponse.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Sažmi njihovu biografiju</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Sažmi biografiju i značajan rad ove osobe.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Privatno pitaj bilo što</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Nedavna čavrljanja</string>
 
@@ -345,4 +345,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Pitaj o stranici</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Uredi poruku</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Uređivanjem će se odgovor zamijeniti novim.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Háttér összefoglalása</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Foglald össze ennek a személynek a hátterét és jelentősebb munkáit.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Kérdezz bármit privátban</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Legutóbbi csevegések</string>
 
@@ -343,4 +343,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Kérdés az oldalról</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Üzenet szerkesztése</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">A szerkesztés lecseréli a választ egy újra.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Riassumi il suo profilo</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Riassumi il background e il lavoro più rilevante di questa persona.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Chiedi qualsiasi cosa in privato</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Chat recenti</string>
 
@@ -343,4 +343,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Richiedi informazioni sulla pagina</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Modifica messaggio</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Con la modifica la risposta verrà sostituita da una nuova risposta.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Apibendrink šio asmens biografiją</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Apibendrink šio asmens biografiją ir svarbiausius darbus.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Klausk bet ko privačiai</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Naujausi pokalbiai</string>
 
@@ -345,4 +345,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Klausk apie puslapį</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Redaguoti žinutę</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Redaguojant atsakymas bus pakeistas nauju.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Apkopo informāciju par šo cilvēku</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Apkopo šī cilvēka biogrāfiju un ievērojamākos darbus.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Jautā jebko privāti</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Pēdējās tērzēšanas sarunas</string>
 
@@ -344,4 +344,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Jautā par lapu</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Rediģēt ziņojumu</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Rediģējot atbildi, tā tiks aizstāta ar jaunu.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Oppsummer denne personens bakgrunn</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Oppsummer denne personens bakgrunn og viktigste arbeid.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Spør om hva som helst, privat</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Nylige chatter</string>
 
@@ -343,4 +343,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Spør om siden</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Rediger melding</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Redigering erstatter svaret med et nytt.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Hun achtergrond samenvatten</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Geef een samenvatting van de achtergrond en het belangrijkste werk van deze persoon.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Vraag iets privé</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Recente chats</string>
 
@@ -343,4 +343,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Stel een vraag over de pagina</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Bericht bewerken</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Bewerken vervangt het antwoord door een nieuw antwoord.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Podsumuj doświadczenie tej osoby</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Podsumuj doświadczenie tej osoby i jej najważniejsze osiągnięcia zawodowe.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Zapytaj o cokolwiek prywatnie</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Ostatnie czaty</string>
 
@@ -345,4 +345,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Zapytaj o stronę</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Edytuj wiadomość</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Edycja spowoduje zastąpienie odpowiedzi nową.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Resume o historial deles</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Resume o historial e o trabalho notável desta pessoa.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Pergunta o que quiseres em privado</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Conversas recentes</string>
 
@@ -343,4 +343,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Perguntar sobre a página</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Editar mensagem</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Ao editares, a resposta será substituída por uma nova.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Rezumă parcursul său</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Rezumă parcursul și activitatea notabilă a acestei persoane.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Întreabă orice în mod privat</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Chaturi recente</string>
 
@@ -344,4 +344,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Întreabă despre pagină</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Editează mesajul</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Editarea va înlocui răspunsul cu unul nou.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Кратко изложи биографию этого человека</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Расскажи вкратце об этом человеке и его известных работах.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Задавайте любые вопросы, сохраняя конфиденциальность</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Последние чаты</string>
 
@@ -345,4 +345,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Задать вопрос о странице</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Редактирование сообщения</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">После редактирования текущий ответ будет заменен новым.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Zhrň ich pozadie</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Zhrň pozadie a významnú prácu tejto osoby.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Spýtaj sa na čokoľvek súkromne</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Nedávne čety</string>
 
@@ -345,4 +345,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Opýtaj sa na stránku</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Upraviť správu</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Upravením sa odpoveď nahradí novou.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Povzemi ozadje</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Povzemi ozadje in pomembnejše delo te osebe.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Vprašajte kar koli zasebno</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Nedavni klepeti</string>
 
@@ -345,4 +345,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Vprašajte o strani</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Uredi sporočilo</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Z urejanjem bo odgovor zamenjan z novim.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
@@ -59,7 +59,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Sök eller ange adress</string>
-    <string name="input_screen_search_only_hint">Sökning</string>
+    <string name="input_screen_search_only_hint">Sök</string>
     <string name="input_screen_user_pref_without_ai">Sök endast</string>
     <string name="input_screen_user_pref_with_ai">Sök &amp; Duck.ai</string>
     <string name="input_screen_user_pref_description">Prova den nya funktionen att fråga Duck.ai direkt från adressfältet. <annotation type="share_feedback">Berätta vad du tycker</annotation></string>
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Sammanfatta deras bakgrund</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Sammanfatta den här personens bakgrund och anmärkningsvärda arbete.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Fråga vad som helst privat</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Senaste chattar</string>
 
@@ -343,4 +343,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Fråga om sidan</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Redigera meddelande</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Vid redigering ersätts svaret med ett nytt.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
@@ -204,7 +204,7 @@
     <string name="duckAiSuggestionPersonBackgroundLabel" instruction="Suggested prompt chip: summarize a person&apos;s background">Geçmişini özetle</string>
     <string name="duckAiSuggestionPersonBackgroundPrompt" instruction="Suggested prompt submitted text: summarize a person&apos;s background">Bu kişinin geçmişini ve önemli çalışmalarını özetle.</string>
 
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <!-- Contextual sheet input hint -->
     <string name="contextualSheetImprovedHint">Gizli bir şekilde her şeyi sorabilirsiniz</string>
     <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Son Sohbetler</string>
 
@@ -343,4 +343,9 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Sayfa Hakkında Soru Sor</string>
+
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Mesajı düzenle</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Düzenleme işlemi, önceki yanıtı yeni bir yanıtla değiştirecektir.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -27,9 +27,4 @@
     <!-- Page context attachment -->
     <string name="duckChatPageContextRemoveContentDescription">Remove page context</string>
 
-    <!-- Edit message (placeholder copy pending translation) -->
-    <string name="duck_ai_edit_prompt_title">Edit message</string>
-    <string name="duck_ai_edit_prompt_cancel">Cancel</string>
-    <string name="duck_ai_edit_prompt_lose_responses_warning">Editing will replace the response with a new one.</string>
-
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -343,4 +343,8 @@
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutPage">Ask About Page</string>
 
+    <!-- Editing a message already sent to Duck.ai -->
+    <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Edit message</string>
+    <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Editing will replace the response with a new one.</string>
+
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217486650298566
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

### Description

Requests Smartling translations for the Duck.ai edit message screen.

The screen's copy was sitting in `donottranslate.xml` while the feature was in development. This moves it into `strings-duckchat.xml` so the repository connector picks it up, and adds an `instruction` to each string so translators know what they are looking at:

- `duck_ai_edit_prompt_title` — "Edit message"
- `duck_ai_edit_prompt_lose_responses_warning` — "Editing will replace the response with a new one."

`duck_ai_edit_prompt_cancel` is gone rather than translated. It was the same copy as the design system's `cancel` string, which is already translated in all 24 supported locales, so the toolbar's navigation content description now points at that.

Translations will land as further commits on this branch, one per language, over the next few days. Lint's `MissingTranslation` fails until every locale is in, so CI stays red until the last one arrives.

### Steps to test this PR

_Edit message screen_
- [ ] Open Duck.ai, send a message, then edit it to reach the edit message screen
- [ ] Check the screen title reads "Edit message" and the warning card reads "Editing will replace the response with a new one."
- [ ] Check the close button's content description is announced as "Cancel" by TalkBack
- [ ] Review the English copy and the `instruction` attributes rather than the generated translations — those come from Smartling

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String resource and accessibility description changes only; no chat or edit-message logic changes.
> 
> **Overview**
> Moves **Duck.ai edit message** copy out of `donottranslate.xml` into `strings-duckchat.xml` with Smartling `instruction` attributes so the edit screen title and “response will be replaced” warning can be translated across locales.
> 
> **`EditPromptActivity`** now uses the shared design-system **`cancel`** string for the close button’s TalkBack content description instead of a duplicate `duck_ai_edit_prompt_cancel` entry.
> 
> Locale `strings-duckchat.xml` files gain the two edit-message strings (and drop the old contextual-sheet flag comment on the input hint). A few unrelated locale tweaks appear in the same pass (e.g. French/Swedish search-only hint).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e0adb36a7b1738fefb4450fbea982226ae4849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->