### PR TITLE
Log signedOut in auth token refresh wide event

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_auth_token_refresh.json5
+++ b/PixelDefinitions/pixels/definitions/wide_auth_token_refresh.json5
@@ -99,6 +99,11 @@
                 "examples": ["HttpException", "SocketTimeoutException", "IllegalStateException"]
             },
             {
+                "key": "feature.data.ext.signed_out",
+                "description": "Whether the user was signed out after an irrecoverable error was encountered, such as an invalid refresh token.",
+                "type": "boolean"
+            },
+            {
                 "key": "feature.data.ext.step.lock_acquire",
                 "description": "true if the cross-process refresh lock was acquired, false if it timed out or errored. A false value does not fail the refresh - see lock_outcome.",
                 "type": "boolean"

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEvent.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEvent.kt
@@ -183,7 +183,11 @@ class AuthTokenRefreshWideEventImpl @Inject constructor(
                 metadata = mapOf(KEY_PLAY_LOGIN_ERROR to loginError),
             )
             wideEventClient.intervalEnd(wideEventId = wideEventId, key = INTERVAL_TOTAL_DURATION)
-            wideEventClient.flowFinish(wideEventId = wideEventId, status = FlowStatus.Failure(reason = refreshException.toErrorString()))
+            wideEventClient.flowFinish(
+                wideEventId = wideEventId,
+                status = FlowStatus.Failure(reason = refreshException.toErrorString()),
+                metadata = mapOf(KEY_SIGNED_OUT to signedOut.toString()),
+            )
             ongoingTokenRefreshWideEventId = null
         }
     }
@@ -244,6 +248,7 @@ class AuthTokenRefreshWideEventImpl @Inject constructor(
         const val KEY_SUBSCRIPTION_STATUS = "subscription_status"
         const val KEY_BACKEND_ERROR_RESPONSE = "backend_error_response"
         const val KEY_PLAY_LOGIN_ERROR = "play_login_error"
+        const val KEY_SIGNED_OUT = "signed_out"
         const val KEY_NETP_IS_ENABLED = "netp_is_enabled"
         const val KEY_NETP_IS_RUNNING = "netp_is_running"
         const val KEY_PROCESS_NAME = "process_name"

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEventTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEventTest.kt
@@ -262,13 +262,30 @@ class AuthTokenRefreshWideEventTest {
             metadata = mapOf("play_login_error" to "sign-in-required"),
         )
         verify(wideEventClient).intervalEnd(16L, "total_duration_ms_bucketed")
-        verify(wideEventClient).flowFinish(16L, FlowStatus.Failure("IllegalStateException"), emptyMap())
+        verify(wideEventClient).flowFinish(16L, FlowStatus.Failure("IllegalStateException"), mapOf("signed_out" to "true"))
 
         reset(wideEventClient)
 
         // id cleared -> subsequent calls produce no client interactions
         authWideEvent.onSuccess()
         verifyNoInteractions(wideEventClient)
+    }
+
+    @Test
+    fun `onPlayLoginFailure without signing the user out logs signedOut as false`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .thenReturn(Result.success(20L))
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN, serializationEnabled = true)
+
+        authWideEvent.onPlayLoginFailure(signedOut = false, refreshException = IllegalStateException("boom"), loginError = "UnknownError")
+
+        verify(wideEventClient).flowStep(
+            wideEventId = 20L,
+            stepName = "play_login",
+            success = false,
+            metadata = mapOf("play_login_error" to "UnknownError"),
+        )
+        verify(wideEventClient).flowFinish(20L, FlowStatus.Failure("IllegalStateException"), mapOf("signed_out" to "false"))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217420285797772?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

The previously ignored `signedOut` parameter of `onPlayLoginFailure` is now logged as a `signed_out` field on the auth-token-refresh wide event and documented in the pixel registry.

### Steps to test this PR

QA-optional

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only change; sign-out behavior in SubscriptionsManager is unchanged.
> 
> **Overview**
> When Play login fallback fails during auth token refresh, the wide event **failure** finish now includes **`signed_out`** metadata reflecting whether the session was actually signed out (irrecoverable errors vs transient failures).
> 
> The **`wide_auth-token-refresh`** pixel definition documents **`feature.data.ext.signed_out`** as a boolean. Tests cover both `true` and `false` paths on `onPlayLoginFailure`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 855c9df695e93c67c95d856f86e6ecc90aefe13c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->