### PR TITLE
Remove pdfViewer feature flag

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
@@ -25,7 +25,6 @@ import android.os.Parcel
 import android.provider.OpenableColumns
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
-import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
@@ -57,12 +56,11 @@ interface InlinePdfHandler {
     /**
      * Decides how a download response should be handled for PDF rendering.
      *
-     * - [PdfRenderDecision.Inline]: feature flag on, SDK >= Android 12, MIME or
-     *   `.pdf` URL extension matches, and `Content-Disposition: attachment` not set.
+     * - [PdfRenderDecision.Inline]: SDK >= Android 12, MIME or `.pdf` URL extension
+     *   matches, and `Content-Disposition: attachment` not set.
      * - [PdfRenderDecision.Fallback]: same eligibility but the device is below
      *   Android 12 — caller should fall back to the standard file download.
-     * - [PdfRenderDecision.NotApplicable]: response is not an inline-eligible PDF
-     *   (or the feature flag is off).
+     * - [PdfRenderDecision.NotApplicable]: response is not an inline-eligible PDF.
      */
     fun classifyPdfRequest(url: String, contentDisposition: String?, mimeType: String): PdfRenderDecision
 
@@ -74,9 +72,8 @@ interface InlinePdfHandler {
      * success.
      *
      * Returns [PdfDownloadResult.Failure] with an error category when the network,
-     * server, or file content prevents inline rendering. The feature flag and SDK
-     * gate live in [classifyPdfRequest] so callers shouldn't reach this method when the
-     * feature is off.
+     * server, or file content prevents inline rendering. The SDK gate lives in
+     * [classifyPdfRequest] so callers shouldn't reach this method when ineligible.
      *
      * Cancellation-safe: if the calling coroutine is cancelled (e.g. the user
      * navigates away), the in-flight HTTP request is aborted and any partial
@@ -139,11 +136,9 @@ class RealInlinePdfHandler @Inject constructor(
     @PdfOkHttpClient private val okHttpClient: OkHttpClient,
     private val cookieManagerProvider: CookieManagerProvider,
     private val dispatcherProvider: DispatcherProvider,
-    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
 ) : InlinePdfHandler {
 
     override fun classifyPdfRequest(url: String, contentDisposition: String?, mimeType: String): PdfRenderDecision {
-        if (!androidBrowserConfigFeature.pdfViewer().isEnabled()) return PdfRenderDecision.NotApplicable
         // downloadToCache fetches via OkHttp, which rejects any scheme other than http/https.
         // Let data:/file:/content: PDFs fall through to the standard download flow.
         val scheme = url.toUri().scheme?.lowercase()

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfHandlerComponentToggler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfHandlerComponentToggler.kt
@@ -60,7 +60,6 @@ class PdfHandlerComponentToggler @Inject constructor(
 
     internal fun sync() {
         val shouldEnable = appBuildConfig.sdkInt >= 31 &&
-            androidBrowserConfigFeature.pdfViewer().isEnabled() &&
             androidBrowserConfigFeature.externalPdfHandler().isEnabled()
         context.packageManager.setComponentEnabledSetting(
             ComponentName(appBuildConfig.applicationId, PDF_HANDLER_ALIAS),

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/RealPdfViewerAvailability.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/RealPdfViewerAvailability.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.app.browser.pdf
 
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.pdf.PdfViewerAvailability
-import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -26,7 +25,6 @@ import javax.inject.Inject
 @ContributesBinding(AppScope::class)
 class RealPdfViewerAvailability @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
-    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
 ) : PdfViewerAvailability {
-    override fun isAvailable(): Boolean = appBuildConfig.sdkInt >= 31 && androidBrowserConfigFeature.pdfViewer().isEnabled()
+    override fun isAvailable(): Boolean = appBuildConfig.sdkInt >= 31
 }

--- a/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherViewModel.kt
@@ -155,7 +155,6 @@ class IntentDispatcherViewModel @Inject constructor(
     private fun localPdfUriOrNull(intent: Intent?): Uri? {
         if (intent?.action != Intent.ACTION_VIEW) return null
         if (appBuildConfig.sdkInt < 31) return null
-        if (!androidBrowserConfigFeature.pdfViewer().isEnabled()) return null
         if (!androidBrowserConfigFeature.externalPdfHandler().isEnabled()) return null
         val data = intent.data ?: return null
         val scheme = data.scheme?.lowercase()

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerPreApi31Test.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerPreApi31Test.kt
@@ -19,12 +19,9 @@ package com.duckduckgo.app.browser.pdf
 import android.webkit.CookieManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.cookies.api.CookieManagerProvider
-import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
-import com.duckduckgo.feature.toggles.api.Toggle.State
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -46,7 +43,6 @@ class InlinePdfHandlerPreApi31Test {
     val coroutineTestRule = CoroutineTestRule()
 
     private lateinit var inlinePdfHandler: RealInlinePdfHandler
-    private val androidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
 
     private val cookieManagerProvider = object : CookieManagerProvider {
         override fun forMode(mode: BrowserMode): CookieManager? = null
@@ -60,9 +56,7 @@ class InlinePdfHandlerPreApi31Test {
             okHttpClient = OkHttpClient(),
             cookieManagerProvider = cookieManagerProvider,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
-            androidBrowserConfigFeature = androidBrowserConfigFeature,
         )
-        androidBrowserConfigFeature.pdfViewer().setRawStoredState(State(enable = true))
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
@@ -21,13 +21,10 @@ import android.net.Uri
 import android.webkit.CookieManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
-import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
-import com.duckduckgo.feature.toggles.api.Toggle.State
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
@@ -68,7 +65,6 @@ class InlinePdfHandlerTest {
 
     private lateinit var inlinePdfHandler: RealInlinePdfHandler
     private lateinit var server: MockWebServer
-    private val androidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
 
     private val cookieManagerProvider = object : CookieManagerProvider {
         override fun forMode(mode: BrowserMode): CookieManager? = null
@@ -82,9 +78,7 @@ class InlinePdfHandlerTest {
             okHttpClient = OkHttpClient(),
             cookieManagerProvider = cookieManagerProvider,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
-            androidBrowserConfigFeature = androidBrowserConfigFeature,
         )
-        androidBrowserConfigFeature.pdfViewer().setRawStoredState(State(enable = true))
         server = MockWebServer()
         server.start()
     }
@@ -255,18 +249,6 @@ class InlinePdfHandlerTest {
 
     // endregion
 
-    // region feature flag tests
-
-    @Test
-    fun whenFeatureDisabledThenDecisionIsNotApplicable() {
-        androidBrowserConfigFeature.pdfViewer().setRawStoredState(State(enable = false))
-
-        assertEquals(
-            PdfRenderDecision.NotApplicable,
-            inlinePdfHandler.classifyPdfRequest("https://example.com/doc.pdf", null, "application/pdf"),
-        )
-    }
-
     @Test
     fun whenPdfAlreadyCachedThenReturnsWithoutNetworkRequest() = runTest {
         val pdfBytes = "%PDF-1.4 test content".toByteArray()
@@ -402,7 +384,6 @@ class InlinePdfHandlerTest {
             okHttpClient = OkHttpClient(),
             cookieManagerProvider = cookieAwareProvider,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
-            androidBrowserConfigFeature = androidBrowserConfigFeature,
         )
 
         val pdfBytes = "%PDF-1.4 test content".toByteArray()
@@ -444,7 +425,6 @@ class InlinePdfHandlerTest {
             okHttpClient = OkHttpClient(),
             cookieManagerProvider = mainThreadOnlyProvider,
             dispatcherProvider = dispatchers,
-            androidBrowserConfigFeature = androidBrowserConfigFeature,
         )
 
         val pdfBytes = "%PDF-1.4 test content".toByteArray()
@@ -514,7 +494,6 @@ class InlinePdfHandlerTest {
             okHttpClient = throwingClient,
             cookieManagerProvider = cookieManagerProvider,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
-            androidBrowserConfigFeature = androidBrowserConfigFeature,
         )
 
         val result = handlerWithFailingDns.downloadToCache("https://example.com/test.pdf", browserMode = BrowserMode.REGULAR)
@@ -713,7 +692,6 @@ class InlinePdfHandlerTest {
             okHttpClient = OkHttpClient(),
             cookieManagerProvider = cookieManagerProvider,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
-            androidBrowserConfigFeature = androidBrowserConfigFeature,
         )
 
         val result = handler.cacheLocalPdf(source)
@@ -740,7 +718,6 @@ class InlinePdfHandlerTest {
             okHttpClient = OkHttpClient(),
             cookieManagerProvider = cookieManagerProvider,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
-            androidBrowserConfigFeature = androidBrowserConfigFeature,
         )
 
         val result = handler.cacheLocalPdf(source)
@@ -765,7 +742,6 @@ class InlinePdfHandlerTest {
             okHttpClient = OkHttpClient(),
             cookieManagerProvider = cookieManagerProvider,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
-            androidBrowserConfigFeature = androidBrowserConfigFeature,
         )
 
         val result = handler.cacheLocalPdf(source)
@@ -790,7 +766,6 @@ class InlinePdfHandlerTest {
             okHttpClient = OkHttpClient(),
             cookieManagerProvider = cookieManagerProvider,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
-            androidBrowserConfigFeature = androidBrowserConfigFeature,
         )
 
         val result = handler.cacheLocalPdf(sourceUri)
@@ -819,7 +794,6 @@ class InlinePdfHandlerTest {
             okHttpClient = OkHttpClient(),
             cookieManagerProvider = cookieManagerProvider,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
-            androidBrowserConfigFeature = androidBrowserConfigFeature,
         )
 
         val result = handler.cacheLocalPdf(source)

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/PdfHandlerComponentTogglerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/PdfHandlerComponentTogglerTest.kt
@@ -46,7 +46,6 @@ class PdfHandlerComponentTogglerTest {
     private val context: Context = mock()
     private val packageManager: PackageManager = mock()
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature = mock()
-    private val pdfViewerToggle: Toggle = mock()
     private val externalPdfHandlerToggle: Toggle = mock()
     private val appBuildConfig: AppBuildConfig = mock()
 
@@ -58,7 +57,6 @@ class PdfHandlerComponentTogglerTest {
     fun setUp() {
         whenever(context.packageManager).thenReturn(packageManager)
         whenever(appBuildConfig.applicationId).thenReturn(appId)
-        whenever(androidBrowserConfigFeature.pdfViewer()).thenReturn(pdfViewerToggle)
         whenever(androidBrowserConfigFeature.externalPdfHandler()).thenReturn(externalPdfHandlerToggle)
         whenever(externalPdfHandlerToggle.isEnabled()).thenReturn(true)
 
@@ -72,9 +70,8 @@ class PdfHandlerComponentTogglerTest {
     }
 
     @Test
-    fun `when sdk is 31 and flag is on then enables alias`() {
+    fun `when sdk is 31 and externalPdfHandler is on then enables alias`() {
         whenever(appBuildConfig.sdkInt).thenReturn(31)
-        whenever(pdfViewerToggle.isEnabled()).thenReturn(true)
 
         testee.sync()
 
@@ -89,9 +86,8 @@ class PdfHandlerComponentTogglerTest {
     }
 
     @Test
-    fun `when sdk is 30 and flag is on then disables alias`() {
+    fun `when sdk is 30 and externalPdfHandler is on then disables alias`() {
         whenever(appBuildConfig.sdkInt).thenReturn(30)
-        whenever(pdfViewerToggle.isEnabled()).thenReturn(true)
 
         testee.sync()
 
@@ -106,26 +102,8 @@ class PdfHandlerComponentTogglerTest {
     }
 
     @Test
-    fun `when sdk is 33 and flag is off then disables alias`() {
+    fun `when sdk is 33 and externalPdfHandler is off then disables alias`() {
         whenever(appBuildConfig.sdkInt).thenReturn(33)
-        whenever(pdfViewerToggle.isEnabled()).thenReturn(false)
-
-        testee.sync()
-
-        val componentCaptor = argumentCaptor<ComponentName>()
-        val stateCaptor = argumentCaptor<Int>()
-        val flagsCaptor = argumentCaptor<Int>()
-        verify(packageManager).setComponentEnabledSetting(componentCaptor.capture(), stateCaptor.capture(), flagsCaptor.capture())
-        assertEquals(appId, componentCaptor.firstValue.packageName)
-        assertEquals("com.duckduckgo.app.dispatchers.PdfViewerHandler", componentCaptor.firstValue.className)
-        assertEquals(PackageManager.COMPONENT_ENABLED_STATE_DISABLED, stateCaptor.firstValue)
-        assertEquals(PackageManager.DONT_KILL_APP, flagsCaptor.firstValue)
-    }
-
-    @Test
-    fun `when sdk is 33 and pdfViewer is on but externalPdfHandler is off then disables alias`() {
-        whenever(appBuildConfig.sdkInt).thenReturn(33)
-        whenever(pdfViewerToggle.isEnabled()).thenReturn(true)
         whenever(externalPdfHandlerToggle.isEnabled()).thenReturn(false)
 
         testee.sync()

--- a/app/src/test/java/com/duckduckgo/app/dispatchers/IntentDispatcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/dispatchers/IntentDispatcherViewModelTest.kt
@@ -86,8 +86,6 @@ class IntentDispatcherViewModelTest {
 
         whenever(syncUrlIdentifier.shouldDelegateToSyncSetup(anyOrNull())).thenReturn(false)
         whenever(mockAppBuildConfig.sdkInt).thenReturn(31)
-        val pdfViewerToggle = mockToggle(enabled = false)
-        whenever(androidBrowserConfigFeature.pdfViewer()).thenReturn(pdfViewerToggle)
         val externalPdfHandlerToggle = mockToggle(enabled = false)
         whenever(androidBrowserConfigFeature.externalPdfHandler()).thenReturn(externalPdfHandlerToggle)
     }
@@ -328,7 +326,6 @@ class IntentDispatcherViewModelTest {
         whenever(mockIntent.action).thenReturn(Intent.ACTION_VIEW)
         whenever(mockIntent.data).thenReturn(contentUri)
         whenever(mockIntent.type).thenReturn("application/pdf")
-        whenever(androidBrowserConfigFeature.pdfViewer()).thenReturn(enabledToggle)
         whenever(androidBrowserConfigFeature.externalPdfHandler()).thenReturn(enabledToggle)
         whenever(inlinePdfHandler.cacheLocalPdf(contentUri)).thenReturn(LocalPdfResult.Success(cachedUri, "doc.pdf"))
 
@@ -349,7 +346,6 @@ class IntentDispatcherViewModelTest {
         whenever(mockIntent.action).thenReturn(Intent.ACTION_VIEW)
         whenever(mockIntent.data).thenReturn(contentUri)
         whenever(mockIntent.type).thenReturn(null)
-        whenever(androidBrowserConfigFeature.pdfViewer()).thenReturn(enabledToggle)
         whenever(androidBrowserConfigFeature.externalPdfHandler()).thenReturn(enabledToggle)
         whenever(inlinePdfHandler.cacheLocalPdf(contentUri)).thenReturn(LocalPdfResult.Success(cachedUri, "report.pdf"))
 
@@ -368,7 +364,6 @@ class IntentDispatcherViewModelTest {
         whenever(mockIntent.action).thenReturn(Intent.ACTION_VIEW)
         whenever(mockIntent.data).thenReturn(contentUri)
         whenever(mockIntent.type).thenReturn("application/pdf")
-        whenever(androidBrowserConfigFeature.pdfViewer()).thenReturn(enabledToggle)
         whenever(androidBrowserConfigFeature.externalPdfHandler()).thenReturn(enabledToggle)
         whenever(inlinePdfHandler.cacheLocalPdf(contentUri)).thenReturn(LocalPdfResult.Failure(PdfErrorType.UNKNOWN))
 
@@ -382,32 +377,12 @@ class IntentDispatcherViewModelTest {
     }
 
     @Test
-    fun `when VIEW intent with application pdf type and pdfViewer flag disabled then not treated as local PDF`() = runTest {
-        val contentUri = Uri.parse("content://com.example.provider/files/doc.pdf")
-        val disabledToggle = mockToggle(enabled = false)
-        whenever(mockIntent.action).thenReturn(Intent.ACTION_VIEW)
-        whenever(mockIntent.data).thenReturn(contentUri)
-        whenever(mockIntent.type).thenReturn("application/pdf")
-        whenever(androidBrowserConfigFeature.pdfViewer()).thenReturn(disabledToggle)
-
-        testee.onIntentReceived(mockIntent, isExternal = true)
-
-        testee.viewState.test {
-            val state = awaitItem()
-            assertNull(state.activityParams)
-        }
-        verify(inlinePdfHandler, never()).cacheLocalPdf(any())
-    }
-
-    @Test
     fun `when VIEW intent with application pdf type and externalPdfHandler flag disabled then not treated as local PDF`() = runTest {
         val contentUri = Uri.parse("content://com.example.provider/files/doc.pdf")
-        val enabledToggle = mockToggle(enabled = true)
         val disabledToggle = mockToggle(enabled = false)
         whenever(mockIntent.action).thenReturn(Intent.ACTION_VIEW)
         whenever(mockIntent.data).thenReturn(contentUri)
         whenever(mockIntent.type).thenReturn("application/pdf")
-        whenever(androidBrowserConfigFeature.pdfViewer()).thenReturn(enabledToggle)
         whenever(androidBrowserConfigFeature.externalPdfHandler()).thenReturn(disabledToggle)
 
         testee.onIntentReceived(mockIntent, isExternal = true)

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/pdf/PdfViewerAvailability.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/pdf/PdfViewerAvailability.kt
@@ -17,8 +17,7 @@
 package com.duckduckgo.browser.api.pdf
 
 /**
- * Tells other modules whether DuckDuckGo's native PDF viewer can be launched right now
- * (SDK floor + pdfViewer remote flag), without exposing the feature flag itself outside :app.
+ * Tells other modules whether DuckDuckGo's native PDF viewer can be launched right now (SDK floor).
  */
 interface PdfViewerAvailability {
     fun isAvailable(): Boolean

--- a/browser/browser-feature-toggles/src/main/java/com/duckduckgo/browser/feature/toggles/AndroidBrowserConfigFeature.kt
+++ b/browser/browser-feature-toggles/src/main/java/com/duckduckgo/browser/feature/toggles/AndroidBrowserConfigFeature.kt
@@ -365,18 +365,8 @@ interface AndroidBrowserConfigFeature {
     fun tabStateRestorationFix(): Toggle
 
     /**
-     * @return `true` when the remote config has the global "pdfViewer" androidBrowserConfig
-     * sub-feature flag enabled
-     * If the remote feature is not present defaults to `false`
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
-    fun pdfViewer(): Toggle
-
-    /**
      * Controls whether DuckDuckGo registers as a system handler for already-downloaded PDFs
-     * (system "Open with" sheet). Independent of [pdfViewer] so the external-handler rollout
-     * can be staged separately from the inline PDF viewer rollout; both must be enabled for
-     * DuckDuckGo to open an externally-delivered PDF.
+     * (system "Open with" sheet).
      * @return `true` when the remote config has the global "externalPdfHandler" androidBrowserConfig
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`

--- a/lint-rules/src/main/java/com/duckduckgo/lint/NoNewBrowserFeatureToggleDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/NoNewBrowserFeatureToggleDetector.kt
@@ -128,7 +128,6 @@ class NoNewBrowserFeatureToggleDetector : Detector(), SourceCodeScanner {
             "AndroidBrowserConfigFeature#sendPostIdleSessionWideEvent",
             "AndroidBrowserConfigFeature#storePageContext",
             "AndroidBrowserConfigFeature#tabStateRestorationFix",
-            "AndroidBrowserConfigFeature#pdfViewer",
             "AndroidBrowserConfigFeature#externalPdfHandler",
             "AndroidBrowserConfigFeature#redirectDuckAiLinksFromCustomTab",
             "AndroidBrowserConfigFeature#webViewSessionPersistence",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211850753229323/task/1214730763772576?focus=true

### Description

Removes the `pdfViewer` feature flag from `AndroidBrowserConfigFeature`. Inline rendering eligibility (`InlinePdfHandler.classifyPdfRequest`) and the "Open with" system handler path (`IntentDispatcherViewModel`) are now gated only by the SDK 31 floor and the existing `externalPdfHandler` toggle.

### Steps to test this PR

QA optional

### UI changes

No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ships inline PDF viewing without a remote kill switch (only SDK and `externalPdfHandler` remain for external opens), so a bad rollout can’t be turned off via `pdfViewer` anymore.
> 
> **Overview**
> Removes the **`pdfViewer`** remote toggle from `AndroidBrowserConfigFeature` and stops checking it anywhere inline PDF or viewer availability is decided.
> 
> **Inline web PDFs** (`RealInlinePdfHandler.classifyPdfRequest`) now depend only on URL/MIME/`Content-Disposition` rules and the Android 12 (SDK 31) floor—no remote flag.
> 
> **External “Open with” PDFs** stay gated by SDK 31 plus **`externalPdfHandler`** (`PdfHandlerComponentToggler`, `IntentDispatcherViewModel.localPdfUriOrNull`). **`PdfViewerAvailability.isAvailable()`** is SDK-only for other modules.
> 
> Tests and lint grandfather list are updated; the “feature disabled” classification test is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f1a3626898c994e4e58bdd11f6398fcb4b5709e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->