### PR TITLE
Add the wide_return_session wide event for app returns

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_return_session.json5
+++ b/PixelDefinitions/pixels/definitions/wide_return_session.json5
@@ -1,0 +1,102 @@
+{
+    "wide_return_session": {
+        "description": "Captures every return to the app, from foreground to terminal user action or app background/termination.",
+        "owners": ["GerardPaligot"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": [
+            "widePixelPlatform",
+            "widePixelType",
+            "widePixelSampleRate",
+            "widePixelFeatureStatus",
+            "widePixelAppVersion",
+            "widePixelAppName",
+            "widePixelFormFactor",
+            "widePixelDevMode",
+            "widePixelMetaType",
+            "widePixelMetaVersion",
+            "widePixelIsFirstDailyOccurrence",
+            {
+                "key": "feature.name",
+                "type": "string",
+                "description": "Feature identifier for this wide event",
+                "enum": ["return_session"]
+            },
+            {
+                "key": "feature.data.ext.after_idle",
+                "type": "boolean",
+                "description": "True when an after-idle treatment started the session; filtering true gives the population wide_post_idle_session reports on"
+            },
+            {
+                "key": "feature.data.ext.landed_on",
+                "type": "string",
+                "description": "Surface the user landed on. A resumed tab is reported as web, serp or duck_ai depending on its content; there is no lut value",
+                "enum": ["ntp", "ntp_user_initiated", "web", "serp", "duck_ai"]
+            },
+            {
+                "key": "feature.data.ext.time_away_ms_bucketed",
+                "type": "string",
+                "description": "Time away before this return, bucketed (lower end of bucket, in ms). Absent when there was no prior background timestamp/date",
+                "enum": ["0", "60000", "300000", "900000", "1800000", "3600000"]
+            },
+            {
+                "key": "feature.data.ext.status_reason",
+                "type": "string",
+                "description": "Reason the session ended",
+                "enum": [
+                    "search_submitted",
+                    "ai_prompt_submitted",
+                    "url_submitted",
+                    "return_to_page_tapped",
+                    "tab_switcher_selected",
+                    "favorite_selected",
+                    "chat_selected",
+                    "app_backgrounded",
+                    "app_terminated"
+                ]
+            },
+            {
+                "key": "feature.data.ext.session_duration_ms_bucketed",
+                "type": "string",
+                "description": "Duration from foreground to session end, bucketed (lower end of bucket, in ms)",
+                "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+            },
+            {
+                "key": "feature.data.ext.time_to_first_interaction_ms_bucketed",
+                "type": "string",
+                "description": "Time from session start to the first user interaction with the landing surface, including a successful terminal action; absent if the session ends without interaction. Bucketed (lower end of bucket, in ms)",
+                "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+            },
+            {
+                "key": "feature.data.ext.focused",
+                "type": "boolean",
+                "description": "Whether the landing surface appeared with the address bar/native input focused"
+            },
+            {
+                "key": "feature.data.ext.page_engaged",
+                "type": "boolean",
+                "description": "Whether the user touched the page content during the session (NTP body or WebView)"
+            },
+            {
+                "key": "feature.data.ext.back_pressed",
+                "type": "boolean",
+                "description": "Whether the user pressed back at least once during the session"
+            },
+            {
+                "key": "feature.data.ext.opening_screen_changed",
+                "type": "boolean",
+                "description": "Whether the user changed the app-launch opening screen setting during the session"
+            },
+            {
+                "key": "feature.data.ext.close_tab_tapped",
+                "type": "boolean",
+                "description": "Whether the user tapped the close-tab action on the escape hatch during the session"
+            },
+            {
+                "key": "feature.data.ext.burn_tab_tapped",
+                "type": "boolean",
+                "description": "Whether the user tapped the burn-tab action on the escape hatch during the session"
+            }
+        ]
+    }
+}

--- a/PixelDefinitions/pixels/definitions/wide_return_session.json5
+++ b/PixelDefinitions/pixels/definitions/wide_return_session.json5
@@ -1,7 +1,7 @@
 {
     "wide_return_session": {
         "description": "Captures every return to the app, from foreground to terminal user action or app background/termination.",
-        "owners": ["GerardPaligot"],
+        "owners": ["YoussefKeyrouz"],
         "triggers": ["other"],
         "suffixes": ["daily_count_short", "form_factor"],
         "parameters": [

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -5134,7 +5134,7 @@ class BrowserTabFragment :
         // away on a previous visit isn't left as an icons-only strip.
         omnibar.setExpanded(true)
         launchDownloadMessagesJob()
-        viewModel.onViewVisible()
+        viewModel.onViewVisible(reportLandingFocus = false)
     }
 
     private fun launchDownloadMessagesJob() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1409,6 +1409,7 @@ class BrowserTabFragment :
                 },
                 onSearchSubmitted = { query -> onUserSubmittedText(query) },
                 onDuckAiChatSubmitted = { query, modelId, reasoningEffort, selectedTool, imagesJson, filesJson ->
+                    viewModel.onDuckAiChatPromptSubmitted()
                     contentScopeScripts.sendSubscriptionEvent(
                         SubscriptionEventData(
                             featureName = "aiChat",
@@ -5170,7 +5171,10 @@ class BrowserTabFragment :
         // During the locked Duck.ai onboarding demo, don't navigate within the app — returning false
         // lets BrowserActivity exit (close the app). The user progresses by tapping the fire button.
         if (viewModel.isOmnibarLockedForOnboarding()) return false
-        if (nativeInputManager.hideNativeInput()) return true
+        if (nativeInputManager.hideNativeInput()) {
+            viewModel.onBackInteraction()
+            return true
+        }
         if (isPdfVisible()) {
             hidePdf()
             val currentUrl = webView?.url
@@ -5178,6 +5182,7 @@ class BrowserTabFragment :
             if (currentUrl.isNullOrBlank() || currentUrl == "about:blank") {
                 viewModel.onUserPressedBack(isCustomTab)
             } else {
+                viewModel.onBackInteraction()
                 showBrowser()
             }
             return true

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1283,7 +1283,7 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    fun onViewVisible() {
+    fun onViewVisible(reportLandingFocus: Boolean = true) {
         newTabPageModalPresenterRegistry.register(this)
         setAdClickActiveTabData(url)
 
@@ -1291,7 +1291,7 @@ class BrowserTabViewModel @Inject constructor(
         if (!currentBrowserViewState().browserShowing && !currentBrowserViewState().maliciousSiteBlocked) {
             viewModelScope.launch {
                 val cta = refreshCta()
-                showOrHideKeyboard(cta)
+                showOrHideKeyboard(cta, reportLandingFocus)
                 if (cta == null) {
                     newTabPageModalTrigger.onNewTabPageShown()
                 }
@@ -3804,7 +3804,7 @@ class BrowserTabViewModel @Inject constructor(
     private fun canShowPromo(): Boolean =
         currentGlobalLayoutState() is Browser && !currentBrowserViewState().maliciousSiteBlocked
 
-    private fun showOrHideKeyboard(cta: Cta?) {
+    private fun showOrHideKeyboard(cta: Cta?, reportLandingFocus: Boolean = true) {
         val shouldHideKeyboard = cta?.shouldDropAddressBarFocusWhenShown() == true ||
             duckAiFeatureState.showInputScreen.value ||
             currentBrowserViewState().lastQueryOrigin == QueryOrigin.FromBookmark ||
@@ -3819,7 +3819,9 @@ class BrowserTabViewModel @Inject constructor(
         } else {
             Command.DropAddressBarFocus
         }
-        returnSessionLandingListener.onLandingFocusCaptured(focused)
+        if (reportLandingFocus) {
+            returnSessionLandingListener.onLandingFocusCaptured(focused)
+        }
     }
 
     fun onUserClickCtaOkButton(cta: Cta) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -220,6 +220,7 @@ import com.duckduckgo.app.browser.pdf.PdfPixelName
 import com.duckduckgo.app.browser.pdf.PdfRenderDecision
 import com.duckduckgo.app.browser.progressbar.ProgressBarUpgradeFeature
 import com.duckduckgo.app.browser.refreshpixels.RefreshPixelSender
+import com.duckduckgo.app.browser.returnsession.ReturnSessionLandingListener
 import com.duckduckgo.app.browser.santize.NonHttpAppLinkChecker
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.browser.tabs.TabManager
@@ -573,6 +574,7 @@ class BrowserTabViewModel @Inject constructor(
     private val progressBarUpgradeFeature: ProgressBarUpgradeFeature,
     private val faviconFetchingFixFeature: FaviconFetchingFixFeature,
     private val ntpAfterIdleManager: NtpAfterIdleManager,
+    private val returnSessionLandingListener: ReturnSessionLandingListener,
     private val browserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin>,
     private val browserRefreshTriggerPlugins: PluginPoint<BrowserRefreshTriggerPlugin>,
     private val brokenSiteReportTriggerPlugins: PluginPoint<BrokenSiteReportTriggerPlugin>,
@@ -1439,11 +1441,23 @@ class BrowserTabViewModel @Inject constructor(
         query: String,
         queryOrigin: QueryOrigin = QueryOrigin.FromUser,
     ) {
+        submitQuery(query, queryOrigin, QuerySubmissionSource.USER)
+    }
+
+    private fun submitQuery(
+        query: String,
+        queryOrigin: QueryOrigin,
+        submissionSource: QuerySubmissionSource,
+    ) {
         logcat { "onUserSubmittedQuery $query" }
         navigationAwareLoginDetector.onEvent(NavigationEvent.UserAction.NewQuerySubmitted)
 
         if (query.isBlank()) {
             return
+        }
+
+        if (submissionSource == QuerySubmissionSource.USER) {
+            notifySpecificSubmission(query, queryOrigin)
         }
 
         val layoutState = currentGlobalLayoutState()
@@ -1598,6 +1612,27 @@ class BrowserTabViewModel @Inject constructor(
             )
         autoCompleteViewState.value =
             currentAutoCompleteViewState().copy(showSuggestions = false, showFocusedView = false, searchResults = AutoCompleteResult("", emptyList()))
+    }
+
+    private fun notifySpecificSubmission(
+        query: String,
+        queryOrigin: QueryOrigin,
+    ) {
+        val isUrlSubmission = when (queryOrigin) {
+            QueryOrigin.FromBookmark -> true
+            is FromAutocomplete -> queryOrigin.isNav ?: queryUrlPredictor.isUrl(query.trim())
+            QueryOrigin.FromUser -> queryUrlPredictor.isUrl(query.trim())
+        }
+        if (isUrlSubmission) {
+            browserInteractionsPlugins.getPlugins().forEach { it.onUrlSubmitted() }
+        } else {
+            browserInteractionsPlugins.getPlugins().forEach { it.onSearchSubmitted() }
+        }
+    }
+
+    private enum class QuerySubmissionSource {
+        USER,
+        INTERNAL_NAVIGATION,
     }
 
     private fun isTypedDuckAiUrl(url: String): Boolean {
@@ -1869,6 +1904,10 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun isOmnibarLockedForOnboarding(): Boolean = currentBrowserViewState().isOmnibarLockedForOnboarding
+
+    fun onBackInteraction() {
+        browserInteractionsPlugins.getPlugins().forEach { it.onBackPressed() }
+    }
 
     /**
      * Handles back navigation. Returns false if navigation could not be
@@ -3599,7 +3638,7 @@ class BrowserTabViewModel @Inject constructor(
             val fallbackUrl = lastUrl.ifBlank { url ?: "" }
             if (fallbackUrl.isNotBlank()) {
                 logcat(WARN) { "Restoring last url but page history has been lost - url=[$fallbackUrl]" }
-                onUserSubmittedQuery(fallbackUrl)
+                submitQuery(fallbackUrl, QueryOrigin.FromUser, QuerySubmissionSource.INTERNAL_NAVIGATION)
             }
         }
     }
@@ -3773,12 +3812,14 @@ class BrowserTabViewModel @Inject constructor(
 
         logcat { "shouldHideKeyboard: $shouldHideKeyboard" }
 
-        command.value = if (shouldHideKeyboard) {
-            Command.DropAddressBarFocus
-        } else {
+        val focused = !shouldHideKeyboard
+        command.value = if (focused) {
             alreadyShownKeyboard = true
             ShowKeyboard
+        } else {
+            Command.DropAddressBarFocus
         }
+        returnSessionLandingListener.onLandingFocusCaptured(focused)
     }
 
     fun onUserClickCtaOkButton(cta: Cta) {
@@ -4111,7 +4152,10 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun showErrorWithAction(errorMessage: Int = R.string.crashedWebViewErrorMessage) {
-        command.value = ShowErrorWithAction(errorMessage) { this.onUserSubmittedQuery(url.orEmpty()) }
+        command.value =
+            ShowErrorWithAction(errorMessage) {
+                submitQuery(url.orEmpty(), QueryOrigin.FromUser, QuerySubmissionSource.INTERNAL_NAVIGATION)
+            }
     }
 
     private fun recoverTabWithQuery(query: String) {
@@ -5581,6 +5625,9 @@ class BrowserTabViewModel @Inject constructor(
      */
     fun openDuckAiQuery(query: String, autoPrompt: Boolean) {
         browserInteractionsPlugins.getPlugins().forEach { it.onInputSubmitted() }
+        if (autoPrompt && query.isNotBlank()) {
+            browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted() }
+        }
         navigateToDuckAi(duckChat.getDuckChatUrl(query, autoPrompt))
     }
 
@@ -5594,10 +5641,20 @@ class BrowserTabViewModel @Inject constructor(
         navigateToDuckAi(chatUrl)
     }
 
+    /**
+     * Entry point for a prompt submitted from within an already-open Duck.ai chat (a follow-up
+     * message, not the initial one that opened the chat).
+     */
+    fun onDuckAiChatPromptSubmitted() {
+        // onInputSubmitted() too: an in-chat follow-up is still "the bar was used" for the old
+        // post-idle-session event, which only listens for that generic signal.
+        browserInteractionsPlugins.getPlugins().forEach { it.onInputSubmitted() }
+        browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted() }
+    }
+
     private fun navigateToDuckAi(url: String) {
         if (!currentBrowserViewState().browserShowing) {
-            // On NTP: reuse this tab — don't spawn another empty one.
-            onUserSubmittedQuery(url)
+            submitQuery(url, QueryOrigin.FromUser, QuerySubmissionSource.INTERNAL_NAVIGATION)
         } else {
             command.value = OpenInNewTab(query = url, sourceTabId = tabId)
         }
@@ -5693,13 +5750,21 @@ class BrowserTabViewModel @Inject constructor(
             }
 
             else -> {
-                val url = when {
-                    hasFocus && isNtp && query.isNullOrBlank() -> duckChat.getDuckChatUrl(query ?: "", false)
-                    hasFocus && queryUrlPredictor.isUrl(query ?: "") -> query ?: ""
-                    hasFocus -> duckChat.getDuckChatUrl(query ?: "", true)
-                    else -> duckChat.getDuckChatUrl(query ?: "", false)
+                val (url, submittedAiPrompt) = when {
+                    hasFocus && isNtp && query.isNullOrBlank() -> duckChat.getDuckChatUrl(query ?: "", false) to false
+                    hasFocus && queryUrlPredictor.isUrl(query ?: "") -> (query ?: "") to false
+                    hasFocus -> duckChat.getDuckChatUrl(query ?: "", true) to !query.isNullOrBlank()
+                    else -> duckChat.getDuckChatUrl(query ?: "", false) to false
                 }
-                onUserSubmittedQuery(url)
+                if (duckChat.isDuckChatUrl(url.toUri())) {
+                    if (submittedAiPrompt) {
+                        browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted() }
+                    }
+                    submitQuery(url, QueryOrigin.FromUser, QuerySubmissionSource.INTERNAL_NAVIGATION)
+                } else {
+                    // The typed-URL branch above: genuinely a URL submission, not a Duck.ai one.
+                    onUserSubmittedQuery(url)
+                }
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageView.kt
@@ -130,6 +130,9 @@ class NewTabPageView @JvmOverloads constructor(
     @Inject
     lateinit var hatchInteractionsPlugins: PluginPoint<HatchInteractionsPlugin>
 
+    @Inject
+    lateinit var ntpEngagementTracker: NtpEngagementTracker
+
     private val binding: ViewNewTabBinding by viewBinding()
 
     private val homeBackgroundLogo by lazy { HomeBackgroundLogo(binding.ddgLogo) }
@@ -150,11 +153,8 @@ class NewTabPageView @JvmOverloads constructor(
     private var lastSelectedMode: InputMode? = null
     private var logoAnimator: ValueAnimator? = null
 
-    private var pageEngagedFiredForCurrentAttachment = false
-
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
-        if (ev.actionMasked == MotionEvent.ACTION_DOWN && !pageEngagedFiredForCurrentAttachment) {
-            pageEngagedFiredForCurrentAttachment = true
+        if (ev.actionMasked == MotionEvent.ACTION_DOWN && ntpEngagementTracker.shouldReportEngagement()) {
             hatchInteractionsPlugins.getPlugins().forEach { it.onNtpEngaged() }
         }
         return super.dispatchTouchEvent(ev)
@@ -190,8 +190,6 @@ class NewTabPageView @JvmOverloads constructor(
         conflatedChatModeJob += inputModeState.displayedMode
             .onEach { mode -> updateLogoForMode(mode) }
             .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope!!)
-
-        pageEngagedFiredForCurrentAttachment = false
 
         disableViewStateSaving()
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NtpEngagementTracker.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NtpEngagementTracker.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.newtab
+
+import androidx.annotation.MainThread
+import com.duckduckgo.browser.api.BrowserLifecycleObserver
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+@SingleInstanceIn(AppScope::class)
+@ContributesMultibinding(AppScope::class, boundType = BrowserLifecycleObserver::class)
+class NtpEngagementTracker @Inject constructor() : BrowserLifecycleObserver {
+
+    private var reported = false
+
+    @MainThread
+    override fun onOpen(isFreshLaunch: Boolean) {
+        reported = false
+    }
+
+    @MainThread
+    fun shouldReportEngagement(): Boolean {
+        if (reported) return false
+
+        reported = true
+        return true
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/returnsession/RealReturnSessionWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/returnsession/RealReturnSessionWideEvent.kt
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.returnsession
+
+import android.annotation.SuppressLint
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.generalsettings.showonapplaunch.FirstScreenHandlerImpl
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.wideevents.CleanupPolicy
+import com.duckduckgo.app.statistics.wideevents.FlowStatus
+import com.duckduckgo.app.statistics.wideevents.WideEventClient
+import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.newtabpage.api.interactions.HatchInteractionsPlugin
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.Lazy
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import logcat.logcat
+import javax.inject.Inject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Covers every return to the app.
+ *
+ * Session start waits for [FirstScreenHandlerImpl] to finish applying the opening-screen decision.
+ * This makes `after_idle` and `landed_on` authoritative at [WideEventClient.flowStart].
+ */
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class, boundType = ReturnSessionLandingListener::class)
+@ContributesMultibinding(AppScope::class, boundType = BrowserInteractionsPlugin::class)
+@ContributesMultibinding(AppScope::class, boundType = HatchInteractionsPlugin::class)
+class RealReturnSessionWideEvent @Inject constructor(
+    private val wideEventClient: WideEventClient,
+    private val settingsDataStore: SettingsDataStore,
+    private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
+    private val returnSessionWideEventFeature: Lazy<ReturnSessionWideEventFeature>,
+    private val dispatchers: DispatcherProvider,
+    @AppCoroutineScope appCoroutineScope: CoroutineScope,
+) : BrowserInteractionsPlugin, HatchInteractionsPlugin, ReturnSessionLandingListener {
+
+    // Serializes wide-event mutations.
+    @SuppressLint("AvoidComputationUsage")
+    private val coroutineScope = CoroutineScope(
+        context = appCoroutineScope.coroutineContext +
+            dispatchers.computation().limitedParallelism(1),
+    )
+
+    private val mutex = Mutex()
+    private var activeSession: SessionState? = null
+    private var pendingLandingFocus: Boolean? = null
+
+    init {
+        showOnAppLaunchOptionDataStore.optionFlow
+            .distinctUntilChangedBy { option -> if (option is SpecificPage) option.url else option }
+            .drop(1)
+            .onEach {
+                recordNonTerminal(
+                    action = "opening_screen_changed",
+                    isAlreadyRecorded = { it.openingScreenChanged },
+                ) { it.openingScreenChanged = true }
+            }
+            .launchIn(coroutineScope)
+    }
+
+    override fun onReturnLandingResolved(result: ReturnSessionLandingResult) {
+        coroutineScope.launch {
+            mutex.withLock {
+                if (abortIfDisabled()) return@launch
+
+                activeSession?.let { prior ->
+                    logcat(tag = TAG) { "Aborting prior return session on new foreground" }
+                    wideEventClient.flowAbort(prior.flowId)
+                    activeSession = null
+                }
+
+                val landingFocus = pendingLandingFocus
+                pendingLandingFocus = null
+                val startResult = wideEventClient.flowStart(
+                    name = FEATURE_NAME,
+                    cleanupPolicy = CleanupPolicy.OnProcessStart(
+                        ignoreIfIntervalTimeoutPresent = false,
+                        flowStatus = FlowStatus.Unknown,
+                    ),
+                    metadata = buildMap {
+                        put(KEY_AFTER_IDLE, result.afterIdle.toString())
+                        put(KEY_LANDED_ON, result.landing.value)
+                        timeAwayMsBucketed()?.let { put(KEY_TIME_AWAY, it) }
+                        // Default in case the process is killed before a real terminal reason lands.
+                        // OnProcessStart cleanup sends whatever metadata is already persisted.
+                        put(KEY_STATUS_REASON, REASON_APP_TERMINATED)
+                    },
+                    samplingProbability = SAMPLING_PROBABILITY,
+                )
+
+                startResult.onSuccess { flowId ->
+                    activeSession = SessionState(
+                        flowId = flowId,
+                        afterIdle = result.afterIdle,
+                        landedOn = result.landing,
+                        focused = landingFocus,
+                    )
+                    logcat(tag = TAG) { "Return session started: landedOn=${result.landing.value}" }
+
+                    wideEventClient.intervalStart(flowId, KEY_SESSION_DURATION, buckets = DURATION_BUCKETS)
+                    wideEventClient.intervalStart(flowId, KEY_TIME_TO_FIRST_INTERACTION, buckets = DURATION_BUCKETS)
+                }.onFailure { error ->
+                    logcat(tag = TAG) { "Failed to start return session: ${error.message}" }
+                }
+            }
+        }
+    }
+
+    override fun onLandingFocusCaptured(focused: Boolean) {
+        coroutineScope.launch {
+            mutex.withLock {
+                if (abortIfDisabled()) return@launch
+                val session = activeSession
+                if (session == null) {
+                    if (pendingLandingFocus == null) pendingLandingFocus = focused
+                } else if (session.focused == null) {
+                    session.focused = focused
+                }
+            }
+        }
+    }
+
+    override fun onReturnClosed() {
+        coroutineScope.launch {
+            mutex.withLock {
+                if (abortIfDisabled()) return@launch
+                if (activeSession == null) pendingLandingFocus = null
+                finishSessionLocked(
+                    statusReason = REASON_APP_BACKGROUNDED,
+                    status = FlowStatus.Cancelled,
+                )
+            }
+        }
+    }
+
+    private fun timeAwayMsBucketed(): String? {
+        val lastBackgrounded = settingsDataStore.lastSessionBackgroundTimestamp
+        if (lastBackgrounded == 0L) return null
+        val elapsedMs = System.currentTimeMillis() - lastBackgrounded
+        return when {
+            elapsedMs < 60_000L -> "0"
+            elapsedMs < 300_000L -> "60000"
+            elapsedMs < 900_000L -> "300000"
+            elapsedMs < 1_800_000L -> "900000"
+            elapsedMs < 3_600_000L -> "1800000"
+            else -> "3600000"
+        }
+    }
+
+    override fun onSearchSubmitted() {
+        finishSession(statusReason = REASON_SEARCH_SUBMITTED, status = FlowStatus.Success)
+    }
+
+    override fun onUrlSubmitted() {
+        finishSession(statusReason = REASON_URL_SUBMITTED, status = FlowStatus.Success)
+    }
+
+    override fun onAiPromptSubmitted() {
+        finishSession(statusReason = REASON_AI_PROMPT_SUBMITTED, status = FlowStatus.Success)
+    }
+
+    override fun onChatSelected() {
+        finishSession(statusReason = REASON_CHAT_SELECTED, status = FlowStatus.Success)
+    }
+
+    override fun onReturnToPageTapped() {
+        finishSession(statusReason = REASON_RETURN_TO_PAGE_TAPPED, status = FlowStatus.Success)
+    }
+
+    override fun onTabSwitcherSelected() {
+        finishSession(statusReason = REASON_TAB_SWITCHER_SELECTED, status = FlowStatus.Success)
+    }
+
+    override fun onFavoriteSelected() {
+        finishSession(statusReason = REASON_FAVORITE_SELECTED, status = FlowStatus.Success)
+    }
+
+    override fun onBackPressed() {
+        recordNonTerminal(action = "back_pressed", isAlreadyRecorded = { it.backPressed }) { it.backPressed = true }
+    }
+
+    override fun onWebViewEngaged() {
+        recordNonTerminal(action = "page_engaged", isAlreadyRecorded = { it.pageEngaged }) { it.pageEngaged = true }
+    }
+
+    override fun onNtpEngaged() {
+        recordNonTerminal(action = "page_engaged", isAlreadyRecorded = { it.pageEngaged }) { it.pageEngaged = true }
+    }
+
+    override fun onCloseTabTapped() {
+        recordNonTerminal(action = "close_tab_tapped", isAlreadyRecorded = { it.closeTabTapped }) { it.closeTabTapped = true }
+    }
+
+    override fun onBurnTabTapped() {
+        recordNonTerminal(action = "burn_tab_tapped", isAlreadyRecorded = { it.burnTabTapped }) { it.burnTabTapped = true }
+    }
+
+    private fun recordNonTerminal(
+        action: String,
+        isAlreadyRecorded: (SessionState) -> Boolean,
+        updateState: (SessionState) -> Unit,
+    ) {
+        coroutineScope.launch {
+            mutex.withLock {
+                if (abortIfDisabled()) return@launch
+                val session = activeSession ?: return@launch
+                if (isAlreadyRecorded(session)) return@launch
+
+                updateState(session)
+                if (!session.firstInteractionRecorded) {
+                    wideEventClient.intervalEnd(session.flowId, KEY_TIME_TO_FIRST_INTERACTION)
+                    session.firstInteractionRecorded = true
+                }
+                logcat(tag = TAG) { "Return session: $action recorded" }
+            }
+        }
+    }
+
+    private fun finishSession(statusReason: String, status: FlowStatus) {
+        coroutineScope.launch {
+            mutex.withLock {
+                if (abortIfDisabled()) return@launch
+                finishSessionLocked(statusReason, status)
+            }
+        }
+    }
+
+    private suspend fun finishSessionLocked(
+        statusReason: String,
+        status: FlowStatus,
+    ) {
+        val session = activeSession ?: return
+        activeSession = null
+
+        wideEventClient.intervalEnd(session.flowId, KEY_SESSION_DURATION)
+        if (status == FlowStatus.Success && !session.firstInteractionRecorded) {
+            wideEventClient.intervalEnd(session.flowId, KEY_TIME_TO_FIRST_INTERACTION)
+        }
+        wideEventClient.flowFinish(
+            wideEventId = session.flowId,
+            status = status,
+            metadata = mapOf(
+                KEY_AFTER_IDLE to session.afterIdle.toString(),
+                KEY_LANDED_ON to session.landedOn.value,
+                KEY_STATUS_REASON to statusReason,
+                KEY_FOCUSED to (session.focused ?: false).toString(),
+                KEY_PAGE_ENGAGED to session.pageEngaged.toString(),
+                KEY_BACK_PRESSED to session.backPressed.toString(),
+                KEY_OPENING_SCREEN_CHANGED to session.openingScreenChanged.toString(),
+                KEY_CLOSE_TAB_TAPPED to session.closeTabTapped.toString(),
+                KEY_BURN_TAB_TAPPED to session.burnTabTapped.toString(),
+            ),
+        )
+        logcat(tag = TAG) { "Return session finished: status=$status, reason=$statusReason" }
+    }
+
+    /**
+     * Must be called under [mutex]. When the feature is disabled, aborts any active session instead
+     * of just skipping — otherwise a session started while enabled would linger persisted and get
+     * force-completed as Unknown by process-start cleanup after the kill switch flipped.
+     */
+    private suspend fun abortIfDisabled(): Boolean {
+        if (isFeatureEnabled()) return false
+        pendingLandingFocus = null
+        activeSession?.let { session ->
+            wideEventClient.flowAbort(session.flowId)
+            activeSession = null
+        }
+        return true
+    }
+
+    private suspend fun isFeatureEnabled(): Boolean = withContext(dispatchers.io()) {
+        returnSessionWideEventFeature.get().self().isEnabled()
+    }
+
+    private class SessionState(
+        val flowId: Long,
+        val afterIdle: Boolean,
+        val landedOn: ReturnSessionLanding,
+        var focused: Boolean? = null,
+        var pageEngaged: Boolean = false,
+        var backPressed: Boolean = false,
+        var openingScreenChanged: Boolean = false,
+        var closeTabTapped: Boolean = false,
+        var burnTabTapped: Boolean = false,
+        var firstInteractionRecorded: Boolean = false,
+    )
+
+    private companion object {
+        const val TAG = "RealReturnSessionWideEvent"
+        const val FEATURE_NAME = "return_session"
+        const val SAMPLING_PROBABILITY = 0.05f
+
+        const val REASON_SEARCH_SUBMITTED = "search_submitted"
+        const val REASON_URL_SUBMITTED = "url_submitted"
+        const val REASON_AI_PROMPT_SUBMITTED = "ai_prompt_submitted"
+        const val REASON_CHAT_SELECTED = "chat_selected"
+        const val REASON_RETURN_TO_PAGE_TAPPED = "return_to_page_tapped"
+        const val REASON_TAB_SWITCHER_SELECTED = "tab_switcher_selected"
+        const val REASON_FAVORITE_SELECTED = "favorite_selected"
+        const val REASON_APP_BACKGROUNDED = "app_backgrounded"
+        const val REASON_APP_TERMINATED = "app_terminated"
+
+        const val KEY_AFTER_IDLE = "after_idle"
+        const val KEY_LANDED_ON = "landed_on"
+        const val KEY_TIME_AWAY = "time_away_ms_bucketed"
+        const val KEY_STATUS_REASON = "status_reason"
+        const val KEY_FOCUSED = "focused"
+        const val KEY_PAGE_ENGAGED = "page_engaged"
+        const val KEY_BACK_PRESSED = "back_pressed"
+        const val KEY_OPENING_SCREEN_CHANGED = "opening_screen_changed"
+        const val KEY_CLOSE_TAB_TAPPED = "close_tab_tapped"
+        const val KEY_BURN_TAB_TAPPED = "burn_tab_tapped"
+        const val KEY_SESSION_DURATION = "session_duration_ms_bucketed"
+        const val KEY_TIME_TO_FIRST_INTERACTION = "time_to_first_interaction_ms_bucketed"
+
+        val DURATION_BUCKETS: Set<Duration> = setOf(
+            1.seconds,
+            5.seconds,
+            10.seconds,
+            30.seconds,
+            60.seconds,
+            300.seconds,
+            600.seconds,
+        )
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/returnsession/RealReturnSessionWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/returnsession/RealReturnSessionWideEvent.kt
@@ -76,6 +76,7 @@ class RealReturnSessionWideEvent @Inject constructor(
     private val mutex = Mutex()
     private var activeSession: SessionState? = null
     private var pendingLandingFocus: Boolean? = null
+    private var pendingEngagement: Boolean = false
 
     init {
         showOnAppLaunchOptionDataStore.optionFlow
@@ -103,6 +104,8 @@ class RealReturnSessionWideEvent @Inject constructor(
 
                 val landingFocus = pendingLandingFocus
                 pendingLandingFocus = null
+                val landingEngagement = pendingEngagement
+                pendingEngagement = false
                 val startResult = wideEventClient.flowStart(
                     name = FEATURE_NAME,
                     cleanupPolicy = CleanupPolicy.OnProcessStart(
@@ -121,16 +124,22 @@ class RealReturnSessionWideEvent @Inject constructor(
                 )
 
                 startResult.onSuccess { flowId ->
-                    activeSession = SessionState(
+                    val session = SessionState(
                         flowId = flowId,
                         afterIdle = result.afterIdle,
                         landedOn = result.landing,
                         focused = landingFocus,
+                        pageEngaged = landingEngagement,
                     )
+                    activeSession = session
                     logcat(tag = TAG) { "Return session started: landedOn=${result.landing.value}" }
 
                     wideEventClient.intervalStart(flowId, KEY_SESSION_DURATION, buckets = DURATION_BUCKETS)
                     wideEventClient.intervalStart(flowId, KEY_TIME_TO_FIRST_INTERACTION, buckets = DURATION_BUCKETS)
+                    if (landingEngagement) {
+                        wideEventClient.intervalEnd(flowId, KEY_TIME_TO_FIRST_INTERACTION)
+                        session.firstInteractionRecorded = true
+                    }
                 }.onFailure { error ->
                     logcat(tag = TAG) { "Failed to start return session: ${error.message}" }
                 }
@@ -156,7 +165,10 @@ class RealReturnSessionWideEvent @Inject constructor(
         coroutineScope.launch {
             mutex.withLock {
                 if (abortIfDisabled()) return@launch
-                if (activeSession == null) pendingLandingFocus = null
+                if (activeSession == null) {
+                    pendingLandingFocus = null
+                    pendingEngagement = false
+                }
                 finishSessionLocked(
                     statusReason = REASON_APP_BACKGROUNDED,
                     status = FlowStatus.Cancelled,
@@ -216,7 +228,24 @@ class RealReturnSessionWideEvent @Inject constructor(
     }
 
     override fun onNtpEngaged() {
-        recordNonTerminal(action = "page_engaged", isAlreadyRecorded = { it.pageEngaged }) { it.pageEngaged = true }
+        coroutineScope.launch {
+            mutex.withLock {
+                if (abortIfDisabled()) return@launch
+                val session = activeSession
+                if (session == null) {
+                    pendingEngagement = true
+                    return@launch
+                }
+                if (session.pageEngaged) return@launch
+
+                session.pageEngaged = true
+                if (!session.firstInteractionRecorded) {
+                    wideEventClient.intervalEnd(session.flowId, KEY_TIME_TO_FIRST_INTERACTION)
+                    session.firstInteractionRecorded = true
+                }
+                logcat(tag = TAG) { "Return session: page_engaged recorded" }
+            }
+        }
     }
 
     override fun onCloseTabTapped() {
@@ -294,6 +323,7 @@ class RealReturnSessionWideEvent @Inject constructor(
     private suspend fun abortIfDisabled(): Boolean {
         if (isFeatureEnabled()) return false
         pendingLandingFocus = null
+        pendingEngagement = false
         activeSession?.let { session ->
             wideEventClient.flowAbort(session.flowId)
             activeSession = null

--- a/app/src/main/java/com/duckduckgo/app/browser/returnsession/ReturnSessionLandingListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/returnsession/ReturnSessionLandingListener.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.returnsession
+
+enum class ReturnSessionLanding(val value: String) {
+    NTP("ntp"),
+    NTP_USER_INITIATED("ntp_user_initiated"),
+    WEB("web"),
+    SERP("serp"),
+    DUCK_AI("duck_ai"),
+}
+
+data class ReturnSessionLandingResult(
+    val afterIdle: Boolean,
+    val landing: ReturnSessionLanding,
+)
+
+interface ReturnSessionLandingListener {
+    /** Starts telemetry after the opening-screen pipeline has applied its final destination. */
+    fun onReturnLandingResolved(result: ReturnSessionLandingResult)
+
+    fun onLandingFocusCaptured(focused: Boolean)
+
+    fun onReturnClosed()
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/returnsession/ReturnSessionWideEventFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/returnsession/ReturnSessionWideEventFeature.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.returnsession
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+/**
+ * Controls whether [RealReturnSessionWideEvent] sends the `return_session` wide event.
+ */
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "returnSessionWideEvent",
+)
+interface ReturnSessionWideEventFeature {
+
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun self(): Toggle
+}

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -16,7 +16,12 @@
 
 package com.duckduckgo.app.generalsettings.showonapplaunch
 
+import androidx.core.net.toUri
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.app.browser.autofill.SystemAutofillEngagement
+import com.duckduckgo.app.browser.returnsession.ReturnSessionLanding
+import com.duckduckgo.app.browser.returnsession.ReturnSessionLandingListener
+import com.duckduckgo.app.browser.returnsession.ReturnSessionLandingResult
 import com.duckduckgo.app.browser.state.ModeSwitchRecreateSignal
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
@@ -26,6 +31,7 @@ import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -54,6 +60,7 @@ class FirstScreenHandlerImpl @Inject constructor(
     private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
     private val appBuildConfig: AppBuildConfig,
     private val dispatcherProvider: DispatcherProvider,
+    private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector,
     private val duckChat: DuckChat,
     private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
     private val ntpAfterIdleManager: NtpAfterIdleManager,
@@ -61,6 +68,7 @@ class FirstScreenHandlerImpl @Inject constructor(
     private val customTabDetector: CustomTabDetector,
     private val browserModeStateHolder: BrowserModeStateHolder,
     private val modeSwitchRecreateSignal: ModeSwitchRecreateSignal,
+    private val returnSessionLandingListener: ReturnSessionLandingListener,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val idleThresholdResolver: IdleThresholdResolver,
 ) : BrowserLifecycleObserver {
@@ -86,12 +94,15 @@ class FirstScreenHandlerImpl @Inject constructor(
         // is correct without a fresh trigger. Setting pendingAfterIdle here would leak — no
         // onNtpShown fires (same NTP tab), and the next user action that DOES show an NTP
         // (e.g. opening a new tab manually) would incorrectly consume the stale pending flag.
-        if (isFreshLaunch &&
+        val preAppliedFreshNtpTreatment = if (isFreshLaunch &&
             androidBrowserConfigFeature.showNTPAfterIdleReturn().isEnabled() &&
             computeWasIdle() &&
             isCurrentSelectedTabNtp()
         ) {
             ntpAfterIdleManager.onIdleReturnTriggered()
+            AfterIdleTreatment.NTP
+        } else {
+            null
         }
         appCoroutineScope.launch {
             logcat { "FirstScreen: onOpen isFreshLaunch $isFreshLaunch" }
@@ -99,7 +110,8 @@ class FirstScreenHandlerImpl @Inject constructor(
             // (e.g. GeneralSettings) don't fall back to LastOpenedTab before the
             // after-inactivity flow has had a chance to run.
             ensureNewUserDefault()
-            handleFirstScreen(isFreshLaunch)
+            val resolvedLanding = handleFirstScreen(isFreshLaunch, preAppliedFreshNtpTreatment)
+            returnSessionLandingListener.onReturnLandingResolved(resolvedLanding)
         }
     }
 
@@ -124,22 +136,57 @@ class FirstScreenHandlerImpl @Inject constructor(
 
     // Launch boundary: process-lifecycle callback, no activity graph exists to provide a frozen mode.
     @Suppress("DenyListedApi")
-    private suspend fun handleFirstScreen(isFreshLaunch: Boolean) {
+    private suspend fun handleFirstScreen(
+        isFreshLaunch: Boolean,
+        preAppliedFreshNtpTreatment: AfterIdleTreatment?,
+    ): ReturnSessionLandingResult {
         val currentMode = browserModeStateHolder.currentMode.value
         if (androidBrowserConfigFeature.showNTPAfterIdleReturn().isEnabled()) {
             val lastBackgrounded = settingsDataStore.lastSessionBackgroundTimestamp
             val wasIdle = computeWasIdle()
             if (lastBackgrounded == 0L || wasIdle) {
-                if (!isVoiceSessionActiveOnCurrentTab() && !isActiveTabCustomTab()) {
-                    showOnAppLaunchOptionHandler.handleAfterInactivityOption(wasIdle = wasIdle, currentMode = currentMode)
+                if (isVoiceSessionActiveOnCurrentTab() || isActiveTabCustomTab()) {
+                    return resolveCurrentLanding(currentMode)
                 }
-                return
+                val result = showOnAppLaunchOptionHandler.handleAfterInactivityOption(wasIdle = wasIdle, currentMode = currentMode)
+                return resolveReturnLanding(
+                    result = result,
+                    fallbackTreatment = preAppliedFreshNtpTreatment.takeIf {
+                        currentMode == BrowserMode.REGULAR && result.destinationUrl.isNullOrBlank()
+                    },
+                )
             }
         } else if (isFreshLaunch && showOnAppLaunchFeature.self().isEnabled()) {
-            if (!isVoiceSessionActiveOnCurrentTab()) {
-                showOnAppLaunchOptionHandler.handleAppLaunchOption(currentMode)
+            if (isVoiceSessionActiveOnCurrentTab()) {
+                return resolveCurrentLanding(currentMode)
             }
+            return resolveReturnLanding(showOnAppLaunchOptionHandler.handleAppLaunchOption(currentMode))
         }
+        return resolveCurrentLanding(currentMode)
+    }
+
+    private suspend fun resolveCurrentLanding(currentMode: BrowserMode): ReturnSessionLandingResult {
+        val destinationUrl = tabRepositoryProvider.forMode(currentMode).getSelectedTab()?.url
+        return resolveReturnLanding(
+            ShowOnAppLaunchResult(
+                destinationUrl = destinationUrl,
+                treatment = null,
+            ),
+        )
+    }
+
+    private fun resolveReturnLanding(
+        result: ShowOnAppLaunchResult,
+        fallbackTreatment: AfterIdleTreatment? = null,
+    ): ReturnSessionLandingResult {
+        val afterIdle = (result.treatment ?: fallbackTreatment) != null
+        val landing = when {
+            result.destinationUrl.isNullOrBlank() -> if (afterIdle) ReturnSessionLanding.NTP else ReturnSessionLanding.NTP_USER_INITIATED
+            duckChat.isDuckChatUrl(result.destinationUrl.toUri()) -> ReturnSessionLanding.DUCK_AI
+            duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(result.destinationUrl) -> ReturnSessionLanding.SERP
+            else -> ReturnSessionLanding.WEB
+        }
+        return ReturnSessionLandingResult(afterIdle = afterIdle, landing = landing)
     }
 
     private suspend fun isVoiceSessionActiveOnCurrentTab(): Boolean = withContext(dispatcherProvider.io()) {
@@ -154,6 +201,7 @@ class FirstScreenHandlerImpl @Inject constructor(
     }
 
     override fun onClose() {
+        returnSessionLandingListener.onReturnClosed()
         systemAutofillEngagement.clearIdleReturnTriggered()
         appCoroutineScope.launch(dispatcherProvider.io()) {
             settingsDataStore.lastSessionBackgroundTimestamp = System.currentTimeMillis()

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchO
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
 import com.duckduckgo.app.settings.db.SettingsDataStore
-import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
 import com.duckduckgo.browsermode.api.BrowserMode
@@ -40,9 +39,19 @@ import kotlinx.coroutines.withContext
 import logcat.logcat
 import javax.inject.Inject
 
+enum class AfterIdleTreatment {
+    NTP,
+    LUT,
+}
+
+data class ShowOnAppLaunchResult(
+    val destinationUrl: String?,
+    val treatment: AfterIdleTreatment?,
+)
+
 interface ShowOnAppLaunchOptionHandler {
-    suspend fun handleAfterInactivityOption(wasIdle: Boolean, currentMode: BrowserMode)
-    suspend fun handleAppLaunchOption(currentMode: BrowserMode)
+    suspend fun handleAfterInactivityOption(wasIdle: Boolean, currentMode: BrowserMode): ShowOnAppLaunchResult
+    suspend fun handleAppLaunchOption(currentMode: BrowserMode): ShowOnAppLaunchResult
     suspend fun handleResolvedUrlStorage(
         currentUrl: String?,
         isRootOfTab: Boolean,
@@ -61,58 +70,83 @@ class ShowOnAppLaunchOptionHandlerImpl @Inject constructor(
     private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
 ) : ShowOnAppLaunchOptionHandler {
 
-    override suspend fun handleAfterInactivityOption(wasIdle: Boolean, currentMode: BrowserMode) {
+    override suspend fun handleAfterInactivityOption(wasIdle: Boolean, currentMode: BrowserMode): ShowOnAppLaunchResult {
         logcat { "FirstScreen: Inactivity Timer passed" }
-        applyShowOnAppLaunchOption(fromInactivity = wasIdle, currentMode = currentMode)
+        return applyShowOnAppLaunchOption(afterIdle = wasIdle, currentMode = currentMode)
     }
 
-    override suspend fun handleAppLaunchOption(currentMode: BrowserMode) {
-        applyShowOnAppLaunchOption(fromInactivity = false, currentMode = currentMode)
-    }
+    override suspend fun handleAppLaunchOption(currentMode: BrowserMode): ShowOnAppLaunchResult =
+        applyShowOnAppLaunchOption(afterIdle = false, currentMode = currentMode)
 
-    private suspend fun applyShowOnAppLaunchOption(fromInactivity: Boolean, currentMode: BrowserMode) {
+    private suspend fun applyShowOnAppLaunchOption(
+        afterIdle: Boolean,
+        currentMode: BrowserMode,
+    ): ShowOnAppLaunchResult {
         val option = showOnAppLaunchOptionDataStore.optionFlow.first()
         logcat { "FirstScreen: showing $option on app launch" }
 
-        when (option) {
-            LastOpenedTab -> {
-                if (currentMode != BrowserMode.REGULAR) return
-                if (fromInactivity) {
-                    // Skip when the visible tab is a blank NTP — the NTP path classifies that case.
-                    val selectedTab = tabRepositoryProvider.forMode(BrowserMode.REGULAR).getSelectedTab()
-                    if (selectedTab != null && !selectedTab.url.isNullOrBlank()) {
-                        browserInteractionsPlugins.getPlugins().forEach { it.onLutShownAfterIdle() }
-                    }
-                }
-            }
-            NewTabPage -> {
-                val repo = tabRepositoryProvider.forMode(currentMode)
-                val selectedTab = repo.getSelectedTab()
-                if (selectedTab == null || !selectedTab.url.isNullOrBlank()) {
-                    // The hatch (after-idle classification) only ever applies in Regular mode.
-                    if (fromInactivity && currentMode == BrowserMode.REGULAR) {
-                        // Set pendingAfterIdle BEFORE adding the tab so BrowserViewModel's
-                        // flowSelectedTab emit consumes it via onNtpShown for the new NTP.
-                        ntpAfterIdleManager.onIdleReturnTriggered()
-                        notifyAutofillIdleReturn("new_tab_page")
-                    }
-                    repo.add()
-                }
-                // When the user is already on an NTP we deliberately don't trigger here:
-                // - If the prior session classified this NTP as auto-initiated, NtpAfterIdleManager
-                //   has preserved the state across the background; the hatch is still correct.
-                // - Setting pendingAfterIdle here would leak to the next NTP shown (e.g. a
-                //   manually-opened new tab), incorrectly classifying it as auto-initiated.
-            }
-            is SpecificPage -> {
-                // Normal-mode launch preference — never navigate the Fire session.
-                if (currentMode != BrowserMode.REGULAR) return
-                if (fromInactivity) {
-                    notifyAutofillIdleReturn("specific_page")
-                }
-                handleSpecificPageOption(option)
-            }
+        return when (option) {
+            LastOpenedTab -> handleLastOpenedTab(afterIdle, currentMode)
+            NewTabPage -> handleNewTabPage(afterIdle, currentMode)
+            is SpecificPage -> handleSpecificPage(option, afterIdle, currentMode)
         }
+    }
+
+    private suspend fun handleLastOpenedTab(
+        afterIdle: Boolean,
+        currentMode: BrowserMode,
+    ): ShowOnAppLaunchResult {
+        val selectedUrl = tabRepositoryProvider.forMode(currentMode).getSelectedTab()?.url
+        val isAfterIdleLut = afterIdle && currentMode == BrowserMode.REGULAR && !selectedUrl.isNullOrBlank()
+        val treatment = if (isAfterIdleLut) {
+            browserInteractionsPlugins.getPlugins().forEach { it.onLutShownAfterIdle() }
+            AfterIdleTreatment.LUT
+        } else {
+            null
+        }
+        return ShowOnAppLaunchResult(destinationUrl = selectedUrl, treatment = treatment)
+    }
+
+    private suspend fun handleNewTabPage(
+        afterIdle: Boolean,
+        currentMode: BrowserMode,
+    ): ShowOnAppLaunchResult {
+        val tabRepository = tabRepositoryProvider.forMode(currentMode)
+        val selectedTab = tabRepository.getSelectedTab()
+        val shouldAddNewTab = selectedTab == null || !selectedTab.url.isNullOrBlank()
+        val isAfterIdleNtp = shouldAddNewTab && afterIdle && currentMode == BrowserMode.REGULAR
+        val treatment = if (isAfterIdleNtp) {
+            // Set pendingAfterIdle before adding the tab so the selected-tab emission consumes it for this NTP.
+            ntpAfterIdleManager.onIdleReturnTriggered()
+            notifyAutofillIdleReturn("new_tab_page")
+            AfterIdleTreatment.NTP
+        } else {
+            null
+        }
+
+        if (shouldAddNewTab) {
+            tabRepository.add()
+        }
+        // An existing NTP keeps its prior classification; triggering here would leak treatment to the next NTP.
+        return ShowOnAppLaunchResult(destinationUrl = null, treatment = treatment)
+    }
+
+    private suspend fun handleSpecificPage(
+        option: SpecificPage,
+        afterIdle: Boolean,
+        currentMode: BrowserMode,
+    ): ShowOnAppLaunchResult {
+        if (currentMode != BrowserMode.REGULAR) {
+            val selectedUrl = tabRepositoryProvider.forMode(currentMode).getSelectedTab()?.url
+            return ShowOnAppLaunchResult(destinationUrl = selectedUrl, treatment = null)
+        }
+        if (afterIdle) {
+            notifyAutofillIdleReturn("specific_page")
+        }
+        return ShowOnAppLaunchResult(
+            destinationUrl = handleSpecificPageOption(option),
+            treatment = null,
+        )
     }
 
     override suspend fun handleResolvedUrlStorage(
@@ -121,12 +155,8 @@ class ShowOnAppLaunchOptionHandlerImpl @Inject constructor(
         tabId: String,
     ) {
         withContext(dispatchers.io()) {
-            val shouldSaveCurrentUrlForShowOnAppLaunch = currentUrl != null &&
-                isRootOfTab &&
-                tabId == showOnAppLaunchOptionDataStore.showOnAppLaunchTabId
-
-            if (shouldSaveCurrentUrlForShowOnAppLaunch) {
-                showOnAppLaunchOptionDataStore.setResolvedPageUrl(currentUrl!!)
+            if (currentUrl != null && isRootOfTab && tabId == showOnAppLaunchOptionDataStore.showOnAppLaunchTabId) {
+                showOnAppLaunchOptionDataStore.setResolvedPageUrl(currentUrl)
             }
         }
     }
@@ -137,25 +167,22 @@ class ShowOnAppLaunchOptionHandlerImpl @Inject constructor(
         }
     }
 
-    private suspend fun handleSpecificPageOption(option: SpecificPage) {
+    private suspend fun handleSpecificPageOption(option: SpecificPage): String {
         val tabRepository = tabRepositoryProvider.forMode(BrowserMode.REGULAR)
-        val userUri = option.url.toUri()
-        val resolvedUri = option.resolvedUrl?.toUri()
+        val urls = listOfNotNull(option.url, option.resolvedUrl).map { stripIfHttpOrHttps(it.toUri()) }
 
-        val urls = listOfNotNull(userUri, resolvedUri).map { uri ->
-            stripIfHttpOrHttps(uri)
+        val existingTab = tabRepository.flowTabs.first().findLast { tab ->
+            tab.url?.takeIf { it.isNotBlank() }?.let { stripIfHttpOrHttps(it.toUri()) in urls } == true
         }
 
-        val tabIdUrlMap = getTabIdUrlMap(tabRepository.flowTabs.first())
-
-        val existingTabId = tabIdUrlMap.entries.findLast { it.value in urls }?.key
-
-        if (existingTabId != null) {
-            showOnAppLaunchOptionDataStore.setShowOnAppLaunchTabId(existingTabId)
-            tabRepository.select(existingTabId)
+        return if (existingTab != null) {
+            showOnAppLaunchOptionDataStore.setShowOnAppLaunchTabId(existingTab.tabId)
+            tabRepository.select(existingTab.tabId)
+            existingTab.url ?: option.url
         } else {
             val tabId = tabRepository.add(url = option.url)
             showOnAppLaunchOptionDataStore.setShowOnAppLaunchTabId(tabId)
+            option.url
         }
     }
 
@@ -174,15 +201,5 @@ class ShowOnAppLaunchOptionHandlerImpl @Inject constructor(
             .authority(authority)
             .toString()
             .replaceFirst("//", "")
-    }
-
-    private fun getTabIdUrlMap(tabs: List<TabEntity>): Map<String, String> {
-        return tabs
-            .filterNot { tab -> tab.url.isNullOrBlank() }
-            .associate { tab ->
-                val tabUri = tab.url!!.toUri()
-                val strippedUrl = stripIfHttpOrHttps(tabUri)
-                tab.tabId to strippedUrl
-            }
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -147,6 +147,7 @@ import com.duckduckgo.app.browser.pdf.PdfPixelName
 import com.duckduckgo.app.browser.pdf.PdfRenderDecision
 import com.duckduckgo.app.browser.progressbar.ProgressBarUpgradeFeature
 import com.duckduckgo.app.browser.refreshpixels.RefreshPixelSender
+import com.duckduckgo.app.browser.returnsession.ReturnSessionLandingListener
 import com.duckduckgo.app.browser.santize.NonHttpAppLinkChecker
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.browser.tabs.TabManager
@@ -637,6 +638,7 @@ class BrowserTabViewModelTest {
     private val mockBrokenSitePrompt: BrokenSitePrompt = mock()
     private val mockTabStatsBucketing: TabStatsBucketing = mock()
     private val mockNtpAfterIdleManager: NtpAfterIdleManager = mock()
+    private val mockReturnSessionLandingListener: ReturnSessionLandingListener = mock()
     private val mockBrowserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin> = mock()
     private val browserRefreshTriggerFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     private val browserRefreshTriggerPlugin: BrowserRefreshTriggerPlugin = mock {
@@ -1041,6 +1043,7 @@ class BrowserTabViewModelTest {
                 progressBarUpgradeFeature = fakeProgressBarUpgradeFeature,
                 faviconFetchingFixFeature = fakeFaviconFetchingFixFeature,
                 ntpAfterIdleManager = mockNtpAfterIdleManager,
+                returnSessionLandingListener = mockReturnSessionLandingListener,
                 browserInteractionsPlugins = mockBrowserInteractionsPlugins,
                 browserRefreshTriggerPlugins = mockBrowserRefreshTriggerPlugins,
                 brokenSiteReportTriggerPlugins = mockBrokenSiteReportTriggerPlugins,
@@ -1127,6 +1130,7 @@ class BrowserTabViewModelTest {
             testee.onViewVisible()
             verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
             assertTrue(commandCaptor.allValues.contains(Command.ShowKeyboard))
+            verify(mockReturnSessionLandingListener).onLandingFocusCaptured(focused = true)
         }
 
     @Test
@@ -1154,6 +1158,7 @@ class BrowserTabViewModelTest {
             testee.onViewVisible()
 
             assertCommandIssued<Command.DropAddressBarFocus>()
+            verify(mockReturnSessionLandingListener).onLandingFocusCaptured(focused = false)
         }
 
     @Test
@@ -1649,6 +1654,68 @@ class BrowserTabViewModelTest {
         runTest {
             verify(mockTabRepository).deleteTabAndSelectSource(selectedTabLiveData.value!!.tabId)
         }
+    }
+
+    @Test
+    fun whenUserSubmitsSearchFromInvalidatedTabThenOnlyReturnSessionSpecificClassifierFires() {
+        givenOneActiveTabSelected()
+        givenInvalidatedGlobalLayout()
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+        whenever(mockQueryUrlPredictor.isUrl("foo")).thenReturn(false)
+
+        testee.onUserSubmittedQuery("foo")
+
+        verify(plugin, never()).onInputSubmitted()
+        verify(plugin, times(1)).onSearchSubmitted()
+        verify(plugin, never()).onUrlSubmitted()
+    }
+
+    @Test
+    fun whenUserSubmitsCurrentUrlThenOnlyReturnSessionSpecificUrlClassifierFires() {
+        val currentUrl = "https://example.com/"
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+        whenever(mockQueryUrlPredictor.isUrl(currentUrl)).thenReturn(true)
+        whenever(mockOmnibarConverter.convertQueryToUrl(currentUrl, null)).thenReturn(currentUrl)
+        loadUrl(currentUrl, isBrowserShowing = true)
+
+        testee.onUserSubmittedQuery(currentUrl)
+
+        // The generic callback deliberately retains its pre-return-session query != url guard;
+        // only the new specific classifier distinguishes this genuine user submission from restoration.
+        verify(plugin, never()).onInputSubmitted()
+        verify(plugin, times(1)).onUrlSubmitted()
+        verify(plugin, never()).onSearchSubmitted()
+    }
+
+    @Test
+    fun whenUserSubmitsSearchThenGenericAndSpecificClassifiersEachFireOnce() {
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+        whenever(mockQueryUrlPredictor.isUrl("cats")).thenReturn(false)
+        whenever(mockOmnibarConverter.convertQueryToUrl("cats", null)).thenReturn("https://duckduckgo.com/?q=cats")
+
+        testee.onUserSubmittedQuery("cats")
+
+        verify(plugin, times(1)).onInputSubmitted()
+        verify(plugin, times(1)).onSearchSubmitted()
+        verify(plugin, never()).onUrlSubmitted()
+    }
+
+    @Test
+    fun whenUserSubmitsUrlThenGenericAndSpecificClassifiersEachFireOnce() {
+        val submittedUrl = "https://duckduckgo.com/"
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+        whenever(mockQueryUrlPredictor.isUrl(submittedUrl)).thenReturn(true)
+        whenever(mockOmnibarConverter.convertQueryToUrl(submittedUrl, null)).thenReturn(submittedUrl)
+
+        testee.onUserSubmittedQuery(submittedUrl)
+
+        verify(plugin, times(1)).onInputSubmitted()
+        verify(plugin, times(1)).onUrlSubmitted()
+        verify(plugin, never()).onSearchSubmitted()
     }
 
     @Test
@@ -3161,6 +3228,38 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenRestoringCurrentUrlThenNoBrowserInteractionClassifierFires() = runTest {
+        val currentUrl = "https://example.com/"
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+        whenever(mockOmnibarConverter.convertQueryToUrl(currentUrl)).thenReturn(currentUrl)
+        loadUrl(currentUrl, isBrowserShowing = true)
+        webViewSessionStorage.stub { onBlocking { restoreSession(anyOrNull(), anyString()) }.thenReturn(false) }
+
+        testee.restoreWebViewState(null, currentUrl)
+
+        verifyNoInteractions(plugin)
+    }
+
+    @Test
+    fun whenRestoringDifferentFallbackUrlThenOldGenericClassifierStillFiresButSpecificClassifiersDoNot() = runTest {
+        val currentUrl = "https://example.com/current"
+        val fallbackUrl = "https://example.com/restored"
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+        whenever(mockOmnibarConverter.convertQueryToUrl(fallbackUrl)).thenReturn(fallbackUrl)
+        loadUrl(currentUrl, isBrowserShowing = true)
+        webViewSessionStorage.stub { onBlocking { restoreSession(anyOrNull(), anyString()) }.thenReturn(false) }
+
+        testee.restoreWebViewState(null, fallbackUrl)
+
+        // The generic callback is intentionally unchanged: historically query != url fired it.
+        verify(plugin, times(1)).onInputSubmitted()
+        verify(plugin, never()).onSearchSubmitted()
+        verify(plugin, never()).onUrlSubmitted()
+    }
+
+    @Test
     fun whenRestoringWebViewSessionNotRestorableAndNoPreviousUrlThenNoUrlLoaded() = runTest {
         webViewSessionStorage.stub { onBlocking { restoreSession(anyOrNull(), anyString()) }.thenReturn(false) }
         testee.restoreWebViewState(null, "")
@@ -3245,6 +3344,20 @@ class BrowserTabViewModelTest {
         runTest {
             verify(mockTabRepository).deleteTabAndSelectSource(selectedTabLiveData.value!!.tabId)
         }
+    }
+
+    @Test
+    fun whenUserClicksOnErrorRecoveryActionThenNoBrowserInteractionClassifierFires() {
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+        givenOneActiveTabSelected()
+        testee.recoverFromRenderProcessGone()
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        val showErrorWithAction = commandCaptor.lastValue as Command.ShowErrorWithAction
+
+        showErrorWithAction.action()
+
+        verifyNoInteractions(plugin)
     }
 
     @Test
@@ -3701,6 +3814,16 @@ class BrowserTabViewModelTest {
             testee.closeAndSelectSourceTab()
             verify(mockTabRepository).deleteTabAndSelectSource(selectedTabLiveData.value!!.tabId)
         }
+
+    @Test
+    fun whenBackInteractionThenBrowserInteractionPluginFiresOnce() {
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+
+        testee.onBackInteraction()
+
+        verify(plugin, times(1)).onBackPressed()
+    }
 
     @Test
     fun whenUserPressesBackAndSkippingHomeThenWebViewPreviewGenerated() {
@@ -8592,9 +8715,48 @@ class BrowserTabViewModelTest {
 
         testee.openDuckAiQuery(query = "hello", autoPrompt = true)
 
-        // Fires once from openDuckAiQuery itself and once more from the onUserSubmittedQuery it
-        // routes through via navigateToDuckAi — pre-existing on this path, not new here.
+        // Preserve the pre-return-session behavior: one callback is explicit and one comes from
+        // reusing the NTP tab. The new AI classifier must still fire exactly once without a URL.
         verify(plugin, times(2)).onInputSubmitted()
+        verify(plugin, times(1)).onAiPromptSubmitted()
+        verify(plugin, never()).onUrlSubmitted()
+        verify(plugin, never()).onSearchSubmitted()
+    }
+
+    @Test
+    fun whenOpenDuckAiWithoutQueryThenDoesNotFireOnAiPromptSubmitted() = runTest {
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+        setBrowserShowing(true)
+
+        testee.openDuckAiQuery(query = "", autoPrompt = false)
+
+        verify(plugin).onInputSubmitted()
+        verify(plugin, never()).onAiPromptSubmitted()
+    }
+
+    @Test
+    fun whenOpenDuckAiWithPrefillThenDoesNotFireOnAiPromptSubmitted() = runTest {
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+        setBrowserShowing(true)
+
+        testee.openDuckAiQuery(query = "prefill", autoPrompt = false)
+
+        verify(plugin).onInputSubmitted()
+        verify(plugin, never()).onAiPromptSubmitted()
+    }
+
+    @Test
+    fun whenOpenDuckAiWithAutoPromptThenFiresOnAiPromptSubmitted() = runTest {
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+        setBrowserShowing(true)
+
+        testee.openDuckAiQuery(query = "hello", autoPrompt = true)
+
+        verify(plugin).onInputSubmitted()
+        verify(plugin).onAiPromptSubmitted()
     }
 
     @Test
@@ -8606,6 +8768,33 @@ class BrowserTabViewModelTest {
         testee.openDuckAiChatById("https://duck.ai/chat?chatId=abc")
 
         verify(plugin).onChatSelected()
+    }
+
+    @Test
+    fun whenOpenDuckAiChatByIdReusesNtpTabThenPreservesGenericCallbackWithoutUrlClassification() = runTest {
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+        setBrowserShowing(false)
+        whenever(mockOmnibarConverter.convertQueryToUrl("https://duck.ai/chat?chatId=abc", null))
+            .thenReturn("https://duck.ai/chat?chatId=abc")
+
+        testee.openDuckAiChatById("https://duck.ai/chat?chatId=abc")
+
+        verify(plugin, times(1)).onChatSelected()
+        verify(plugin, times(1)).onInputSubmitted()
+        verify(plugin, never()).onSearchSubmitted()
+        verify(plugin, never()).onUrlSubmitted()
+    }
+
+    @Test
+    fun whenDuckAiChatPromptSubmittedThenFiresOnInputSubmittedAndOnAiPromptSubmitted() = runTest {
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+
+        testee.onDuckAiChatPromptSubmitted()
+
+        verify(plugin).onInputSubmitted()
+        verify(plugin).onAiPromptSubmitted()
     }
 
     @Test
@@ -8852,17 +9041,45 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenOnDuckChatOmnibarButtonClickedResolvesToDuckChatUrlThenFiresOnAiPromptSubmitted() {
+        whenever(mockOmnibarConverter.convertQueryToUrl(duckChatURL, null)).thenReturn(duckChatURL)
+        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+
+        testee.onDuckChatOmnibarButtonClicked(query = "example", hasFocus = true, isNtp = false)
+
+        verify(plugin).onInputSubmitted()
+        verify(plugin).onAiPromptSubmitted()
+        verify(plugin, never()).onUrlSubmitted()
+    }
+
+    @Test
     fun whenOnDuckChatOmnibarButtonClickedWithoutFocusThenGetsDuckChatUrl() {
         whenever(mockOmnibarConverter.convertQueryToUrl(duckChatURL, null)).thenReturn(duckChatURL)
+        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+
         testee.onDuckChatOmnibarButtonClicked(query = "example", hasFocus = false, isNtp = false)
+
         verify(mockDuckChat).getDuckChatUrl(eq("example"), eq(false), any())
+        verify(plugin).onInputSubmitted()
+        verify(plugin, never()).onAiPromptSubmitted()
     }
 
     @Test
     fun whenOnDuckChatOmnibarButtonClickedWithNullQueryAndFocusThenGetsDuckChatUrlWithAutoPrompt() {
         whenever(mockOmnibarConverter.convertQueryToUrl(duckChatURL, null)).thenReturn(duckChatURL)
+        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+
         testee.onDuckChatOmnibarButtonClicked(query = null, hasFocus = true, isNtp = false)
+
         verify(mockDuckChat).getDuckChatUrl(eq(""), eq(true), any())
+        verify(plugin).onInputSubmitted()
+        verify(plugin, never()).onAiPromptSubmitted()
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/NtpEngagementTrackerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/NtpEngagementTrackerTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.newtab
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class NtpEngagementTrackerTest {
+
+    private lateinit var testee: NtpEngagementTracker
+
+    @Before
+    fun setup() {
+        testee = NtpEngagementTracker()
+    }
+
+    @Test
+    fun whenEngagementHasNotBeenReportedThenShouldReportEngagement() {
+        assertTrue(testee.shouldReportEngagement())
+    }
+
+    @Test
+    fun whenEngagementHasAlreadyBeenReportedThenShouldNotReportEngagementAgain() {
+        testee.shouldReportEngagement()
+
+        assertFalse(testee.shouldReportEngagement())
+    }
+
+    @Test
+    fun whenFreshLaunchOpensThenEngagementCanBeReportedAgain() {
+        testee.shouldReportEngagement()
+
+        testee.onOpen(isFreshLaunch = true)
+
+        assertTrue(testee.shouldReportEngagement())
+    }
+
+    @Test
+    fun whenNonFreshLaunchOpensThenEngagementCanBeReportedAgain() {
+        testee.shouldReportEngagement()
+
+        testee.onOpen(isFreshLaunch = false)
+
+        assertTrue(testee.shouldReportEngagement())
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/returnsession/RealReturnSessionWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/returnsession/RealReturnSessionWideEventTest.kt
@@ -551,6 +551,44 @@ class RealReturnSessionWideEventTest {
     }
 
     @Test
+    fun `when ntp engagement is captured before landing resolves then page_engaged metadata is true on terminal`() = runTest {
+        testee.onNtpEngaged()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["page_engaged"] == "true" },
+        )
+        verify(wideEventClient).intervalEnd(123L, "time_to_first_interaction_ms_bucketed")
+    }
+
+    @Test
+    fun `when return closes before landing resolves then pending engagement is cleared`() = runTest {
+        testee.onNtpEngaged()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        testee.onReturnClosed()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["page_engaged"] == "false" },
+        )
+    }
+
+    @Test
     fun `when return closes with active session then flowFinish is Cancelled with app_backgrounded reason`() = runTest {
         startSession()
         coroutineRule.testScope.testScheduler.advanceUntilIdle()

--- a/app/src/test/java/com/duckduckgo/app/browser/returnsession/RealReturnSessionWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/returnsession/RealReturnSessionWideEventTest.kt
@@ -1,0 +1,831 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.returnsession
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.wideevents.CleanupPolicy
+import com.duckduckgo.app.statistics.wideevents.FlowStatus
+import com.duckduckgo.app.statistics.wideevents.WideEventClient
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.robolectric.annotation.Config
+import kotlin.time.Duration.Companion.milliseconds
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class RealReturnSessionWideEventTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule(StandardTestDispatcher())
+
+    private val wideEventClient: WideEventClient = mock()
+    private val settingsDataStore: SettingsDataStore = mock()
+    private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore = mock()
+
+    // MutableSharedFlow, not StateFlow: needs to be able to re-emit the same value (simulating the
+    // underlying DataStore re-emitting on an unrelated Preferences write) without built-in dedup.
+    private val optionFlow = MutableSharedFlow<ShowOnAppLaunchOption>(replay = 1)
+    private val returnSessionWideEventFeature =
+        FakeFeatureToggleFactory.create(ReturnSessionWideEventFeature::class.java)
+
+    private lateinit var testee: RealReturnSessionWideEvent
+
+    private val defaultMetadata = mapOf(
+        "after_idle" to "false",
+        "landed_on" to "ntp_user_initiated",
+        "status_reason" to "app_terminated",
+    )
+
+    @Before
+    fun setup() = runTest {
+        optionFlow.tryEmit(ShowOnAppLaunchOption.NewTabPage)
+        whenever(showOnAppLaunchOptionDataStore.optionFlow).thenReturn(optionFlow)
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(0L)
+        returnSessionWideEventFeature.self().setRawStoredState(Toggle.State(true))
+
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any())).thenReturn(Result.success(123L))
+        whenever(wideEventClient.intervalStart(any(), any(), anyOrNull(), anyOrNull())).thenReturn(Result.success(Unit))
+        whenever(wideEventClient.intervalEnd(any(), any())).thenReturn(Result.success(100.milliseconds))
+        whenever(wideEventClient.flowFinish(any(), any(), any())).thenReturn(Result.success(Unit))
+        whenever(wideEventClient.flowAbort(any())).thenReturn(Result.success(Unit))
+
+        testee = buildTestee()
+    }
+
+    // Only tests that need optionFlow seeded to something other than NewTabPage before construction
+    // (so that value becomes the collector's dropped baseline) call this to get a fresh instance.
+    private fun buildTestee(): RealReturnSessionWideEvent = RealReturnSessionWideEvent(
+        wideEventClient = wideEventClient,
+        settingsDataStore = settingsDataStore,
+        showOnAppLaunchOptionDataStore = showOnAppLaunchOptionDataStore,
+        returnSessionWideEventFeature = { returnSessionWideEventFeature },
+        dispatchers = coroutineRule.testDispatcherProvider,
+        appCoroutineScope = coroutineRule.testScope,
+    )
+
+    private fun startSession(
+        testee: RealReturnSessionWideEvent = this.testee,
+        afterIdle: Boolean = false,
+        landing: ReturnSessionLanding = if (afterIdle) ReturnSessionLanding.NTP else ReturnSessionLanding.NTP_USER_INITIATED,
+    ) {
+        testee.onReturnLandingResolved(ReturnSessionLandingResult(afterIdle, landing))
+    }
+
+    @Test
+    fun `when ordinary return landing resolves with no selected tab then landed_on is ntp_user_initiated`() = runTest {
+        testee.onReturnLandingResolved(
+            ReturnSessionLandingResult(
+                afterIdle = false,
+                landing = ReturnSessionLanding.NTP_USER_INITIATED,
+            ),
+        )
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowStart(
+            name = eq("return_session"),
+            flowEntryPoint = isNull(),
+            metadata = eq(defaultMetadata),
+            cleanupPolicy = eq(CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = false, flowStatus = FlowStatus.Unknown)),
+            samplingProbability = eq(0.05f),
+            definition = any(),
+        )
+    }
+
+    @Test
+    fun `when after-idle return landing resolves with no selected tab then landed_on is ntp`() = runTest {
+        testee.onReturnLandingResolved(
+            ReturnSessionLandingResult(
+                afterIdle = true,
+                landing = ReturnSessionLanding.NTP,
+            ),
+        )
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowStart(
+            name = eq("return_session"),
+            flowEntryPoint = isNull(),
+            metadata = eq(
+                defaultMetadata +
+                    mapOf(
+                        "after_idle" to "true",
+                        "landed_on" to "ntp",
+                    ),
+            ),
+            cleanupPolicy = any(),
+            samplingProbability = eq(0.05f),
+            definition = any(),
+        )
+    }
+
+    @Test
+    fun `when landing resolves as ntp then emitted landed_on uses the passed destination`() = runTest {
+        testee.onReturnLandingResolved(
+            ReturnSessionLandingResult(
+                afterIdle = true,
+                landing = ReturnSessionLanding.NTP,
+            ),
+        )
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowStart(
+            name = eq("return_session"),
+            flowEntryPoint = isNull(),
+            metadata = argThat { this["landed_on"] == "ntp" },
+            cleanupPolicy = any(),
+            samplingProbability = any(),
+            definition = any(),
+        )
+    }
+
+    @Test
+    fun `when after-idle NTP landing resolves then finish metadata reflects after_idle true and landed_on ntp`() = runTest {
+        startSession(afterIdle = true)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["after_idle"] == "true" && this["landed_on"] == "ntp" },
+        )
+    }
+
+    @Test
+    fun `when after-idle web landing resolves then finish metadata reflects after_idle true and keeps resolved landed_on`() =
+        runTest {
+            startSession(afterIdle = true, landing = ReturnSessionLanding.WEB)
+            coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+            testee.onSearchSubmitted()
+            coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+            verify(wideEventClient).flowFinish(
+                wideEventId = eq(123L),
+                status = eq<FlowStatus>(FlowStatus.Success),
+                metadata = argThat { this["after_idle"] == "true" && this["landed_on"] == "web" },
+            )
+        }
+
+    @Test
+    fun `when after-idle Duck AI LUT landing resolves then landed_on reflects the resumed tab`() = runTest {
+        startSession(afterIdle = true, landing = ReturnSessionLanding.DUCK_AI)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["after_idle"] == "true" && this["landed_on"] == "duck_ai" },
+        )
+    }
+
+    @Test
+    fun `when resolved landing is duck ai then landed_on is duck_ai`() = runTest {
+        startSession(landing = ReturnSessionLanding.DUCK_AI)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowStart(
+            name = eq("return_session"),
+            flowEntryPoint = isNull(),
+            metadata = eq(defaultMetadata + ("landed_on" to "duck_ai")),
+            cleanupPolicy = any(),
+            samplingProbability = eq(0.05f),
+            definition = any(),
+        )
+    }
+
+    @Test
+    fun `when resolved landing is serp then landed_on is serp`() = runTest {
+        startSession(landing = ReturnSessionLanding.SERP)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowStart(
+            name = eq("return_session"),
+            flowEntryPoint = isNull(),
+            metadata = eq(defaultMetadata + ("landed_on" to "serp")),
+            cleanupPolicy = any(),
+            samplingProbability = eq(0.05f),
+            definition = any(),
+        )
+    }
+
+    @Test
+    fun `when resolved landing is regular website then landed_on is web`() = runTest {
+        startSession(landing = ReturnSessionLanding.WEB)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowStart(
+            name = eq("return_session"),
+            flowEntryPoint = isNull(),
+            metadata = eq(defaultMetadata + ("landed_on" to "web")),
+            cleanupPolicy = any(),
+            samplingProbability = eq(0.05f),
+            definition = any(),
+        )
+    }
+
+    @Test
+    fun `when resolved landing is user initiated ntp then landed_on is ntp_user_initiated`() = runTest {
+        startSession(landing = ReturnSessionLanding.NTP_USER_INITIATED)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowStart(
+            name = eq("return_session"),
+            flowEntryPoint = isNull(),
+            metadata = eq(defaultMetadata),
+            cleanupPolicy = any(),
+            samplingProbability = eq(0.05f),
+            definition = any(),
+        )
+    }
+
+    @Test
+    fun `when there is no prior background timestamp then time_away_ms_bucketed is omitted`() = runTest {
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(0L)
+
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowStart(
+            name = eq("return_session"),
+            flowEntryPoint = isNull(),
+            metadata = eq(defaultMetadata),
+            cleanupPolicy = any(),
+            samplingProbability = any(),
+            definition = any(),
+        )
+    }
+
+    @Test
+    fun `when backgrounded under a minute ago then time_away_ms_bucketed is 0`() = runTest {
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(System.currentTimeMillis() - 1_000L)
+
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowStart(
+            name = eq("return_session"),
+            flowEntryPoint = isNull(),
+            metadata = eq(defaultMetadata + ("time_away_ms_bucketed" to "0")),
+            cleanupPolicy = any(),
+            samplingProbability = any(),
+            definition = any(),
+        )
+    }
+
+    @Test
+    fun `when backgrounded exactly a minute ago then time_away_ms_bucketed is 60000`() = runTest {
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(System.currentTimeMillis() - 60_000L)
+
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowStart(
+            name = eq("return_session"),
+            flowEntryPoint = isNull(),
+            metadata = eq(defaultMetadata + ("time_away_ms_bucketed" to "60000")),
+            cleanupPolicy = any(),
+            samplingProbability = any(),
+            definition = any(),
+        )
+    }
+
+    @Test
+    fun `when backgrounded over an hour ago then time_away_ms_bucketed is 3600000`() = runTest {
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(System.currentTimeMillis() - 3_700_000L)
+
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowStart(
+            name = eq("return_session"),
+            flowEntryPoint = isNull(),
+            metadata = eq(defaultMetadata + ("time_away_ms_bucketed" to "3600000")),
+            cleanupPolicy = any(),
+            samplingProbability = eq(0.05f),
+            definition = any(),
+        )
+    }
+
+    @Test
+    fun `when onOpen called twice then prior flow is aborted before new flowStart`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .thenReturn(Result.success(1L))
+            .thenReturn(Result.success(2L))
+
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowAbort(1L)
+    }
+
+    @Test
+    fun `when feature flag disabled then no flow operations occur`() = runTest {
+        returnSessionWideEventFeature.self().setRawStoredState(Toggle.State(false))
+
+        startSession()
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verifyNoInteractions(wideEventClient)
+    }
+
+    @Test
+    fun `when feature flag disabled mid-session then active flow is aborted instead of left dangling`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        returnSessionWideEventFeature.self().setRawStoredState(Toggle.State(false))
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowAbort(123L)
+        verify(wideEventClient, never()).flowFinish(any(), any(), any())
+    }
+
+    @Test
+    fun `when onSearchSubmitted terminates session then flowFinish is Success with search_submitted reason`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = eq(
+                mapOf(
+                    "after_idle" to "false",
+                    "landed_on" to "ntp_user_initiated",
+                    "status_reason" to "search_submitted",
+                    "focused" to "false",
+                    "page_engaged" to "false",
+                    "back_pressed" to "false",
+                    "opening_screen_changed" to "false",
+                    "close_tab_tapped" to "false",
+                    "burn_tab_tapped" to "false",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `when onUrlSubmitted terminates session then flowFinish reason is url_submitted`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onUrlSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["status_reason"] == "url_submitted" },
+        )
+    }
+
+    @Test
+    fun `when onAiPromptSubmitted terminates session then flowFinish reason is ai_prompt_submitted`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onAiPromptSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["status_reason"] == "ai_prompt_submitted" },
+        )
+    }
+
+    @Test
+    fun `when onChatSelected terminates session then flowFinish is Success with chat_selected reason`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onChatSelected()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["status_reason"] == "chat_selected" },
+        )
+    }
+
+    @Test
+    fun `when onFavoriteSelected terminates session then flowFinish is Success with favorite_selected reason`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onFavoriteSelected()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["status_reason"] == "favorite_selected" },
+        )
+    }
+
+    @Test
+    fun `when onReturnToPageTapped terminates session then flowFinish is Success with return_to_page_tapped reason`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onReturnToPageTapped()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["status_reason"] == "return_to_page_tapped" },
+        )
+    }
+
+    @Test
+    fun `when onTabSwitcherSelected terminates session then flowFinish is Success with tab_switcher_selected reason`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onTabSwitcherSelected()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["status_reason"] == "tab_switcher_selected" },
+        )
+    }
+
+    @Test
+    fun `when successful terminal occurs before another interaction then time to first interaction ends`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).intervalEnd(123L, "time_to_first_interaction_ms_bucketed")
+    }
+
+    @Test
+    fun `when return closes before any interaction then time to first interaction does not end`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onReturnClosed()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient, never()).intervalEnd(123L, "time_to_first_interaction_ms_bucketed")
+    }
+
+    @Test
+    fun `when return closes after page interaction then time to first interaction does not end again`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onWebViewEngaged()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        testee.onReturnClosed()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient, times(1)).intervalEnd(123L, "time_to_first_interaction_ms_bucketed")
+    }
+
+    @Test
+    fun `when return closes before any interaction then session duration still ends`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onReturnClosed()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).intervalEnd(123L, "session_duration_ms_bucketed")
+    }
+
+    @Test
+    fun `when return closes with active session then flowFinish is Cancelled with app_backgrounded reason`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onReturnClosed()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Cancelled),
+            metadata = argThat { this["status_reason"] == "app_backgrounded" },
+        )
+    }
+
+    @Test
+    fun `when return closes without active session then no flowFinish occurs`() = runTest {
+        testee.onReturnClosed()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient, never()).flowFinish(any(), any(), any())
+    }
+
+    @Test
+    fun `when return closes before landing resolves then pending focus is cleared`() = runTest {
+        testee.onLandingFocusCaptured(focused = true)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        testee.onReturnClosed()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["focused"] == "false" },
+        )
+    }
+
+    @Test
+    fun `when landing input is initially focused then focused metadata is true on terminal`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onLandingFocusCaptured(focused = true)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["focused"] == "true" },
+        )
+    }
+
+    @Test
+    fun `when landing focus is captured before landing resolves then focused metadata is true on terminal`() = runTest {
+        testee.onLandingFocusCaptured(focused = true)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["focused"] == "true" },
+        )
+    }
+
+    @Test
+    fun `when landing focus is captured while session start is suspended then focused metadata is true on terminal`() = runTest {
+        val flowStartResult = CompletableDeferred<Result<Long>>()
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .doSuspendableAnswer { flowStartResult.await() }
+
+        startSession()
+        coroutineRule.testScope.testScheduler.runCurrent()
+
+        testee.onLandingFocusCaptured(focused = true)
+        coroutineRule.testScope.testScheduler.runCurrent()
+
+        flowStartResult.complete(Result.success(123L))
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["focused"] == "true" },
+        )
+    }
+
+    @Test
+    fun `when landing input is initially unfocused then later focus does not change focused metadata`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onLandingFocusCaptured(focused = false)
+        testee.onLandingFocusCaptured(focused = true)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["focused"] == "false" },
+        )
+    }
+
+    @Test
+    fun `when optionFlow re-emits the identical option then opening_screen_changed stays false`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        optionFlow.tryEmit(ShowOnAppLaunchOption.NewTabPage)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["opening_screen_changed"] == "false" },
+        )
+    }
+
+    @Test
+    fun `when a Specific Page resolvedUrl updates then opening_screen_changed stays false`() = runTest {
+        // Reproduces the real trigger: setResolvedPageUrl() re-emits a *different* SpecificPage
+        // instance (resolvedUrl is part of its equals()) as the destination loads, even though the
+        // user's configured option (the url) never changed. Drain setup()'s NewTabPage seed first
+        // (via the @Before testee's own collector), then seed SpecificPage and rebuild testee, so
+        // *that* value — not NewTabPage — is what the new collector drops as its initial baseline;
+        // otherwise the NewTabPage-to-SpecificPage transition itself would be the (correctly)
+        // recorded change, masking the thing under test.
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        optionFlow.tryEmit(ShowOnAppLaunchOption.SpecificPage(url = "https://example.com", resolvedUrl = null))
+        val testee = buildTestee()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        startSession(testee = testee)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        optionFlow.tryEmit(ShowOnAppLaunchOption.SpecificPage(url = "https://example.com", resolvedUrl = "https://example.com/resolved"))
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["opening_screen_changed"] == "false" },
+        )
+    }
+
+    @Test
+    fun `when optionFlow emits a genuinely different option then opening_screen_changed is true`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        optionFlow.tryEmit(ShowOnAppLaunchOption.LastOpenedTab)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["opening_screen_changed"] == "true" },
+        )
+    }
+
+    @Test
+    fun `when a Specific Page url genuinely changes then opening_screen_changed is true`() = runTest {
+        // Same baseline-isolation reasoning as the resolvedUrl test above.
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        optionFlow.tryEmit(ShowOnAppLaunchOption.SpecificPage(url = "https://example.com", resolvedUrl = null))
+        val testee = buildTestee()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        startSession(testee = testee)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        optionFlow.tryEmit(ShowOnAppLaunchOption.SpecificPage(url = "https://other.com", resolvedUrl = null))
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["opening_screen_changed"] == "true" },
+        )
+    }
+
+    @Test
+    fun `when onCloseTabTapped recorded then close_tab_tapped metadata is true on terminal`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onCloseTabTapped()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["close_tab_tapped"] == "true" },
+        )
+    }
+
+    @Test
+    fun `when onBurnTabTapped recorded then burn_tab_tapped metadata is true on terminal`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onBurnTabTapped()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["burn_tab_tapped"] == "true" },
+        )
+    }
+
+    @Test
+    fun `when onBackPressed recorded without active session then is a no-op`() = runTest {
+        testee.onBackPressed()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient, never()).intervalEnd(any(), any())
+        verify(wideEventClient, never()).flowFinish(any(), any(), any())
+    }
+
+    @Test
+    fun `when onBackPressed recorded with active session then back_pressed metadata is true on terminal`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onBackPressed()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["back_pressed"] == "true" },
+        )
+    }
+
+    @Test
+    fun `when terminal already fired then subsequent terminal calls produce only one finish`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onSearchSubmitted()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        testee.onTabSwitcherSelected()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient, times(1)).flowFinish(any(), any(), any())
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
@@ -18,7 +18,11 @@ package com.duckduckgo.app.generalsettings.showonapplaunch
 
 import androidx.lifecycle.MutableLiveData
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.app.browser.autofill.SystemAutofillEngagement
+import com.duckduckgo.app.browser.returnsession.ReturnSessionLanding
+import com.duckduckgo.app.browser.returnsession.ReturnSessionLandingListener
+import com.duckduckgo.app.browser.returnsession.ReturnSessionLandingResult
 import com.duckduckgo.app.browser.state.ModeSwitchRecreateSignal
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
@@ -62,9 +66,15 @@ class FirstScreenHandlerImplTest {
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature = mock()
     private val showOnAppLaunchFeature: ShowOnAppLaunchFeature = mock()
     private val settingsDataStore: SettingsDataStore = mock()
-    private val showOnAppLaunchOptionHandler: ShowOnAppLaunchOptionHandler = mock()
+    private val showOnAppLaunchOptionHandler: ShowOnAppLaunchOptionHandler = mock {
+        onBlocking { handleAfterInactivityOption(wasIdle = any(), currentMode = any()) } doReturn
+            ShowOnAppLaunchResult(destinationUrl = null, treatment = null)
+        onBlocking { handleAppLaunchOption(currentMode = any()) } doReturn
+            ShowOnAppLaunchResult(destinationUrl = null, treatment = null)
+    }
     private lateinit var showOnAppLaunchOptionDataStore: FakeShowOnAppLaunchOptionDataStore
     private val appBuildConfig: AppBuildConfig = mock()
+    private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector = mock()
     private val duckChat: DuckChat = mock()
     private val tabRepository: TabRepository = mock()
     private val browserModeFlow = MutableStateFlow(BrowserMode.REGULAR)
@@ -80,6 +90,7 @@ class FirstScreenHandlerImplTest {
     private val showOnAppLaunchToggle: Toggle = mock()
     private val ntpAfterIdleManager: NtpAfterIdleManager = mock()
     private val modeSwitchRecreateSignal = ModeSwitchRecreateSignal()
+    private val returnSessionLandingListener: ReturnSessionLandingListener = mock()
     private val testScope = coroutineTestRule.testScope
 
     private lateinit var testee: FirstScreenHandlerImpl
@@ -104,6 +115,7 @@ class FirstScreenHandlerImplTest {
             showOnAppLaunchOptionHandler = showOnAppLaunchOptionHandler,
             showOnAppLaunchOptionDataStore = showOnAppLaunchOptionDataStore,
             appBuildConfig = appBuildConfig,
+            duckDuckGoUrlDetector = duckDuckGoUrlDetector,
             duckChat = duckChat,
             tabRepositoryProvider = tabRepositoryProvider,
             browserModeStateHolder = browserModeStateHolder,
@@ -111,6 +123,7 @@ class FirstScreenHandlerImplTest {
             systemAutofillEngagement = systemAutofillEngagement,
             customTabDetector = customTabDetector,
             modeSwitchRecreateSignal = modeSwitchRecreateSignal,
+            returnSessionLandingListener = returnSessionLandingListener,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
             appCoroutineScope = testScope,
             idleThresholdResolver = RealIdleThresholdResolver(androidBrowserConfigFeature),
@@ -187,6 +200,123 @@ class FirstScreenHandlerImplTest {
     }
 
     @Test
+    fun whenIdleReturnCreatesNtpTreatmentThenReportsAfterIdleNtpLanding() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(System.currentTimeMillis() - (6 * 60 * 1000))
+        whenever(showOnAppLaunchOptionHandler.handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR))
+            .thenReturn(
+                ShowOnAppLaunchResult(
+                    destinationUrl = null,
+                    treatment = AfterIdleTreatment.NTP,
+                ),
+            )
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(returnSessionLandingListener).onReturnLandingResolved(
+            ReturnSessionLandingResult(
+                afterIdle = true,
+                landing = ReturnSessionLanding.NTP,
+            ),
+        )
+    }
+
+    @Test
+    fun whenIdleReturnResolvesWhileAlreadyOnNtpThenReportsOrdinaryNtpLanding() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(System.currentTimeMillis() - (6 * 60 * 1000))
+        liveSelectedTab.value = TabEntity(tabId = "ntp", url = null)
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(returnSessionLandingListener).onReturnLandingResolved(
+            ReturnSessionLandingResult(
+                afterIdle = false,
+                landing = ReturnSessionLanding.NTP_USER_INITIATED,
+            ),
+        )
+    }
+
+    @Test
+    fun whenIdleReturnResumesLutThenReportsAfterIdleClassifiedDestination() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(System.currentTimeMillis() - (6 * 60 * 1000))
+        whenever(tabRepository.getSelectedTab()).thenReturn(TabEntity(tabId = "stale", url = null))
+        whenever(showOnAppLaunchOptionHandler.handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR))
+            .thenReturn(
+                ShowOnAppLaunchResult(
+                    destinationUrl = "https://example.com",
+                    treatment = AfterIdleTreatment.LUT,
+                ),
+            )
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(returnSessionLandingListener).onReturnLandingResolved(
+            ReturnSessionLandingResult(
+                afterIdle = true,
+                landing = ReturnSessionLanding.WEB,
+            ),
+        )
+    }
+
+    @Test
+    fun whenIdleSpecificPageResolvesToDuckAiThenReportsOrdinaryDuckAiLanding() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(System.currentTimeMillis() - (6 * 60 * 1000))
+        whenever(showOnAppLaunchOptionHandler.handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR))
+            .thenReturn(
+                ShowOnAppLaunchResult(
+                    destinationUrl = "https://duck.ai/chat",
+                    treatment = null,
+                ),
+            )
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(returnSessionLandingListener).onReturnLandingResolved(
+            ReturnSessionLandingResult(
+                afterIdle = false,
+                landing = ReturnSessionLanding.DUCK_AI,
+            ),
+        )
+    }
+
+    @Test
+    fun whenResolvedDestinationIsSerpThenReportsSerpLanding() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(System.currentTimeMillis() - (6 * 60 * 1000))
+        whenever(showOnAppLaunchOptionHandler.handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR))
+            .thenReturn(
+                ShowOnAppLaunchResult(
+                    destinationUrl = "https://duckduckgo.com/?q=test",
+                    treatment = AfterIdleTreatment.LUT,
+                ),
+            )
+        whenever(duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(any())).thenReturn(true)
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(returnSessionLandingListener).onReturnLandingResolved(
+            ReturnSessionLandingResult(
+                afterIdle = true,
+                landing = ReturnSessionLanding.SERP,
+            ),
+        )
+    }
+
+    @Test
     fun whenIdleReturnEnabledAndFreshLaunchAndElapsedExceedsTimeoutThenDelegatesWithWasIdleTrue() = runTest {
         whenever(idleReturnToggle.isEnabled()).thenReturn(true)
         whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
@@ -210,6 +340,12 @@ class FirstScreenHandlerImplTest {
         testScope.testScheduler.advanceUntilIdle()
 
         verifyNoInteractions(showOnAppLaunchOptionHandler)
+        verify(returnSessionLandingListener).onReturnLandingResolved(
+            ReturnSessionLandingResult(
+                afterIdle = false,
+                landing = ReturnSessionLanding.NTP_USER_INITIATED,
+            ),
+        )
     }
 
     @Test
@@ -235,6 +371,12 @@ class FirstScreenHandlerImplTest {
         testScope.testScheduler.advanceUntilIdle()
 
         verify(showOnAppLaunchOptionHandler).handleAfterInactivityOption(wasIdle = false, currentMode = BrowserMode.REGULAR)
+        verify(returnSessionLandingListener).onReturnLandingResolved(
+            ReturnSessionLandingResult(
+                afterIdle = false,
+                landing = ReturnSessionLanding.NTP_USER_INITIATED,
+            ),
+        )
     }
 
     @Test
@@ -274,6 +416,12 @@ class FirstScreenHandlerImplTest {
         testScope.testScheduler.advanceUntilIdle()
 
         verifyNoInteractions(showOnAppLaunchOptionHandler)
+        verify(returnSessionLandingListener).onReturnLandingResolved(
+            ReturnSessionLandingResult(
+                afterIdle = false,
+                landing = ReturnSessionLanding.NTP_USER_INITIATED,
+            ),
+        )
     }
 
     @Test
@@ -367,6 +515,12 @@ class FirstScreenHandlerImplTest {
         testScope.testScheduler.advanceUntilIdle()
 
         verifyNoInteractions(showOnAppLaunchOptionHandler)
+        verify(returnSessionLandingListener).onReturnLandingResolved(
+            ReturnSessionLandingResult(
+                afterIdle = false,
+                landing = ReturnSessionLanding.DUCK_AI,
+            ),
+        )
     }
 
     @Test
@@ -447,7 +601,7 @@ class FirstScreenHandlerImplTest {
     // --- Synchronous onIdleReturnTriggered (only on fresh launch when current tab is already an NTP) ---
 
     @Test
-    fun whenFreshLaunchAndIdleReturnEnabledAndIdleAndCurrentTabIsNtpThenNotifiesNtpAfterIdleManagerSynchronously() {
+    fun whenFreshLaunchAndIdleReturnEnabledAndIdleAndCurrentTabIsNtpThenAppliesNtpTreatmentSynchronously() = runTest {
         whenever(idleReturnToggle.isEnabled()).thenReturn(true)
         whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
         val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
@@ -458,6 +612,13 @@ class FirstScreenHandlerImplTest {
 
         // Called synchronously from onOpen, before any coroutine advances.
         verify(ntpAfterIdleManager).onIdleReturnTriggered()
+        testScope.testScheduler.advanceUntilIdle()
+        verify(returnSessionLandingListener).onReturnLandingResolved(
+            ReturnSessionLandingResult(
+                afterIdle = true,
+                landing = ReturnSessionLanding.NTP,
+            ),
+        )
     }
 
     @Test
@@ -530,9 +691,11 @@ class FirstScreenHandlerImplTest {
 
     @Test
     fun whenOnCloseThenWritesTimestamp() {
+        testee.onOpen(isFreshLaunch = false)
         testee.onClose()
 
         verify(settingsDataStore).lastSessionBackgroundTimestamp = org.mockito.kotlin.any()
+        verify(returnSessionLandingListener).onReturnClosed()
     }
 
     @Test
@@ -626,6 +789,12 @@ class FirstScreenHandlerImplTest {
         testScope.testScheduler.advanceUntilIdle()
 
         verify(showOnAppLaunchOptionHandler, never()).handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR)
+        verify(returnSessionLandingListener).onReturnLandingResolved(
+            ReturnSessionLandingResult(
+                afterIdle = false,
+                landing = ReturnSessionLanding.NTP_USER_INITIATED,
+            ),
+        )
     }
 
     @Test
@@ -653,6 +822,31 @@ class FirstScreenHandlerImplTest {
         testScope.testScheduler.advanceUntilIdle()
 
         verify(showOnAppLaunchOptionHandler).handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR)
+    }
+
+    @Test
+    fun whenIdleReturnRunsInFireModeThenReportsNoTreatment() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(System.currentTimeMillis() - (6 * 60 * 1000))
+        browserModeFlow.value = BrowserMode.FIRE
+        whenever(showOnAppLaunchOptionHandler.handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.FIRE))
+            .thenReturn(
+                ShowOnAppLaunchResult(
+                    destinationUrl = "https://example.com",
+                    treatment = null,
+                ),
+            )
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(returnSessionLandingListener).onReturnLandingResolved(
+            ReturnSessionLandingResult(
+                afterIdle = false,
+                landing = ReturnSessionLanding.WEB,
+            ),
+        )
     }
 
     // --- Mode-switch recreate guard ---

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
@@ -97,7 +97,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
     fun whenOptionIsLastTabOpenedThenNoTabIsAdded() = runTest {
         fakeDataStore.setShowOnAppLaunchOption(LastOpenedTab)
 
-        testee.handleAppLaunchOption(BrowserMode.REGULAR)
+        val result = testee.handleAppLaunchOption(BrowserMode.REGULAR)
 
         fakeTabRepository.flowTabs.test {
             val tabs = awaitItem()
@@ -105,6 +105,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
             assertTrue(tabs.isEmpty())
         }
+        assertEquals(ShowOnAppLaunchResult(destinationUrl = null, treatment = null), result)
     }
 
     @Test
@@ -113,7 +114,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
         (fakeTabRepository as FakeTabRepository).selectedTab =
             TabEntity(tabId = "1", url = "https://example.com", position = 0)
 
-        testee.handleAppLaunchOption(BrowserMode.REGULAR)
+        val result = testee.handleAppLaunchOption(BrowserMode.REGULAR)
 
         fakeTabRepository.flowTabs.test {
             val tabs = awaitItem()
@@ -122,13 +123,14 @@ class ShowOnAppLaunchOptionHandlerImplTest {
             assertTrue(tabs.size == 1)
             assertTrue(tabs.last().url == "")
         }
+        assertEquals(ShowOnAppLaunchResult(destinationUrl = null, treatment = null), result)
     }
 
     @Test
     fun whenOptionIsNewTabPageAndNoSelectedTabThenNewTabPageIsAdded() = runTest {
         fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
 
-        testee.handleAppLaunchOption(BrowserMode.REGULAR)
+        val result = testee.handleAppLaunchOption(BrowserMode.REGULAR)
 
         fakeTabRepository.flowTabs.test {
             val tabs = awaitItem()
@@ -137,6 +139,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
             assertTrue(tabs.size == 1)
             assertTrue(tabs.last().url == "")
         }
+        assertEquals(ShowOnAppLaunchResult(destinationUrl = null, treatment = null), result)
     }
 
     @Test
@@ -145,7 +148,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
         (fakeTabRepository as FakeTabRepository).selectedTab =
             TabEntity(tabId = "1", url = null, position = 0)
 
-        testee.handleAppLaunchOption(BrowserMode.REGULAR)
+        val result = testee.handleAppLaunchOption(BrowserMode.REGULAR)
 
         fakeTabRepository.flowTabs.test {
             val tabs = awaitItem()
@@ -153,6 +156,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
             assertTrue(tabs.isEmpty())
         }
+        assertEquals(ShowOnAppLaunchResult(destinationUrl = null, treatment = null), result)
     }
 
     @Test
@@ -161,7 +165,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
         (fakeTabRepository as FakeTabRepository).selectedTab =
             TabEntity(tabId = "1", url = "", position = 0)
 
-        testee.handleAppLaunchOption(BrowserMode.REGULAR)
+        val result = testee.handleAppLaunchOption(BrowserMode.REGULAR)
 
         fakeTabRepository.flowTabs.test {
             val tabs = awaitItem()
@@ -169,6 +173,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
             assertTrue(tabs.isEmpty())
         }
+        assertEquals(ShowOnAppLaunchResult(destinationUrl = null, treatment = null), result)
     }
 
     @Test
@@ -177,7 +182,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
         fakeDataStore.setShowOnAppLaunchOption(SpecificPage(url))
 
-        testee.handleAppLaunchOption(BrowserMode.REGULAR)
+        val result = testee.handleAppLaunchOption(BrowserMode.REGULAR)
 
         fakeTabRepository.flowTabs.test {
             val tabs = awaitItem()
@@ -186,6 +191,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
             assertTrue(tabs.size == 1)
             assertTrue(tabs.last().url == url)
         }
+        assertEquals(ShowOnAppLaunchResult(destinationUrl = url, treatment = null), result)
     }
 
     @Test
@@ -194,7 +200,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
         fakeDataStore.setShowOnAppLaunchOption(SpecificPage(url))
 
-        testee.handleAppLaunchOption(BrowserMode.REGULAR)
+        val result = testee.handleAppLaunchOption(BrowserMode.REGULAR)
 
         fakeTabRepository.flowTabs.test {
             val tab = awaitItem()
@@ -202,6 +208,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
             assertTrue(fakeDataStore.showOnAppLaunchTabId == tab.first().tabId)
         }
+        assertEquals(ShowOnAppLaunchResult(destinationUrl = url, treatment = null), result)
     }
 
     @Test
@@ -211,7 +218,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
         fakeDataStore.setShowOnAppLaunchOption(SpecificPage(url))
         val existingTabId = fakeTabRepository.add(url)
 
-        testee.handleAppLaunchOption(BrowserMode.REGULAR)
+        val result = testee.handleAppLaunchOption(BrowserMode.REGULAR)
 
         fakeTabRepository.flowTabs.test {
             awaitItem()
@@ -219,6 +226,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
             assertTrue(fakeDataStore.showOnAppLaunchTabId == existingTabId)
         }
+        assertEquals(ShowOnAppLaunchResult(destinationUrl = url, treatment = null), result)
     }
 
     @Test
@@ -807,10 +815,14 @@ class ShowOnAppLaunchOptionHandlerImplTest {
     // handleAfterInactivityOption tests
 
     @Test
-    fun whenLastOpenedTabSelectedThenNoTabAdded() = runTest {
+    fun whenIdleAndLastOpenedTabIsRealPageThenReturnsLutTreatmentAndPreservesCallback() = runTest {
+        val plugin: BrowserInteractionsPlugin = mock()
         fakeDataStore.setShowOnAppLaunchOption(LastOpenedTab)
+        (fakeTabRepository as FakeTabRepository).selectedTab =
+            TabEntity(tabId = "1", url = "https://example.com", position = 0)
+        whenever(browserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
 
-        testee.handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR)
+        val result = testee.handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR)
 
         fakeTabRepository.flowTabs.test {
             val tabs = awaitItem()
@@ -818,13 +830,21 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
             assertTrue(tabs.isEmpty())
         }
+        assertEquals(
+            ShowOnAppLaunchResult(
+                destinationUrl = "https://example.com",
+                treatment = AfterIdleTreatment.LUT,
+            ),
+            result,
+        )
+        verify(plugin).onLutShownAfterIdle()
     }
 
     @Test
-    fun whenNewTabPageSelectedThenTabIsAdded() = runTest {
+    fun whenIdleAndNewTabPageIsCreatedThenReturnsNtpTreatmentAndPreservesTrigger() = runTest {
         fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
 
-        testee.handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR)
+        val result = testee.handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR)
 
         fakeTabRepository.flowTabs.test {
             val tabs = awaitItem()
@@ -833,13 +853,39 @@ class ShowOnAppLaunchOptionHandlerImplTest {
             assertTrue(tabs.size == 1)
             assertTrue(tabs.last().url == "")
         }
+        assertEquals(
+            ShowOnAppLaunchResult(
+                destinationUrl = null,
+                treatment = AfterIdleTreatment.NTP,
+            ),
+            result,
+        )
+        verify(ntpAfterIdleManager).onIdleReturnTriggered()
     }
 
     @Test
-    fun whenSpecificPageSelectedThenNavigatesToSpecificPage() = runTest {
+    fun whenIdleAndNewTabPageIsAlreadyVisibleThenReturnsNoTreatmentAndPreservesNoTrigger() = runTest {
+        fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
+        (fakeTabRepository as FakeTabRepository).selectedTab =
+            TabEntity(tabId = "1", url = null, position = 0)
+
+        val result = testee.handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR)
+
+        assertEquals(
+            ShowOnAppLaunchResult(
+                destinationUrl = null,
+                treatment = null,
+            ),
+            result,
+        )
+        verify(ntpAfterIdleManager, never()).onIdleReturnTriggered()
+    }
+
+    @Test
+    fun whenIdleAndSpecificPageSelectedThenReturnsDestinationWithoutTreatment() = runTest {
         fakeDataStore.setShowOnAppLaunchOption(SpecificPage("https://example.com/"))
 
-        testee.handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR)
+        val result = testee.handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR)
 
         fakeTabRepository.flowTabs.test {
             val tabs = awaitItem()
@@ -848,6 +894,31 @@ class ShowOnAppLaunchOptionHandlerImplTest {
             assertTrue(tabs.size == 1)
             assertTrue(tabs.last().url == "https://example.com/")
         }
+        assertEquals(
+            ShowOnAppLaunchResult(
+                destinationUrl = "https://example.com/",
+                treatment = null,
+            ),
+            result,
+        )
+        verify(browserInteractionsPlugins, never()).getPlugins()
+        verify(ntpAfterIdleManager, never()).onIdleReturnTriggered()
+    }
+
+    @Test
+    fun whenColdStartCreatesNewTabPageThenReturnsNoTreatment() = runTest {
+        fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
+
+        val result = testee.handleAfterInactivityOption(wasIdle = false, currentMode = BrowserMode.REGULAR)
+
+        assertEquals(
+            ShowOnAppLaunchResult(
+                destinationUrl = null,
+                treatment = null,
+            ),
+            result,
+        )
+        verify(ntpAfterIdleManager, never()).onIdleReturnTriggered()
     }
 
     // onIdleReturnTriggered notification tests

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/wideevents/BrowserInteractionsPlugin.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/wideevents/BrowserInteractionsPlugin.kt
@@ -27,6 +27,15 @@ interface BrowserInteractionsPlugin {
     /** User submitted a typed query via the omnibar (search or chat prompt). */
     fun onInputSubmitted() {}
 
+    /** User submitted a typed search query (not a URL, not a Duck.ai prompt) via the omnibar. */
+    fun onSearchSubmitted() {}
+
+    /** User submitted a typed URL via the omnibar. */
+    fun onUrlSubmitted() {}
+
+    /** User submitted a Duck.ai chat prompt. */
+    fun onAiPromptSubmitted() {}
+
     /** User selected a Duck.ai chat suggestion (without typing a prompt). */
     fun onChatSelected() {}
 

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
@@ -180,6 +180,7 @@ class NewTabReturnHatchViewModel @Inject constructor(
     fun closeTab() {
         pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_CLOSE_TAB, type = Count)
         pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_CLOSE_TAB_DAILY, type = Daily())
+        ntpAfterIdleManager.onCloseTabTapped()
         val tabId = viewState.value.currentTabId
         if (tabId.isEmpty()) return
         pendingCloseMode = snapshotTarget.value?.mode ?: BrowserMode.REGULAR
@@ -197,6 +198,7 @@ class NewTabReturnHatchViewModel @Inject constructor(
         val params = mapOf(Pixel.PixelParameter.BROWSER_MODE to viewState.value.mode.name.lowercase())
         pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_BURN_TAB, params, type = Count)
         pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_BURN_TAB_DAILY, params, type = Daily())
+        ntpAfterIdleManager.onBurnTabTapped()
     }
 
     fun onUndoCloseTab(tabId: String) {

--- a/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
+++ b/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
@@ -484,6 +484,13 @@ class NewTabReturnHatchViewModelTest {
     }
 
     @Test
+    fun whenCloseTabThenNotifiesNtpAfterIdleManager() = runTest {
+        testee.closeTab()
+
+        verify(mockNtpAfterIdleManager).onCloseTabTapped()
+    }
+
+    @Test
     fun whenBurnTabPressedAndTabRemovedFromRepositoryThenHatchHides() = runTest {
         val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
         tabsFlow.value = listOf(tab)
@@ -543,6 +550,13 @@ class NewTabReturnHatchViewModelTest {
         val params = mapOf(Pixel.PixelParameter.BROWSER_MODE to "regular")
         verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_BURN_TAB, params, type = Count)
         verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_BURN_TAB_DAILY, params, type = Daily())
+    }
+
+    @Test
+    fun whenOnBurnTabPressedThenNotifiesNtpAfterIdleManager() = runTest {
+        testee.onBurnTabPressed()
+
+        verify(mockNtpAfterIdleManager).onBurnTabTapped()
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -20,10 +20,12 @@ import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.install.AppInstall
+import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.ui.view.encodeBitmapToBase64
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
@@ -34,6 +36,8 @@ import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.EditPromptRequest
 import com.duckduckgo.duckchat.impl.ModelTier
 import com.duckduckgo.duckchat.impl.ReportMetric
+import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_SUBMIT_FIRST_PROMPT
+import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_SUBMIT_PROMPT
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.messaging.sync.isSyncable
 import com.duckduckgo.duckchat.impl.models.AIChatAttachmentUsage
@@ -122,6 +126,7 @@ class RealDuckChatJSHelper @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
     private val subscriptions: Subscriptions,
     private val editPromptSessionStore: EditPromptSessionStore,
+    private val browserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin>,
 ) : DuckChatJSHelper {
 
     private val registerOpenedJob = ConflatedJob()
@@ -252,6 +257,9 @@ class RealDuckChatJSHelper @Inject constructor(
 
                 reportMetric?.let {
                     duckChatPixels.sendReportMetricPixel(it, modelTier, source)
+                    if (it == USER_DID_SUBMIT_PROMPT || it == USER_DID_SUBMIT_FIRST_PROMPT) {
+                        browserInteractionsPlugins.getPlugins().forEach { plugin -> plugin.onAiPromptSubmitted() }
+                    }
                 }
                 null
             }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -21,8 +21,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.install.AppInstall
+import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
@@ -112,6 +114,10 @@ class RealDuckChatJSHelperTest {
         onBlocking { isEligible() } doReturn false
     }
     private val mockEditPromptSessionStore: EditPromptSessionStore = mock()
+    private val mockBrowserInteractionsPlugin: BrowserInteractionsPlugin = mock()
+    private val mockBrowserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin> = mock {
+        on { getPlugins() } doReturn listOf(mockBrowserInteractionsPlugin)
+    }
     private val testee = RealDuckChatJSHelper(
         duckChat = mockDuckChat,
         duckChatPixels = mockDuckChatPixels,
@@ -130,6 +136,7 @@ class RealDuckChatJSHelperTest {
         appBuildConfig = mockAppBuildConfig,
         subscriptions = mockSubscriptions,
         editPromptSessionStore = mockEditPromptSessionStore,
+        browserInteractionsPlugins = mockBrowserInteractionsPlugins,
     )
     private val viewModel =
         object {
@@ -1863,6 +1870,50 @@ class RealDuckChatJSHelperTest {
         )
 
         verify(mockDuckChatPixels).sendReportMetricPixel(USER_DID_SUBMIT_FIRST_PROMPT)
+    }
+
+    @Test
+    fun whenReportMetricWithSubmittedPromptThenNotifiesAiPromptSubmittedOnly() = runTest {
+        val data = JSONObject(mapOf("metricName" to "userDidSubmitPrompt"))
+
+        testee.processJsCallbackMessage(
+            featureName = "aiChat",
+            method = "reportMetric",
+            id = "123",
+            data = data,
+        )
+
+        verify(mockBrowserInteractionsPlugin).onAiPromptSubmitted()
+        verify(mockBrowserInteractionsPlugin, never()).onInputSubmitted()
+    }
+
+    @Test
+    fun whenReportMetricWithFirstSubmittedPromptThenNotifiesAiPromptSubmittedOnly() = runTest {
+        val data = JSONObject(mapOf("metricName" to "userDidSubmitFirstPrompt"))
+
+        testee.processJsCallbackMessage(
+            featureName = "aiChat",
+            method = "reportMetric",
+            id = "123",
+            data = data,
+        )
+
+        verify(mockBrowserInteractionsPlugin).onAiPromptSubmitted()
+        verify(mockBrowserInteractionsPlugin, never()).onInputSubmitted()
+    }
+
+    @Test
+    fun whenReportMetricIsUnrelatedThenDoesNotNotifyBrowserInteractions() = runTest {
+        val data = JSONObject(mapOf("metricName" to "userDidOpenHistory"))
+
+        testee.processJsCallbackMessage(
+            featureName = "aiChat",
+            method = "reportMetric",
+            id = "123",
+            data = data,
+        )
+
+        verifyNoInteractions(mockBrowserInteractionsPlugin)
     }
 
     @Test

--- a/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NtpAfterIdleManager.kt
+++ b/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NtpAfterIdleManager.kt
@@ -35,6 +35,12 @@ interface NtpAfterIdleManager {
     /** Called when the user opens the tab switcher from the hatch. */
     fun onTabSwitcherSelected()
 
+    /** Called when the user taps the close-tab action on the hatch. */
+    fun onCloseTabTapped()
+
+    /** Called when the user taps the burn-tab action on the hatch. */
+    fun onBurnTabTapped()
+
     /** Called when the user submits a search from the NTP. */
     fun onNtpSearchSubmitted()
 

--- a/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/interactions/HatchInteractionsPlugin.kt
+++ b/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/interactions/HatchInteractionsPlugin.kt
@@ -35,4 +35,10 @@ interface HatchInteractionsPlugin {
 
     /** User touched the NTP body. */
     fun onNtpEngaged() {}
+
+    /** User tapped the close-tab action on the hatch. */
+    fun onCloseTabTapped() {}
+
+    /** User tapped the burn-tab action on the hatch. */
+    fun onBurnTabTapped() {}
 }

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImpl.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImpl.kt
@@ -112,6 +112,14 @@ class NtpAfterIdleManagerImpl @Inject constructor(
         hatchInteractionsPlugins.getPlugins().forEach { it.onTabSwitcherSelected() }
     }
 
+    override fun onCloseTabTapped() {
+        hatchInteractionsPlugins.getPlugins().forEach { it.onCloseTabTapped() }
+    }
+
+    override fun onBurnTabTapped() {
+        hatchInteractionsPlugins.getPlugins().forEach { it.onBurnTabTapped() }
+    }
+
     override fun onNtpSearchSubmitted() {
         if (_isAfterIdleReturn.value) {
             pixel.fire(BAR_USED_FROM_NTP_AFTER_IDLE, type = Count)

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImplTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImplTest.kt
@@ -86,10 +86,14 @@ class NtpAfterIdleManagerImplTest {
         verify(pixel).fire(NTP_SHOWN_USER_INITIATED_DAILY, type = Daily())
         verify(pixel, never()).fire(NTP_SHOWN_AFTER_IDLE, type = Count)
         verify(pixel, never()).fire(NTP_SHOWN_AFTER_IDLE_DAILY, type = Daily())
+        verify(hatchInteractionsPlugins, never()).getPlugins()
     }
 
     @Test
     fun whenIdleReturnTriggeredAndThenOnNtpShownThenFiresAfterIdleShownPixels() {
+        val plugin: HatchInteractionsPlugin = mock()
+        whenever(hatchInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+
         testee.onIdleReturnTriggered()
         testee.onNtpShown()
 
@@ -97,6 +101,7 @@ class NtpAfterIdleManagerImplTest {
         verify(pixel).fire(NTP_SHOWN_AFTER_IDLE_DAILY, type = Daily())
         verify(pixel, never()).fire(NTP_SHOWN_USER_INITIATED, type = Count)
         verify(pixel, never()).fire(NTP_SHOWN_USER_INITIATED_DAILY, type = Daily())
+        verify(plugin).onHatchShownAfterIdle()
     }
 
     @Test
@@ -121,6 +126,26 @@ class NtpAfterIdleManagerImplTest {
         testee.onTabSwitcherSelected()
 
         verify(plugin).onTabSwitcherSelected()
+    }
+
+    @Test
+    fun whenOnCloseTabTappedThenForwardsToHatchPlugins() {
+        val plugin: HatchInteractionsPlugin = mock()
+        whenever(hatchInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+
+        testee.onCloseTabTapped()
+
+        verify(plugin).onCloseTabTapped()
+    }
+
+    @Test
+    fun whenOnBurnTabTappedThenForwardsToHatchPlugins() {
+        val plugin: HatchInteractionsPlugin = mock()
+        whenever(hatchInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+
+        testee.onBurnTabTapped()
+
+        verify(plugin).onBurnTabTapped()
     }
 
     // --- onReturnToPageTapped classification ---


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1217573106920334?focus=true 
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1217382844057496?focus=true
API Proposals URL(s) (if applicable):
- https://app.asana.com/1/137249556945/project/1212810093780571/task/1217532302535421?focus=true
- https://app.asana.com/1/137249556945/project/1212810093780571/task/1217532302535422?focus=true

### Description

This adds `wide_return_session`. `wide_return_session` starts after the app came to the foreground.

**Data**
- `feature.data.ext.after_idle`: `true` only when the inactivity treatment was applied.
- `feature.data.ext.landed_on`: `ntp`, `ntp_user_initiated`, `web`, `serp`, or `duck_ai`. LUT and
  Specific Page returns are classified by their actual destination.
- `feature.data.ext.time_away_ms_bucketed`: lower-bound bucket `0`, `60000`, `300000`, `900000`,
  `1800000`, or `3600000`.
- `feature.data.ext.focused`: one snapshot of whether the visible landing input had focus immediately
  after the landing fragment resumed. Later focus changes do not alter it.
- `feature.data.ext.page_engaged`, `back_pressed`, `opening_screen_changed`, `close_tab_tapped`, and
  `burn_tab_tapped`: sticky booleans, finalized as `true` or `false`.
- `feature.data.ext.session_duration_ms_bucketed` and
  `feature.data.ext.time_to_first_interaction_ms_bucketed`: lower-bound duration bucket `0`, `1000`,
  `5000`, `10000`, `30000`, `60000`, `300000`, or `600000`. Time to first interaction is omitted when
  the only terminal is app backgrounding and no interaction was recorded.

Successful terminals set `feature.status=SUCCESS` and `feature.data.ext.status_reason` to `search_submitted`, `url_submitted`, `ai_prompt_submitted`, `return_to_page_tapped`, `tab_switcher_selected`, `favorite_selected`, or `chat_selected`.

Backgrounding sets `feature.status=CANCELLED` and `feature.data.ext.status_reason=app_backgrounded`. If the process dies with an open flow, next-process cleanup emits `feature.status=UNKNOWN` and `feature.data.ext.status_reason=app_terminated`.

The event is gated by `returnSessionWideEvent` FF and the global `wideEvents` framework flag.

### Steps to test this PR

**Prerequisites**

- [ ] Install an internal build and complete this setup:
  - Set `SAMPLING_PROBABILITY = 1.0f` in `RealReturnSessionWideEvent.kt` for testing only. This will allow you to see every pixel and not a sampling of it. 
  - In Internal Settings > Feature Flags, make sure `wideEvents`, `enqueueWideEventPixels`, `sendWideEventsViaPixels`, and `returnSessionWideEvent.self` are ENABLED.
  - Force-stop and relaunch if you change FF for them to take effect.

**How to monitor**
- Filter Android studio log cat on `Pixel sent: wide_return_session` to view all the pixels sent at the end of the session (you won’t see a pixel until you finish the session)
- You can also filter on `RealReturnSessionWideEvent` to view individual events as the session record them
- Alternatively you can run this comment (requires rg installed) in a terminal to view all events
    `adb logcat | rg 'RealReturnSessionWideEvent|Pixel sent:.*wide_(return|post_idle)_session_[cd]'`.

#### Instructions

1. Set Settings > General > After Inactivity to **1 minute**, unless a row says **Always**.
2. To start with no active session. If the previous case left the app backgrounded, reopen it, submit a
   throwaway search or click on switch tab to finish that session, wait for its pixel confirming the session ended.
3. When you perform the row's action. Wait for `Pixel sent: ... wide_return_session_c`; the first event of the
   day also sends `wide_return_session_d`. Inspect the encoded `feature.data.ext.*` values.
4. Short keys in the tables, such as `landed_on`, mean `feature.data.ext.landed_on`.
5. When the instructions say: “Finish the session” it means perform any action that would trigger the session to finish. Easiest ones are submitting a throway search or clicking on the tab switcher.

#### Landing, focus, submission, and coexistence

- [ ] Run each row with the instructions. Inspect the listed fields

| Coverage | Setup | Action | Expected log values |
| --- | --- | --- | --- |
| Ordinary NTP and focused input | launch app on NTP and leave its input and keyboard open | Finish the session | `after_idle=false`, `landed_on=ntp_user_initiated`, `focused=true` |
| Ordinary web, unfocused input, page engagement, and URL submission | launch app on a website and touch/scroll in the WebView | Touch the WebView, then submit a url (example.com) | `after_idle=false`, `landed_on=web`, `focused=false`, `page_engaged=true`, `status_reason=url_submitted` |
| Ordinary SERP and Back | Build Back history ending on a DuckDuckGo results page, put app in background and the start it again | Press Back once while remaining in the browser, then finish the session | `after_idle=false`, `landed_on=serp`, `back_pressed=true` |
| Ordinary Duck.ai and native AI submission | Open app on NTP, Enable open Duck.ai from the menu (hamburger menu) without submitting | Submit a real non-empty native prompt | `after_idle=false`, `landed_on=duck_ai`, `status_reason=ai_prompt_submitted` |
| After-idle NTP, search submission | use **Always > New Tab Page** for idle config, with hatch enabled. | Trigger a idle return then Submit a search from the address bar| Return event: `feature.status=SUCCESS`, `after_idle=true`, `landed_on=ntp`, `status_reason=search_submitted`. |
| After-idle LUT | Use **Always > Last Opened Tab** on `https://example.com` | Trigger an idle return then Finish the session | `after_idle=true`, `landed_on=web` |
| Changing opening screen | Start a session on the browser with Last Opened Tab selected in the idle menu | Open the idle menu and Change the option from Last Opened Tab to New Tab Page. Return to browser and submit a search to end the session | `opening_screen_changed=true` |

#### Remaining terminals, negative case, and interaction flags

The after-idle NTP row is the primary `feature.status=SUCCESS` check. For successful rows below,
inspect only the unique `status_reason`. Rows ending mechanically use the baseline action without
re-asserting `search_submitted`.

- [ ] Run each remaining unique case:

| Unique case | Action | Expected log values |
| --- | --- | --- |
| Favorite | From a fresh NTP return, tap a favorite | `status_reason=favorite_selected` |
| Existing chat | From a fresh Duck.ai return, select an existing chat suggestion without typing | `status_reason=chat_selected` |
| Tab switcher | From any fresh return, tap the Tabs button | `status_reason=tab_switcher_selected` |
| Return to Page | Use **Always > New Tab Page** from a web tab, then tap **Return to Page** | `status_reason=return_to_page_tapped`; landing treatment was already verified in the after-idle NTP row |
| Empty Duck.ai negative | From a fresh NTP return, open Duck.ai with empty input but do not submit; return to the NTP and finish the session using the baseline action | No event may complete before the baseline finish, especially none with `status_reason=ai_prompt_submitted` |
| Background with no interaction | Press Home without touching the landing page or input | `feature.status=CANCELLED`, `status_reason=app_backgrounded`, `session_duration_ms_bucketed` present, `time_to_first_interaction_ms_bucketed` absent |
| Process cleanup | While a fresh web return is foregrounded, run `adb shell am force-stop <package>`, then relaunch | Identify the prior flow's cleanup separately from the new return: `feature.status=UNKNOWN`, `status_reason=app_terminated`; landing and time-away classifications were already verified above |
| Close tab | Use **Always > New Tab Page** from a web tab, tap **Close Tab**, then finish the session using the baseline action | `close_tab_tapped=true`, `burn_tab_tapped=false` |
| Burn tab | Use **Always > New Tab Page** from a web tab, tap **Burn Tab**, then finish the session using the baseline action | `burn_tab_tapped=true`, `close_tab_tapped=false` |

#### Timing
- [ ] Trigger various sessions and verify that `time_to_first_interaction_ms_bucketed`, `time_away_ms_bucketed`, and `session_duration_ms_bucketed` reflect the correct time buckets. 

#### Feature gate and reset

- [ ] With no active session, turn only `returnSessionWideEvent` **off**, force-stop/relaunch,
  open an NTP, press Home, immediately reopen, and finish using any action. Confirm no
  `wide_return_session`.



### UI changes

 No UI changes


<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Medium Risk**
> Touches first-screen and omnibar submission paths used on every app open; changes are mostly additive telemetry with a feature toggle, but misclassification of user vs internal navigation could skew session metrics.
> 
> **Overview**
> Adds a **`return_session`** wide event that runs from each foreground return until a terminal action (search, URL, AI prompt, hatch actions, background, etc.), with landing surface, after-idle treatment, bucketed time away, session duration, and engagement metadata.
> 
> **`RealReturnSessionWideEvent`** starts the flow after **`FirstScreenHandler`** resolves landing (`after_idle`, `landed_on` as NTP, web, SERP, or Duck.ai), listens via **`BrowserInteractionsPlugin`** / **`HatchInteractionsPlugin`**, and is gated by **`ReturnSessionWideEventFeature`**. **`ShowOnAppLaunchOptionHandler`** now returns **`ShowOnAppLaunchResult`** so idle NTP/LUT treatments align with telemetry.
> 
> **`BrowserTabViewModel`** splits user vs internal query submission so restoration and error recovery do not fire search/URL classifiers; **`onLandingFocusCaptured`**, back handling, and Duck.ai prompt paths hook the new plugins. **`NtpEngagementTracker`** limits one NTP body engagement per app open; hatch close/burn and JS **`reportMetric`** prompt submissions feed the same session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d7b52224cf61e0f0dc5b267d34366e1f24ac1d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-screen and omnibar submission paths used on every app open. Changes are mostly additive telemetry behind a feature toggle, but misclassifying user vs internal navigation could skew session metrics.
> 
> **Overview**
> Adds a **`return_session`** wide event that runs from each foreground return until a terminal action (search, URL, AI prompt, hatch actions, background, etc.), capturing landing surface, after-idle treatment, bucketed time away, session duration, and engagement flags.
> 
> **`RealReturnSessionWideEvent`** starts after **`FirstScreenHandler`** resolves landing (`after_idle`, `landed_on` as NTP, web, SERP, or Duck.ai). It listens via **`BrowserInteractionsPlugin`** / **`HatchInteractionsPlugin`** and is gated by **`ReturnSessionWideEventFeature`**. **`ShowOnAppLaunchOptionHandler`** now returns **`ShowOnAppLaunchResult`** so idle NTP/LUT treatments match telemetry.
> 
> **`BrowserTabViewModel`** splits user vs internal query submission so restoration and error recovery do not fire search/URL classifiers. Landing focus, back, Duck.ai prompts, hatch close/burn, and JS `reportMetric` submissions feed the same session. **`NtpEngagementTracker`** reports NTP body engagement once per app open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d39ae080c764fae7cc41c287fe10fc60c6f87b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->