### PR TITLE
Pin HttpsUpgradesTest interactions to the tab's WebView

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/HttpsUpgradesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/HttpsUpgradesTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.espresso.privacy
 
+import android.view.View
 import android.webkit.WebView
 import androidx.core.net.toUri
 import androidx.test.espresso.IdlingRegistry
@@ -39,6 +40,7 @@ import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.sameInstance
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -64,18 +66,24 @@ class HttpsUpgradesTest {
             webView = it.findViewById(R.id.browserWebView)
         }
 
-        val idlingResourceForDisableProtections = WebViewIdlingResource(webView!!)
+        val testWebView = webView!!
+
+        // The upgrade-navigation test calls window.open, so a second tab (and WebView) exists while the
+        // test runs; match this tab's WebView explicitly instead of relying on there being only one.
+        val testWebViewMatcher = sameInstance<View>(testWebView)
+
+        val idlingResourceForDisableProtections = WebViewIdlingResource(testWebView)
         IdlingRegistry.getInstance().register(idlingResourceForDisableProtections)
 
-        onWebView()
+        onWebView(testWebViewMatcher)
             .withElement(findElement(ID, "start"))
             .check(webMatches(getText(), containsString("Start test")))
             .perform(webClick())
 
-        val idlingResourceForScript = WebViewIdlingResource(webView!!)
+        val idlingResourceForScript = WebViewIdlingResource(testWebView)
         IdlingRegistry.getInstance().register(idlingResourceForScript)
 
-        val results = onWebView()
+        val results = onWebView(testWebViewMatcher)
             .perform(script(SCRIPT))
             .get()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217636326375070
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

### Description

`HttpsUpgradesTest.whenProtectionsAreEnabledHttpsUpgradedCorrectly` has been failing with `AmbiguousViewMatcherException`: the matcher `an instance of android.webkit.WebView and webView.getSettings().getJavaScriptEnabled() is <true>` matched two `DuckDuckGoWebView`s, both with `res-name=browserWebView` and both visible.

The second WebView belongs to a second tab. The `upgrade-navigation` case on `privacy-test-pages.site/privacy-protections/https-upgrades/` calls `window.open(...)`, and `BrowserChromeClient.onCreateWindow` forces `isGesture = true` under instrumentation, so the popup always becomes a real tab. Its fragment sits in the tab pager alongside the original one until the page calls `otherWindow.close()`, and Espresso's default web matcher selects purely on type and id, so whenever it resolved inside that window the test failed. Nothing changed recently on either side to cause this: the `window.open` call has been on the test page since it was created in 2020 and the tab pager has been in place since early 2025, so this is a latent race whose timing on the test runner has shifted.

Both interactions now match the `WebView` instance the test already captured and registers its idling resources against, which is the one holding the page's `results` object. How many tabs exist at that moment no longer matters.

### Steps to test this PR

_HttpsUpgradesTest passes_
- [x] Check the Privacy Tests workflow on this PR is green (it runs the `@PrivacyTest` suite, including this test)
- [x] Optionally, run it locally against an API 34 emulator, since Espresso 3.6.1 cannot inject events on API 36+: `./gradlew :app:connectedPlayDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.duckduckgo.espresso.privacy.HttpsUpgradesTest`
- [x] While the test runs, note the second tab that appears when the test page opens its popup, and that the assertions still read the original tab

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Android instrumentation test change only; no production code or security-sensitive paths affected.
> 
> **Overview**
> Fixes **`HttpsUpgradesTest`** failures from **`AmbiguousViewMatcherException`** when the HTTPS upgrades test page opens a popup via **`window.open`**, leaving two visible **`browserWebView`** instances in the tab pager.
> 
> Espresso **`onWebView()`** calls now use a **`sameInstance`** matcher on the **`WebView`** already captured from the activity (aligned with the idling resources), so clicks and script reads always target the original tab’s page rather than whichever WebView the default matcher picks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 145e4db4ab82e7ed2ea67467cbe9aa5cdd83bd40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->