### PR TITLE
Add daily variants for app links snackbar pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/app_links.json5
+++ b/PixelDefinitions/pixels/definitions/app_links.json5
@@ -1,0 +1,30 @@
+{
+    "m_app_links_snackbar_shown": {
+        "description": "Fired when the 'open in app' snackbar is shown.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "app_links_snackbar_shown_daily": {
+        "description": "Fired at most once per day when the 'open in app' snackbar is shown.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_app_links_snackbar_open_action_pressed": {
+        "description": "Fired when the user taps the open action on the 'open in app' snackbar.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "app_links_snackbar_open_action_pressed_daily": {
+        "description": "Fired at most once per day when the user taps the open action on the 'open in app' snackbar.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.AppLink
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.common.ui.view.makeSnackbarWithNoBottomInset
 import com.duckduckgo.di.scopes.AppScope
 import com.google.android.material.snackbar.BaseTransientBottomBar
@@ -52,6 +53,7 @@ class DuckDuckGoAppLinksSnackBarConfigurator @Inject constructor(
             it.makeSnackbarWithNoBottomInset(message, Snackbar.LENGTH_LONG).apply {
                 setAction(action) {
                     pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_OPEN_ACTION_PRESSED)
+                    pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_OPEN_ACTION_PRESSED_DAILY, type = Daily())
                     appLinksLauncher.openAppLink(context, appLink, viewModel)
                 }
                 addCallback(
@@ -59,6 +61,7 @@ class DuckDuckGoAppLinksSnackBarConfigurator @Inject constructor(
                         override fun onShown(transientBottomBar: Snackbar?) {
                             super.onShown(transientBottomBar)
                             pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_SHOWN)
+                            pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_SHOWN_DAILY, type = Daily())
                         }
                     },
                 )

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -249,7 +249,9 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     APP_FEEDBACK_DIALOG_USER_CANCELLED("mrp_f_d%d_c"),
 
     APP_LINKS_SNACKBAR_SHOWN("m_app_links_snackbar_shown"),
+    APP_LINKS_SNACKBAR_SHOWN_DAILY("app_links_snackbar_shown_daily"),
     APP_LINKS_SNACKBAR_OPEN_ACTION_PRESSED("m_app_links_snackbar_open_action_pressed"),
+    APP_LINKS_SNACKBAR_OPEN_ACTION_PRESSED_DAILY("app_links_snackbar_open_action_pressed_daily"),
 
     AUTOCOMPLETE_TOGGLED_OFF("m_autocomplete_recent_sites_toggled_off"),
     AUTOCOMPLETE_TOGGLED_ON("m_autocomplete_recent_sites_toggled_on"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1163321984198618/task/1217644628446916?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

### Steps to test this PR
QA-optional

### UI changes
n/a

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change; no user-facing behavior, auth, or data-handling logic is modified.
> 
> **Overview**
> Adds once-per-day pixels for the “open in app” snackbar, fired alongside the existing count pixels when the snackbar is shown and when the open action is tapped.
> 
> New pixel names and definitions are registered in `AppPixelName` and `app_links.json5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97e0d7b740c7fd41bc0f38e2eaa7f1cfad05eaf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->