### PR TITLE
Make AI-off unified input E2E rollout agnostic

### DIFF
--- a/.maestro/unified_input_screen/shared/flow_open_duckai_back_to_ntp.yaml
+++ b/.maestro/unified_input_screen/shared/flow_open_duckai_back_to_ntp.yaml
@@ -1,19 +1,20 @@
 appId: com.duckduckgo.mobile.android
 ---
-# unified input is open by default with nativeInputToggle="true";
-# wait for it to settle after onboarding skip
+# with inputWithAiToggle="false" the address bar is in search-only mode, where the
+# `nativeInputOmnibar.nativeInputSearchOnly` remote flag (percentage rollout) decides
+# whether we get the native input widget or the legacy omnibar. Wait for either.
 - extendedWaitUntil:
     visible:
-      id: "inputModeWidget"
+      id: "inputModeWidget|omnibarTextInput"
     timeout: 15000
 
-# focus the input field and type a question
+# focus whichever field is live and type a question
 - tapOn:
-    id: "inputField"
+    id: "omnibarTextInput|inputField"
 - inputText: "what is a car"
 
-# with inputWithAiToggle=false there is no Duck.ai tab — a Duck.ai icon
-# inside the input mode widget is the entry point to chat
+# with inputWithAiToggle=false there is no Duck.ai tab — the Duck.ai icon is the
+# entry point to chat, and it carries the same id in both input paths
 - assertVisible:
     id: "aiChatIconMenu"
 - tapOn:

--- a/.maestro/unified_input_screen/shared/launch_and_skip_onboarding_search_only.yaml
+++ b/.maestro/unified_input_screen/shared/launch_and_skip_onboarding_search_only.yaml
@@ -1,0 +1,17 @@
+appId: com.duckduckgo.mobile.android
+---
+# Search-only (Duck.ai off in the address bar) variant of launch_and_skip_onboarding.yaml.
+# Which input the NTP lands on depends on the `nativeInputOmnibar.nativeInputSearchOnly`
+# remote flag, which is on a percentage rollout: with it on we get the native input widget,
+# with it off the legacy omnibar. Wait for whichever field is live so the suite doesn't
+# depend on the rollout dice.
+- extendedWaitUntil:
+    visible:
+      id: "skipOnboardingButton"
+    timeout: 30000
+- tapOn:
+    id: "skipOnboardingButton"
+- extendedWaitUntil:
+    visible:
+      id: "inputModeWidget|omnibarTextInput"
+    timeout: 30000

--- a/.maestro/unified_input_screen/unified_input_open_duckai_back_to_ntp.yaml
+++ b/.maestro/unified_input_screen/unified_input_open_duckai_back_to_ntp.yaml
@@ -16,7 +16,7 @@ tags:
             inputWithAiToggle: "false"
             omnibarPosition: "top"
             addFavorites: "example.com;duckduckgo.com;privacytest.com"
-      - runFlow: shared/launch_and_skip_onboarding.yaml
+      - runFlow: shared/launch_and_skip_onboarding_search_only.yaml
       - runFlow: shared/flow_open_duckai_back_to_ntp.yaml
 
 # 2/3 — omnibar bottom
@@ -32,7 +32,7 @@ tags:
             inputWithAiToggle: "false"
             omnibarPosition: "bottom"
             addFavorites: "example.com;duckduckgo.com;privacytest.com"
-      - runFlow: shared/launch_and_skip_onboarding.yaml
+      - runFlow: shared/launch_and_skip_onboarding_search_only.yaml
       - runFlow: shared/flow_open_duckai_back_to_ntp.yaml
 
 # 3/3 — omnibar split
@@ -48,5 +48,5 @@ tags:
             inputWithAiToggle: "false"
             omnibarPosition: "split"
             addFavorites: "example.com;duckduckgo.com;privacytest.com"
-      - runFlow: shared/launch_and_skip_onboarding.yaml
+      - runFlow: shared/launch_and_skip_onboarding_search_only.yaml
       - runFlow: shared/flow_open_duckai_back_to_ntp.yaml

--- a/.maestro/unified_input_screen/unified_input_with_seeded_favorites.yaml
+++ b/.maestro/unified_input_screen/unified_input_with_seeded_favorites.yaml
@@ -64,7 +64,7 @@ tags:
             inputWithAiToggle: "false"
             omnibarPosition: "top"
             addFavorites: "example.com;duckduckgo.com;privacytest.com"
-      - runFlow: shared/launch_and_skip_onboarding.yaml
+      - runFlow: shared/launch_and_skip_onboarding_search_only.yaml
       - runFlow: shared/assert_seeded_favorites_visible.yaml
 
 # 5/6 — AI off, omnibar bottom
@@ -80,7 +80,7 @@ tags:
             inputWithAiToggle: "false"
             omnibarPosition: "bottom"
             addFavorites: "example.com;duckduckgo.com;privacytest.com"
-      - runFlow: shared/launch_and_skip_onboarding.yaml
+      - runFlow: shared/launch_and_skip_onboarding_search_only.yaml
       - runFlow: shared/assert_seeded_favorites_visible.yaml
 
 # 6/6 — AI off, omnibar split
@@ -96,5 +96,5 @@ tags:
             inputWithAiToggle: "false"
             omnibarPosition: "split"
             addFavorites: "example.com;duckduckgo.com;privacytest.com"
-      - runFlow: shared/launch_and_skip_onboarding.yaml
+      - runFlow: shared/launch_and_skip_onboarding_search_only.yaml
       - runFlow: shared/assert_seeded_favorites_visible.yaml


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217636326375060?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

The nightly Unified Input Field suite went red with `Assertion is false: id: inputModeWidget is visible` on the two AI-off flows (open duck.ai via icon, seeded favorites).

This is not an app regression. `nativeInputSearchOnly`, now a subfeature of `nativeInputOmnibar`, is on a percentage rollout in the live privacy config. Read off an internal build on device:

```
nativeInputOmnibar                       -> enable:true
nativeInputOmnibar_nativeInputSearchOnly -> enable:false, rollout:[10.0], rolloutThreshold:16.94
```

Remote state beats the `INTERNAL` default, so with `inputWithAiToggle=false` the address bar is in search-only mode and falls back to the legacy omnibar, where `inputModeWidget` does not exist. Every `clearState: true` launch draws a fresh rollout threshold, so the flows are nondeterministic rather than consistently broken.

The flows now wait for and tap whichever field is live, mirroring the alternate-id pattern already used in the privacy and serp flows:

- new `shared/launch_and_skip_onboarding_search_only.yaml`, waiting on `inputModeWidget|omnibarTextInput`. AI-on flows keep using the strict shared launch flow
- `shared/flow_open_duckai_back_to_ntp.yaml` waits on the same alternation and taps `omnibarTextInput|inputField`
- the 3 AI-off iterations in `unified_input_open_duckai_back_to_ntp.yaml` and the 3 in `unified_input_with_seeded_favorites.yaml` use the new launch flow

Pinning the flag from a test seeder was considered and rejected: the override loses the race with the privacy config download, which lands seconds after launch and rewrites the stored state with the rollout value.

The two ids never coexist, since the widget replaces the omnibar with `inputModeWidgetNavLayout`, so the alternation cannot match the wrong node. When the rollout reaches 100% these should be tightened back to `inputModeWidget` and `inputField`, otherwise the legacy half goes dead and coverage quietly narrows to the native path.

Tests only, no app code changes.

### Steps to test this PR

_Unified input E2E_
- [x] Robin run on the internal binary, API 34, tag `unifiedInputTest`: 6/6 flows SUCCESS, including both previously failing ones. https://github.com/duckduckgo/Android/actions/runs/32256120213
- [x] Locally on a Pixel 9 internalDebug build, all 3 omnibar positions of `unified_input_open_duckai_back_to_ntp.yaml` pass on the legacy path, which is the assertion that was failing

### UI changes
No UI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Maestro YAML only; no production code, auth, or data-handling changes.
> 
> **Overview**
> Fixes nondeterministic failures in the nightly **Unified Input** Maestro suite when `inputWithAiToggle=false`. Remote **`nativeInputSearchOnly`** rollout can show the legacy omnibar (`omnibarTextInput`) instead of the native widget (`inputModeWidget`), so flows that only waited on `inputModeWidget` intermittently failed.
> 
> Adds **`launch_and_skip_onboarding_search_only.yaml`**, which after skip waits for **`inputModeWidget|omnibarTextInput`**. Updates **`flow_open_duckai_back_to_ntp.yaml`** to use the same alternation for wait and **`omnibarTextInput|inputField`** for tap. The six AI-off scenarios in **`unified_input_open_duckai_back_to_ntp.yaml`** and **`unified_input_with_seeded_favorites.yaml`** switch from the strict launch flow to the search-only variant; AI-on cases still use **`launch_and_skip_onboarding.yaml`**.
> 
> **Tests only** — no application code changes. No hardcoded secrets in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fb8a0a045c76ad5e96cfbb475873eecce8548cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->