### PR TITLE
RMF: Message auto dismissed pixel

### DIFF
--- a/PixelDefinitions/pixels/definitions/remote_messaging_framework.json5
+++ b/PixelDefinitions/pixels/definitions/remote_messaging_framework.json5
@@ -48,6 +48,20 @@
             }
         ]
     },
+    "m_remote_message_auto_dismissed": {
+        "description": "Triggered when RMF dismisses a remote message because one of its display conditions was met",
+        "owners": ["nalcalag"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "message",
+                "description": "The identifier for the message, sourced from the remote message configuration",
+                "type": "string"
+            }
+        ]
+    },
     "m_remote_message_action_clicked": {
         "description": "Triggered when the user clicks the action button on the remote message",
         "owners": ["cmonfortep"],

--- a/app/src/main/java/com/duckduckgo/app/pixels/campaign/RmfCampaignPixelParamsAdditionPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/campaign/RmfCampaignPixelParamsAdditionPlugin.kt
@@ -31,6 +31,7 @@ class RmfCampaignPixelParamsAdditionPlugin @Inject constructor() : CampaignPixel
         "m_remote_message_shown",
         "m_remote_message_shown_unique",
         "m_remote_message_dismissed",
+        "m_remote_message_auto_dismissed",
         "m_remote_message_primary_action_clicked",
         "m_remote_message_secondary_action_clicked",
         "m_remote_message_action_clicked",

--- a/app/src/test/java/com/duckduckgo/app/pixels/campaign/CampaignPixelParamsAdditionInterceptorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/pixels/campaign/CampaignPixelParamsAdditionInterceptorTest.kt
@@ -120,6 +120,24 @@ class CampaignPixelParamsAdditionInterceptorTest {
     }
 
     @Test
+    fun whenFeatureIsEnabledAndPixelIsRMFAutoDismissedWithValidMessageThenAppendAdditionalParamsToPixel() = runTest {
+        additionalPixelParamsFeature.self().setRawStoredState(Toggle.State(enable = true))
+        val startUrl = URL_PIXEL_BASE + "m_remote_message_auto_dismissed_android_phone?message=valid_test_origin1"
+        val resultUrl = interceptor.intercept(FakeChain(startUrl)).request.url
+
+        assertEquals("$startUrl&test1=value1&test2=value2&test3=value3&test4=value4", resultUrl.toString())
+    }
+
+    @Test
+    fun whenFeatureIsEnabledAndPixelIsRMFAutoDismissedWithInvalidMessageThenNoChangesInPixel() = runTest {
+        additionalPixelParamsFeature.self().setRawStoredState(Toggle.State(enable = true))
+        val startUrl = URL_PIXEL_BASE + "m_remote_message_auto_dismissed_android_phone?message=invalid"
+        val resultUrl = interceptor.intercept(FakeChain(startUrl)).request.url
+
+        assertEquals(startUrl, resultUrl.toString())
+    }
+
+    @Test
     fun whenFeatureIsEnabledAndPixelIsRMFPrimaryClickedWithValidMessageThenAppendAdditionalParamsToPixel() = runTest {
         additionalPixelParamsFeature.self().setRawStoredState(Toggle.State(enable = true))
         val startUrl = URL_PIXEL_BASE + "m_remote_message_primary_action_clicked_android_phone?message=valid_test_origin1"

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.Surface
 import com.duckduckgo.remote.messaging.impl.mappers.MessageMapper
+import com.duckduckgo.remote.messaging.impl.pixels.RemoteMessagingPixels
 import com.duckduckgo.remote.messaging.impl.store.RemoteMessageImageStore
 import com.duckduckgo.remote.messaging.store.RemoteMessageEntity
 import com.duckduckgo.remote.messaging.store.RemoteMessageEntity.Status
@@ -54,6 +55,7 @@ class AppRemoteMessagingRepository(
     private val messageMapper: MessageMapper,
     private val remoteMessageImageStore: RemoteMessageImageStore,
     private val currentTimeProvider: CurrentTimeProvider,
+    private val remoteMessagingPixels: RemoteMessagingPixels,
 ) : RemoteMessagingRepository {
 
     override fun getMessageById(id: String): RemoteMessage? {
@@ -91,7 +93,7 @@ class AppRemoteMessagingRepository(
 
         val remoteMessage = messageMapper.fromMessage(messageEntity.message) ?: return null
         if (remoteMessage.shouldBeDismissed(messageEntity)) {
-            dismissMessageSilently(messageEntity.id)
+            dismissMessageSilently(remoteMessage)
             return null
         }
         return remoteMessage
@@ -105,7 +107,7 @@ class AppRemoteMessagingRepository(
 
                 val remoteMessage = messageMapper.fromMessage(messageEntity.message) ?: return@map null
                 if (remoteMessage.shouldBeDismissed(messageEntity)) {
-                    dismissMessageSilently(messageEntity.id)
+                    dismissMessageSilently(remoteMessage)
                     return@map null
                 }
                 RemoteMessage(
@@ -134,10 +136,10 @@ class AppRemoteMessagingRepository(
         return impressions >= cap
     }
 
-    private fun dismissMessageSilently(id: String) {
-        // TODO add pixel for dismiss silently
-        remoteMessagesDao.updateState(id, Status.DISMISSED)
+    private fun dismissMessageSilently(remoteMessage: RemoteMessage) {
+        remoteMessagesDao.updateState(remoteMessage.id, Status.DISMISSED)
         remoteMessagingConfigRepository.invalidate()
+        remoteMessagingPixels.fireRemoteMessageAutoDismissedPixel(remoteMessage)
     }
 
     override suspend fun dismissMessage(id: String) {

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
@@ -20,7 +20,6 @@ import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.Surface
 import com.duckduckgo.remote.messaging.impl.mappers.MessageMapper
-import com.duckduckgo.remote.messaging.impl.pixels.RemoteMessagingPixels
 import com.duckduckgo.remote.messaging.impl.store.RemoteMessageImageStore
 import com.duckduckgo.remote.messaging.store.RemoteMessageEntity
 import com.duckduckgo.remote.messaging.store.RemoteMessageEntity.Status
@@ -30,7 +29,6 @@ import com.duckduckgo.remote.messaging.store.RemoteMessagingConfigRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.map
-import java.util.concurrent.TimeUnit
 
 interface RemoteMessagingRepository {
     fun getMessageById(id: String): RemoteMessage?
@@ -55,7 +53,7 @@ class AppRemoteMessagingRepository(
     private val messageMapper: MessageMapper,
     private val remoteMessageImageStore: RemoteMessageImageStore,
     private val currentTimeProvider: CurrentTimeProvider,
-    private val remoteMessagingPixels: RemoteMessagingPixels,
+    private val autoDismissEvaluator: RemoteMessageAutoDismissEvaluator,
 ) : RemoteMessagingRepository {
 
     override fun getMessageById(id: String): RemoteMessage? {
@@ -92,8 +90,8 @@ class AppRemoteMessagingRepository(
         if (messageEntity == null || messageEntity.message.isEmpty()) return null
 
         val remoteMessage = messageMapper.fromMessage(messageEntity.message) ?: return null
-        if (remoteMessage.shouldBeDismissed(messageEntity)) {
-            dismissMessageSilently(remoteMessage)
+        if (autoDismissEvaluator.shouldAutoDismiss(remoteMessage, messageEntity)) {
+            markDismissed(messageEntity.id)
             return null
         }
         return remoteMessage
@@ -106,8 +104,8 @@ class AppRemoteMessagingRepository(
                 if (messageEntity == null || messageEntity.message.isEmpty()) return@map null
 
                 val remoteMessage = messageMapper.fromMessage(messageEntity.message) ?: return@map null
-                if (remoteMessage.shouldBeDismissed(messageEntity)) {
-                    dismissMessageSilently(remoteMessage)
+                if (autoDismissEvaluator.shouldAutoDismiss(remoteMessage, messageEntity)) {
+                    markDismissed(messageEntity.id)
                     return@map null
                 }
                 RemoteMessage(
@@ -121,28 +119,9 @@ class AppRemoteMessagingRepository(
             }
     }
 
-    private fun RemoteMessage.shouldBeDismissed(entity: RemoteMessageEntity): Boolean =
-        isExpired(entity.firstShownDate) || hasReachedImpressionCap(entity.impressions)
+    override suspend fun dismissMessage(id: String) = markDismissed(id)
 
-    private fun RemoteMessage.isExpired(firstShownDate: Long?): Boolean {
-        val threshold = displayConditions?.dismissAfterDaysShown?.takeIf { it > 0 } ?: return false
-        val firstShown = firstShownDate ?: return false
-        val elapsedDays = TimeUnit.MILLISECONDS.toDays(currentTimeProvider.currentTimeMillis() - firstShown)
-        return elapsedDays >= threshold
-    }
-
-    private fun RemoteMessage.hasReachedImpressionCap(impressions: Int): Boolean {
-        val cap = displayConditions?.maxImpressions?.takeIf { it > 0 } ?: return false
-        return impressions >= cap
-    }
-
-    private fun dismissMessageSilently(remoteMessage: RemoteMessage) {
-        remoteMessagesDao.updateState(remoteMessage.id, Status.DISMISSED)
-        remoteMessagingConfigRepository.invalidate()
-        remoteMessagingPixels.fireRemoteMessageAutoDismissedPixel(remoteMessage)
-    }
-
-    override suspend fun dismissMessage(id: String) {
+    private fun markDismissed(id: String) {
         remoteMessagesDao.updateState(id, Status.DISMISSED)
         remoteMessagingConfigRepository.invalidate()
     }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RemoteMessageAutoDismissEvaluator.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RemoteMessageAutoDismissEvaluator.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.impl
+
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.remote.messaging.api.RemoteMessage
+import com.duckduckgo.remote.messaging.impl.pixels.RemoteMessagingPixels
+import com.duckduckgo.remote.messaging.store.RemoteMessageEntity
+import com.squareup.anvil.annotations.ContributesBinding
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+interface RemoteMessageAutoDismissEvaluator {
+
+    /**
+     * Whether [remoteMessage] has run out the display conditions
+     *
+     * @return true when the message must no longer be surfaced.
+     */
+    fun shouldAutoDismiss(
+        remoteMessage: RemoteMessage,
+        entity: RemoteMessageEntity,
+    ): Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class RealRemoteMessageAutoDismissEvaluator @Inject constructor(
+    private val remoteMessagingPixels: RemoteMessagingPixels,
+    private val currentTimeProvider: CurrentTimeProvider,
+) : RemoteMessageAutoDismissEvaluator {
+
+    override fun shouldAutoDismiss(
+        remoteMessage: RemoteMessage,
+        entity: RemoteMessageEntity,
+    ): Boolean {
+        if (!remoteMessage.isExpired(entity.firstShownDate) && !remoteMessage.hasReachedImpressionCap(entity.impressions)) {
+            return false
+        }
+        remoteMessagingPixels.fireRemoteMessageAutoDismissedPixel(remoteMessage)
+        return true
+    }
+
+    private fun RemoteMessage.isExpired(firstShownDate: Long?): Boolean {
+        val threshold = displayConditions?.dismissAfterDaysShown?.takeIf { it > 0 } ?: return false
+        val firstShown = firstShownDate ?: return false
+        val elapsedDays = TimeUnit.MILLISECONDS.toDays(currentTimeProvider.currentTimeMillis() - firstShown)
+        return elapsedDays >= threshold
+    }
+
+    private fun RemoteMessage.hasReachedImpressionCap(impressions: Int): Boolean {
+        val cap = displayConditions?.maxImpressions?.takeIf { it > 0 } ?: return false
+        return impressions >= cap
+    }
+}

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.remote.messaging.impl.matchers.AndroidAppAttributeMatcher
 import com.duckduckgo.remote.messaging.impl.matchers.DeviceAttributeMatcher
 import com.duckduckgo.remote.messaging.impl.matchers.UserAttributeMatcher
 import com.duckduckgo.remote.messaging.impl.network.RemoteMessagingService
+import com.duckduckgo.remote.messaging.impl.pixels.RemoteMessagingPixels
 import com.duckduckgo.remote.messaging.impl.store.GlideRemoteMessageImageStore
 import com.duckduckgo.remote.messaging.impl.store.RemoteMessageImageStore
 import com.duckduckgo.remote.messaging.store.LocalRemoteMessagingConfigRepository
@@ -104,6 +105,7 @@ object DataSourceModule {
         messageMapper: MessageMapper,
         remoteMessageImageStore: RemoteMessageImageStore,
         currentTimeProvider: CurrentTimeProvider,
+        remoteMessagingPixels: RemoteMessagingPixels,
     ): RemoteMessagingRepository {
         return AppRemoteMessagingRepository(
             remoteMessagingConfigRepository,
@@ -111,6 +113,7 @@ object DataSourceModule {
             messageMapper,
             remoteMessageImageStore,
             currentTimeProvider,
+            remoteMessagingPixels,
         )
     }
 

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
@@ -36,7 +36,6 @@ import com.duckduckgo.remote.messaging.impl.matchers.AndroidAppAttributeMatcher
 import com.duckduckgo.remote.messaging.impl.matchers.DeviceAttributeMatcher
 import com.duckduckgo.remote.messaging.impl.matchers.UserAttributeMatcher
 import com.duckduckgo.remote.messaging.impl.network.RemoteMessagingService
-import com.duckduckgo.remote.messaging.impl.pixels.RemoteMessagingPixels
 import com.duckduckgo.remote.messaging.impl.store.GlideRemoteMessageImageStore
 import com.duckduckgo.remote.messaging.impl.store.RemoteMessageImageStore
 import com.duckduckgo.remote.messaging.store.LocalRemoteMessagingConfigRepository
@@ -105,7 +104,7 @@ object DataSourceModule {
         messageMapper: MessageMapper,
         remoteMessageImageStore: RemoteMessageImageStore,
         currentTimeProvider: CurrentTimeProvider,
-        remoteMessagingPixels: RemoteMessagingPixels,
+        autoDismissEvaluator: RemoteMessageAutoDismissEvaluator,
     ): RemoteMessagingRepository {
         return AppRemoteMessagingRepository(
             remoteMessagingConfigRepository,
@@ -113,7 +112,7 @@ object DataSourceModule {
             messageMapper,
             remoteMessageImageStore,
             currentTimeProvider,
-            remoteMessagingPixels,
+            autoDismissEvaluator,
         )
     }
 

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/pixels/RemoteMessagingPixelName.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/pixels/RemoteMessagingPixelName.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 enum class RemoteMessagingPixelName(override val pixelName: String) : Pixel.PixelName {
 
     REMOTE_MESSAGE_DISMISSED("m_remote_message_dismissed"),
+    REMOTE_MESSAGE_AUTO_DISMISSED("m_remote_message_auto_dismissed"),
     REMOTE_MESSAGE_SHOWN("m_remote_message_shown"),
     REMOTE_MESSAGE_SHOWN_UNIQUE("m_remote_message_shown_unique"),
     REMOTE_MESSAGE_PRIMARY_ACTION_CLICKED("m_remote_message_primary_action_clicked"),

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/pixels/RemoteMessagingPixels.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/pixels/RemoteMessagingPixels.kt
@@ -28,6 +28,7 @@ interface RemoteMessagingPixels {
 
     fun fireRemoteMessageShownPixel(remoteMessage: RemoteMessage)
     fun fireRemoteMessageDismissedPixel(remoteMessage: RemoteMessage)
+    fun fireRemoteMessageAutoDismissedPixel(remoteMessage: RemoteMessage)
     fun fireRemoteMessagePrimaryActionClickedPixel(remoteMessage: RemoteMessage)
     fun fireRemoteMessageSecondaryActionClickedPixel(remoteMessage: RemoteMessage)
     fun fireRemoteMessageActionClickedPixel(remoteMessage: RemoteMessage)
@@ -49,6 +50,10 @@ class RealRemoteMessagingPixels @Inject constructor(
 
     override fun fireRemoteMessageDismissedPixel(remoteMessage: RemoteMessage) {
         pixel.fire(pixel = RemoteMessagingPixelName.REMOTE_MESSAGE_DISMISSED, parameters = remoteMessage.asPixelParams())
+    }
+
+    override fun fireRemoteMessageAutoDismissedPixel(remoteMessage: RemoteMessage) {
+        pixel.fire(pixel = RemoteMessagingPixelName.REMOTE_MESSAGE_AUTO_DISMISSED, parameters = remoteMessage.asPixelParams())
     }
 
     override fun fireRemoteMessagePrimaryActionClickedPixel(remoteMessage: RemoteMessage) {

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
@@ -79,6 +79,7 @@ class AppRemoteMessagingRepositoryTest {
     private val remoteMessageImageStore: RemoteMessageImageStore = mock()
     private val currentTimeProvider: CurrentTimeProvider = mock()
     private val remoteMessagingPixels: RemoteMessagingPixels = mock()
+    private val autoDismissEvaluator = RealRemoteMessageAutoDismissEvaluator(remoteMessagingPixels, currentTimeProvider)
 
     private val testee = AppRemoteMessagingRepository(
         remoteMessagingConfigRepository,
@@ -86,7 +87,7 @@ class AppRemoteMessagingRepositoryTest {
         getMessageMapper(),
         remoteMessageImageStore,
         currentTimeProvider,
-        remoteMessagingPixels,
+        autoDismissEvaluator,
     )
 
     @After
@@ -737,7 +738,7 @@ class AppRemoteMessagingRepositoryTest {
             getMessageMapper(),
             remoteMessageImageStore,
             currentTimeProvider,
-            remoteMessagingPixels,
+            autoDismissEvaluator,
         )
     }
 

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.remote.messaging.api.MessageTrigger
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.Surface
 import com.duckduckgo.remote.messaging.fixtures.getMessageMapper
+import com.duckduckgo.remote.messaging.impl.pixels.RemoteMessagingPixels
 import com.duckduckgo.remote.messaging.impl.store.RemoteMessageImageStore
 import com.duckduckgo.remote.messaging.store.RemoteMessageEntity
 import com.duckduckgo.remote.messaging.store.RemoteMessageEntity.Status
@@ -51,7 +52,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.concurrent.TimeUnit
@@ -74,6 +78,7 @@ class AppRemoteMessagingRepositoryTest {
     private val remoteMessagingConfigRepository: RemoteMessagingConfigRepository = mock()
     private val remoteMessageImageStore: RemoteMessageImageStore = mock()
     private val currentTimeProvider: CurrentTimeProvider = mock()
+    private val remoteMessagingPixels: RemoteMessagingPixels = mock()
 
     private val testee = AppRemoteMessagingRepository(
         remoteMessagingConfigRepository,
@@ -81,6 +86,7 @@ class AppRemoteMessagingRepositoryTest {
         getMessageMapper(),
         remoteMessageImageStore,
         currentTimeProvider,
+        remoteMessagingPixels,
     )
 
     @After
@@ -731,7 +737,66 @@ class AppRemoteMessagingRepositoryTest {
             getMessageMapper(),
             remoteMessageImageStore,
             currentTimeProvider,
+            remoteMessagingPixels,
         )
+    }
+
+    @Test
+    fun whenImpressionCapReachedThenAutoDismissedPixelFired() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1000L)
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", displayConditions(maxImpressions = 1)))
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertNull(testee.message())
+
+        verify(remoteMessagingPixels).fireRemoteMessageAutoDismissedPixel(argThat { id == "id" })
+    }
+
+    @Test
+    fun whenExpiryReachedThenAutoDismissedPixelFired() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(0L, TimeUnit.DAYS.toMillis(5))
+        testee.activeMessage(
+            aRemoteMessageWithDisplayConditions("id", DisplayConditions(trigger = null, dismissAfterDaysShown = 5, maxImpressions = null)),
+        )
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertNull(testee.message())
+
+        verify(remoteMessagingPixels).fireRemoteMessageAutoDismissedPixel(argThat { id == "id" })
+    }
+
+    @Test
+    fun whenBothExpiredAndCappedThenAutoDismissedPixelFiredOnce() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(0L, TimeUnit.DAYS.toMillis(5))
+        testee.activeMessage(
+            aRemoteMessageWithDisplayConditions("id", DisplayConditions(trigger = null, dismissAfterDaysShown = 5, maxImpressions = 1)),
+        )
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertNull(testee.message())
+
+        verify(remoteMessagingPixels).fireRemoteMessageAutoDismissedPixel(argThat { id == "id" })
+    }
+
+    @Test
+    fun whenMessageStillWithinItsConditionsThenAutoDismissedPixelNotFired() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1000L)
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", displayConditions(maxImpressions = 3)))
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertEquals("id", testee.message()?.id)
+
+        verify(remoteMessagingPixels, never()).fireRemoteMessageAutoDismissedPixel(any())
+    }
+
+    @Test
+    fun whenUserDismissesMessageThenAutoDismissedPixelNotFired() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1000L)
+        testee.activeMessage(aRemoteMessage("id"))
+
+        testee.dismissMessage("id")
+
+        verify(remoteMessagingPixels, never()).fireRemoteMessageAutoDismissedPixel(any())
     }
 
     @Test

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessageAutoDismissEvaluatorTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessageAutoDismissEvaluatorTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.impl
+
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.remote.messaging.api.DisplayConditions
+import com.duckduckgo.remote.messaging.api.RemoteMessage
+import com.duckduckgo.remote.messaging.fixtures.RemoteMessageOM.aSmallMessage
+import com.duckduckgo.remote.messaging.impl.pixels.RemoteMessagingPixels
+import com.duckduckgo.remote.messaging.store.RemoteMessageEntity
+import com.duckduckgo.remote.messaging.store.RemoteMessageEntity.Status
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import java.util.concurrent.TimeUnit
+
+class RemoteMessageAutoDismissEvaluatorTest {
+
+    private val remoteMessagingPixels: RemoteMessagingPixels = mock()
+    private val currentTimeProvider: CurrentTimeProvider = mock()
+
+    private val testee = RealRemoteMessageAutoDismissEvaluator(remoteMessagingPixels, currentTimeProvider)
+
+    @Test
+    fun whenNoDisplayConditionsThenMessageIsKept() {
+        assertFalse(testee.shouldAutoDismiss(aSmallMessage(), anEntity()))
+
+        verifyNoInteractions(remoteMessagingPixels)
+    }
+
+    @Test
+    fun whenImpressionsBelowCapThenMessageIsKept() {
+        val message = aMessageWith(maxImpressions = 3)
+
+        assertFalse(testee.shouldAutoDismiss(message, anEntity(impressions = 2)))
+
+        verifyNoInteractions(remoteMessagingPixels)
+    }
+
+    @Test
+    fun whenImpressionCapReachedThenMessageIsReported() {
+        val message = aMessageWith(maxImpressions = 3)
+
+        assertTrue(testee.shouldAutoDismiss(message, anEntity(impressions = 3)))
+
+        verify(remoteMessagingPixels).fireRemoteMessageAutoDismissedPixel(message)
+    }
+
+    @Test
+    fun whenImpressionsPastCapThenMessageIsReported() {
+        val message = aMessageWith(maxImpressions = 3)
+
+        assertTrue(testee.shouldAutoDismiss(message, anEntity(impressions = 4)))
+
+        verify(remoteMessagingPixels).fireRemoteMessageAutoDismissedPixel(message)
+    }
+
+    @Test
+    fun whenImpressionCapIsZeroOrNegativeThenMessageIsNeverCapped() {
+        assertFalse(testee.shouldAutoDismiss(aMessageWith(maxImpressions = 0), anEntity(impressions = 10)))
+        assertFalse(testee.shouldAutoDismiss(aMessageWith(maxImpressions = -1), anEntity(impressions = 10)))
+
+        verifyNoInteractions(remoteMessagingPixels)
+    }
+
+    @Test
+    fun whenExpiryThresholdReachedThenMessageIsReported() {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(TimeUnit.DAYS.toMillis(5))
+        val message = aMessageWith(dismissAfterDaysShown = 5)
+
+        assertTrue(testee.shouldAutoDismiss(message, anEntity(firstShownDate = 0L)))
+
+        verify(remoteMessagingPixels).fireRemoteMessageAutoDismissedPixel(message)
+    }
+
+    @Test
+    fun whenWithinExpiryThresholdThenMessageIsKept() {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(TimeUnit.DAYS.toMillis(4))
+
+        assertFalse(testee.shouldAutoDismiss(aMessageWith(dismissAfterDaysShown = 5), anEntity(firstShownDate = 0L)))
+
+        verifyNoInteractions(remoteMessagingPixels)
+    }
+
+    @Test
+    fun whenNeverShownThenExpiryCannotRetireTheMessage() {
+        assertFalse(testee.shouldAutoDismiss(aMessageWith(dismissAfterDaysShown = 5), anEntity(firstShownDate = null)))
+
+        verifyNoInteractions(remoteMessagingPixels)
+    }
+
+    @Test
+    fun whenExpiryThresholdIsZeroThenMessageNeverExpires() {
+        assertFalse(testee.shouldAutoDismiss(aMessageWith(dismissAfterDaysShown = 0), anEntity(firstShownDate = 0L)))
+
+        verifyNoInteractions(remoteMessagingPixels)
+    }
+
+    @Test
+    fun whenBothExpiredAndCappedThenMessageIsReportedOnce() {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(TimeUnit.DAYS.toMillis(5))
+        val message = aMessageWith(dismissAfterDaysShown = 5, maxImpressions = 1)
+
+        assertTrue(testee.shouldAutoDismiss(message, anEntity(firstShownDate = 0L, impressions = 1)))
+
+        verify(remoteMessagingPixels).fireRemoteMessageAutoDismissedPixel(message)
+    }
+
+    private fun aMessageWith(
+        dismissAfterDaysShown: Int? = null,
+        maxImpressions: Int? = null,
+    ): RemoteMessage = aSmallMessage().copy(
+        displayConditions = DisplayConditions(
+            trigger = null,
+            dismissAfterDaysShown = dismissAfterDaysShown,
+            maxImpressions = maxImpressions,
+        ),
+    )
+
+    private fun anEntity(
+        firstShownDate: Long? = null,
+        impressions: Int = 0,
+    ) = RemoteMessageEntity(
+        id = "id",
+        message = "message",
+        status = Status.SCHEDULED,
+        firstShownDate = firstShownDate,
+        impressions = impressions,
+    )
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1217578254898968?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Add a pixel for when message is auto dismissed becasue a display condition is not met anymore

### Steps to test this PR

_pixel fires_
- [x] Fresh install form branch
- [x] Point the app at `https://api.jsonblob.com/01a00f53-7d27-71d5-b54d-01dc0109cb23/json` via **Settings → Internal → RMF config source → Custom URL**
- [x] Make sure you finished onboarding
- [x] Open new tabs (3) until the message `Cap = 2` is dismissed
- [x] Verify `Pixel sent: m_remote_message_auto_dismissed with params: {message=test_cap_two} {}` is in logcat so the pixel was fired

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry and internal refactor only; auto-dismiss behavior stays the same aside from firing the new pixel.
> 
> **Overview**
> Adds **`m_remote_message_auto_dismissed`** analytics when remote messaging retires a message because display limits are exhausted (max impressions or days-since-first-shown), distinct from user-driven **`m_remote_message_dismissed`**.
> 
> Auto-dismiss checks move from **`AppRemoteMessagingRepository`** into **`RemoteMessageAutoDismissEvaluator`**, which fires the new pixel before the repository marks the message dismissed. Pixel definitions, **`RemoteMessagingPixels`**, and RMF campaign param injection include the new event; tests cover evaluator rules and interceptor campaign params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a495135743679ce8400e35da0818486cc2365e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->