### PR TITLE
Report hotfix orchestrator failures in Asana

### DIFF
--- a/.github/workflows/hotfix_create_task.yml
+++ b/.github/workflows/hotfix_create_task.yml
@@ -11,6 +11,11 @@ on:
         description: 'Commit SHA(s) cherry-picked into the hotfix (space- or comma-separated)'
         required: true
         type: string
+      create_asana_task:
+        description: 'Create an Asana failure task on failure (set false when a caller handles failure reporting)'
+        required: false
+        type: boolean
+        default: true
   workflow_dispatch:
     inputs:
       app-version:
@@ -21,6 +26,11 @@ on:
         description: 'Commit SHA(s) cherry-picked into the hotfix (space- or comma-separated)'
         required: true
         type: string
+      create_asana_task:
+        description: 'Create an Asana failure task on failure (set false when a caller handles failure reporting)'
+        required: false
+        type: boolean
+        default: true
 
 env:
   ASANA_PAT: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -92,7 +102,7 @@ jobs:
           action: 'send-mattermost-message'
 
       - name: Create Asana task when workflow failed
-        if: ${{ failure() }}
+        if: ${{ failure() && inputs.create_asana_task == true }}
         uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/hotfix_finish.yml
+++ b/.github/workflows/hotfix_finish.yml
@@ -7,12 +7,22 @@ on:
         description: 'Hotfix version to release (e.g. 5.284.1)'
         required: true
         type: string
+      create_asana_task:
+        description: 'Create an Asana failure task on failure (set false when a caller handles failure reporting)'
+        required: false
+        type: boolean
+        default: true
   workflow_dispatch:
     inputs:
       app-version:
         description: 'Hotfix version to release (e.g. 5.284.1)'
         required: true
         type: string
+      create_asana_task:
+        description: 'Create an Asana failure task on failure (set false when a caller handles failure reporting)'
+        required: false
+        type: boolean
+        default: true
 
 env:
   ASANA_PAT: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -71,3 +81,14 @@ jobs:
       - name: Finish hotfix (merge to main and develop, tag, push)
         run: |
           bundle exec fastlane hotfix-finish
+
+      - name: Create Asana task when workflow failed
+        if: ${{ failure() && inputs.create_asana_task == true }}
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
+          asana-task-name: GH Workflow Failure - Finish Hotfix
+          asana-task-description: The Finish Hotfix workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
+          action: 'create-asana-task'

--- a/.github/workflows/hotfix_orchestrator.yml
+++ b/.github/workflows/hotfix_orchestrator.yml
@@ -24,6 +24,7 @@ jobs:
       app-version: ${{ inputs.app-version }}
       commit-hashes: ${{ inputs.commit-hashes }}
       release-notes: ${{ inputs.release-notes }}
+      create_asana_task: false
     secrets: inherit
 
   # Create the Asana hotfix tracking task up-front; mirrors the manual "task first, then tag" order
@@ -33,6 +34,7 @@ jobs:
     with:
       app-version: ${{ inputs.app-version }}
       commit-hashes: ${{ inputs.commit-hashes }}
+      create_asana_task: false
     secrets: inherit
 
   resolve-hotfix-sha:
@@ -65,4 +67,20 @@ jobs:
     uses: ./.github/workflows/hotfix_finish.yml
     with:
       app-version: ${{ inputs.app-version }}
+      create_asana_task: false
     secrets: inherit
+
+  notify-failure:
+    needs: [prepare, create-hotfix-task, resolve-hotfix-sha, release-blocking-checks, finish]
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Asana task when any orchestrator step failed
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
+          asana-task-name: GH Workflow Failure - Hotfix Orchestrator ${{ inputs.app-version }}
+          asana-task-description: The Hotfix Orchestrator workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
+          action: 'create-asana-task'

--- a/.github/workflows/hotfix_prepare.yml
+++ b/.github/workflows/hotfix_prepare.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: 'Bug fixes and other improvements'
         type: string
+      create_asana_task:
+        description: 'Create an Asana failure task on failure (set false when a caller handles failure reporting)'
+        required: false
+        type: boolean
+        default: true
   workflow_dispatch:
     inputs:
       app-version:
@@ -31,6 +36,11 @@ on:
         required: false
         default: 'Bug fixes and other improvements'
         type: string
+      create_asana_task:
+        description: 'Create an Asana failure task on failure (set false when a caller handles failure reporting)'
+        required: false
+        type: boolean
+        default: true
 
 env:
   ASANA_PAT: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -128,3 +138,14 @@ jobs:
       - name: Push hotfix branch
         run: |
           git push origin hotfix/${{ inputs.app-version }}
+
+      - name: Create Asana task when workflow failed
+        if: ${{ failure() && inputs.create_asana_task == true }}
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
+          asana-task-name: GH Workflow Failure - Prepare Hotfix Branch
+          asana-task-description: The Prepare Hotfix Branch workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
+          action: 'create-asana-task'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1217642062093326?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

Adds failure reporting to the hotfix orchestrator so a failure in **any** step creates an Asana blocker task.

Previously only `hotfix_create_task` self-reported on failure; a failure in branch prep, SHA resolution, blocking checks, or the finish/merge/tag step produced no Asana task (just a failed run + Mattermost notice).

Changes:
- **`hotfix_orchestrator.yml`**: new `notify-failure` job that `needs:` every other job and runs on `failure()`, filing a single "GH Workflow Failure - Hotfix Orchestrator" task into the releases blocker section. It fires once for whichever step failed.
- To avoid duplicate tasks, each standalone-capable sub-workflow (`hotfix_prepare`, `hotfix_create_task`, `hotfix_finish`) gets a new `create_asana_task` input (default `true`) gating its own failure-task step. The orchestrator passes `create_asana_task: false` to all three, so orchestrated runs report once via the catch-all while direct `workflow_dispatch` runs still self-report.
- `release_blocking_checks` already had its own `create_asana_tasks` flag (passed `false` here), so it's unchanged.

### Steps to test this PR
n/a

### UI changes
No UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflow YAML for hotfix release automation; no app code, auth, or data paths are touched.
> 
> **Overview**
> Hotfix orchestrator failures now create **one** Asana blocker task when any step fails (prep, task creation, SHA resolution, blocking checks, or finish), instead of only `hotfix_create_task` self-reporting.
> 
> **`hotfix_orchestrator.yml`** adds a `notify-failure` job that depends on every orchestrator job and runs on `failure()`, filing a single “GH Workflow Failure - Hotfix Orchestrator” task with the app version.
> 
> To avoid duplicate tasks, **`hotfix_prepare`**, **`hotfix_create_task`**, and **`hotfix_finish`** gain a `create_asana_task` input (default `true`) that gates their per-workflow failure Asana steps. The orchestrator passes `create_asana_task: false` to all three. **`hotfix_prepare`** and **`hotfix_finish`** also add failure-task steps that were missing before; **`hotfix_create_task`**’s existing failure step is now gated the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a4e38bdaeefb7cc5a3fdb942b456de1d48592ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->