### PR TITLE
Prefer first_daily_count suffix for count+daily pixel pairs

### DIFF
--- a/.claude/docs/pixels.md
+++ b/.claude/docs/pixels.md
@@ -19,6 +19,11 @@ Sent every time the event occurs. Use for events where per-occurrence volume mat
 
 Sent at most once per calendar day per event. Use to measure the number of unique users affected by something (e.g., how many users hit a particular error per day). Most daily pixel implementations also support a "count" variant that fires every time.
 
+When a pixel fires as a plain count+daily pair with identical parameters, register it as **one**
+definition entry using the `first_daily_count` suffix rather than two separate `_count`/`_daily`
+entries — see `.claude/rules/pixel-definitions.md`. The firing code is unchanged either way: it still
+calls `pixel.fire()` twice with the explicit `_count`/`_daily` wire-string names.
+
 ### Unique Pixels
 
 Sent once per install for the lifetime of the install. Use for one-time lifecycle events (e.g., first activation, first use of a feature).

--- a/.claude/rules/pixel-definitions.md
+++ b/.claude/rules/pixel-definitions.md
@@ -74,6 +74,15 @@ inline an object supporting `description`, `enum`, and optionally `key`, `type`,
 "suffixes": ["first_daily_count"]
 ```
 
+**Prefer `first_daily_count` for count+daily pairs.** When a pixel simply fires a count variant and a
+daily variant with the same parameters, define **one** entry (base pixel name, no `_count`/`_daily` in
+the key) with `"suffixes": ["first_daily_count", ...]`, instead of two separate `_count`/`_daily`
+entries. This is the default going forward — only fall back to separate entries when the count and
+daily variants genuinely need different parameters or descriptions. The Kotlin code is unaffected: it
+still fires two distinct wire-string pixels (`..._count`, `..._daily`) via `fireCountAndDaily` or
+equivalent; only the JSON5 registration collapses to one entry. See the `m_aichat_recent_chat_delete_*`
+pixels in `duck_chat.json5` for a worked example.
+
 - Suffixes are **order-sensitive and required**. Enums must not contain `null` or `""`.
 - Define suffixes as `enum` unless the type is bounded (e.g. `boolean`). Unbounded numeric and string
   values belong in `parameters` instead.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214901934989258/task/1217484868332141
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

Doc-only change, prompted by a review nit on #9497: the pixel-definitions doc already showed `first_daily_count` as one possible suffix, but didn't say when to prefer it over registering separate `_count`/`_daily` entries. Most of `duck_chat.json5` uses the separate-entries pattern (majority by volume), so a fresh pixel pair defaults there by pattern-matching even though the single-entry-with-suffix form is simpler and already used elsewhere (`m_aichat_recent_chat_delete_*`).

Makes `first_daily_count` the explicit default for a plain count+daily pair with identical parameters, with separate entries kept as the documented fallback for when the two variants genuinely differ. No code changes — the firing side (`fireCountAndDaily` etc.) is unaffected either way.

### Steps to test this PR

_Docs only — no runtime behavior to test_
- [ ] Read `.claude/rules/pixel-definitions.md`'s Suffixes section and `.claude/docs/pixels.md`'s Daily Pixels section — confirm the guidance reads clearly and points to a real worked example (`m_aichat_recent_chat_delete_*` in `duck_chat.json5`)

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only internal pixel documentation is updated; no runtime, schema, or firing logic changes.
> 
> **Overview**
> **Documentation-only** update clarifying how to register count+daily pixel pairs in JSON5 definitions.
> 
> **Daily Pixels** (`pixels.md`) now says that when count and daily fire with the same parameters, authors should use a **single** definition keyed on the base name with the `first_daily_count` suffix—not separate `_count` and `_daily` keys. Runtime behavior stays the same: code still fires explicit `_count`/`_daily` wire names.
> 
> **Suffixes** (`pixel-definitions.md`) makes `first_daily_count` the **default** for plain count+daily pairs and reserves separate `_count`/`_daily` entries for when parameters or descriptions differ. It points to `m_aichat_recent_chat_delete_*` in `duck_chat.json5` as the worked example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63baeb6819fa42892af9b0b05e1297ff7d3e17c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->