### PR TITLE
Disable Gradle cache cleanup in the assemble action

### DIFF
--- a/.github/actions/checkout-and-assemble/action.yml
+++ b/.github/actions/checkout-and-assemble/action.yml
@@ -122,8 +122,9 @@ runs:
       uses: gradle/actions/setup-gradle@v5
       with:
         cache-encryption-key: ${{ inputs.gradle_encryption_key }}
-        # Two Gradle builds run per job: cleanup evicts the deps the play build never touched,
-        # then the internal build reuses its config cache and fails instead of re-downloading them.
+        # Cleanup prunes dependencies a job did not use before saving the cache, which can drop the
+        # internal-only artifacts while the saved configuration cache still points at them. The
+        # restored pair then fails assembleInternalRelease instead of re-downloading.
         cache-cleanup: never
 
     - name: Assemble release APK

--- a/.github/actions/checkout-and-assemble/action.yml
+++ b/.github/actions/checkout-and-assemble/action.yml
@@ -125,8 +125,6 @@ runs:
         # Two Gradle builds run per job: cleanup evicts the deps the play build never touched,
         # then the internal build reuses its config cache and fails instead of re-downloading them.
         cache-cleanup: never
-        # TEMP: verification only, revert before merge.
-        cache-write-only: true
 
     - name: Assemble release APK
       if: ${{ inputs.flavours == 'all' || inputs.flavours == 'play' }}

--- a/.github/actions/checkout-and-assemble/action.yml
+++ b/.github/actions/checkout-and-assemble/action.yml
@@ -125,6 +125,8 @@ runs:
         # Two Gradle builds run per job: cleanup evicts the deps the play build never touched,
         # then the internal build reuses its config cache and fails instead of re-downloading them.
         cache-cleanup: never
+        # TEMP: verification only, revert before merge.
+        cache-write-only: true
 
     - name: Assemble release APK
       if: ${{ inputs.flavours == 'all' || inputs.flavours == 'play' }}

--- a/.github/actions/checkout-and-assemble/action.yml
+++ b/.github/actions/checkout-and-assemble/action.yml
@@ -122,6 +122,9 @@ runs:
       uses: gradle/actions/setup-gradle@v5
       with:
         cache-encryption-key: ${{ inputs.gradle_encryption_key }}
+        # Two Gradle builds run per job: cleanup evicts the deps the play build never touched,
+        # then the internal build reuses its config cache and fails instead of re-downloading them.
+        cache-cleanup: never
 
     - name: Assemble release APK
       if: ${{ inputs.flavours == 'all' || inputs.flavours == 'play' }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1157893581871903/task/1217533406718211
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

The nightly E2E job fails in `Assemble APKs`: `assemblePlayRelease` succeeds, `assembleInternalRelease` dies seconds later.

```
Execution failed for task ':app:mergeInternalReleaseArtProfile'.
> Could not resolve all files for configuration ':app:internalReleaseRuntimeClasspath'.
   > Failed to transform lottie-compose-6.7.1.aar ...
      > .../modules-2/files-2.1/com.airbnb.android/lottie-compose/6.7.1/13aa9b7e.../lottie-compose-6.7.1.aar (No such file or directory)
```

The dependency is not involved: `6.7.1` has been pinned in `versions.properties` since #8391, the artifact is immutable on Maven Central, and the standalone `Assemble internalRelease` job in the same run builds the same flavour successfully.

Every missing artifact is internal-flavour-only:

| missing | consumer |
| --- | --- |
| lottie-compose | `design-system-internal` |
| nanohttpd | `duckchat-internal` |
| zjsonpatch (+ jackson, commons-collections4 transitively) | `privacy-config-internal` |

Two things combine. The saved Gradle home cache is missing those artifacts while still carrying a configuration cache entry that references them; `cache-cleanup: on-success` prunes dependencies a job did not use before saving, which is what produces that inconsistent pair. On restore, `assembleInternalRelease` reuses the configuration cache, skips dependency resolution, and fails on the recorded file paths instead of re-downloading.

Verified in an isolated `GRADLE_USER_HOME`: deleting `lottie-compose-6.7.1.aar` makes `:app:mergeInternalReleaseArtProfile` fail with the identical error under a reused configuration cache, while the same build with `--no-configuration-cache` re-downloads it and succeeds.

**`cache-cleanup: never` alone does not unblock CI.** A run on this branch with the flag applied still failed identically ([run 32014742090](https://github.com/duckduckgo/Android/actions/runs/32014742090)), because the already-poisoned entry keeps being restored. A second run with `cache-write-only: true` temporarily added, so the bad entry was ignored, assembled both flavours and uploaded the internal APK ([run 32015368188](https://github.com/duckduckgo/Android/actions/runs/32015368188)).

So this PR is the prevention half. **The caches for the E2E workflows also need deleting once** (`gh cache list` / `gh cache delete`) so a clean entry gets written; without that, the next nightly fails the same way.

### Steps to test this PR

_Nightly E2E assemble_
- [ ] Delete the existing Gradle caches for the E2E workflows (`gh cache list --repo duckduckgo/Android`)
- [ ] Trigger `End to End Tests - Full Suite (Nightly)` via workflow_dispatch on this branch with `ddg_di` set to `Metro`
- [ ] Confirm `Assemble APKs` succeeds: both `assemblePlayRelease` and `assembleInternalRelease` reach `BUILD SUCCESSFUL`
- [ ] Confirm the job log shows no `Preparing cache for cleanup.` line under `Setup Gradle`
- [ ] Confirm the Maestro flows downstream of the assemble step run (they were skipped while the assemble failed)

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |
