### PR TITLE
Do not fire pixel if app links setting not actually changed

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/permissions/PermissionsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/permissions/PermissionsViewModel.kt
@@ -110,6 +110,8 @@ class PermissionsViewModel @Inject constructor(
     }
 
     fun onAppLinksSettingChanged(appLinkSettingType: AppLinkSettingType) {
+        if (appLinkSettingType == viewState.value.appLinksSettingType) return
+
         logcat(INFO) { "User changed app links setting, is now: ${appLinkSettingType.name}" }
 
         val (pixelName, dailyPixelName) =

--- a/app/src/test/java/com/duckduckgo/app/permissions/PermissionsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/permissions/PermissionsViewModelTest.kt
@@ -34,7 +34,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class PermissionsViewModelTest {
 
@@ -101,6 +103,9 @@ class PermissionsViewModelTest {
 
     @Test
     fun whenAppLinksSetToAskEverytimeThenDataStoreIsUpdatedAndPixelIsSent() {
+        whenever(mockAppSettingsDataStore.appLinksEnabled).thenReturn(false)
+        testee.start()
+
         testee.onAppLinksSettingChanged(AppLinkSettingType.ASK_EVERYTIME)
 
         verify(mockAppSettingsDataStore).appLinksEnabled = true
@@ -111,6 +116,9 @@ class PermissionsViewModelTest {
 
     @Test
     fun whenAppLinksSetToAlwaysThenDataStoreIsUpdatedAndPixelIsSent() {
+        whenever(mockAppSettingsDataStore.appLinksEnabled).thenReturn(false)
+        testee.start()
+
         testee.onAppLinksSettingChanged(AppLinkSettingType.ALWAYS)
 
         verify(mockAppSettingsDataStore).appLinksEnabled = true
@@ -121,12 +129,27 @@ class PermissionsViewModelTest {
 
     @Test
     fun whenAppLinksSetToNeverThenDataStoreIsUpdatedAndPixelIsSent() {
+        whenever(mockAppSettingsDataStore.appLinksEnabled).thenReturn(true)
+        testee.start()
+
         testee.onAppLinksSettingChanged(AppLinkSettingType.NEVER)
 
         verify(mockAppSettingsDataStore).appLinksEnabled = false
         verify(mockAppSettingsDataStore).showAppLinksPrompt = false
         verify(mockPixel).fire(AppPixelName.SETTINGS_APP_LINKS_NEVER_SELECTED)
         verify(mockPixel).fire(AppPixelName.SETTINGS_APP_LINKS_NEVER_SELECTED_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenAppLinksSetToSameSettingThenNoPixelIsSent() {
+        whenever(mockAppSettingsDataStore.appLinksEnabled).thenReturn(true)
+        whenever(mockAppSettingsDataStore.showAppLinksPrompt).thenReturn(true)
+        testee.start()
+
+        testee.onAppLinksSettingChanged(AppLinkSettingType.ASK_EVERYTIME)
+
+        verify(mockPixel, never()).fire(AppPixelName.SETTINGS_APP_LINKS_ASK_EVERY_TIME_SELECTED)
+        verify(mockPixel, never()).fire(AppPixelName.SETTINGS_APP_LINKS_ASK_EVERY_TIME_SELECTED_DAILY, type = Daily())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/permissions/PermissionsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/permissions/PermissionsViewModelTest.kt
@@ -104,6 +104,7 @@ class PermissionsViewModelTest {
     @Test
     fun whenAppLinksSetToAskEverytimeThenDataStoreIsUpdatedAndPixelIsSent() {
         whenever(mockAppSettingsDataStore.appLinksEnabled).thenReturn(false)
+        whenever(mockAppSettingsDataStore.showAppLinksPrompt).thenReturn(false)
         testee.start()
 
         testee.onAppLinksSettingChanged(AppLinkSettingType.ASK_EVERYTIME)
@@ -117,6 +118,7 @@ class PermissionsViewModelTest {
     @Test
     fun whenAppLinksSetToAlwaysThenDataStoreIsUpdatedAndPixelIsSent() {
         whenever(mockAppSettingsDataStore.appLinksEnabled).thenReturn(false)
+        whenever(mockAppSettingsDataStore.showAppLinksPrompt).thenReturn(false)
         testee.start()
 
         testee.onAppLinksSettingChanged(AppLinkSettingType.ALWAYS)
@@ -130,6 +132,7 @@ class PermissionsViewModelTest {
     @Test
     fun whenAppLinksSetToNeverThenDataStoreIsUpdatedAndPixelIsSent() {
         whenever(mockAppSettingsDataStore.appLinksEnabled).thenReturn(true)
+        whenever(mockAppSettingsDataStore.showAppLinksPrompt).thenReturn(false)
         testee.start()
 
         testee.onAppLinksSettingChanged(AppLinkSettingType.NEVER)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1163321984198618/task/1217638947037607?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Only fire app links selection pixels if setting actually changed

### Steps to test this PR

_Feature 1_
- [ ] Open App links settings (under permissions)
- [ ] Click save without making any change
- [ ] Check no pixels are fired
- [ ] Open the dialog again and now select a different option and click save
- [ ] Check pixel is fired

### UI changes
n/a

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in permissions settings analytics with no auth or data-handling impact; behavior only affects when pixels fire.
> 
> **Overview**
> **App links save** no longer updates settings or fires selection analytics when the user confirms the same option that was already active.
> 
> `onAppLinksSettingChanged` compares the incoming `AppLinkSettingType` to `viewState.appLinksSettingType` and returns early, so datastore writes, view-state emission, and `SETTINGS_APP_LINKS_*_SELECTED` pixels only run on a real change.
> 
> Tests now call `start()` with mocked datastore values so `appLinksSettingType` matches production, plus a case that asserts no pixels when saving **Ask every time** while already on that setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d8263c06094410a81c4baf641b5c63c33992961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->