### PR TITLE
Run required checks on merge_group so the merge queue can pass

### DIFF
--- a/.github/workflows/action-pr-opened.yaml
+++ b/.github/workflows/action-pr-opened.yaml
@@ -3,6 +3,10 @@ name: 'Pull Request opened -> Comment on task and add it to Android Release Boar
 on:
   pull_request:
     types: [opened, reopened, edited, synchronize, ready_for_review]
+  # `process-internal-pr` is a required status check, so it has to report on the merge queue's
+  # temporary branch too. There is no pull request context there, so every step below no-ops and
+  # the job reports success without repeating the Asana bookkeeping.
+  merge_group:
 
 jobs:
   process-internal-pr:
@@ -11,7 +15,7 @@ jobs:
       issues: write
     steps:
       - name: Find Asana Task ID
-        if: ${{ github.event.pull_request.base.ref == github.event.repository.default_branch }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == github.event.repository.default_branch }}
         id: find-asana-task
         uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
       - main
       - develop
   pull_request:
+  # Required by the merge queue: it validates a temporary merge-group branch and waits for the same required checks
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,8 +33,8 @@ jobs:
           if [[ "${{ github.event_name }}" == "push" ]]; then
             echo "Direct push to branch — running checks"; echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          BASE="${{ github.event.pull_request.base.sha }}"
-          HEAD="${{ github.event.pull_request.head.sha }}"
+          BASE="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
+          HEAD="${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}"
           if ! CHANGED=$(git diff --name-only "$BASE" "$HEAD"); then
             echo "git diff failed — running checks as fallback"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
@@ -82,7 +84,8 @@ jobs:
   source_patches:
     name: E2E Source Patches
     needs: [check_changes]
-    if: needs.check_changes.outputs.should_run == 'true'
+    # Not a required check, so skip it in the merge queue — it already ran on the PR.
+    if: needs.check_changes.outputs.should_run == 'true' && github.event_name != 'merge_group'
     runs-on: ubuntu-24.04
 
     steps:
@@ -148,7 +151,9 @@ jobs:
 
       - name: JVM tests
         if: needs.check_changes.outputs.should_run == 'true'
-        run: ./gradlew jvm_tests -Pddg.di=${{ matrix.di }} ${{ github.event_name != 'pull_request' && '-Dpts.enabled=false' || '' }}
+        # Predictive test selection narrows the suite to the tests a change set can affect, so it
+        # only applies to PRs and merge groups. Pushes and manual runs get the full suite.
+        run: ./gradlew jvm_tests -Pddg.di=${{ matrix.di }} -Dpts.enabled=${{ contains(fromJSON('["pull_request", "merge_group"]'), github.event_name) }}
 
       - name: Bundle the JVM checks report
         if: always() && needs.check_changes.outputs.should_run == 'true'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1217615427730726?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
We want to enable the merge queue, and so need to ensure that the required CI checks will run on the merge queue event (in addition to PRs). This is controlled by a `merge_group` event, as per https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions.


This PR subscribes the two workflows that produce required checks to `merge_group`:
  - `ci.yml`: for `Code Formatting`, `Lint`, `Lint (Metro)`, `Unit tests`,
    `Unit tests (Metro)`, `Android CI tests` and `Android CI tests (Metro)`.
  - `action-pr-opened.yaml`: for `process-internal-pr`. Its steps are all gated on pull request fields, so on a merge group they no-op and the job simply reports success. Keeping it wired this way avoids having to drop it from the  required list, so the PR-time Asana bookkeeping is unchanged.

### Steps to test this PR

- qa optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions triggers and conditional logic; no application code, auth, or data handling is modified.
> 
> **Overview**
> Enables GitHub **merge queue** by subscribing the workflows that emit **required status checks** to the `merge_group` event, so temporary merge-group branches get the same gates as pull requests.
> 
> In **`ci.yml`**, `check_changed` resolves `BASE`/`HEAD` from `merge_group` SHAs when there is no PR context. **E2E Source Patches** is skipped on merge groups because it is not required and already ran on the PR. **Unit tests** turn on predictive test selection (`pts.enabled`) for both `pull_request` and `merge_group`; pushes and manual runs still run the full suite.
> 
> In **`action-pr-opened.yaml`**, the workflow also listens on `merge_group` so **`process-internal-pr`** reports success there. The Asana find-task step is gated on `event_name == pull_request`; other steps already depend on PR fields, so merge-queue runs no-op the bookkeeping without removing the check from the required list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73f2cbd7e91384816a6404fe21224df13a549bd1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->