### PR TITLE
Remove sendPostIdleSessionWideEvent feature flag

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/postidle/RealPostIdleSessionWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/postidle/RealPostIdleSessionWideEvent.kt
@@ -23,13 +23,11 @@ import com.duckduckgo.app.statistics.wideevents.FlowStatus
 import com.duckduckgo.app.statistics.wideevents.WideEventClient
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
-import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.newtabpage.api.interactions.HatchInteractionsPlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
-import dagger.Lazy
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.drop
@@ -38,7 +36,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 import logcat.logcat
 import javax.inject.Inject
 
@@ -49,7 +46,6 @@ import javax.inject.Inject
 class RealPostIdleSessionWideEvent @Inject constructor(
     private val wideEventClient: WideEventClient,
     private val duckChatInputModeState: DuckChatInputModeState,
-    private val androidBrowserConfigFeature: Lazy<AndroidBrowserConfigFeature>,
     private val dispatchers: DispatcherProvider,
     @AppCoroutineScope appCoroutineScope: CoroutineScope,
 ) : BrowserInteractionsPlugin, HatchInteractionsPlugin, BrowserLifecycleObserver {
@@ -80,8 +76,6 @@ class RealPostIdleSessionWideEvent @Inject constructor(
     private fun onSurfaceShown(surface: Surface) {
         coroutineScope.launch {
             mutex.withLock {
-                if (!isFeatureEnabled()) return@launch
-
                 activeSession?.let { prior ->
                     logcat(tag = TAG) { "Aborting prior post-idle session ${prior.flowId} on new surface ${surface.value}" }
                     wideEventClient.flowAbort(prior.flowId)
@@ -166,7 +160,6 @@ class RealPostIdleSessionWideEvent @Inject constructor(
     ) {
         coroutineScope.launch {
             mutex.withLock {
-                if (!isFeatureEnabled()) return@launch
                 val session = activeSession ?: return@launch
                 if (isAlreadyRecorded(session)) return@launch
 
@@ -183,7 +176,6 @@ class RealPostIdleSessionWideEvent @Inject constructor(
     private fun finishSession(statusReason: String, status: FlowStatus) {
         coroutineScope.launch {
             mutex.withLock {
-                if (!isFeatureEnabled()) return@launch
                 val session = activeSession ?: return@launch
                 activeSession = null
 
@@ -205,10 +197,6 @@ class RealPostIdleSessionWideEvent @Inject constructor(
                 logcat(tag = TAG) { "Post-idle session ${session.flowId} finished: status=$status, reason=$statusReason" }
             }
         }
-    }
-
-    private suspend fun isFeatureEnabled(): Boolean = withContext(dispatchers.io()) {
-        androidBrowserConfigFeature.get().sendPostIdleSessionWideEvent().isEnabled()
     }
 
     private class SessionState(

--- a/app/src/test/java/com/duckduckgo/app/browser/postidle/RealPostIdleSessionWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/postidle/RealPostIdleSessionWideEventTest.kt
@@ -20,12 +20,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.statistics.wideevents.CleanupPolicy
 import com.duckduckgo.app.statistics.wideevents.FlowStatus
 import com.duckduckgo.app.statistics.wideevents.WideEventClient
-import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.InputMode
-import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
-import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -40,7 +37,6 @@ import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
 import kotlin.time.Duration.Companion.milliseconds
@@ -55,15 +51,12 @@ class RealPostIdleSessionWideEventTest {
     private val wideEventClient: WideEventClient = mock()
     private val displayedModeFlow = MutableStateFlow(InputMode.SEARCH)
     private val duckChatInputModeState: DuckChatInputModeState = mock()
-    private val androidBrowserConfigFeature =
-        FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
 
     private lateinit var testee: RealPostIdleSessionWideEvent
 
     @Before
     fun setup() = runTest {
         whenever(duckChatInputModeState.displayedMode).thenReturn(displayedModeFlow)
-        androidBrowserConfigFeature.sendPostIdleSessionWideEvent().setRawStoredState(Toggle.State(true))
 
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any())).thenReturn(Result.success(123L))
         whenever(wideEventClient.flowStep(any(), any(), any(), any())).thenReturn(Result.success(Unit))
@@ -75,7 +68,6 @@ class RealPostIdleSessionWideEventTest {
         testee = RealPostIdleSessionWideEvent(
             wideEventClient = wideEventClient,
             duckChatInputModeState = duckChatInputModeState,
-            androidBrowserConfigFeature = { androidBrowserConfigFeature },
             dispatchers = coroutineRule.testDispatcherProvider,
             appCoroutineScope = coroutineRule.testScope,
         )
@@ -124,17 +116,6 @@ class RealPostIdleSessionWideEventTest {
             samplingProbability = eq(0.05f),
             definition = any(),
         )
-    }
-
-    @Test
-    fun `when feature flag disabled then no flow operations occur`() = runTest {
-        androidBrowserConfigFeature.sendPostIdleSessionWideEvent().setRawStoredState(Toggle.State(false))
-
-        testee.onHatchShownAfterIdle()
-        testee.onInputSubmitted()
-        coroutineRule.testScope.testScheduler.advanceUntilIdle()
-
-        verifyNoInteractions(wideEventClient)
     }
 
     @Test

--- a/browser/browser-feature-toggles/src/main/java/com/duckduckgo/browser/feature/toggles/AndroidBrowserConfigFeature.kt
+++ b/browser/browser-feature-toggles/src/main/java/com/duckduckgo/browser/feature/toggles/AndroidBrowserConfigFeature.kt
@@ -336,15 +336,6 @@ interface AndroidBrowserConfigFeature {
     fun sendPageLoadWideEvent(): Toggle
 
     /**
-     * Controls whether post-idle session wide events are sent.
-     * @return `true` when the remote config has the global "sendPostIdleSessionWideEvent" androidBrowserConfig
-     * sub-feature flag enabled
-     * If the remote feature is not present defaults to `internal`
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
-    fun sendPostIdleSessionWideEvent(): Toggle
-
-    /**
      * Controls whether page content is cached in Room for each tab.
      * @return `true` when the remote config has the global "storePageContext" androidBrowserConfig
      * sub-feature flag enabled

--- a/lint-rules/src/main/java/com/duckduckgo/lint/NoNewBrowserFeatureToggleDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/NoNewBrowserFeatureToggleDetector.kt
@@ -125,7 +125,6 @@ class NoNewBrowserFeatureToggleDetector : Detector(), SourceCodeScanner {
             "AndroidBrowserConfigFeature#sendDataClearingWideEvent",
             "AndroidBrowserConfigFeature#reduceBrowserTabBundleSize",
             "AndroidBrowserConfigFeature#sendPageLoadWideEvent",
-            "AndroidBrowserConfigFeature#sendPostIdleSessionWideEvent",
             "AndroidBrowserConfigFeature#storePageContext",
             "AndroidBrowserConfigFeature#tabStateRestorationFix",
             "AndroidBrowserConfigFeature#pdfViewer",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211850753229323/task/1215317943922643?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Removes the `sendPostIdleSessionWideEvent` feature flag from `AndroidBrowserConfigFeature` and the gate it controlled in `RealPostIdleSessionWideEvent`, so the post-idle-session wide event now always fires (subject only to its existing sampling rate).

### Steps to test this PR

QA optional

### UI changes

No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only flag removal with no change to user-facing behavior; sampling still limits event volume.
> 
> **Overview**
> Removes the **`sendPostIdleSessionWideEvent`** remote toggle from **`AndroidBrowserConfigFeature`** and drops the **`isFeatureEnabled()`** gate in **`RealPostIdleSessionWideEvent`**, so post-idle session wide events always run through the existing flow (still subject to the **5%** sampling rate).
> 
> **`RealPostIdleSessionWideEvent`** no longer injects **`AndroidBrowserConfigFeature`** or checks the flag on surface show, interaction recording, or session finish. Tests shed the fake toggle setup and the case that asserted no **`WideEventClient`** calls when disabled. The lint grandfather list for frozen browser toggles is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f27aed4c424148e744cb1c910bd7e8328450393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->