### PR TITLE
RMF: maxImpressions display condition

### DIFF
--- a/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
+++ b/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
@@ -54,6 +54,7 @@ enum class Surface(val jsonValue: String) {
 data class DisplayConditions(
     val trigger: MessageTrigger?,
     val dismissAfterDaysShown: Int?,
+    val maxImpressions: Int? = null,
 )
 
 /**

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
@@ -135,7 +135,7 @@ class AppRemoteMessagingRepository(
     }
 
     private fun dismissMessageSilently(id: String) {
-        //TODO add pixel for dismiss silently
+        // TODO add pixel for dismiss silently
         remoteMessagesDao.updateState(id, Status.DISMISSED)
         remoteMessagingConfigRepository.invalidate()
     }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
@@ -80,6 +80,7 @@ class AppRemoteMessagingRepository(
             messageEntity.copy(
                 shown = true,
                 firstShownDate = messageEntity.firstShownDate ?: currentTimeProvider.currentTimeMillis(),
+                impressions = messageEntity.impressions + 1,
             ),
         )
     }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
@@ -27,7 +27,7 @@ import com.duckduckgo.remote.messaging.store.RemoteMessageEntity.Status.SCHEDULE
 import com.duckduckgo.remote.messaging.store.RemoteMessagesDao
 import com.duckduckgo.remote.messaging.store.RemoteMessagingConfigRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.map
 import java.util.concurrent.TimeUnit
 
@@ -90,32 +90,37 @@ class AppRemoteMessagingRepository(
         if (messageEntity == null || messageEntity.message.isEmpty()) return null
 
         val remoteMessage = messageMapper.fromMessage(messageEntity.message) ?: return null
-        if (remoteMessage.isExpired(messageEntity.firstShownDate)) {
-            dismissExpiredMessage(messageEntity.id)
+        if (remoteMessage.shouldBeDismissed(messageEntity)) {
+            dismissMessageSilently(messageEntity.id)
             return null
         }
         return remoteMessage
     }
 
     override fun messageFlow(): Flow<RemoteMessage?> {
-        return remoteMessagesDao.messagesFlow().distinctUntilChanged().map { messageEntity ->
-            if (messageEntity == null || messageEntity.message.isEmpty()) return@map null
+        return remoteMessagesDao.messagesFlow()
+            .distinctUntilChangedBy { it?.id to it?.message }
+            .map { messageEntity ->
+                if (messageEntity == null || messageEntity.message.isEmpty()) return@map null
 
-            val remoteMessage = messageMapper.fromMessage(messageEntity.message) ?: return@map null
-            if (remoteMessage.isExpired(messageEntity.firstShownDate)) {
-                dismissExpiredMessage(messageEntity.id)
-                return@map null
+                val remoteMessage = messageMapper.fromMessage(messageEntity.message) ?: return@map null
+                if (remoteMessage.shouldBeDismissed(messageEntity)) {
+                    dismissMessageSilently(messageEntity.id)
+                    return@map null
+                }
+                RemoteMessage(
+                    id = messageEntity.id,
+                    content = remoteMessage.content,
+                    emptyList(),
+                    emptyList(),
+                    remoteMessage.surfaces,
+                    remoteMessage.displayConditions,
+                )
             }
-            RemoteMessage(
-                id = messageEntity.id,
-                content = remoteMessage.content,
-                emptyList(),
-                emptyList(),
-                remoteMessage.surfaces,
-                remoteMessage.displayConditions,
-            )
-        }
     }
+
+    private fun RemoteMessage.shouldBeDismissed(entity: RemoteMessageEntity): Boolean =
+        isExpired(entity.firstShownDate) || hasReachedImpressionCap(entity.impressions)
 
     private fun RemoteMessage.isExpired(firstShownDate: Long?): Boolean {
         val threshold = displayConditions?.dismissAfterDaysShown?.takeIf { it > 0 } ?: return false
@@ -124,7 +129,13 @@ class AppRemoteMessagingRepository(
         return elapsedDays >= threshold
     }
 
-    private fun dismissExpiredMessage(id: String) {
+    private fun RemoteMessage.hasReachedImpressionCap(impressions: Int): Boolean {
+        val cap = displayConditions?.maxImpressions?.takeIf { it > 0 } ?: return false
+        return impressions >= cap
+    }
+
+    private fun dismissMessageSilently(id: String) {
+        //TODO add pixel for dismiss silently
         remoteMessagesDao.updateState(id, Status.DISMISSED)
         remoteMessagingConfigRepository.invalidate()
     }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonRemoteMessageMapper.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonRemoteMessageMapper.kt
@@ -193,8 +193,10 @@ private fun List<String>?.toSurfaceList(): List<Surface> {
     } ?: listOf(Surface.NEW_TAB_PAGE)
 }
 
-// Returns null when a trigger string is present but unrecognized, so the caller can drop the
-// message (forward-compat). A null trigger is valid and means "no trigger" (unrestricted).
+// An unrecognized trigger is the only condition that drops the message, because it means the
+// message targets a context this client version doesn't understand. Every other condition fails
+// open: only one message is scheduled at a time, so a bad value must not hold that slot with
+// something permanently invisible.
 private fun JsonDisplayConditions.toDisplayConditionsOrNull(): DisplayConditions? {
     val resolvedTrigger = if (trigger == null) {
         null
@@ -204,6 +206,7 @@ private fun JsonDisplayConditions.toDisplayConditionsOrNull(): DisplayConditions
     return DisplayConditions(
         trigger = resolvedTrigger,
         dismissAfterDaysShown = dismissAfterDaysShown,
+        maxImpressions = maxImpressions?.takeIf { it > 0 },
     )
 }
 

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/models/JsonRemoteMessagingConfig.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/models/JsonRemoteMessagingConfig.kt
@@ -38,6 +38,7 @@ data class JsonRemoteMessage(
 data class JsonDisplayConditions(
     val trigger: String? = null,
     val dismissAfterDaysShown: Int? = null,
+    val maxImpressions: Int? = null,
 )
 
 data class JsonContent(

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
@@ -491,6 +491,35 @@ class AppRemoteMessagingRepositoryTest {
     }
 
     @Test
+    fun whenMarkAsShownThenImpressionsCounted() {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1000L)
+        testee.activeMessage(aRemoteMessage("id"))
+        assertEquals(0, dao.messagesById("id")?.impressions)
+
+        testee.markAsShown(aRemoteMessage("id"))
+        assertEquals(1, dao.messagesById("id")?.impressions)
+
+        testee.markAsShown(aRemoteMessage("id"))
+        assertEquals(2, dao.messagesById("id")?.impressions)
+    }
+
+    @Test
+    fun whenSameMessageRescheduledThenImpressionCountPreserved() {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1000L)
+        testee.activeMessage(aRemoteMessage("id"))
+        testee.markAsShown(aRemoteMessage("id"))
+        testee.markAsShown(aRemoteMessage("id"))
+
+        // a config re-push updates the row rather than replacing it, so the count is lifetime
+        testee.activeMessage(aRemoteMessage("id"))
+        assertEquals(2, dao.messagesById("id")?.impressions)
+
+        testee.activeMessage(aRemoteMessage("otherId"))
+        testee.activeMessage(aRemoteMessage("id"))
+        assertEquals(2, dao.messagesById("id")?.impressions)
+    }
+
+    @Test
     fun whenExpiryThresholdReachedThenMessageDismissedAndConfigInvalidated() = runTest {
         whenever(currentTimeProvider.currentTimeMillis()).thenReturn(0L, TimeUnit.DAYS.toMillis(5))
         testee.activeMessage(aRemoteMessageWithDisplayConditions("id", DisplayConditions(trigger = null, dismissAfterDaysShown = 5)))

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
@@ -37,9 +37,12 @@ import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.Surface
 import com.duckduckgo.remote.messaging.fixtures.getMessageMapper
 import com.duckduckgo.remote.messaging.impl.store.RemoteMessageImageStore
+import com.duckduckgo.remote.messaging.store.RemoteMessageEntity
 import com.duckduckgo.remote.messaging.store.RemoteMessageEntity.Status
+import com.duckduckgo.remote.messaging.store.RemoteMessagesDao
 import com.duckduckgo.remote.messaging.store.RemoteMessagingConfigRepository
 import com.duckduckgo.remote.messaging.store.RemoteMessagingDatabase
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -568,6 +571,170 @@ class AppRemoteMessagingRepositoryTest {
     }
 
     @Test
+    fun whenImpressionsBelowCapThenMessageReturned() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1000L)
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", displayConditions(maxImpressions = 3)))
+
+        testee.markAsShown(aRemoteMessage("id"))
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertEquals("id", testee.message()?.id)
+        assertEquals(Status.SCHEDULED, dao.messagesById("id")?.status)
+    }
+
+    @Test
+    fun whenImpressionCapReachedThenMessageDismissedAndConfigInvalidated() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1000L)
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", displayConditions(maxImpressions = 2)))
+
+        testee.markAsShown(aRemoteMessage("id"))
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertNull(testee.message())
+        assertEquals(Status.DISMISSED, dao.messagesById("id")?.status)
+        // mirrors dismissMessage(): invalidate so the next eligible message is scheduled
+        verify(remoteMessagingConfigRepository).invalidate()
+    }
+
+    @Test
+    fun whenImpressionCapIsZeroThenMessageNeverCapped() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1000L)
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", displayConditions(maxImpressions = 0)))
+
+        repeat(10) { testee.markAsShown(aRemoteMessage("id")) }
+
+        assertEquals("id", testee.message()?.id)
+    }
+
+    @Test
+    fun whenImpressionCapIsNegativeThenMessageNeverCapped() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1000L)
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", displayConditions(maxImpressions = -1)))
+
+        repeat(10) { testee.markAsShown(aRemoteMessage("id")) }
+
+        assertEquals("id", testee.message()?.id)
+    }
+
+    @Test
+    fun whenNoImpressionCapConfiguredThenMessageNeverCapped() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1000L)
+        testee.activeMessage(aRemoteMessage("id"))
+
+        repeat(100) { testee.markAsShown(aRemoteMessage("id")) }
+
+        assertEquals("id", testee.message()?.id)
+    }
+
+    @Test
+    fun whenExpiryReachedBeforeImpressionCapThenMessageDismissed() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(0L, TimeUnit.DAYS.toMillis(5))
+        testee.activeMessage(
+            aRemoteMessageWithDisplayConditions("id", DisplayConditions(trigger = null, dismissAfterDaysShown = 5, maxImpressions = 99)),
+        )
+
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertNull(testee.message())
+        assertEquals(Status.DISMISSED, dao.messagesById("id")?.status)
+    }
+
+    @Test
+    fun whenImpressionCapReachedBeforeExpiryThenMessageDismissed() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(0L, 0L, TimeUnit.DAYS.toMillis(1))
+        testee.activeMessage(
+            aRemoteMessageWithDisplayConditions("id", DisplayConditions(trigger = null, dismissAfterDaysShown = 99, maxImpressions = 2)),
+        )
+
+        testee.markAsShown(aRemoteMessage("id"))
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertNull(testee.message())
+        assertEquals(Status.DISMISSED, dao.messagesById("id")?.status)
+    }
+
+    @Test
+    fun whenOnlyImpressionTrackingChangesThenVisibleMessageIsNotWithdrawnFromOngoingCollection() = runTest {
+        // feeds the row states Room would emit as impressions are recorded, so the assertion does
+        // not depend on when the invalidation tracker delivers them
+        val testee = repositoryObserving(
+            storedEntity(maxImpressions = 2),
+            storedEntity(maxImpressions = 2).copy(shown = true, firstShownDate = 1000L, impressions = 1),
+            storedEntity(maxImpressions = 2).copy(shown = true, firstShownDate = 1000L, impressions = 2),
+        )
+
+        testee.messageFlow().test {
+            assertEquals("id", awaitItem()?.id)
+            // counting an impression must not emit, or the card would vanish as it is being shown
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun whenCapIsOneThenMessageIsNotWithdrawnByItsOwnFirstImpression() = runTest {
+        val testee = repositoryObserving(
+            storedEntity(maxImpressions = 1),
+            // the first impression also flips shown and stamps firstShownDate
+            storedEntity(maxImpressions = 1).copy(shown = true, firstShownDate = 1000L, impressions = 1),
+        )
+
+        testee.messageFlow().test {
+            assertEquals("id", awaitItem()?.id)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun whenScheduledMessageChangesThenFlowStillEmits() = runTest {
+        val testee = repositoryObserving(
+            storedEntity(maxImpressions = 2),
+            storedEntity(maxImpressions = 2, id = "otherId").copy(shown = true, firstShownDate = 1000L, impressions = 1),
+        )
+
+        testee.messageFlow().test {
+            assertEquals("id", awaitItem()?.id)
+            // only the impression-tracking columns are ignored; a different message must get through
+            assertEquals("otherId", awaitItem()?.id)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun whenCappedMessageCollectedAfreshThenNullEmitted() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1000L)
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", displayConditions(maxImpressions = 1)))
+        testee.markAsShown(aRemoteMessage("id"))
+
+        testee.messageFlow().test {
+            assertNull(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(Status.DISMISSED, dao.messagesById("id")?.status)
+    }
+
+    private fun storedEntity(
+        maxImpressions: Int,
+        id: String = "id",
+    ) = RemoteMessageEntity(
+        id = id,
+        message = getMessageMapper().toString(aRemoteMessageWithDisplayConditions(id, displayConditions(maxImpressions))),
+        status = Status.SCHEDULED,
+    )
+
+    private fun repositoryObserving(vararg emissions: RemoteMessageEntity): AppRemoteMessagingRepository {
+        val fakeDao: RemoteMessagesDao = mock<RemoteMessagesDao>().apply {
+            whenever(this.messagesFlow()).thenReturn(flowOf(*emissions))
+        }
+        return AppRemoteMessagingRepository(
+            remoteMessagingConfigRepository,
+            fakeDao,
+            getMessageMapper(),
+            remoteMessageImageStore,
+            currentTimeProvider,
+        )
+    }
+
+    @Test
     fun whenMessageHasDisplayConditionsThenStoredAndReadBackIntact() = runTest {
         val conditions = DisplayConditions(trigger = MessageTrigger.AFTER_IDLE, dismissAfterDaysShown = 5)
         testee.activeMessage(aRemoteMessageWithDisplayConditions("id", conditions))
@@ -596,5 +763,11 @@ class AppRemoteMessagingRepositoryTest {
             id: String,
             displayConditions: DisplayConditions,
         ) = aRemoteMessage(id).copy(displayConditions = displayConditions)
+
+        fun displayConditions(maxImpressions: Int) = DisplayConditions(
+            trigger = null,
+            dismissAfterDaysShown = null,
+            maxImpressions = maxImpressions,
+        )
     }
 }

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/JsonRemoteMessageDisplayConditionsTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/JsonRemoteMessageDisplayConditionsTest.kt
@@ -81,4 +81,69 @@ class JsonRemoteMessageDisplayConditionsTest {
 
         assertNull(mapped.single().displayConditions)
     }
+
+    @Test
+    fun whenMaxImpressionsPresentThenParsed() {
+        val conditions = displayConditionsOf(JsonDisplayConditions(maxImpressions = 3))
+
+        assertEquals(3, conditions?.maxImpressions)
+    }
+
+    @Test
+    fun whenMaxImpressionsAbsentThenNull() {
+        val conditions = displayConditionsOf(JsonDisplayConditions(dismissAfterDaysShown = 5))
+
+        assertNull(conditions?.maxImpressions)
+    }
+
+    @Test
+    fun whenMaxImpressionsIsZeroThenNull() {
+        val conditions = displayConditionsOf(JsonDisplayConditions(maxImpressions = 0))
+
+        assertNull(conditions?.maxImpressions)
+    }
+
+    @Test
+    fun whenMaxImpressionsIsNegativeThenNull() {
+        val conditions = displayConditionsOf(JsonDisplayConditions(maxImpressions = -1))
+
+        assertNull(conditions?.maxImpressions)
+    }
+
+    @Test
+    fun whenMaxImpressionsCombinedWithTriggerAndExpiryThenAllParsed() {
+        val conditions = displayConditionsOf(
+            JsonDisplayConditions(
+                trigger = "after_idle",
+                dismissAfterDaysShown = 5,
+                maxImpressions = 3,
+            ),
+        )
+
+        assertEquals(MessageTrigger.AFTER_IDLE, conditions?.trigger)
+        assertEquals(5, conditions?.dismissAfterDaysShown)
+        assertEquals(3, conditions?.maxImpressions)
+    }
+
+    @Test
+    fun whenTriggerUnrecognizedThenMessageDroppedEvenWithValidMaxImpressions() {
+        val mapped = listOf(
+            aJsonMessage(
+                id = "id",
+                content = smallJsonContent(),
+                displayConditions = JsonDisplayConditions(
+                    trigger = "some_future_trigger",
+                    maxImpressions = 3,
+                ),
+            ),
+        ).mapToRemoteMessage(Locale.US, messageActionPlugins)
+
+        assertTrue(mapped.isEmpty())
+    }
+
+    private fun displayConditionsOf(conditions: JsonDisplayConditions) =
+        listOf(aJsonMessage(id = "id", content = smallJsonContent(), displayConditions = conditions))
+            .mapToRemoteMessage(Locale.US, messageActionPlugins)
+            .single()
+            .displayConditions
 }

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingConfigJsonMapperTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingConfigJsonMapperTest.kt
@@ -28,6 +28,8 @@ import com.duckduckgo.remote.messaging.api.Content
 import com.duckduckgo.remote.messaging.api.Content.Placeholder.ANNOUNCE
 import com.duckduckgo.remote.messaging.api.Content.Placeholder.APP_UPDATE
 import com.duckduckgo.remote.messaging.api.Content.Placeholder.CRITICAL_UPDATE
+import com.duckduckgo.remote.messaging.api.DisplayConditions
+import com.duckduckgo.remote.messaging.api.MessageTrigger.AFTER_IDLE
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.Surface.MODAL
 import com.duckduckgo.remote.messaging.api.Surface.NEW_TAB_PAGE
@@ -350,6 +352,26 @@ class RemoteMessagingConfigJsonMapperTest {
             surfaces = listOf(NEW_TAB_PAGE),
         )
         assertEquals(bigSingleActionMessage, config.messages[0])
+    }
+
+    @Test
+    fun whenJsonHasDisplayConditionsThenMappedIntoRemoteConfig() = runTest {
+        fakeFeatureToggles.remoteMessageModalSurface().setRawStoredState(State(enable = false))
+        val result = getConfigFromJson("json/remote_messaging_config_display_conditions.json")
+
+        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, jsonMatchingAttributeMappers, messageActionPlugins, fakeFeatureToggles)
+
+        val config = testee.map(result)
+
+        assertEquals(2, config.messages.size)
+        assertEquals(
+            DisplayConditions(trigger = AFTER_IDLE, dismissAfterDaysShown = 5, maxImpressions = 3),
+            config.messages[0].displayConditions,
+        )
+        assertEquals(
+            DisplayConditions(trigger = null, dismissAfterDaysShown = null, maxImpressions = 1),
+            config.messages[1].displayConditions,
+        )
     }
 
     private fun getConfigFromJson(resourceName: String): JsonRemoteMessagingConfig {

--- a/remote-messaging/remote-messaging-impl/src/test/resources/json/remote_messaging_config_display_conditions.json
+++ b/remote-messaging/remote-messaging-impl/src/test/resources/json/remote_messaging_config_display_conditions.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "messages": [
+    {
+      "id": "message-with-display-conditions",
+      "content": {
+        "messageType": "small",
+        "titleText": "title",
+        "descriptionText": "description"
+      },
+      "displayConditions": {
+        "trigger": "after_idle",
+        "dismissAfterDaysShown": 5,
+        "maxImpressions": 3
+      },
+      "translations": {}
+    },
+    {
+      "id": "message-with-only-max-impressions",
+      "content": {
+        "messageType": "small",
+        "titleText": "title",
+        "descriptionText": "description"
+      },
+      "displayConditions": {
+        "maxImpressions": 1
+      },
+      "translations": {}
+    }
+  ],
+  "rules": []
+}

--- a/remote-messaging/remote-messaging-store/schemas/com.duckduckgo.remote.messaging.store.RemoteMessagingDatabase/4.json
+++ b/remote-messaging/remote-messaging-store/schemas/com.duckduckgo.remote.messaging.store.RemoteMessagingDatabase/4.json
@@ -1,0 +1,120 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "f9f73d445c930704983f427c6afc7ac3",
+    "entities": [
+      {
+        "tableName": "remote_messaging",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `version` INTEGER NOT NULL, `invalidate` INTEGER NOT NULL, `evaluationTimestamp` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "invalidate",
+            "columnName": "invalidate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "evaluationTimestamp",
+            "columnName": "evaluationTimestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `message` TEXT NOT NULL, `status` TEXT NOT NULL, `shown` INTEGER NOT NULL, `firstShownDate` INTEGER, `impressions` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shown",
+            "columnName": "shown",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstShownDate",
+            "columnName": "firstShownDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "impressions",
+            "columnName": "impressions",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_messaging_cohort",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `percentile` REAL NOT NULL, PRIMARY KEY(`messageId`))",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percentile",
+            "columnName": "percentile",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "messageId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f9f73d445c930704983f427c6afc7ac3')"
+    ]
+  }
+}

--- a/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/RemoteMessageEntity.kt
+++ b/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/RemoteMessageEntity.kt
@@ -26,6 +26,7 @@ data class RemoteMessageEntity(
     val status: Status,
     val shown: Boolean = false,
     val firstShownDate: Long? = null,
+    val impressions: Int = 0,
 ) {
     enum class Status {
         SCHEDULED,

--- a/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/RemoteMessagingDatabase.kt
+++ b/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/RemoteMessagingDatabase.kt
@@ -23,7 +23,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     exportSchema = true,
-    version = 3,
+    version = 4,
     entities = [
         RemoteMessagingConfig::class,
         RemoteMessageEntity::class,
@@ -53,7 +53,12 @@ abstract class RemoteMessagingDatabase : RoomDatabase() {
                 db.execSQL("ALTER TABLE `remote_message` ADD COLUMN `firstShownDate` INTEGER")
             }
         }
+        private val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `remote_message` ADD COLUMN `impressions` INTEGER NOT NULL DEFAULT 0")
+            }
+        }
         val ALL_MIGRATIONS: Array<Migration>
-            get() = arrayOf(MIGRATION_1_2, MIGRATION_2_3)
+            get() = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
     }
 }

--- a/remote-messaging/remote-messaging-store/src/test/java/com/duckduckgo/remote/messaging/store/RemoteMessagingDatabaseMigrationTest.kt
+++ b/remote-messaging/remote-messaging-store/src/test/java/com/duckduckgo/remote/messaging/store/RemoteMessagingDatabaseMigrationTest.kt
@@ -59,6 +59,32 @@ class RemoteMessagingDatabaseMigrationTest {
     }
 
     @Test
+    fun whenMigratingFromV3ToV4ThenImpressionsAddedAsZeroAndExistingRowPreserved() {
+        testHelper.createDatabase(TEST_DB_NAME, 3).apply {
+            execSQL(
+                "INSERT INTO remote_message (id, message, status, shown, firstShownDate) " +
+                    "VALUES ('id1', '{}', 'SCHEDULED', 1, 1234)",
+            )
+            close()
+        }
+
+        testHelper.runMigrationsAndValidate(TEST_DB_NAME, 4, true, *RemoteMessagingDatabase.ALL_MIGRATIONS).apply {
+            val cursor = query(
+                "SELECT message, status, shown, firstShownDate, impressions FROM remote_message WHERE id = 'id1'",
+            )
+            cursor.moveToFirst()
+            assertEquals("{}", cursor.getString(cursor.getColumnIndexOrThrow("message")))
+            assertEquals("SCHEDULED", cursor.getString(cursor.getColumnIndexOrThrow("status")))
+            assertEquals(1, cursor.getInt(cursor.getColumnIndexOrThrow("shown")))
+            assertEquals(1234, cursor.getLong(cursor.getColumnIndexOrThrow("firstShownDate")))
+            // a message shown before the migration starts counting from zero rather than arriving pre-capped
+            assertEquals(0, cursor.getInt(cursor.getColumnIndexOrThrow("impressions")))
+            cursor.close()
+            close()
+        }
+    }
+
+    @Test
     fun whenMigratingToLatestThenValidatesAgainstCurrentSchema() {
         testHelper.createDatabase(TEST_DB_NAME, 2).apply { close() }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216654827752205?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): https://app.asana.com/1/137249556945/project/1201807753394693/task/1217542420067379?focus=true

### Description
Add maxImpressions parameter to DisplayConditions

### Steps to test this PR
  _Pre steps_
  - [ ] Host a test config somewhere you can edit (e.g. jsonblob) and point the app at it via **Settings → Internal → RMF config source → Custom URL**. 
  - [ ] See message examples in https://app.asana.com/1/137249556945/task/1217542456113489/comment/1217535882281645?focus=true

  _Feature 1: existing messages are unaffected (regression)_
  - [ ] Use a config with a message that has **no** `maxImpressions` in displayConditions
  - [ ] Install from branch
  - [ ] Open several new tabs and verify the message never disappears on its own
  - [ ] Tap the message's close button and verify it dismisses, and does not come back

  _Feature 2: maxImpressions cap_
  - [ ] Now, use a config with a message that has `maxImpressions=2` displayConditions
  - [ ] Open a new tab, message shows
  - [ ] Navigate to a site or perform a search
  - [ ] Open a second new tab, message still shows
  - [ ] Navigate away again
  - [ ] Open a new tab
  - [ ] Verify the message is auto dissmissed

  _Feature 3: maxImpressions combined with dismissAfterDaysShown_
  - [ ] Use a config with for example: `"displayConditions": { "maxImpressions": 2, "dismissAfterDaysShown": 5 }`
  - [ ] Open new tabs (navigating away first) so the maxImpressions cap fires first
  - [ ] Verify message is dismissed the third time

  _Feature 4: upgrade from develop (DB migration)_
  - [ ] Install a build from `develop`
  - [ ] Point it at a config containing `"displayConditions": { "maxImpressions": 2 }`
  - [ ] Verify message is shown
  - [ ] Open several new tabs and verify message is not auto dimissed
  - [ ] DB check: Open App Inspector and check the `impressions` column does **not** exist yet (`remote_message` table)
  - [ ] Now install build from this branch
  - [ ] App launches with no crash, and the previously scheduled message still shows
  - [ ] DB check: `impressions` column now exists and is `0`
  - [ ] Open new tabs and verify message is dismissed after maxImpressions cap is reached

### No UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scheduled-message visibility and Room migration for all users with stored RMF messages; behavior changes are intentional but warrant regression on dismiss/expiry and upgrade paths.
> 
> **Overview**
> Adds **`maxImpressions`** to remote messaging **display conditions** so configs can cap how many times a message may be shown before it is auto-dismissed.
> 
> **`markAsShown`** now increments a persisted **`impressions`** counter on `RemoteMessageEntity`, with a Room **v3→v4** migration defaulting existing rows to `0`. Dismissal logic is unified in **`shouldBeDismissed`**, which applies both day-based expiry and the impression cap; silent dismiss still invalidates config so the next message can be scheduled.
> 
> **`messageFlow`** uses **`distinctUntilChangedBy { id to message }`** so impression-only DB updates do not re-emit and withdraw a card while it is on screen; a fresh collection after the cap still dismisses and emits null.
> 
> JSON parsing maps **`maxImpressions`** only when positive (zero/negative treated as no cap); invalid **`maxImpressions`** does not drop messages—only unknown triggers still drop. Tests and a sample config JSON cover parsing, caps, expiry interaction, flow behavior, and migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ba8b825c58300d5def7acbdbe56d25348201832. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->