### PR TITLE
Update content scope scripts to version 16.10.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -548,8 +548,9 @@
     "webEvents",
     "pageObserver",
     "hover",
-    "trackerProtection"
+    "trackerProtection",
     // only enabled on apple platforms
+    "textSelection"
   ];
   var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
@@ -623,7 +624,8 @@
       "browserUiLock",
       "trackerProtection",
       "tabSuspension",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "textSelection"
     ]
   );
   var platformSupport = {
@@ -644,7 +646,8 @@
       "webTelemetry",
       "pageObserver",
       "hover",
-      "tabSuspension"
+      "tabSuspension",
+      "textSelection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -2063,8 +2063,9 @@
     "webEvents",
     "pageObserver",
     "hover",
-    "trackerProtection"
+    "trackerProtection",
     // only enabled on apple platforms
+    "textSelection"
   ];
   var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
@@ -2167,7 +2168,8 @@
       "browserUiLock",
       "trackerProtection",
       "tabSuspension",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "textSelection"
     ]
   );
   var platformSupport = {
@@ -2188,7 +2190,8 @@
       "webTelemetry",
       "pageObserver",
       "hover",
-      "tabSuspension"
+      "tabSuspension",
+      "textSelection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2063,8 +2063,9 @@
     "webEvents",
     "pageObserver",
     "hover",
-    "trackerProtection"
+    "trackerProtection",
     // only enabled on apple platforms
+    "textSelection"
   ];
   var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
@@ -2139,7 +2140,8 @@
       "browserUiLock",
       "trackerProtection",
       "tabSuspension",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "textSelection"
     ]
   );
   var platformSupport = {
@@ -2160,7 +2162,8 @@
       "webTelemetry",
       "pageObserver",
       "hover",
-      "tabSuspension"
+      "tabSuspension",
+      "textSelection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1419,8 +1419,9 @@
     "webEvents",
     "pageObserver",
     "hover",
-    "trackerProtection"
+    "trackerProtection",
     // only enabled on apple platforms
+    "textSelection"
   ];
   var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
@@ -1504,7 +1505,8 @@
       "browserUiLock",
       "trackerProtection",
       "tabSuspension",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "textSelection"
     ]
   );
   var platformSupport = {
@@ -1525,7 +1527,8 @@
       "webTelemetry",
       "pageObserver",
       "hover",
-      "tabSuspension"
+      "tabSuspension",
+      "textSelection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -530,8 +530,9 @@
     "webEvents",
     "pageObserver",
     "hover",
-    "trackerProtection"
+    "trackerProtection",
     // only enabled on apple platforms
+    "textSelection"
   ];
   var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
@@ -605,7 +606,8 @@
       "browserUiLock",
       "trackerProtection",
       "tabSuspension",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "textSelection"
     ]
   );
   var platformSupport = {
@@ -626,7 +628,8 @@
       "webTelemetry",
       "pageObserver",
       "hover",
-      "tabSuspension"
+      "tabSuspension",
+      "textSelection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
@@ -530,8 +530,9 @@
     "webEvents",
     "pageObserver",
     "hover",
-    "trackerProtection"
+    "trackerProtection",
     // only enabled on apple platforms
+    "textSelection"
   ];
   var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
@@ -605,7 +606,8 @@
       "browserUiLock",
       "trackerProtection",
       "tabSuspension",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "textSelection"
     ]
   );
   var platformSupport = {
@@ -626,7 +628,8 @@
       "webTelemetry",
       "pageObserver",
       "hover",
-      "tabSuspension"
+      "tabSuspension",
+      "textSelection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -1451,8 +1451,8 @@
     }
   }
   function L(n2, l3, u3, t3, i3, r3, o3, e3, f3, c3, a3) {
-    var s3, h3, p3, v3, y3, _3, g3, m3 = t3 && t3.__k || w, b2 = l3.length;
-    for (f3 = T(u3, l3, m3, f3, b2), s3 = 0; s3 < b2; s3++) null != (p3 = u3.__k[s3]) && (h3 = -1 != p3.__i && m3[p3.__i] || d, p3.__i = s3, _3 = q(n2, p3, h3, i3, r3, o3, e3, f3, c3, a3), v3 = p3.__e, p3.ref && h3.ref != p3.ref && (h3.ref && J(h3.ref, null, p3), a3.push(p3.ref, p3.__c || v3, p3)), null == y3 && null != v3 && (y3 = v3), (g3 = !!(4 & p3.__u)) || h3.__k === p3.__k ? (f3 = j(p3, f3, n2, g3), g3 && h3.__e && (h3.__e = null)) : "function" == typeof p3.type && void 0 !== _3 ? f3 = _3 : v3 && (f3 = v3.nextSibling), p3.__u &= -7);
+    var s3, h3, p3, v3, y3, _3, g3 = t3 && t3.__k || w, m3 = l3.length;
+    for (f3 = T(u3, l3, g3, f3, m3), s3 = 0; s3 < m3; s3++) null != (p3 = u3.__k[s3]) && (h3 = -1 != p3.__i && g3[p3.__i] || d, p3.__i = s3, _3 = q(n2, p3, h3, i3, r3, o3, e3, f3, c3, a3), v3 = p3.__e, p3.ref && h3.ref != p3.ref && (h3.ref && J(h3.ref, null, p3), a3.push(p3.ref, p3.__c || v3, p3)), null == y3 && null != v3 && (y3 = v3), 4 & p3.__u ? (f3 = j(p3, f3, n2), h3.__e && (h3.__e = null)) : "function" == typeof p3.type && void 0 !== _3 ? f3 = _3 : v3 && (f3 = v3.nextSibling), p3.__u &= -7);
     return u3.__e = y3, f3;
   }
   function T(n2, l3, u3, t3, i3) {
@@ -1461,13 +1461,13 @@
     if (s3) for (r3 = 0; r3 < a3; r3++) null != (e3 = u3[r3]) && 0 == (2 & e3.__u) && (e3.__e == t3 && (t3 = $(e3)), K(e3, e3));
     return t3;
   }
-  function j(n2, l3, u3, t3) {
-    var i3, r3;
+  function j(n2, l3, u3) {
+    var t3, i3;
     if ("function" == typeof n2.type) {
-      for (i3 = n2.__k, r3 = 0; i3 && r3 < i3.length; r3++) i3[r3] && (i3[r3].__ = n2, l3 = j(i3[r3], l3, u3, t3));
+      for (t3 = n2.__k, i3 = 0; t3 && i3 < t3.length; i3++) t3[i3] && (t3[i3].__ = n2, l3 = j(t3[i3], l3, u3));
       return l3;
     }
-    n2.__e != l3 && (t3 && (l3 && n2.type && !l3.parentNode && (l3 = $(n2)), u3.insertBefore(n2.__e, l3 || null)), l3 = n2.__e);
+    n2.__e != l3 && (l3 && n2.type && !l3.parentNode && (l3 = $(n2)), l3 = u3.insertBefore(n2.__e, l3 || null));
     do {
       l3 = l3 && l3.nextSibling;
     } while (null != l3 && 8 == l3.nodeType);
@@ -1513,35 +1513,35 @@
     };
   }
   function q(n2, u3, t3, i3, r3, o3, e3, f3, c3, a3) {
-    var s3, h3, p3, v3, y3, d3, _3, k3, x3, M, $2, I2, P2, A3, H2, T3, j3 = u3.type;
+    var s3, h3, p3, v3, y3, d3, _3, k3, x3, M, I2, P2, A3, H2, T3, j3, F = u3.type;
     if (void 0 !== u3.constructor) return null;
     128 & t3.__u && (c3 = !!(32 & t3.__u), o3 = [f3 = u3.__e = t3.__e]), (s3 = l.__b) && s3(u3);
-    n: if ("function" == typeof j3) {
+    n: if ("function" == typeof F) {
       h3 = e3.length;
       try {
-        if (x3 = u3.props, M = j3.prototype && j3.prototype.render, $2 = (s3 = j3.contextType) && i3[s3.__c], I2 = s3 ? $2 ? $2.props.value : s3.__ : i3, t3.__c ? k3 = (p3 = u3.__c = t3.__c).__ = p3.__E : (M ? u3.__c = p3 = new j3(x3, I2) : (u3.__c = p3 = new C(x3, I2), p3.constructor = j3, p3.render = Q), $2 && $2.sub(p3), p3.state || (p3.state = {}), p3.__n = i3, v3 = p3.__d = true, p3.__h = [], p3._sb = []), M && null == p3.__s && (p3.__s = p3.state), M && null != j3.getDerivedStateFromProps && (p3.__s == p3.state && (p3.__s = m({}, p3.__s)), m(p3.__s, j3.getDerivedStateFromProps(x3, p3.__s))), y3 = p3.props, d3 = p3.state, p3.__v = u3, v3) M && null == j3.getDerivedStateFromProps && null != p3.componentWillMount && p3.componentWillMount(), M && null != p3.componentDidMount && p3.__h.push(p3.componentDidMount);
+        if (x3 = u3.props, M = F.prototype && F.prototype.render, I2 = (s3 = F.contextType) && i3[s3.__c], P2 = s3 ? I2 ? I2.props.value : s3.__ : i3, t3.__c ? k3 = (p3 = u3.__c = t3.__c).__ = p3.__E : (M ? u3.__c = p3 = new F(x3, P2) : (u3.__c = p3 = new C(x3, P2), p3.constructor = F, p3.render = Q), I2 && I2.sub(p3), p3.state || (p3.state = {}), p3.__n = i3, v3 = p3.__d = true, p3.__h = [], p3._sb = []), M && null == p3.__s && (p3.__s = p3.state), M && null != F.getDerivedStateFromProps && (p3.__s == p3.state && (p3.__s = m({}, p3.__s)), m(p3.__s, F.getDerivedStateFromProps(x3, p3.__s))), y3 = p3.props, d3 = p3.state, p3.__v = u3, v3) M && null == F.getDerivedStateFromProps && null != p3.componentWillMount && p3.componentWillMount(), M && null != p3.componentDidMount && p3.__h.push(p3.componentDidMount);
         else {
-          if (M && null == j3.getDerivedStateFromProps && x3 !== y3 && null != p3.componentWillReceiveProps && p3.componentWillReceiveProps(x3, I2), u3.__v == t3.__v || !p3.__e && null != p3.shouldComponentUpdate && false === p3.shouldComponentUpdate(x3, p3.__s, I2)) {
+          if (M && null == F.getDerivedStateFromProps && x3 !== y3 && null != p3.componentWillReceiveProps && p3.componentWillReceiveProps(x3, P2), u3.__v == t3.__v || !p3.__e && null != p3.shouldComponentUpdate && false === p3.shouldComponentUpdate(x3, p3.__s, P2)) {
             u3.__v != t3.__v && (p3.props = x3, p3.state = p3.__s, p3.__d = false), u3.__e = t3.__e, u3.__k = t3.__k, u3.__k.some(function(n3) {
               n3 && (n3.__ = u3);
-            }), w.push.apply(p3.__h, p3._sb), p3._sb = [], p3.__h.length && e3.push(p3);
+            }), w.push.apply(p3.__h, p3._sb), p3._sb = [], p3.__h.length && e3.push(p3), f3 = $(t3);
             break n;
           }
-          null != p3.componentWillUpdate && p3.componentWillUpdate(x3, p3.__s, I2), M && null != p3.componentDidUpdate && p3.__h.push(function() {
+          null != p3.componentWillUpdate && p3.componentWillUpdate(x3, p3.__s, P2), M && null != p3.componentDidUpdate && p3.__h.push(function() {
             p3.componentDidUpdate(y3, d3, _3);
           });
         }
-        if (p3.context = I2, p3.props = x3, p3.__P = n2, p3.__e = false, P2 = l.__r, A3 = 0, M) p3.state = p3.__s, p3.__d = false, P2 && P2(u3), s3 = p3.render(p3.props, p3.state, p3.context), w.push.apply(p3.__h, p3._sb), p3._sb = [];
+        if (p3.context = P2, p3.props = x3, p3.__P = n2, p3.__e = false, A3 = l.__r, H2 = 0, M) p3.state = p3.__s, p3.__d = false, A3 && A3(u3), s3 = p3.render(p3.props, p3.state, p3.context), w.push.apply(p3.__h, p3._sb), p3._sb = [];
         else do {
-          p3.__d = false, P2 && P2(u3), s3 = p3.render(p3.props, p3.state, p3.context), p3.state = p3.__s;
-        } while (p3.__d && ++A3 < 25);
-        p3.state = p3.__s, null != p3.getChildContext && (i3 = m(m({}, i3), p3.getChildContext())), M && !v3 && null != p3.getSnapshotBeforeUpdate && (_3 = p3.getSnapshotBeforeUpdate(y3, d3)), H2 = null != s3 && s3.type === S && null == s3.key ? E(s3.props.children) : s3, f3 = L(n2, g(H2) ? H2 : [H2], u3, t3, i3, r3, o3, e3, f3, c3, a3), p3.base = u3.__e, u3.__u &= -161, p3.__h.length && e3.push(p3), k3 && (p3.__E = p3.__ = null);
+          p3.__d = false, A3 && A3(u3), s3 = p3.render(p3.props, p3.state, p3.context), p3.state = p3.__s;
+        } while (p3.__d && ++H2 < 25);
+        p3.state = p3.__s, null != p3.getChildContext && (i3 = m(m({}, i3), p3.getChildContext())), M && !v3 && null != p3.getSnapshotBeforeUpdate && (_3 = p3.getSnapshotBeforeUpdate(y3, d3)), T3 = null != s3 && s3.type === S && null == s3.key ? E(s3.props.children) : s3, f3 = L(n2, g(T3) ? T3 : [T3], u3, t3, i3, r3, o3, e3, f3, c3, a3), p3.base = u3.__e, u3.__u &= -161, p3.__h.length && e3.push(p3), k3 && (p3.__E = p3.__ = null);
       } catch (n3) {
         if (e3.length = h3, u3.__v = null, c3 || null != o3) {
           if (n3.then) {
             for (u3.__u |= c3 ? 160 : 128; f3 && 8 == f3.nodeType && f3.nextSibling; ) f3 = f3.nextSibling;
             null != o3 && (o3[o3.indexOf(f3)] = null), u3.__e = f3;
-          } else if (null != o3) for (T3 = o3.length; T3--; ) b(o3[T3]);
+          } else if (null != o3) for (j3 = o3.length; j3--; ) b(o3[j3]);
         } else u3.__e = t3.__e;
         null == u3.__k && (u3.__k = t3.__k || []), n3.then || B(u3), l.__e(n3, u3, t3);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^16.23.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.8.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.10.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -61,7 +61,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9bb13ba44c2e73f97ebe45c8ce77c238578f3ce5",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#166f2f6c9213b1e92745178d23ff7c0f91088750",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^16.23.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.8.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.10.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217581842307227

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Vendor content-scope scripts run in WebViews and affect privacy/compat behavior. The new `textSelection` feature is gated as Apple-only, so Android impact is mainly the bundled script refresh.
> 
> **Overview**
> Bumps `@duckduckgo/content-scope-scripts` from **16.8.0** to **16.10.0** and refreshes the vendored Android builds.
> 
> The update registers a new **`textSelection`** feature as platform-specific (Apple-only) and includes it in the unknown-feature list and `apple-isolated` support. Duck Player’s bundled page JS is also updated as part of the package refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04cfc098b559b1be9e9989665791cfb5a64b9337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->