### PR TITLE
Contextual/DuckAi: Suggested prompt UI improvements

### DIFF
--- a/android-design-system/design-system/src/main/res/drawable/duck_ai_suggested_prompts_background.xml
+++ b/android-design-system/design-system/src/main/res/drawable/duck_ai_suggested_prompts_background.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?attr/daxColorSurface" />
+    <stroke
+        android:width="1dp"
+        android:color="?attr/daxColorContainer" />
+    <corners android:radius="20dp" />
+</shape>

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualEntryPromptStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualEntryPromptStore.kt
@@ -27,7 +27,8 @@ import javax.inject.Inject
  * straight into the chat (WEBVIEW) and auto-submit it, rather than reopening the initial input state.
  *
  * [serializedPageContext] is the page context the dialog had attached at submit time, so "Ask about
- * page" keeps its context across the hand-off.
+ * page" keeps its context across the hand-off. When it is null the dialog had no context attached
+ * (never available, or the user removed it), and the sheet must not auto-attach one on hand-off.
  */
 data class ContextualEntryPrompt(
     val tabId: String,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -111,6 +111,11 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
     // is ready (onWebAppReady). Held between opening the sheet and that ready signal.
     private var pendingEntryPrompt: NativeInputPrompt? = null
 
+    // The page context the entry dialog had attached to [pendingEntryPrompt] at hand-off (null if none).
+    // Frozen so the first webview prompt reflects the dialog's choice, regardless of the sheet's own
+    // native-input auto-attach that may run before the web app is ready.
+    private var pendingEntryPageContext: String? = null
+
     private var hidingSheetForNewChat = false
 
     sealed class Command {
@@ -156,6 +161,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         val contextUrl: String = "",
         val contextTitle: String = "",
         val tabId: String = "",
+        val userRemovedContext: Boolean = false,
         val isFireButtonEnabled: Boolean = false,
         val recentChats: List<ChatHistoryItem> = emptyList(),
     )
@@ -293,30 +299,25 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         tabId: String,
         entry: ContextualEntryPrompt,
     ) {
+        // Freeze the prompt and the dialog's attachment decision (a page context, or none). The first
+        // webview prompt carries exactly this; the sheet's own native-input attachment state must not add
+        // to or remove from it.
         pendingEntryPrompt = entry.prompt
+        pendingEntryPageContext = entry.serializedPageContext
+        val handedOffWithoutContext = entry.serializedPageContext == null
         val chatUrl = duckChat.getDuckChatUrl("", false, sidebar = true)
         withContext(dispatchers.main()) {
             setSheetUrl(chatUrl)
-            entry.serializedPageContext?.let { attachProvidedPageContext(it) }
             _viewState.update {
-                it.copy(showFullscreen = hasChatId(chatUrl), tabId = tabId)
+                it.copy(
+                    showFullscreen = hasChatId(chatUrl),
+                    tabId = tabId,
+                    showContext = false,
+                    userRemovedContext = handedOffWithoutContext,
+                )
             }
             commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_EXPANDED))
             commandChannel.trySend(Command.LoadUrl(chatUrl))
-        }
-    }
-
-    private fun attachProvidedPageContext(serializedPageContext: String) {
-        if (!isContextValid(serializedPageContext)) return
-        currentPageContext = serializedPageContext
-        pageContextState = pageContextState.copy(attachedPage = serializedPageContext)
-        val json = JSONObject(serializedPageContext)
-        _viewState.update {
-            it.copy(
-                showContext = true,
-                contextTitle = json.optString("title"),
-                contextUrl = json.optString("url"),
-            )
         }
     }
 
@@ -327,14 +328,17 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
      */
     fun onWebAppReady() {
         val entry = pendingEntryPrompt ?: return
+        val entryPageContext = pendingEntryPageContext
         pendingEntryPrompt = null
-        onPromptSent(
+        pendingEntryPageContext = null
+        submitPrompt(
             prompt = entry.prompt,
             modelId = entry.modelId,
             reasoningEffort = entry.reasoningEffort,
             selectedTool = entry.selectedTool,
             imagesJson = entry.imagesJson,
             filesJson = entry.filesJson,
+            pageContextSerialized = entryPageContext,
         )
     }
 
@@ -347,8 +351,22 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         imagesJson: JSONArray? = null,
         filesJson: JSONArray? = null,
     ) {
+        val attachedContext = pageContextState.attachedPage.takeIf { _viewState.value.showContext }
+        submitPrompt(prompt, followUpPrefill, modelId, reasoningEffort, selectedTool, imagesJson, filesJson, attachedContext)
+    }
+
+    private fun submitPrompt(
+        prompt: String,
+        followUpPrefill: String? = null,
+        modelId: String? = null,
+        reasoningEffort: String? = null,
+        selectedTool: String? = null,
+        imagesJson: JSONArray? = null,
+        filesJson: JSONArray? = null,
+        pageContextSerialized: String?,
+    ) {
         viewModelScope.launch(dispatchers.io()) {
-            val contextPrompt = generateContextPrompt(prompt, modelId, reasoningEffort, selectedTool, imagesJson, filesJson)
+            val contextPrompt = generateContextPrompt(prompt, modelId, reasoningEffort, selectedTool, imagesJson, filesJson, pageContextSerialized)
             val prefillText = followUpPrefill?.takeIf { it.isNotEmpty() }
             val prefillEvent = prefillText?.let { generatePrefillEvent(it) }
             withContext(dispatchers.main()) {
@@ -435,20 +453,12 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         selectedTool: String? = null,
         imagesJson: JSONArray? = null,
         filesJson: JSONArray? = null,
+        pageContextSerialized: String?,
     ): SubscriptionEventData {
-        val viewState = _viewState.value
         val pageContext =
-            if (viewState.showContext) {
-                pageContextState.attachedPage
-                    .takeIf { it.isNotBlank() }
-                    ?.let { runCatching { JSONObject(it) }.getOrNull() }
-                    ?: run {
-                        logcat { "Duck.ai: no pageContext available, skipping pageContext in prompt" }
-                        null
-                    }
-            } else {
-                null
-            }
+            pageContextSerialized
+                ?.takeIf { it.isNotBlank() }
+                ?.let { runCatching { JSONObject(it) }.getOrNull() }
 
         if (pageContext == null) {
             duckChatPixels.reportContextualPromptSubmittedWithoutContextNative()
@@ -505,7 +515,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         }
 
         val params = JSONObject().apply {
-            if (duckChatInternal.isAutomaticContextAttachmentEnabled()) {
+            if (duckChatInternal.isAutomaticContextAttachmentEnabled() && _viewState.value.showContext) {
                 put("pageContext", pageContext)
             } else {
                 put("pageContext", null)
@@ -550,7 +560,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
     fun removePageContext() {
         logcat { "Duck.ai Contextual: removePageContext" }
         _viewState.update { current ->
-            current.copy(showContext = false)
+            current.copy(showContext = false, userRemovedContext = true)
         }
         duckChatPixels.reportContextualPageContextRemovedNative()
     }
@@ -571,6 +581,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         _viewState.update { current ->
             current.copy(
                 showContext = true,
+                userRemovedContext = false,
                 contextTitle = json.optString("title"),
                 contextUrl = json.optString("url"),
             )
@@ -635,14 +646,35 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
             val url = json.optString("url")
 
             logcat { "Duck.ai: onPageContextReceived for url $url" }
-            _viewState.update { current ->
-                current.copy(
+            val current = _viewState.value
+            val allowsAutomaticContextAttachment = duckChatInternal.isAutomaticContextAttachmentEnabled()
+
+            val urlChanged = current.contextUrl.isNotEmpty() && url != current.contextUrl
+            val remainsUserRemoved = current.userRemovedContext && !urlChanged
+            val dropStaleAttachment = !allowsAutomaticContextAttachment && current.showContext && urlChanged
+
+            val showContext = when {
+                allowsAutomaticContextAttachment -> !remainsUserRemoved
+                dropStaleAttachment -> false
+                else -> current.showContext
+            }
+            val newlyAutoAttached = showContext && !current.showContext
+            if (showContext) {
+                pageContextState = pageContextState.copy(attachedPage = pageContext)
+            }
+            _viewState.update {
+                it.copy(
                     contextTitle = title,
                     contextUrl = url,
                     tabId = tabId,
+                    showContext = showContext,
+                    userRemovedContext = remainsUserRemoved,
                 )
             }
-            if (duckChatInternal.isAutomaticContextAttachmentEnabled() || duckChatInternal.areMultipleContentAttachmentsEnabled()) {
+            if (newlyAutoAttached) {
+                duckChatPixels.reportContextualPageContextAutoAttached()
+            }
+            if (allowsAutomaticContextAttachment || duckChatInternal.areMultipleContentAttachmentsEnabled()) {
                 val pageContextEvent = generatePageContextEventData()
                 viewModelScope.launch(dispatchers.main()) {
                     _subscriptionEventDataChannel.trySend(pageContextEvent)
@@ -727,6 +759,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
                     it.copy(
                         showFullscreen = true,
                         showContext = false,
+                        userRemovedContext = false,
                     )
                 }
                 val subscriptionEvent = duckChatJSHelper.onNativeAction(NativeAction.NEW_CHAT)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/suggestions/ContextualSuggestionsView.kt
@@ -21,6 +21,7 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.LinearLayout
 import androidx.annotation.DrawableRes
+import androidx.core.content.res.use
 import androidx.core.view.doOnAttach
 import androidx.core.view.isNotEmpty
 import androidx.core.view.isVisible
@@ -41,6 +42,7 @@ import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
+import com.duckduckgo.mobile.android.R as CommonR
 
 @InjectWith(ViewScope::class)
 class ContextualSuggestionsView @JvmOverloads constructor(
@@ -65,8 +67,14 @@ class ContextualSuggestionsView @JvmOverloads constructor(
 
     private val viewStateJob = ConflatedJob()
 
+    @DrawableRes
+    private val suggestionBackgroundRes: Int = context.obtainStyledAttributes(attrs, R.styleable.ContextualSuggestionsView).use {
+        it.getResourceId(R.styleable.ContextualSuggestionsView_suggestionBackground, CommonR.drawable.duck_ai_prompt_background)
+    }
+
     init {
         orientation = VERTICAL
+        loadingView.setBackgroundResource(suggestionBackgroundRes)
         addView(
             loadingView,
             LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT).apply { bottomMargin = LOADING_MARGIN_BOTTOM_DP.toPx() },
@@ -128,6 +136,7 @@ class ContextualSuggestionsView @JvmOverloads constructor(
             val inflater = LayoutInflater.from(context)
             viewState.suggestions.forEach { suggestion ->
                 val itemBinding = ItemContextualSuggestionBinding.inflate(inflater, cardsContainer, false)
+                itemBinding.suggestionLabel.setBackgroundResource(suggestionBackgroundRes)
                 itemBinding.suggestionLabel.text = suggestion.label
                 itemBinding.suggestionLabel.setCompoundDrawablesRelativeWithIntrinsicBounds(iconResFor(suggestion.icon), 0, 0, 0)
                 itemBinding.root.setOnClickListener {

--- a/duckchat/duckchat-impl/src/main/res/layout/dialog_contextual_duck_ai_entry.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/dialog_contextual_duck_ai_entry.xml
@@ -44,17 +44,19 @@
             <com.duckduckgo.duckchat.impl.contextual.suggestions.ContextualSuggestionsView
                 android:id="@+id/entrySuggestionsView"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                app:suggestionBackground="@drawable/duck_ai_suggested_prompts_background" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextView
                 android:id="@+id/entryPromptQuickAction"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/keyline_2"
-                android:background="@drawable/background_large_rounded_surface"
+                android:background="@drawable/duck_ai_suggested_prompts_background"
                 android:drawableStart="@drawable/ic_summarize_16"
                 android:drawablePadding="@dimen/keyline_2"
-                android:padding="@dimen/keyline_2"
+                android:paddingVertical="@dimen/keyline_2"
+                android:paddingHorizontal="@dimen/keyline_3"
                 android:text="@string/duckAIContextualPromptSummarize"
                 android:visibility="gone"
                 app:typography="body2_bold" />

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_webview.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_webview.xml
@@ -54,11 +54,10 @@
             android:background="@drawable/selectable_item_rounded_corner_background"
             android:contentDescription="@string/browserMenuChatHistory"
             android:scaleType="center"
-            android:layout_marginEnd="@dimen/keyline_2"
             app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/contextualTitle"
-            app:srcCompat="@drawable/ic_expand_24" />
+            app:srcCompat="@drawable/ic_open_in_24" />
 
         <ImageView
             android:id="@+id/contextualNewChat"
@@ -70,7 +69,7 @@
             android:visibility="gone"
             tools:visibility="visible"
             app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
-            app:layout_constraintStart_toEndOf="@+id/contextualFullScreen"
+            app:layout_constraintStart_toEndOf="@+id/contextualClose"
             app:layout_constraintTop_toTopOf="@id/contextualTitle"
             app:srcCompat="@drawable/ic_chats_24" />
 
@@ -79,7 +78,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/keyline_4"
-            android:drawableStart="@drawable/ic_duck_ai_color_24"
+            android:drawableStart="@drawable/ic_ai_chat_color_24"
             android:drawablePadding="@dimen/keyline_2"
             android:gravity="center"
             android:text="@string/duck_chat_title"
@@ -98,7 +97,7 @@
             android:visibility="gone"
             tools:visibility="visible"
             app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
-            app:layout_constraintEnd_toStartOf="@+id/contextualClose"
+            app:layout_constraintEnd_toStartOf="@+id/contextualFullScreen"
             app:layout_constraintTop_toTopOf="@id/contextualTitle"
             app:srcCompat="@drawable/ic_fire_24" />
 
@@ -111,7 +110,7 @@
             android:contentDescription="@string/browserMenuChatHistory"
             android:scaleType="center"
             app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/contextualTitle"
             app:srcCompat="@drawable/ic_close_24_small" />
 

--- a/duckchat/duckchat-impl/src/main/res/layout/item_contextual_suggestion.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/item_contextual_suggestion.xml
@@ -25,7 +25,8 @@
     android:layout_marginBottom="@dimen/keyline_2"
     android:background="@drawable/duck_ai_prompt_background"
     android:drawablePadding="@dimen/keyline_2"
-    android:padding="@dimen/keyline_2"
+    android:paddingVertical="@dimen/keyline_2"
+    android:paddingHorizontal="@dimen/keyline_3"
     app:typography="body2_bold"
     tools:drawableStart="@drawable/ic_summarize_16"
     tools:text="Summarize this page" />

--- a/duckchat/duckchat-impl/src/main/res/values/attrs-contextual-suggestions-view.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/attrs-contextual-suggestions-view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <declare-styleable name="ContextualSuggestionsView">
+        <attr name="suggestionBackground" format="reference" />
+    </declare-styleable>
+</resources>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
@@ -107,4 +107,20 @@ class DuckChatContextualEntryViewModelTest {
         verify(store).store(captor.capture())
         assertNull(captor.firstValue.serializedPageContext)
     }
+
+    @Test
+    fun whenContextRemovedThenPromptStoredWithNullContext() = runTest {
+        viewModel.start("tab-1")
+        viewModel.onPageContextReceived(validContext)
+        viewModel.onContextRemoved()
+
+        viewModel.commands.test {
+            viewModel.onPromptSubmitted(samplePrompt)
+            assertEquals(DuckChatContextualEntryViewModel.Command.HandOffToSheet, awaitItem())
+        }
+
+        val captor = argumentCaptor<ContextualEntryPrompt>()
+        verify(store).store(captor.capture())
+        assertNull(captor.firstValue.serializedPageContext)
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -183,6 +183,147 @@ class DuckChatContextualWebViewViewModelTest {
     }
 
     @Test
+    fun `onPageContextReceived auto-attaches the current context when automatic attachment is enabled`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("Page Title", testee.viewState.value.contextTitle)
+        verify(duckChatPixels).reportContextualPageContextAutoAttached()
+    }
+
+    @Test
+    fun `onPageContextReceived does not auto-attach when automatic attachment is disabled`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+
+        assertFalse(testee.viewState.value.showContext)
+        verify(duckChatPixels, never()).reportContextualPageContextAutoAttached()
+    }
+
+    @Test
+    fun `onPageContextReceived does not re-attach context the user removed`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        testee.removePageContext()
+        testee.onPageContextReceived("tab-1", serializedPageData)
+
+        assertFalse(testee.viewState.value.showContext)
+    }
+
+    @Test
+    fun `native input auto-attach during hand-off does not add context to the first prompt`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.subscriptionEventDataFlow.test {
+            // The entry dialog handed off no context, so the sheet must not auto-attach the current page...
+            testee.onPageContextReceived("tab-1", serializedPageData)
+            assertEquals("submitAIChatPageContext", awaitItem().subscriptionName)
+            assertFalse(testee.viewState.value.showContext)
+
+            // ...and the first prompt is frozen to the entry dialog's (empty) attachment, so it carries none.
+            testee.onWebAppReady()
+            val promptEvent = awaitItem()
+            assertEquals("submitAIChatNativePrompt", promptEvent.subscriptionName)
+            assertTrue(promptEvent.params.isNull("pageContext"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `first prompt from a with-context entry hand-off carries the entry page context`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = serializedPageData))
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.subscriptionEventDataFlow.test {
+            testee.onWebAppReady()
+
+            val promptEvent = awaitItem()
+            assertEquals("submitAIChatNativePrompt", promptEvent.subscriptionName)
+            assertEquals("Page Title", promptEvent.params.getJSONObject("pageContext").getString("title"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `no-context entry hand-off does not re-attach the current page while it stays put`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+
+        // A repeated report for the same page still must not auto-attach.
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+    }
+
+    @Test
+    fun `no-context entry hand-off re-attaches after the user navigates to a new page`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+
+        val otherPageData =
+            """
+            {
+                "title": "Other Page",
+                "url": "https://other.example.com",
+                "content": "Other extracted DOM text...",
+                "truncated": false,
+                "fullContentLength": 4321
+            }
+            """.trimIndent()
+        testee.onPageContextReceived("tab-1", otherPageData)
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("Other Page", testee.viewState.value.contextTitle)
+    }
+
+    @Test
+    fun `no-context entry hand-off re-attaches when the user manually attaches`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+
+        testee.addPageContext()
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("Page Title", testee.viewState.value.contextTitle)
+    }
+
+    @Test
     fun `onNewChatRequestedFromPopup resets chat and hands off to the entry dialog`() = runTest {
         testee.onSheetOpened("tab-1")
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1217362081874312?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
UI changes (match https://www.figma.com/design/JPmFyhhOHdgfYl5n8uShpU/O-J-Contextual-Duck.ai-Improvements?node-id=406-22221&m=dev)
- Radius of the suggested prompt chip is 20dp 
- Adds a 1dp border on the suggested prompt chip
- Matches padding

### Steps to test this PR

_contextualRedesign FF OFF (Default) - verify no regression_
- [x] Load bbc.com and select a specific article
- [x] Before the site loads completely, select contextual entry
- [x] Verify you see suggested prompts loading and eventually receives prompts
- [x] Verify that everything looks the same as in an INTERNAL build
- [x] Select a suggested prompt
- [x] Verify it submits the prompt with attached context
- [ ] Close sheet and reopen, verify that sheet shows the previous chat
- [ ] On a new tab, load another site and verify that a new contextual sheet opens
- [ ] Go back to the previous tab and verify that the state is still the correct chat in progress

_contextualRedesign FF ON (Enable via FF inventory + restart app)_
- [x] Open a new tab, Load bbc.com and select a specific article
- [x] Before the site loads completely, select contextual entry > Ask About page
- [x] Verify you see suggested prompts loading and eventually receives prompts
- [x] Verify it shows the sheet with transparent background and the page context is attached.
- [x] click anywhere outside the prompts and input
- [x] Verify that the sheet is dismissed
- [x] Open the sheet again
- [x] Test that the buttons on the Native Input are working as expected (change model, change to Reasoning, try the Add file, Add Image and Take photo - verify the appear on the attachments. Remove all attachments before proceeding)
- [x] Select Ask About Page from attachment menu
- [x] Verify right context is attached
- [x] Select any of the suggested prompts
- [x] Verify chat in progress sheet is shown with the correct prompt + context
- [x] Verify that right model  and reasoning were used.
- [x] Dismiss sheet
- [x] Open a new tab and load a different site
- [x] Verify that contextual menu is shown and choosing Asks About Page shows a fresh entry with correct suggested prompts
- [x] Go back to the previous tab and Click on contextual entry
- [x] Verify that correct chat in progress is shown
- [x] Open chats menu > New chat
- [x] Verify that transparent sheet is shown again

_contextualRedesign FF ON + other controls_
- [x] Smoke test voice chat, voice search and all other features in the transparent entry and webview chat in progress sheet - verify that native input state and overall sheet state and behavior are as expected.
- [x] NOTE: Voice search sheet is transparent - so it will have to show the transparent sheet under.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how page context is attached and submitted across entry dialog and webview sheet hand-off, which affects core contextual Duck.ai prompts; coverage is expanded in ViewModel tests but behavior is easy to regress across FF states.
> 
> **Overview**
> Updates **suggested prompt chips** in the contextual entry flow to match design: **20dp corner radius**, **1dp border**, and adjusted padding via a new `duck_ai_suggested_prompts_background` drawable. `ContextualSuggestionsView` gains a **`suggestionBackground`** styleable so the entry dialog can use that chip style while other surfaces keep the default.
> 
> **Page context** behavior is tightened for the redesign sheet. The first prompt after entry→sheet hand-off uses the **frozen** context from the entry dialog (`serializedPageContext`), not whatever the webview sheet auto-attaches before the web app is ready. A **`userRemovedContext`** flag blocks re-auto-attach on the same URL until navigation or manual attach; auto-attach when enabled reports **`reportContextualPageContextAutoAttached`**. Prompt submission is routed through **`submitPrompt`** with an explicit serialized context parameter.
> 
> The **chat-in-progress sheet header** is rearranged (close left, open-in fullscreen right, chats after close) with updated title and fullscreen icons.
> 
> Tests cover removed context on submit, hand-off without/with context, and auto-attach edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2509a693904592de0a00afa00a6f4c7f1a2a4bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->