### PR TITLE
Cut per-request cost of CNAME detection and Duck Player interception

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayer.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayer.kt
@@ -384,14 +384,16 @@ class RealDuckPlayer @Inject constructor(
             return processDuckPlayerUri(url, webView)
         } else {
             if (!isFeatureEnabled) return null
-            val webViewUrl = withContext(dispatchers.main()) { webView.url }
             if (isYoutubeWatchUrl(url)) {
                 return processYouTubeWatchUri(request, url, webView)
             } else if (isSimulatedYoutubeNoCookie(url)) {
                 return processSimulatedYouTubeNoCookieUri(url, webView)
-            } else if (duckPlayerFeature.addCustomEmbedReferer().isEnabled() && isYouTubeNoCookieEmbedUri(url, webViewUrl)) {
-                return getEmbedWithReferer(request)?.let { inputStream ->
-                    WebResourceResponse("text/html", "UTF-8", inputStream)
+            } else if (isYouTubeNoCookieUri(url) && duckPlayerFeature.addCustomEmbedReferer().isEnabled()) {
+                val webViewUrl = withContext(dispatchers.main()) { webView.url }
+                if (isYouTubeNoCookieEmbedUri(url, webViewUrl)) {
+                    return getEmbedWithReferer(request)?.let { inputStream ->
+                        WebResourceResponse("text/html", "UTF-8", inputStream)
+                    }
                 }
             }
         }

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
@@ -53,6 +53,7 @@ import com.duckduckgo.app.trackerdetection.db.TdsCnameEntityDao
 import com.duckduckgo.app.trackerdetection.db.TdsDomainEntityDao
 import com.duckduckgo.app.trackerdetection.db.TdsEntityDao
 import com.duckduckgo.app.trackerdetection.db.WebTrackersBlockedDao
+import com.duckduckgo.app.trackerdetection.flags.OptimizeCnameDetectionRCWrapper
 import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.FileUtilities
@@ -112,6 +113,9 @@ class DomainsReferenceTest(private val testCase: TestCase) {
     private val mockRequestFilterer: RequestFilterer = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
+    private val cachedCnameLookupEnabled = object : OptimizeCnameDetectionRCWrapper {
+        override val enabled: Boolean = true
+    }
     private val fakeUserAgent: UserAgent = UserAgentFake()
     private val fakeToggle: FeatureToggle = FeatureToggleFake()
     private val fakeUserAllowListRepository = UserAllowListRepositoryFake()
@@ -180,7 +184,12 @@ class DomainsReferenceTest(private val testCase: TestCase) {
             gpc = mockGpc,
             userAgentProvider = userAgentProvider,
             adClickManager = mockAdClickManager,
-            cloakedCnameDetector = CloakedCnameDetectorImpl(tdsCnameEntityDao, mockTrackerAllowlist, mockUserAllowListRepository),
+            cloakedCnameDetector = CloakedCnameDetectorImpl(
+                tdsCnameEntityDao,
+                mockTrackerAllowlist,
+                mockUserAllowListRepository,
+                cachedCnameLookupEnabled,
+            ),
             requestFilterer = mockRequestFilterer,
             requestBlocklist = mockRequestBlocklist,
             contentBlocking = mockContentBlocking,

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/RequestBlocklistReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/RequestBlocklistReferenceTest.kt
@@ -54,6 +54,7 @@ import com.duckduckgo.app.trackerdetection.db.TdsCnameEntityDao
 import com.duckduckgo.app.trackerdetection.db.TdsDomainEntityDao
 import com.duckduckgo.app.trackerdetection.db.TdsEntityDao
 import com.duckduckgo.app.trackerdetection.db.WebTrackersBlockedDao
+import com.duckduckgo.app.trackerdetection.flags.OptimizeCnameDetectionRCWrapper
 import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.FileUtilities
@@ -117,6 +118,9 @@ class RequestBlocklistReferenceTest(private val testCase: TestCase) {
     private lateinit var testee: WebViewRequestInterceptor
 
     private val resourceSurrogates = ResourceSurrogatesImpl()
+    private val cachedCnameLookupEnabled = object : OptimizeCnameDetectionRCWrapper {
+        override val enabled: Boolean = true
+    }
     private var webView: WebView = mock()
     private val userAllowlistDao: UserAllowListDao = mock()
     private val contentBlockingRepository: ContentBlockingRepository = mock()
@@ -220,7 +224,12 @@ class RequestBlocklistReferenceTest(private val testCase: TestCase) {
             gpc = mockGpc,
             userAgentProvider = userAgentProvider,
             adClickManager = mockAdClickManager,
-            cloakedCnameDetector = CloakedCnameDetectorImpl(tdsCnameEntityDao, trackerAllowlist, userAllowListRepository),
+            cloakedCnameDetector = CloakedCnameDetectorImpl(
+                tdsCnameEntityDao,
+                trackerAllowlist,
+                userAllowListRepository,
+                cachedCnameLookupEnabled,
+            ),
             requestFilterer = mockRequestFilterer,
             requestBlocklist = requestBlocklist,
             contentBlocking = contentBlocking,

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/CloakedCnameDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/CloakedCnameDetector.kt
@@ -17,8 +17,10 @@
 package com.duckduckgo.app.trackerdetection
 
 import android.net.Uri
+import androidx.annotation.WorkerThread
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.trackerdetection.db.TdsCnameEntityDao
+import com.duckduckgo.app.trackerdetection.flags.OptimizeCnameDetectionRCWrapper
 import com.duckduckgo.common.utils.UrlScheme
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.config.api.TrackerAllowlist
@@ -32,34 +34,62 @@ interface CloakedCnameDetector {
     fun detectCnameCloakedHost(documentUrl: String?, url: Uri): String?
 }
 
-@ContributesBinding(AppScope::class)
+interface CloakedCnameRefresher {
+    @WorkerThread
+    fun refresh()
+}
+
+@ContributesBinding(AppScope::class, boundType = CloakedCnameDetector::class)
+@ContributesBinding(AppScope::class, boundType = CloakedCnameRefresher::class)
 @SingleInstanceIn(AppScope::class)
 class CloakedCnameDetectorImpl @Inject constructor(
     private val tdsCnameEntityDao: TdsCnameEntityDao,
     private val trackerAllowlist: TrackerAllowlist,
     private val userAllowListRepository: UserAllowListRepository,
-) : CloakedCnameDetector {
+    private val optimizeCnameDetectionRCWrapper: OptimizeCnameDetectionRCWrapper,
+) : CloakedCnameDetector, CloakedCnameRefresher {
+
+    /**
+     * The CNAME table is only rewritten when TDS is downloaded, so it is held in memory and
+     * recomputed on [refresh] rather than queried per request.
+     */
+    @Volatile
+    private var cnames: Map<String, String>? = null
+
+    override fun refresh() {
+        cnames = loadCnames()
+    }
 
     override fun detectCnameCloakedHost(documentUrl: String?, url: Uri): String? {
+        val host = url.host ?: return null
+        val uncloakedHostName = uncloakedHostFor(host) ?: return null
+
         if (documentUrl != null && trackerAllowlist.isAnException(documentUrl, url.toString()) ||
             userAllowListRepository.isUriInUserAllowList(url)
         ) { return null }
 
-        url.host?.let { host ->
-            tdsCnameEntityDao.get(host)?.let { cnameEntity ->
-                var uncloakedHostName = cnameEntity.uncloakedHostName
-                logcat(VERBOSE) { "$host is a CNAME cloaked host. Uncloaked host name: $uncloakedHostName" }
-                url.path?.let { path ->
-                    uncloakedHostName += path
-                }
-                uncloakedHostName = if (url.scheme != null) {
-                    "${url.scheme}://$uncloakedHostName"
-                } else {
-                    "${UrlScheme.http}://$uncloakedHostName"
-                }
-                return uncloakedHostName
-            }
-        }
-        return null
+        logcat(VERBOSE) { "$host is a CNAME cloaked host. Uncloaked host name: $uncloakedHostName" }
+
+        val scheme = url.scheme ?: UrlScheme.http
+        return "$scheme://$uncloakedHostName${url.path.orEmpty()}"
     }
+
+    private fun uncloakedHostFor(host: String): String? {
+        return if (optimizeCnameDetectionRCWrapper.enabled) {
+            activeCnames()[host]
+        } else {
+            tdsCnameEntityDao.get(host)?.uncloakedHostName
+        }
+    }
+
+    private fun activeCnames(): Map<String, String> {
+        cnames?.let { return it }
+        return synchronized(this) {
+            cnames ?: loadCnames().also { cnames = it }
+        }
+    }
+
+    @WorkerThread
+    private fun loadCnames(): Map<String, String> =
+        tdsCnameEntityDao.getAll().associate { it.cloakedHostName to it.uncloakedHostName }
 }

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDataLoader.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDataLoader.kt
@@ -66,6 +66,7 @@ class TrackerDataLoader @Inject constructor(
     private val moshi: Moshi,
     private val urlToTypeMapper: UrlToTypeMapper,
     private val entityLookupRefresher: EntityLookupRefresher,
+    private val cloakedCnameRefresher: CloakedCnameRefresher,
     private val dispatcherProvider: DispatcherProvider,
     private val optimizeTrackerEvaluationRCWrapper: OptimizeTrackerEvaluationRCWrapper,
     private val precompileTdsRegexRCWrapper: PrecompileTdsRegexRCWrapper,
@@ -129,6 +130,7 @@ class TrackerDataLoader @Inject constructor(
         )
         trackerDetectorClientProvider.addClient(client)
         entityLookupRefresher.refresh()
+        cloakedCnameRefresher.refresh()
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/flags/OptimizeCnameDetectionFeatures.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/flags/OptimizeCnameDetectionFeatures.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.trackerdetection.flags
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "optimizeCnameDetection",
+)
+interface OptimizeCnameDetectionFeatures {
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun self(): Toggle
+
+    /**
+     * Resolve CNAME cloaked hosts from an in-memory map rebuilt when TDS is downloaded, rather than
+     * running a Room query against tds_cname_entity on every intercepted request.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun cacheCnamesInMemory(): Toggle
+}

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/flags/OptimizeCnameDetectionRCWrapper.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/flags/OptimizeCnameDetectionRCWrapper.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.trackerdetection.flags
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface OptimizeCnameDetectionRCWrapper {
+    val enabled: Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class RealOptimizeCnameDetectionRCWrapper @Inject constructor(
+    private val optimizeCnameDetectionFeatures: OptimizeCnameDetectionFeatures,
+) : OptimizeCnameDetectionRCWrapper {
+    override val enabled by lazy { optimizeCnameDetectionFeatures.cacheCnamesInMemory().isEnabled() }
+}

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/CloakedCnameDetectorImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/CloakedCnameDetectorImplTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.trackerdetection
 import android.net.Uri
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.trackerdetection.db.TdsCnameEntityDao
+import com.duckduckgo.app.trackerdetection.flags.OptimizeCnameDetectionRCWrapper
 import com.duckduckgo.app.trackerdetection.model.TdsCnameEntity
 import com.duckduckgo.privacy.config.api.TrackerAllowlist
 import junit.framework.TestCase.assertEquals
@@ -28,6 +29,9 @@ import org.junit.Test
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 class CloakedCnameDetectorImplTest {
@@ -37,10 +41,17 @@ class CloakedCnameDetectorImplTest {
     private val mockTrackerAllowList: TrackerAllowlist = mock()
     private val mockUri: Uri = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
+    private val mockOptimizeCnameDetectionRCWrapper: OptimizeCnameDetectionRCWrapper = mock()
 
     @Before
     fun setup() {
-        testee = CloakedCnameDetectorImpl(mockCnameEntityDao, mockTrackerAllowList, mockUserAllowListRepository)
+        whenever(mockOptimizeCnameDetectionRCWrapper.enabled).thenReturn(true)
+        testee = CloakedCnameDetectorImpl(
+            mockCnameEntityDao,
+            mockTrackerAllowList,
+            mockUserAllowListRepository,
+            mockOptimizeCnameDetectionRCWrapper,
+        )
     }
 
     @Test
@@ -52,7 +63,7 @@ class CloakedCnameDetectorImplTest {
     @Test
     fun whenDetectCnameAndCnameDetectedThenReturnUncloakedHost() {
         whenever(mockUri.host).thenReturn("host.com")
-        whenever(mockCnameEntityDao.get(any())).thenReturn(TdsCnameEntity("host.com", "uncloaked-host.com"))
+        whenever(mockCnameEntityDao.getAll()).thenReturn(listOf(TdsCnameEntity("host.com", "uncloaked-host.com")))
         assertEquals("http://uncloaked-host.com", testee.detectCnameCloakedHost("foo.com", mockUri))
     }
 
@@ -60,14 +71,14 @@ class CloakedCnameDetectorImplTest {
     fun whenDetectCnameAndCnameDetectedAndHasSchemeThenReturnUncloakedHostWithScheme() {
         whenever(mockUri.host).thenReturn("host.com")
         whenever(mockUri.scheme).thenReturn("https")
-        whenever(mockCnameEntityDao.get(any())).thenReturn(TdsCnameEntity("host.com", "uncloaked-host.com"))
+        whenever(mockCnameEntityDao.getAll()).thenReturn(listOf(TdsCnameEntity("host.com", "uncloaked-host.com")))
         assertEquals("https://uncloaked-host.com", testee.detectCnameCloakedHost("foo.com", mockUri))
     }
 
     @Test
     fun whenDetectCnameAndCnameNotDetectedThenReturnNull() {
         whenever(mockUri.host).thenReturn("host.com")
-        whenever(mockCnameEntityDao.get(any())).thenReturn(null)
+        whenever(mockCnameEntityDao.getAll()).thenReturn(emptyList())
         assertEquals(null, testee.detectCnameCloakedHost("foo.com", mockUri))
     }
 
@@ -75,7 +86,7 @@ class CloakedCnameDetectorImplTest {
     fun whenDetectCnameAndCnameDetectedAndHasPathThenReturnUncloakedHostWithPathAppended() {
         whenever(mockUri.host).thenReturn("host.com")
         whenever(mockUri.path).thenReturn("/path")
-        whenever(mockCnameEntityDao.get(any())).thenReturn(TdsCnameEntity("host.com", "uncloaked-host.com"))
+        whenever(mockCnameEntityDao.getAll()).thenReturn(listOf(TdsCnameEntity("host.com", "uncloaked-host.com")))
         assertEquals("http://uncloaked-host.com/path", testee.detectCnameCloakedHost("foo.com", mockUri))
     }
 
@@ -84,19 +95,69 @@ class CloakedCnameDetectorImplTest {
         whenever(mockUri.host).thenReturn("host.com")
         whenever(mockUri.path).thenReturn("/path")
         whenever(mockUri.scheme).thenReturn("https")
-        whenever(mockCnameEntityDao.get(any())).thenReturn(TdsCnameEntity("host.com", "uncloaked-host.com"))
+        whenever(mockCnameEntityDao.getAll()).thenReturn(listOf(TdsCnameEntity("host.com", "uncloaked-host.com")))
         assertEquals("https://uncloaked-host.com/path", testee.detectCnameCloakedHost("foo.com", mockUri))
     }
 
     @Test
     fun whenRequestUrlIsInAllowListThenReturnNull() {
+        whenever(mockUri.host).thenReturn("host.com")
+        whenever(mockCnameEntityDao.getAll()).thenReturn(listOf(TdsCnameEntity("host.com", "uncloaked-host.com")))
         whenever(mockTrackerAllowList.isAnException(anyString(), anyString())).thenReturn(true)
         assertEquals(null, testee.detectCnameCloakedHost("foo.com", mockUri))
     }
 
     @Test
     fun whenDetectCnameCloakedHostAndUrlIsInUserAllowListThenReturnNull() {
+        whenever(mockUri.host).thenReturn("host.com")
+        whenever(mockCnameEntityDao.getAll()).thenReturn(listOf(TdsCnameEntity("host.com", "uncloaked-host.com")))
         whenever(mockUserAllowListRepository.isUriInUserAllowList(any())).thenReturn(true)
         assertNull(testee.detectCnameCloakedHost("foo.com", mockUri))
+    }
+
+    @Test
+    fun whenHostIsNotCloakedThenAllowlistsAreNotEvaluated() {
+        whenever(mockUri.host).thenReturn("host.com")
+        whenever(mockCnameEntityDao.getAll()).thenReturn(listOf(TdsCnameEntity("other-host.com", "uncloaked-host.com")))
+
+        assertNull(testee.detectCnameCloakedHost("foo.com", mockUri))
+
+        verifyNoInteractions(mockTrackerAllowList)
+        verifyNoInteractions(mockUserAllowListRepository)
+    }
+
+    @Test
+    fun whenDetectCnameRepeatedlyThenCnameTableIsReadOnce() {
+        whenever(mockUri.host).thenReturn("host.com")
+        whenever(mockCnameEntityDao.getAll()).thenReturn(listOf(TdsCnameEntity("host.com", "uncloaked-host.com")))
+
+        testee.detectCnameCloakedHost("foo.com", mockUri)
+        testee.detectCnameCloakedHost("foo.com", mockUri)
+
+        verify(mockCnameEntityDao).getAll()
+        verify(mockCnameEntityDao, never()).get(anyString())
+    }
+
+    @Test
+    fun whenRefreshedThenSubsequentDetectionUsesTheNewCnameTable() {
+        whenever(mockUri.host).thenReturn("host.com")
+        whenever(mockCnameEntityDao.getAll()).thenReturn(emptyList())
+        assertNull(testee.detectCnameCloakedHost("foo.com", mockUri))
+
+        whenever(mockCnameEntityDao.getAll()).thenReturn(listOf(TdsCnameEntity("host.com", "uncloaked-host.com")))
+        (testee as CloakedCnameRefresher).refresh()
+
+        assertEquals("http://uncloaked-host.com", testee.detectCnameCloakedHost("foo.com", mockUri))
+    }
+
+    @Test
+    fun whenCacheIsDisabledThenCnameIsResolvedFromTheDao() {
+        whenever(mockOptimizeCnameDetectionRCWrapper.enabled).thenReturn(false)
+        whenever(mockUri.host).thenReturn("host.com")
+        whenever(mockCnameEntityDao.get(any())).thenReturn(TdsCnameEntity("host.com", "uncloaked-host.com"))
+
+        assertEquals("http://uncloaked-host.com", testee.detectCnameCloakedHost("foo.com", mockUri))
+
+        verify(mockCnameEntityDao, never()).getAll()
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDataLoaderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDataLoaderTest.kt
@@ -65,6 +65,7 @@ class TrackerDataLoaderTest {
     private val mockAppDatabase: AppDatabase = mock()
     private val mockUrlToTypeMapper: UrlToTypeMapper = mock()
     private val mockEntityLookupRefresher: EntityLookupRefresher = mock()
+    private val mockCloakedCnameRefresher: CloakedCnameRefresher = mock()
 
     private val runnableCaptor = argumentCaptor<Runnable>()
     private val tdsMetaDataCaptor = argumentCaptor<TdsMetadata>()
@@ -84,6 +85,7 @@ class TrackerDataLoaderTest {
             moshi = Moshi.Builder().build(),
             urlToTypeMapper = mockUrlToTypeMapper,
             entityLookupRefresher = mockEntityLookupRefresher,
+            cloakedCnameRefresher = mockCloakedCnameRefresher,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             optimizeTrackerEvaluationRCWrapper = object : OptimizeTrackerEvaluationRCWrapper {
                 override val enabled: Boolean
@@ -116,5 +118,12 @@ class TrackerDataLoaderTest {
         verify(mockTdsDomainEntityDao).updateAll(tdsJson.jsonToDomainEntities())
         verify(mockTdsTrackerDao).updateAll(tdsJson.jsonToTrackers().values)
         verify(mockTdsCnameEntityDao).updateAll(tdsJson.jsonToCnameEntities())
+    }
+
+    @Test
+    fun whenLoadTrackersThenCnameCacheIsRefreshed() {
+        testee.loadTrackers()
+
+        verify(mockCloakedCnameRefresher).refresh()
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214749231578703/task/1217247690319342
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
CloakedCnameDetectorImpl ran a Room SELECT against tds_cname_entity on every intercepted request, preceded by a full trackerAllowlist.isAnException evaluation that TrackerDetectorImpl had already performed for the same URL pair. The table is only rewritten on TDS download, so it is now held in memory and rebuilt from TrackerDataLoader.loadTrackers(), which covers both startup and post-download refresh. The host lookup also moves ahead of the allowlist checks, so those only run for hosts that are actually cloaked. The in-memory path is behind the optimizeCnameDetection.cacheCnamesInMemory toggle.

RealDuckPlayer.intercept read webView.url through the main dispatcher for every non-duck:// URL, but only the YouTube-nocookie embed branch uses it. That read now happens inside the branch, behind the cheap isYouTubeNoCookieUri check, so ordinary subresources no longer hop to the main thread.


### Steps to test this PR
No behavior change is expected.

To test the cname cloacking:

- Visit dell.com
- Check 3rd party requests blocked.
- sm.dell.com is there (with and without the flag enabled).
- sm.dell.com shares the same dell domain, but is cloaked and reroutes to dell.com.ssl.d1.sc.omtrdc.net according to our tracker detection list.
- No other behavior change is expected.

### UI changes
None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the hot path for tracker/CNAME detection and Duck Player interception; correctness depends on cache refresh staying aligned with TDS updates, though the flag preserves the old DAO-per-request path.
> 
> **Overview**
> Reduces per-request work on the WebView interception path in two places, with no intended behavior change when toggles match prior defaults.
> 
> **CNAME cloaking** — `CloakedCnameDetectorImpl` no longer runs a Room `get(host)` on every intercepted request. When `optimizeCnameDetection.cacheCnamesInMemory` is on, cloaked hosts are resolved from an in-memory map loaded via `getAll()` and rebuilt when `TrackerDataLoader.loadTrackers()` runs (startup and after TDS updates). Allowlist and user-allowlist checks now run only after a host is known to be cloaked, skipping redundant work for non-cloaked hosts.
> 
> **Duck Player** — `RealDuckPlayer.intercept` no longer reads `webView.url` on the main dispatcher for every non-`duck://` URL. That read is deferred to the YouTube-nocookie embed + custom referer branch, after a cheap `isYouTubeNoCookieUri` check, so typical subresources avoid a main-thread hop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6d7b2562f94bfdfefcc5947bc37df8ed087d566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->