### PR TITLE
Document the Smartling translation process

### DIFF
--- a/.claude/docs/translations.md
+++ b/.claude/docs/translations.md
@@ -24,8 +24,8 @@ lint rule fails the build otherwise:
 ```
 
 **During development, add new strings to `donottranslate.xml`.** Move them into the real strings file
-only when the copy is final and you're ready to request translations — see
-`.claude/skills/request-translations/SKILL.md` for that flow.
+only when the copy is final and you're ready to request translations: pushing half-finished copy costs
+days, since each round trip through Smartling takes a few.
 
 ## Rules for translatable strings
 

--- a/.claude/docs/translations.md
+++ b/.claude/docs/translations.md
@@ -29,19 +29,25 @@ days, since each round trip through Smartling takes a few.
 
 ## Rules for translatable strings
 
-1. **Every placeholder needs an `instruction`** explaining what it stands for. Translators see the
-   `instruction` attribute and nothing else — not the surrounding code, not the screen.
+1. **Add an `instruction` only where the string isn't self-evident** — always for a string with a
+   placeholder, and for copy whose meaning depends on the screen around it. Translators see the
+   `instruction` attribute and nothing else, not the surrounding code and not the screen. Plain
+   unambiguous copy ("Settings", "Done") needs none; don't add one for its own sake.
 
    ```xml
    <string name="authenticationDialogMessage" instruction="Placeholder is the name of a website">%1$s requires a username and password.</string>
    ```
 
-2. **Use positional placeholders** — `%1$s`, `%2$s`, never bare `%s`. Word order differs by language, so
+2. **Reuse copy that is already translated** instead of adding a key for it. Common words like "Cancel"
+   or "Done" live in the design system's `strings-common-ui.xml` and are translated in all 24 locales,
+   so point at the existing string. A duplicate key means paying for a translation we already have.
+
+3. **Use positional placeholders** — `%1$s`, `%2$s`, never bare `%s`. Word order differs by language, so
    translators need to be able to reorder them.
 
-3. **Don't skip plurals.** Use `<plurals>` where the English has a count; quantity sets differ per language.
+4. **Don't skip plurals.** Use `<plurals>` where the English has a count; quantity sets differ per language.
 
-4. **Entity escaping is off globally.** A string that needs escaping has to flip the directive around
+5. **Entity escaping is off globally.** A string that needs escaping has to flip the directive around
    itself, and flip it back afterwards:
 
    ```xml
@@ -50,13 +56,13 @@ days, since each round trip through Smartling takes a few.
    <!-- smartling.entity_escaping = false -->
    ```
 
-5. **Constrained UI takes a character limit**, declared above the string:
+6. **Constrained UI takes a character limit**, declared above the string:
 
    ```xml
    <!-- smartling.character_limit = 42 -->
    ```
 
-6. **Never put lint annotations inside a translated string** — the next translation job overwrites the
+7. **Never put lint annotations inside a translated string** — the next translation job overwrites the
    file and deletes them. Fix the underlying issue, or record the check in the lint baseline instead.
 
 Prefer whole sentences with placeholders over sentence fragments concatenated in code: languages
@@ -69,15 +75,25 @@ reorder and inflect, and a fragment gives the translator nothing to work with.
 | Add a string | Add the English string to the strings file |
 | Change English copy | Delete the old key, add a **new key** with the new copy, update references. Leave the other languages alone — Smartling prunes them |
 | Remove a string | Delete the English string only. Smartling removes the translations |
-| Fix a bad translation | Edit it in the Smartling dashboard (DuckDuckGo Android project → language → search the key → Edit Translation). It lands with the next job; to ship sooner, also edit the `values-<locale>` file directly |
+| Fix a bad translation | A developer edits it in the Smartling dashboard (DuckDuckGo Android project → language → search the key → Edit Translation). It lands with the next job; to ship sooner, also edit the `values-<locale>` file directly |
 
 Reusing a key with different copy leaves every locale holding a stale translation of the old text,
 which is why an English change is delete-plus-new-key rather than an edit in place.
 
+Fixing a translation is the one job that happens outside the repo — it needs a Smartling login, so an
+agent cannot do it and should hand it to the developer.
+
 ## Reference
 
-- [Android Smartling Translation Guide](https://app.asana.com/1/137249556945/project/1202561462274611/task/1203224618541800)
-- [Typical Development Flow and FAQs](https://app.asana.com/1/137249556945/project/1202561462274611/task/1211223880022672)
-- [How to Use Smartling for Translations](https://app.asana.com/1/137249556945/project/904401899170/task/1185688234072009) — account setup
-- [Tips for better translation tokens](https://app.asana.com/1/137249556945/project/904401899170/task/1200205345312078)
-- [Translation/Localization AOR](https://app.asana.com/1/137249556945/project/904401899170) — ask here when something looks wrong
+This file is the working reference — enough to add a string or request a translation without opening
+anything else. The Asana sources are the authority behind it; read one only when this file is silent or
+looks wrong, not up front:
+
+- [Android Smartling Translation Guide](https://app.asana.com/1/137249556945/project/1202561462274611/task/1203224618541800) — the connector, branch naming, the Smartling rules
+- [Typical Development Flow and FAQs](https://app.asana.com/1/137249556945/project/1202561462274611/task/1211223880022672) — an add/change/remove case this file doesn't cover
+- [Tips for better translation tokens](https://app.asana.com/1/137249556945/project/904401899170/task/1200205345312078) — writing copy translators can work with
+- [How to Use Smartling for Translations](https://app.asana.com/1/137249556945/project/904401899170/task/1185688234072009) — Smartling account setup, for a developer who needs dashboard access
+
+When translations stall or a translation looks wrong, ask the
+[Translation/Localization AOR](https://app.asana.com/1/137249556945/project/904401899170) — people to
+talk to, not a document to read.

--- a/.claude/docs/translations.md
+++ b/.claude/docs/translations.md
@@ -1,0 +1,83 @@
+# Translations
+
+The app ships in 24 languages. Translation is automated: a Smartling repository connector reads
+English strings from branches, and commits the translated files back to the same branch.
+
+`smartling-config.json` (repo root) is the source of truth for the locale list and the file mapping:
+every `**/values/strings*.xml` is sent for translation and comes back as
+`values-<locale>/strings*.xml`.
+
+## Where strings go
+
+| File | Translated? |
+|---|---|
+| `<module>/src/main/res/values/strings-<module>.xml` | yes — picked up by the connector |
+| `<module>/src/main/res/values/donottranslate.xml` | no — excluded |
+
+Translatable string files must be named `strings-<module>.xml` (`app` uses `strings.xml`), and must
+carry both Smartling directives above the `<resources>` element — the `MissingSmartlingRequiredDirectives`
+lint rule fails the build otherwise:
+
+```xml
+<!-- smartling.entity_escaping = false -->
+<!-- smartling.instruction_attributes = instruction -->
+```
+
+**During development, add new strings to `donottranslate.xml`.** Move them into the real strings file
+only when the copy is final and you're ready to request translations — see
+`.claude/skills/request-translations/SKILL.md` for that flow.
+
+## Rules for translatable strings
+
+1. **Every placeholder needs an `instruction`** explaining what it stands for. Translators see the
+   `instruction` attribute and nothing else — not the surrounding code, not the screen.
+
+   ```xml
+   <string name="authenticationDialogMessage" instruction="Placeholder is the name of a website">%1$s requires a username and password.</string>
+   ```
+
+2. **Use positional placeholders** — `%1$s`, `%2$s`, never bare `%s`. Word order differs by language, so
+   translators need to be able to reorder them.
+
+3. **Don't skip plurals.** Use `<plurals>` where the English has a count; quantity sets differ per language.
+
+4. **Entity escaping is off globally.** A string that needs escaping has to flip the directive around
+   itself, and flip it back afterwards:
+
+   ```xml
+   <!-- smartling.entity_escaping = true -->
+   <string name="example">My escaped string here</string>
+   <!-- smartling.entity_escaping = false -->
+   ```
+
+5. **Constrained UI takes a character limit**, declared above the string:
+
+   ```xml
+   <!-- smartling.character_limit = 42 -->
+   ```
+
+6. **Never put lint annotations inside a translated string** — the next translation job overwrites the
+   file and deletes them. Fix the underlying issue, or record the check in the lint baseline instead.
+
+Prefer whole sentences with placeholders over sentence fragments concatenated in code: languages
+reorder and inflect, and a fragment gives the translator nothing to work with.
+
+## Changing strings that are already translated
+
+| Goal | What to do |
+|---|---|
+| Add a string | Add the English string to the strings file |
+| Change English copy | Delete the old key, add a **new key** with the new copy, update references. Leave the other languages alone — Smartling prunes them |
+| Remove a string | Delete the English string only. Smartling removes the translations |
+| Fix a bad translation | Edit it in the Smartling dashboard (DuckDuckGo Android project → language → search the key → Edit Translation). It lands with the next job; to ship sooner, also edit the `values-<locale>` file directly |
+
+Reusing a key with different copy leaves every locale holding a stale translation of the old text,
+which is why an English change is delete-plus-new-key rather than an edit in place.
+
+## Reference
+
+- [Android Smartling Translation Guide](https://app.asana.com/1/137249556945/project/1202561462274611/task/1203224618541800)
+- [Typical Development Flow and FAQs](https://app.asana.com/1/137249556945/project/1202561462274611/task/1211223880022672)
+- [How to Use Smartling for Translations](https://app.asana.com/1/137249556945/project/904401899170/task/1185688234072009) — account setup
+- [Tips for better translation tokens](https://app.asana.com/1/137249556945/project/904401899170/task/1200205345312078)
+- [Translation/Localization AOR](https://app.asana.com/1/137249556945/project/904401899170) — ask here when something looks wrong

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ what you remember of it.
 | `.claude/docs/navigation.md` | adding a screen or navigating to one — `ActivityParams`, `@ContributeToActivityStarter`, deeplinks, and which `GlobalActivityStarter` overload to use |
 | `.claude/docs/url-classification.md` | routing typed input to navigation vs search — use `QueryUrlPredictor`, not `UriString.isWebUrl()` |
 | `.claude/docs/icons.md` | the change needs an icon the project doesn't have yet — it must be fetched from the internal Icons repository, never invented |
+| `.claude/docs/translations.md` | adding or changing any user-facing string — `donottranslate.xml` vs `strings-<module>.xml`, placeholder/`instruction` rules, how to change or remove already-translated copy |
 
 ---
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214901934989258/task/1217484868332131
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

### Description

Our Smartling translation process was documented only in Asana, so nothing in the repo told an engineer — or an agent working in it — which file a new string belongs in, why a placeholder needs an `instruction`, or how to change copy that is already translated in 24 languages.

Adds `.claude/docs/translations.md`, distilled from the [Android Smartling Translation Guide](https://app.asana.com/1/137249556945/project/1202561462274611/task/1203224618541800) and the [Typical Development Flow and FAQs](https://app.asana.com/1/137249556945/project/1202561462274611/task/1211223880022672):

- Where strings live: `donottranslate.xml` while copy is in flux, `values/strings-<module>.xml` once it's final and ready to be picked up by the repository connector
- The rules the connector and lint enforce: required Smartling directives, an `instruction` on every placeholder, positional `%1$s`, plurals, entity escaping, character limits, and why lint annotations must not live inside a translated string
- Recipes for adding, changing and removing already-translated copy — notably that an English change is delete-plus-new-key rather than an edit in place, so no locale keeps a stale translation
- Links back to the Asana guides and the Translation/Localization AOR

Also adds a row to the CLAUDE.md table so the doc gets read whenever a change touches user-facing strings.

Docs only — no product code, no strings.

### Steps to test this PR

_Documentation review_
- [ ] Read `.claude/docs/translations.md` and check it matches how we actually use Smartling
- [ ] Confirm the locale list and file mapping it describes match `smartling-config.json`
- [ ] Confirm the CLAUDE.md row reads consistently with the rest of the table

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no product code or string resource edits.
> 
> **Overview**
> Adds **in-repo documentation** for the Smartling workflow (previously only in Asana) so engineers and agents know how to handle user-facing strings.
> 
> **`.claude/docs/translations.md`** covers where English copy lives (`donottranslate.xml` during development vs `strings-<module>.xml` for connector pickup), required Smartling directives and lint rules (`MissingSmartlingRequiredDirectives`, placeholders, `instruction`, plurals, escaping, character limits), and workflows for **add / change / remove** already-translated strings—including **delete old key + new key** for English copy changes so locales don’t keep stale translations. It also points to Asana references and the Translation/Localization AOR.
> 
> **`CLAUDE.md`** gains a table row so this doc is consulted whenever work touches user-facing strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 644c3ff61d2a0ac029c7033730daeeba61712ee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->