### PR TITLE
Fix: Escape hatch Fire tab burning

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModel.kt
@@ -41,8 +41,11 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FIRE_ANIMATION
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.dataclearing.api.fire.FireDialogProvider.FireDialogOrigin
 import com.duckduckgo.dataclearing.api.fire.FireDialogProvider.FireDialogOrigin.Browser
@@ -83,6 +86,8 @@ class SingleTabFireDialogViewModel @Inject constructor(
     private val fireButtonStore: FireButtonStore,
     private val dispatcherProvider: DispatcherProvider,
     private val tabRepository: TabRepository,
+    private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
+    private val fireModeAvailability: FireModeAvailability,
     private val webViewCapabilityChecker: WebViewCapabilityChecker,
     private val downloadsRepository: DownloadsRepository,
     private val duckChat: DuckChat,
@@ -243,7 +248,9 @@ class SingleTabFireDialogViewModel @Inject constructor(
         viewModelScope.launch {
             shouldRestartAfterClearing = false
 
-            val browserModeParams = mapOf(Pixel.PixelParameter.BROWSER_MODE to browserMode.name.lowercase())
+            val target = withContext(dispatcherProvider.io()) { resolveTarget(origin.value) }
+
+            val browserModeParams = mapOf(Pixel.PixelParameter.BROWSER_MODE to (target?.second ?: browserMode).name.lowercase())
             pixel.enqueueFire(AppPixelName.FIRE_DIALOG_CLEAR_SINGLE_TAB_PRESSED, browserModeParams)
             pixel.enqueueFire(AppPixelName.FIRE_DIALOG_CLEAR_SINGLE_TAB_PRESSED_DAILY, browserModeParams, type = Daily())
             fireDataClearingSurfacePixels()
@@ -263,19 +270,16 @@ class SingleTabFireDialogViewModel @Inject constructor(
                 command.send(Command.PlayAnimation)
             }
 
-            val originalTabId = withContext(dispatcherProvider.io()) {
-                resolveTargetTabId(origin.value)
-            }
-
             val result = withContext(dispatcherProvider.io()) {
-                if (originalTabId != null) {
+                if (target != null) {
+                    val (tabId, mode) = target
                     if (origin.value == DuckAiContextualChat) {
-                        dataClearing.clearTabContextualChat(originalTabId, browserMode)
+                        dataClearing.clearTabContextualChat(tabId, mode)
                     } else {
                         dataClearing.clearSingleTabData(
-                            tabId = originalTabId,
+                            tabId = tabId,
                             replaceCurrentTab = origin.value !is Hatch,
-                            browserMode = browserMode,
+                            browserMode = mode,
                         )
                     }
                 } else {
@@ -288,7 +292,7 @@ class SingleTabFireDialogViewModel @Inject constructor(
                 is ClearDataResult.Success -> {
                     if (origin.value != DuckAiContextualChat) {
                         // in case of contextual chat the origin tab is never closed, don't need this
-                        waitForTabsToUpdate(originalTabId)
+                        waitForTabsToUpdate(target?.first)
                     }
                     command.send(Command.OnSingleTabClearComplete)
                 }
@@ -362,14 +366,24 @@ class SingleTabFireDialogViewModel @Inject constructor(
         )
     }
 
-    private suspend fun resolveTargetTabId(dialogOrigin: FireDialogOrigin?): String? = when (dialogOrigin) {
-        is Hatch -> dialogOrigin.tabId
-        else -> tabRepository.getSelectedTab()?.tabId
+    private suspend fun resolveTarget(dialogOrigin: FireDialogOrigin?): Pair<String, BrowserMode>? = when (dialogOrigin) {
+        is Hatch -> findTabAcrossModes(dialogOrigin.tabId)?.let { (mode, tab) -> tab.tabId to mode }
+        else -> tabRepository.getSelectedTab()?.let { it.tabId to browserMode }
     }
 
     private suspend fun resolveTargetTabUrl(dialogOrigin: FireDialogOrigin): String? = when (dialogOrigin) {
-        is Hatch -> tabRepository.getTab(dialogOrigin.tabId)?.url
+        is Hatch -> findTabAcrossModes(dialogOrigin.tabId)?.second?.url
         else -> tabRepository.getSelectedTab()?.url
+    }
+
+    private suspend fun findTabAcrossModes(tabId: String): Pair<BrowserMode, TabEntity>? {
+        val modes = if (fireModeAvailability.isAvailable()) BrowserMode.entries else listOf(BrowserMode.REGULAR)
+        
+        // The Hatch renders in Regular mode but can offer a Fire tab, so its tab must be looked up
+        // across all repositories. Tab ids are unique across both, so at most one match exists.
+        return modes.firstNotNullOfOrNull { mode ->
+            tabRepositoryProvider.forMode(mode).getTab(tabId)?.let { mode to it }
+        }
     }
 
     private suspend fun waitForTabsToUpdate(originalTabId: String?) {

--- a/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModel.kt
@@ -378,7 +378,7 @@ class SingleTabFireDialogViewModel @Inject constructor(
 
     private suspend fun findTabAcrossModes(tabId: String): Pair<BrowserMode, TabEntity>? {
         val modes = if (fireModeAvailability.isAvailable()) BrowserMode.entries else listOf(BrowserMode.REGULAR)
-        
+
         // The Hatch renders in Regular mode but can offer a Fire tab, so its tab must be looked up
         // across all repositories. Tab ids are unique across both, so at most one match exists.
         return modes.firstNotNullOfOrNull { mode ->

--- a/app/src/test/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModelTest.kt
@@ -46,6 +46,8 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.dataclearing.api.fire.FireDialogProvider.FireDialogOrigin
@@ -90,6 +92,9 @@ class SingleTabFireDialogViewModelTest {
     private val mockFireButtonStore: FireButtonStore = mock()
     private val mockDispatcherProvider: DispatcherProvider = mock()
     private val mockTabRepository: TabRepository = mock()
+    private val mockFireTabRepository: TabRepository = mock()
+    private val mockTabRepositoryProvider: BrowserModeDataProvider<TabRepository> = mock()
+    private val mockFireModeAvailability: FireModeAvailability = mock()
     private val mockWebViewCapabilityChecker: WebViewCapabilityChecker = mock()
     private val mockDownloadsRepository: DownloadsRepository = mock()
     private val mockDuckChat: DuckChat = mock()
@@ -102,6 +107,9 @@ class SingleTabFireDialogViewModelTest {
     @Before
     fun setup() {
         whenever(mockTabRepository.flowSelectedTab).thenReturn(selectedTabFlow)
+        whenever(mockFireModeAvailability.isAvailable()).thenReturn(true)
+        whenever(mockTabRepositoryProvider.forMode(BrowserMode.REGULAR)).thenReturn(mockTabRepository)
+        whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
         whenever(mockDispatcherProvider.io()).thenReturn(coroutineTestRule.testDispatcherProvider.io())
         whenever(mockSettingsDataStore.selectedFireAnimation).thenReturn(FireAnimation.HeroFire)
         whenever(mockSettingsDataStore.fireAnimationEnabled).thenReturn(true)
@@ -130,6 +138,8 @@ class SingleTabFireDialogViewModelTest {
         fireButtonStore = mockFireButtonStore,
         dispatcherProvider = mockDispatcherProvider,
         tabRepository = mockTabRepository,
+        tabRepositoryProvider = mockTabRepositoryProvider,
+        fireModeAvailability = mockFireModeAvailability,
         webViewCapabilityChecker = mockWebViewCapabilityChecker,
         downloadsRepository = mockDownloadsRepository,
         duckChat = mockDuckChat,
@@ -1994,6 +2004,47 @@ class SingleTabFireDialogViewModelTest {
 
         verify(mockDataClearing).clearSingleTabData(tabId = "hatch-tab", replaceCurrentTab = false, browserMode = BrowserMode.REGULAR)
         verify(mockDataClearing, never()).clearSingleTabData(eq("selected-tab"), any(), any())
+    }
+
+    @Test
+    fun `when delete this tab clicked with fire hatch origin in regular mode then clears in fire mode`() = runTest {
+        whenever(mockSettingsDataStore.fireAnimationEnabled).thenReturn(false)
+        whenever(mockFireTabRepository.getTab("fire-tab")).thenReturn(
+            TabEntity(tabId = "fire-tab", url = "https://news.example.com", title = "News"),
+        )
+        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(false)
+        testee = createViewModel(browserMode = BrowserMode.REGULAR)
+
+        testee.commands().test {
+            testee.setOrigin(FireDialogOrigin.Hatch("fire-tab"))
+            awaitItem() // OnShow
+
+            testee.onDeleteThisTabClicked()
+
+            cancelAndConsumeRemainingEvents()
+        }
+
+        verify(mockDataClearing).clearSingleTabData(tabId = "fire-tab", replaceCurrentTab = false, browserMode = BrowserMode.FIRE)
+    }
+
+    @Test
+    fun `when delete this tab clicked with hatch origin and tab is gone then clears nothing and reports error`() = runTest {
+        whenever(mockSettingsDataStore.fireAnimationEnabled).thenReturn(false)
+        whenever(mockTabRepository.getTab("gone-tab")).thenReturn(null)
+        whenever(mockFireTabRepository.getTab("gone-tab")).thenReturn(null)
+        testee = createViewModel(browserMode = BrowserMode.REGULAR)
+
+        testee.commands().test {
+            testee.setOrigin(FireDialogOrigin.Hatch("gone-tab"))
+            awaitItem() // OnShow
+
+            testee.onDeleteThisTabClicked()
+
+            assertTrue(expectMostRecentItem() is SingleTabFireDialogViewModel.Command.OnSingleTabClearError)
+            cancelAndConsumeRemainingEvents()
+        }
+
+        verify(mockDataClearing, never()).clearSingleTabData(any(), any(), any())
     }
 
     // endregion


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1217623992746975?focus=true

### Description

This PR fixes the escape hatch Fire tab burning.

### Steps to test this PR

- [ ] Go to Settings -> General -> After Inactivity
- [ ] Choose an inactivity timer to `Always`
- [ ] Select New Tab Page from the options
- [ ] Enter Fire mode in the tab switcher
- [ ] Create a Fire tab
- [ ] Kill and restart the app
- [ ] On the NTP escape hatch showing a Fire tab, tap on the Fire button
- [ ] Delete the tab
- [ ] Go to Tab switcher -> Fire mode
- [ ] Verify the Fire tab was burned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes data-clearing target resolution for the single-tab fire dialog; scope is limited to Hatch origin and mode-aware tab lookup, but incorrect mode selection could clear the wrong tab store.
> 
> **Overview**
> Fixes **escape hatch** “burn this tab” when the NTP shows a **Fire tab** while the browser is still in **Regular** mode. Previously `onDeleteThisTabClicked` resolved the Hatch tab only via the current-mode `tabRepository` and cleared with the injected `browserMode`, so Fire tabs were not found or cleared in the wrong store.
> 
> **`SingleTabFireDialogViewModel`** now resolves a `(tabId, BrowserMode)` target: Hatch uses `findTabAcrossModes`, which queries `BrowserModeDataProvider` for Regular and Fire (when `FireModeAvailability` allows). That mode is used for `clearSingleTabData` / contextual chat clearing and for single-tab fire pixels. Hatch tab URL resolution uses the same cross-mode lookup.
> 
> Tests cover clearing a Fire Hatch tab from Regular mode and error when the tab id is missing in both repositories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4896a98dfd66ee56f5068350bc6e6036b299c513. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->