### PR TITLE
Carry user gesture across redirects when handing off App Links

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -147,7 +147,7 @@ class BrowserWebViewClient @Inject constructor(
     private var lastPageStarted: String? = null
 
     // WebView clears hasGesture() on redirect hops, but the App Link rules assume Chromium's per-navigation gesture flag.
-    private var mainFrameNavigationHadGesture = false
+    private var mainFrameGestureOriginUrl: String? = null
     private var start: Long? = null
     private var lastInterceptedAppSchemeUrl: String? = null
     private var pageCommitVisibleFired: Boolean = false
@@ -242,9 +242,12 @@ class BrowserWebViewClient @Inject constructor(
         try {
             logcat(VERBOSE) { "shouldOverride webViewUrl: ${webView.url} URL: $url" }
             if (isForMainFrame && !isRedirect) {
-                mainFrameNavigationHadGesture = hasGesture
+                // Anchored to originalUrl, not the request's own URL, so both comparison sides share one source,
+                // stable across a chain's redirects, changes once an unrelated navigation commits.
+                mainFrameGestureOriginUrl = webView.originalUrl.takeIf { hasGesture }
             }
-            val hasGestureInNavigation = hasGesture || (isForMainFrame && isRedirect && mainFrameNavigationHadGesture)
+            val hasGestureInNavigation = hasGesture ||
+                (isForMainFrame && isRedirect && mainFrameGestureOriginUrl != null && mainFrameGestureOriginUrl == webView.originalUrl)
             webViewClientListener?.onShouldOverride()
             if (requestInterceptor.shouldOverrideUrlLoading(webViewClientListener, url, webView.url?.toUri(), isForMainFrame)) {
                 return true
@@ -285,6 +288,10 @@ class BrowserWebViewClient @Inject constructor(
 
                 is SpecialUrlDetector.UrlType.AppLink -> {
                     logcat(INFO) { "Found app link for ${urlType.uriString}" }
+                    if (hasGestureInNavigation) {
+                        // Re-anchor here so a further redirect (e.g. app-not-installed fallback) still carries the gesture, not the stale first hop.
+                        mainFrameGestureOriginUrl = webView.originalUrl
+                    }
                     webViewClientListener?.let { listener ->
                         return listener.handleAppLink(urlType, isForMainFrame, hasGestureInNavigation)
                     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -145,6 +145,9 @@ class BrowserWebViewClient @Inject constructor(
     var webViewClientListener: WebViewClientListener? = null
     var clientProvider: ClientBrandHintProvider? = null
     private var lastPageStarted: String? = null
+
+    // WebView clears hasGesture() on redirect hops, but the App Link rules assume Chromium's per-navigation gesture flag.
+    private var mainFrameNavigationHadGesture = false
     private var start: Long? = null
     private var lastInterceptedAppSchemeUrl: String? = null
     private var pageCommitVisibleFired: Boolean = false
@@ -238,6 +241,10 @@ class BrowserWebViewClient @Inject constructor(
     ): Boolean {
         try {
             logcat(VERBOSE) { "shouldOverride webViewUrl: ${webView.url} URL: $url" }
+            if (isForMainFrame && !isRedirect) {
+                mainFrameNavigationHadGesture = hasGesture
+            }
+            val hasGestureInNavigation = hasGesture || (isForMainFrame && isRedirect && mainFrameNavigationHadGesture)
             webViewClientListener?.onShouldOverride()
             if (requestInterceptor.shouldOverrideUrlLoading(webViewClientListener, url, webView.url?.toUri(), isForMainFrame)) {
                 return true
@@ -279,7 +286,7 @@ class BrowserWebViewClient @Inject constructor(
                 is SpecialUrlDetector.UrlType.AppLink -> {
                     logcat(INFO) { "Found app link for ${urlType.uriString}" }
                     webViewClientListener?.let { listener ->
-                        return listener.handleAppLink(urlType, isForMainFrame, hasGesture)
+                        return listener.handleAppLink(urlType, isForMainFrame, hasGestureInNavigation)
                     }
                     false
                 }
@@ -374,7 +381,7 @@ class BrowserWebViewClient @Inject constructor(
                             ) {
                                 is SpecialUrlDetector.UrlType.AppLink -> {
                                     loadUrl(listener, webView, urlType.cleanedUrl)
-                                    listener.handleAppLink(parameterStrippedType, isForMainFrame, hasGesture)
+                                    listener.handleAppLink(parameterStrippedType, isForMainFrame, hasGestureInNavigation)
                                 }
 
                                 is SpecialUrlDetector.UrlType.ExtractedAmpLink -> {

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -813,6 +813,33 @@ class BrowserWebViewClientTest {
     }
 
     @Test
+    fun whenRedirectFollowsANavigationDispatchedOutsideShouldOverrideThenStaleGestureIsNotReused() {
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = DDG_URL)
+        whenever(listener.handleAppLink(any(), any(), any())).thenReturn(true)
+
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.Web(EXAMPLE_URL))
+        val userInitiated = mock<WebResourceRequest>()
+        whenever(userInitiated.url).thenReturn(EXAMPLE_URL.toUri())
+        whenever(userInitiated.isForMainFrame).thenReturn(true)
+        whenever(userInitiated.isRedirect).thenReturn(false)
+        whenever(userInitiated.hasGesture()).thenReturn(true)
+        testee.shouldOverrideUrlLoading(webView, userInitiated)
+
+        // Simulates loadUrl() (omnibar, restore, rewrite): originalUrl advances though shouldOverride is never called for it.
+        (webView as TestWebView).originalUrlOverride = DDG_URL
+
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+        whenever(webResourceRequest.url).thenReturn(DDG_URL.toUri())
+        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+        whenever(webResourceRequest.isRedirect).thenReturn(true)
+        whenever(webResourceRequest.hasGesture()).thenReturn(false)
+        testee.shouldOverrideUrlLoading(webView, webResourceRequest)
+
+        verify(listener).handleAppLink(urlType, isForMainFrame = true, hasGesture = false)
+    }
+
+    @Test
     fun whenGestureCarriesAcrossMultipleRedirectHopsInSameChainThenHasGestureStaysTrue() {
         val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL)
         whenever(listener.handleAppLink(any(), any(), any())).thenReturn(true)
@@ -2089,10 +2116,11 @@ class BrowserWebViewClientTest {
         context: Context,
     ) : WebView(context) {
         var webViewUrl: String? = null
+        var originalUrlOverride: String? = EXAMPLE_URL
 
         override fun getUrl(): String? = webViewUrl
 
-        override fun getOriginalUrl(): String = EXAMPLE_URL
+        override fun getOriginalUrl(): String? = originalUrlOverride
 
         override fun getProgress(): Int = 100
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -746,6 +746,103 @@ class BrowserWebViewClientTest {
     }
 
     @Test
+    fun whenAppLinkReachedByRedirectFromUserInitiatedNavigationThenHasGestureIsTrue() {
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL)
+        whenever(listener.handleAppLink(any(), any(), any())).thenReturn(true)
+
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.Web(EXAMPLE_URL))
+        val userInitiated = mock<WebResourceRequest>()
+        whenever(userInitiated.url).thenReturn(EXAMPLE_URL.toUri())
+        whenever(userInitiated.isForMainFrame).thenReturn(true)
+        whenever(userInitiated.isRedirect).thenReturn(false)
+        whenever(userInitiated.hasGesture()).thenReturn(true)
+        testee.shouldOverrideUrlLoading(webView, userInitiated)
+
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+        whenever(webResourceRequest.isRedirect).thenReturn(true)
+        whenever(webResourceRequest.hasGesture()).thenReturn(false)
+        testee.shouldOverrideUrlLoading(webView, webResourceRequest)
+
+        verify(listener).handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
+    }
+
+    @Test
+    fun whenAppLinkReachedByRedirectAndNoPrecedingNavigationThenHasGestureIsFalse() {
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL)
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+        whenever(listener.handleAppLink(any(), any(), any())).thenReturn(true)
+
+        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+        whenever(webResourceRequest.isRedirect).thenReturn(true)
+        whenever(webResourceRequest.hasGesture()).thenReturn(false)
+        testee.shouldOverrideUrlLoading(webView, webResourceRequest)
+
+        verify(listener).handleAppLink(urlType, isForMainFrame = true, hasGesture = false)
+    }
+
+    @Test
+    fun whenUserInitiatedNavigationIsFollowedByFreshScriptNavigationThenGestureIsNotCarriedOver() {
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL)
+        whenever(listener.handleAppLink(any(), any(), any())).thenReturn(true)
+
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.Web(EXAMPLE_URL))
+        val userInitiated = mock<WebResourceRequest>()
+        whenever(userInitiated.url).thenReturn(EXAMPLE_URL.toUri())
+        whenever(userInitiated.isForMainFrame).thenReturn(true)
+        whenever(userInitiated.isRedirect).thenReturn(false)
+        whenever(userInitiated.hasGesture()).thenReturn(true)
+        testee.shouldOverrideUrlLoading(webView, userInitiated)
+
+        val scriptInitiated = mock<WebResourceRequest>()
+        whenever(scriptInitiated.url).thenReturn(EXAMPLE_URL.toUri())
+        whenever(scriptInitiated.isForMainFrame).thenReturn(true)
+        whenever(scriptInitiated.isRedirect).thenReturn(false)
+        whenever(scriptInitiated.hasGesture()).thenReturn(false)
+        testee.shouldOverrideUrlLoading(webView, scriptInitiated)
+
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+        whenever(webResourceRequest.isRedirect).thenReturn(true)
+        whenever(webResourceRequest.hasGesture()).thenReturn(false)
+        testee.shouldOverrideUrlLoading(webView, webResourceRequest)
+
+        verify(listener).handleAppLink(urlType, isForMainFrame = true, hasGesture = false)
+    }
+
+    @Test
+    fun whenGestureCarriesAcrossMultipleRedirectHopsInSameChainThenHasGestureStaysTrue() {
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL)
+        whenever(listener.handleAppLink(any(), any(), any())).thenReturn(true)
+
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.Web(EXAMPLE_URL))
+        val userInitiated = mock<WebResourceRequest>()
+        whenever(userInitiated.url).thenReturn(EXAMPLE_URL.toUri())
+        whenever(userInitiated.isForMainFrame).thenReturn(true)
+        whenever(userInitiated.isRedirect).thenReturn(false)
+        whenever(userInitiated.hasGesture()).thenReturn(true)
+        testee.shouldOverrideUrlLoading(webView, userInitiated)
+
+        val firstRedirectHop = mock<WebResourceRequest>()
+        whenever(firstRedirectHop.url).thenReturn(EXAMPLE_URL.toUri())
+        whenever(firstRedirectHop.isForMainFrame).thenReturn(true)
+        whenever(firstRedirectHop.isRedirect).thenReturn(true)
+        whenever(firstRedirectHop.hasGesture()).thenReturn(false)
+        testee.shouldOverrideUrlLoading(webView, firstRedirectHop)
+
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+        whenever(webResourceRequest.isRedirect).thenReturn(true)
+        whenever(webResourceRequest.hasGesture()).thenReturn(false)
+        testee.shouldOverrideUrlLoading(webView, webResourceRequest)
+
+        verify(listener).handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
+    }
+
+    @Test
     fun whenNonHttpAppLinkDetectedAndIsHandledThenReturnTrue() {
         val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink(EXAMPLE_URL, Intent(), EXAMPLE_URL)
         whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210379416433601/task/1217296985483195
GitHub Issue: https://github.com/duckduckgo/Android/issues/9441
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

OAuth logins started from a Custom Tab now return to the launching app instead of stranding the user on the callback page. WebView drops the user-gesture flag on server redirects, so the endless-loop guard was suppressing the App Link hand-off; the gesture is now carried across the redirect chain.

### Steps to test this PR

> [!NOTE]
> Prerequisites:
> - [x] DuckDuckGo set as default browser
> - [x] Bluesky account
> - [x] Install Heron App: https://play.google.com/store/apps/details?id=com.tunjid.heron

- [x] Open Heron App, enter your bluesky account and press login
- [x] Enter your credentials and press authorize
- [x] You are redirected to the app, connected with your Bluesky account

### UI changes

No user-facing UI changes.

https://github.com/user-attachments/assets/4ab4d25b-2e8c-48e5-884d-f91fbdc5bd4c


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how user-gesture is inferred for App Link launches (OAuth/custom tabs), which affects when external apps open; logic is narrow and covered by new unit tests.
> 
> **Overview**
> Fixes **Custom Tab OAuth** flows where the user authorizes in the browser but stays on the callback page instead of returning to the launching app. WebView reports **`hasGesture()` false** on redirect hops even when the chain started from a tap, so App Link handling treated the navigation as non-user-initiated and blocked the handoff.
> 
> `BrowserWebViewClient` now tracks **`mainFrameGestureOriginUrl`** on non-redirect main-frame navigations with a gesture, and derives **`hasGestureInNavigation`** for redirect hops when `originalUrl` still matches that anchor. The same flag is passed into **`handleAppLink`** (including tracking-parameter stripped App Links), with re-anchoring at App Link detection for further redirects.
> 
> Tests cover multi-hop redirects, script-initiated navigations, and stale gesture when `originalUrl` advances without `shouldOverride`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c77416cc322f2b301474ee4ecf75d3e18c9815a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->