### PR TITLE
Fix scrollToPositionWithOffset IllegalArgumentException

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3775,6 +3775,7 @@ class BrowserTabFragment :
                     viewModel.onUserSelectedToEditQuery(it.phrase)
                 },
                 autoCompleteDeleteClickListener = {
+                    storeAutocompletePosition()
                     viewModel.onUserRequestedToDeleteAutocompleteItem(it)
                 },
                 omnibarType = settingsDataStore.omnibarType,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3237,6 +3237,7 @@ class BrowserTabFragment :
         position: Int,
         offset: Int,
     ) {
+        if (!isAdded || view == null) return
         val layoutManager = binding.autoCompleteSuggestionsList.layoutManager as LinearLayoutManager
         layoutManager.scrollToPositionWithOffset(position, offset - AUTOCOMPLETE_PADDING_DP.toPx())
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1217632970255657?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

- Fixes an crash where autocomplete is scrolled to position after detach
- Also fixes an issue where the list was not scrolled to position

### Steps to test this PR

- [x] Scroll down the list of autocomplete entries
- [x] Delete an item
- [x] Verify that the list is scrolled to position

### UI changes

Before

https://github.com/user-attachments/assets/3deab3bb-ac4d-4c87-9b70-bdbb434201a8

After

https://github.com/user-attachments/assets/1e7edbac-7ea2-45e8-941b-24c8a334e938

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single defensive guard on a UI scroll path; no auth, data, or business-logic changes.
> 
> **Overview**
> Fixes a crash when the autocomplete suggestions list is scrolled after **`BrowserTabFragment`** is no longer attached to its activity.
> 
> **`scrollToPositionWithOffset`** now returns immediately if **`!isAdded`** or **`view == null`**, before touching **`binding.autoCompleteSuggestionsList`**. That path is invoked from a keyboard visibility listener in **`showKeyboardAndRestorePosition`** (used when restoring scroll after an autocomplete item is removed), which can fire after the user leaves the tab or the fragment is destroyed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dbc908a2b8bc1d0117ee0c02f968301b92fbea0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->