### PR TITLE
Send is_tablet on ATB install/activity requests

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterJsonTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterJsonTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.FileUtilities.loadText
 import com.duckduckgo.common.test.InstantSchedulersRule
 import com.duckduckgo.common.utils.AppUrl.ParamKey
+import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.experiments.api.VariantManager
 import com.squareup.moshi.Moshi
@@ -58,6 +59,7 @@ class StatisticsRequesterJsonTest {
     private lateinit var statisticsStore: StatisticsDataStore
     private lateinit var testee: StatisticsRequester
     private var mockEmailManager: EmailManager = mock()
+    private var mockDeviceInfo: DeviceInfo = mock()
 
     private val server = MockWebServer()
 
@@ -91,8 +93,10 @@ class StatisticsRequesterJsonTest {
             mockEmailManager,
             TestScope(),
             coroutineTestRule.testDispatcherProvider,
+            mockDeviceInfo,
         )
         whenever(mockVariantManager.getVariantKey()).thenReturn("ma")
+        whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
     }
 
     @After
@@ -213,6 +217,16 @@ class StatisticsRequesterJsonTest {
         val extiRequest = takeRequestImmediately()
         val testParam = extiRequest?.extractQueryParam(ParamKey.DEV_MODE)
         assertTestParameterSent(testParam)
+    }
+
+    @Test
+    fun whenNotYetInitializedAtbInitializationSendsTabletSignal() {
+        queueResponseFromFile(VALID_JSON)
+        queueResponseFromString("", 200)
+        testee.initializeAtb()
+        val atbRequest = takeRequestImmediately()
+        val isTabletParam = atbRequest?.extractQueryParam(ParamKey.IS_TABLET)
+        assertEquals("0", isTabletParam)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/user_segments/DuckAiRetentionIntegrationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/user_segments/DuckAiRetentionIntegrationTest.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.FileUtilities.loadText
 import com.duckduckgo.common.test.InstantSchedulersRule
+import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.data.store.impl.SharedPreferencesProviderImpl
 import com.duckduckgo.experiments.api.VariantManager
@@ -87,6 +88,7 @@ class DuckAiRetentionIntegrationTest {
     private val mockVariantManager: VariantManager = mock()
     private val mockEmailManager: EmailManager = mock()
     private val mockAppBuildConfig: AppBuildConfig = mock()
+    private val mockDeviceInfo: DeviceInfo = mock()
 
     @Before
     fun setup() {
@@ -116,6 +118,7 @@ class DuckAiRetentionIntegrationTest {
         )
 
         whenever(mockVariantManager.getVariantKey()).thenReturn("ma")
+        whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
         runBlocking {
             whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
         }
@@ -149,6 +152,7 @@ class DuckAiRetentionIntegrationTest {
             mockEmailManager,
             coroutineRule.testScope,
             coroutineRule.testDispatcherProvider,
+            mockDeviceInfo,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
@@ -21,6 +21,8 @@ import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
 import com.duckduckgo.common.utils.AppUrl.ParamKey
 import com.duckduckgo.common.utils.AppUrl.ParamValue
+import com.duckduckgo.common.utils.device.DeviceInfo
+import com.duckduckgo.common.utils.device.isTablet
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.experiments.api.VariantManager
 import com.duckduckgo.referral.api.AppReferrer
@@ -41,6 +43,7 @@ class DuckDuckGoRequestRewriter(
     private val duckChat: DuckChat,
     private val androidConfigFeatures: AndroidBrowserConfigFeature,
     private val serpSettingsFeature: SerpSettingsFeature,
+    private val deviceInfo: DeviceInfo,
 ) : RequestRewriter {
 
     private val hideDuckAiSerpKillSwitch by lazy { androidConfigFeatures.hideDuckAiInSerpKillSwitch().isEnabled() }
@@ -79,7 +82,11 @@ class DuckDuckGoRequestRewriter(
             builder.appendQueryParameter(ParamKey.ATB, atb.formatWithVariant(variantManager.getVariantKey()))
         }
 
-        val sourceValue = if (appReferrer.isInstalledFromEuAuction()) ParamValue.SOURCE_EU_AUCTION else ParamValue.SOURCE
+        val sourceValue = if (appReferrer.isInstalledFromEuAuction()) {
+            ParamValue.SOURCE_EU_AUCTION
+        } else {
+            if (deviceInfo.isTablet()) ParamValue.SOURCE_TABLET else ParamValue.SOURCE
+        }
 
         builder.appendQueryParameter(ParamKey.HIDE_SERP, ParamValue.HIDE_SERP)
         if (!serpSettingsFeature.storeSerpSettings().isEnabled()) {

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -76,6 +76,7 @@ import com.duckduckgo.app.trackerdetection.CloakedCnameDetector
 import com.duckduckgo.app.trackerdetection.db.WebTrackersBlockedDao
 import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.cookies.api.ThirdPartyCookieNames
 import com.duckduckgo.di.scopes.AppScope
@@ -117,6 +118,7 @@ class BrowserModule {
         duckChat: DuckChat,
         androidBrowserConfigFeature: AndroidBrowserConfigFeature,
         serpSettingsFeature: SerpSettingsFeature,
+        deviceInfo: DeviceInfo,
     ): RequestRewriter {
         return DuckDuckGoRequestRewriter(
             urlDetector,
@@ -126,6 +128,7 @@ class BrowserModule {
             duckChat,
             androidBrowserConfigFeature,
             serpSettingsFeature,
+            deviceInfo,
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriterTest.kt
@@ -25,6 +25,9 @@ import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
 import com.duckduckgo.common.utils.AppUrl.ParamKey
 import com.duckduckgo.common.utils.AppUrl.ParamValue
+import com.duckduckgo.common.utils.device.DeviceInfo
+import com.duckduckgo.common.utils.device.DeviceInfo.FormFactor.PHONE
+import com.duckduckgo.common.utils.device.DeviceInfo.FormFactor.TABLET
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.experiments.api.VariantManager
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
@@ -51,6 +54,7 @@ class DuckDuckGoRequestRewriterTest {
     private val duckChat: DuckChat = mock()
     private val serpSettingsFeature: SerpSettingsFeature = FakeFeatureToggleFactory.create(SerpSettingsFeature::class.java)
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+    private val mockDeviceInfo: DeviceInfo = mock()
     private lateinit var builder: Uri.Builder
 
     @Before
@@ -58,6 +62,7 @@ class DuckDuckGoRequestRewriterTest {
         whenever(mockVariantManager.getVariantKey()).thenReturn("")
         whenever(mockAppReferrer.isInstalledFromEuAuction()).thenReturn(false)
         whenever(duckChat.isEnabled()).thenReturn(true)
+        whenever(mockDeviceInfo.formFactor()).thenReturn(PHONE)
 
         androidBrowserConfigFeature.hideDuckAiInSerpKillSwitch().setRawStoredState(State(true))
 
@@ -69,6 +74,7 @@ class DuckDuckGoRequestRewriterTest {
             duckChat,
             androidBrowserConfigFeature,
             serpSettingsFeature,
+            mockDeviceInfo,
         )
         builder = Uri.Builder()
     }
@@ -88,6 +94,24 @@ class DuckDuckGoRequestRewriterTest {
         val uri = builder.build()
         assertTrue(uri.queryParameterNames.contains(ParamKey.SOURCE))
         assertEquals("ddg_androideu", uri.getQueryParameter(ParamKey.SOURCE))
+    }
+
+    @Test
+    fun whenAddingCustomParamsAndNotEuAuctionAndPhoneThenSourceParameterIsAdded() {
+        whenever(mockAppReferrer.isInstalledFromEuAuction()).thenReturn(false)
+        whenever(mockDeviceInfo.formFactor()).thenReturn(PHONE)
+        testee.addCustomQueryParams(builder)
+        val uri = builder.build()
+        assertEquals(ParamValue.SOURCE, uri.getQueryParameter(ParamKey.SOURCE))
+    }
+
+    @Test
+    fun whenAddingCustomParamsAndNotEuAuctionAndTabletThenTabletSourceParameterIsAdded() {
+        whenever(mockAppReferrer.isInstalledFromEuAuction()).thenReturn(false)
+        whenever(mockDeviceInfo.formFactor()).thenReturn(TABLET)
+        testee.addCustomQueryParams(builder)
+        val uri = builder.build()
+        assertEquals(ParamValue.SOURCE_TABLET, uri.getQueryParameter(ParamKey.SOURCE))
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -25,6 +25,8 @@ import com.duckduckgo.app.browser.omnibar.QueryUrlPredictor
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.device.DeviceInfo
+import com.duckduckgo.common.utils.device.DeviceInfo.FormFactor.PHONE
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.experiments.api.VariantManager
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
@@ -61,6 +63,7 @@ class QueryUrlConverterTest {
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
     private val serpSettingsFeature: SerpSettingsFeature = FakeFeatureToggleFactory.create(SerpSettingsFeature::class.java)
     private val queryUrlPredictor: QueryUrlPredictor = mock()
+    private val mockDeviceInfo: DeviceInfo = mock()
     private val requestRewriter =
         DuckDuckGoRequestRewriter(
             DuckDuckGoUrlDetectorImpl(),
@@ -70,6 +73,7 @@ class QueryUrlConverterTest {
             duckChat,
             androidBrowserConfigFeature,
             serpSettingsFeature,
+            mockDeviceInfo,
         )
     private val testee: QueryUrlConverter = createTestee(useUrlPredictorEnabled = false)
 
@@ -78,6 +82,7 @@ class QueryUrlConverterTest {
         whenever(variantManager.getVariantKey()).thenReturn("")
         whenever(duckChat.isEnabled()).thenReturn(true)
         whenever(queryUrlPredictor.isReady()).thenReturn(true)
+        whenever(mockDeviceInfo.formFactor()).thenReturn(PHONE)
         androidBrowserConfigFeature.hideDuckAiInSerpKillSwitch().setRawStoredState(State(true))
     }
 

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/AppUrl.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/AppUrl.kt
@@ -48,6 +48,7 @@ class AppUrl {
     object ParamValue {
         const val SOURCE = "ddg_android"
         const val SOURCE_EU_AUCTION = "ddg_androideu"
+        const val SOURCE_TABLET = "ddg_android_tablet"
         const val HIDE_SERP = "-1"
         const val HIDE_DUCK_AI = "-1"
         const val CHAT_VERTICAL = "chat"

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/AppUrl.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/AppUrl.kt
@@ -34,6 +34,7 @@ class AppUrl {
         const val SOURCE = "t"
         const val ATB = "atb"
         const val RETENTION_ATB = "set_atb"
+        const val IS_TABLET = "is_tablet"
         const val DEV_MODE = "test"
         const val LANGUAGE = "lg"
         const val EMAIL = "email"

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
@@ -22,6 +22,8 @@ import com.duckduckgo.app.statistics.model.Atb
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.device.DeviceInfo
+import com.duckduckgo.common.utils.device.isTablet
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.experiments.api.VariantManager
@@ -47,6 +49,7 @@ class StatisticsRequester @Inject constructor(
     private val emailManager: EmailManager,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
+    private val deviceInfo: DeviceInfo,
 ) : StatisticsUpdater {
 
     /**
@@ -73,6 +76,7 @@ class StatisticsRequester @Inject constructor(
 
         service
             .atb(
+                isTablet = isTabletSignal(),
                 email = emailSignInState(),
             )
             .subscribeOn(Schedulers.io())
@@ -83,7 +87,7 @@ class StatisticsRequester @Inject constructor(
                 val atbWithVariant = atb.formatWithVariant(variantManager.getVariantKey())
 
                 logcat(INFO) { "Initialized ATB: $atbWithVariant" }
-                service.exti(atbWithVariant)
+                service.exti(atbWithVariant, isTablet = isTabletSignal())
             }
             .subscribe(
                 {
@@ -119,6 +123,7 @@ class StatisticsRequester @Inject constructor(
                     service.updateSearchAtb(
                         atb = fullAtb,
                         retentionAtb = retentionAtb,
+                        isTablet = isTabletSignal(),
                         email = email,
                     )
                 },
@@ -149,6 +154,7 @@ class StatisticsRequester @Inject constructor(
                     service.updateDuckAiAtb(
                         atb = fullAtb,
                         retentionAtb = retentionAtb,
+                        isTablet = isTabletSignal(),
                         email = email,
                     )
                 },
@@ -181,6 +187,7 @@ class StatisticsRequester @Inject constructor(
                 service.updateAppAtb(
                     atb = fullAtb,
                     retentionAtb = retentionAtb,
+                    isTablet = isTabletSignal(),
                     email = email,
                 )
             },
@@ -193,6 +200,8 @@ class StatisticsRequester @Inject constructor(
 
     private fun emailSignInState(): Int =
         kotlin.runCatching { emailManager.isSignedIn().asInt() }.getOrDefault(0)
+
+    private fun isTabletSignal(): Int = deviceInfo.isTablet().asInt()
 
     @SuppressLint("CheckResult")
     private fun refreshRetentionAtb(

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/api/StatisticsService.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/api/StatisticsService.kt
@@ -32,11 +32,13 @@ interface StatisticsService {
     @GET("/exti/")
     fun exti(
         @Query(ParamKey.ATB) atb: String,
+        @Query(ParamKey.IS_TABLET) isTablet: Int,
         @Query(ParamKey.DEV_MODE) devMode: Int? = if (BuildConfig.DEBUG) 1 else null,
     ): Observable<ResponseBody>
 
     @GET("/atb.js")
     fun atb(
+        @Query(ParamKey.IS_TABLET) isTablet: Int,
         @Query(ParamKey.DEV_MODE) devMode: Int? = if (BuildConfig.DEBUG) 1 else null,
         @Query(ParamKey.EMAIL) email: Int?,
     ): Observable<Atb>
@@ -45,6 +47,7 @@ interface StatisticsService {
     fun updateSearchAtb(
         @Query(ParamKey.ATB) atb: String,
         @Query(ParamKey.RETENTION_ATB) retentionAtb: String,
+        @Query(ParamKey.IS_TABLET) isTablet: Int,
         @Query(ParamKey.DEV_MODE) devMode: Int? = if (BuildConfig.DEBUG) 1 else null,
         @Query(ParamKey.EMAIL) email: Int?,
     ): Observable<Atb>
@@ -53,6 +56,7 @@ interface StatisticsService {
     fun updateAppAtb(
         @Query(ParamKey.ATB) atb: String,
         @Query(ParamKey.RETENTION_ATB) retentionAtb: String,
+        @Query(ParamKey.IS_TABLET) isTablet: Int,
         @Query(ParamKey.DEV_MODE) devMode: Int? = if (BuildConfig.DEBUG) 1 else null,
         @Query(ParamKey.EMAIL) email: Int?,
     ): Observable<Atb>
@@ -61,6 +65,7 @@ interface StatisticsService {
     fun updateDuckAiAtb(
         @Query(ParamKey.ATB) atb: String,
         @Query(ParamKey.RETENTION_ATB) retentionAtb: String,
+        @Query(ParamKey.IS_TABLET) isTablet: Int,
         @Query(ParamKey.DEV_MODE) devMode: Int? = if (BuildConfig.DEBUG) 1 else null,
         @Query(ParamKey.EMAIL) email: Int?,
     ): Observable<Atb>

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.InstantSchedulersRule
+import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.experiments.api.VariantManager
 import io.reactivex.Observable
@@ -43,6 +44,7 @@ class StatisticsRequesterTest {
     private var mockResponseBody: ResponseBody = mock()
     private var mockVariantManager: VariantManager = mock()
     private val mockEmailManager: EmailManager = mock()
+    private val mockDeviceInfo: DeviceInfo = mock()
 
     private val plugins = object : PluginPoint<AtbLifecyclePlugin> {
         override fun getPlugins(): Collection<AtbLifecyclePlugin> {
@@ -64,22 +66,24 @@ class StatisticsRequesterTest {
         mockEmailManager,
         TestScope(),
         coroutineTestRule.testDispatcherProvider,
+        mockDeviceInfo,
     )
 
     @Before
     fun before() {
         whenever(mockVariantManager.getVariantKey()).thenReturn("ma")
         whenever(mockVariantManager.defaultVariantKey()).thenReturn("")
-        whenever(mockService.atb(any(), any())).thenReturn(Observable.just(ATB))
-        whenever(mockService.updateSearchAtb(any(), any(), any(), any())).thenReturn(Observable.just(Atb(NEW_ATB)))
-        whenever(mockService.updateDuckAiAtb(any(), any(), any(), any())).thenReturn(Observable.just(Atb(NEW_ATB)))
-        whenever(mockService.exti(any(), any())).thenReturn(Observable.just(mockResponseBody))
+        whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
+        whenever(mockService.atb(any(), any(), any())).thenReturn(Observable.just(ATB))
+        whenever(mockService.updateSearchAtb(any(), any(), any(), any(), any())).thenReturn(Observable.just(Atb(NEW_ATB)))
+        whenever(mockService.updateDuckAiAtb(any(), any(), any(), any(), any())).thenReturn(Observable.just(Atb(NEW_ATB)))
+        whenever(mockService.exti(any(), any(), any())).thenReturn(Observable.just(mockResponseBody))
     }
 
     @Test
     fun whenUpdateVersionPresentDuringRefreshSearchRetentionThenPreviousAtbIsReplacedWithUpdateVersion() {
         configureStoredStatistics()
-        whenever(mockService.updateSearchAtb(any(), any(), any(), eq(0))).thenReturn(Observable.just(UPDATE_ATB))
+        whenever(mockService.updateSearchAtb(any(), any(), any(), any(), eq(0))).thenReturn(Observable.just(UPDATE_ATB))
         testee.refreshSearchRetentionAtb()
         verify(mockStatisticsStore).atb = Atb(UPDATE_ATB.updateVersion!!)
     }
@@ -87,7 +91,7 @@ class StatisticsRequesterTest {
     @Test
     fun whenUpdateVersionPresentDuringRefreshSearchRetentionThenPreviousVariantIsReplacedWithDefaultVariant() {
         configureStoredStatistics()
-        whenever(mockService.updateSearchAtb(any(), any(), any(), eq(0))).thenReturn(Observable.just(UPDATE_ATB))
+        whenever(mockService.updateSearchAtb(any(), any(), any(), any(), eq(0))).thenReturn(Observable.just(UPDATE_ATB))
         testee.refreshSearchRetentionAtb()
         verify(mockStatisticsStore).variant = ""
     }
@@ -95,7 +99,7 @@ class StatisticsRequesterTest {
     @Test
     fun whenUpdateVersionPresentDuringRefreshAppRetentionThenPreviousAtbIsReplacedWithUpdateVersion() {
         configureStoredStatistics()
-        whenever(mockService.updateAppAtb(any(), any(), any(), eq(0))).thenReturn(Observable.just(UPDATE_ATB))
+        whenever(mockService.updateAppAtb(any(), any(), any(), any(), eq(0))).thenReturn(Observable.just(UPDATE_ATB))
         testee.refreshAppRetentionAtb()
         verify(mockStatisticsStore).atb = Atb(UPDATE_ATB.updateVersion!!)
     }
@@ -103,7 +107,7 @@ class StatisticsRequesterTest {
     @Test
     fun whenUpdateVersionPresentDuringRefreshAppRetentionThenPreviousVariantIsReplacedWithDefaultVariant() {
         configureStoredStatistics()
-        whenever(mockService.updateAppAtb(any(), any(), any(), eq(0))).thenReturn(Observable.just(UPDATE_ATB))
+        whenever(mockService.updateAppAtb(any(), any(), any(), any(), eq(0))).thenReturn(Observable.just(UPDATE_ATB))
         testee.refreshAppRetentionAtb()
         verify(mockStatisticsStore).variant = ""
     }
@@ -112,8 +116,8 @@ class StatisticsRequesterTest {
     fun whenNoStatisticsStoredThenInitializeAtbInvokesExti() {
         configureNoStoredStatistics()
         testee.initializeAtb()
-        verify(mockService).atb(any(), eq(0))
-        verify(mockService).exti(eq(ATB_WITH_VARIANT), any())
+        verify(mockService).atb(any(), any(), eq(0))
+        verify(mockService).exti(eq(ATB_WITH_VARIANT), any(), any())
         verify(mockStatisticsStore).saveAtb(ATB)
     }
 
@@ -121,16 +125,16 @@ class StatisticsRequesterTest {
     fun whenStatisticsStoredThenInitializeAtbDoesNothing() {
         configureStoredStatistics()
         testee.initializeAtb()
-        verify(mockService, never()).atb(any(), any())
-        verify(mockService, never()).exti(eq(ATB.version), any())
+        verify(mockService, never()).atb(any(), any(), any())
+        verify(mockService, never()).exti(eq(ATB.version), any(), any())
     }
 
     @Test
     fun whenNoStatisticsStoredThenRefreshSearchRetentionRetrievesAtbAndInvokesExti() {
         configureNoStoredStatistics()
         testee.refreshSearchRetentionAtb()
-        verify(mockService).atb(any(), any())
-        verify(mockService).exti(eq(ATB_WITH_VARIANT), any())
+        verify(mockService).atb(any(), any(), any())
+        verify(mockService).exti(eq(ATB_WITH_VARIANT), any(), any())
         verify(mockStatisticsStore).saveAtb(ATB)
     }
 
@@ -138,14 +142,14 @@ class StatisticsRequesterTest {
     fun whenNoStatisticsStoredThenRefreshAppRetentionRetrievesAtbAndInvokesExti() {
         configureNoStoredStatistics()
         testee.refreshAppRetentionAtb()
-        verify(mockService).atb(any(), any())
-        verify(mockService).exti(eq(ATB_WITH_VARIANT), any())
+        verify(mockService).atb(any(), any(), any())
+        verify(mockService).exti(eq(ATB_WITH_VARIANT), any(), any())
         verify(mockStatisticsStore).saveAtb(ATB)
     }
 
     @Test
     fun whenExtiFailsThenAtbCleared() {
-        whenever(mockService.exti(any(), any())).thenReturn(Observable.error(Throwable()))
+        whenever(mockService.exti(any(), any(), any())).thenReturn(Observable.error(Throwable()))
         configureNoStoredStatistics()
         testee.initializeAtb()
         verify(mockStatisticsStore).saveAtb(ATB)
@@ -158,14 +162,14 @@ class StatisticsRequesterTest {
         val retentionAtb = "foo"
         whenever(mockStatisticsStore.searchRetentionAtb).thenReturn(retentionAtb)
         testee.refreshSearchRetentionAtb()
-        verify(mockService).updateSearchAtb(eq(ATB_WITH_VARIANT), eq(retentionAtb), any(), any())
+        verify(mockService).updateSearchAtb(eq(ATB_WITH_VARIANT), eq(retentionAtb), any(), any(), any())
     }
 
     @Test
     fun whenStatisticsStoredThenRefreshUpdatesAtb() {
         configureStoredStatistics()
         testee.refreshSearchRetentionAtb()
-        verify(mockService).updateSearchAtb(eq(ATB_WITH_VARIANT), eq(ATB.version), any(), any())
+        verify(mockService).updateSearchAtb(eq(ATB_WITH_VARIANT), eq(ATB.version), any(), any(), any())
         verify(mockStatisticsStore).searchRetentionAtb = NEW_ATB
         verify(mockStatisticsStore, never()).atb = any()
         verify(mockStatisticsStore, never()).appRetentionAtb = any()
@@ -188,7 +192,7 @@ class StatisticsRequesterTest {
     fun whenStatisticsStoredThenRefreshDuckAiUpdatesAtb() {
         configureStoredStatistics()
         testee.refreshDuckAiRetentionAtb()
-        verify(mockService).updateDuckAiAtb(eq(ATB_WITH_VARIANT), eq(ATB.version), any(), any())
+        verify(mockService).updateDuckAiAtb(eq(ATB_WITH_VARIANT), eq(ATB.version), any(), any(), any())
         verify(mockStatisticsStore).duckaiRetentionAtb = NEW_ATB
         verify(mockStatisticsStore, never()).atb = any()
         verify(mockStatisticsStore, never()).searchRetentionAtb = any()
@@ -212,29 +216,49 @@ class StatisticsRequesterTest {
 
         testee.initializeAtb()
 
-        verify(mockService).atb(any(), eq(1))
+        verify(mockService).atb(any(), any(), eq(1))
     }
 
     @Test
     fun whenRefreshSearchAtbAndEmailEnabledThenEmailSignalToTrue() {
         whenever(mockEmailManager.isSignedIn()).thenReturn(true)
         configureStoredStatistics()
-        whenever(mockService.updateSearchAtb(any(), any(), any(), eq(1))).thenReturn(Observable.just(UPDATE_ATB))
+        whenever(mockService.updateSearchAtb(any(), any(), any(), any(), eq(1))).thenReturn(Observable.just(UPDATE_ATB))
 
         testee.refreshSearchRetentionAtb()
 
-        verify(mockService).updateSearchAtb(any(), any(), any(), eq(1))
+        verify(mockService).updateSearchAtb(any(), any(), any(), any(), eq(1))
     }
 
     @Test
     fun whenRefreshAppRetentionAndEmailEnabledThenEmailSignalToTrue() {
         whenever(mockEmailManager.isSignedIn()).thenReturn(true)
         configureStoredStatistics()
-        whenever(mockService.updateAppAtb(any(), any(), any(), eq(1))).thenReturn(Observable.just(UPDATE_ATB))
+        whenever(mockService.updateAppAtb(any(), any(), any(), any(), eq(1))).thenReturn(Observable.just(UPDATE_ATB))
 
         testee.refreshAppRetentionAtb()
 
-        verify(mockService).updateAppAtb(any(), any(), any(), eq(1))
+        verify(mockService).updateAppAtb(any(), any(), any(), any(), eq(1))
+    }
+
+    @Test
+    fun whenInitializeAtbAndDeviceIsTabletThenTabletSignalToTrue() {
+        whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.TABLET)
+        configureNoStoredStatistics()
+
+        testee.initializeAtb()
+
+        verify(mockService).atb(eq(1), any(), any())
+    }
+
+    @Test
+    fun whenInitializeAtbAndDeviceIsPhoneThenTabletSignalToFalse() {
+        whenever(mockDeviceInfo.formFactor()).thenReturn(DeviceInfo.FormFactor.PHONE)
+        configureNoStoredStatistics()
+
+        testee.initializeAtb()
+
+        verify(mockService).atb(eq(0), any(), any())
     }
 
     private fun configureNoStoredStatistics() {

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
@@ -179,9 +179,9 @@ class StatisticsRequesterTest {
     @Test
     fun whenStatisticsStoredThenRefreshAppUpdatesAtb() {
         configureStoredStatistics()
-        whenever(mockService.updateAppAtb(any(), any(), any(), any())).thenReturn(Observable.just(Atb(NEW_ATB)))
+        whenever(mockService.updateAppAtb(any(), any(), any(), any(), any())).thenReturn(Observable.just(Atb(NEW_ATB)))
         testee.refreshAppRetentionAtb()
-        verify(mockService).updateAppAtb(eq(ATB_WITH_VARIANT), eq(ATB.version), any(), any())
+        verify(mockService).updateAppAtb(eq(ATB_WITH_VARIANT), eq(ATB.version), any(), any(), any())
         verify(mockStatisticsStore).appRetentionAtb = NEW_ATB
         verify(mockStatisticsStore, never()).atb = any()
         verify(mockStatisticsStore, never()).searchRetentionAtb = any()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1213321438935159?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Adds `is_tablet` flag on ATB requests, and tablet-specific `t=` typetags on search requests, so retention and traffic pipelines can distinguish Android tablets from phones the way pixels already do via form factor.

### Steps to test this PR

_ATB happy path_
- [x] On a phone-sized device/emulator, trigger an ATB install call (fresh install or clear app data) → inspect the outgoing `/exti/` and `/atb.js` requests (app inspection) → confirm `is_tablet=0`.
- [x] On a tablet-sized device/emulator (smallest width ≥ 600dp), repeat → confirm `is_tablet=1`.

_Search typetag happy path (blocked commit — verify only, do not merge)_
- [x] Filter your logcat with `ddg_android_tablet` keyword 
- [x] Type a query in the omnibar on a tablet → check request has `t=ddg_android_tablet`.
- [x] Repeat on a phone → confirm `t=ddg_android`.

### UI changes

No user-facing UI changeis


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query parameters on all ATB install/retention calls and omnibar search URL rewriting; EU auction precedence is preserved but misclassified form factor would skew analytics cohorts.
> 
> **Overview**
> Adds **tablet vs phone** signaling to ATB/statistics traffic and DuckDuckGo search URLs so retention and analytics can split Android tablets from phones (aligned with existing pixel form-factor behavior).
> 
> **ATB pipeline:** `StatisticsRequester` injects `DeviceInfo` and sends `is_tablet=1` or `0` on `/atb.js` (install, search/app/Duck.ai retention refreshes) and `/exti/`. New `ParamKey.IS_TABLET` is wired through `StatisticsService`.
> 
> **Search typetags:** `DuckDuckGoRequestRewriter` uses `ddg_android_tablet` for the `t=` source when the device is a tablet; phones still use `ddg_android`. EU auction installs still use `ddg_androideu` (tablet typetag does not override EU).
> 
> Tests and integration setups mock `DeviceInfo` and cover phone/tablet source params and ATB `is_tablet` on init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c3fb5b99356a9be0b743285d3dfc91227edf21f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->