### PR TITLE
enable onboardingBrandDesignUpdate#configDrivenDialogs for all

### DIFF
--- a/.github/workflows/e2e-nightly-non-blockers-suite.yml
+++ b/.github/workflows/e2e-nightly-non-blockers-suite.yml
@@ -173,27 +173,6 @@ jobs:
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           test_suite_name: Onboarding${{ env.DI_PAREN_SUFFIX }}
 
-      # The internal binary resolves configDrivenDialogs (INTERNAL default) to true, so rerunning
-      # the onboarding flows here covers the config-driven renderer without an extra build.
-      - name: Onboarding, config-driven renderer
-        id: maestro-onboarding-config-driven-renderer
-        # Run regardless of earlier suite failures, but only if the internal binary uploaded.
-        if: ${{ !cancelled() && steps.maestro-upload-internal-binary.outcome == 'success' }}
-        uses: ./.github/actions/maestro-cloud-asana-reporter
-        timeout-minutes: 120
-        with:
-          maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
-          maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: onboardingConfigDrivenRenderer${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
-          maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
-          maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 34
-          maestro_include_tags: onboardingTest
-          asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Onboarding, config-driven renderer${{ env.DI_PAREN_SUFFIX }}
-
       - name: SERP Flows
         id: maestro-serp-flows
         # Run regardless of earlier suite failures, but only if the internal binary uploaded.
@@ -225,9 +204,10 @@ jobs:
           asana-task-description: The end to end workflow${{ env.DI_PAREN_SUFFIX }} has failed. These are non release blocking tests, follow the steps in [Maintenance Playbook](https://app.asana.com/1/137249556945/project/1210669871036405/task/1210684104726187?focus=true). See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
           action: 'create-asana-task'
 
-  # Internal-only and preonboarding flows only run on internal builds, where configDrivenDialogs
-  # resolves to true — so the legacy renderer production ships is untested for them. The flag is
-  # read at launch, so a source patch pins it to FALSE at compile time (see the patch header).
+  # configDrivenDialogs now defaults to TRUE, so every build renders the config-driven
+  # dialogs and the legacy renderer — still the fallback when the flag is remotely disabled — is
+  # otherwise untested. The flag is read at launch, so a source patch pins it to FALSE at compile
+  # time (see the patch header).
   onboarding_legacy_renderer_on_internal:
     runs-on: ubuntu-latest
     name: Onboarding, legacy renderer on internal
@@ -284,7 +264,7 @@ jobs:
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
           maestro_api_level: 36
-          maestro_include_tags: onboardingInternalTest,onboardingNonReleaseBlockingTest
+          maestro_include_tags: onboardingTest,onboardingInternalTest,onboardingNonReleaseBlockingTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}

--- a/.maestro/onboarding/source_patches/config_driven_dialogs_disabled.patch
+++ b/.maestro/onboarding/source_patches/config_driven_dialogs_disabled.patch
@@ -1,17 +1,18 @@
-Pins onboardingBrandDesignUpdate.configDrivenDialogs to FALSE so the nightly E2E suite can run
-the internal-flavour onboarding flows against the legacy renderer — the renderer production
-ships while the flag sits on INTERNAL. The flag is read during app launch, so only a
+Pins onboardingBrandDesignUpdate.configDrivenDialogs to FALSE so the nightly E2E suite still covers
+the legacy onboarding renderer. The config-driven renderer is now the compile-time default (TRUE), so
+every unpatched build renders it — the legacy renderer only appears when the flag is remotely
+disabled, and no unpatched binary can reproduce that. The flag is read during app launch, so only a
 compile-time change can pin it.
 
 Applied only by the "Onboarding, legacy renderer on internal" job in
 .github/workflows/e2e-nightly-non-blockers-suite.yml.
 
-This patch is meant to stop applying once the default moves off INTERNAL. CI fails loudly at
-that point, and whoever changes the default decides what coverage is still missing:
+This patch is meant to stop applying once the legacy renderer is deleted. CI fails loudly if the
+default changes again, and whoever changes it decides what coverage is still missing:
 
-  - default becomes TRUE: rewrite this patch to pin FALSE against TRUE and run on the play
-    binary, until the legacy renderer is deleted.
   - legacy renderer deleted: delete this patch and the job that applies it.
+  - default moves back off TRUE: rewrite this patch to pin FALSE against the new default, or drop it
+    if an unpatched binary already covers the legacy renderer.
 
 See .claude/rules/maestro-ui-tests.md for the full mechanism.
 
@@ -20,6 +21,6 @@ diff --git a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/On
 +++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
 @@ -60,3 +60,3 @@ interface OnboardingBrandDesignUpdateToggles {
       */
--    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+-    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
 +    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
      fun configDrivenDialogs(): Toggle

--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
@@ -58,6 +58,6 @@ interface OnboardingBrandDesignUpdateToggles {
     /**
      * Selects the config-driven renderer for the brand-design onboarding dialogs.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun configDrivenDialogs(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1216981414381705?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Changes `configDrivenDialogs` to `TRUE`.

### Steps to test this PR
QA optional.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the default onboarding renderer affects first-run UX for all users; risk is moderated by remote kill-switch and retained legacy-renderer E2E coverage via the source patch.
> 
> **Overview**
> Turns on **config-driven onboarding dialogs** for everyone by changing `onboardingBrandDesignUpdate#configDrivenDialogs` from `INTERNAL` to **`TRUE`**. New installs and users without a remote override now get the config-driven renderer instead of the brand-design update renderer; the legacy renderer remains only when the flag is turned off remotely.
> 
> **Nightly E2E** is adjusted for that default: the separate Maestro suite that re-ran onboarding on an internal binary “for config-driven coverage” is **removed** (unpatched builds already use the config-driven path). The **legacy renderer** job keeps running via the compile-time patch that pins the flag to `FALSE`; it now also runs tests tagged `onboardingTest`, and workflow/patch comments describe TRUE as the new baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c17cebb0aa9f6d628c7ffae0b7848489b760599b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->