### PR TITLE
Hide Back, Forward and Refresh in the menu on Duck.ai

### DIFF
--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheet.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheet.kt
@@ -447,13 +447,14 @@ class BrowserMenuBottomSheet(
     }
 
     private fun renderDuckAiMenu(viewState: BrowserMenuViewState.DuckAi) {
-        forwardMenuItem.isEnabled = false
+        backMenuItem.isVisible = false
+        forwardMenuItem.isVisible = false
         newTabMenuItem.isEnabled = true
         newDuckChatMenuItem.isEnabled = false
         newDuckChatMenuItem.isVisible = false
         settingsMenuItem.isEnabled = true
 
-        refreshMenuItem.isVisible = true
+        refreshMenuItem.isVisible = false
         // Duck.ai issues aren't site breakage, they go through the feedback flow instead
         brokenSiteMenuItem.isVisible = false
         printPageMenuItem.isVisible = viewState.canPrintPage
@@ -470,7 +471,7 @@ class BrowserMenuBottomSheet(
         )
 
         binding.urlPageActionsSectionDivider.isVisible = true
-        binding.librarySectionDivider.isVisible = true
+        binding.librarySectionDivider.isVisible = false
         binding.privacyToolsSectionDivider.isVisible = false
         binding.utilitiesSectionDivider.isVisible = true
         binding.customTabsMenuDivider.isVisible = false

--- a/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheetTest.kt
+++ b/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheetTest.kt
@@ -224,12 +224,12 @@ class BrowserMenuBottomSheetTest {
 
         dialog.render(viewState)
 
-        assertTrue(dialog.backMenuItem.isVisible)
-        assertTrue(dialog.forwardMenuItem.isVisible)
+        assertFalse(dialog.backMenuItem.isVisible)
+        assertFalse(dialog.forwardMenuItem.isVisible)
         assertTrue(dialog.newTabMenuItem.isVisible)
         assertFalse(dialog.newDuckChatMenuItem.isVisible)
         assertTrue(dialog.settingsMenuItem.isVisible)
-        assertTrue(dialog.refreshMenuItem.isVisible)
+        assertFalse(dialog.refreshMenuItem.isVisible)
         assertFalse(dialog.refreshActionMenuItem.isVisible)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214749231578703/task/1217330274056219?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Hides Back, Forward and Refresh from the browser menu when opened on Duck.ai, to match iOS. Print stays, since it's still relevant for a chat surface.

### Steps to test this PR

> [!NOTE]
> - Install Internal Debug
> - Open Duck.ai from the omnibar or new tab page

_Happy path_
- [x] open the browser menu on Duck.ai → confirm Back, Forward and Refresh are not shown
- [x] confirm Print is still shown and works
- [x] open the browser menu on a regular site (e.g. SERP) → confirm Back, Forward and Refresh are unaffected

### UI changes
| Before  | After |
| ------ | ----- |
<img width="504" height="1122" alt="image" src="https://github.com/user-attachments/assets/9aea6d93-c604-4262-8938-fd74b2bf0822" /> | <img width="504" height="1122" alt="image" src="https://github.com/user-attachments/assets/c30a5262-b6f1-40b1-b5a3-31f57d3e021a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visibility-only changes in the Duck.ai menu branch; no auth, data, or navigation logic changes.
> 
> **Overview**
> When the browser menu is shown on **Duck.ai**, **Back**, **Forward**, and **Refresh** are now hidden so Android matches iOS. **Print** and other Duck.ai-specific items stay as before.
> 
> `renderDuckAiMenu` sets those action items to not visible (instead of only disabling forward) and hides the **library** section divider for that layout. Unit tests for Duck AI menu mode expect back, forward, and refresh to be hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34eef966cc1fff221713d2902343ce9f2043d33c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->