### PR TITLE
Sync: self-heal device_info and wrap account_info for every credential

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoKeyManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoKeyManager.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.store.AccountInfoPublicKey
+import com.duckduckgo.sync.store.ScopedPassword
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -44,7 +45,7 @@ interface AccountInfoKeyManager {
 
     /**
      * Mints a fresh `account_info` keypair, wraps it for every credential this account currently holds
-     * (ddg always, 3party if a scoped password exists), and registers it with the server via set-if-absent.
+     * (ddg always, 3party whenever the account has that credential), and registers it with the server via set-if-absent.
      *
      * If another device already registered a key for this purpose first, the local mint is discarded and the server's key is adopted instead.
      * The winning public key is returned in [AccountInfoKeyResult] and cached in [SyncStore.accountInfoPublicKey].
@@ -72,6 +73,7 @@ class RealAccountInfoKeyManager @Inject constructor(
     private val syncJweCrypto: SyncJweCrypto,
     private val nativeLib: SyncLib,
     private val thirdPartyKeyWrapper: ThirdPartyKeyWrapper,
+    private val thirdPartyCredentialManager: ThirdPartyCredentialManager,
     private val dispatchers: DispatcherProvider,
 ) : AccountInfoKeyManager {
 
@@ -116,9 +118,15 @@ class RealAccountInfoKeyManager @Inject constructor(
             keySizeBits = RSA_KEY_SIZE_ACCOUNT_INFO,
         )
 
+    /**
+     * The spec requires the key to be wrapped for every credential the account holds. A cached scoped password is only evidence that this device
+     * created, recovered or logged into the 3party credential — not that the account lacks one — so when it's absent we ask the server before
+     * settling for a `ddg`-only key. Failing to recover one is not fatal: a `ddg`-only key still lets this device write `device_info`, and login
+     * re-wraps for the missing credential.
+     */
     private fun wrapForCredentials(minted: MintedProtectedKey): Result<List<ProtectedKeyEntry>> {
         val entries = mutableListOf(minted.entry)
-        val scopedPassword = syncStore.scopedPassword
+        val scopedPassword = syncStore.scopedPassword ?: recoverScopedPassword()
         val userId = syncStore.userId
         if (scopedPassword != null && userId != null) {
             entries += when (val result = thirdPartyKeyWrapper.wrap(minted, SYNC_PURPOSE_ACCOUNT_INFO, scopedPassword, userId)) {
@@ -127,6 +135,22 @@ class RealAccountInfoKeyManager @Inject constructor(
             }
         }
         return Success(entries)
+    }
+
+    private fun recoverScopedPassword(): ScopedPassword? {
+        logcat { "Sync-UnifiedDevices: no cached scoped password; checking whether the account has a 3party credential to wrap for" }
+        return when (val result = thirdPartyCredentialManager.refresh()) {
+            is Success -> if (result.data) {
+                syncStore.scopedPassword
+            } else {
+                logcat { "Sync-UnifiedDevices: account has no 3party credential; wrapping $SYNC_PURPOSE_ACCOUNT_INFO for ddg only" }
+                null
+            }
+            is Error -> {
+                logcat(ERROR) { "Sync-UnifiedDevices: could not recover scoped password, wrapping for ddg only: ${result.reason}" }
+                null
+            }
+        }
     }
 
     private fun onSetIfAbsentSuccess(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoMigrator.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoMigrator.kt
@@ -92,8 +92,8 @@ class RealDeviceInfoMigrator @Inject constructor(
                 return Precheck.Stop(Error(reason = "DeviceInfoMigration: not signed in"))
             }
 
-        if (!syncFeature.canWriteUnifiedDeviceList().isEnabled()) {
-            logcat { "Sync-UnifiedDevices: migration skipped — canWriteUnifiedDeviceList disabled" }
+        if (!syncFeature.canWriteDeviceInfo()) {
+            logcat { "Sync-UnifiedDevices: migration skipped — writing device_info is disabled" }
             return Precheck.Stop(Success(Unit))
         }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoUpdater.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoUpdater.kt
@@ -69,7 +69,7 @@ class RealDeviceInfoUpdater @Inject constructor(
      * @return the server's device list as it stands after the update
      */
     private suspend fun setName(name: String): Result<List<DeviceV2>> {
-        val includeDeviceInfo = syncFeature.canWriteUnifiedDeviceList().isEnabled()
+        val includeDeviceInfo = syncFeature.canWriteDeviceInfo()
 
         val token = syncStore.token.takeUnless { it.isNullOrEmpty() }
             ?: return Error(reason = "UpdateDeviceInfo: not signed in")

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -64,6 +64,7 @@ import logcat.LogPriority.WARN
 import logcat.asLog
 import logcat.logcat
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
 import javax.inject.*
 
 interface SyncAccountRepository {
@@ -182,6 +183,9 @@ class AppSyncAccountRepository @Inject constructor(
 
     // Bounded backoff for the 3party→ddg upgrade network calls.
     internal var upgradeRetryDelayMillis: Long = DEFAULT_UPGRADE_RETRY_DELAY_MILLIS
+
+    // The user id we've already re-published device_info for. Stops us repairing again every time the device list is shown.
+    private val republishedDeviceInfoForUserId = AtomicReference<String?>(null)
 
     /**
      * If there is a key-exchange flow in progress, we need to keep a reference to them
@@ -418,7 +422,7 @@ class AppSyncAccountRepository @Inject constructor(
             return@withContext Error(reason = "Rename Device: only this device can be renamed").alsoFireUpdateDeviceErrorPixel()
         }
 
-        val withDeviceInfo = syncFeature.canWriteUnifiedDeviceList().isEnabled()
+        val withDeviceInfo = syncFeature.canWriteDeviceInfo()
         val canPatchDevice = withDeviceInfo || syncFeature.canUsePatchEndpointForLegacyDeviceRename().isEnabled()
         logcat { "Sync-UnifiedDevices: rename via ${if (canPatchDevice) "PATCH" else "login"}, withDeviceInfo=$withDeviceInfo" }
         if (canPatchDevice) {
@@ -980,14 +984,42 @@ class AppSyncAccountRepository @Inject constructor(
         is Success -> {
             val entriesV2 = result.data.entriesV2
             val devices = if (entriesV2 != null) {
-                val decryptResult = thirdPartyDeviceListDecryptor.decryptAll(entriesV2)
+                val decryptResult = thirdPartyDeviceListDecryptor.decryptAll(entriesV2, syncStore.deviceId)
                 logoutFailedV2Devices(decryptResult.undecryptable)
+                if (decryptResult.thisDeviceInfoUnresolved) republishThisDeviceInfo()
                 decryptResult.decrypted.map { it.toConnectedDevice() }
             } else {
                 // entries_v2 missing
                 decryptLegacyEntries(result.data.entries, primaryKey)
             }
             finishWith(devices)
+        }
+    }
+
+    /**
+     * Re-writes this device's `device_info` with the name it already has, after rendering the device list showed that our own blob is missing or
+     * undecryptable. A flag-off rename is the expected cause: it omits `device_info`, so the server clears it, and migration's done-marker is a
+     * latch that won't put it back.
+     *
+     * Best-effort, so a failure never affects the list the caller is building; a failed attempt is retried on the next load.
+     */
+    private fun republishThisDeviceInfo() {
+        // an ungated repair would omit device_info and so delete the blob it is trying to restore
+        if (!syncFeature.canWriteDeviceInfo()) return
+        val userId = syncStore.userId ?: return
+        // keyed by account rather than latched outright, so signing into a different account in the same process can still repair
+        if (republishedDeviceInfoForUserId.getAndSet(userId) == userId) return
+
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            logcat { "Sync-UnifiedDevices: this device's device_info did not resolve on read; re-publishing it" }
+            when (val result = deviceInfoUpdater.setThisDeviceName(syncDeviceIds.deviceName())) {
+                is Success -> logcat { "Sync-UnifiedDevices: device_info re-published" }
+                is Error -> {
+                    logcat(WARN) { "Sync-UnifiedDevices: device_info re-publish failed: ${result.reason}" }
+                    // release the slot so the next device list load can try again, without clobbering a claim another account has since made
+                    republishedDeviceInfoForUserId.compareAndSet(userId, null)
+                }
+            }
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -112,9 +112,15 @@ interface SyncFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun preventStaleTokenLogout(): Toggle
 
+    /**
+     * Gates writing `device_info`
+     */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun canWriteUnifiedDeviceList(): Toggle
 
+    /**
+     * Gates reading from `device_info`
+     */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun canReadUnifiedDeviceList(): Toggle
 
@@ -128,3 +134,11 @@ interface SyncFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun canUsePatchEndpointForLegacyDeviceRename(): Toggle
 }
+
+/**
+ * `device_info` is read only on the v2 device-list path, and the `account_info` key backing it must be wrapped for every credential on the
+ * account, which needs the scoped credentials [SyncFeature.canUseV2ConnectFlow] governs. Writing it with v2 disabled would publish a blob
+ * nobody on this device reads, off a key we can only wrap for `ddg`.
+ */
+internal fun SyncFeature.canWriteDeviceInfo(): Boolean =
+    canUseV2ConnectFlow().isEnabled() && canWriteUnifiedDeviceList().isEnabled()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptor.kt
@@ -36,7 +36,10 @@ import javax.inject.Inject
  */
 @WorkerThread
 interface ThirdPartyDeviceListDecryptor {
-    fun decryptAll(entries: List<DeviceV2>): DecryptAllResult
+    /**
+     * @param thisDeviceId this device's sync id, used to report back whether our own `device_info` resolved
+     */
+    fun decryptAll(entries: List<DeviceV2>, thisDeviceId: String?): DecryptAllResult
 
     companion object {
         const val FALLBACK_TYPE_3PARTY = "Browser"
@@ -44,9 +47,14 @@ interface ThirdPartyDeviceListDecryptor {
     }
 }
 
+/**
+ * @param thisDeviceInfoUnresolved this device's own row was in the batch but did not resolve via `device_info` — either the server holds no blob
+ *   for us or the one it holds can't be decrypted. Only ever set when the read flag is on, since with it off no blob is read at all.
+ */
 data class DecryptAllResult(
     val decrypted: List<DecryptedDevice>,
     val undecryptable: List<String>,
+    val thisDeviceInfoUnresolved: Boolean = false,
 )
 
 @ContributesBinding(AppScope::class)
@@ -57,7 +65,7 @@ class RealThirdPartyDeviceListDecryptor @Inject constructor(
     private val syncFeature: SyncFeature,
 ) : ThirdPartyDeviceListDecryptor {
 
-    override fun decryptAll(entries: List<DeviceV2>): DecryptAllResult {
+    override fun decryptAll(entries: List<DeviceV2>, thisDeviceId: String?): DecryptAllResult {
         if (entries.isEmpty()) return DecryptAllResult(emptyList(), emptyList())
 
         val readEnabled = syncFeature.canReadUnifiedDeviceList().isEnabled()
@@ -89,6 +97,10 @@ class RealThirdPartyDeviceListDecryptor @Inject constructor(
         return DecryptAllResult(
             decrypted = viaDeviceInfo + legacy.viaLegacy + legacy.fallbacks,
             undecryptable = legacy.undecryptable,
+            thisDeviceInfoUnresolved = readEnabled &&
+                thisDeviceId != null &&
+                entries.any { it.deviceId == thisDeviceId } &&
+                viaDeviceInfo.none { it.deviceId == thisDeviceId },
         )
     }
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoKeyManagerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoKeyManagerTest.kt
@@ -54,6 +54,7 @@ class AccountInfoKeyManagerTest {
     private val syncApi: SyncApi = mock()
     private val syncJweCrypto: SyncJweCrypto = mock()
     private val nativeLib: SyncLib = mock()
+    private val thirdPartyCredentialManager: ThirdPartyCredentialManager = mock()
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
@@ -68,12 +69,14 @@ class AccountInfoKeyManagerTest {
             syncJweCrypto = syncJweCrypto,
             nativeLib = nativeLib,
             thirdPartyKeyWrapper = RealThirdPartyKeyWrapper(syncJweCrypto),
+            thirdPartyCredentialManager = thirdPartyCredentialManager,
             dispatchers = coroutineTestRule.testDispatcherProvider,
         )
         configureForSuccessfulKeypairMint()
     }
 
     private fun configureForSuccessfulKeypairMint() {
+        whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(false))
         whenever(syncStore.token).thenReturn(token)
         whenever(syncStore.secretKey).thenReturn(secretKey)
         whenever(syncJweCrypto.generateRsaKeyPair(any())).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
@@ -139,6 +142,50 @@ class AccountInfoKeyManagerTest {
     }
 
     @Test
+    fun whenNoScopedPasswordCachedThenAsksServerWhetherAccountHasThirdPartyCredential() = runTest {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncApi.setKeysIfAbsent(eq(token), eq("account_info"), any())).thenReturn(Success(SetKeysIfAbsentResult.Created))
+
+        manager.ensureKeyRegistered()
+
+        verify(thirdPartyCredentialManager).refresh()
+    }
+
+    @Test
+    fun whenScopedPasswordRecoveredFromServerThenBothWrapsAreSent() = runTest {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncStore.userId).thenReturn(userId)
+        // a successful refresh stores the recovered scoped password
+        whenever(thirdPartyCredentialManager.refresh()).thenAnswer {
+            whenever(syncStore.scopedPassword).thenReturn(ScopedPassword("c3BSYXc="))
+            Success(true)
+        }
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), any(), any())).thenReturn(ByteArray(32))
+        whenever(syncJweCrypto.jweEncryptSymmetric(any(), any(), anyOrNull())).thenReturn("3party_wrapped")
+        whenever(syncApi.setKeysIfAbsent(eq(token), eq("account_info"), any())).thenReturn(Success(SetKeysIfAbsentResult.Created))
+
+        val result = manager.ensureKeyRegistered() as Success
+
+        assertEquals(2, result.data.wrapsSent)
+        verify(syncApi).setKeysIfAbsent(
+            eq(token),
+            eq("account_info"),
+            check { keys -> assertEquals(setOf("ddg", "3party"), keys.map { it.encryptedWith }.toSet()) },
+        )
+    }
+
+    @Test
+    fun whenScopedPasswordRecoveryFailsThenKeyIsStillRegisteredForDdgOnly() = runTest {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(thirdPartyCredentialManager.refresh()).thenReturn(Error(reason = "no network"))
+        whenever(syncApi.setKeysIfAbsent(eq(token), eq("account_info"), any())).thenReturn(Success(SetKeysIfAbsentResult.Created))
+
+        val result = manager.ensureKeyRegistered() as Success
+
+        assertEquals(1, result.data.wrapsSent)
+    }
+
+    @Test
     fun whenScopedPasswordPresentThenBothWrapsAreSentSharingOneKid() = runTest {
         whenever(syncStore.scopedPassword).thenReturn(ScopedPassword("c3BSYXc="))
         whenever(syncStore.userId).thenReturn(userId)
@@ -150,6 +197,7 @@ class AccountInfoKeyManagerTest {
 
         assertTrue(result is Success)
         assertEquals(2, (result as Success).data.wrapsSent)
+        verify(thirdPartyCredentialManager, never()).refresh()
         verify(syncApi).setKeysIfAbsent(
             eq(token),
             eq("account_info"),

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -690,7 +690,7 @@ class AppSyncAccountRepositoryTest {
         whenever(syncApi.getDevices(anyString())).thenReturn(
             Success(DeviceEntries(entries = emptyList(), entriesV2 = listOf(v2Entry))),
         )
-        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(v2Entry))).thenReturn(
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(v2Entry), deviceId)).thenReturn(
             DecryptAllResult(
                 decrypted = listOf(DecryptedDevice(deviceId = "d1", name = "Chrome/148", type = "Browser")),
                 undecryptable = emptyList(),
@@ -701,7 +701,7 @@ class AppSyncAccountRepositoryTest {
 
         assertEquals(1, result.data.size)
         assertEquals("Chrome/148", result.data[0].deviceName)
-        verify(thirdPartyDeviceListDecryptor).decryptAll(listOf(v2Entry))
+        verify(thirdPartyDeviceListDecryptor).decryptAll(listOf(v2Entry), deviceId)
         verify(syncApi, never()).logout(anyString(), anyString())
     }
 
@@ -719,7 +719,7 @@ class AppSyncAccountRepositoryTest {
 
         // Fell back to legacy decrypt — same library path as the legacy `entries`-only response.
         assertEquals(1, result.data.size)
-        verify(thirdPartyDeviceListDecryptor, never()).decryptAll(any())
+        verify(thirdPartyDeviceListDecryptor, never()).decryptAll(any(), anyOrNull())
     }
 
     @Test
@@ -744,7 +744,7 @@ class AppSyncAccountRepositoryTest {
         whenever(syncApi.getDevices(anyString())).thenReturn(
             Success(DeviceEntries(entries = emptyList(), entriesV2 = listOf(v2Entry))),
         )
-        whenever(thirdPartyDeviceListDecryptor.decryptAll(any())).thenReturn(
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(any(), anyOrNull())).thenReturn(
             DecryptAllResult(decrypted = emptyList(), undecryptable = listOf("d-other")),
         )
         whenever(syncApi.logout(eq(token), eq("d-other"))).thenReturn(Success(Logout("d-other")))
@@ -766,7 +766,7 @@ class AppSyncAccountRepositoryTest {
         whenever(syncApi.getDevices(anyString())).thenReturn(
             Success(DeviceEntries(entries = emptyList(), entriesV2 = listOf(v2Entry))),
         )
-        whenever(thirdPartyDeviceListDecryptor.decryptAll(any())).thenReturn(
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(any(), anyOrNull())).thenReturn(
             DecryptAllResult(decrypted = emptyList(), undecryptable = listOf(deviceId)),
         )
 
@@ -786,7 +786,107 @@ class AppSyncAccountRepositoryTest {
 
         syncRepo.getConnectedDevices()
 
-        verify(thirdPartyDeviceListDecryptor, never()).decryptAll(any())
+        verify(thirdPartyDeviceListDecryptor, never()).decryptAll(any(), anyOrNull())
+    }
+
+    @Test
+    fun whenThisDeviceInfoUnresolvedThenRepublishesItWithTheCurrentName() = runTest {
+        givenThisDeviceInfoUnresolvedOnRead()
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
+        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Success(emptyList()))
+
+        syncRepo.getConnectedDevices()
+
+        verify(deviceInfoUpdater).setThisDeviceName(deviceName)
+    }
+
+    @Test
+    fun whenThisDeviceInfoUnresolvedOnEveryRenderThenRepublishesOnlyOncePerProcess() = runTest {
+        givenThisDeviceInfoUnresolvedOnRead()
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
+        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Success(emptyList()))
+
+        syncRepo.getConnectedDevices()
+        syncRepo.getConnectedDevices()
+
+        verify(deviceInfoUpdater, times(1)).setThisDeviceName(anyString())
+    }
+
+    @Test
+    fun whenRepublishFailsThenRetriesOnTheNextRender() = runTest {
+        givenThisDeviceInfoUnresolvedOnRead()
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
+        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Error(reason = "no network"))
+
+        syncRepo.getConnectedDevices()
+        syncRepo.getConnectedDevices()
+
+        verify(deviceInfoUpdater, times(2)).setThisDeviceName(anyString())
+    }
+
+    @Test
+    fun whenSignedIntoAnotherAccountInTheSameProcessThenRepublishesAgain() = runTest {
+        givenThisDeviceInfoUnresolvedOnRead()
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
+        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Success(emptyList()))
+
+        syncRepo.getConnectedDevices()
+        whenever(syncStore.userId).thenReturn("anotherUserId")
+        syncRepo.getConnectedDevices()
+
+        verify(deviceInfoUpdater, times(2)).setThisDeviceName(anyString())
+    }
+
+    @Test
+    fun whenNotSignedInThenDoesNotRepublish() = runTest {
+        givenThisDeviceInfoUnresolvedOnRead()
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
+        whenever(syncStore.userId).thenReturn(null)
+
+        syncRepo.getConnectedDevices()
+
+        verifyNoInteractions(deviceInfoUpdater)
+    }
+
+    @Test
+    fun whenThisDeviceInfoUnresolvedButWritingDeviceInfoDisabledThenDoesNotRepublish() = runTest {
+        // the PATCH would omit device_info and the backend would clear it, deleting the blob we're repairing
+        givenThisDeviceInfoUnresolvedOnRead()
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = false))
+
+        syncRepo.getConnectedDevices()
+
+        verifyNoInteractions(deviceInfoUpdater)
+    }
+
+    @Test
+    fun whenThisDeviceInfoResolvedThenDoesNotRepublish() = runTest {
+        givenThisDeviceInfoUnresolvedOnRead(unresolved = false)
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
+
+        syncRepo.getConnectedDevices()
+
+        verifyNoInteractions(deviceInfoUpdater)
+    }
+
+    private fun givenThisDeviceInfoUnresolvedOnRead(unresolved: Boolean = true) {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.deviceId).thenReturn(deviceId)
+        whenever(syncStore.userId).thenReturn(userId)
+        whenever(syncDeviceIds.deviceName()).thenReturn(deviceName)
+        val ownEntry = DeviceV2(deviceId = deviceId, deviceName = "ENC", credentialId = "ddg")
+        whenever(syncApi.getDevices(anyString())).thenReturn(
+            Success(DeviceEntries(entries = emptyList(), entriesV2 = listOf(ownEntry))),
+        )
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(any(), anyOrNull())).thenReturn(
+            DecryptAllResult(
+                decrypted = listOf(DecryptedDevice(deviceId = deviceId, name = deviceName, type = "phone")),
+                undecryptable = emptyList(),
+                thisDeviceInfoUnresolved = unresolved,
+            ),
+        )
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoMigratorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoMigratorTest.kt
@@ -88,6 +88,17 @@ class DeviceInfoMigratorTest {
     }
 
     @Test
+    fun whenV2ConnectFlowDisabledThenNoOpAndNotMarked() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(enable = false))
+
+        val result = migrator.ensureMigrated()
+
+        assertTrue(result is Result.Success)
+        verify(syncApi, never()).getDevices(any())
+        verify(syncStore, never()).unifiedDeviceListMigratedForUserId = any()
+    }
+
+    @Test
     fun whenNotSignedInThenErrorWithoutNetwork() = runTest {
         whenever(syncStore.userId).thenReturn(null)
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoUpdaterTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoUpdaterTest.kt
@@ -206,6 +206,19 @@ class DeviceInfoUpdaterTest {
     }
 
     @Test
+    fun whenV2ConnectFlowDisabledThenOmitDeviceInfoEvenThoughWritingIsEnabled() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(enable = false))
+        whenever(syncStore.accountInfoPublicKey).thenReturn(null)
+        givenEncryptionAndPatchSucceed()
+
+        val result = updater.setThisDeviceName("My Phone")
+
+        assertTrue(result is Result.Success)
+        verify(syncApi).patchThisDevice(token, "encName", "encType", null)
+        verify(accountInfoKeyManager, never()).ensureKeyRegistered()
+    }
+
+    @Test
     fun whenWriteFeatureEnabledThenSendDeviceInfoAlongsideTheLegacyFields() = runTest {
         givenEncryptionAndPatchSucceed()
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptorTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.ThirdPartyDeviceListDecryptor.Companion.FALLBACK_NAME
 import com.duckduckgo.sync.impl.ThirdPartyDeviceListDecryptor.Companion.FALLBACK_TYPE_3PARTY
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -60,7 +61,7 @@ class ThirdPartyDeviceListDecryptorTest {
 
     @Test
     fun whenInputIsEmptyThenReturnsEmptyAndNoRefreshCall() {
-        val result = decryptor.decryptAll(emptyList())
+        val result = decryptor.decryptAll(emptyList(), thisDeviceId = null)
 
         assertTrue(result.decrypted.isEmpty())
         assertTrue(result.undecryptable.isEmpty())
@@ -74,7 +75,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Pixel 7", "phone")))
         whenever(fieldDecryptor.decrypt(tp)).thenReturn(Success(DecryptedDevice("d2", "Chrome", "Browser")))
 
-        val result = decryptor.decryptAll(listOf(ddg, tp))
+        val result = decryptor.decryptAll(listOf(ddg, tp), thisDeviceId = null)
 
         assertEquals(2, result.decrypted.size)
         assertTrue(result.undecryptable.isEmpty())
@@ -89,7 +90,7 @@ class ThirdPartyDeviceListDecryptorTest {
             .thenReturn(Success(DecryptedDevice("d1", "Chrome", "Browser")))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(true))
 
-        val result = decryptor.decryptAll(listOf(tp))
+        val result = decryptor.decryptAll(listOf(tp), thisDeviceId = null)
 
         assertEquals(listOf(DecryptedDevice("d1", "Chrome", "Browser")), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())
@@ -103,7 +104,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(tp)).thenReturn(Error(reason = "still bad"))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(true))
 
-        val result = decryptor.decryptAll(listOf(tp))
+        val result = decryptor.decryptAll(listOf(tp), thisDeviceId = null)
 
         assertTrue(result.decrypted.isEmpty())
         assertEquals(listOf("d1"), result.undecryptable)
@@ -116,7 +117,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(tp)).thenReturn(Error(reason = "still bad"))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Error(reason = "server down"))
 
-        val result = decryptor.decryptAll(listOf(tp))
+        val result = decryptor.decryptAll(listOf(tp), thisDeviceId = null)
 
         assertEquals(listOf(DecryptedDevice("d1", FALLBACK_NAME, FALLBACK_TYPE_3PARTY)), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())
@@ -129,7 +130,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(tp)).thenReturn(Error(reason = "still bad"))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(false))
 
-        val result = decryptor.decryptAll(listOf(tp))
+        val result = decryptor.decryptAll(listOf(tp), thisDeviceId = null)
 
         assertEquals(listOf(DecryptedDevice("d1", FALLBACK_NAME, FALLBACK_TYPE_3PARTY)), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())
@@ -144,7 +145,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(tp2)).thenReturn(Error(reason = "bad"))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(true))
 
-        val result = decryptor.decryptAll(listOf(tp1, tp2))
+        val result = decryptor.decryptAll(listOf(tp1, tp2), thisDeviceId = null)
 
         assertEquals(listOf("d1", "d2"), result.undecryptable)
         verify(thirdPartyCredentialManager, times(1)).refresh()
@@ -155,7 +156,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC")
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Error(reason = "primaryKey rotated?"))
 
-        val result = decryptor.decryptAll(listOf(ddg))
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
 
         assertTrue(result.decrypted.isEmpty())
         assertEquals(listOf("d1"), result.undecryptable)
@@ -170,7 +171,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(tp)).thenReturn(Error(reason = "3p bad"))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Error(reason = "network"))
 
-        val result = decryptor.decryptAll(listOf(ddg, tp))
+        val result = decryptor.decryptAll(listOf(ddg, tp), thisDeviceId = null)
 
         assertEquals(listOf(DecryptedDevice("d2", FALLBACK_NAME, FALLBACK_TYPE_3PARTY)), result.decrypted)
         assertEquals(listOf("d1"), result.undecryptable)
@@ -182,7 +183,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val orphan = DeviceV2(deviceId = null, credentialId = "ddg", deviceName = "ENC")
         whenever(fieldDecryptor.decrypt(orphan)).thenReturn(Error(reason = "no id"))
 
-        val result = decryptor.decryptAll(listOf(orphan))
+        val result = decryptor.decryptAll(listOf(orphan), thisDeviceId = null)
 
         assertTrue(result.decrypted.isEmpty())
         assertTrue(result.undecryptable.isEmpty())
@@ -200,7 +201,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(tpOk)).thenReturn(Success(DecryptedDevice("d3", "Edge", "Browser")))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(true))
 
-        val result = decryptor.decryptAll(listOf(ddgOk, tpFail, tpOk))
+        val result = decryptor.decryptAll(listOf(ddgOk, tpFail, tpOk), thisDeviceId = null)
 
         assertEquals(3, result.decrypted.size)
         assertTrue(result.undecryptable.isEmpty())
@@ -216,7 +217,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val ddg2 = DeviceV2(deviceId = "d2", credentialId = null, deviceName = "n")
         whenever(fieldDecryptor.decrypt(any())).thenReturn(Error(reason = "bad"))
 
-        val result = decryptor.decryptAll(listOf(ddg1, ddg2))
+        val result = decryptor.decryptAll(listOf(ddg1, ddg2), thisDeviceId = null)
 
         assertEquals(listOf("d1", "d2"), result.undecryptable)
         verify(thirdPartyCredentialManager, never()).refresh()
@@ -227,7 +228,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
 
-        val result = decryptor.decryptAll(listOf(ddg))
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
 
         assertEquals(listOf(DecryptedDevice("d1", "Legacy Pixel", "phone")), result.decrypted)
         verify(deviceInfoDecryptor, never()).openSession()
@@ -241,7 +242,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Pixel", "phone")))
         whenever(fieldDecryptor.decrypt(tp)).thenReturn(Success(DecryptedDevice("d2", "Chrome", "Browser")))
 
-        val result = decryptor.decryptAll(listOf(ddg, tp))
+        val result = decryptor.decryptAll(listOf(ddg, tp), thisDeviceId = null)
 
         assertEquals(2, result.decrypted.size)
         verify(deviceInfoDecryptor, never()).openSession()
@@ -253,7 +254,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
         whenever(session.decrypt("info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Unified Pixel", type = "phone")))
 
-        val result = decryptor.decryptAll(listOf(ddg))
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
 
         assertEquals(listOf(DecryptedDevice("d1", "Unified Pixel", "phone")), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())
@@ -269,7 +270,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(session.decrypt("ddg.info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Pixel", type = "phone")))
         whenever(session.decrypt("3p.info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Chrome", type = "Browser")))
 
-        val result = decryptor.decryptAll(listOf(ddg, tp))
+        val result = decryptor.decryptAll(listOf(ddg, tp), thisDeviceId = null)
 
         assertEquals(
             listOf(DecryptedDevice("d1", "Pixel", "phone"), DecryptedDevice("d2", "Chrome", "Browser")),
@@ -286,7 +287,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
 
-        val result = decryptor.decryptAll(listOf(ddg))
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
 
         assertEquals(listOf(DecryptedDevice("d1", "Legacy Pixel", "phone")), result.decrypted)
         verify(session, never()).decrypt(any())
@@ -299,7 +300,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(session.decrypt("corrupt.jwe")).thenReturn(Error(reason = "bad device_info"))
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
 
-        val result = decryptor.decryptAll(listOf(ddg))
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
 
         assertEquals(listOf(DecryptedDevice("d1", "Legacy Pixel", "phone")), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())
@@ -312,7 +313,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
 
-        val result = decryptor.decryptAll(listOf(ddg))
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
 
         assertEquals(listOf(DecryptedDevice("d1", "Legacy Pixel", "phone")), result.decrypted)
         verify(session, never()).decrypt(any())
@@ -326,7 +327,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(session.decrypt("info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Pixel", type = "phone")))
         whenever(fieldDecryptor.decrypt(viaLegacy)).thenReturn(Success(DecryptedDevice("d2", "Chrome", "Browser")))
 
-        val result = decryptor.decryptAll(listOf(viaInfo, viaLegacy))
+        val result = decryptor.decryptAll(listOf(viaInfo, viaLegacy), thisDeviceId = null)
 
         assertEquals(2, result.decrypted.size)
         assertTrue(result.decrypted.contains(DecryptedDevice("d1", "Pixel", "phone")))
@@ -341,7 +342,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Error(reason = "primaryKey rotated?"))
 
-        val result = decryptor.decryptAll(listOf(ddg))
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
 
         assertEquals(listOf(DecryptedDevice("d1", FALLBACK_NAME, null)), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())
@@ -355,10 +356,81 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(tp)).thenReturn(Error(reason = "still bad"))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(true))
 
-        val result = decryptor.decryptAll(listOf(tp))
+        val result = decryptor.decryptAll(listOf(tp), thisDeviceId = null)
 
         assertEquals(listOf(DecryptedDevice("d1", FALLBACK_NAME, FALLBACK_TYPE_3PARTY)), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())
+    }
+
+    @Test
+    fun whenOwnDeviceInfoDecryptsThenNotReportedAsUnresolved() {
+        enableReadFlag()
+        val own = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
+        whenever(session.decrypt("info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Pixel", type = "phone")))
+
+        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1")
+
+        assertFalse(result.thisDeviceInfoUnresolved)
+    }
+
+    @Test
+    fun whenOwnDeviceInfoIsAbsentThenReportedAsUnresolved() {
+        enableReadFlag()
+        val own = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
+        val other = DeviceV2(deviceId = "d2", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
+        whenever(session.decrypt("info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Chrome", type = "Browser")))
+        whenever(fieldDecryptor.decrypt(own)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
+
+        val result = decryptor.decryptAll(listOf(own, other), thisDeviceId = "d1")
+
+        assertTrue(result.thisDeviceInfoUnresolved)
+    }
+
+    @Test
+    fun whenOwnDeviceInfoIsUndecryptableThenReportedAsUnresolved() {
+        enableReadFlag()
+        val own = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "corrupt.jwe")
+        whenever(session.decrypt("corrupt.jwe")).thenReturn(Error(reason = "bad device_info"))
+        whenever(fieldDecryptor.decrypt(own)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
+
+        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1")
+
+        assertTrue(result.thisDeviceInfoUnresolved)
+    }
+
+    @Test
+    fun whenOnlyAnotherDeviceInfoIsUnresolvedThenNotReported() {
+        enableReadFlag()
+        val own = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
+        val other = DeviceV2(deviceId = "d2", credentialId = "3party", deviceName = "ENC", deviceInfo = null)
+        whenever(session.decrypt("info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Pixel", type = "phone")))
+        whenever(fieldDecryptor.decrypt(other)).thenReturn(Success(DecryptedDevice("d2", "Chrome", "Browser")))
+
+        val result = decryptor.decryptAll(listOf(own, other), thisDeviceId = "d1")
+
+        assertFalse(result.thisDeviceInfoUnresolved)
+    }
+
+    @Test
+    fun whenOwnDeviceIsNotInTheListThenNotReportedAsUnresolved() {
+        enableReadFlag()
+        val other = DeviceV2(deviceId = "d2", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
+        whenever(fieldDecryptor.decrypt(other)).thenReturn(Success(DecryptedDevice("d2", "Chrome", "Browser")))
+
+        val result = decryptor.decryptAll(listOf(other), thisDeviceId = "d1")
+
+        assertFalse(result.thisDeviceInfoUnresolved)
+    }
+
+    @Test
+    fun whenReadFlagOffThenOwnUnresolvedDeviceInfoIsNotReported() {
+        // with the flag off no blob is read at all, so "unresolved" would be true for every device on every render
+        val own = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
+        whenever(fieldDecryptor.decrypt(own)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
+
+        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1")
+
+        assertFalse(result.thisDeviceInfoUnresolved)
     }
 
     @Test
@@ -368,7 +440,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(session.decrypt("corrupt.jwe")).thenReturn(Error(reason = "bad device_info"))
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Error(reason = "bad legacy"))
 
-        val result = decryptor.decryptAll(listOf(ddg))
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
 
         assertEquals(listOf(DecryptedDevice("d1", FALLBACK_NAME, null)), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1217487243679943?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
There are two ways our own device can end up _unreadable_ in the unified device list, both of which previously only healed if the device signed out and back into sync. This PR adds self-healing attempts for the following:

1. **The `account_info` key wasn't always wrapped for the `3party` credential**
Whether the key got a `3party` wrap depended on local state and not the backend state. We only added that wrap if this device happened to have the scoped password cached. A device that signed in before the `3party` credential existed created a `ddg`-only key. 
**Fix**: when no scoped password is cached, ask the server first; that tells us whether the account has a `3party` credential at all. If that lookup fails we still wrap it as `ddg`-only as before.

2. **Our own `device_info` could stay broken**
When the device list is rendered we already know whether our own row was readable (decryptable) from `device_info` or whether it was falling back to legacy device name reads. If it falls back to legacy now, we re-publish this device's `device_info`. The usual root cause of such a scenario would be renaming a device while the `canWrite` feature flag is disabled.
**Fix :** re-publish this device's `device_info` when we detect the fallback, once per app launch; a failed attempt releases its claim so it retries on the next device list load.

### Steps to test this PR
You'll need two devices/emulators.

> [!NOTE]
> Logcat filter: `Sync-UnifiedDevices`

_Setup_
  - [ ] Both devices: fresh install of the `internal` variant
  - [ ] Both devices: `canWriteUnifiedDeviceList` and `canReadUnifiedDeviceList`
  - [ ] Device A: set up sync
  - [ ] Device B: sync to the same account 
  - [ ] Device A: in sync dev tools, tap "Fetch & decrypt devices" and confirm both devices have a `device_info` blob

_Scenario 1: a broken device_info is repaired_
  - [ ] Device A: turn `canWriteUnifiedDeviceList` **off**
  - [ ] Device A: in the real Sync settings (not the dev screen), rename this device to `Repair Me` — this clears the blob server-side
  - [ ] Device A: tap "Fetch & decrypt devices" and confirm this device now shows `(no device_info)`
  - [ ] Device A: turn `canWriteUnifiedDeviceList` back **on**
  - [ ] Device A: open Sync settings so the device list loads
  - [ ] Device A: logcat shows `did not resolve on read; re-publishing it` then `device_info re-published`
  - [ ] Device A: tap "Fetch & decrypt devices" and confirm the blob is back, with the name `Repair Me`
  - [ ] Device B: open Sync settings and confirm Device A shows as `Repair Me`

_Scenario 2: no repair happens while writes are disabled_
  - [ ] Device A: repeat the first three steps of Scenario 1 to clear the blob again, but leave `canWriteUnifiedDeviceList` **off** after renaming
  - [ ] Device A: open Sync settings
  - [ ] Device A: confirm logcat **does not** show `re-publishing it` line
  - [ ] Device A: turn `canWriteUnifiedDeviceList` on and `canReadUnifiedDeviceList` **off**, force-stop, relaunch, open Sync settings
  - [ ] Device A: confirm logcat again **does not** show `re-publishing it` line (nothing is detected when reads are off)

_Scenario 3: the account_info key is wrapped for every credential_
  - [ ] Device A: tap "Delete Cached account_info Key", then "Create & Register account_info Key"
  - [ ] Device A: on an account with no `3party` credential, logcat shows `no cached scoped password; checking whether the account has a 3party credential to wrap for` followed by `account has no 3party credential; wrapping account_info for ddg only`, and registration still succeeds
  - [ ] Device A: with airplane mode on, repeat and confirm logcat shows `could not recover scoped password, wrapping for ddg only`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2f42c666d736c07289133099af049cf728a4d686. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->