### PR TITLE
Restructure nativeInputSearchOnly FF as subfeature

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -188,7 +188,7 @@ class RealNativeInputManager @Inject constructor(
     private val duckChatInputModeState: DuckChatInputModeState,
     private val pixel: Pixel,
     private val nativeInputStateBugKillSwitch: NativeInputStateBugKillSwitch,
-    private val nativeInputSearchOnlyFeature: NativeInputSearchOnlyFeature,
+    private val nativeInputOmnibarFeature: NativeInputOmnibarFeature,
     private val nativeInputEventListener: NativeInputEventListener,
     private val edgeToEdgeProvider: EdgeToEdgeProvider,
     private val edgeToEdgeHandler: EdgeToEdgeHandler,
@@ -277,7 +277,7 @@ class RealNativeInputManager @Inject constructor(
                 // the browser omnibar, whose two search layouts differ. An active Duck.ai input is unaffected,
                 // so just refresh its nav bar.
                 val rebuildOnRefocus = !isNativeInputActive() ||
-                    (nativeInputSearchOnlyFeature.self().isEnabled() && !omnibarController.isDuckAiMode())
+                    (isSearchOnlyRestoreEnabled() && !omnibarController.isDuckAiMode())
                 if (rebuildOnRefocus) {
                     hideNativeInput(animate = false)
                 } else {
@@ -302,8 +302,11 @@ class RealNativeInputManager @Inject constructor(
         val inDuckAi = ::omnibarController.isInitialized && omnibarController.isDuckAiMode()
         return inDuckAi ||
             inputModeCapability == NativeInputState.InputMode.SEARCH_AND_DUCK_AI ||
-            (nativeInputSearchOnlyFeature.self().isEnabled() && inputModeCapability == NativeInputState.InputMode.SEARCH_ONLY)
+            (isSearchOnlyRestoreEnabled() && inputModeCapability == NativeInputState.InputMode.SEARCH_ONLY)
     }
+
+    private fun isSearchOnlyRestoreEnabled(): Boolean =
+        nativeInputOmnibarFeature.self().isEnabled() && nativeInputOmnibarFeature.nativeInputSearchOnly().isEnabled()
 
     override fun isNativeInputShown(): Boolean {
         if (!::rootView.isInitialized) return false

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarFeature.kt
@@ -22,15 +22,23 @@ import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 /**
- * Gates using the native input field for the browser omnibar while the address bar is in search-only
- * mode (Duck.ai off in the address bar). When disabled, search-only falls back to the legacy omnibar
+ * Feature flags for the native input field in the browser omnibar.
  */
 @ContributesRemoteFeature(
     scope = AppScope::class,
-    featureName = "nativeInputSearchOnly",
+    featureName = "nativeInputOmnibar",
 )
-interface NativeInputSearchOnlyFeature {
+interface NativeInputOmnibarFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun self(): Toggle
+
+    /**
+     * @return `true` when the native input field should be used for the browser omnibar while the
+     * address bar is in search-only mode (Duck.ai off in the address bar). When disabled, search-only
+     * falls back to the legacy omnibar.
+     * If the remote feature is not present defaults to `internal`.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun nativeInputSearchOnly(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -31,7 +31,7 @@ import com.duckduckgo.app.browser.animations.AddressBarTrackersAnimationManager
 import com.duckduckgo.app.browser.customtabs.CustomTabPixelNames
 import com.duckduckgo.app.browser.menu.BrowserMenuHighlight
 import com.duckduckgo.app.browser.menu.BrowserViewMode
-import com.duckduckgo.app.browser.nativeinput.NativeInputSearchOnlyFeature
+import com.duckduckgo.app.browser.nativeinput.NativeInputOmnibarFeature
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.Browser
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.CustomTab
@@ -126,7 +126,7 @@ class OmnibarLayoutViewModel @Inject constructor(
     private val addressBarTrackersAnimationManager: AddressBarTrackersAnimationManager,
     private val standardizedLeadingIconToggle: StandardizedLeadingIconFeatureToggle,
     private val progressBarUpgradeFeature: ProgressBarUpgradeFeature,
-    private val nativeInputSearchOnlyFeature: NativeInputSearchOnlyFeature,
+    private val nativeInputOmnibarFeature: NativeInputOmnibarFeature,
     private val browserMode: BrowserMode,
 ) : ViewModel() {
 
@@ -358,7 +358,10 @@ class OmnibarLayoutViewModel @Inject constructor(
             duckChat.observeNativeInputFieldUserSettingEnabled(),
             duckChat.observeNativeChatInputEnabled(),
             duckChatInputModeState.inputModeCapability,
-            nativeInputSearchOnlyFeature.self().enabled(),
+            combine(
+                nativeInputOmnibarFeature.self().enabled(),
+                nativeInputOmnibarFeature.nativeInputSearchOnly().enabled(),
+            ) { self, searchOnly -> self && searchOnly },
         ) { nativeInputEnabled, nativeChatInputEnabled, inputModeCapability, searchOnlyRestoreEnabled ->
             _viewState.update {
                 it.copy(

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
@@ -82,7 +82,7 @@ class RealNativeInputManagerTest {
     private val edgeToEdgeProvider: EdgeToEdgeProvider = mock()
     private val edgeToEdgeHandler = EdgeToEdgeHandler()
     private val nativeInputStateBugKillSwitch = FakeFeatureToggleFactory.create(NativeInputStateBugKillSwitch::class.java)
-    private val nativeInputSearchOnlyFeature = FakeFeatureToggleFactory.create(NativeInputSearchOnlyFeature::class.java)
+    private val nativeInputOmnibarFeature = FakeFeatureToggleFactory.create(NativeInputOmnibarFeature::class.java)
 
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val rootView: ViewGroup = FrameLayout(context)
@@ -97,7 +97,7 @@ class RealNativeInputManagerTest {
     fun setUp() {
         whenever(duckChatInputModeState.inputModeCapability).thenReturn(inputModeCapabilityFlow)
         whenever(duckChat.observeNativeInputNavBarEnabled()).thenReturn(MutableStateFlow(false))
-        nativeInputSearchOnlyFeature.self().setRawStoredState(State(enable = false))
+        nativeInputOmnibarFeature.self().setRawStoredState(State(enable = false))
         testee = RealNativeInputManager(
             duckChat,
             animator,
@@ -108,7 +108,7 @@ class RealNativeInputManagerTest {
             duckChatInputModeState,
             pixel,
             nativeInputStateBugKillSwitch,
-            nativeInputSearchOnlyFeature,
+            nativeInputOmnibarFeature,
             nativeInputEventListener,
             edgeToEdgeProvider,
             edgeToEdgeHandler,

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -11,7 +11,7 @@ import com.duckduckgo.app.browser.animations.AddressBarTrackersAnimationManager
 import com.duckduckgo.app.browser.customtabs.CustomTabPixelNames
 import com.duckduckgo.app.browser.menu.BrowserMenuHighlight
 import com.duckduckgo.app.browser.menu.BrowserViewMode
-import com.duckduckgo.app.browser.nativeinput.NativeInputSearchOnlyFeature
+import com.duckduckgo.app.browser.nativeinput.NativeInputOmnibarFeature
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command.LaunchNativeInput
@@ -108,7 +108,7 @@ class OmnibarLayoutViewModelTest {
     private val duckAiShowOmnibarShortcutInAllStatesFlow = MutableStateFlow(true)
     private val nativeInputFieldSettingFlow = MutableStateFlow(false)
     private val nativeChatInputEnabledFlow = MutableStateFlow(false)
-    private val fakeNativeInputSearchOnlyFeature = FakeFeatureToggleFactory.create(NativeInputSearchOnlyFeature::class.java)
+    private val fakeNativeInputOmnibarFeature = FakeFeatureToggleFactory.create(NativeInputOmnibarFeature::class.java)
     private val inputScreenUserSettingFlow = MutableStateFlow(false)
     private val activeVoiceSessionsFlow = MutableStateFlow<Set<String>>(emptySet())
     private val selectedTabFlow = MutableStateFlow<TabEntity?>(null)
@@ -156,7 +156,8 @@ class OmnibarLayoutViewModelTest {
         whenever(urlDisplayRepository.isFullUrlEnabled).then { isFullUrlEnabledFlow }
         whenever(duckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(nativeInputFieldSettingFlow)
         whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(nativeChatInputEnabledFlow)
-        fakeNativeInputSearchOnlyFeature.self().setRawStoredState(State(enable = false))
+        fakeNativeInputOmnibarFeature.self().setRawStoredState(State(enable = false))
+        fakeNativeInputOmnibarFeature.nativeInputSearchOnly().setRawStoredState(State(enable = false))
         whenever(duckChatInputModeState.inputModeCapability).thenReturn(inputModeCapabilityFlow)
         whenever(duckChat.activeVoiceChatSessions).thenReturn(activeVoiceSessionsFlow)
         whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(inputScreenUserSettingFlow)
@@ -217,7 +218,7 @@ class OmnibarLayoutViewModelTest {
             addressBarTrackersAnimationManager = addressBarTrackersAnimationManager,
             standardizedLeadingIconToggle = fakeStandardizedLeadingIconToggle,
             progressBarUpgradeFeature = fakeProgressBarUpgradeFeature,
-            nativeInputSearchOnlyFeature = fakeNativeInputSearchOnlyFeature,
+            nativeInputOmnibarFeature = fakeNativeInputOmnibarFeature,
             browserMode = browserMode,
         )
     }
@@ -1652,7 +1653,8 @@ class OmnibarLayoutViewModelTest {
 
     @Test
     fun whenSearchOnlyAndRestoreFlagEnabledThenShowClickCatcherTrue() = runTest {
-        fakeNativeInputSearchOnlyFeature.self().setRawStoredState(State(enable = true))
+        fakeNativeInputOmnibarFeature.self().setRawStoredState(State(enable = true))
+        fakeNativeInputOmnibarFeature.nativeInputSearchOnly().setRawStoredState(State(enable = true))
         nativeInputFieldSettingFlow.value = true
         inputModeCapabilityFlow.value = NativeInputState.InputMode.SEARCH_ONLY
         initializeViewModel()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217529315790175?focus=true 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
If we want to rollout the `nativeInputSearchOnly` feature flag slowly and monitor feedback we cannot do so if the flag is a main feature. 

This PR converts it to a sub feature of the “NativeInputOmnibarFeature” feature to enable rollout. 

### Steps to test this PR

_Feature flag_
- [x] Set mode to “Search Only” (not search + duck.ai)
- [x] Enable both `nativeInputOmnibar` and `nativeInputSearchOnly` in the developer settings.  
- [x] Validate that when the omnibar is focused the native input is shown (can tell by it being slightly bigger)
- [x] Turn off: `nativeInputSearchOnly` only -> Validate omnibar focus is now the legacy field 
- [x]  Turn off: `nativeInputOmnibar` only -> Validate omnibar focus is now the legacy field  

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 44c9e521e931780977b75f5dbfedbc318b17a292. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->