### PR TITLE
PIR: Fix crash when email confirmation step has no actions

### DIFF
--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
@@ -400,6 +400,7 @@ class PirEndToEndTest {
             webViewDataCleaner = fakePirWebViewDataCleaner,
             pirWebViewCountProvider = pirWebViewCountProvider,
             pirWorkDistributor = pirWorkDistributor,
+            jobRecordUpdater = jobRecordUpdater,
         )
 
         pirEmailConfirmationJobsRunner = RealPirEmailConfirmationJobsRunner(

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/BrokerStepsParser.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/BrokerStepsParser.kt
@@ -163,16 +163,25 @@ class RealBrokerStepsParser @Inject constructor(
             if (profile != null) {
                 adapter.fromJson(optOutStepJson)?.run {
                     val optOutStepActions = this as OptOutStepActions
-                    EmailConfirmationStep(
-                        broker = broker,
-                        step = OptOutStepActions(
-                            stepType = optOutStepActions.stepType,
-                            actions = optOutStepActions.actions.dropWhile { it !is BrokerAction.EmailConfirmation },
-                            optOutType = optOutStepActions.optOutType,
-                        ),
-                        emailConfirmationJob = emailConfirmationJob,
-                        profileToOptOut = profile,
-                    )
+                    val confirmationActions = optOutStepActions.actions.dropWhile { it !is BrokerAction.EmailConfirmation }
+                    if (confirmationActions.isEmpty()) {
+                        // The broker's opt-out flow no longer has an email confirmation action, so a job recorded
+                        // against an earlier broker version can never run. This happens when a broker becomes a
+                        // mirror of another one and its opt-out flow is replaced by an empty parentSiteOptOut step.
+                        logcat(ERROR) { "PIR-SCAN: No email confirmation action left for ${broker.name}" }
+                        null
+                    } else {
+                        EmailConfirmationStep(
+                            broker = broker,
+                            step = OptOutStepActions(
+                                stepType = optOutStepActions.stepType,
+                                actions = confirmationActions,
+                                optOutType = optOutStepActions.optOutType,
+                            ),
+                            emailConfirmationJob = emailConfirmationJob,
+                            profileToOptOut = profile,
+                        )
+                    }
                 }
             } else {
                 null

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandler.kt
@@ -70,7 +70,7 @@ class BrokerStepCompletedEventHandler @Inject constructor(
                     broker = currentBrokerStep.broker,
                     extractedProfile = (currentBrokerStep as OptOutStep).profileToOptOut,
                     attemptId = state.attemptId,
-                    lastActionId = currentBrokerStep.step.actions[state.currentActionIndex].id,
+                    lastActionId = currentBrokerStep.step.actions.getOrNull(state.currentActionIndex)?.id.orEmpty(),
                     durationMs = currentTimeProvider.currentTimeMillis() - state.stageStatus.stageStartMs,
                     currentActionAttemptCount = state.actionRetryCount + 1,
                     generatedEmail = state.generatedEmailData?.emailAddress,
@@ -109,13 +109,18 @@ class BrokerStepCompletedEventHandler @Inject constructor(
         val currentBrokerStep = state.brokerStep
         val brokerStartTime = state.brokerStepStartTime
         val isSuccess = stepStatus is Success
+        val lastAction = if (isSuccess) {
+            currentBrokerStep.step.actions.getLastActionForSuccess(state.currentActionIndex)
+        } else {
+            currentBrokerStep.step.actions.getLastActionForFailure(state.currentActionIndex)
+        }
 
         when (state.runType) {
             RunType.MANUAL, SCHEDULED -> {
                 val isManual = state.runType == RunType.MANUAL
-                if (isSuccess) {
-                    val lastAction = currentBrokerStep.step.actions.getLastActionForSuccess(state.currentActionIndex)
+                if (lastAction == null) return
 
+                if (isSuccess) {
                     pirRunStateHandler.handleState(
                         BrokerScanSuccess(
                             broker = currentBrokerStep.broker,
@@ -128,7 +133,6 @@ class BrokerStepCompletedEventHandler @Inject constructor(
                         ),
                     )
                 } else {
-                    val lastAction = currentBrokerStep.step.actions.getLastActionForFailure(state.currentActionIndex)
                     val failure = stepStatus as Failure
 
                     pirRunStateHandler.handleState(
@@ -149,9 +153,9 @@ class BrokerStepCompletedEventHandler @Inject constructor(
 
             RunType.OPTOUT -> {
                 val currentOptOutStep = currentBrokerStep as OptOutStep
-                if (isSuccess) {
-                    val lastAction = currentBrokerStep.step.actions.getLastActionForSuccess(state.currentActionIndex)
+                if (lastAction == null) return
 
+                if (isSuccess) {
                     pirRunStateHandler.handleState(
                         BrokerOptOutStageValidate(
                             broker = currentBrokerStep.broker,
@@ -172,8 +176,6 @@ class BrokerStepCompletedEventHandler @Inject constructor(
                         ),
                     )
                 } else {
-                    val lastAction = currentBrokerStep.step.actions.getLastActionForFailure(state.currentActionIndex)
-
                     pirRunStateHandler.handleState(
                         BrokerRecordOptOutFailed(
                             broker = currentBrokerStep.broker,
@@ -195,11 +197,7 @@ class BrokerStepCompletedEventHandler @Inject constructor(
                     BrokerRecordEmailConfirmationCompleted(
                         broker = currentBrokerStep.broker,
                         isSuccess = isSuccess,
-                        lastActionId = if (isSuccess) {
-                            currentOptOutStep.step.actions.getLastActionForSuccess(state.currentActionIndex)
-                        } else {
-                            currentOptOutStep.step.actions.getLastActionForFailure(state.currentActionIndex)
-                        }.id,
+                        lastActionId = lastAction?.id.orEmpty(),
                         totalTimeMillis = totalTimeMillis,
                         extractedProfile = currentOptOutStep.profileToOptOut,
                         attemptId = state.attemptId,
@@ -214,13 +212,13 @@ class BrokerStepCompletedEventHandler @Inject constructor(
         }
     }
 
-    private fun List<BrokerAction>.getLastActionForSuccess(currentActionIndex: Int): BrokerAction {
+    private fun List<BrokerAction>.getLastActionForSuccess(currentActionIndex: Int): BrokerAction? {
         // If success, it means we reached currentActionIndex == currentBrokerStep.step.actions.size, so last action would be -1.
-        return this[currentActionIndex - 1]
+        return getOrNull(currentActionIndex - 1)
     }
 
-    private fun List<BrokerAction>.getLastActionForFailure(currentActionIndex: Int): BrokerAction {
+    private fun List<BrokerAction>.getLastActionForFailure(currentActionIndex: Int): BrokerAction? {
         // Whatever last action that was executed is the last action that failed.
-        return this[currentActionIndex]
+        return getOrNull(currentActionIndex)
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepEventHandler.kt
@@ -129,7 +129,7 @@ class ExecuteBrokerStepEventHandler @Inject constructor(
                     BrokerRecordEmailConfirmationStarted(
                         broker = currentBrokerStep.broker,
                         extractedProfileId = (currentBrokerStep as EmailConfirmationStep).emailConfirmationJob.extractedProfileId,
-                        firstActionId = currentBrokerStep.step.actions[state.currentActionIndex].id,
+                        firstActionId = currentBrokerStep.step.actions.getOrNull(state.currentActionIndex)?.id.orEmpty(),
                     ),
                 )
             }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/RealPirActionsRunnerStateEngine.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/RealPirActionsRunnerStateEngine.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEf
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
 import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.pixels.PirStage
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
@@ -35,6 +36,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
+import logcat.LogPriority.ERROR
 import logcat.logcat
 
 class RealPirActionsRunnerStateEngine(
@@ -94,7 +96,17 @@ class RealPirActionsRunnerStateEngine(
 
         logcat { "PIR-ENGINE($this): $newEvent dispatched to $eventHandler" }
 
-        val next = eventHandler.invoke(engineState, newEvent)
+        val next = try {
+            eventHandler.invoke(engineState, newEvent)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            // A failing handler must not escape the collector, as that cancels the engine scope and takes down
+            // the whole process. End the run instead so the runner and its WebView are released.
+            logcat(ERROR) { "PIR-ENGINE($this): $eventHandler failed to handle $newEvent: $e" }
+            sideEffectFlow.emit(SideEffect.CompleteExecution)
+            return
+        }
 
         logcat { "PIR-ENGINE($this): Event resulted to state: ${next.nextState}" }
         logcat { "PIR-ENGINE($this): Event resulted to event: ${next.nextEvent}" }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/email/PirEmailConfirmation.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/email/PirEmailConfirmation.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.pir.impl.common.PirWorkDistributor
 import com.duckduckgo.pir.impl.common.RealPirActionsRunner
 import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord
+import com.duckduckgo.pir.impl.scheduling.JobRecordUpdater
 import com.duckduckgo.pir.impl.scripts.PirCssScriptLoader
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.squareup.anvil.annotations.ContributesBinding
@@ -80,6 +81,7 @@ class RealPirEmailConfirmation @Inject constructor(
     private val webViewDataCleaner: PirWebViewDataCleaner,
     private val pirWebViewCountProvider: PirWebViewCountProvider,
     private val pirWorkDistributor: PirWorkDistributor,
+    private val jobRecordUpdater: JobRecordUpdater,
     callbacks: PluginPoint<PirCallbacks>,
 ) : PirJob(callbacks),
     PirEmailConfirmation {
@@ -169,6 +171,9 @@ class RealPirEmailConfirmation @Inject constructor(
             if (profileQuery != null && brokerStep != null) {
                 profileQuery to brokerStep
             } else {
+                // Count the skipped job as an attempt, otherwise a record we can never run is retried on every
+                // execution instead of ageing out through the max-attempt cleanup.
+                jobRecordUpdater.recordEmailConfirmationAttempt(it.extractedProfileId)
                 null
             }
         }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealBrokerStepsParserTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealBrokerStepsParserTest.kt
@@ -319,44 +319,6 @@ class RealBrokerStepsParserTest {
     }
 
     @Test
-    fun whenParseEmailConfirmationStepWithNoEmailConfirmationActionThenReturnStepWithEmptyActions() = runTest {
-        val optOutJson = """
-            {
-                "stepType": "optOut",
-                "optOutType": "form",
-                "actions": [
-                    {
-                        "actionType": "navigate",
-                        "id": "nav-1",
-                        "url": "https://testbroker.com/optout"
-                    },
-                    {
-                        "actionType": "navigate",
-                        "id": "nav-2",
-                        "url": "https://testbroker.com/submit"
-                    }
-                ]
-            }
-        """.trimIndent()
-
-        val emailConfirmationJob = EmailConfirmationJobRecord(
-            brokerName = "testBroker",
-            userProfileId = 100L,
-            extractedProfileId = 1L,
-            emailData = EmailData(email = "test@example.com", attemptId = "attempt-123"),
-        )
-
-        whenever(mockRepository.getExtractedProfile(eq(1L))).thenReturn(testProfile1)
-
-        val result = testee.parseEmailConfirmationStep(testBroker, optOutJson, emailConfirmationJob)
-
-        assertTrue(result is EmailConfirmationStep)
-        val emailConfStep = result as? EmailConfirmationStep
-        assertTrue(emailConfStep != null)
-        assertTrue(emailConfStep!!.step.actions.isEmpty())
-    }
-
-    @Test
     fun whenParseEmailConfirmationStepWithMissingProfileThenReturnNull() = runTest {
         val optOutJson = """
             {
@@ -432,5 +394,60 @@ class RealBrokerStepsParserTest {
         assertEquals(2, scanStep.step.actions.size)
         assertTrue(scanStep.step.actions[0] is BrokerAction.Navigate)
         assertTrue(scanStep.step.actions[1] is BrokerAction.EmailConfirmation)
+    }
+
+    @Test
+    fun whenParseEmailConfirmationStepWithNoEmailConfirmationActionThenReturnNull() = runTest {
+        val optOutJson = """
+            {
+                "stepType": "optOut",
+                "optOutType": "form",
+                "actions": [
+                    {
+                        "actionType": "navigate",
+                        "id": "nav-1",
+                        "url": "https://testbroker.com/optout"
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val emailConfirmationJob = EmailConfirmationJobRecord(
+            brokerName = "testBroker",
+            userProfileId = 100L,
+            extractedProfileId = 1L,
+            emailData = EmailData(email = "test@example.com", attemptId = "attempt-123"),
+        )
+
+        whenever(mockRepository.getExtractedProfile(eq(1L))).thenReturn(testProfile1)
+
+        val result = testee.parseEmailConfirmationStep(testBroker, optOutJson, emailConfirmationJob)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenParseEmailConfirmationStepWithEmptyActionsThenReturnNull() = runTest {
+        // Mirrors a broker that became a parentSiteOptOut mirror while a confirmation job was pending
+        val optOutJson = """
+            {
+                "stepType": "optOut",
+                "optOutType": "parentSiteOptOut",
+                "actions": []
+            }
+        """.trimIndent()
+
+        val emailConfirmationJob = EmailConfirmationJobRecord(
+            brokerName = "testBroker",
+            userProfileId = 100L,
+            extractedProfileId = 1L,
+            emailData = EmailData(email = "test@example.com", attemptId = "attempt-123"),
+        )
+
+        whenever(mockRepository.getExtractedProfile(eq(1L))).thenReturn(testProfile1)
+
+        val result = testee.parseEmailConfirmationStep(testBroker, optOutJson, emailConfirmationJob)
+
+        assertNull(result)
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandlerTest.kt
@@ -57,6 +57,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -717,5 +718,72 @@ class BrokerStepCompletedEventHandlerTest {
 
         assertEquals(CompleteExecution, result.sideEffect)
         assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenScanStepHasNoActionsAndSucceedsThenDoesNotCrashAndEmitsNoState() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = emptyList(),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStep = scanStep,
+            profileQuery = testProfileQuery,
+            currentActionIndex = 0,
+            brokerStepStartTime = testBrokerStartTime,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = false,
+            stepStatus = StepStatus.Success,
+        )
+
+        val result = testee.invoke(state, event)
+
+        verify(mockPirRunStateHandler, never()).handleState(any())
+        assertEquals(CompleteExecution, result.sideEffect)
+    }
+
+    @Test
+    fun whenEmailConfirmationStepHasNoActionsAndSucceedsThenEmitsCompletedWithEmptyActionId() = runTest {
+        val emailConfirmationStep = EmailConfirmationStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = emptyList(),
+                optOutType = "form",
+            ),
+            emailConfirmationJob = testEmailConfirmationJob,
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.EMAIL_CONFIRMATION,
+            brokerStep = emailConfirmationStep,
+            profileQuery = testProfileQuery,
+            currentActionIndex = 0,
+            brokerStepStartTime = testBrokerStartTime,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = false,
+            stepStatus = StepStatus.Success,
+        )
+
+        testee.invoke(state, event)
+
+        val capturedState = argumentCaptor<BrokerRecordEmailConfirmationCompleted>()
+        verify(mockPirRunStateHandler).handleState(capturedState.capture())
+        assertEquals("", capturedState.firstValue.lastActionId)
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepEventHandlerTest.kt
@@ -504,4 +504,35 @@ class ExecuteBrokerStepEventHandlerTest {
 
         assertEquals(false, result.nextState.preseeding)
     }
+
+    @Test
+    fun whenEmailConfirmationStepHasNoActionsThenDoesNotCrash() = runTest {
+        val emailConfirmationStep = EmailConfirmationStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = emptyList(),
+                optOutType = "form",
+            ),
+            emailConfirmationJob = testEmailConfirmationJob,
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.EMAIL_CONFIRMATION,
+            brokerStep = emailConfirmationStep,
+            profileQuery = testProfileQuery,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteBrokerStep
+
+        testee.invoke(state, event)
+
+        val capturedPixel = argumentCaptor<BrokerRecordEmailConfirmationStarted>()
+        verify(mockPirRunStateHandler).handleState(capturedPixel.capture())
+        assertEquals("", capturedPixel.firstValue.firstActionId)
+    }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/RealPirActionsRunnerStateEngineTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/RealPirActionsRunnerStateEngineTest.kt
@@ -1061,4 +1061,41 @@ class RealPirActionsRunnerStateEngineTest {
             profileQuery = profileQuery,
         )
     }
+
+    @Test
+    fun whenEventHandlerThrowsThenEngineSurvivesAndCompletesExecution() = runTest {
+        val handler1: EventHandler = mock()
+        val handler2: EventHandler = mock()
+        var secondHandlerInvoked = false
+
+        whenever(handler1.event).thenReturn(Event.Started::class)
+        whenever(handler1.invoke(any(), any())).thenAnswer {
+            throw IndexOutOfBoundsException("Index 0 out of bounds for length 0")
+        }
+
+        whenever(handler2.event).thenReturn(Event.ExecuteBrokerStep::class)
+        whenever(handler2.invoke(any(), any())).thenAnswer {
+            secondHandlerInvoked = true
+            Next(nextState = testState)
+        }
+
+        whenever(mockEventHandlers.getPlugins()).thenReturn(listOf(handler1, handler2))
+
+        testee = createEngine()
+
+        val sideEffects = mutableListOf<SideEffect>()
+        val collectJob = launch { testee.sideEffect.toList(sideEffects) }
+
+        testee.dispatch(Event.Started)
+        advanceUntilIdle()
+
+        // The engine must not be torn down by a failing handler
+        testee.dispatch(Event.ExecuteBrokerStep)
+        advanceUntilIdle()
+
+        assertTrue(secondHandlerInvoked)
+        assertTrue(sideEffects.contains(SideEffect.CompleteExecution))
+
+        collectJob.cancel()
+    }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/email/RealPirEmailConfirmationTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/email/RealPirEmailConfirmationTest.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.pir.impl.models.ExtractedProfile
 import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.EmailData
+import com.duckduckgo.pir.impl.scheduling.JobRecordUpdater
 import com.duckduckgo.pir.impl.scripts.PirCssScriptLoader
 import com.duckduckgo.pir.impl.store.PirRepository
 import kotlinx.coroutines.test.runTest
@@ -69,6 +70,7 @@ class RealPirEmailConfirmationTest {
     private val mockPirActionsRunner: RealPirActionsRunner = mock()
     private val mockWebViewDataCleaner: PirWebViewDataCleaner = mock()
     private val mockPirWebViewCountProvider: PirWebViewCountProvider = mock()
+    private val mockJobRecordUpdater: JobRecordUpdater = mock()
 
     @Before
     fun setUp() {
@@ -89,6 +91,7 @@ class RealPirEmailConfirmationTest {
             callbacks = mockCallbacks,
             webViewDataCleaner = mockWebViewDataCleaner,
             pirWebViewCountProvider = mockPirWebViewCountProvider,
+            jobRecordUpdater = mockJobRecordUpdater,
         )
     }
 
@@ -706,5 +709,30 @@ class RealPirEmailConfirmationTest {
         assert(result.isSuccess)
         verify(mockPirActionsRunner).execute(deprecatedProfile, testEmailConfirmationStep)
         verify(mockWebViewDataCleaner).cleanWebViewData()
+    }
+
+    @Test
+    fun whenBrokerStepsParsingReturnsNullThenRecordsAttemptSoJobCanAgeOut() = runTest {
+        whenever(mockRepository.getBrokerOptOutSteps(testBrokerName)).thenReturn(testStepsJson)
+        whenever(mockRepository.getAllActiveBrokerObjects()).thenReturn(listOf(testBroker1))
+        whenever(mockRepository.getAllUserProfileQueries()).thenReturn(testUserProfileQueries)
+        whenever(
+            mockBrokerStepsParser.parseEmailConfirmationStep(
+                testBroker1,
+                testStepsJson,
+                testEmailConfirmationJobRecord,
+            ),
+        ).thenReturn(null)
+
+        val result = testee.executeForEmailConfirmationJobs(
+            listOf(testEmailConfirmationJobRecord),
+            mockContext,
+            RunType.MANUAL,
+        )
+
+        assert(result.isSuccess)
+        verify(mockJobRecordUpdater).recordEmailConfirmationAttempt(
+            testEmailConfirmationJobRecord.extractedProfileId,
+        )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1217594084465288?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description
A broker that becomes a mirror ships an empty parentSiteOptOut step, so pending email confirmation jobs parsed to a step with zero actions and crashed the `:pir`process on `actions[0]`. Reject those steps at the parser and count them as an attempt so the job ages out.

### Steps to test this PR
QA-optional 

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PIR broker-step execution and email-confirmation scheduling paths where crashes previously occurred; behavior is more defensive but alters how stuck jobs and empty steps are handled.
> 
> **Overview**
> Fixes a **`:pir` process crash** when pending email confirmation jobs are parsed against broker opt-out flows that no longer include an email confirmation action (e.g. a broker becomes a mirror with an empty `parentSiteOptOut` step).
> 
> **Parser:** `parseEmailConfirmationStep` now returns **`null`** instead of a step with zero actions when no confirmation actions remain after filtering, with an error log.
> 
> **Email confirmation runner:** Skipped jobs (null step or missing profile) call **`jobRecordUpdater.recordEmailConfirmationAttempt`** so they increment attempts and can age out via max-attempt cleanup instead of retrying forever.
> 
> **Defensive indexing:** Broker step event handlers use **`getOrNull`** on action lists and treat missing last/first actions as empty IDs or skip success/failure pixels when there is no action to reference.
> 
> **State engine:** Event handler failures (other than cancellation) are caught so a thrown exception emits **`CompleteExecution`** instead of cancelling the engine scope and taking down the process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf83fc015b891c94a93fdb5217d6a179ea68656b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->