### PR TITLE
Make new address bar picker sheet scrollable and remove the wing

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarPickerBottomSheetDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarPickerBottomSheetDialog.kt
@@ -31,7 +31,6 @@ import android.view.LayoutInflater
 import android.view.View
 import androidx.core.content.ContextCompat.getString
 import androidx.core.view.isVisible
-import androidx.core.view.postDelayed
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.BottomSheetNewAddressBarPickerBinding
 import com.duckduckgo.app.onboardingquicksetup.ui.BrandDesignInputScreenPicker.Transition
@@ -73,7 +72,6 @@ class NewAddressBarPickerBottomSheetDialog(
 
     private var searchAndDuckAiSelected = true
     private var originalOrientation: Int = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
-    private var leftWingRunnable: Runnable? = null
     private var contentFadeInAnimatorSet: AnimatorSet? = null
 
     init {
@@ -111,7 +109,6 @@ class NewAddressBarPickerBottomSheetDialog(
             if (!isWindowValid()) return@setOnShowListener
             (it as BottomSheetDialog).setRoundCorners()
             callback?.onDisplayed()
-            playLeftWingAnimation()
             revealContent()
         }
 
@@ -159,17 +156,6 @@ class NewAddressBarPickerBottomSheetDialog(
         }
     }
 
-    private fun playLeftWingAnimation() {
-        binding.leftWing.apply {
-            alpha = 0f
-            setMaxProgress(WING_STOP_PROGRESS)
-            leftWingRunnable = postDelayed(WING_START_DELAY) {
-                animate().alpha(1f).setDuration(WING_FADE_IN_DURATION).start()
-                playAnimation()
-            }
-        }
-    }
-
     @SuppressLint("SourceLockedOrientationActivity")
     private fun lockOrientationToPortrait() {
         (context as? Activity)?.let {
@@ -187,8 +173,6 @@ class NewAddressBarPickerBottomSheetDialog(
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         contentFadeInAnimatorSet?.cancel()
-        leftWingRunnable?.let { binding.leftWing.removeCallbacks(it) }
-        binding.leftWing.cancelAnimation()
         binding.inputScreen.inputScreenPicker.cancelLottieAnimations()
         restoreOrientation()
     }
@@ -198,9 +182,6 @@ class NewAddressBarPickerBottomSheetDialog(
     } ?: false
 
     private companion object {
-        private const val WING_STOP_PROGRESS = 0.5f
-        private const val WING_START_DELAY = 300L
-        private const val WING_FADE_IN_DURATION = 150L
         private const val CONTENT_FADE_IN_DURATION = 200L
     }
 }

--- a/app/src/main/res/layout/bottom_sheet_new_address_bar_picker.xml
+++ b/app/src/main/res/layout/bottom_sheet_new_address_bar_picker.xml
@@ -50,37 +50,48 @@
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/keyline_5"
         android:layout_marginTop="@dimen/keyline_4"
+        android:layout_marginBottom="@dimen/keyline_5"
         app:showArrow="false"
         app:arrowOffsetStart="96dp"
+        app:layout_constrainedHeight="true"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/eyebrow"
+        app:layout_constraintVertical_bias="0"
         app:layout_constraintWidth_max="600dp">
 
-        <LinearLayout
+        <ScrollView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="@dimen/keyline_5">
+            android:fadeScrollbars="false">
 
-            <include
-                android:id="@+id/inputScreen"
-                layout="@layout/include_brand_design_input_screen"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:visibility="gone"
-                tools:visibility="visible" />
+                android:orientation="vertical"
+                android:padding="@dimen/keyline_5">
 
-            <com.duckduckgo.common.ui.view.button.DaxButtonBrand
-                android:id="@+id/confirmButton"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/keyline_5"
-                android:alpha="0"
-                android:text="@string/newAddressBarPickerConfirm"
-                app:daxButtonBrandTypography="duckSans" />
+                <include
+                    android:id="@+id/inputScreen"
+                    layout="@layout/include_brand_design_input_screen"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
 
-        </LinearLayout>
+                <com.duckduckgo.common.ui.view.button.DaxButtonBrand
+                    android:id="@+id/confirmButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/keyline_5"
+                    android:alpha="0"
+                    android:text="@string/newAddressBarPickerConfirm"
+                    app:daxButtonBrandTypography="duckSans" />
+
+            </LinearLayout>
+
+        </ScrollView>
 
     </com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleBrandDesignUpdateCardView>
 

--- a/app/src/main/res/layout/bottom_sheet_new_address_bar_picker.xml
+++ b/app/src/main/res/layout/bottom_sheet_new_address_bar_picker.xml
@@ -118,16 +118,4 @@
 
     </FrameLayout>
 
-    <com.airbnb.lottie.LottieAnimationView
-        android:id="@+id/leftWing"
-        android:layout_width="wrap_content"
-        android:layout_height="160dp"
-        android:adjustViewBounds="true"
-        android:importantForAccessibility="no"
-        app:layout_constrainedWidth="true"
-        app:layout_constraintBottom_toBottomOf="@id/backgroundIllustration"
-        app:layout_constraintStart_toStartOf="parent"
-        app:lottie_loop="false"
-        app:lottie_rawRes="@raw/onboarding_wing_left" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/bottom_sheet_new_address_bar_picker.xml
+++ b/app/src/main/res/layout/bottom_sheet_new_address_bar_picker.xml
@@ -22,6 +22,17 @@
     android:theme="@style/ThemeOverlay.DuckDuckGo.Onboarding">
 
     <ImageView
+        android:id="@+id/backgroundIllustration"
+        android:layout_width="0dp"
+        android:layout_height="180dp"
+        android:importantForAccessibility="no"
+        android:scaleType="centerCrop"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:srcCompat="@drawable/onboarding_input_type_background" />
+
+    <ImageView
         android:id="@+id/duckAiLogo"
         android:layout_width="48dp"
         android:layout_height="48dp"
@@ -44,67 +55,68 @@
         app:textType="secondary"
         app:typography="caption_allCaps" />
 
-    <com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleBrandDesignUpdateCardView
-        android:id="@+id/daxBubble"
+    <!--
+      The card wraps its content but must never grow past the bottom edge. ConstraintLayout measures a
+      wrap_content child without applying its constraints, and layout_constrainedHeight resolves the
+      available height incorrectly here, so the bound comes from this fixed-height container instead:
+      it hands the card AT_MOST(available), which is exactly wrap-until-it-no-longer-fits.
+    -->
+    <FrameLayout
+        android:id="@+id/daxBubbleContainer"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:layout_marginHorizontal="@dimen/keyline_5"
-        android:layout_marginTop="@dimen/keyline_4"
-        android:layout_marginBottom="@dimen/keyline_5"
-        app:showArrow="false"
-        app:arrowOffsetStart="96dp"
-        app:layout_constrainedHeight="true"
+        android:layout_marginVertical="@dimen/keyline_4"
+        android:clipChildren="false"
+        android:clipToPadding="false"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/eyebrow"
-        app:layout_constraintVertical_bias="0"
         app:layout_constraintWidth_max="600dp">
 
-        <ScrollView
+        <com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleBrandDesignUpdateCardView
+            android:id="@+id/daxBubble"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:fadeScrollbars="false">
+            android:layout_gravity="top"
+            app:showArrow="false">
 
-            <LinearLayout
+            <ScrollView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="@dimen/keyline_5">
+                android:fadeScrollbars="false">
 
-                <include
-                    android:id="@+id/inputScreen"
-                    layout="@layout/include_brand_design_input_screen"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
+                    android:orientation="vertical"
+                    android:padding="@dimen/keyline_5">
 
-                <com.duckduckgo.common.ui.view.button.DaxButtonBrand
-                    android:id="@+id/confirmButton"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/keyline_5"
-                    android:alpha="0"
-                    android:text="@string/newAddressBarPickerConfirm"
-                    app:daxButtonBrandTypography="duckSans" />
+                    <include
+                        android:id="@+id/inputScreen"
+                        layout="@layout/include_brand_design_input_screen"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:visibility="gone"
+                        tools:visibility="visible" />
 
-            </LinearLayout>
+                    <com.duckduckgo.common.ui.view.button.DaxButtonBrand
+                        android:id="@+id/confirmButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/keyline_5"
+                        android:alpha="0"
+                        android:text="@string/newAddressBarPickerConfirm"
+                        app:daxButtonBrandTypography="duckSans" />
 
-        </ScrollView>
+                </LinearLayout>
 
-    </com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleBrandDesignUpdateCardView>
+            </ScrollView>
 
-    <ImageView
-        android:id="@+id/backgroundIllustration"
-        android:layout_width="0dp"
-        android:layout_height="180dp"
-        android:importantForAccessibility="no"
-        android:scaleType="centerCrop"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:srcCompat="@drawable/onboarding_input_type_background" />
+        </com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleBrandDesignUpdateCardView>
+
+    </FrameLayout>
 
     <com.airbnb.lottie.LottieAnimationView
         android:id="@+id/leftWing"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217157598098304?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

The card content had no scroll container and no height bound, so on small screens or with large font scales the confirm button was pushed off screen with no way to reach it. Wrap the content in a `ScrollView` and bound the card height against the parent so it can detect the overflow. 

Also, remove the left wing embellishment which collided with the card on most of the screens.

### Steps to test this PR
- [ ] Apply below diff:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarPickerManager.kt b/app/src/main/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarPickerManager.kt
index 00d230129d..a57ffb80af 100644
--- a/app/src/main/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarPickerManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarPickerManager.kt
@@ -63,7 +63,7 @@ class RealNewAddressBarPickerManager @Inject constructor(
 
     override suspend fun showChoiceScreen(activity: DuckDuckGoActivity) {
         showChoiceScreenMutex.withLock {
-            if (validate(activity)) {
+            if (true) {
                 logcat(DEBUG) { "NewAddressBarPickerManager: All conditions met, showing choice screen" }
                 withContext(dispatchers.main()) {
                     // The sheet is non-cancelable, so don't present a second one while one is already showing

```
- [ ] Significantly increase the font size.
- [ ] Open the app.
- [ ] A full-screen modal should show asking to pick the input mode but the "Confirm" is out of bounds.
- [ ] Verify the view is scrollable and you can reach the "Confirm" button.

### UI changes
#### Regular font size

| Before | After |
| --- | --- |
| <img width="480" height="1071" alt="Screenshot_20260817_110026" src="https://github.com/user-attachments/assets/38f6345b-061f-4df1-8b88-b103decfa8ed" /> | <img width="480" height="1071" alt="Screenshot_20260817_112303" src="https://github.com/user-attachments/assets/27ca38a3-4e9a-4bdb-8674-62758a407c41" />

_large font size: before_

https://github.com/user-attachments/assets/530f7942-c9a2-4b84-8aa0-c8692efd2864

_large font size: after_

https://github.com/user-attachments/assets/4eda61b0-f90b-4467-9581-75a70a6885d4



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UI layout and animation only; no auth, data, or business-logic changes.
> 
> **Overview**
> Fixes the **new address bar picker** bottom sheet so **Confirm** stays reachable on small screens and large font scales, and drops the **left wing** decoration that overlapped the card.
> 
> The DAX bubble is now inside a **height-bounded** `daxBubbleContainer` (between the eyebrow and bottom of the sheet) so the card cannot grow past the screen. Card content—including the input picker and **Confirm**—sits in a **ScrollView**, so overflow scrolls instead of clipping the button.
> 
> **Kotlin** no longer runs the left-wing Lottie intro (`playLeftWingAnimation`, delayed runnable, and detach cleanup). Show flow still uses `revealContent()` and the existing content fade-in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d45b6bdbcf1cf7e30f9f9eddbae87f0bf65d5b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->