### PR TITLE
Pixel for when settings is opened with subscription available

### DIFF
--- a/PixelDefinitions/pixels/definitions/subscription_pixels.json5
+++ b/PixelDefinitions/pixels/definitions/subscription_pixels.json5
@@ -259,5 +259,12 @@
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
+    },
+    "m_privacy-pro_app-settings_non-subscriber_impression": {
+        "description": "Fired each time the app settings screen is opened by a user who is eligible for subscription purchase",
+        "owners": ["nalcalag"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/PixelDefinitions/pixels/definitions/subscription_pixels.json5
+++ b/PixelDefinitions/pixels/definitions/subscription_pixels.json5
@@ -260,7 +260,7 @@
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_privacy-pro_app-settings_non-subscriber_impression": {
+    "m_subscription_settings_impression": {
         "description": "Fired each time the app settings screen is opened by a user who is eligible for subscription purchase",
         "owners": ["nalcalag"],
         "triggers": ["other"],

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -369,6 +369,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     REMOTE_MESSAGE_SHARED("m_remote_message_share"),
 
     SUBSCRIPTION_IS_ENABLED_AND_ELIGIBLE("m_privacy-pro_is-enabled"),
+    PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION("m_privacy-pro_app-settings_non-subscriber_impression"),
 
     SSL_CERTIFICATE_WARNING_CLOSE_PRESSED("m_certificate_warning_leave_clicked"),
     SSL_CERTIFICATE_WARNING_ADVANCED_PRESSED("m_certificate_warning_advanced_clicked"),

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -145,6 +145,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     BROWSER_MODE_SWITCHED("m_browser_mode_switched"),
 
     SETTINGS_OPENED("ms"),
+    SETTINGS_OPENED_WITH_SUBSCRIPTION_AVAILABLE("m_subscription_settings_impression"),
     SETTINGS_THEME_OPENED("ms_t_o"),
     SETTINGS_THEME_TOGGLED_LIGHT("ms_tl"),
     SETTINGS_THEME_TOGGLED_DARK("ms_td"),
@@ -369,7 +370,6 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     REMOTE_MESSAGE_SHARED("m_remote_message_share"),
 
     SUBSCRIPTION_IS_ENABLED_AND_ELIGIBLE("m_privacy-pro_is-enabled"),
-    PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION("m_privacy-pro_app-settings_non-subscriber_impression"),
 
     SSL_CERTIFICATE_WARNING_CLOSE_PRESSED("m_certificate_warning_leave_clicked"),
     SSL_CERTIFICATE_WARNING_ADVANCED_PRESSED("m_certificate_warning_advanced_clicked"),

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsPixelDispatcher.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsPixelDispatcher.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.settings
 
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.pixels.AppPixelName.PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_EMAIL_PROTECTION_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_SYNC_PRESSED
 import com.duckduckgo.app.pixels.duckchat.createWasUsedBeforePixelParams
@@ -99,7 +99,7 @@ class SettingsPixelDispatcherImpl @Inject constructor(
     override fun fireSettingsOpenedWithSubscriptionPurchaseAvailable() {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             if (subscriptions.isEligible() && subscriptions.getSubscriptionStatus() == UNKNOWN) {
-                pixel.fire(PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION)
+                pixel.fire(AppPixelName.SETTINGS_OPENED_WITH_SUBSCRIPTION_AVAILABLE)
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsPixelDispatcher.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsPixelDispatcher.kt
@@ -17,15 +17,19 @@
 package com.duckduckgo.app.settings
 
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.pixels.AppPixelName.PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_EMAIL_PROTECTION_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_SYNC_PRESSED
 import com.duckduckgo.app.pixels.duckchat.createWasUsedBeforePixelParams
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.api.email.EmailManager
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_SETTINGS_PRESSED
+import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
+import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.sync.api.SyncState.OFF
 import com.duckduckgo.sync.api.SyncStateMonitor
 import com.squareup.anvil.annotations.ContributesBinding
@@ -42,6 +46,7 @@ interface SettingsPixelDispatcher {
     fun fireSyncPressed()
     fun fireDuckChatPressed()
     fun fireEmailPressed()
+    fun fireSettingsOpenedWithSubscriptionPurchaseAvailable()
 }
 
 @ContributesBinding(scope = AppScope::class)
@@ -52,6 +57,8 @@ class SettingsPixelDispatcherImpl @Inject constructor(
     private val syncStateMonitor: SyncStateMonitor,
     private val duckChat: DuckChat,
     private val emailManager: EmailManager,
+    private val subscriptions: Subscriptions,
+    private val dispatcherProvider: DispatcherProvider,
 ) : SettingsPixelDispatcher {
 
     override fun fireSyncPressed() {
@@ -86,6 +93,14 @@ class SettingsPixelDispatcherImpl @Inject constructor(
                     PARAM_EMAIL_IS_SIGNED_IN to isSignedIn.toBinaryString(),
                 ),
             )
+        }
+    }
+
+    override fun fireSettingsOpenedWithSubscriptionPurchaseAvailable() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            if (subscriptions.isEligible() && subscriptions.getSubscriptionStatus() == UNKNOWN) {
+                pixel.fire(PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION)
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -198,6 +198,7 @@ class SettingsViewModel @Inject constructor(
         pixel.fire(SETTINGS_OPENED)
         pixel.fire(PRODUCT_TELEMETRY_SURFACE_SETTINGS_OPENED)
         pixel.fire(PRODUCT_TELEMETRY_SURFACE_SETTINGS_OPENED_DAILY, type = Pixel.PixelType.Daily())
+        settingsPixelDispatcher.fireSettingsOpenedWithSubscriptionPurchaseAvailable()
 
         duckAiFeatureState.showSettings.onEach { showDuckAiSettings ->
             viewState.update { it.copy(isDuckChatEnabled = showDuckAiSettings) }

--- a/app/src/test/java/com/duckduckgo/app/settings/SettingsPixelDispatcherTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/SettingsPixelDispatcherTest.kt
@@ -16,8 +16,8 @@
 
 package com.duckduckgo.app.settings
 
-import com.duckduckgo.app.pixels.AppPixelName.PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_EMAIL_PROTECTION_PRESSED
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_OPENED_WITH_SUBSCRIPTION_AVAILABLE
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_SYNC_PRESSED
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.api.email.EmailManager
@@ -187,7 +187,7 @@ class SettingsPixelDispatcherTest {
         val testee = createTestee()
         testee.fireSettingsOpenedWithSubscriptionPurchaseAvailable()
 
-        verify(pixelMock).fire(PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION)
+        verify(pixelMock).fire(SETTINGS_OPENED_WITH_SUBSCRIPTION_AVAILABLE)
     }
 
     @Test
@@ -198,7 +198,7 @@ class SettingsPixelDispatcherTest {
         val testee = createTestee()
         testee.fireSettingsOpenedWithSubscriptionPurchaseAvailable()
 
-        verify(pixelMock, never()).fire(PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION)
+        verify(pixelMock, never()).fire(SETTINGS_OPENED_WITH_SUBSCRIPTION_AVAILABLE)
     }
 
     @Test
@@ -209,7 +209,7 @@ class SettingsPixelDispatcherTest {
         val testee = createTestee()
         testee.fireSettingsOpenedWithSubscriptionPurchaseAvailable()
 
-        verify(pixelMock, never()).fire(PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION)
+        verify(pixelMock, never()).fire(SETTINGS_OPENED_WITH_SUBSCRIPTION_AVAILABLE)
     }
 
     @Test
@@ -220,7 +220,7 @@ class SettingsPixelDispatcherTest {
         val testee = createTestee()
         testee.fireSettingsOpenedWithSubscriptionPurchaseAvailable()
 
-        verify(pixelMock, never()).fire(PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION)
+        verify(pixelMock, never()).fire(SETTINGS_OPENED_WITH_SUBSCRIPTION_AVAILABLE)
     }
 
     private fun createTestee() = SettingsPixelDispatcherImpl(

--- a/app/src/test/java/com/duckduckgo/app/settings/SettingsPixelDispatcherTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/SettingsPixelDispatcherTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.settings
 
+import com.duckduckgo.app.pixels.AppPixelName.PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_EMAIL_PROTECTION_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_SYNC_PRESSED
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -23,6 +24,8 @@ import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
+import com.duckduckgo.subscriptions.api.SubscriptionStatus
+import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.sync.api.SyncState
 import com.duckduckgo.sync.api.SyncStateMonitor
 import kotlinx.coroutines.flow.emptyFlow
@@ -33,6 +36,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -48,6 +52,8 @@ class SettingsPixelDispatcherTest {
     @Mock private lateinit var duckChatMock: DuckChat
 
     @Mock private lateinit var emailManagerMock: EmailManager
+
+    @Mock private lateinit var subscriptionsMock: Subscriptions
 
     lateinit var testee: SettingsPixelDispatcherImpl
 
@@ -173,11 +179,57 @@ class SettingsPixelDispatcherTest {
         )
     }
 
+    @Test
+    fun `when fireSettingsOpenedWithSubscriptionPurchaseAvailable and eligible with no subscription, then send a pixel`() = runTest {
+        whenever(subscriptionsMock.isEligible()).thenReturn(true)
+        whenever(subscriptionsMock.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
+
+        val testee = createTestee()
+        testee.fireSettingsOpenedWithSubscriptionPurchaseAvailable()
+
+        verify(pixelMock).fire(PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION)
+    }
+
+    @Test
+    fun `when fireSettingsOpenedWithSubscriptionPurchaseAvailable and subscription is active, then do not send a pixel`() = runTest {
+        whenever(subscriptionsMock.isEligible()).thenReturn(true)
+        whenever(subscriptionsMock.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
+
+        val testee = createTestee()
+        testee.fireSettingsOpenedWithSubscriptionPurchaseAvailable()
+
+        verify(pixelMock, never()).fire(PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION)
+    }
+
+    @Test
+    fun `when fireSettingsOpenedWithSubscriptionPurchaseAvailable and subscription is expired, then do not send a pixel`() = runTest {
+        whenever(subscriptionsMock.isEligible()).thenReturn(true)
+        whenever(subscriptionsMock.getSubscriptionStatus()).thenReturn(SubscriptionStatus.EXPIRED)
+
+        val testee = createTestee()
+        testee.fireSettingsOpenedWithSubscriptionPurchaseAvailable()
+
+        verify(pixelMock, never()).fire(PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION)
+    }
+
+    @Test
+    fun `when fireSettingsOpenedWithSubscriptionPurchaseAvailable and not eligible, then do not send a pixel`() = runTest {
+        whenever(subscriptionsMock.isEligible()).thenReturn(false)
+        whenever(subscriptionsMock.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
+
+        val testee = createTestee()
+        testee.fireSettingsOpenedWithSubscriptionPurchaseAvailable()
+
+        verify(pixelMock, never()).fire(PRIVACY_PRO_APP_SETTINGS_NON_SUBSCRIBER_IMPRESSION)
+    }
+
     private fun createTestee() = SettingsPixelDispatcherImpl(
         appCoroutineScope = coroutinesTestRule.testScope,
         pixel = pixelMock,
         syncStateMonitor = syncStateMonitorMock,
         duckChat = duckChatMock,
         emailManager = emailManagerMock,
+        subscriptions = subscriptionsMock,
+        dispatcherProvider = coroutinesTestRule.testDispatcherProvider,
     )
 }

--- a/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -161,6 +161,7 @@ class SettingsViewModelTest {
         verify(pixelMock).fire(AppPixelName.SETTINGS_OPENED)
         verify(pixelMock).fire(AppPixelName.PRODUCT_TELEMETRY_SURFACE_SETTINGS_OPENED)
         verify(pixelMock).fire(AppPixelName.PRODUCT_TELEMETRY_SURFACE_SETTINGS_OPENED_DAILY, type = Pixel.PixelType.Daily())
+        verify(settingsPixelDispatcherMock).fireSettingsOpenedWithSubscriptionPurchaseAvailable()
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201807753394693/task/1217594040569254
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description
Add a pixel for settings opened when subscription is available

### Steps to test this PR

_Pixel is not fired when subscription not available_
- [x] Install from branch
- [x] Go to app Settings
- [x] Verify pixel is not sent because debug builds don't have subscription available

_Pixel is fired when subscription available_
- [x] Apply patch on https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true
- [x] Install from branch
- [x] Go to app Settings
- [x] Check `m_subscription_settings_impression` is sent (you can filter by `pixel sent` in logcat

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change gated on existing subscription eligibility APIs; no purchase flow or settings UI behavior is modified.
> 
> **Overview**
> Adds subscription funnel telemetry when users open **Settings** while they can buy Privacy Pro but have no active subscription.
> 
> Registers **`m_subscription_settings_impression`** in pixel definitions and maps it to **`SETTINGS_OPENED_WITH_SUBSCRIPTION_AVAILABLE`** in `AppPixelName`. On settings screen init, `SettingsViewModel` delegates to `SettingsPixelDispatcher.fireSettingsOpenedWithSubscriptionPurchaseAvailable()`, which fires the pixel on IO only when `subscriptions.isEligible()` is true and `getSubscriptionStatus()` is **`UNKNOWN`** (not active, expired, etc.).
> 
> Unit tests cover fire vs skip for eligible/unknown, active subscription, expired, and not eligible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93dbc49d4b32c8a10271527dd24b0278f4661150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->