### PR TITLE
Remove aiChat historyScreen feature flag

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -897,8 +897,7 @@ class RealDuckChat @Inject constructor(
 
     override suspend fun isChatHistoryAvailable(): Boolean = withContext(dispatchers.io()) {
         isEnabled() &&
-            duckChatFeature.useNativeStorageChatData().isEnabled() &&
-            duckChatFeature.historyScreen().isEnabled()
+            duckChatFeature.useNativeStorageChatData().isEnabled()
     }
 
     override suspend fun hasUserEnabledChatHistory(): Boolean {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -207,13 +207,6 @@ interface DuckChatFeature {
     fun useNativeStorageChatData(): Toggle
 
     /**
-     * @return `true` when the native chat history screen can be launched.
-     * If the remote feature is not present defaults to `internal`.
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
-    fun historyScreen(): Toggle
-
-    /**
      * @return `true` when the per-row Fire-icon delete affordance on Duck.ai chat-history
      * suggestions in the omnibar autocomplete is visible.
      * If the remote feature is not present defaults to `internal`.

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -1788,19 +1788,10 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun whenHistoryScreenOffThenIsChatHistoryAvailableFalse() = runTest {
-        enableChatHistoryFlags()
-        duckChatFeature.historyScreen().setRawStoredState(State(enable = false))
-
-        assertFalse(testee.isChatHistoryAvailable())
-    }
-
-    @Test
     fun whenAllChatHistoryFlagsOffThenIsChatHistoryAvailableFalse() = runTest {
         duckChatFeature.self().setRawStoredState(State(enable = false))
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(false)
         duckChatFeature.useNativeStorageChatData().setRawStoredState(State(enable = false))
-        duckChatFeature.historyScreen().setRawStoredState(State(enable = false))
         testee.onPrivacyConfigDownloaded()
         coroutineRule.testScope.advanceUntilIdle()
 
@@ -1836,7 +1827,6 @@ class RealDuckChatTest {
     private suspend fun enableChatHistoryFlags() {
         duckChatFeature.self().setRawStoredState(State(enable = true))
         duckChatFeature.useNativeStorageChatData().setRawStoredState(State(enable = true))
-        duckChatFeature.historyScreen().setRawStoredState(State(enable = true))
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
         testee.onPrivacyConfigDownloaded()
         coroutineRule.testScope.advanceUntilIdle()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211850753229323/task/1215715478095426?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Removes the `historyScreen` toggle from `DuckChatFeature` now that the native chat history screen is fully rolled out — `isChatHistoryAvailable()` now only gates on `useNativeStorageChatData`.

### Steps to test this PR

QA optional

### UI changes

No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag cleanup with a narrower gate on `isChatHistoryAvailable`; no auth or data-path changes beyond dropping an obsolete remote toggle.
> 
> **Overview**
> Removes the rolled-out **`historyScreen`** toggle from **`DuckChatFeature`** now that the native chat history screen is fully shipped.
> 
> **`isChatHistoryAvailable()`** no longer checks that flag; availability is gated only on Duck.ai being enabled and **`useNativeStorageChatData`**. Tests drop the history-screen-off case and related flag setup in **`enableChatHistoryFlags`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2090484e480c7f3200126d8ec2ff33b5441a87f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->