### PR TITLE
Contextual/DuckAi: Make sheet initial state transparent 

### DIFF
--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/DuckDuckGoBottomSheetDialogFragment.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/DuckDuckGoBottomSheetDialogFragment.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui
+
+import android.content.Context
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import dagger.android.AndroidInjector
+import dagger.android.HasDaggerInjector
+import dagger.android.InjectorFactoryMap
+import dagger.android.getFactory
+import dagger.android.support.AndroidSupportInjection
+import dev.zacsweers.metro.HasMemberInjections
+import javax.inject.Inject
+
+/**
+ * Base bottom-sheet dialog that wires DuckDuckGo's Dagger injection, mirroring [DuckDuckGoFragment].
+ *
+ * It implements [HasDaggerInjector] so that child views which self-inject (e.g.
+ * `@InjectWith(ViewScope::class)` views resolving their injector by walking up to the hosting
+ * fragment) work inside a dialog, just as they do inside a [DuckDuckGoFragment].
+ */
+@HasMemberInjections
+abstract class DuckDuckGoBottomSheetDialogFragment : BottomSheetDialogFragment(), HasDaggerInjector {
+
+    @Inject
+    lateinit var injectorFactoryMap: InjectorFactoryMap
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun daggerFactoryFor(key: Class<*>): AndroidInjector.Factory<*, *> {
+        return injectorFactoryMap.getFactory(key)
+            ?: throw RuntimeException(
+                """
+                Could not find the dagger component for ${key.simpleName}.
+                You probably forgot to annotate your class with @InjectWith(Scope::class).
+                """.trimIndent(),
+            )
+    }
+}

--- a/android-design-system/design-system/src/main/res/drawable/duck_ai_suggested_prompts_background.xml
+++ b/android-design-system/design-system/src/main/res/drawable/duck_ai_suggested_prompts_background.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?attr/daxColorSurface" />
+    <stroke
+        android:width="1dp"
+        android:color="?attr/daxColorContainer" />
+    <corners android:radius="20dp" />
+</shape>

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3975,7 +3975,7 @@ class BrowserTabFragment :
 
     private fun createNewContextualFragment(tabId: String) {
         logcat { "Duck.ai Contextual: createNewContextualFragment" }
-        val fragment = duckChatContextual.createSheet(tabId)
+        val fragment = duckChatContextual.createChatSurface(tabId)
 
         duckAiContextualFragment = fragment
         val transaction = childFragmentManager.beginTransaction()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2164,6 +2164,10 @@ class BrowserTabFragment :
                         viewModel.collectPageContext()
                     }
 
+                    is DuckChatContextualSharedViewModel.Command.ShowSheet -> {
+                        showDuckChatContextualSheet(command.tabId)
+                    }
+
                     else -> {}
                 }
             }.launchIn(viewLifecycleOwner.lifecycleScope)
@@ -3992,7 +3996,7 @@ class BrowserTabFragment :
         transaction.show(fragment)
         transaction.commit()
 
-        sharedContextualViewModel.onOpenRequested()
+        sharedContextualViewModel.onReloadChatRequested()
     }
 
     private fun reactToDuckChatContextualSheetResult() {

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatContextual.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatContextual.kt
@@ -31,24 +31,25 @@ interface DuckChatContextual {
      * (anchored to [anchor]) or opens the contextual sheet directly.
      * [sourceTabId] is the host tab the flow was launched from; a new chat tab is anchored to it so
      * closing that tab returns here rather than leaving an orphan tab.
-     * [onAskAboutPage] is invoked (on the launching host) when the embedded contextual
+     * [showChatSurface] is invoked (on the launching host) when the embedded contextual
      * sheet should be shown. A null [anchor] (no entry-point view, e.g. from native input) always
      * opens the sheet directly.
      */
     suspend fun launch(
         sourceTabId: String,
         anchor: View?,
-        onAskAboutPage: () -> Unit,
+        showChatSurface: () -> Unit,
     )
 
     /**
-     * Creates the contextual sheet fragment for [tabId]. The host embeds it in its own bottom-sheet
-     * container and drives its visibility.
+     * Creates the chat-in-progress surface of the contextual sheet for [tabId] — the fragment hosting
+     * the Duck.ai conversation. The host embeds it in its own bottom-sheet container and drives its
+     * visibility.
      *
      * The fragment reports the "open in full-screen Duck.ai" outcome back to the host via the Fragment
      * Result API, keyed by [RESULT_KEY] with the URL under [RESULT_URL].
      */
-    fun createSheet(tabId: String): Fragment
+    fun createChatSurface(tabId: String): Fragment
 
     companion object {
         const val RESULT_KEY: String = "KEY_DUCK_AI_CONTEXTUAL_RESULT"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualEntryPromptStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualEntryPromptStore.kt
@@ -27,7 +27,8 @@ import javax.inject.Inject
  * straight into the chat (WEBVIEW) and auto-submit it, rather than reopening the initial input state.
  *
  * [serializedPageContext] is the page context the dialog had attached at submit time, so "Ask about
- * page" keeps its context across the hand-off.
+ * page" keeps its context across the hand-off. When it is null the dialog had no context attached
+ * (never available, or the user removed it), and the sheet must not auto-attach one on hand-off.
  */
 data class ContextualEntryPrompt(
     val tabId: String,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualEntryPromptStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualEntryPromptStore.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+
+/**
+ * A prompt composed in the contextual entry dialog, handed to the contextual sheet so it can open
+ * straight into the chat (WEBVIEW) and auto-submit it, rather than reopening the initial input state.
+ *
+ * [serializedPageContext] is the page context the dialog had attached at submit time, so "Ask about
+ * page" keeps its context across the hand-off.
+ */
+data class ContextualEntryPrompt(
+    val tabId: String,
+    val prompt: NativeInputPrompt,
+    val serializedPageContext: String?,
+)
+
+/**
+ * AppScope hand-off between the entry dialog (writer) and the sheet (reader): they are distinct
+ * fragments with distinct ViewModels, so the pending submission is parked here in between.
+ *
+ * Keyed per tab so concurrent tabs don't clobber each other and so a pending prompt can be cleared
+ * when its tab is deleted (see [clear]) rather than lingering until it is consumed.
+ */
+interface ContextualEntryPromptStore {
+    fun store(entry: ContextualEntryPrompt)
+
+    /** Returns and clears the pending prompt for [tabId], otherwise null. */
+    fun consume(tabId: String): ContextualEntryPrompt?
+
+    /** Drops any pending prompt for [tabId] (e.g. when the tab is deleted or cleared). */
+    fun clear(tabId: String)
+
+    /** Drops all pending prompts (e.g. when all tabs are cleared). */
+    fun clearAll()
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealContextualEntryPromptStore @Inject constructor() : ContextualEntryPromptStore {
+
+    private val pending = ConcurrentHashMap<String, ContextualEntryPrompt>()
+
+    override fun store(entry: ContextualEntryPrompt) {
+        pending[entry.tabId] = entry
+    }
+
+    override fun consume(tabId: String): ContextualEntryPrompt? = pending.remove(tabId)
+
+    override fun clear(tabId: String) {
+        pending.remove(tabId)
+    }
+
+    override fun clearAll() {
+        pending.clear()
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
@@ -20,6 +20,7 @@ import android.app.Activity
 import android.app.Dialog
 import android.content.DialogInterface
 import android.content.Intent
+import android.content.res.Configuration
 import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
@@ -233,6 +234,7 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
                 }
             }
             pendingUploadTask = null
+            restoreInputFocusAfterPicker()
         }
     }
 
@@ -276,6 +278,19 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
             binding.entryNativeInputWidget.focusInput(activity)
         }
     }
+
+    private fun restoreInputFocusAfterPicker() {
+        binding.entryNativeInputWidget.doOnLayout {
+            if (isExternalKeyboardConnected()) {
+                binding.entryNativeInputWidget.requestInputFocus()
+            } else {
+                binding.entryNativeInputWidget.focusInput(activity)
+            }
+        }
+    }
+
+    private fun isExternalKeyboardConnected(): Boolean =
+        resources.configuration.keyboard != Configuration.KEYBOARD_NOKEYS
 
     private fun configureSuggestions() {
         binding.entrySuggestionsView.onSuggestionSelected = { suggestion ->
@@ -391,9 +406,11 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
         pendingUploadTask = null
         if (resultCode != Activity.RESULT_OK || data == null) {
             uploadTask?.onReceiveValue(null)
+            restoreInputFocusAfterPicker()
             return
         }
         uploadTask?.onReceiveValue(fileChooserIntentBuilder.extractSelectedFileUris(data))
+        restoreInputFocusAfterPicker()
     }
 
     override fun onDismiss(dialog: DialogInterface) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
@@ -51,7 +51,10 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 import javax.inject.Named
@@ -261,10 +264,15 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
         sharedContextualViewModel.commands
             .onEach { command ->
                 if (command is DuckChatContextualSharedViewModel.Command.PageContextAttached) {
-                    binding.entrySuggestionsView.onPageContextUpdated(command.pageContext)
                     viewModel.onPageContextReceived(command.pageContext)
                 }
             }
+            .launchIn(viewLifecycleOwner.lifecycleScope)
+        viewModel.viewState
+            .map { it.attachedContext?.serialized }
+            .filterNotNull()
+            .distinctUntilChanged()
+            .onEach { binding.entrySuggestionsView.onPageContextUpdated(it) }
             .launchIn(viewLifecycleOwner.lifecycleScope)
         binding.entrySuggestionsView.load()
         sharedContextualViewModel.requestPageContext()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
@@ -45,6 +45,7 @@ import com.duckduckgo.common.ui.DuckDuckGoBottomSheetDialogFragment
 import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.databinding.DialogContextualDuckAiEntryBinding
@@ -344,7 +345,7 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
             onAskAboutPage = { viewModel.onAttachContextRequested() },
             onPageContextRemoved = { viewModel.onContextRemoved() },
             onVoiceChatRequested = {
-                duckChat.openVoiceDuckChat()
+                duckChat.openVoiceDuckChat(DuckChatEntryPoint.VOICE)
                 dismiss()
             },
             onVoiceSearchRequested = {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
@@ -42,12 +42,17 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.common.ui.DuckDuckGoBottomSheetDialogFragment
 import com.duckduckgo.common.utils.FragmentViewModelFactory
+import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.databinding.DialogContextualDuckAiEntryBinding
 import com.duckduckgo.duckchat.impl.ui.filechooser.FileChooserIntentBuilder
 import com.duckduckgo.duckchat.impl.ui.filechooser.capture.launcher.UploadFromExternalMediaAppLauncher
 import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.voice.api.VoiceSearchLauncher
+import com.duckduckgo.voice.api.VoiceSearchLauncher.Source.BROWSER
+import com.duckduckgo.voice.api.VoiceSearchLauncher.VoiceSearchMode
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.snackbar.Snackbar
@@ -84,6 +89,12 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
     lateinit var browserNav: BrowserNav
 
     @Inject
+    lateinit var duckChat: DuckChatInternal
+
+    @Inject
+    lateinit var voiceSearchLauncher: VoiceSearchLauncher
+
+    @Inject
     lateinit var fileChooserIntentBuilder: FileChooserIntentBuilder
 
     @Inject
@@ -117,6 +128,19 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
     ) {
         if (fragmentManager.isStateSaved) return
         super.show(fragmentManager, tag)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        voiceSearchLauncher.registerResultsCallback(this, requireActivity(), BROWSER) { event ->
+            if (event is VoiceSearchLauncher.Event.VoiceRecognitionSuccess) {
+                val result = event.result
+                onVoiceRecognitionSuccess(
+                    query = result.query,
+                    isDuckAiResult = result is VoiceSearchLauncher.VoiceRecognitionResult.DuckAiResult,
+                )
+            }
+        }
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -304,9 +328,30 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
             onFilePickerRequested = { callback, mimeTypes -> launchFilePicker(callback, mimeTypes) },
             onAskAboutPage = { viewModel.onAttachContextRequested() },
             onPageContextRemoved = { viewModel.onContextRemoved() },
+            onVoiceChatRequested = {
+                duckChat.openVoiceDuckChat()
+                dismiss()
+            },
+            onVoiceSearchRequested = {
+                activity?.hideKeyboard()
+                voiceSearchLauncher.launch(requireActivity(), VoiceSearchMode.DUCK_AI)
+            },
         )
         contextualNativeInputManager.onInputMode()
         contextualNativeInputManager.onContextualReopened(tabId)
+    }
+
+    private fun onVoiceRecognitionSuccess(
+        query: String,
+        isDuckAiResult: Boolean,
+    ) {
+        if (query.isBlank()) return
+        if (isDuckAiResult) {
+            viewModel.onPromptSubmitted(NativeInputPrompt(query, null, null, null, null, null))
+        } else {
+            startActivity(browserNav.openInNewTab(requireContext(), query))
+            dismiss()
+        }
     }
 
     private fun updateQuickActionVisibility() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual
+
+import android.app.Activity
+import android.app.Dialog
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.provider.MediaStore
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.ValueCallback
+import androidx.core.os.bundleOf
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.doOnLayout
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.tabs.BrowserNav
+import com.duckduckgo.common.ui.DuckDuckGoBottomSheetDialogFragment
+import com.duckduckgo.common.utils.FragmentViewModelFactory
+import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.databinding.DialogContextualDuckAiEntryBinding
+import com.duckduckgo.duckchat.impl.ui.filechooser.FileChooserIntentBuilder
+import com.duckduckgo.duckchat.impl.ui.filechooser.capture.launcher.UploadFromExternalMediaAppLauncher
+import com.duckduckgo.js.messaging.api.JsMessaging
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+import javax.inject.Named
+import com.duckduckgo.mobile.android.R as CommonR
+import com.google.android.material.R as MaterialR
+
+/**
+ * The contextual Duck.ai entry surface shown when "Ask about page" is chosen from the entry menu.
+ *
+ * Presented as a scrimmed dialog (same scrim as the fire dialog) with a transparent background so
+ * only the suggested prompts and the native input float over the page. It owns the INPUT stage: when
+ * the user submits a prompt or picks a suggestion, it hands control back to the host via
+ * [onAskAboutPage], which embeds and shows the contextual sheet.
+ */
+@InjectWith(FragmentScope::class)
+class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
+
+    @Inject
+    lateinit var contextualNativeInputManager: ContextualNativeInputManager
+
+    @Inject
+    @Named("ContentScopeScripts")
+    lateinit var contentScopeScripts: JsMessaging
+
+    @Inject
+    lateinit var browserNav: BrowserNav
+
+    @Inject
+    lateinit var fileChooserIntentBuilder: FileChooserIntentBuilder
+
+    @Inject
+    lateinit var externalCameraLauncher: UploadFromExternalMediaAppLauncher
+
+    @Inject
+    lateinit var viewModelFactory: FragmentViewModelFactory
+
+    private val viewModel: DuckChatContextualEntryViewModel by lazy {
+        ViewModelProvider(this, viewModelFactory)[DuckChatContextualEntryViewModel::class.java]
+    }
+
+    private val sharedContextualViewModel: DuckChatContextualSharedViewModel by viewModels({ requireParentFragment() })
+    private lateinit var tabId: String
+    private var onAskAboutPage: (() -> Unit)? = null
+
+    // No running chat in the entry stage; the widget's chat-id-driven affordances stay collapsed.
+    private val chatIdFlow = MutableStateFlow<String?>(null)
+    private var _binding: DialogContextualDuckAiEntryBinding? = null
+    private val binding get() = _binding!!
+
+    // Pending WebView-style file/image upload callback while the picker/camera activity is in flight.
+    private var pendingUploadTask: ValueCallback<Array<Uri>>? = null
+
+    override fun show(
+        fragmentManager: FragmentManager,
+        tag: String?,
+    ) {
+        if (fragmentManager.isStateSaved) return
+        super.show(fragmentManager, tag)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return BottomSheetDialog(requireContext(), R.style.Widget_DuckDuckGo_DuckAiContextualEntryDialog)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        // Make the sheet full-height so the root's weighted layout applies: the suggestions area flexes
+        // and scrolls while the input stays pinned at the bottom. Without this the modal frame wraps its
+        // content and, in a short (landscape) window, the input gets pushed off / the sheet oscillates.
+        (dialog as? BottomSheetDialog)
+            ?.findViewById<View>(MaterialR.id.design_bottom_sheet)
+            ?.updateLayoutParams { height = ViewGroup.LayoutParams.MATCH_PARENT }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = DialogContextualDuckAiEntryBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        if (onAskAboutPage == null) {
+            dismiss()
+            return
+        }
+        tabId = requireNotNull(requireArguments().getString(ARG_TAB_ID)) {
+            "DuckChatContextualEntryDialog requires $ARG_TAB_ID argument"
+        }
+        viewModel.start(tabId)
+        registerFileChooserResult()
+        configureBehavior()
+        configureWindowInsets()
+        configureInput()
+        configureSuggestions()
+        configureQuickAction()
+        configureDismissOnEmptyTap()
+        observeViewModel()
+        focusInput()
+    }
+
+    private fun observeViewModel() {
+        viewModel.viewState
+            .onEach { renderViewState(it) }
+            .launchIn(viewLifecycleOwner.lifecycleScope)
+        viewModel.commands
+            .onEach { handleCommand(it) }
+            .launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+    private fun renderViewState(state: DuckChatContextualEntryViewModel.ViewState) {
+        val context = state.attachedContext
+        if (context != null) {
+            binding.entryNativeInputWidget.setPageContext(context.title, context.url)
+        } else {
+            binding.entryNativeInputWidget.clearPageContext()
+        }
+        updateQuickActionVisibility()
+    }
+
+    private fun handleCommand(command: DuckChatContextualEntryViewModel.Command) {
+        when (command) {
+            DuckChatContextualEntryViewModel.Command.HandOffToSheet -> {
+                onAskAboutPage?.invoke()
+                dismiss()
+            }
+        }
+    }
+
+    private fun registerFileChooserResult() {
+        externalCameraLauncher.registerForResult(this) {
+            when (it) {
+                is UploadFromExternalMediaAppLauncher.MediaCaptureResult.MediaCaptured ->
+                    pendingUploadTask?.onReceiveValue(arrayOf(Uri.fromFile(it.file)))
+
+                is UploadFromExternalMediaAppLauncher.MediaCaptureResult.CouldNotCapturePermissionDenied -> {
+                    pendingUploadTask?.onReceiveValue(null)
+                    externalCameraLauncher.showPermissionRationaleDialog(requireActivity(), it.inputAction)
+                }
+
+                is UploadFromExternalMediaAppLauncher.MediaCaptureResult.NoMediaCaptured -> pendingUploadTask?.onReceiveValue(null)
+                is UploadFromExternalMediaAppLauncher.MediaCaptureResult.ErrorAccessingMediaApp -> {
+                    pendingUploadTask?.onReceiveValue(null)
+                    Snackbar.make(binding.entryDialogRoot, it.messageId, Snackbar.LENGTH_SHORT).show()
+                }
+            }
+            pendingUploadTask = null
+        }
+    }
+
+    private fun configureDismissOnEmptyTap() {
+        val dismissOnTap = View.OnClickListener { dismiss() }
+        binding.entryDialogRoot.setOnClickListener(dismissOnTap)
+        binding.entryPromptsContent.setOnClickListener(dismissOnTap)
+        binding.entryNativeInputCard.isClickable = true
+    }
+
+    private fun configureBehavior() {
+        (dialog as? BottomSheetDialog)?.behavior?.apply {
+            skipCollapsed = true
+            state = BottomSheetBehavior.STATE_EXPANDED
+        }
+    }
+
+    private fun configureQuickAction() {
+        binding.entryPromptQuickAction.setOnClickListener {
+            if (viewModel.viewState.value.attachedContext == null) return@setOnClickListener
+            viewModel.onPromptSubmitted(NativeInputPrompt(getString(R.string.duckAIContextualPromptSummarize), null, null, null, null, null))
+        }
+    }
+
+    private fun configureWindowInsets() {
+        dialog?.window?.let { WindowCompat.setDecorFitsSystemWindows(it, false) }
+        ViewCompat.setOnApplyWindowInsetsListener(binding.entryDialogRoot) { v, insets ->
+            val ime = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+            val systemBottom = insets.getInsets(
+                WindowInsetsCompat.Type.navigationBars() or WindowInsetsCompat.Type.displayCutout(),
+            ).bottom
+            v.updatePadding(bottom = maxOf(ime, systemBottom))
+            insets
+        }
+        ViewCompat.requestApplyInsets(binding.entryDialogRoot)
+    }
+
+    private fun focusInput() {
+        // Auto-focus the composer once laid out so the keyboard comes up as soon as the dialog is shown.
+        binding.entryNativeInputWidget.doOnLayout {
+            binding.entryNativeInputWidget.focusInput(activity)
+        }
+    }
+
+    private fun configureSuggestions() {
+        // On the transparent dialog the chips sit over the dimmed page, so give them a solid surface
+        // background (rather than the sheet's default) for legibility.
+        binding.entrySuggestionsView.chipBackgroundRes = CommonR.drawable.background_large_rounded_surface
+        binding.entrySuggestionsView.onSuggestionSelected = { suggestion ->
+            viewModel.onSuggestionSubmitted(NativeInputPrompt(suggestion.prompt, null, null, null, null, null))
+        }
+
+        binding.entrySuggestionsView.onContentChanged = { updateQuickActionVisibility() }
+        sharedContextualViewModel.commands
+            .onEach { command ->
+                if (command is DuckChatContextualSharedViewModel.Command.PageContextAttached) {
+                    binding.entrySuggestionsView.onPageContextUpdated(command.pageContext)
+                    viewModel.onPageContextReceived(command.pageContext)
+                }
+            }
+            .launchIn(viewLifecycleOwner.lifecycleScope)
+        binding.entrySuggestionsView.load()
+        sharedContextualViewModel.requestPageContext()
+    }
+
+    private fun configureInput() {
+        contextualNativeInputManager.init(
+            tabId = tabId,
+            card = binding.entryNativeInputCard,
+            widget = binding.entryNativeInputWidget,
+            jsMessaging = contentScopeScripts,
+            lifecycleOwner = viewLifecycleOwner,
+            chatIdFlow = chatIdFlow,
+            onSearchSubmitted = { query ->
+                startActivity(browserNav.openInNewTab(requireContext(), query))
+                dismiss()
+            },
+            onPromptSubmitted = { prompt -> viewModel.onPromptSubmitted(prompt) },
+            onCameraCaptureRequested = { callback -> launchCameraCapture(callback) },
+            onFilePickerRequested = { callback, mimeTypes -> launchFilePicker(callback, mimeTypes) },
+            onAskAboutPage = { viewModel.onAttachContextRequested() },
+            onPageContextRemoved = { viewModel.onContextRemoved() },
+        )
+        contextualNativeInputManager.onInputMode()
+    }
+
+    private fun updateQuickActionVisibility() {
+        // Summarize acts on the attached page, and suggestions take its place when present.
+        val show = viewModel.viewState.value.attachedContext != null && !binding.entrySuggestionsView.hasContent()
+        binding.entryPromptQuickAction.visibility = if (show) View.VISIBLE else View.GONE
+    }
+
+    private fun launchCameraCapture(callback: ValueCallback<Array<Uri>>) {
+        val action = MediaStore.ACTION_IMAGE_CAPTURE
+        if (Intent(action).resolveActivity(requireActivity().packageManager) == null) {
+            // No camera app available; fall back to picking an image from the file picker.
+            launchFilePicker(callback, listOf("image/*"))
+            return
+        }
+        pendingUploadTask = callback
+        externalCameraLauncher.launch(action)
+    }
+
+    private fun launchFilePicker(
+        callback: ValueCallback<Array<Uri>>,
+        mimeTypes: List<String>,
+    ) {
+        pendingUploadTask = callback
+        val types = mimeTypes.ifEmpty { listOf("*/*") }
+        startActivityForResult(fileChooserIntentBuilder.intent(types.toTypedArray(), true), REQUEST_CODE_CHOOSE_FILE)
+    }
+
+    override fun onActivityResult(
+        requestCode: Int,
+        resultCode: Int,
+        data: Intent?,
+    ) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode != REQUEST_CODE_CHOOSE_FILE) return
+        val uploadTask = pendingUploadTask
+        pendingUploadTask = null
+        if (resultCode != Activity.RESULT_OK || data == null) {
+            uploadTask?.onReceiveValue(null)
+            return
+        }
+        uploadTask?.onReceiveValue(fileChooserIntentBuilder.extractSelectedFileUris(data))
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        const val TAG = "DuckChatContextualEntryDialog"
+        private const val ARG_TAB_ID = "tabId"
+        private const val REQUEST_CODE_CHOOSE_FILE = 100
+
+        fun newInstance(
+            tabId: String,
+            onAskAboutPage: () -> Unit,
+        ): DuckChatContextualEntryDialog =
+            DuckChatContextualEntryDialog().apply {
+                arguments = bundleOf(ARG_TAB_ID to tabId)
+                this.onAskAboutPage = onAskAboutPage
+            }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.duckchat.impl.contextual
 
 import android.app.Activity
 import android.app.Dialog
+import android.content.DialogInterface
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -58,7 +59,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 import javax.inject.Named
-import com.duckduckgo.mobile.android.R as CommonR
 import com.google.android.material.R as MaterialR
 
 /**
@@ -66,8 +66,9 @@ import com.google.android.material.R as MaterialR
  *
  * Presented as a scrimmed dialog (same scrim as the fire dialog) with a transparent background so
  * only the suggested prompts and the native input float over the page. It owns the INPUT stage: when
- * the user submits a prompt or picks a suggestion, it hands control back to the host via
- * [onAskAboutPage], which embeds and shows the contextual sheet.
+ * the user submits a prompt or picks a suggestion, it parks the prompt and asks the host to show the
+ * contextual sheet (via the shared view model), which consumes the prompt. The hand-off is derived
+ * from the retained tab id, so it survives configuration changes.
  */
 @InjectWith(FragmentScope::class)
 class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
@@ -97,7 +98,10 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
 
     private val sharedContextualViewModel: DuckChatContextualSharedViewModel by viewModels({ requireParentFragment() })
     private lateinit var tabId: String
-    private var onAskAboutPage: (() -> Unit)? = null
+
+    // Set once when the dialog hands off to the sheet, so onDismiss knows the sheet now owns the
+    // contextual input state and must not revert it. Read once on dismiss; the dialog is single-use.
+    private var handedOffToSheet = false
 
     // No running chat in the entry stage; the widget's chat-id-driven affordances stay collapsed.
     private val chatIdFlow = MutableStateFlow<String?>(null)
@@ -143,10 +147,6 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
-        if (onAskAboutPage == null) {
-            dismiss()
-            return
-        }
         tabId = requireNotNull(requireArguments().getString(ARG_TAB_ID)) {
             "DuckChatContextualEntryDialog requires $ARG_TAB_ID argument"
         }
@@ -184,7 +184,8 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
     private fun handleCommand(command: DuckChatContextualEntryViewModel.Command) {
         when (command) {
             DuckChatContextualEntryViewModel.Command.HandOffToSheet -> {
-                onAskAboutPage?.invoke()
+                handedOffToSheet = true
+                sharedContextualViewModel.requestShowSheet(tabId)
                 dismiss()
             }
         }
@@ -253,9 +254,6 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
     }
 
     private fun configureSuggestions() {
-        // On the transparent dialog the chips sit over the dimmed page, so give them a solid surface
-        // background (rather than the sheet's default) for legibility.
-        binding.entrySuggestionsView.chipBackgroundRes = CommonR.drawable.background_large_rounded_surface
         binding.entrySuggestionsView.onSuggestionSelected = { suggestion ->
             viewModel.onSuggestionSubmitted(NativeInputPrompt(suggestion.prompt, null, null, null, null, null))
         }
@@ -353,6 +351,13 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
         uploadTask?.onReceiveValue(fileChooserIntentBuilder.extractSelectedFileUris(data))
     }
 
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        if (!handedOffToSheet && ::tabId.isInitialized && activity?.isChangingConfigurations != true) {
+            contextualNativeInputManager.onContextualClosed(tabId)
+        }
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
@@ -363,13 +368,9 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
         private const val ARG_TAB_ID = "tabId"
         private const val REQUEST_CODE_CHOOSE_FILE = 100
 
-        fun newInstance(
-            tabId: String,
-            onAskAboutPage: () -> Unit,
-        ): DuckChatContextualEntryDialog =
+        fun newInstance(tabId: String): DuckChatContextualEntryDialog =
             DuckChatContextualEntryDialog().apply {
                 arguments = bundleOf(ARG_TAB_ID to tabId)
-                this.onAskAboutPage = onAskAboutPage
             }
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
@@ -263,8 +263,19 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
         binding.entrySuggestionsView.onContentChanged = { updateQuickActionVisibility() }
         sharedContextualViewModel.commands
             .onEach { command ->
-                if (command is DuckChatContextualSharedViewModel.Command.PageContextAttached) {
-                    viewModel.onPageContextReceived(command.pageContext)
+                when (command) {
+                    is DuckChatContextualSharedViewModel.Command.PageContextAttached ->
+                        viewModel.onPageContextReceived(command.pageContext)
+
+                    is DuckChatContextualSharedViewModel.Command.MainBrowserPageFinished ->
+                        // The dialog may have opened while the page was still loading, so the initial
+                        // collection returned no usable context and the suggestions fell back to generic.
+                        // Re-collect now that the page finished so the page-specific prompts can resolve.
+                        // When storePageContext is enabled the browser re-collects and pushes context on
+                        // page finish itself, so only re-request when it isn't.
+                        if (!command.isStorePageContextEnabled) sharedContextualViewModel.requestPageContext()
+
+                    else -> {}
                 }
             }
             .launchIn(viewLifecycleOwner.lifecycleScope)
@@ -297,6 +308,7 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
             onPageContextRemoved = { viewModel.onContextRemoved() },
         )
         contextualNativeInputManager.onInputMode()
+        contextualNativeInputManager.onContextualReopened(tabId)
     }
 
     private fun updateQuickActionVisibility() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModel.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual
+
+import androidx.lifecycle.ViewModel
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.di.scopes.FragmentScope
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import org.json.JSONObject
+import javax.inject.Inject
+
+/**
+ * Owns the entry dialog's INPUT-stage state: page-context attach/validity and the prompt hand-off to
+ * the contextual sheet. View/Android concerns (the dialog window, insets, focus, file pickers, and the
+ * suggestion/input view wiring) stay in [DuckChatContextualEntryDialog].
+ */
+@ContributesViewModel(FragmentScope::class)
+class DuckChatContextualEntryViewModel @Inject constructor(
+    private val contextualEntryPromptStore: ContextualEntryPromptStore,
+) : ViewModel() {
+
+    data class ViewState(
+        val attachedContext: AttachedPageContext? = null,
+    )
+
+    data class AttachedPageContext(
+        val serialized: String,
+        val title: String,
+        val url: String,
+    )
+
+    sealed class Command {
+        /** The prompt is parked in the store; the host should open the sheet and the dialog should close. */
+        data object HandOffToSheet : Command()
+    }
+
+    private val _viewState = MutableStateFlow(ViewState())
+    val viewState: StateFlow<ViewState> = _viewState.asStateFlow()
+
+    private val commandChannel = Channel<Command>(capacity = 1, onBufferOverflow = DROP_OLDEST)
+    val commands = commandChannel.receiveAsFlow()
+
+    private var tabId: String = ""
+
+    // The latest valid page context delivered for this tab — the source for auto- and manual attachment.
+    private var latestValidPageContext: String? = null
+
+    // Set once the user explicitly removes the context, so a later context update doesn't silently re-attach.
+    private var userRemovedContext: Boolean = false
+
+    fun start(tabId: String) {
+        this.tabId = tabId
+    }
+
+    fun onPageContextReceived(serializedPageContext: String) {
+        if (!isContextValid(serializedPageContext)) return
+        latestValidPageContext = serializedPageContext
+        // The dialog is only shown from "Ask about page", so attach regardless of the auto-attach feature
+        // flag — unless the user explicitly removed the context this session.
+        if (!userRemovedContext) attach(serializedPageContext)
+    }
+
+    /** The composer's "attach page context" affordance (shown when nothing is attached). */
+    fun onAttachContextRequested() {
+        latestValidPageContext?.let { attach(it) }
+    }
+
+    fun onContextRemoved() {
+        userRemovedContext = true
+        _viewState.update { it.copy(attachedContext = null) }
+    }
+
+    /** A suggested prompt was picked; suggestions are page-specific, so attach the context before submit. */
+    fun onSuggestionSubmitted(prompt: NativeInputPrompt) {
+        if (_viewState.value.attachedContext == null) latestValidPageContext?.let { attach(it) }
+        submit(prompt)
+    }
+
+    /** A typed prompt or the Summarize quick action was submitted. */
+    fun onPromptSubmitted(prompt: NativeInputPrompt) {
+        submit(prompt)
+    }
+
+    private fun submit(prompt: NativeInputPrompt) {
+        contextualEntryPromptStore.store(
+            ContextualEntryPrompt(tabId, prompt, _viewState.value.attachedContext?.serialized),
+        )
+        commandChannel.trySend(Command.HandOffToSheet)
+    }
+
+    private fun attach(serializedPageContext: String) {
+        val json = runCatching { JSONObject(serializedPageContext) }.getOrNull() ?: return
+        userRemovedContext = false
+        _viewState.update {
+            it.copy(
+                attachedContext = AttachedPageContext(
+                    serialized = serializedPageContext,
+                    title = json.optString("title"),
+                    url = json.optString("url"),
+                ),
+            )
+        }
+    }
+
+    private fun isContextValid(serializedPageContext: String): Boolean {
+        val json = runCatching { JSONObject(serializedPageContext) }.getOrNull() ?: return false
+        return json.optString("title").isNotBlank() && json.optString("content").isNotBlank()
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -441,6 +441,8 @@ class DuckChatContextualFragment :
                                             if (method == RealDuckChatJSHelper.METHOD_GET_AI_CHAT_NATIVE_HANDOFF_DATA) {
                                                 logcat { "Duck.ai: requesting page context after chat fully loaded" }
                                                 sharedContextualViewModel.requestPageContext()
+                                                // Submit any prompt handed over from the entry dialog now that the web app is ready.
+                                                viewModel.onWebAppReady()
                                             }
                                         }
                                     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -771,6 +771,12 @@ class DuckChatContextualFragment :
                         showChatsPopup(command.showNewChatHeader, command.recentChats)
                     }
 
+                    is DuckChatContextualViewModel.Command.ShowNewChatEntryDialog -> {
+                        // Hide the running chat so it isn't left dimmed behind the transparent entry dialog.
+                        bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
+                        showContextualEntryDialogForNewChat(command.tabId)
+                    }
+
                     is DuckChatContextualViewModel.Command.OpenChatUrl -> {
                         viewModel.onContextualClose()
                         startActivity(browserNav.openInNewTab(requireContext(), command.url, command.sourceTabId))
@@ -959,6 +965,14 @@ class DuckChatContextualFragment :
         binding.contextualSuggestionsView.onContentChanged = {
             applyQuickActionVisibility(viewModel.viewState.value)
         }
+    }
+
+    private fun showContextualEntryDialogForNewChat(tabId: String) {
+        val fragmentManager = parentFragment?.childFragmentManager ?: return
+        if (fragmentManager.isStateSaved) return
+        DuckChatContextualEntryDialog
+            .newInstance(tabId) { viewModel.onNewChatFromEntryDialog() }
+            .show(fragmentManager, DuckChatContextualEntryDialog.TAG)
     }
 
     private fun showChatsPopup(showNewChatHeader: Boolean, recentChats: List<ChatHistoryItem>) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualSharedViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualSharedViewModel.kt
@@ -30,8 +30,24 @@ class DuckChatContextualSharedViewModel() : ViewModel() {
         _command.tryEmit(Command.PageContextAttached(tabId, pageContext, isStorePageContextEnabled))
     }
 
-    fun onOpenRequested() {
-        _command.tryEmit(Command.OpenSheet)
+    /**
+     * Emitted by the host once it has shown the sheet, telling the sheet fragment to reload its chat
+     * content (reopen the chat, consume any parked entry prompt). The content-side counterpart of
+     * [requestShowSheet]: [Command.ShowSheet] asks the host to show the sheet UI; [Command.ReloadChat]
+     * then tells the now-visible sheet to load its chat.
+     */
+    fun onReloadChatRequested() {
+        _command.tryEmit(Command.ReloadChat)
+    }
+
+    /**
+     * Asks the host to show the contextual sheet UI (un-hide its container and embed/show the sheet
+     * fragment) for [tabId]. Used by the New Chat → entry-dialog handoff, which runs while the sheet is
+     * hidden: the host must show the container before the sheet can reload, otherwise the chat loads into
+     * a hidden container. The host then emits [Command.ReloadChat] so the sheet loads its chat content.
+     */
+    fun requestShowSheet(tabId: String) {
+        _command.tryEmit(Command.ShowSheet(tabId))
     }
 
     fun requestPageContext() {
@@ -54,7 +70,11 @@ class DuckChatContextualSharedViewModel() : ViewModel() {
             val isStorePageContextEnabled: Boolean = false,
         ) : Command()
 
-        data object OpenSheet : Command()
+        // Host → sheet: the sheet has been shown; (re)load its chat content.
+        data object ReloadChat : Command()
+
+        // Sheet → host: show the sheet UI (un-hide the container and embed/show the fragment).
+        data class ShowSheet(val tabId: String) : Command()
 
         data object CollectPageContext : Command()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -877,8 +877,8 @@ class DuckChatContextualViewModel @Inject constructor(
     }
 
     fun onNewChatRequestedFromPopup() {
-        duckChatPixels.reportContextualSheetNewChatFromPopup()
         renderNewChatState()
+        duckChatPixels.reportContextualSheetNewChatFromPopup()
     }
 
     fun onChatsIconClicked() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -155,6 +155,7 @@ class DuckChatContextualViewModel @Inject constructor(
             val showNewChatHeader: Boolean,
             val recentChats: List<ChatHistoryItem>,
         ) : Command()
+        data class ShowNewChatEntryDialog(val tabId: String) : Command()
         data class OpenChatUrl(
             val url: String,
             val sourceTabId: String,
@@ -953,8 +954,29 @@ class DuckChatContextualViewModel @Inject constructor(
     }
 
     fun onNewChatRequestedFromPopup() {
-        renderNewChatState()
         duckChatPixels.reportContextualSheetNewChatFromPopup()
+        if (duckChatInternal.isContextualSheetRedesignEnabled()) {
+            // Hand New Chat off to the transparent entry dialog: clear the current chat's stored status
+            // now so it isn't resumed, then let the dialog command hide the sheet. sheetState = null so
+            // renderNewChatState emits no ChangeSheetState of its own — a second command would race this
+            // one on the capacity-1 channel and one would be dropped.
+            renderNewChatState(sheetState = null)
+            commandChannel.trySend(Command.ShowNewChatEntryDialog(_viewState.value.tabId))
+        } else {
+            renderNewChatState()
+        }
+    }
+
+    /**
+     * The entry dialog opened from New Chat has parked a composed prompt, so consume it and start a fresh
+     * chat from it (same delivery path as the initial entry hand-off).
+     */
+    fun onNewChatFromEntryDialog() {
+        viewModelScope.launch(dispatchers.io()) {
+            val tabId = _viewState.value.tabId
+            val pendingEntry = contextualEntryPromptStore.consume(tabId) ?: return@launch
+            startChatFromEntryPrompt(tabId, pendingEntry)
+        }
     }
 
     fun onChatsIconClicked() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -78,6 +78,7 @@ class DuckChatContextualViewModel @Inject constructor(
     private val modelManager: DuckAiModelManager,
     private val contextualNativeInputManager: ContextualNativeInputManager,
     private val chatHistoryRepository: ChatHistoryRepository,
+    private val contextualEntryPromptStore: ContextualEntryPromptStore,
     private val context: Context,
 ) : ViewModel() {
 
@@ -131,6 +132,10 @@ class DuckChatContextualViewModel @Inject constructor(
 
     @VisibleForTesting
     internal var isPageContextRequested: Boolean = false
+
+    // A prompt handed over from the contextual entry dialog, submitted once the chat web app signals it
+    // is ready (onWebAppReady). Held between opening the sheet in WEBVIEW and that ready signal.
+    private var pendingEntryPrompt: NativeInputPrompt? = null
 
     sealed class Command {
         data class LoadUrl(val url: String) : Command()
@@ -237,6 +242,15 @@ class DuckChatContextualViewModel @Inject constructor(
         contextualNativeInputManager.onContextualReopened(_viewState.value.tabId)
 
         viewModelScope.launch(dispatchers.io()) {
+            val tabId = _viewState.value.tabId
+            val pendingEntry = contextualEntryPromptStore.consume(tabId)
+            if (pendingEntry != null) {
+                // Composed in the entry dialog while the (persisted) sheet was hidden: reload into a fresh
+                // chat and auto-submit. The reload makes the web app re-request its hand-off data, so
+                // onWebAppReady fires again — the same delivery path as the first open.
+                startChatFromEntryPrompt(tabId, pendingEntry)
+                return@launch
+            }
             withContext(dispatchers.main()) {
                 logcat { "Duck.ai: requesting page context after sheet reopened" }
                 isPageContextRequested = true
@@ -309,6 +323,14 @@ class DuckChatContextualViewModel @Inject constructor(
     fun onSheetOpened(tabId: String) {
         _viewState.update { it.copy(tabId = tabId) }
         viewModelScope.launch(dispatchers.io()) {
+            val pendingEntry = contextualEntryPromptStore.consume(tabId)
+            if (pendingEntry != null) {
+                // Composed in the entry dialog: open straight into the chat and auto-submit, rather than
+                // reopening the initial input state. Page context came over with the prompt, so there's no
+                // need to request it again here.
+                startChatFromEntryPrompt(tabId, pendingEntry)
+                return@launch
+            }
             logcat { "Duck.ai: onSheetOpened for tab=$tabId" }
             withContext(dispatchers.main()) {
                 isPageContextRequested = true
@@ -367,6 +389,60 @@ class DuckChatContextualViewModel @Inject constructor(
             }
         }
         duckChatPixels.reportContextualSheetOpened()
+    }
+
+    private suspend fun startChatFromEntryPrompt(
+        tabId: String,
+        entry: ContextualEntryPrompt,
+    ) {
+        pendingEntryPrompt = entry.prompt
+        val chatUrl = duckChat.getDuckChatUrl("", false, sidebar = true)
+        withContext(dispatchers.main()) {
+            entry.serializedPageContext?.let { attachProvidedPageContext(it) }
+            _viewState.update {
+                it.copy(
+                    sheetMode = SheetMode.WEBVIEW,
+                    showFullscreen = hasChatId(chatUrl),
+                    tabId = tabId,
+                    allowsAutomaticContextAttachment = duckChatInternal.isAutomaticContextAttachmentEnabled(),
+                )
+            }
+            commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_EXPANDED))
+            commandChannel.trySend(Command.LoadUrl(chatUrl))
+        }
+    }
+
+    private fun attachProvidedPageContext(serializedPageContext: String) {
+        if (!isContextValid(serializedPageContext)) return
+        currentPageContext = serializedPageContext
+        pageContextState = pageContextState.copy(attachedPage = serializedPageContext)
+        val json = JSONObject(serializedPageContext)
+        _viewState.update {
+            it.copy(
+                showContext = true,
+                userRemovedContext = false,
+                contextTitle = json.optString("title"),
+                contextUrl = json.optString("url"),
+            )
+        }
+    }
+
+    /**
+     * Signalled by the fragment when the chat web app has requested its hand-off data (i.e. it is loaded
+     * and subscribed). Submitting the entry-dialog prompt here — rather than at page-finished — avoids a
+     * race where the prompt event is emitted before the web app can receive it.
+     */
+    fun onWebAppReady() {
+        val entry = pendingEntryPrompt ?: return
+        pendingEntryPrompt = null
+        onPromptSent(
+            prompt = entry.prompt,
+            modelId = entry.modelId,
+            reasoningEffort = entry.reasoningEffort,
+            selectedTool = entry.selectedTool,
+            imagesJson = entry.imagesJson,
+            filesJson = entry.filesJson,
+        )
     }
 
     fun onPromptSent(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -78,7 +78,6 @@ class DuckChatContextualViewModel @Inject constructor(
     private val modelManager: DuckAiModelManager,
     private val contextualNativeInputManager: ContextualNativeInputManager,
     private val chatHistoryRepository: ChatHistoryRepository,
-    private val contextualEntryPromptStore: ContextualEntryPromptStore,
     private val context: Context,
 ) : ViewModel() {
 
@@ -133,10 +132,6 @@ class DuckChatContextualViewModel @Inject constructor(
     @VisibleForTesting
     internal var isPageContextRequested: Boolean = false
 
-    // A prompt handed over from the contextual entry dialog, submitted once the chat web app signals it
-    // is ready (onWebAppReady). Held between opening the sheet in WEBVIEW and that ready signal.
-    private var pendingEntryPrompt: NativeInputPrompt? = null
-
     sealed class Command {
         data class LoadUrl(val url: String) : Command()
         data object SendSubscriptionAuthUpdateEvent : Command()
@@ -155,7 +150,6 @@ class DuckChatContextualViewModel @Inject constructor(
             val showNewChatHeader: Boolean,
             val recentChats: List<ChatHistoryItem>,
         ) : Command()
-        data class ShowNewChatEntryDialog(val tabId: String) : Command()
         data class OpenChatUrl(
             val url: String,
             val sourceTabId: String,
@@ -243,15 +237,6 @@ class DuckChatContextualViewModel @Inject constructor(
         contextualNativeInputManager.onContextualReopened(_viewState.value.tabId)
 
         viewModelScope.launch(dispatchers.io()) {
-            val tabId = _viewState.value.tabId
-            val pendingEntry = contextualEntryPromptStore.consume(tabId)
-            if (pendingEntry != null) {
-                // Composed in the entry dialog while the (persisted) sheet was hidden: reload into a fresh
-                // chat and auto-submit. The reload makes the web app re-request its hand-off data, so
-                // onWebAppReady fires again — the same delivery path as the first open.
-                startChatFromEntryPrompt(tabId, pendingEntry)
-                return@launch
-            }
             withContext(dispatchers.main()) {
                 logcat { "Duck.ai: requesting page context after sheet reopened" }
                 isPageContextRequested = true
@@ -324,14 +309,6 @@ class DuckChatContextualViewModel @Inject constructor(
     fun onSheetOpened(tabId: String) {
         _viewState.update { it.copy(tabId = tabId) }
         viewModelScope.launch(dispatchers.io()) {
-            val pendingEntry = contextualEntryPromptStore.consume(tabId)
-            if (pendingEntry != null) {
-                // Composed in the entry dialog: open straight into the chat and auto-submit, rather than
-                // reopening the initial input state. Page context came over with the prompt, so there's no
-                // need to request it again here.
-                startChatFromEntryPrompt(tabId, pendingEntry)
-                return@launch
-            }
             logcat { "Duck.ai: onSheetOpened for tab=$tabId" }
             withContext(dispatchers.main()) {
                 isPageContextRequested = true
@@ -390,60 +367,6 @@ class DuckChatContextualViewModel @Inject constructor(
             }
         }
         duckChatPixels.reportContextualSheetOpened()
-    }
-
-    private suspend fun startChatFromEntryPrompt(
-        tabId: String,
-        entry: ContextualEntryPrompt,
-    ) {
-        pendingEntryPrompt = entry.prompt
-        val chatUrl = duckChat.getDuckChatUrl("", false, sidebar = true)
-        withContext(dispatchers.main()) {
-            entry.serializedPageContext?.let { attachProvidedPageContext(it) }
-            _viewState.update {
-                it.copy(
-                    sheetMode = SheetMode.WEBVIEW,
-                    showFullscreen = hasChatId(chatUrl),
-                    tabId = tabId,
-                    allowsAutomaticContextAttachment = duckChatInternal.isAutomaticContextAttachmentEnabled(),
-                )
-            }
-            commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_EXPANDED))
-            commandChannel.trySend(Command.LoadUrl(chatUrl))
-        }
-    }
-
-    private fun attachProvidedPageContext(serializedPageContext: String) {
-        if (!isContextValid(serializedPageContext)) return
-        currentPageContext = serializedPageContext
-        pageContextState = pageContextState.copy(attachedPage = serializedPageContext)
-        val json = JSONObject(serializedPageContext)
-        _viewState.update {
-            it.copy(
-                showContext = true,
-                userRemovedContext = false,
-                contextTitle = json.optString("title"),
-                contextUrl = json.optString("url"),
-            )
-        }
-    }
-
-    /**
-     * Signalled by the fragment when the chat web app has requested its hand-off data (i.e. it is loaded
-     * and subscribed). Submitting the entry-dialog prompt here — rather than at page-finished — avoids a
-     * race where the prompt event is emitted before the web app can receive it.
-     */
-    fun onWebAppReady() {
-        val entry = pendingEntryPrompt ?: return
-        pendingEntryPrompt = null
-        onPromptSent(
-            prompt = entry.prompt,
-            modelId = entry.modelId,
-            reasoningEffort = entry.reasoningEffort,
-            selectedTool = entry.selectedTool,
-            imagesJson = entry.imagesJson,
-            filesJson = entry.filesJson,
-        )
     }
 
     fun onPromptSent(
@@ -955,28 +878,7 @@ class DuckChatContextualViewModel @Inject constructor(
 
     fun onNewChatRequestedFromPopup() {
         duckChatPixels.reportContextualSheetNewChatFromPopup()
-        if (duckChatInternal.isContextualSheetRedesignEnabled()) {
-            // Hand New Chat off to the transparent entry dialog: clear the current chat's stored status
-            // now so it isn't resumed, then let the dialog command hide the sheet. sheetState = null so
-            // renderNewChatState emits no ChangeSheetState of its own — a second command would race this
-            // one on the capacity-1 channel and one would be dropped.
-            renderNewChatState(sheetState = null)
-            commandChannel.trySend(Command.ShowNewChatEntryDialog(_viewState.value.tabId))
-        } else {
-            renderNewChatState()
-        }
-    }
-
-    /**
-     * The entry dialog opened from New Chat has parked a composed prompt, so consume it and start a fresh
-     * chat from it (same delivery path as the initial entry hand-off).
-     */
-    fun onNewChatFromEntryDialog() {
-        viewModelScope.launch(dispatchers.io()) {
-            val tabId = _viewState.value.tabId
-            val pendingEntry = contextualEntryPromptStore.consume(tabId) ?: return@launch
-            startChatFromEntryPrompt(tabId, pendingEntry)
-        }
+        renderNewChatState()
     }
 
     fun onChatsIconClicked() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewFragment.kt
@@ -21,21 +21,15 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.graphics.Rect
 import android.net.Uri
 import android.os.Bundle
 import android.os.Environment
 import android.os.Message
 import android.provider.MediaStore
-import android.text.Editable
 import android.text.TextUtils
-import android.text.TextWatcher
-import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewTreeObserver
-import android.view.inputmethod.EditorInfo
 import android.webkit.CookieManager
 import android.webkit.MimeTypeMap
 import android.webkit.ValueCallback
@@ -43,20 +37,14 @@ import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.widget.LinearLayout
-import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.AnyThread
 import androidx.core.content.ContextCompat
-import androidx.core.view.doOnNextLayout
-import androidx.core.view.isInvisible
-import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.InjectWith
-import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
@@ -66,7 +54,6 @@ import com.duckduckgo.common.ui.DuckDuckGoFragment
 import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.ui.view.PopupMenuItemView
 import com.duckduckgo.common.ui.view.dialog.ActionBottomSheetDialog
-import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.makeSnackbarWithNoBottomInset
 import com.duckduckgo.common.ui.view.show
@@ -75,7 +62,6 @@ import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.common.utils.extensions.hideKeyboard
-import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_DELAY
@@ -86,12 +72,11 @@ import com.duckduckgo.downloads.api.DownloadStateListener
 import com.duckduckgo.downloads.api.DownloadsFileActions
 import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.duckchat.api.DuckChatContextual
-import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatHistoryNoParams
 import com.duckduckgo.duckchat.api.viewmodel.DuckChatSharedViewModel
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
-import com.duckduckgo.duckchat.impl.databinding.FragmentContextualDuckAiNativeBinding
+import com.duckduckgo.duckchat.impl.databinding.FragmentContextualDuckAiWebviewBinding
 import com.duckduckgo.duckchat.impl.feature.AIChatDownloadFeature
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.helper.Mode
@@ -104,7 +89,6 @@ import com.duckduckgo.duckchat.impl.ui.filechooser.capture.camera.CameraHardware
 import com.duckduckgo.duckchat.impl.ui.filechooser.capture.launcher.UploadFromExternalMediaAppLauncher
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
-import com.duckduckgo.js.messaging.api.SubscriptionEventData
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.subscriptions.api.SUBSCRIPTIONS_FEATURE_NAME
 import com.duckduckgo.subscriptions.api.SubscriptionsJSHelper
@@ -116,9 +100,7 @@ import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.cancellable
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -128,18 +110,23 @@ import org.json.JSONObject
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Named
-import com.duckduckgo.mobile.android.R as CommonR
 
+/**
+ * The redesign-ON contextual sheet surface. It only ever hosts the chat-in-progress WebView plus the
+ * follow-up composer; the INPUT/entry stage lives in [DuckChatContextualEntryDialog]. Compared to
+ * [DuckChatContextualFragment] this drops the suggestions carousel, quick action, legacy composer and
+ * keyboard-driven sheet sizing.
+ */
 @InjectWith(FragmentScope::class)
-class DuckChatContextualFragment :
-    DuckDuckGoFragment(R.layout.fragment_contextual_duck_ai_native),
+class DuckChatContextualWebViewFragment :
+    DuckDuckGoFragment(R.layout.fragment_contextual_duck_ai_webview),
     DownloadConfirmationDialogListener {
 
     @Inject
     lateinit var viewModelFactory: FragmentViewModelFactory
 
-    private val viewModel: DuckChatContextualViewModel by lazy {
-        ViewModelProvider(this, viewModelFactory)[DuckChatContextualViewModel::class.java]
+    private val viewModel: DuckChatContextualWebViewViewModel by lazy {
+        ViewModelProvider(this, viewModelFactory)[DuckChatContextualWebViewViewModel::class.java]
     }
 
     private val sharedContextualViewModel: DuckChatContextualSharedViewModel by viewModels({ requireParentFragment() })
@@ -202,9 +189,6 @@ class DuckChatContextualFragment :
     lateinit var globalActivityStarter: GlobalActivityStarter
 
     @Inject
-    lateinit var faviconManager: FaviconManager
-
-    @Inject
     lateinit var contextualNativeInputManager: ContextualNativeInputManager
 
     @Inject
@@ -224,7 +208,7 @@ class DuckChatContextualFragment :
     private var pendingFileDownload: FileDownloader.PendingFileDownload? = null
     private val downloadMessagesJob = ConflatedJob()
 
-    private val binding: FragmentContextualDuckAiNativeBinding by viewBinding()
+    private val binding: FragmentContextualDuckAiWebviewBinding by viewBinding()
     private var pendingUploadTask: ValueCallback<Array<Uri>>? = null
 
     private val root: ViewGroup by lazy { binding.root }
@@ -232,37 +216,8 @@ class DuckChatContextualFragment :
     private lateinit var bottomSheetBehavior: BottomSheetBehavior<View>
     private lateinit var backPressedCallback: OnBackPressedCallback
     internal val simpleWebview: WebView by lazy { binding.simpleWebview }
-    private var isKeyboardVisible = false
     private var chatsPopup: PopupMenu? = null
 
-    private val keyboardVisibilityListener =
-        ViewTreeObserver.OnGlobalLayoutListener {
-            runCatching {
-                updateContentAreaHeight()
-                val rootView = binding.root
-                val rect = Rect()
-                rootView.getWindowVisibleDisplayFrame(rect)
-                val visibleHeight = rect.height()
-                val totalHeight = rootView.rootView.height
-                val heightDiff = totalHeight - visibleHeight
-                val threshold = (resources.displayMetrics.density * 100).toInt()
-                val imeVisible = heightDiff > threshold
-                if (imeVisible != isKeyboardVisible) {
-                    isKeyboardVisible = imeVisible
-                    if (!imeVisible) {
-                        reserveSpaceForSuggestions()
-                    }
-                    val composerHasFocus = if (viewModel.viewState.value.contextualNativeInputEnabled) {
-                        binding.contextualNativeInputWidget.hasFocus()
-                    } else {
-                        binding.contextualModeNativeContent.hasFocus()
-                    }
-                    if (composerHasFocus) {
-                        viewModel.onKeyboardVisibilityChanged(imeVisible)
-                    }
-                }
-            }
-        }
     private val bottomSheetCallback =
         object : BottomSheetBehavior.BottomSheetCallback() {
             override fun onStateChanged(
@@ -271,20 +226,14 @@ class DuckChatContextualFragment :
             ) {
                 if (newState == BottomSheetBehavior.STATE_HIDDEN) {
                     viewModel.onSheetClosed()
-                    binding.contextualSuggestionsView.clear()
-                }
-                if (newState == BottomSheetBehavior.STATE_HALF_EXPANDED) {
-                    bottomSheet.requestLayout()
                 }
                 backPressedCallback.isEnabled = newState != BottomSheetBehavior.STATE_HIDDEN
-                updateContentAreaHeight()
             }
 
             override fun onSlide(
                 bottomSheet: View,
                 slideOffset: Float,
             ) {
-                updateContentAreaHeight()
             }
         }
 
@@ -441,6 +390,8 @@ class DuckChatContextualFragment :
                                             if (method == RealDuckChatJSHelper.METHOD_GET_AI_CHAT_NATIVE_HANDOFF_DATA) {
                                                 logcat { "Duck.ai: requesting page context after chat fully loaded" }
                                                 sharedContextualViewModel.requestPageContext()
+                                                // Submit any prompt handed over from the entry dialog now that the web app is ready.
+                                                viewModel.onWebAppReady()
                                             }
                                         }
                                     }
@@ -496,7 +447,7 @@ class DuckChatContextualFragment :
         configureBottomSheet(view)
         setupBackPressHandling()
         val tabId = requireNotNull(requireArguments().getString(KEY_DUCK_AI_CONTEXTUAL_TAB_ID)) {
-            "DuckChatContextualFragment requires $KEY_DUCK_AI_CONTEXTUAL_TAB_ID argument"
+            "DuckChatContextualWebViewFragment requires $KEY_DUCK_AI_CONTEXTUAL_TAB_ID argument"
         }
         contextualNativeInputManager.init(
             tabId = tabId,
@@ -529,7 +480,7 @@ class DuckChatContextualFragment :
             onPageContextRemoved = { viewModel.removePageContext() },
             onVoiceChatRequested = {
                 viewModel.onContextualClose()
-                duckChat.openVoiceDuckChat(DuckChatEntryPoint.VOICE)
+                duckChat.openVoiceDuckChat()
             },
             onVoiceSearchRequested = {
                 activity?.hideKeyboard()
@@ -539,40 +490,13 @@ class DuckChatContextualFragment :
         observeViewModel()
 
         viewModel.onSheetOpened(tabId)
-        setupKeyboardVisibilityListener()
     }
 
     private fun configureBottomSheet(view: View) {
         val parent = view.parent as? View ?: return
         bottomSheetBehavior = BottomSheetBehavior.from(parent)
-
         configureBehaviour(bottomSheetBehavior)
         configureButtons()
-        configureSuggestions()
-        binding.contextualModeRoot.doOnNextLayout { reserveSpaceForSuggestions() }
-        binding.contextualInputContainer.addOnLayoutChangeListener { _, _, top, _, bottom, _, oldTop, _, oldBottom ->
-            if (bottom - top != oldBottom - oldTop) reserveSpaceForSuggestions()
-        }
-    }
-
-    private fun isSheetVisible(): Boolean = bottomSheetBehavior.state != BottomSheetBehavior.STATE_HIDDEN
-
-    private fun reserveSpaceForSuggestions() {
-        if (!viewModel.viewState.value.contextualSuggestionsEnabled) return
-        if (isKeyboardVisible) return
-        val sheet = binding.contextualModeRoot.parent as? View ?: return
-        val coordinatorHeight = (sheet.parent as? View)?.height?.takeIf { it > 0 } ?: return
-        val prompts = binding.contextualModePrompts.getChildAt(0) ?: return
-        val cardHeight = binding.contextualPromptQuickAction.height + resources.getDimensionPixelSize(CommonR.dimen.keyline_2)
-        val reservedSpace = binding.contextualModeButtons.height + binding.contextualInputContainer.height +
-            prompts.paddingTop + prompts.paddingBottom + MAX_PROMPT_CARDS * cardHeight
-        val ratio = (reservedSpace.toFloat() / coordinatorHeight).coerceIn(HALF_EXPANDED_RATIO, MAX_HALF_EXPANDED_RATIO)
-        if (bottomSheetBehavior.halfExpandedRatio != ratio) {
-            bottomSheetBehavior.halfExpandedRatio = ratio
-            if (bottomSheetBehavior.state == BottomSheetBehavior.STATE_HALF_EXPANDED) {
-                sheet.requestLayout()
-            }
-        }
     }
 
     private fun configureBehaviour(bottomSheetBehavior: BottomSheetBehavior<View>) {
@@ -583,42 +507,6 @@ class DuckChatContextualFragment :
         bottomSheetBehavior.isFitToContents = false
         bottomSheetBehavior.expandedOffset = 0
         bottomSheetBehavior.halfExpandedRatio = HALF_EXPANDED_RATIO
-    }
-
-    private fun updateContentAreaHeight() {
-        // contextualContentArea holds either the contextual prompts or the chat webview.
-        val contentArea = binding.contextualContentArea
-        // Let the content area flex (weight 1) to fill the remaining height, input kept as wrap_content
-        // below it, when:
-        //  - WEBVIEW mode: the webview should always take the rest; never resize it per-frame (glitches).
-        //  - Expanded: the sheet fills the coordinator, so BrowserActivity's adjustResize can lift the
-        //    input above the keyboard natively instead of the per-frame resize below fighting the IME.
-        val isWebViewMode = viewModel.viewState.value.sheetMode == DuckChatContextualViewModel.SheetMode.WEBVIEW
-        if (isWebViewMode || bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
-            val params = contentArea.layoutParams as LinearLayout.LayoutParams
-            if (params.height != 0 || params.weight != 1f) {
-                contentArea.updateLayoutParams<LinearLayout.LayoutParams> {
-                    weight = 1f
-                    height = 0
-                }
-            }
-            return
-        }
-
-        val sheet = binding.contextualModeRoot.parent as? View ?: return
-        val coordinatorHeight = (sheet.parent as? View)?.height ?: return
-        if (coordinatorHeight <= 0) return
-        val halfExpandedHeight = (coordinatorHeight * bottomSheetBehavior.halfExpandedRatio).toInt()
-        val visibleSheetHeight = (coordinatorHeight - sheet.top).coerceAtLeast(halfExpandedHeight)
-        val chromeHeight = binding.contextualModeButtons.height + binding.contextualInputContainer.height
-        val contentHeight = (visibleSheetHeight - chromeHeight).coerceAtLeast(0)
-        // Size the middle to the visible sheet minus header + input, so the input sits on the visible edge.
-        if (contentArea.layoutParams.height != contentHeight) {
-            contentArea.updateLayoutParams<LinearLayout.LayoutParams> {
-                weight = 0f
-                height = contentHeight
-            }
-        }
     }
 
     private fun setupBackPressHandling() {
@@ -639,7 +527,7 @@ class DuckChatContextualFragment :
             viewModel.onContextualClose()
         }
         binding.contextualNewChat.setOnClickListener {
-            hideKeyboard(binding.legacyInputField)
+            activity?.hideKeyboard()
             viewModel.onChatsIconClicked()
         }
         binding.contextualFire.setOnClickListener {
@@ -647,157 +535,67 @@ class DuckChatContextualFragment :
         }
         binding.contextualModeButtons.setOnClickListener { }
         binding.contextualModeRoot.setOnClickListener { }
-        binding.legacyInputField.setOnEditorActionListener(
-            TextView.OnEditorActionListener { _, actionId, keyEvent ->
-                if (actionId == EditorInfo.IME_ACTION_GO || keyEvent?.keyCode == KeyEvent.KEYCODE_ENTER) {
-                    sendNativePrompt()
-                    return@OnEditorActionListener true
-                }
-                false
-            },
-        )
-        binding.legacyInputField.addTextChangedListener(
-            object : TextWatcher {
-                override fun beforeTextChanged(
-                    s: CharSequence?,
-                    start: Int,
-                    count: Int,
-                    after: Int,
-                ) {
-                    // NOOP
-                }
-
-                override fun onTextChanged(
-                    s: CharSequence?,
-                    start: Int,
-                    before: Int,
-                    count: Int,
-                ) {
-                    // NOOP
-                }
-
-                override fun afterTextChanged(text: Editable?) {
-                    binding.duckAiContextualSend.isEnabled = !text.toString().isEmpty()
-                    binding.duckAiContextualClearText.isInvisible = text.toString().isEmpty()
-                }
-            },
-        )
-        binding.duckAiContextualSend.setOnClickListener {
-            sendNativePrompt()
-        }
-
-        binding.duckAiContextualClearText.setOnClickListener {
-            // Typed text lives only in the EditText (it isn't mirrored into the ViewModel), so clear it directly.
-            clearInputField()
-        }
-
         binding.contextualFullScreen.setOnClickListener {
             viewModel.onFullModeRequested()
         }
-        binding.duckAiContextualPageRemove.setOnClickListener {
-            viewModel.removePageContext()
-        }
-        binding.contextualPromptQuickAction.setOnClickListener {
-            val currentInput = if (viewModel.viewState.value.contextualNativeInputEnabled) {
-                binding.contextualNativeInputWidget.text
-            } else {
-                binding.legacyInputField.text.toString()
-            }
-            viewModel.onQuickActionClicked(currentInput, binding.contextualSuggestionsView.currentPageType())
-        }
-    }
-
-    private fun clearInputField() {
-        binding.legacyInputField.text.clear()
-        binding.legacyInputField.setSelection(0)
-        binding.legacyInputField.scrollTo(0, 0)
-    }
-
-    private fun sendNativePrompt() {
-        val prompt = binding.legacyInputField.text.toString()
-        if (prompt.isNotEmpty()) {
-            viewModel.onPromptSent(prompt)
-            clearInputField()
-            hideKeyboard(binding.legacyInputField)
-        }
-    }
-
-    private fun openDuckAiWithPrompt(query: String) {
-        duckChat.openDuckChatWithAutoPrompt(query, DuckChatEntryPoint.CONTEXTUAL_CHAT)
     }
 
     private fun observeViewModel() {
         viewModel.commands
             .onEach { command ->
                 when (command) {
-                    is DuckChatContextualViewModel.Command.SendSubscriptionAuthUpdateEvent -> {
-                        val authUpdateEvent = SubscriptionEventData(
-                            featureName = SUBSCRIPTIONS_FEATURE_NAME,
-                            subscriptionName = "authUpdate",
-                            params = JSONObject(),
-                        )
-                        contentScopeScripts.sendSubscriptionEvent(authUpdateEvent)
-                    }
-
-                    is DuckChatContextualViewModel.Command.LoadUrl -> {
+                    is DuckChatContextualWebViewViewModel.Command.LoadUrl -> {
                         simpleWebview.loadUrl(command.url)
                     }
 
-                    is DuckChatContextualViewModel.Command.OpenFullscreenMode -> {
-                        binding.root.viewTreeObserver.removeOnGlobalLayoutListener(keyboardVisibilityListener)
+                    is DuckChatContextualWebViewViewModel.Command.OpenFullscreenMode -> {
                         val result = Bundle().apply {
                             putString(DuckChatContextual.RESULT_URL, command.url)
                         }
-
                         setFragmentResult(DuckChatContextual.RESULT_KEY, result)
                     }
 
-                    is DuckChatContextualViewModel.Command.ChangeSheetState -> {
+                    is DuckChatContextualWebViewViewModel.Command.ChangeSheetState -> {
                         command.prefillNativeInput?.let { binding.contextualNativeInputWidget.text = it }
                         if (command.hideKeyboard) activity?.hideKeyboard()
                         bottomSheetBehavior.state = command.newState
                     }
-                    is DuckChatContextualViewModel.Command.RequestPageContext -> {
+
+                    is DuckChatContextualWebViewViewModel.Command.RequestPageContext -> {
                         sharedContextualViewModel.requestPageContext()
                     }
 
-                    is DuckChatContextualViewModel.Command.ShowFireConfirmation -> {
+                    is DuckChatContextualWebViewViewModel.Command.ShowFireConfirmation -> {
                         showFireConfirmationDialog()
                     }
 
-                    is DuckChatContextualViewModel.Command.ShowChatsPopup -> {
-                        showChatsPopup(command.showNewChatHeader, command.recentChats)
+                    is DuckChatContextualWebViewViewModel.Command.ShowChatsPopup -> {
+                        showChatsPopup(command.recentChats)
                     }
 
-                    is DuckChatContextualViewModel.Command.OpenChatUrl -> {
+                    is DuckChatContextualWebViewViewModel.Command.ShowNewChatEntryDialog -> {
+                        // Hide the running chat so it isn't left dimmed behind the transparent entry dialog.
+                        bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
+                        showContextualEntryDialogForNewChat(command.tabId)
+                    }
+
+                    is DuckChatContextualWebViewViewModel.Command.OpenChatUrl -> {
                         viewModel.onContextualClose()
                         startActivity(browserNav.openInNewTab(requireContext(), command.url, command.sourceTabId))
                     }
 
-                    is DuckChatContextualViewModel.Command.LaunchChatHistory -> {
+                    is DuckChatContextualWebViewViewModel.Command.LaunchChatHistory -> {
                         viewModel.onContextualClose()
                         globalActivityStarter.start(requireContext(), DuckChatHistoryNoParams)
                     }
 
-                    is DuckChatContextualViewModel.Command.OpenSearchInNewTab -> {
+                    is DuckChatContextualWebViewViewModel.Command.OpenSearchInNewTab -> {
                         viewModel.onContextualClose()
                         startActivity(browserNav.openInNewTab(requireContext(), command.query))
                     }
 
-                    is DuckChatContextualViewModel.Command.OpenDuckAiWithPrompt -> {
-                        viewModel.onContextualClose()
-                        openDuckAiWithPrompt(command.query)
-                    }
-
-                    is DuckChatContextualViewModel.Command.FocusInput -> {
-                        if (viewModel.viewState.value.contextualNativeInputEnabled) {
-                            binding.contextualNativeInputWidget.focusInput(activity)
-                        } else {
-                            binding.legacyInputField.let {
-                                it.requestFocus()
-                                activity?.showKeyboard(it)
-                            }
-                        }
+                    is DuckChatContextualWebViewViewModel.Command.FocusInput -> {
+                        binding.contextualNativeInputWidget.focusInput(activity)
                     }
                 }
             }.launchIn(lifecycleScope)
@@ -806,23 +604,12 @@ class DuckChatContextualFragment :
             .onEach { command ->
                 when (command) {
                     is DuckChatContextualSharedViewModel.Command.PageContextAttached -> {
-                        viewModel.onPageContextReceived(command.tabId, command.pageContext, command.isStorePageContextEnabled)
-                        if (isSheetVisible() && viewModel.viewState.value.sheetMode == DuckChatContextualViewModel.SheetMode.INPUT) {
-                            binding.contextualSuggestionsView.onPageContextUpdated(command.pageContext)
-                        }
-                    }
-
-                    is DuckChatContextualSharedViewModel.Command.MainBrowserPageFinished -> {
-                        viewModel.onMainBrowserPageFinished(command.isStorePageContextEnabled)
+                        viewModel.onPageContextReceived(command.tabId, command.pageContext)
                     }
 
                     DuckChatContextualSharedViewModel.Command.ReloadChat -> {
                         logcat { "Duck.ai Contextual: ReloadChat" }
-                        setupKeyboardVisibilityListener()
                         viewModel.onSheetReopened()
-                        if (viewModel.viewState.value.sheetMode == DuckChatContextualViewModel.SheetMode.INPUT) {
-                            binding.contextualSuggestionsView.load()
-                        }
                     }
 
                     is DuckChatContextualSharedViewModel.Command.OnContextualFireConfirmed -> {
@@ -838,25 +625,10 @@ class DuckChatContextualFragment :
                 renderViewState(viewState)
             }.launchIn(lifecycleScope)
 
-        viewModel.viewState
-            .map { it.sheetMode }
-            .distinctUntilChanged()
-            .onEach { sheetMode ->
-                when (sheetMode) {
-                    DuckChatContextualViewModel.SheetMode.INPUT -> binding.contextualSuggestionsView.load()
-                    DuckChatContextualViewModel.SheetMode.WEBVIEW -> binding.contextualSuggestionsView.clear()
-                }
-            }.launchIn(lifecycleScope)
-
         observeSubscriptionEventDataChannel()
     }
 
-    private fun setupKeyboardVisibilityListener() {
-        binding.root.viewTreeObserver.removeOnGlobalLayoutListener(keyboardVisibilityListener)
-        binding.root.viewTreeObserver.addOnGlobalLayoutListener(keyboardVisibilityListener)
-    }
-
-    private fun renderViewState(viewState: DuckChatContextualViewModel.ViewState) {
+    private fun renderViewState(viewState: DuckChatContextualWebViewViewModel.ViewState) {
         logcat { "Duck.ai Contextual: render $viewState" }
         if (viewState.showFullscreen) {
             binding.contextualFullScreen.show()
@@ -864,55 +636,9 @@ class DuckChatContextualFragment :
             binding.contextualFullScreen.gone()
         }
 
-        applyQuickActionVisibility(viewState)
-        binding.legacyInputField.setHint(R.string.contextualSheetImprovedHint)
-
-        binding.contextualNewChat.setImageResource(com.duckduckgo.mobile.android.R.drawable.ic_chats_24)
-
-        when (viewState.sheetMode) {
-            DuckChatContextualViewModel.SheetMode.INPUT -> {
-                binding.contextualWebviewContainer.gone()
-                binding.contextualModePrompts.show()
-                binding.contextualInputContainer.setBackgroundColor(
-                    requireContext().getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorBackground),
-                )
-                contextualNativeInputManager.onInputMode()
-
-                binding.contextualNewChat.show()
-                binding.contextualFire.gone()
-
-                if (viewState.contextualNativeInputEnabled) {
-                    // The unified input widget is the INPUT composer; ContextualNativeInputManager.onInputMode()
-                    // shows its card. Hide the legacy EditText composer and its context chip/placeholder.
-                    binding.contextualModeNativeContent.gone()
-                } else {
-                    binding.contextualModeNativeContent.show()
-
-                    renderPageContext(viewState.contextTitle, viewState.contextUrl, viewState.tabId)
-
-                    if (viewState.quickActionState != DuckChatContextualViewModel.QuickActionState.ASK_ABOUT_PAGE &&
-                        viewState.showContext
-                    ) {
-                        binding.duckAiContextualLayout.show()
-                    } else {
-                        binding.duckAiContextualLayout.gone()
-                    }
-                    clearInputField()
-                }
-            }
-
-            DuckChatContextualViewModel.SheetMode.WEBVIEW -> {
-                binding.contextualModeNativeContent.gone()
-                binding.contextualModePrompts.gone()
-                binding.contextualInputContainer.setBackgroundColor(
-                    requireContext().getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorDuckAiBackground),
-                )
-                binding.contextualWebviewContainer.show()
-                binding.contextualNewChat.show()
-                if (viewState.isFireButtonEnabled) binding.contextualFire.show() else binding.contextualFire.gone()
-                contextualNativeInputManager.onWebViewMode()
-            }
-        }
+        binding.contextualNewChat.show()
+        if (viewState.isFireButtonEnabled) binding.contextualFire.show() else binding.contextualFire.gone()
+        contextualNativeInputManager.onWebViewMode()
 
         if (viewState.showContext && viewState.contextTitle.isNotEmpty()) {
             binding.contextualNativeInputWidget.setPageContext(
@@ -928,39 +654,18 @@ class DuckChatContextualFragment :
         duckChatSharedViewModel.onContextualFireButtonClicked()
     }
 
-    private fun applyQuickActionVisibility(viewState: DuckChatContextualViewModel.ViewState) {
-        val isSummarizeQuickAction =
-            viewState.quickActionState == DuckChatContextualViewModel.QuickActionState.SUBMIT_SUMMARIZE
-
-        binding.contextualSuggestionsView.setReservedQuickActionSlots(
-            if (viewState.quickActionState == DuckChatContextualViewModel.QuickActionState.ASK_ABOUT_PAGE) 1 else 0,
-        )
-
-        if (isSummarizeQuickAction && binding.contextualSuggestionsView.hasContent()) {
-            binding.contextualPromptQuickAction.gone()
-        } else {
-            binding.contextualPromptQuickAction.show()
-            binding.contextualPromptQuickAction.setText(viewState.quickActionState.labelResId)
-            binding.contextualPromptQuickAction.setCompoundDrawablesRelativeWithIntrinsicBounds(viewState.quickActionState.iconResId, 0, 0, 0)
-        }
+    private fun showContextualEntryDialogForNewChat(tabId: String) {
+        val fragmentManager = parentFragment?.childFragmentManager ?: return
+        if (fragmentManager.isStateSaved) return
+        DuckChatContextualEntryDialog
+            // Route the hand-off through the host so it re-shows the sheet container (hidden when New Chat
+            // opened this dialog); the reopened sheet then consumes the parked prompt in onSheetReopened.
+            .newInstance(tabId) { sharedContextualViewModel.requestShowSheet(tabId) }
+            .show(fragmentManager, DuckChatContextualEntryDialog.TAG)
     }
 
-    private fun configureSuggestions() {
-        binding.contextualSuggestionsView.onSuggestionSelected = { suggestion ->
-            val currentInput = if (viewModel.viewState.value.contextualNativeInputEnabled) {
-                binding.contextualNativeInputWidget.text
-            } else {
-                binding.legacyInputField.text.toString()
-            }
-            viewModel.onSuggestionSelected(suggestion, currentInput)
-        }
-        binding.contextualSuggestionsView.onContentChanged = {
-            applyQuickActionVisibility(viewModel.viewState.value)
-        }
-    }
-
-    private fun showChatsPopup(showNewChatHeader: Boolean, recentChats: List<ChatHistoryItem>) {
-        logcat { "Duck.ai Contextual: showChatsPopup header=$showNewChatHeader chats=${recentChats.size}" }
+    private fun showChatsPopup(recentChats: List<ChatHistoryItem>) {
+        logcat { "Duck.ai Contextual: showChatsPopup chats=${recentChats.size}" }
         val popup = PopupMenu(
             layoutInflater = layoutInflater,
             resourceId = R.layout.popup_contextual_chats_menu,
@@ -968,13 +673,12 @@ class DuckChatContextualFragment :
         )
         val content = popup.contentView
 
+        // The webview surface always exposes New Chat (there is always a chat in progress to replace).
         val newChatRow = content.findViewById<PopupMenuItemView>(R.id.contextualChatsPopupNewChat)
         val headerDivider = content.findViewById<View>(R.id.contextualChatsPopupHeaderDivider)
-        newChatRow.visibility = if (showNewChatHeader) View.VISIBLE else View.GONE
-        headerDivider.visibility = if (showNewChatHeader) View.VISIBLE else View.GONE
-        if (showNewChatHeader) {
-            popup.onMenuItemClicked(newChatRow) { viewModel.onNewChatRequestedFromPopup() }
-        }
+        newChatRow.visibility = View.VISIBLE
+        headerDivider.visibility = View.VISIBLE
+        popup.onMenuItemClicked(newChatRow) { viewModel.onNewChatRequestedFromPopup() }
 
         val recentContainer = content.findViewById<LinearLayout>(R.id.contextualChatsPopupRecentContainer)
         recentContainer.removeAllViews()
@@ -1011,17 +715,6 @@ class DuckChatContextualFragment :
         viewModel.subscriptionEventDataFlow.onEach { subscriptionEventData ->
             contentScopeScripts.sendSubscriptionEvent(subscriptionEventData)
         }.launchIn(lifecycleScope)
-    }
-
-    private fun renderPageContext(
-        pageTitle: String,
-        pageUrl: String,
-        tabId: String,
-    ) {
-        binding.duckAiContextualPageTitle.text = pageTitle
-        viewModel.viewModelScope.launch {
-            faviconManager.loadToViewFromLocalWithPlaceholder(tabId, pageUrl, binding.duckAiContextualFavicon)
-        }
     }
 
     private fun launchCameraCapture(callback: ValueCallback<Array<Uri>>) {
@@ -1308,7 +1001,6 @@ class DuckChatContextualFragment :
 
     override fun onDestroyView() {
         bottomSheetBehavior.removeBottomSheetCallback(bottomSheetCallback)
-        binding.root.viewTreeObserver.removeOnGlobalLayoutListener(keyboardVisibilityListener)
         super.onDestroyView()
         appCoroutineScope.launch(dispatcherProvider.io()) {
             cookieManager?.flush()
@@ -1317,8 +1009,6 @@ class DuckChatContextualFragment :
 
     companion object {
         private const val HALF_EXPANDED_RATIO = 0.5f
-        private const val MAX_HALF_EXPANDED_RATIO = 0.9f
-        private const val MAX_PROMPT_CARDS = 4
         private const val MAX_CHAT_TITLE_LINES = 1
         private const val PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE = 200
         private const val CUSTOM_UA =

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewFragment.kt
@@ -72,6 +72,7 @@ import com.duckduckgo.downloads.api.DownloadStateListener
 import com.duckduckgo.downloads.api.DownloadsFileActions
 import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.duckchat.api.DuckChatContextual
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatHistoryNoParams
 import com.duckduckgo.duckchat.api.viewmodel.DuckChatSharedViewModel
 import com.duckduckgo.duckchat.impl.DuckChatInternal
@@ -480,7 +481,7 @@ class DuckChatContextualWebViewFragment :
             onPageContextRemoved = { viewModel.removePageContext() },
             onVoiceChatRequested = {
                 viewModel.onContextualClose()
-                duckChat.openVoiceDuckChat()
+                duckChat.openVoiceDuckChat(DuckChatEntryPoint.VOICE)
             },
             onVoiceSearchRequested = {
                 activity?.hideKeyboard()
@@ -596,6 +597,14 @@ class DuckChatContextualWebViewFragment :
 
                     is DuckChatContextualWebViewViewModel.Command.FocusInput -> {
                         binding.contextualNativeInputWidget.focusInput(activity)
+                    }
+
+                    is DuckChatContextualWebViewViewModel.Command.ApplyContextualReopened -> {
+                        contextualNativeInputManager.onContextualReopened(command.tabId)
+                    }
+
+                    is DuckChatContextualWebViewViewModel.Command.ApplyContextualClosed -> {
+                        contextualNativeInputManager.onContextualClosed(command.tabId)
                     }
                 }
             }.launchIn(viewLifecycleOwner.lifecycleScope)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewFragment.kt
@@ -598,7 +598,7 @@ class DuckChatContextualWebViewFragment :
                         binding.contextualNativeInputWidget.focusInput(activity)
                     }
                 }
-            }.launchIn(lifecycleScope)
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
 
         sharedContextualViewModel.commands
             .onEach { command ->
@@ -618,12 +618,12 @@ class DuckChatContextualWebViewFragment :
 
                     else -> {}
                 }
-            }.launchIn(lifecycleScope)
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
 
         viewModel.viewState
             .onEach { viewState ->
                 renderViewState(viewState)
-            }.launchIn(lifecycleScope)
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
 
         observeSubscriptionEventDataChannel()
     }
@@ -657,10 +657,10 @@ class DuckChatContextualWebViewFragment :
     private fun showContextualEntryDialogForNewChat(tabId: String) {
         val fragmentManager = parentFragment?.childFragmentManager ?: return
         if (fragmentManager.isStateSaved) return
+        // The dialog asks the host to re-show the sheet container (hidden when New Chat opened it) itself;
+        // the reopened sheet then consumes the parked prompt in onSheetReopened.
         DuckChatContextualEntryDialog
-            // Route the hand-off through the host so it re-shows the sheet container (hidden when New Chat
-            // opened this dialog); the reopened sheet then consumes the parked prompt in onSheetReopened.
-            .newInstance(tabId) { sharedContextualViewModel.requestShowSheet(tabId) }
+            .newInstance(tabId)
             .show(fragmentManager, DuckChatContextualEntryDialog.TAG)
     }
 
@@ -714,7 +714,7 @@ class DuckChatContextualWebViewFragment :
     private fun observeSubscriptionEventDataChannel() {
         viewModel.subscriptionEventDataFlow.onEach { subscriptionEventData ->
             contentScopeScripts.sendSubscriptionEvent(subscriptionEventData)
-        }.launchIn(lifecycleScope)
+        }.launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
     private fun launchCameraCapture(callback: ValueCallback<Array<Uri>>) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -186,6 +186,9 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
                 startChatFromEntryPrompt(tabId, pendingEntry)
                 return@launch
             }
+            // No fresh prompt for this open — drop any leftover from an aborted hand-off (sheet dismissed
+            // before onWebAppReady) so this load's onWebAppReady doesn't auto-submit a stale prompt.
+            pendingEntryPrompt = null
             logcat { "Duck.ai: onSheetOpened for tab=$tabId" }
             withContext(dispatchers.main()) {
                 commandChannel.trySend(Command.RequestPageContext)
@@ -220,6 +223,9 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
                 startChatFromEntryPrompt(tabId, pendingEntry)
                 return@launch
             }
+            // No fresh prompt for this reopen — drop any leftover from an aborted hand-off (sheet dismissed
+            // before onWebAppReady) so this load's onWebAppReady doesn't auto-submit a stale prompt.
+            pendingEntryPrompt = null
             withContext(dispatchers.main()) {
                 logcat { "Duck.ai: requesting page context after sheet reopened" }
                 commandChannel.trySend(Command.RequestPageContext)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -74,7 +74,6 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
     private val duckChatPixels: DuckChatPixels,
     private val duckChatFeature: DuckChatFeature,
     private val modelManager: DuckAiModelManager,
-    private val contextualNativeInputManager: ContextualNativeInputManager,
     private val chatHistoryRepository: ChatHistoryRepository,
     private val contextualEntryPromptStore: ContextualEntryPromptStore,
 ) : ViewModel() {
@@ -132,6 +131,8 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         data object LaunchChatHistory : Command()
         data object FocusInput : Command()
         data class OpenSearchInNewTab(val query: String) : Command()
+        data class ApplyContextualReopened(val tabId: String) : Command()
+        data class ApplyContextualClosed(val tabId: String) : Command()
     }
 
     private val _viewState: MutableStateFlow<ViewState> = MutableStateFlow(ViewState())
@@ -211,7 +212,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
 
     fun onSheetReopened() {
         logcat { "Duck.ai: onSheetReopened" }
-        contextualNativeInputManager.onContextualReopened(_viewState.value.tabId)
+        commandChannel.trySend(Command.ApplyContextualReopened(_viewState.value.tabId))
 
         viewModelScope.launch(dispatchers.io()) {
             val tabId = _viewState.value.tabId
@@ -531,7 +532,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         }
         persistTabClosed()
         duckChatPixels.reportContextualSheetDismissed()
-        contextualNativeInputManager.onContextualClosed(_viewState.value.tabId)
+        commandChannel.trySend(Command.ApplyContextualClosed(_viewState.value.tabId))
     }
 
     private fun persistTabClosed() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -1,0 +1,753 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual
+
+import androidx.core.net.toUri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.toChatIdOrNull
+import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
+import com.duckduckgo.duckchat.impl.helper.NativeAction
+import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
+import com.duckduckgo.duckchat.impl.history.ChatHistoryItem
+import com.duckduckgo.duckchat.impl.history.ChatHistoryRepository
+import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
+import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
+import com.duckduckgo.js.messaging.api.SubscriptionEventData
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import logcat.logcat
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+import javax.inject.Inject
+
+/**
+ * Drives the redesign-ON contextual sheet, which only ever shows the chat-in-progress WebView (the
+ * INPUT/entry stage lives in [DuckChatContextualEntryDialog]). Compared to [DuckChatContextualViewModel]
+ * this drops all SheetMode/QuickAction/suggestions/keyboard-driven-sheet-state logic; the sheet is
+ * always in the WebView state and carries only the follow-up composer alongside the chat.
+ */
+@ContributesViewModel(FragmentScope::class)
+class DuckChatContextualWebViewViewModel @Inject constructor(
+    private val dispatchers: DispatcherProvider,
+    private val duckChat: DuckChat,
+    private val duckChatInternal: DuckChatInternal,
+    private val duckChatJSHelper: DuckChatJSHelper,
+    private val contextualDataStore: DuckChatContextualDataStore,
+    private val sessionTimeoutProvider: DuckChatContextualSessionTimeoutProvider,
+    private val timeProvider: DuckChatContextualTimeProvider,
+    private val duckChatPixels: DuckChatPixels,
+    private val duckChatFeature: DuckChatFeature,
+    private val modelManager: DuckAiModelManager,
+    private val contextualNativeInputManager: ContextualNativeInputManager,
+    private val chatHistoryRepository: ChatHistoryRepository,
+    private val contextualEntryPromptStore: ContextualEntryPromptStore,
+) : ViewModel() {
+
+    private val commandChannel = Channel<Command>(capacity = 1, onBufferOverflow = DROP_OLDEST)
+    val commands = commandChannel.receiveAsFlow()
+
+    private val _subscriptionEventDataChannel = Channel<SubscriptionEventData>(capacity = Channel.BUFFERED)
+    val subscriptionEventDataFlow = _subscriptionEventDataChannel.receiveAsFlow()
+
+    private var fullModeUrl: String = ""
+
+    private data class PageContextState(
+        // The current page reported by the browser — what a manual attach grabs.
+        val currentPage: String = "",
+        // The frozen snapshot actually submitted for the current attachment, so passive navigation
+        // doesn't change what an existing attachment sends.
+        val attachedPage: String = "",
+    )
+
+    private var pageContextState = PageContextState()
+
+    var currentPageContext: String
+        get() = pageContextState.currentPage
+        set(value) {
+            pageContextState = pageContextState.copy(currentPage = value)
+        }
+
+    // Chat id currently shown in the contextual webview, derived from the URL query param.
+    private val _chatId = MutableStateFlow<String?>(null)
+    val chatId: StateFlow<String?> = _chatId.asStateFlow()
+
+    // A prompt handed over from the contextual entry dialog, submitted once the chat web app signals it
+    // is ready (onWebAppReady). Held between opening the sheet and that ready signal.
+    private var pendingEntryPrompt: NativeInputPrompt? = null
+
+    private var hidingSheetForNewChat = false
+
+    sealed class Command {
+        data class LoadUrl(val url: String) : Command()
+        data class OpenFullscreenMode(val url: String) : Command()
+        data class ChangeSheetState(
+            val newState: Int,
+            val prefillNativeInput: String? = null,
+            val hideKeyboard: Boolean = false,
+        ) : Command()
+        data object RequestPageContext : Command()
+        data object ShowFireConfirmation : Command()
+        data class ShowChatsPopup(val recentChats: List<ChatHistoryItem>) : Command()
+        data class ShowNewChatEntryDialog(val tabId: String) : Command()
+        data class OpenChatUrl(
+            val url: String,
+            val sourceTabId: String,
+        ) : Command()
+        data object LaunchChatHistory : Command()
+        data object FocusInput : Command()
+        data class OpenSearchInNewTab(val query: String) : Command()
+    }
+
+    private val _viewState: MutableStateFlow<ViewState> = MutableStateFlow(ViewState())
+    val viewState: StateFlow<ViewState> = _viewState.asStateFlow()
+
+    init {
+        viewModelScope.launch(dispatchers.io()) {
+            _viewState.update {
+                it.copy(isFireButtonEnabled = duckChatFeature.contextualFireButton().isEnabled())
+            }
+            observeRecentChats()
+        }
+    }
+
+    data class ViewState(
+        val showFullscreen: Boolean = true,
+        val showContext: Boolean = false,
+        val contextUrl: String = "",
+        val contextTitle: String = "",
+        val tabId: String = "",
+        val isFireButtonEnabled: Boolean = false,
+        val recentChats: List<ChatHistoryItem> = emptyList(),
+    )
+
+    private suspend fun isStoredChatMissingFromHistory(url: String?): Boolean {
+        val chatId = extractChatId(url) ?: return false
+        val chats = chatHistoryRepository.observeChats().firstOrNull() ?: return false
+        return chats.none { it.chatId == chatId }
+    }
+
+    private fun observeRecentChats() {
+        combine(chatHistoryRepository.observeChats(), _chatId) { chats, currentChatId ->
+            chats
+                .asSequence()
+                .filterNot { it.chatId == currentChatId }
+                .sortedByDescending { it.lastEditMillis }
+                .take(MAX_RECENT_CHATS)
+                .toList()
+        }
+            .flowOn(dispatchers.io())
+            .onEach { recent -> _viewState.update { it.copy(recentChats = recent) } }
+            .launchIn(viewModelScope)
+    }
+
+    fun onSheetOpened(tabId: String) {
+        _viewState.update { it.copy(tabId = tabId) }
+        viewModelScope.launch(dispatchers.io()) {
+            val pendingEntry = contextualEntryPromptStore.consume(tabId)
+            if (pendingEntry != null) {
+                // Composed in the entry dialog: open straight into the chat and auto-submit. Page context
+                // came over with the prompt, so there's no need to request it again here.
+                startChatFromEntryPrompt(tabId, pendingEntry)
+                return@launch
+            }
+            logcat { "Duck.ai: onSheetOpened for tab=$tabId" }
+            withContext(dispatchers.main()) {
+                commandChannel.trySend(Command.RequestPageContext)
+            }
+
+            val existingChatUrl = contextualDataStore.getTabChatUrl(tabId)
+            val shouldReuseUrl = !existingChatUrl.isNullOrBlank() &&
+                shouldReuseStoredChatUrl(tabId) &&
+                !isStoredChatMissingFromHistory(existingChatUrl)
+            if (shouldReuseUrl) {
+                logcat { "Duck.ai: tab=$tabId has an existing url and don't need to restart the session" }
+                loadWebViewUrl(tabId, existingChatUrl!!)
+            } else {
+                logcat { "Duck.ai: tab=$tabId session expired or absent, starting a new chat" }
+                loadFreshChat(tabId)
+            }
+        }
+        duckChatPixels.reportContextualSheetOpened()
+    }
+
+    fun onSheetReopened() {
+        logcat { "Duck.ai: onSheetReopened" }
+        contextualNativeInputManager.onContextualReopened(_viewState.value.tabId)
+
+        viewModelScope.launch(dispatchers.io()) {
+            val tabId = _viewState.value.tabId
+            val pendingEntry = contextualEntryPromptStore.consume(tabId)
+            if (pendingEntry != null) {
+                // Composed in the entry dialog while the (persisted) sheet was hidden: reload into a fresh
+                // chat and auto-submit. The reload makes the web app re-request its hand-off data, so
+                // onWebAppReady fires again — the same delivery path as the first open.
+                startChatFromEntryPrompt(tabId, pendingEntry)
+                return@launch
+            }
+            withContext(dispatchers.main()) {
+                logcat { "Duck.ai: requesting page context after sheet reopened" }
+                commandChannel.trySend(Command.RequestPageContext)
+            }
+            reopenWebViewState(tabId)
+        }
+        duckChatPixels.reportContextualSheetOpened()
+    }
+
+    private suspend fun reopenWebViewState(tabId: String) {
+        val shouldReuseSession = shouldReuseStoredChatUrl(tabId)
+        val existingChatUrl = contextualDataStore.getTabChatUrl(tabId)
+        if (!shouldReuseSession || isStoredChatMissingFromHistory(existingChatUrl)) {
+            resetToNewChat()
+            return
+        }
+        withContext(dispatchers.main()) {
+            commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_EXPANDED))
+        }
+        if (existingChatUrl == null) {
+            loadFreshChat(tabId)
+        } else {
+            withContext(dispatchers.main()) {
+                setSheetUrl(existingChatUrl)
+                _viewState.update { state ->
+                    state.copy(showFullscreen = hasChatId(existingChatUrl))
+                }
+            }
+            duckChatPixels.reportContextualSheetSessionRestored()
+        }
+    }
+
+    private suspend fun loadFreshChat(tabId: String) {
+        val chatUrl = duckChat.getDuckChatUrl("", false, sidebar = true)
+        withContext(dispatchers.main()) {
+            setSheetUrl(chatUrl)
+            _viewState.update {
+                it.copy(showFullscreen = hasChatId(chatUrl), tabId = tabId)
+            }
+            commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_EXPANDED))
+            commandChannel.trySend(Command.LoadUrl(chatUrl))
+        }
+    }
+
+    private suspend fun loadWebViewUrl(
+        tabId: String,
+        existingChatUrl: String,
+    ) {
+        val hasChatHistory = hasChatId(existingChatUrl)
+        withContext(dispatchers.main()) {
+            setSheetUrl(existingChatUrl)
+            _viewState.update { current ->
+                current.copy(showFullscreen = hasChatHistory, tabId = tabId)
+            }
+            commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_EXPANDED))
+            commandChannel.trySend(Command.LoadUrl(existingChatUrl))
+        }
+    }
+
+    private suspend fun startChatFromEntryPrompt(
+        tabId: String,
+        entry: ContextualEntryPrompt,
+    ) {
+        pendingEntryPrompt = entry.prompt
+        val chatUrl = duckChat.getDuckChatUrl("", false, sidebar = true)
+        withContext(dispatchers.main()) {
+            entry.serializedPageContext?.let { attachProvidedPageContext(it) }
+            _viewState.update {
+                it.copy(showFullscreen = hasChatId(chatUrl), tabId = tabId)
+            }
+            commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_EXPANDED))
+            commandChannel.trySend(Command.LoadUrl(chatUrl))
+        }
+    }
+
+    private fun attachProvidedPageContext(serializedPageContext: String) {
+        if (!isContextValid(serializedPageContext)) return
+        currentPageContext = serializedPageContext
+        pageContextState = pageContextState.copy(attachedPage = serializedPageContext)
+        val json = JSONObject(serializedPageContext)
+        _viewState.update {
+            it.copy(
+                showContext = true,
+                contextTitle = json.optString("title"),
+                contextUrl = json.optString("url"),
+            )
+        }
+    }
+
+    /**
+     * Signalled by the fragment when the chat web app has requested its hand-off data (i.e. it is loaded
+     * and subscribed). Submitting the entry-dialog prompt here — rather than at page-finished — avoids a
+     * race where the prompt event is emitted before the web app can receive it.
+     */
+    fun onWebAppReady() {
+        val entry = pendingEntryPrompt ?: return
+        pendingEntryPrompt = null
+        onPromptSent(
+            prompt = entry.prompt,
+            modelId = entry.modelId,
+            reasoningEffort = entry.reasoningEffort,
+            selectedTool = entry.selectedTool,
+            imagesJson = entry.imagesJson,
+            filesJson = entry.filesJson,
+        )
+    }
+
+    fun onPromptSent(
+        prompt: String,
+        followUpPrefill: String? = null,
+        modelId: String? = null,
+        reasoningEffort: String? = null,
+        selectedTool: String? = null,
+        imagesJson: JSONArray? = null,
+        filesJson: JSONArray? = null,
+    ) {
+        viewModelScope.launch(dispatchers.io()) {
+            val contextPrompt = generateContextPrompt(prompt, modelId, reasoningEffort, selectedTool, imagesJson, filesJson)
+            val prefillText = followUpPrefill?.takeIf { it.isNotEmpty() }
+            val prefillEvent = prefillText?.let { generatePrefillEvent(it) }
+            withContext(dispatchers.main()) {
+                _viewState.update {
+                    // The context has already been captured in contextPrompt above, so drop the
+                    // page-context chip from the composer once the prompt is sent.
+                    it.copy(showContext = false)
+                }
+                _subscriptionEventDataChannel.trySend(contextPrompt)
+                prefillEvent?.let { _subscriptionEventDataChannel.trySend(it) }
+                // Always pass a non-null prefill: a draft preserves the typed text, empty clears the native
+                // chat input so stale text from a previous interaction doesn't reappear.
+                commandChannel.trySend(
+                    Command.ChangeSheetState(
+                        newState = BottomSheetBehavior.STATE_EXPANDED,
+                        prefillNativeInput = prefillText.orEmpty(),
+                    ),
+                )
+            }
+        }
+    }
+
+    fun onVoiceRecognitionSuccess(
+        query: String,
+        isDuckAiResult: Boolean,
+    ) {
+        if (query.isBlank()) return
+        if (isDuckAiResult) {
+            onPromptSent(query)
+        } else {
+            emitCommand(Command.OpenSearchInNewTab(query))
+        }
+    }
+
+    private fun emitCommand(command: Command) {
+        viewModelScope.launch(dispatchers.main()) {
+            commandChannel.trySend(command)
+        }
+    }
+
+    private fun generatePrefillEvent(text: String): SubscriptionEventData {
+        val params = JSONObject().apply {
+            put("platform", "android")
+            put("tool", "query")
+            put(
+                "query",
+                JSONObject().apply {
+                    put("prompt", text)
+                    put("autoSubmit", false)
+                },
+            )
+        }
+        return SubscriptionEventData(
+            featureName = RealDuckChatJSHelper.DUCK_CHAT_FEATURE_NAME,
+            subscriptionName = "submitAIChatNativePrompt",
+            params = params,
+        )
+    }
+
+    fun onChatPageLoaded(url: String?) {
+        logcat { "Duck.ai: onChatPageLoaded $url" }
+        if (url == null) return
+        setSheetUrl(url)
+        val hasChatId = hasChatId(url)
+
+        viewModelScope.launch {
+            _viewState.update { current -> current.copy(showFullscreen = hasChatId) }
+        }
+
+        if (hasChatId) {
+            val tabId = _viewState.value.tabId
+            if (tabId.isNotBlank()) {
+                viewModelScope.launch(dispatchers.io()) {
+                    contextualDataStore.persistTabChatUrl(tabId, url)
+                }
+            }
+        }
+    }
+
+    private fun generateContextPrompt(
+        prompt: String,
+        modelId: String? = null,
+        reasoningEffort: String? = null,
+        selectedTool: String? = null,
+        imagesJson: JSONArray? = null,
+        filesJson: JSONArray? = null,
+    ): SubscriptionEventData {
+        val viewState = _viewState.value
+        val pageContext =
+            if (viewState.showContext) {
+                pageContextState.attachedPage
+                    .takeIf { it.isNotBlank() }
+                    ?.let { runCatching { JSONObject(it) }.getOrNull() }
+                    ?: run {
+                        logcat { "Duck.ai: no pageContext available, skipping pageContext in prompt" }
+                        null
+                    }
+            } else {
+                null
+            }
+
+        if (pageContext == null) {
+            duckChatPixels.reportContextualPromptSubmittedWithoutContextNative()
+        } else {
+            duckChatPixels.reportContextualPromptSubmittedWithContextNative()
+        }
+
+        // The unified input widget is the source of truth for model/reasoning/tool/attachments when it
+        // is the composer; fall back to the shared model manager for callers that don't pass them.
+        val resolvedModelId = modelId ?: modelManager.getSelectedModelId()
+        val resolvedReasoningEffort = reasoningEffort ?: modelManager.getResolvedReasoningEffort()
+        val params =
+            JSONObject().apply {
+                put("platform", "android")
+                put("tool", "query")
+                put(
+                    "query",
+                    JSONObject().apply {
+                        put("prompt", prompt)
+                        put("autoSubmit", true)
+                        if (resolvedModelId != null) {
+                            put("modelId", resolvedModelId)
+                        }
+                        if (resolvedReasoningEffort != null) {
+                            put("reasoningEffort", resolvedReasoningEffort)
+                        }
+                        if (selectedTool != null) {
+                            put("toolChoice", JSONArray().apply { put(selectedTool) })
+                        }
+                        if (imagesJson != null) {
+                            put("images", imagesJson)
+                        }
+                        if (filesJson != null) {
+                            put("files", filesJson)
+                        }
+                    },
+                )
+                pageContext?.let { put("pageContext", it) }
+            }
+
+        return SubscriptionEventData(
+            featureName = RealDuckChatJSHelper.DUCK_CHAT_FEATURE_NAME,
+            subscriptionName = "submitAIChatNativePrompt",
+            params = params,
+        )
+    }
+
+    private fun generatePageContextEventData(): SubscriptionEventData {
+        val pageContext = if (isContextValid(currentPageContext)) {
+            JSONObject(currentPageContext)
+        } else {
+            logcat { "Duck.ai: pageContext is not valid" }
+            null
+        }
+
+        val params = JSONObject().apply {
+            if (duckChatInternal.isAutomaticContextAttachmentEnabled()) {
+                put("pageContext", pageContext)
+            } else {
+                put("pageContext", null)
+            }
+        }
+        return SubscriptionEventData(
+            featureName = RealDuckChatJSHelper.DUCK_CHAT_FEATURE_NAME,
+            subscriptionName = "submitAIChatPageContext",
+            params = params,
+        )
+    }
+
+    fun onContextualClose() {
+        viewModelScope.launch(dispatchers.main()) {
+            commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_HIDDEN))
+        }
+    }
+
+    fun onSheetClosed() {
+        if (hidingSheetForNewChat) {
+            // New Chat hid the sheet only to hand off to the entry dialog — not a user dismissal. Skip
+            // onContextualClosed (which would revert the tab's contextual input state and strip the entry
+            // dialog composer's affordances) and the dismissed pixel. The STATE_HIDDEN callback lands
+            // after the sheet's settle animation, so this consume happens well after the dialog opened.
+            hidingSheetForNewChat = false
+            return
+        }
+        persistTabClosed()
+        duckChatPixels.reportContextualSheetDismissed()
+        contextualNativeInputManager.onContextualClosed(_viewState.value.tabId)
+    }
+
+    private fun persistTabClosed() {
+        viewModelScope.launch(dispatchers.io()) {
+            val tabId = _viewState.value.tabId
+            if (tabId.isNotBlank()) {
+                contextualDataStore.persistTabClosedTimestamp(tabId, timeProvider.currentTimeMillis())
+            }
+        }
+    }
+
+    fun removePageContext() {
+        logcat { "Duck.ai Contextual: removePageContext" }
+        _viewState.update { current ->
+            current.copy(showContext = false)
+        }
+        duckChatPixels.reportContextualPageContextRemovedNative()
+    }
+
+    fun addPageContext() {
+        logcat { "Duck.ai Contextual: addPageContext" }
+        viewModelScope.launch {
+            if (isContextValid(currentPageContext, reportInvalidPixels = true)) {
+                duckChatPixels.reportContextualPageContextManuallyAttachedNative()
+                attachCurrentPageContext()
+            }
+        }
+    }
+
+    private fun attachCurrentPageContext() {
+        pageContextState = pageContextState.copy(attachedPage = pageContextState.currentPage)
+        val json = JSONObject(currentPageContext)
+        _viewState.update { current ->
+            current.copy(
+                showContext = true,
+                contextTitle = json.optString("title"),
+                contextUrl = json.optString("url"),
+            )
+        }
+    }
+
+    private fun isContextValid(
+        pageContext: String,
+        reportInvalidPixels: Boolean = false,
+    ): Boolean {
+        if (pageContext.isEmpty()) {
+            logcat { "Duck.ai: pageContext is empty" }
+            if (reportInvalidPixels) duckChatPixels.reportContextualPageContextInvalidEmpty()
+            return false
+        }
+        val json = try {
+            JSONObject(pageContext)
+        } catch (_: JSONException) {
+            logcat { "Duck.ai: pageContext is not valid JSON" }
+            if (reportInvalidPixels) duckChatPixels.reportContextualPageContextCollectionEmpty()
+            return false
+        }
+        val title = json.optString("title").takeIf { it.isNotBlank() }
+        val content = json.optString("content").takeIf { it.isNotBlank() }
+        if (reportInvalidPixels) {
+            if (title == null) duckChatPixels.reportContextualPageContextInvalidNoTitle()
+            if (content == null) duckChatPixels.reportContextualPageContextInvalidNoContent()
+        }
+        return title != null && content != null
+    }
+
+    fun onAskAboutPageClicked() {
+        if (!isContextValid(currentPageContext)) {
+            // Page context not ready/valid; do nothing (and don't fire invalid-context pixels).
+            return
+        }
+        addPageContext()
+        commandChannel.trySend(Command.FocusInput)
+    }
+
+    fun onFullModeRequested() {
+        logcat { "Duck.ai: request fullmode url $fullModeUrl" }
+        val chatUrl = fullModeUrl.ifEmpty { duckChat.getDuckChatUrl("", false, sidebar = false) }
+        viewModelScope.launch {
+            commandChannel.trySend(Command.OpenFullscreenMode(chatUrl))
+        }
+        duckChatPixels.reportContextualSheetExpanded()
+    }
+
+    fun onPageContextReceived(
+        tabId: String,
+        pageContext: String,
+    ) {
+        if (isContextValid(pageContext)) {
+            currentPageContext = pageContext
+        }
+        if (isContextValid(pageContext, reportInvalidPixels = true)) {
+            val json = JSONObject(pageContext)
+            val title = json.optString("title")
+            val url = json.optString("url")
+
+            logcat { "Duck.ai: onPageContextReceived for url $url" }
+            _viewState.update { current ->
+                current.copy(
+                    contextTitle = title,
+                    contextUrl = url,
+                    tabId = tabId,
+                )
+            }
+            if (duckChatInternal.isAutomaticContextAttachmentEnabled() || duckChatInternal.areMultipleContentAttachmentsEnabled()) {
+                val pageContextEvent = generatePageContextEventData()
+                viewModelScope.launch(dispatchers.main()) {
+                    _subscriptionEventDataChannel.trySend(pageContextEvent)
+                }
+            }
+        }
+    }
+
+    fun handleJSCall(method: String): Boolean {
+        return when (method) {
+            RealDuckChatJSHelper.METHOD_CLOSE_AI_CHAT -> {
+                logcat { "Duck.ai: $method handled at the VM level" }
+                onContextualClose()
+                true
+            }
+
+            else -> false
+        }
+    }
+
+    fun onNewChatRequestedFromPopup() {
+        // Hand New Chat off to the transparent entry dialog: clear the current chat's stored status now
+        // so it isn't resumed, then let the dialog command hide the sheet. Mark the impending hide as a
+        // handoff so onSheetClosed doesn't revert the tab's contextual input state.
+        duckChatPixels.reportContextualSheetNewChatFromPopup()
+        hidingSheetForNewChat = true
+        resetToNewChat()
+        commandChannel.trySend(Command.ShowNewChatEntryDialog(_viewState.value.tabId))
+    }
+
+    fun onChatsIconClicked() {
+        val state = _viewState.value
+        logcat { "Duck.ai Contextual: onChatsIconClicked recentChats=${state.recentChats.size}" }
+        duckChatPixels.reportContextualChatsMenuTapped()
+        if (state.recentChats.isEmpty()) {
+            // No recent chats means there's no popup to show, so go straight to chat history.
+            commandChannel.trySend(Command.LaunchChatHistory)
+        } else {
+            duckChatPixels.reportContextualRecentChatsPopupDisplayed()
+            commandChannel.trySend(Command.ShowChatsPopup(recentChats = state.recentChats))
+        }
+    }
+
+    fun onRecentChatClicked(chatId: String) {
+        duckChatPixels.reportContextualRecentChatSelected()
+        val url = duckChatInternal.buildChatUrl(chatId)
+        val sourceTabId = _viewState.value.tabId
+        commandChannel.trySend(Command.OpenChatUrl(url = url, sourceTabId = sourceTabId))
+    }
+
+    fun onViewAllChatsClicked() {
+        duckChatPixels.reportContextualViewAllChatsTapped()
+        commandChannel.trySend(Command.LaunchChatHistory)
+    }
+
+    fun onFireButtonClicked() {
+        duckChatPixels.reportContextualFireButtonTapped()
+        viewModelScope.launch {
+            commandChannel.trySend(Command.ShowFireConfirmation)
+        }
+    }
+
+    fun onContextualFireConfirmed() {
+        duckChatPixels.reportContextualFireButtonConfirmed()
+        resetToNewChat()
+        commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_HIDDEN))
+    }
+
+    // Clears the current chat and resets attachment/context so the next open starts fresh, without
+    // touching the sheet position (callers decide what to do with the sheet). Fires the NEW_CHAT
+    // native action so the web app resets too.
+    private fun resetToNewChat() {
+        viewModelScope.launch(dispatchers.io()) {
+            val currentTabId = _viewState.value.tabId
+            if (currentTabId.isBlank()) return@launch
+            contextualDataStore.clearTabChatUrl(currentTabId)
+            withContext(dispatchers.main()) {
+                clearSheetUrl()
+                pageContextState = pageContextState.copy(attachedPage = "")
+                _viewState.update {
+                    it.copy(
+                        showFullscreen = true,
+                        showContext = false,
+                    )
+                }
+                val subscriptionEvent = duckChatJSHelper.onNativeAction(NativeAction.NEW_CHAT)
+                _subscriptionEventDataChannel.trySend(subscriptionEvent)
+            }
+        }
+    }
+
+    private fun hasChatId(url: String?): Boolean = !extractChatId(url).isNullOrBlank()
+
+    private fun extractChatId(url: String?): String? {
+        val uri = url?.toUri() ?: return null
+        return uri.toChatIdOrNull(duckChat)
+    }
+
+    // Owns the coupled (fullModeUrl, _chatId) invariant: _chatId is always extractChatId(fullModeUrl).
+    private fun setSheetUrl(url: String) {
+        fullModeUrl = url
+        _chatId.value = extractChatId(url)
+    }
+
+    private fun clearSheetUrl() {
+        fullModeUrl = ""
+        _chatId.value = null
+    }
+
+    private suspend fun shouldReuseStoredChatUrl(tabId: String): Boolean {
+        val lastClosedTimestamp = contextualDataStore.getTabClosedTimestamp(tabId) ?: return true
+        val timeoutMs = sessionTimeoutProvider.sessionTimeoutMillis()
+        if (timeoutMs <= 0) return false
+        val elapsedMs = timeProvider.currentTimeMillis() - lastClosedTimestamp
+        return elapsedMs <= timeoutMs
+    }
+
+    companion object {
+        const val MAX_RECENT_CHATS = 5
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.toChatIdOrNull
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
@@ -120,6 +121,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
             val prefillNativeInput: String? = null,
             val hideKeyboard: Boolean = false,
         ) : Command()
+
         data object RequestPageContext : Command()
         data object ShowFireConfirmation : Command()
         data class ShowChatsPopup(val recentChats: List<ChatHistoryItem>) : Command()
@@ -128,6 +130,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
             val url: String,
             val sourceTabId: String,
         ) : Command()
+
         data object LaunchChatHistory : Command()
         data object FocusInput : Command()
         data class OpenSearchInNewTab(val query: String) : Command()
@@ -610,10 +613,12 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
 
     fun onFullModeRequested() {
         logcat { "Duck.ai: request fullmode url $fullModeUrl" }
+        val hasPrompt = fullModeUrl.isNotEmpty()
         val chatUrl = fullModeUrl.ifEmpty { duckChat.getDuckChatUrl("", false, sidebar = false) }
         viewModelScope.launch {
             commandChannel.trySend(Command.OpenFullscreenMode(chatUrl))
         }
+        duckChatInternal.reportDuckChatEntry(DuckChatEntryPoint.CONTEXTUAL_CHAT, opensNewTab = true, hasPrompt = hasPrompt)
         duckChatPixels.reportContextualSheetExpanded()
     }
 
@@ -685,6 +690,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         duckChatPixels.reportContextualRecentChatSelected()
         val url = duckChatInternal.buildChatUrl(chatId)
         val sourceTabId = _viewState.value.tabId
+        duckChatInternal.reportDuckChatEntry(DuckChatEntryPoint.CHAT_HISTORY_OPEN_CHAT, opensNewTab = true, hasPrompt = false)
         commandChannel.trySend(Command.OpenChatUrl(url = url, sourceTabId = sourceTabId))
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -286,6 +286,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         pendingEntryPrompt = entry.prompt
         val chatUrl = duckChat.getDuckChatUrl("", false, sidebar = true)
         withContext(dispatchers.main()) {
+            setSheetUrl(chatUrl)
             entry.serializedPageContext?.let { attachProvidedPageContext(it) }
             _viewState.update {
                 it.copy(showFullscreen = hasChatId(chatUrl), tabId = tabId)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -111,6 +111,11 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
     // is ready (onWebAppReady). Held between opening the sheet and that ready signal.
     private var pendingEntryPrompt: NativeInputPrompt? = null
 
+    // The page context the entry dialog had attached to [pendingEntryPrompt] at hand-off (null if none).
+    // Frozen so the first webview prompt reflects the dialog's choice, regardless of the sheet's own
+    // native-input auto-attach that may run before the web app is ready.
+    private var pendingEntryPageContext: String? = null
+
     private var hidingSheetForNewChat = false
 
     sealed class Command {
@@ -156,6 +161,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         val contextUrl: String = "",
         val contextTitle: String = "",
         val tabId: String = "",
+        val userRemovedContext: Boolean = false,
         val isFireButtonEnabled: Boolean = false,
         val recentChats: List<ChatHistoryItem> = emptyList(),
     )
@@ -293,30 +299,25 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         tabId: String,
         entry: ContextualEntryPrompt,
     ) {
+        // Freeze the prompt and the dialog's attachment decision (a page context, or none). The first
+        // webview prompt carries exactly this; the sheet's own native-input attachment state must not add
+        // to or remove from it.
         pendingEntryPrompt = entry.prompt
+        pendingEntryPageContext = entry.serializedPageContext
+        val handedOffWithoutContext = entry.serializedPageContext == null
         val chatUrl = duckChat.getDuckChatUrl("", false, sidebar = true)
         withContext(dispatchers.main()) {
             setSheetUrl(chatUrl)
-            entry.serializedPageContext?.let { attachProvidedPageContext(it) }
             _viewState.update {
-                it.copy(showFullscreen = hasChatId(chatUrl), tabId = tabId)
+                it.copy(
+                    showFullscreen = hasChatId(chatUrl),
+                    tabId = tabId,
+                    showContext = false,
+                    userRemovedContext = handedOffWithoutContext,
+                )
             }
             commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_EXPANDED))
             commandChannel.trySend(Command.LoadUrl(chatUrl))
-        }
-    }
-
-    private fun attachProvidedPageContext(serializedPageContext: String) {
-        if (!isContextValid(serializedPageContext)) return
-        currentPageContext = serializedPageContext
-        pageContextState = pageContextState.copy(attachedPage = serializedPageContext)
-        val json = JSONObject(serializedPageContext)
-        _viewState.update {
-            it.copy(
-                showContext = true,
-                contextTitle = json.optString("title"),
-                contextUrl = json.optString("url"),
-            )
         }
     }
 
@@ -327,14 +328,17 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
      */
     fun onWebAppReady() {
         val entry = pendingEntryPrompt ?: return
+        val entryPageContext = pendingEntryPageContext
         pendingEntryPrompt = null
-        onPromptSent(
+        pendingEntryPageContext = null
+        submitPrompt(
             prompt = entry.prompt,
             modelId = entry.modelId,
             reasoningEffort = entry.reasoningEffort,
             selectedTool = entry.selectedTool,
             imagesJson = entry.imagesJson,
             filesJson = entry.filesJson,
+            pageContextSerialized = entryPageContext,
         )
     }
 
@@ -347,8 +351,22 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         imagesJson: JSONArray? = null,
         filesJson: JSONArray? = null,
     ) {
+        val attachedContext = pageContextState.attachedPage.takeIf { _viewState.value.showContext }
+        submitPrompt(prompt, followUpPrefill, modelId, reasoningEffort, selectedTool, imagesJson, filesJson, attachedContext)
+    }
+
+    private fun submitPrompt(
+        prompt: String,
+        followUpPrefill: String? = null,
+        modelId: String? = null,
+        reasoningEffort: String? = null,
+        selectedTool: String? = null,
+        imagesJson: JSONArray? = null,
+        filesJson: JSONArray? = null,
+        pageContextSerialized: String?,
+    ) {
         viewModelScope.launch(dispatchers.io()) {
-            val contextPrompt = generateContextPrompt(prompt, modelId, reasoningEffort, selectedTool, imagesJson, filesJson)
+            val contextPrompt = generateContextPrompt(prompt, modelId, reasoningEffort, selectedTool, imagesJson, filesJson, pageContextSerialized)
             val prefillText = followUpPrefill?.takeIf { it.isNotEmpty() }
             val prefillEvent = prefillText?.let { generatePrefillEvent(it) }
             withContext(dispatchers.main()) {
@@ -435,20 +453,12 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         selectedTool: String? = null,
         imagesJson: JSONArray? = null,
         filesJson: JSONArray? = null,
+        pageContextSerialized: String?,
     ): SubscriptionEventData {
-        val viewState = _viewState.value
         val pageContext =
-            if (viewState.showContext) {
-                pageContextState.attachedPage
-                    .takeIf { it.isNotBlank() }
-                    ?.let { runCatching { JSONObject(it) }.getOrNull() }
-                    ?: run {
-                        logcat { "Duck.ai: no pageContext available, skipping pageContext in prompt" }
-                        null
-                    }
-            } else {
-                null
-            }
+            pageContextSerialized
+                ?.takeIf { it.isNotBlank() }
+                ?.let { runCatching { JSONObject(it) }.getOrNull() }
 
         if (pageContext == null) {
             duckChatPixels.reportContextualPromptSubmittedWithoutContextNative()
@@ -505,7 +515,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         }
 
         val params = JSONObject().apply {
-            if (duckChatInternal.isAutomaticContextAttachmentEnabled()) {
+            if (duckChatInternal.isAutomaticContextAttachmentEnabled() && _viewState.value.showContext) {
                 put("pageContext", pageContext)
             } else {
                 put("pageContext", null)
@@ -550,7 +560,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
     fun removePageContext() {
         logcat { "Duck.ai Contextual: removePageContext" }
         _viewState.update { current ->
-            current.copy(showContext = false)
+            current.copy(showContext = false, userRemovedContext = true)
         }
         duckChatPixels.reportContextualPageContextRemovedNative()
     }
@@ -571,6 +581,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         _viewState.update { current ->
             current.copy(
                 showContext = true,
+                userRemovedContext = false,
                 contextTitle = json.optString("title"),
                 contextUrl = json.optString("url"),
             )
@@ -635,14 +646,35 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
             val url = json.optString("url")
 
             logcat { "Duck.ai: onPageContextReceived for url $url" }
-            _viewState.update { current ->
-                current.copy(
+            val current = _viewState.value
+            val allowsAutomaticContextAttachment = duckChatInternal.isAutomaticContextAttachmentEnabled()
+
+            val urlChanged = current.contextUrl.isNotEmpty() && url != current.contextUrl
+            val remainsUserRemoved = current.userRemovedContext && !urlChanged
+            val dropStaleAttachment = !allowsAutomaticContextAttachment && current.showContext && urlChanged
+
+            val showContext = when {
+                allowsAutomaticContextAttachment -> !remainsUserRemoved
+                dropStaleAttachment -> false
+                else -> current.showContext
+            }
+            val newlyAutoAttached = showContext && !current.showContext
+            if (showContext) {
+                pageContextState = pageContextState.copy(attachedPage = pageContext)
+            }
+            _viewState.update {
+                it.copy(
                     contextTitle = title,
                     contextUrl = url,
                     tabId = tabId,
+                    showContext = showContext,
+                    userRemovedContext = remainsUserRemoved,
                 )
             }
-            if (duckChatInternal.isAutomaticContextAttachmentEnabled() || duckChatInternal.areMultipleContentAttachmentsEnabled()) {
+            if (newlyAutoAttached) {
+                duckChatPixels.reportContextualPageContextAutoAttached()
+            }
+            if (allowsAutomaticContextAttachment || duckChatInternal.areMultipleContentAttachmentsEnabled()) {
                 val pageContextEvent = generatePageContextEventData()
                 viewModelScope.launch(dispatchers.main()) {
                     _subscriptionEventDataChannel.trySend(pageContextEvent)
@@ -727,6 +759,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
                     it.copy(
                         showFullscreen = true,
                         showContext = false,
+                        userRemovedContext = false,
                     )
                 }
                 val subscriptionEvent = duckChatJSHelper.onNativeAction(NativeAction.NEW_CHAT)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
@@ -117,7 +117,7 @@ class RealDuckChatContextual @Inject constructor(
             onAskAboutPage()
             return
         }
-        DuckChatContextualEntryDialog.newInstance(sourceTabId, onAskAboutPage)
+        DuckChatContextualEntryDialog.newInstance(sourceTabId)
             .show(fragmentManager, DuckChatContextualEntryDialog.TAG)
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
@@ -46,17 +46,17 @@ class RealDuckChatContextual @Inject constructor(
     override suspend fun launch(
         sourceTabId: String,
         anchor: View?,
-        onAskAboutPage: () -> Unit,
+        showChatSurface: () -> Unit,
     ) {
         if (anchor == null || !duckChatInternal.isContextualSheetRedesignEnabled()) {
-            onAskAboutPage()
+            showChatSurface()
             return
         }
         if (hasChatInProgress(sourceTabId)) {
             // The sheet would reopen the existing chat for this tab, so skip the entry menu and open it directly.
-            onAskAboutPage()
+            showChatSurface()
         } else {
-            showMenu(sourceTabId, anchor, onAskAboutPage)
+            showMenu(sourceTabId, anchor, showChatSurface)
         }
     }
 
@@ -72,7 +72,7 @@ class RealDuckChatContextual @Inject constructor(
         return timeProvider.currentTimeMillis() - lastClosedTimestamp <= timeoutMs
     }
 
-    override fun createSheet(tabId: String): Fragment {
+    override fun createChatSurface(tabId: String): Fragment {
         return DuckChatContextualFragment().apply {
             arguments = Bundle().apply {
                 putString(DuckChatContextualFragment.KEY_DUCK_AI_CONTEXTUAL_TAB_ID, tabId)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
@@ -73,9 +73,17 @@ class RealDuckChatContextual @Inject constructor(
     }
 
     override fun createChatSurface(tabId: String): Fragment {
-        return DuckChatContextualFragment().apply {
-            arguments = Bundle().apply {
-                putString(DuckChatContextualFragment.KEY_DUCK_AI_CONTEXTUAL_TAB_ID, tabId)
+        return if (duckChatInternal.isContextualSheetRedesignEnabled()) {
+            DuckChatContextualWebViewFragment().apply {
+                arguments = Bundle().apply {
+                    putString(DuckChatContextualWebViewFragment.KEY_DUCK_AI_CONTEXTUAL_TAB_ID, tabId)
+                }
+            }
+        } else {
+            DuckChatContextualFragment().apply {
+                arguments = Bundle().apply {
+                    putString(DuckChatContextualFragment.KEY_DUCK_AI_CONTEXTUAL_TAB_ID, tabId)
+                }
             }
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
@@ -22,6 +22,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.findFragment
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.di.scopes.AppScope
@@ -88,8 +89,28 @@ class RealDuckChatContextual @Inject constructor(
         val popup = PopupMenu(LayoutInflater.from(activity), R.layout.popup_contextual_chat_menu)
         val content = popup.contentView
         popup.onMenuItemClicked(content.findViewById(R.id.contextualChatMenuNewChat)) { openNewChatTab(activity, sourceTabId) }
-        popup.onMenuItemClicked(content.findViewById(R.id.contextualChatMenuAskAboutPage)) { onAskAboutPage() }
+        popup.onMenuItemClicked(content.findViewById(R.id.contextualChatMenuAskAboutPage)) {
+            showEntryDialog(anchor, sourceTabId, onAskAboutPage)
+        }
         popup.showAnchoredView(activity, anchor.rootView, anchor)
+    }
+
+    private fun showEntryDialog(
+        anchor: View,
+        sourceTabId: String,
+        onAskAboutPage: () -> Unit,
+    ) {
+        // Attach the dialog to the host fragment (the one owning the anchor) so it shares the host's
+        // DuckChatContextualSharedViewModel — the same page-context plumbing the sheet uses.
+        val hostFragment = runCatching { anchor.findFragment<Fragment>() }.getOrNull()
+        val fragmentManager = hostFragment?.childFragmentManager
+        if (fragmentManager == null || fragmentManager.isStateSaved) {
+            // No fragment host to attach to; fall back to showing the sheet directly.
+            onAskAboutPage()
+            return
+        }
+        DuckChatContextualEntryDialog.newInstance(sourceTabId, onAskAboutPage)
+            .show(fragmentManager, DuckChatContextualEntryDialog.TAG)
     }
 
     private fun openNewChatTab(activity: Activity, sourceTabId: String) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
@@ -60,10 +60,6 @@ class ContextualSuggestionsView @JvmOverloads constructor(
 
     var onContentChanged: (() -> Unit)? = null
 
-    /** Optional per-instance override for the suggestion chip background; null keeps the item layout's default. */
-    @DrawableRes
-    var chipBackgroundRes: Int? = null
-
     private val loadingView = ContextualSuggestionsLoadingView(context)
     private val cardsContainer = LinearLayout(context).apply { orientation = VERTICAL }
 
@@ -126,7 +122,6 @@ class ContextualSuggestionsView @JvmOverloads constructor(
 
     private fun render(viewState: ContextualSuggestionsViewModel.ViewState) {
         if (viewState.loading) {
-            chipBackgroundRes?.let { loadingView.setBackgroundResource(it) }
             loadingView.show()
         } else {
             loadingView.gone()
@@ -139,7 +134,6 @@ class ContextualSuggestionsView @JvmOverloads constructor(
                 val itemBinding = ItemContextualSuggestionBinding.inflate(inflater, cardsContainer, false)
                 itemBinding.suggestionLabel.text = suggestion.label
                 itemBinding.suggestionLabel.setCompoundDrawablesRelativeWithIntrinsicBounds(iconResFor(suggestion.icon), 0, 0, 0)
-                chipBackgroundRes?.let { itemBinding.suggestionLabel.setBackgroundResource(it) }
                 itemBinding.root.setOnClickListener {
                     viewModel.onSuggestionSelected(suggestion.id)
                     onSuggestionSelected?.invoke(suggestion)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
@@ -121,11 +121,7 @@ class ContextualSuggestionsView @JvmOverloads constructor(
     fun hasContent(): Boolean = loadingView.isVisible || cardsContainer.isNotEmpty()
 
     private fun render(viewState: ContextualSuggestionsViewModel.ViewState) {
-        if (viewState.loading) {
-            loadingView.show()
-        } else {
-            loadingView.gone()
-        }
+        if (viewState.loading) loadingView.show() else loadingView.gone()
 
         cardsContainer.removeAllViews()
         if (!viewState.loading && viewState.suggestions.isNotEmpty()) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
@@ -21,6 +21,7 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.LinearLayout
 import androidx.annotation.DrawableRes
+import androidx.core.content.res.use
 import androidx.core.view.doOnAttach
 import androidx.core.view.isNotEmpty
 import androidx.core.view.isVisible
@@ -41,6 +42,7 @@ import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
+import com.duckduckgo.mobile.android.R as CommonR
 
 @InjectWith(ViewScope::class)
 class ContextualSuggestionsView @JvmOverloads constructor(
@@ -65,8 +67,14 @@ class ContextualSuggestionsView @JvmOverloads constructor(
 
     private val viewStateJob = ConflatedJob()
 
+    @DrawableRes
+    private val suggestionBackgroundRes: Int = context.obtainStyledAttributes(attrs, R.styleable.ContextualSuggestionsView).use {
+        it.getResourceId(R.styleable.ContextualSuggestionsView_suggestionBackground, CommonR.drawable.duck_ai_prompt_background)
+    }
+
     init {
         orientation = VERTICAL
+        loadingView.setBackgroundResource(suggestionBackgroundRes)
         addView(
             loadingView,
             LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT).apply { bottomMargin = LOADING_MARGIN_BOTTOM_DP.toPx() },
@@ -128,6 +136,7 @@ class ContextualSuggestionsView @JvmOverloads constructor(
             val inflater = LayoutInflater.from(context)
             viewState.suggestions.forEach { suggestion ->
                 val itemBinding = ItemContextualSuggestionBinding.inflate(inflater, cardsContainer, false)
+                itemBinding.suggestionLabel.setBackgroundResource(suggestionBackgroundRes)
                 itemBinding.suggestionLabel.text = suggestion.label
                 itemBinding.suggestionLabel.setCompoundDrawablesRelativeWithIntrinsicBounds(iconResFor(suggestion.icon), 0, 0, 0)
                 itemBinding.root.setOnClickListener {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
@@ -60,6 +60,10 @@ class ContextualSuggestionsView @JvmOverloads constructor(
 
     var onContentChanged: (() -> Unit)? = null
 
+    /** Optional per-instance override for the suggestion chip background; null keeps the item layout's default. */
+    @DrawableRes
+    var chipBackgroundRes: Int? = null
+
     private val loadingView = ContextualSuggestionsLoadingView(context)
     private val cardsContainer = LinearLayout(context).apply { orientation = VERTICAL }
 
@@ -121,7 +125,12 @@ class ContextualSuggestionsView @JvmOverloads constructor(
     fun hasContent(): Boolean = loadingView.isVisible || cardsContainer.isNotEmpty()
 
     private fun render(viewState: ContextualSuggestionsViewModel.ViewState) {
-        if (viewState.loading) loadingView.show() else loadingView.gone()
+        if (viewState.loading) {
+            chipBackgroundRes?.let { loadingView.setBackgroundResource(it) }
+            loadingView.show()
+        } else {
+            loadingView.gone()
+        }
 
         cardsContainer.removeAllViews()
         if (!viewState.loading && viewState.suggestions.isNotEmpty()) {
@@ -130,6 +139,7 @@ class ContextualSuggestionsView @JvmOverloads constructor(
                 val itemBinding = ItemContextualSuggestionBinding.inflate(inflater, cardsContainer, false)
                 itemBinding.suggestionLabel.text = suggestion.label
                 itemBinding.suggestionLabel.setCompoundDrawablesRelativeWithIntrinsicBounds(iconResFor(suggestion.icon), 0, 0, 0)
+                chipBackgroundRes?.let { itemBinding.suggestionLabel.setBackgroundResource(it) }
                 itemBinding.root.setOnClickListener {
                     viewModel.onSuggestionSelected(suggestion.id)
                     onSuggestionSelected?.invoke(suggestion)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatContextualDataStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatContextualDataStore.kt
@@ -23,6 +23,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.contextual.ContextualEntryPromptStore
 import com.duckduckgo.duckchat.impl.di.DuckChat
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.JsonAdapter
@@ -52,6 +53,7 @@ class RealDuckChatContextualDataStore @Inject constructor(
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
     moshi: Moshi,
+    private val contextualEntryPromptStore: ContextualEntryPromptStore,
 ) : DuckChatContextualDataStore {
 
     private object Keys {
@@ -116,6 +118,9 @@ class RealDuckChatContextualDataStore @Inject constructor(
     }
 
     override fun clearTabChatUrl(tabId: String) {
+        // A tab's contextual chat state includes any pending entry-dialog prompt parked for it, so drop
+        // that too (covers tab deletion and fire, which both route through here).
+        contextualEntryPromptStore.clear(tabId)
         coroutineScope.launch(dispatchers.io()) {
             store.edit { prefs ->
                 val updated =
@@ -140,6 +145,7 @@ class RealDuckChatContextualDataStore @Inject constructor(
     }
 
     override fun clearAll() {
+        contextualEntryPromptStore.clearAll()
         coroutineScope.launch(dispatchers.io()) {
             store.edit { prefs ->
                 prefs.remove(Keys.TAB_CHAT_URLS)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -595,7 +595,12 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 
     fun configureContextual(tabId: String) {
         activeTabId.value = tabId
-        widgetConfig.update { it.copy(inputContext = NativeInputState.InputContext.DUCK_AI_CONTEXTUAL) }
+        widgetConfig.update {
+            it.copy(
+                inputContext = NativeInputState.InputContext.DUCK_AI_CONTEXTUAL,
+                toggleSelection = NativeInputState.ToggleSelection.DUCK_AI,
+            )
+        }
         replayPendingState(tabId)
     }
 

--- a/duckchat/duckchat-impl/src/main/res/layout/dialog_contextual_duck_ai_entry.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/dialog_contextual_duck_ai_entry.xml
@@ -44,17 +44,19 @@
             <com.duckduckgo.duckchat.impl.contextual.suggestions.ContextualSuggestionsView
                 android:id="@+id/entrySuggestionsView"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                app:suggestionBackground="@drawable/duck_ai_suggested_prompts_background" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextView
                 android:id="@+id/entryPromptQuickAction"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/keyline_2"
-                android:background="@drawable/background_large_rounded_surface"
+                android:background="@drawable/duck_ai_suggested_prompts_background"
                 android:drawableStart="@drawable/ic_summarize_16"
                 android:drawablePadding="@dimen/keyline_2"
-                android:padding="@dimen/keyline_2"
+                android:paddingVertical="@dimen/keyline_2"
+                android:paddingHorizontal="@dimen/keyline_3"
                 android:text="@string/duckAIContextualPromptSummarize"
                 android:visibility="gone"
                 app:typography="body2_bold" />

--- a/duckchat/duckchat-impl/src/main/res/layout/dialog_contextual_duck_ai_entry.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/dialog_contextual_duck_ai_entry.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/entryDialogRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/transparent"
+    android:orientation="vertical">
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/entryPrompts"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:id="@+id/entryPromptsContent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="bottom"
+            android:paddingHorizontal="@dimen/keyline_4"
+            android:paddingTop="@dimen/keyline_4"
+            android:paddingBottom="@dimen/keyline_1">
+
+            <com.duckduckgo.duckchat.impl.contextual.suggestions.ContextualSuggestionsView
+                android:id="@+id/entrySuggestionsView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/entryPromptQuickAction"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/keyline_2"
+                android:background="@drawable/background_large_rounded_surface"
+                android:drawableStart="@drawable/ic_summarize_16"
+                android:drawablePadding="@dimen/keyline_2"
+                android:padding="@dimen/keyline_2"
+                android:text="@string/duckAIContextualPromptSummarize"
+                android:visibility="gone"
+                app:typography="body2_bold" />
+
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <FrameLayout
+        android:id="@+id/entryInputContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/entryNativeInputCard"
+            android:theme="?attr/daxInputModeCardThemeOverlay"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:layout_marginHorizontal="@dimen/keyline_2"
+            android:layout_marginBottom="@dimen/keyline_2"
+            app:cardBackgroundColor="?attr/daxColorWindow"
+            app:cardElevation="4dp"
+            app:cardUseCompatPadding="false">
+
+            <com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
+                android:id="@+id/entryNativeInputWidget"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingHorizontal="8dp"
+                android:paddingVertical="4dp" />
+
+        </com.google.android.material.card.MaterialCardView>
+
+    </FrameLayout>
+
+</LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_webview.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_webview.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/contextualModeRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/contextual_sheet_background"
+    tools:ignore="Overdraw"
+    android:orientation="vertical">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/contextualModeButtons"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingHorizontal="@dimen/keyline_2"
+        android:paddingTop="@dimen/keyline_4"
+        android:paddingBottom="@dimen/keyline_4"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <View
+            android:id="@+id/contextualDragHandle"
+            android:layout_width="32dp"
+            android:layout_height="4dp"
+            android:background="@drawable/duck_ai_prompt_background"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/contextualFullScreen"
+            android:layout_width="@dimen/toolbarIcon"
+            android:layout_height="@dimen/toolbarIcon"
+            android:background="@drawable/selectable_item_rounded_corner_background"
+            android:contentDescription="@string/browserMenuChatHistory"
+            android:scaleType="center"
+            android:layout_marginEnd="@dimen/keyline_2"
+            app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/contextualTitle"
+            app:srcCompat="@drawable/ic_expand_24" />
+
+        <ImageView
+            android:id="@+id/contextualNewChat"
+            android:layout_width="@dimen/toolbarIcon"
+            android:layout_height="@dimen/toolbarIcon"
+            android:background="@drawable/selectable_item_rounded_corner_background"
+            android:contentDescription="@string/browserMenuChatHistory"
+            android:scaleType="center"
+            android:visibility="gone"
+            tools:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
+            app:layout_constraintStart_toEndOf="@+id/contextualFullScreen"
+            app:layout_constraintTop_toTopOf="@id/contextualTitle"
+            app:srcCompat="@drawable/ic_chats_24" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/contextualTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/keyline_4"
+            android:drawableStart="@drawable/ic_duck_ai_color_24"
+            android:drawablePadding="@dimen/keyline_2"
+            android:gravity="center"
+            android:text="@string/duck_chat_title"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/contextualDragHandle"
+            app:typography="h2" />
+
+        <ImageView
+            android:id="@+id/contextualFire"
+            android:layout_width="@dimen/toolbarIcon"
+            android:layout_height="@dimen/toolbarIcon"
+            android:background="@drawable/selectable_item_rounded_corner_background"
+            android:contentDescription="@string/duckAIContextualFireButtonContentDescription"
+            android:scaleType="center"
+            android:visibility="gone"
+            tools:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
+            app:layout_constraintEnd_toStartOf="@+id/contextualClose"
+            app:layout_constraintTop_toTopOf="@id/contextualTitle"
+            app:srcCompat="@drawable/ic_fire_24" />
+
+        <ImageView
+            android:id="@+id/contextualClose"
+            android:layout_width="@dimen/toolbarIcon"
+            android:layout_height="@dimen/toolbarIcon"
+            android:layout_gravity="end"
+            android:background="@drawable/selectable_item_rounded_corner_background"
+            android:contentDescription="@string/browserMenuChatHistory"
+            android:scaleType="center"
+            app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/contextualTitle"
+            app:srcCompat="@drawable/ic_close_24_small" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <FrameLayout
+        android:id="@+id/contextualContentArea"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <FrameLayout
+            android:id="@+id/contextualWebviewContainer"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <WebView
+                android:id="@+id/simpleWebview"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+        </FrameLayout>
+
+    </FrameLayout>
+
+    <FrameLayout
+        android:id="@+id/contextualInputContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/daxColorDuckAiBackground">
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/contextualNativeInputCard"
+            android:theme="?attr/daxInputModeCardThemeOverlay"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:layout_marginHorizontal="@dimen/keyline_2"
+            android:layout_marginBottom="@dimen/keyline_2"
+            app:cardBackgroundColor="?attr/daxColorWindow"
+            app:cardElevation="4dp"
+            app:cardUseCompatPadding="false">
+
+            <com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
+                android:id="@+id/contextualNativeInputWidget"
+                android:paddingHorizontal="8dp"
+                android:paddingVertical="4dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+        </com.google.android.material.card.MaterialCardView>
+
+    </FrameLayout>
+
+</LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_webview.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_webview.xml
@@ -54,11 +54,10 @@
             android:background="@drawable/selectable_item_rounded_corner_background"
             android:contentDescription="@string/browserMenuChatHistory"
             android:scaleType="center"
-            android:layout_marginEnd="@dimen/keyline_2"
             app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/contextualTitle"
-            app:srcCompat="@drawable/ic_expand_24" />
+            app:srcCompat="@drawable/ic_open_in_24" />
 
         <ImageView
             android:id="@+id/contextualNewChat"
@@ -70,7 +69,7 @@
             android:visibility="gone"
             tools:visibility="visible"
             app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
-            app:layout_constraintStart_toEndOf="@+id/contextualFullScreen"
+            app:layout_constraintStart_toEndOf="@+id/contextualClose"
             app:layout_constraintTop_toTopOf="@id/contextualTitle"
             app:srcCompat="@drawable/ic_chats_24" />
 
@@ -79,7 +78,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/keyline_4"
-            android:drawableStart="@drawable/ic_duck_ai_color_24"
+            android:drawableStart="@drawable/ic_ai_chat_color_24"
             android:drawablePadding="@dimen/keyline_2"
             android:gravity="center"
             android:text="@string/duck_chat_title"
@@ -98,7 +97,7 @@
             android:visibility="gone"
             tools:visibility="visible"
             app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
-            app:layout_constraintEnd_toStartOf="@+id/contextualClose"
+            app:layout_constraintEnd_toStartOf="@+id/contextualFullScreen"
             app:layout_constraintTop_toTopOf="@id/contextualTitle"
             app:srcCompat="@drawable/ic_fire_24" />
 
@@ -111,7 +110,7 @@
             android:contentDescription="@string/browserMenuChatHistory"
             android:scaleType="center"
             app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/contextualTitle"
             app:srcCompat="@drawable/ic_close_24_small" />
 

--- a/duckchat/duckchat-impl/src/main/res/layout/item_contextual_suggestion.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/item_contextual_suggestion.xml
@@ -25,7 +25,8 @@
     android:layout_marginBottom="@dimen/keyline_2"
     android:background="@drawable/duck_ai_prompt_background"
     android:drawablePadding="@dimen/keyline_2"
-    android:padding="@dimen/keyline_2"
+    android:paddingVertical="@dimen/keyline_2"
+    android:paddingHorizontal="@dimen/keyline_3"
     app:typography="body2_bold"
     tools:drawableStart="@drawable/ic_summarize_16"
     tools:text="Summarize this page" />

--- a/duckchat/duckchat-impl/src/main/res/values/attrs-contextual-suggestions-view.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/attrs-contextual-suggestions-view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <declare-styleable name="ContextualSuggestionsView">
+        <attr name="suggestionBackground" format="reference" />
+    </declare-styleable>
+</resources>

--- a/duckchat/duckchat-impl/src/main/res/values/widgets.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/widgets.xml
@@ -14,11 +14,25 @@
   ~ limitations under the License.
   -->
 
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="Widget.DuckDuckGo.DuckChatContextualFavicon">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">@dimen/smallShapeCornerRadius</item>
+    </style>
+
+    <style name="Widget.DuckDuckGo.DuckAiContextualEntryDialog" parent="@style/Theme.Design.BottomSheetDialog">
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="enableEdgeToEdge">true</item>
+        <item name="android:enforceNavigationBarContrast" tools:targetApi="q">false</item>
+        <item name="bottomSheetStyle">@style/Widget.DuckDuckGo.DuckAiContextualEntryDialogStyle
+        </item>
+    </style>
+
+    <style name="Widget.DuckDuckGo.DuckAiContextualEntryDialogStyle" parent="@style/Widget.Design.BottomSheet.Modal">
+        <item name="android:background">@android:color/transparent</item>
     </style>
 
 </resources>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
@@ -107,4 +107,20 @@ class DuckChatContextualEntryViewModelTest {
         verify(store).store(captor.capture())
         assertNull(captor.firstValue.serializedPageContext)
     }
+
+    @Test
+    fun whenContextRemovedThenPromptStoredWithNullContext() = runTest {
+        viewModel.start("tab-1")
+        viewModel.onPageContextReceived(validContext)
+        viewModel.onContextRemoved()
+
+        viewModel.commands.test {
+            viewModel.onPromptSubmitted(samplePrompt)
+            assertEquals(DuckChatContextualEntryViewModel.Command.HandOffToSheet, awaitItem())
+        }
+
+        val captor = argumentCaptor<ContextualEntryPrompt>()
+        verify(store).store(captor.capture())
+        assertNull(captor.firstValue.serializedPageContext)
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual
+
+import app.cash.turbine.test
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class DuckChatContextualEntryViewModelTest {
+
+    private val store: ContextualEntryPromptStore = mock()
+    private val viewModel = DuckChatContextualEntryViewModel(store)
+
+    private val validContext = """{"title":"Example","url":"https://example.com","content":"some page content"}"""
+    private val samplePrompt = NativeInputPrompt("hi", "model-1", "high", "tool-1", null, null)
+
+    @Test
+    fun whenValidPageContextReceivedThenAttached() {
+        viewModel.onPageContextReceived(validContext)
+
+        val attached = viewModel.viewState.value.attachedContext
+        assertEquals(validContext, attached?.serialized)
+        assertEquals("Example", attached?.title)
+        assertEquals("https://example.com", attached?.url)
+    }
+
+    @Test
+    fun whenPageContextInvalidThenNotAttached() {
+        viewModel.onPageContextReceived("""{"title":"Example","url":"https://example.com","content":""}""")
+
+        assertNull(viewModel.viewState.value.attachedContext)
+    }
+
+    @Test
+    fun whenContextRemovedThenLaterContextNotReAttached() {
+        viewModel.onPageContextReceived(validContext)
+        viewModel.onContextRemoved()
+        assertNull(viewModel.viewState.value.attachedContext)
+
+        viewModel.onPageContextReceived(validContext)
+
+        assertNull(viewModel.viewState.value.attachedContext)
+    }
+
+    @Test
+    fun whenPromptSubmittedThenStoredWithAttachedContextAndHandsOff() = runTest {
+        viewModel.start("tab-1")
+        viewModel.onPageContextReceived(validContext)
+
+        viewModel.commands.test {
+            viewModel.onPromptSubmitted(samplePrompt)
+            assertEquals(DuckChatContextualEntryViewModel.Command.HandOffToSheet, awaitItem())
+        }
+
+        val captor = argumentCaptor<ContextualEntryPrompt>()
+        verify(store).store(captor.capture())
+        assertEquals("tab-1", captor.firstValue.tabId)
+        assertEquals(samplePrompt, captor.firstValue.prompt)
+        assertEquals(validContext, captor.firstValue.serializedPageContext)
+    }
+
+    @Test
+    fun whenSuggestionSubmittedAfterRemovalThenReAttachesContextBeforeStoring() = runTest {
+        viewModel.start("tab-1")
+        viewModel.onPageContextReceived(validContext)
+        viewModel.onContextRemoved()
+
+        viewModel.commands.test {
+            viewModel.onSuggestionSubmitted(samplePrompt)
+            assertEquals(DuckChatContextualEntryViewModel.Command.HandOffToSheet, awaitItem())
+        }
+
+        val captor = argumentCaptor<ContextualEntryPrompt>()
+        verify(store).store(captor.capture())
+        assertEquals(validContext, captor.firstValue.serializedPageContext)
+    }
+
+    @Test
+    fun whenPromptSubmittedWithoutContextThenStoredWithNullContext() = runTest {
+        viewModel.start("tab-1")
+
+        viewModel.commands.test {
+            viewModel.onPromptSubmitted(samplePrompt)
+            assertEquals(DuckChatContextualEntryViewModel.Command.HandOffToSheet, awaitItem())
+        }
+
+        val captor = argumentCaptor<ContextualEntryPrompt>()
+        verify(store).store(captor.capture())
+        assertNull(captor.firstValue.serializedPageContext)
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualSharedViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualSharedViewModelTest.kt
@@ -63,12 +63,12 @@ class DuckChatContextualSharedViewModelTest {
     }
 
     @Test
-    fun whenOpenRequestedThenOpenSheetCommandEmitted() = runTest {
+    fun whenReloadChatRequestedThenReloadChatCommandEmitted() = runTest {
         testee.commands.test {
-            testee.onOpenRequested()
+            testee.onReloadChatRequested()
 
             val command = awaitItem()
-            assertEquals(DuckChatContextualSharedViewModel.Command.OpenSheet, command)
+            assertEquals(DuckChatContextualSharedViewModel.Command.ReloadChat, command)
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -121,23 +121,23 @@ class DuckChatContextualSharedViewModelTest {
     fun whenMultipleSubscribersThenAllReceiveCommands() = runTest {
         testee.commands.test {
             testee.commands.test {
-                testee.onOpenRequested()
+                testee.onReloadChatRequested()
 
-                assertEquals(DuckChatContextualSharedViewModel.Command.OpenSheet, awaitItem())
+                assertEquals(DuckChatContextualSharedViewModel.Command.ReloadChat, awaitItem())
                 cancelAndConsumeRemainingEvents()
             }
 
-            assertEquals(DuckChatContextualSharedViewModel.Command.OpenSheet, awaitItem())
+            assertEquals(DuckChatContextualSharedViewModel.Command.ReloadChat, awaitItem())
             cancelAndConsumeRemainingEvents()
         }
     }
 
     @Test
-    fun whenOpenRequestedThenSingleOpenSheetCommandEmitted() = runTest {
+    fun whenReloadChatRequestedThenSingleReloadChatCommandEmitted() = runTest {
         testee.commands.test {
-            testee.onOpenRequested()
+            testee.onReloadChatRequested()
 
-            assertEquals(DuckChatContextualSharedViewModel.Command.OpenSheet, awaitItem())
+            assertEquals(DuckChatContextualSharedViewModel.Command.ReloadChat, awaitItem())
             expectNoEvents()
             cancelAndConsumeRemainingEvents()
         }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1359,6 +1359,46 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
+    fun `onNewChatRequestedFromPopup with redesign enabled hands off to entry dialog and reports popup pixel`() = runTest {
+        whenever(duckChatInternal.isContextualSheetRedesignEnabled()).thenReturn(true)
+
+        testee.commands.test {
+            testee.onNewChatRequestedFromPopup()
+
+            assertTrue(awaitItem() is DuckChatContextualViewModel.Command.ShowNewChatEntryDialog)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify(duckChatPixels).reportContextualSheetNewChatFromPopup()
+    }
+
+    @Test
+    fun `onNewChatFromEntryDialog consumes parked prompt and starts a new chat`() = runTest {
+        val tabId = "tab-1"
+        testee.onSheetOpened(tabId)
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume(tabId)).thenReturn(ContextualEntryPrompt(tabId, prompt, null))
+
+        testee.onNewChatFromEntryDialog()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(DuckChatContextualViewModel.SheetMode.WEBVIEW, testee.viewState.value.sheetMode)
+    }
+
+    @Test
+    fun `onNewChatFromEntryDialog with nothing parked does not start a chat`() = runTest {
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onNewChatFromEntryDialog()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(DuckChatContextualViewModel.SheetMode.INPUT, testee.viewState.value.sheetMode)
+    }
+
+    @Test
     fun `onChatPageLoaded in Input Mode doesn't store url`() = runTest {
         val tabId = "tab-1"
         val url = "https://duck.ai/chat?chatID=123"

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -83,6 +83,7 @@ class DuckChatContextualViewModelTest {
     private val modelManager: com.duckduckgo.duckchat.impl.models.DuckAiModelManager = mock()
     private val contextualNativeInputManager: ContextualNativeInputManager = mock()
     private val chatHistoryRepository: ChatHistoryRepository = mock()
+    private val contextualEntryPromptStore: ContextualEntryPromptStore = mock()
     private val recentChatsFlow = MutableStateFlow<List<ChatHistoryItem>>(emptyList())
     private val context: Context = ApplicationProvider.getApplicationContext()
 
@@ -441,6 +442,7 @@ class DuckChatContextualViewModelTest {
                     modelManager = modelManager,
                     contextualNativeInputManager = contextualNativeInputManager,
                     chatHistoryRepository = chatHistoryRepository,
+                    contextualEntryPromptStore = contextualEntryPromptStore,
                     context = context,
                 )
 
@@ -848,6 +850,7 @@ class DuckChatContextualViewModelTest {
                     modelManager = modelManager,
                     contextualNativeInputManager = contextualNativeInputManager,
                     chatHistoryRepository = chatHistoryRepository,
+                    contextualEntryPromptStore = contextualEntryPromptStore,
                     context = context,
                 )
 
@@ -889,6 +892,7 @@ class DuckChatContextualViewModelTest {
                     modelManager = modelManager,
                     contextualNativeInputManager = contextualNativeInputManager,
                     chatHistoryRepository = chatHistoryRepository,
+                    contextualEntryPromptStore = contextualEntryPromptStore,
                     context = context,
                 )
 
@@ -2618,6 +2622,7 @@ class DuckChatContextualViewModelTest {
         modelManager = modelManager,
         contextualNativeInputManager = contextualNativeInputManager,
         chatHistoryRepository = chatHistoryRepository,
+        contextualEntryPromptStore = contextualEntryPromptStore,
         context = context,
     )
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -83,7 +83,6 @@ class DuckChatContextualViewModelTest {
     private val modelManager: com.duckduckgo.duckchat.impl.models.DuckAiModelManager = mock()
     private val contextualNativeInputManager: ContextualNativeInputManager = mock()
     private val chatHistoryRepository: ChatHistoryRepository = mock()
-    private val contextualEntryPromptStore: ContextualEntryPromptStore = mock()
     private val recentChatsFlow = MutableStateFlow<List<ChatHistoryItem>>(emptyList())
     private val context: Context = ApplicationProvider.getApplicationContext()
 
@@ -442,7 +441,6 @@ class DuckChatContextualViewModelTest {
                     modelManager = modelManager,
                     contextualNativeInputManager = contextualNativeInputManager,
                     chatHistoryRepository = chatHistoryRepository,
-                    contextualEntryPromptStore = contextualEntryPromptStore,
                     context = context,
                 )
 
@@ -850,7 +848,6 @@ class DuckChatContextualViewModelTest {
                     modelManager = modelManager,
                     contextualNativeInputManager = contextualNativeInputManager,
                     chatHistoryRepository = chatHistoryRepository,
-                    contextualEntryPromptStore = contextualEntryPromptStore,
                     context = context,
                 )
 
@@ -892,7 +889,6 @@ class DuckChatContextualViewModelTest {
                     modelManager = modelManager,
                     contextualNativeInputManager = contextualNativeInputManager,
                     chatHistoryRepository = chatHistoryRepository,
-                    contextualEntryPromptStore = contextualEntryPromptStore,
                     context = context,
                 )
 
@@ -1356,46 +1352,6 @@ class DuckChatContextualViewModelTest {
 
         verify(duckChatPixels).reportContextualSheetNewChatFromPopup()
         verify(duckChatPixels, never()).reportContextualSheetNewChat()
-    }
-
-    @Test
-    fun `onNewChatRequestedFromPopup with redesign enabled hands off to entry dialog and reports popup pixel`() = runTest {
-        whenever(duckChatInternal.isContextualSheetRedesignEnabled()).thenReturn(true)
-
-        testee.commands.test {
-            testee.onNewChatRequestedFromPopup()
-
-            assertTrue(awaitItem() is DuckChatContextualViewModel.Command.ShowNewChatEntryDialog)
-            cancelAndIgnoreRemainingEvents()
-        }
-
-        verify(duckChatPixels).reportContextualSheetNewChatFromPopup()
-    }
-
-    @Test
-    fun `onNewChatFromEntryDialog consumes parked prompt and starts a new chat`() = runTest {
-        val tabId = "tab-1"
-        testee.onSheetOpened(tabId)
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
-        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
-        whenever(contextualEntryPromptStore.consume(tabId)).thenReturn(ContextualEntryPrompt(tabId, prompt, null))
-
-        testee.onNewChatFromEntryDialog()
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
-        assertEquals(DuckChatContextualViewModel.SheetMode.WEBVIEW, testee.viewState.value.sheetMode)
-    }
-
-    @Test
-    fun `onNewChatFromEntryDialog with nothing parked does not start a chat`() = runTest {
-        testee.onSheetOpened("tab-1")
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
-        testee.onNewChatFromEntryDialog()
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
-        assertEquals(DuckChatContextualViewModel.SheetMode.INPUT, testee.viewState.value.sheetMode)
     }
 
     @Test
@@ -2662,7 +2618,6 @@ class DuckChatContextualViewModelTest {
         modelManager = modelManager,
         contextualNativeInputManager = contextualNativeInputManager,
         chatHistoryRepository = chatHistoryRepository,
-        contextualEntryPromptStore = contextualEntryPromptStore,
         context = context,
     )
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.contextual
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
@@ -250,6 +251,25 @@ class DuckChatContextualWebViewViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
         verify(duckChatPixels).reportContextualSheetExpanded()
+    }
+
+    @Test
+    fun `onFullModeRequested with no existing chat reports entry without a prompt`() = runTest {
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+
+        testee.onFullModeRequested()
+
+        verify(duckChatInternal).reportDuckChatEntry(DuckChatEntryPoint.CONTEXTUAL_CHAT, opensNewTab = true, hasPrompt = false)
+    }
+
+    @Test
+    fun `onFullModeRequested with an existing chat reports entry with a prompt`() = runTest {
+        testee.onChatPageLoaded("https://duckduckgo.com/?chatID=abc")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onFullModeRequested()
+
+        verify(duckChatInternal).reportDuckChatEntry(DuckChatEntryPoint.CONTEXTUAL_CHAT, opensNewTab = true, hasPrompt = true)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -1,0 +1,406 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
+import com.duckduckgo.duckchat.impl.helper.NativeAction
+import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
+import com.duckduckgo.duckchat.impl.history.ChatHistoryItem
+import com.duckduckgo.duckchat.impl.history.ChatHistoryRepository
+import com.duckduckgo.duckchat.impl.models.ChatType
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
+import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.js.messaging.api.SubscriptionEventData
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+class DuckChatContextualWebViewViewModelTest {
+
+    @get:Rule
+    @Suppress("unused")
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: DuckChatContextualWebViewViewModel
+    private val duckChat: com.duckduckgo.duckchat.api.DuckChat = FakeDuckChat()
+    private val duckChatInternal: DuckChatInternal = mock()
+    private val duckChatJSHelper: DuckChatJSHelper = mock()
+    private val contextualDataStore = FakeDuckChatContextualDataStore()
+    private val timeProvider = FakeDuckChatContextualTimeProvider()
+    private val sessionTimeoutProvider = FakeDuckChatContextualSessionTimeoutProvider()
+    private val duckChatPixels: DuckChatPixels = mock()
+    private val duckChatFeature: DuckChatFeature = mock()
+    private val contextualFireButtonToggle: Toggle = mock()
+    private val modelManager: com.duckduckgo.duckchat.impl.models.DuckAiModelManager = mock()
+    private val contextualNativeInputManager: ContextualNativeInputManager = mock()
+    private val chatHistoryRepository: ChatHistoryRepository = mock()
+    private val contextualEntryPromptStore: ContextualEntryPromptStore = mock()
+    private val recentChatsFlow = MutableStateFlow<List<ChatHistoryItem>>(emptyList())
+
+    private val serializedPageData =
+        """
+        {
+            "title": "Page Title",
+            "url": "https://example.com",
+            "content": "Extracted DOM text...",
+            "truncated": false,
+            "fullContentLength": 1234
+        }
+        """.trimIndent()
+
+    @Before
+    fun setup() {
+        whenever(duckChatFeature.contextualFireButton()).thenReturn(contextualFireButtonToggle)
+        whenever(contextualFireButtonToggle.isEnabled()).thenReturn(false)
+        whenever(chatHistoryRepository.observeChats()).thenReturn(recentChatsFlow)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+        whenever(duckChatJSHelper.onNativeAction(NativeAction.NEW_CHAT)).thenReturn(
+            SubscriptionEventData(RealDuckChatJSHelper.DUCK_CHAT_FEATURE_NAME, "submitNewChatAction", JSONObject()),
+        )
+        testee = buildViewModel()
+    }
+
+    @Test
+    fun `onSheetOpened with no existing chat loads a fresh chat expanded`() = runTest {
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+
+        testee.commands.test {
+            testee.onSheetOpened("tab-1")
+
+            assertTrue(expectMostRecentItem() is DuckChatContextualWebViewViewModel.Command.LoadUrl)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals("tab-1", testee.viewState.value.tabId)
+        verify(duckChatPixels).reportContextualSheetOpened()
+    }
+
+    @Test
+    fun `onSheetOpened with pending entry prompt submits it once web app is ready`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1")).thenReturn(ContextualEntryPrompt("tab-1", prompt, null))
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.subscriptionEventDataFlow.test {
+            testee.onWebAppReady()
+
+            val event = awaitItem()
+            assertEquals("submitAIChatNativePrompt", event.subscriptionName)
+            assertEquals("hello", event.params.getJSONObject("query").getString("prompt"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onPromptSent with attached page context includes it in the event`() = runTest {
+        testee.onSheetOpened("tab-1")
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        testee.addPageContext()
+
+        testee.subscriptionEventDataFlow.test {
+            testee.onPromptSent("Summarize this page")
+
+            val event = expectMostRecentItem()
+            assertEquals("submitAIChatNativePrompt", event.subscriptionName)
+            val pageContext = event.params.getJSONObject("pageContext")
+            assertEquals("Page Title", pageContext.getString("title"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `removePageContext hides the attached context`() = runTest {
+        testee.onSheetOpened("tab-1")
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        testee.addPageContext()
+        assertTrue(testee.viewState.value.showContext)
+
+        testee.removePageContext()
+
+        assertFalse(testee.viewState.value.showContext)
+        verify(duckChatPixels).reportContextualPageContextRemovedNative()
+    }
+
+    @Test
+    fun `onNewChatRequestedFromPopup resets chat and hands off to the entry dialog`() = runTest {
+        testee.onSheetOpened("tab-1")
+
+        testee.commands.test {
+            testee.onNewChatRequestedFromPopup()
+
+            assertTrue(expectMostRecentItem() is DuckChatContextualWebViewViewModel.Command.ShowNewChatEntryDialog)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(duckChatPixels).reportContextualSheetNewChatFromPopup()
+    }
+
+    @Test
+    fun `sheet closed after New Chat handoff does not revert the contextual input state`() = runTest {
+        testee.onSheetOpened("tab-1")
+        testee.onNewChatRequestedFromPopup()
+
+        // The STATE_HIDDEN that follows the New Chat handoff must not be treated as a dismissal.
+        testee.onSheetClosed()
+
+        verify(contextualNativeInputManager, never()).onContextualClosed(any())
+        verify(duckChatPixels, never()).reportContextualSheetDismissed()
+    }
+
+    @Test
+    fun `sheet closed by the user reverts the contextual input state`() = runTest {
+        testee.onSheetOpened("tab-1")
+
+        testee.onSheetClosed()
+
+        verify(contextualNativeInputManager).onContextualClosed("tab-1")
+        verify(duckChatPixels).reportContextualSheetDismissed()
+    }
+
+    @Test
+    fun `onContextualFireConfirmed resets chat and hides the sheet`() = runTest {
+        testee.onSheetOpened("tab-1")
+
+        testee.commands.test {
+            testee.onContextualFireConfirmed()
+
+            val command = expectMostRecentItem()
+            assertTrue(command is DuckChatContextualWebViewViewModel.Command.ChangeSheetState)
+            assertEquals(BottomSheetBehavior.STATE_HIDDEN, (command as DuckChatContextualWebViewViewModel.Command.ChangeSheetState).newState)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(duckChatPixels).reportContextualFireButtonConfirmed()
+    }
+
+    @Test
+    fun `onFullModeRequested opens fullscreen`() = runTest {
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+
+        testee.commands.test {
+            testee.onFullModeRequested()
+
+            assertTrue(expectMostRecentItem() is DuckChatContextualWebViewViewModel.Command.OpenFullscreenMode)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(duckChatPixels).reportContextualSheetExpanded()
+    }
+
+    @Test
+    fun `onChatsIconClicked with no recent chats launches chat history`() = runTest {
+        testee.commands.test {
+            testee.onChatsIconClicked()
+
+            assertTrue(expectMostRecentItem() is DuckChatContextualWebViewViewModel.Command.LaunchChatHistory)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onChatsIconClicked with recent chats shows the popup`() = runTest {
+        recentChatsFlow.value = listOf(
+            ChatHistoryItem(
+                chatId = "c1",
+                displayTitle = "Chat",
+                type = ChatType.Discussion,
+                model = "",
+                pinned = false,
+                lastEditMillis = 1L,
+            ),
+        )
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.commands.test {
+            testee.onChatsIconClicked()
+
+            assertTrue(expectMostRecentItem() is DuckChatContextualWebViewViewModel.Command.ShowChatsPopup)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onContextualClose hides the sheet`() = runTest {
+        testee.commands.test {
+            testee.onContextualClose()
+
+            val command = expectMostRecentItem()
+            assertTrue(command is DuckChatContextualWebViewViewModel.Command.ChangeSheetState)
+            assertEquals(BottomSheetBehavior.STATE_HIDDEN, (command as DuckChatContextualWebViewViewModel.Command.ChangeSheetState).newState)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onChatPageLoaded with a chat id persists the url and shows fullscreen`() = runTest {
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onChatPageLoaded("https://duckduckgo.com/?chatID=abc")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(testee.viewState.value.showFullscreen)
+        assertEquals("https://duckduckgo.com/?chatID=abc", contextualDataStore.getTabChatUrl("tab-1"))
+    }
+
+    @Test
+    fun `handleJSCall close returns true and closes the sheet`() = runTest {
+        assertTrue(testee.handleJSCall(RealDuckChatJSHelper.METHOD_CLOSE_AI_CHAT))
+        assertFalse(testee.handleJSCall("some.other.method"))
+    }
+
+    @Test
+    fun `onVoiceRecognitionSuccess opens a search for a non duck ai result`() = runTest {
+        testee.commands.test {
+            testee.onVoiceRecognitionSuccess("weather today", isDuckAiResult = false)
+
+            assertTrue(expectMostRecentItem() is DuckChatContextualWebViewViewModel.Command.OpenSearchInNewTab)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun buildViewModel() = DuckChatContextualWebViewViewModel(
+        dispatchers = coroutineRule.testDispatcherProvider,
+        duckChat = duckChat,
+        duckChatInternal = duckChatInternal,
+        duckChatJSHelper = duckChatJSHelper,
+        contextualDataStore = contextualDataStore,
+        sessionTimeoutProvider = sessionTimeoutProvider,
+        timeProvider = timeProvider,
+        duckChatPixels = duckChatPixels,
+        duckChatFeature = duckChatFeature,
+        modelManager = modelManager,
+        contextualNativeInputManager = contextualNativeInputManager,
+        chatHistoryRepository = chatHistoryRepository,
+        contextualEntryPromptStore = contextualEntryPromptStore,
+    )
+
+    private class FakeDuckChat : com.duckduckgo.duckchat.api.DuckChat {
+        var nextUrl: String = ""
+        private val nativeChatInputEnabled = MutableStateFlow(false)
+
+        override fun isEnabled(): Boolean = true
+        override fun openDuckChat() = Unit
+        override fun openDuckChatWithAutoPrompt(query: String) = Unit
+        override fun openDuckChatWithPrefill(query: String) = Unit
+        override fun getDuckChatUrl(
+            query: String,
+            autoPrompt: Boolean,
+            sidebar: Boolean,
+        ): String = nextUrl
+
+        override fun getDuckChatSettingsUrl(): String = "https://duck.ai?settings=open"
+
+        override fun isDuckChatUrl(uri: android.net.Uri): Boolean =
+            uri.host == "duck.ai" || uri.host == "duckduckgo.com"
+        override suspend fun wasOpenedBefore(): Boolean = false
+
+        override suspend fun setInputScreenUserSetting(enabled: Boolean) = Unit
+        override suspend fun isInputScreenEverEnabled(): Boolean = false
+        override suspend fun setCosmeticInputScreenUserSetting(enabled: Boolean) = Unit
+        override fun observeInputScreenUserSettingEnabled(): Flow<Boolean> = emptyFlow()
+        override fun observeCosmeticInputScreenUserSettingEnabled(): Flow<Boolean?> = emptyFlow()
+        override fun observeAutomaticContextAttachmentUserSettingEnabled(): Flow<Boolean> = flowOf(true)
+        override fun observeNativeInputFieldUserSettingEnabled(): Flow<Boolean> = emptyFlow()
+        override fun observeNativeChatInputEnabled(): Flow<Boolean> = nativeChatInputEnabled
+        override fun observeNativeInputNavBarEnabled(): Flow<Boolean> = emptyFlow()
+        override suspend fun isStandaloneMigrationCompleted(): Boolean = true
+        override suspend fun setChatSuggestionsUserSetting(enabled: Boolean) = Unit
+        override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = flowOf(true)
+        override fun openVoiceDuckChat() { }
+        override fun isVoiceChatSessionActive(tabId: String): Boolean = false
+        override val activeVoiceChatSessions: Flow<Set<String>> = flowOf(emptySet())
+        override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = emptyFlow()
+        override fun endVoiceChatSession(tabId: String) { }
+        override suspend fun isChatHistoryAvailable(): Boolean = false
+        override suspend fun hasUserEnabledChatHistory(): Boolean = false
+        override fun observeHasChatSuggestions(): Flow<Boolean> = emptyFlow()
+        override suspend fun onAddressBarPickerDuckAiSelected() = Unit
+    }
+
+    private class FakeDuckChatContextualDataStore : DuckChatContextualDataStore {
+        private val urls = mutableMapOf<String, String>()
+        private val closeTimestamps = mutableMapOf<String, Long>()
+
+        override suspend fun persistTabChatUrl(
+            tabId: String,
+            url: String,
+        ) {
+            urls[tabId] = url
+        }
+
+        override suspend fun getTabChatUrl(tabId: String): String? = urls[tabId]
+
+        override suspend fun persistTabClosedTimestamp(
+            tabId: String,
+            timestampMs: Long,
+        ) {
+            closeTimestamps[tabId] = timestampMs
+        }
+
+        override suspend fun getTabClosedTimestamp(tabId: String): Long? = closeTimestamps[tabId]
+
+        override fun clearTabChatUrl(tabId: String) {
+            urls.remove(tabId)
+        }
+
+        override fun clearTabClosedTimestamp(tabId: String) {
+            closeTimestamps.remove(tabId)
+        }
+
+        override fun clearAll() {
+            urls.clear()
+            closeTimestamps.clear()
+        }
+    }
+
+    private class FakeDuckChatContextualSessionTimeoutProvider : DuckChatContextualSessionTimeoutProvider {
+        var timeoutMs: Long = 0L
+
+        override fun sessionTimeoutMillis(): Long = timeoutMs
+    }
+
+    private class FakeDuckChatContextualTimeProvider : DuckChatContextualTimeProvider {
+        var nowMs: Long = 0L
+
+        override fun currentTimeMillis(): Long = nowMs
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -133,6 +133,27 @@ class DuckChatContextualWebViewViewModelTest {
     }
 
     @Test
+    fun `entry prompt aborted before web app ready is not auto-submitted on a later reopen`() = runTest {
+        val prompt = NativeInputPrompt("stale", "model-1", "high", null, null, null)
+        // Consumed once on open; nothing parked on the subsequent reopen.
+        whenever(contextualEntryPromptStore.consume("tab-1")).thenReturn(ContextualEntryPrompt("tab-1", prompt, null), null)
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+
+        // Open with a parked prompt, but dismiss before the web app is ready (no onWebAppReady).
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        // Reopen with nothing parked; the leftover prompt must be dropped.
+        testee.onSheetReopened()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.subscriptionEventDataFlow.test {
+            testee.onWebAppReady()
+            expectNoEvents()
+        }
+    }
+
+    @Test
     fun `onPromptSent with attached page context includes it in the event`() = runTest {
         testee.onSheetOpened("tab-1")
         testee.onPageContextReceived("tab-1", serializedPageData)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -183,6 +183,147 @@ class DuckChatContextualWebViewViewModelTest {
     }
 
     @Test
+    fun `onPageContextReceived auto-attaches the current context when automatic attachment is enabled`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("Page Title", testee.viewState.value.contextTitle)
+        verify(duckChatPixels).reportContextualPageContextAutoAttached()
+    }
+
+    @Test
+    fun `onPageContextReceived does not auto-attach when automatic attachment is disabled`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+
+        assertFalse(testee.viewState.value.showContext)
+        verify(duckChatPixels, never()).reportContextualPageContextAutoAttached()
+    }
+
+    @Test
+    fun `onPageContextReceived does not re-attach context the user removed`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        testee.removePageContext()
+        testee.onPageContextReceived("tab-1", serializedPageData)
+
+        assertFalse(testee.viewState.value.showContext)
+    }
+
+    @Test
+    fun `native input auto-attach during hand-off does not add context to the first prompt`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.subscriptionEventDataFlow.test {
+            // The entry dialog handed off no context, so the sheet must not auto-attach the current page...
+            testee.onPageContextReceived("tab-1", serializedPageData)
+            assertEquals("submitAIChatPageContext", awaitItem().subscriptionName)
+            assertFalse(testee.viewState.value.showContext)
+
+            // ...and the first prompt is frozen to the entry dialog's (empty) attachment, so it carries none.
+            testee.onWebAppReady()
+            val promptEvent = awaitItem()
+            assertEquals("submitAIChatNativePrompt", promptEvent.subscriptionName)
+            assertTrue(promptEvent.params.isNull("pageContext"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `first prompt from a with-context entry hand-off carries the entry page context`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = serializedPageData))
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.subscriptionEventDataFlow.test {
+            testee.onWebAppReady()
+
+            val promptEvent = awaitItem()
+            assertEquals("submitAIChatNativePrompt", promptEvent.subscriptionName)
+            assertEquals("Page Title", promptEvent.params.getJSONObject("pageContext").getString("title"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `no-context entry hand-off does not re-attach the current page while it stays put`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+
+        // A repeated report for the same page still must not auto-attach.
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+    }
+
+    @Test
+    fun `no-context entry hand-off re-attaches after the user navigates to a new page`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+
+        val otherPageData =
+            """
+            {
+                "title": "Other Page",
+                "url": "https://other.example.com",
+                "content": "Other extracted DOM text...",
+                "truncated": false,
+                "fullContentLength": 4321
+            }
+            """.trimIndent()
+        testee.onPageContextReceived("tab-1", otherPageData)
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("Other Page", testee.viewState.value.contextTitle)
+    }
+
+    @Test
+    fun `no-context entry hand-off re-attaches when the user manually attaches`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+
+        testee.addPageContext()
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("Page Title", testee.viewState.value.contextTitle)
+    }
+
+    @Test
     fun `onNewChatRequestedFromPopup resets chat and hands off to the entry dialog`() = runTest {
         testee.onSheetOpened("tab-1")
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -46,7 +46,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -71,7 +70,6 @@ class DuckChatContextualWebViewViewModelTest {
     private val duckChatFeature: DuckChatFeature = mock()
     private val contextualFireButtonToggle: Toggle = mock()
     private val modelManager: com.duckduckgo.duckchat.impl.models.DuckAiModelManager = mock()
-    private val contextualNativeInputManager: ContextualNativeInputManager = mock()
     private val chatHistoryRepository: ChatHistoryRepository = mock()
     private val contextualEntryPromptStore: ContextualEntryPromptStore = mock()
     private val recentChatsFlow = MutableStateFlow<List<ChatHistoryItem>>(emptyList())
@@ -201,10 +199,13 @@ class DuckChatContextualWebViewViewModelTest {
         testee.onSheetOpened("tab-1")
         testee.onNewChatRequestedFromPopup()
 
-        // The STATE_HIDDEN that follows the New Chat handoff must not be treated as a dismissal.
-        testee.onSheetClosed()
+        testee.commands.test {
+            // The STATE_HIDDEN that follows the New Chat handoff must not be treated as a dismissal.
+            testee.onSheetClosed()
 
-        verify(contextualNativeInputManager, never()).onContextualClosed(any())
+            assertFalse(expectMostRecentItem() is DuckChatContextualWebViewViewModel.Command.ApplyContextualClosed)
+            cancelAndIgnoreRemainingEvents()
+        }
         verify(duckChatPixels, never()).reportContextualSheetDismissed()
     }
 
@@ -212,9 +213,14 @@ class DuckChatContextualWebViewViewModelTest {
     fun `sheet closed by the user reverts the contextual input state`() = runTest {
         testee.onSheetOpened("tab-1")
 
-        testee.onSheetClosed()
+        testee.commands.test {
+            testee.onSheetClosed()
 
-        verify(contextualNativeInputManager).onContextualClosed("tab-1")
+            val command = expectMostRecentItem()
+            assertTrue(command is DuckChatContextualWebViewViewModel.Command.ApplyContextualClosed)
+            assertEquals("tab-1", (command as DuckChatContextualWebViewViewModel.Command.ApplyContextualClosed).tabId)
+            cancelAndIgnoreRemainingEvents()
+        }
         verify(duckChatPixels).reportContextualSheetDismissed()
     }
 
@@ -329,7 +335,6 @@ class DuckChatContextualWebViewViewModelTest {
         duckChatPixels = duckChatPixels,
         duckChatFeature = duckChatFeature,
         modelManager = modelManager,
-        contextualNativeInputManager = contextualNativeInputManager,
         chatHistoryRepository = chatHistoryRepository,
         contextualEntryPromptStore = contextualEntryPromptStore,
     )
@@ -339,9 +344,14 @@ class DuckChatContextualWebViewViewModelTest {
         private val nativeChatInputEnabled = MutableStateFlow(false)
 
         override fun isEnabled(): Boolean = true
-        override fun openDuckChat() = Unit
-        override fun openDuckChatWithAutoPrompt(query: String) = Unit
-        override fun openDuckChatWithPrefill(query: String) = Unit
+        override fun openDuckChat(entryPoint: com.duckduckgo.duckchat.api.DuckChatEntryPoint) = Unit
+        override fun openDuckChatWithAutoPrompt(query: String, entryPoint: com.duckduckgo.duckchat.api.DuckChatEntryPoint) = Unit
+        override fun openDuckChatWithPrefill(query: String, entryPoint: com.duckduckgo.duckchat.api.DuckChatEntryPoint) = Unit
+        override fun reportDuckChatEntry(
+            entryPoint: com.duckduckgo.duckchat.api.DuckChatEntryPoint,
+            opensNewTab: Boolean,
+            hasPrompt: Boolean,
+        ) = Unit
         override fun getDuckChatUrl(
             query: String,
             autoPrompt: Boolean,
@@ -366,7 +376,7 @@ class DuckChatContextualWebViewViewModelTest {
         override suspend fun isStandaloneMigrationCompleted(): Boolean = true
         override suspend fun setChatSuggestionsUserSetting(enabled: Boolean) = Unit
         override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = flowOf(true)
-        override fun openVoiceDuckChat() { }
+        override fun openVoiceDuckChat(entryPoint: com.duckduckgo.duckchat.api.DuckChatEntryPoint) { }
         override fun isVoiceChatSessionActive(tabId: String): Boolean = false
         override val activeVoiceChatSessions: Flow<Set<String>> = flowOf(emptySet())
         override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = emptyFlow()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/store/RealDuckChatContextualDataStoreTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/store/RealDuckChatContextualDataStoreTest.kt
@@ -24,6 +24,7 @@ import androidx.datastore.preferences.preferencesDataStoreFile
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.impl.contextual.RealContextualEntryPromptStore
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -59,6 +60,7 @@ class RealDuckChatContextualDataStoreTest {
                 coroutineRule.testScope,
                 coroutineRule.testDispatcherProvider,
                 Moshi.Builder().build(),
+                RealContextualEntryPromptStore(),
             )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1217146291865568?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1217235340374866
API Proposals URL(s) (if applicable): N/A

### Description
 - Adds a transparent contextual Duck.ai entry dialog (`DuckChatContextualEntryDialog` + `DuckChatContextualEntryViewModel`) as the initial input state of the contextual sheet, shown when tapping "Ask about page" from the entry menu. It lets the user compose a prompt, pick a suggested prompt, or run the Summarize quick action before any chat opens.
  - Auto-attaches the current page context to the composed prompt (validated, and re-attachable via the composer affordance), and resolves page-specific suggestions from the retained page context. Explicit removal is remembered for the session so a later context update won't silently re-attach.
  - Adds a dedicated webview-only chat surface (`DuckChatContextualWebViewFragment` + `DuckChatContextualWebViewViewModel`) that the redesign opens into directly, auto-submitting the parked prompt instead of reopening the input state.
  - Hands the composed prompt from the dialog to the sheet via a new AppScope `ContextualEntryPromptStore`, keyed per tab (cleared on tab delete/clear-all) so concurrent tabs don't clobber each other.
  - Routes the chats-popup New Chat action through the redesigned entry dialog, splitting the shared view model's open signal into ShowSheet (host shows the container) and ReloadChat (sheet loads its chat).
  - Renames the DuckChatContextual API's createSheet → createChatSurface and onAskAboutPage → showChatSurface; wires up voice actions in the entry dialog and restyles the Duck.ai entry suggestion pills.

All new behavior is gated behind the existing `isContextualSheetRedesignEnabled()` flag; when off, the previous `DuckChatContextualFragment` flow is unchanged.

NOTE: Pixel related fixes are NOT YET included in this PR.

### Steps to test this PR
Testing should be done on the top stack.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, multi-fragment contextual chat flow with WebView JS hand-off and page-context state, but behavior is gated behind `isContextualSheetRedesignEnabled()` and includes substantial unit test coverage.
> 
> **Overview**
> When **contextual sheet redesign** is enabled, **“Ask about page”** no longer opens the old combined sheet in INPUT mode. It shows a **transparent scrimmed entry dialog** with suggestions, Summarize, and the native composer; on submit the prompt is parked in **`ContextualEntryPromptStore`** and the host is asked via **`ShowSheet`** to reveal the embedded chat surface.
> 
> The redesign chat surface is **`DuckChatContextualWebViewFragment`**: WebView chat plus follow-up composer only. It **consumes** the parked prompt after the web app is ready (**`onWebAppReady`**) and preserves the entry dialog’s page-context choice across the hand-off. **New Chat** from the chats menu hides the sheet and reopens the same entry dialog.
> 
> **`DuckChatContextualSharedViewModel`** splits host vs sheet signaling: **`requestShowSheet`** / **`ShowSheet`** vs **`onReloadChatRequested`** / **`ReloadChat`** (replacing **`OpenSheet`**). **`createSheet` → `createChatSurface`** picks webview vs legacy fragment; **`DuckDuckGoBottomSheetDialogFragment`** enables Dagger in the entry dialog. Pending entry prompts are cleared when contextual tab data is cleared. Legacy flow stays when redesign is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ff20a368be0e5d3aa8ee39861b266b302798f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->