### PR TITLE
Add feature flag for the Suggest redirect feature

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/suggestredirect/SuggestRedirectOnUnresolvedErrorFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/suggestredirect/SuggestRedirectOnUnresolvedErrorFeature.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.suggestredirect
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+/**
+ * Controls whether the error page shown for an unresolved bare domain (e.g. example.com) offers a
+ * suggestion link to its "www" subdomain (e.g. www.example.com) when such subdomain resolves.
+ */
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "suggestRedirectOnUnresolvedError",
+)
+interface SuggestRedirectOnUnresolvedErrorFeature {
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun self(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun suggestRedirect(): Toggle
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216807998862658/task/1217572324167492?focus=true

### Description
Add the feature flag interface inside the package where the feature will reside. Default value set to `false`.

### Steps to test this PR
1. Tap on Settings > Feature Flag Inventory.
2. Search for “suggest”.
3. Verify that both the `suggestRedirectOnUnresolvedError` toggle and its `suggestRedirect` sub-feature toggle are present.

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Toggle-only addition with no navigation or error-page logic changes; risk is limited to feature inventory registration.
> 
> **Overview**
> Introduces **`SuggestRedirectOnUnresolvedErrorFeature`** in `app/browser/suggestredirect` as a remote-controllable flag for an upcoming behavior: on unresolved bare-domain errors, optionally offer a link to the `www` subdomain when it resolves.
> 
> The feature is registered as **`suggestRedirectOnUnresolvedError`** with **`self()`** and a **`suggestRedirect()`** sub-toggle; both default to **off**. No user-facing behavior is wired in this PR—only inventory/toggle plumbing for later rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0879433e0f396954e5bfd610f55e5b1ba7134a47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->