### PR TITLE
Add temporary pixel for opening in YouTube app

### DIFF
--- a/PixelDefinitions/pixels/definitions/app_links.json5
+++ b/PixelDefinitions/pixels/definitions/app_links.json5
@@ -26,5 +26,37 @@
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
+    },
+    "app_links_snackbar_youtube_shown": {
+        "description": "Fired when the 'open in app' snackbar is shown for a link whose destination app is YouTube. Gated by the 'sendPixelForYouTubeAppLinks' androidBrowserConfig remote config flag.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"],
+        "expires": "2026-09-15"
+    },
+    "app_links_snackbar_youtube_shown_daily": {
+        "description": "Fired at most once per day when the 'open in app' snackbar is shown for a link whose destination app is YouTube. Gated by the 'sendPixelForYouTubeAppLinks' androidBrowserConfig remote config flag.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"],
+        "expires": "2026-09-15"
+    },
+    "app_links_snackbar_youtube_open_action_pressed": {
+        "description": "Fired when the user taps the open action on the 'open in app' snackbar for a link whose destination app is YouTube. Gated by the 'sendPixelForYouTubeAppLinks' androidBrowserConfig remote config flag.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"],
+        "expires": "2026-09-15"
+    },
+    "app_links_snackbar_youtube_open_action_pressed_daily": {
+        "description": "Fired at most once per day when the user taps the open action on the 'open in app' snackbar for a link whose destination app is YouTube. Gated by the 'sendPixelForYouTubeAppLinks' androidBrowserConfig remote config flag.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"],
+        "expires": "2026-09-15"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksPixelsFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksPixelsFeature.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.applinks
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "appLinksPixels",
+)
+interface AppLinksPixelsFeature {
+
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun self(): Toggle
+
+    /**
+     * Controls whether the YouTube-specific "open in app" snackbar pixels are sent.
+     * If the remote feature is not present defaults to `false`.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun sendPixelForYouTubeAppLinks(): Toggle
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
@@ -43,17 +43,24 @@ interface AppLinksSnackBarConfigurator {
 class DuckDuckGoAppLinksSnackBarConfigurator @Inject constructor(
     private val appLinksLauncher: AppLinksLauncher,
     private val pixel: Pixel,
+    private val appLinksPixelsFeature: AppLinksPixelsFeature,
 ) : AppLinksSnackBarConfigurator {
 
     override fun configureAppLinkSnackBar(view: View?, appLink: AppLink, viewModel: BrowserTabViewModel): Snackbar? {
         return view?.let {
             val context = it.context
             val (message, action) = getSnackBarContent(context, appLink) ?: return null
+            val sendPixelForYouTube = appLink.appIntent?.component?.packageName == YOUTUBE_PACKAGE &&
+                appLinksPixelsFeature.sendPixelForYouTubeAppLinks().isEnabled()
 
             it.makeSnackbarWithNoBottomInset(message, Snackbar.LENGTH_LONG).apply {
                 setAction(action) {
                     pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_OPEN_ACTION_PRESSED)
                     pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_OPEN_ACTION_PRESSED_DAILY, type = Daily())
+                    if (sendPixelForYouTube) {
+                        pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_YOUTUBE_OPEN_ACTION_PRESSED)
+                        pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_YOUTUBE_OPEN_ACTION_PRESSED_DAILY, type = Daily())
+                    }
                     appLinksLauncher.openAppLink(context, appLink, viewModel)
                 }
                 addCallback(
@@ -62,6 +69,10 @@ class DuckDuckGoAppLinksSnackBarConfigurator @Inject constructor(
                             super.onShown(transientBottomBar)
                             pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_SHOWN)
                             pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_SHOWN_DAILY, type = Daily())
+                            if (sendPixelForYouTube) {
+                                pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_YOUTUBE_SHOWN)
+                                pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_YOUTUBE_SHOWN_DAILY, type = Daily())
+                            }
                         }
                     },
                 )
@@ -97,5 +108,6 @@ class DuckDuckGoAppLinksSnackBarConfigurator @Inject constructor(
 
     companion object {
         const val DURATION = 6000
+        private const val YOUTUBE_PACKAGE = "com.google.android.youtube"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -252,6 +252,10 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     APP_LINKS_SNACKBAR_SHOWN_DAILY("app_links_snackbar_shown_daily"),
     APP_LINKS_SNACKBAR_OPEN_ACTION_PRESSED("m_app_links_snackbar_open_action_pressed"),
     APP_LINKS_SNACKBAR_OPEN_ACTION_PRESSED_DAILY("app_links_snackbar_open_action_pressed_daily"),
+    APP_LINKS_SNACKBAR_YOUTUBE_SHOWN("app_links_snackbar_youtube_shown"),
+    APP_LINKS_SNACKBAR_YOUTUBE_SHOWN_DAILY("app_links_snackbar_youtube_shown_daily"),
+    APP_LINKS_SNACKBAR_YOUTUBE_OPEN_ACTION_PRESSED("app_links_snackbar_youtube_open_action_pressed"),
+    APP_LINKS_SNACKBAR_YOUTUBE_OPEN_ACTION_PRESSED_DAILY("app_links_snackbar_youtube_open_action_pressed_daily"),
 
     AUTOCOMPLETE_TOGGLED_OFF("m_autocomplete_recent_sites_toggled_off"),
     AUTOCOMPLETE_TOGGLED_ON("m_autocomplete_recent_sites_toggled_on"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1163321984198618/task/1217611902150923?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only change behind a default-off remote toggle; no user-facing or security behavior is modified.
> 
> **Overview**
> Adds temporary, feature-flagged pixels for when the “open in app” snackbar is shown or opened for YouTube (`com.google.android.youtube`). Existing generic snackbar pixels are unchanged.
> 
> Firing is gated by `AppLinksPixelsFeature.sendPixelForYouTubeAppLinks()` (default off). Count and daily variants expire 2026-09-15.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 196ae0f6e89a5d20508458f4917af86a134e7715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->