### PR TITLE
Retire wirePluginView() in native input

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProvider.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProvider.kt
@@ -41,9 +41,9 @@ interface EffectiveModelProvider {
 
     /**
      * Records the model picked during the FE model-change recovery flow. It wins over the chat's stored
-     * model until that window closes, because the FE syncs the new model back to us asynchronously.
+     * model while that window is open, because the FE syncs the new model back to us asynchronously.
      */
-    fun onRecoveryModelPicked(chatId: String?, modelId: String)
+    fun onRecoveryModelPicked(modelId: String)
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -55,15 +55,13 @@ class RealEffectiveModelProvider @Inject constructor(
     private val duckAiChatStore: DuckAiChatStore,
 ) : EffectiveModelProvider {
 
-    private data class RecoverySelection(val chatId: String?, val modelId: String)
-
     private data class ActiveChat(
         val chatId: String?,
         val modelChangeMode: Boolean,
         val chatModel: String?,
     )
 
-    private val recoverySelection = MutableStateFlow<RecoverySelection?>(null)
+    private val recoveryModelId = MutableStateFlow<String?>(null)
 
     // mapLatest: a chatId flip cancels an in-flight lookup, so a slow read can't resolve into a stale chat.
     private val activeChat: Flow<ActiveChat> = nativeInputStateProvider.state
@@ -80,17 +78,17 @@ class RealEffectiveModelProvider @Inject constructor(
     override val effectiveModelId: Flow<String?> = combine(
         modelManager.modelState,
         activeChat,
-        recoverySelection,
+        recoveryModelId,
     ) { modelState, chat, recovery ->
         val modelIds = modelState.models.mapTo(HashSet()) { it.id }
+        // Honoured only while the model-change window is open; it closes per tab, so a stale pick cannot leak.
         val recovered = recovery
-            ?.takeIf { chat.modelChangeMode && it.chatId == chat.chatId }
-            ?.modelId
+            ?.takeIf { chat.modelChangeMode }
             ?.takeIf { it in modelIds }
         recovered ?: chat.chatModel?.takeIf { it in modelIds } ?: modelState.selectedModelId
     }.distinctUntilChanged()
 
-    override fun onRecoveryModelPicked(chatId: String?, modelId: String) {
-        recoverySelection.value = RecoverySelection(chatId, modelId)
+    override fun onRecoveryModelPicked(modelId: String) {
+        recoveryModelId.value = modelId
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProvider.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProvider.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.duckchat.impl.nativeinput
 
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
@@ -47,8 +47,10 @@ interface EffectiveModelProvider {
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@SingleInstanceIn(AppScope::class)
-@ContributesBinding(AppScope::class)
+// ActivityScope, not AppScope: the unqualified DuckAiChatStore is bound per activity so it can resolve
+// the browser mode. One instance per activity is what the plugins sharing a widget need anyway.
+@SingleInstanceIn(ActivityScope::class)
+@ContributesBinding(ActivityScope::class)
 class RealEffectiveModelProvider @Inject constructor(
     private val modelManager: DuckAiModelManager,
     private val nativeInputStateProvider: NativeInputStateProvider,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProvider.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProvider.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.nativeinput
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
+import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
+import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
+
+/**
+ * The model whose capabilities the native input controls should reflect for the active tab. Shared so
+ * the model picker and the options menu resolve it identically instead of one asking the other.
+ */
+interface EffectiveModelProvider {
+
+    val effectiveModelId: Flow<String?>
+
+    /**
+     * Records the model picked during the FE model-change recovery flow. It wins over the chat's stored
+     * model until that window closes, because the FE syncs the new model back to us asynchronously.
+     */
+    fun onRecoveryModelPicked(chatId: String?, modelId: String)
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealEffectiveModelProvider @Inject constructor(
+    private val modelManager: DuckAiModelManager,
+    private val nativeInputStateProvider: NativeInputStateProvider,
+    private val duckAiChatStore: DuckAiChatStore,
+) : EffectiveModelProvider {
+
+    private data class RecoverySelection(val chatId: String?, val modelId: String)
+
+    private data class ActiveChat(
+        val chatId: String?,
+        val modelChangeMode: Boolean,
+        val chatModel: String?,
+    )
+
+    private val recoverySelection = MutableStateFlow<RecoverySelection?>(null)
+
+    // mapLatest: a chatId flip cancels an in-flight lookup, so a slow read can't resolve into a stale chat.
+    private val activeChat: Flow<ActiveChat> = nativeInputStateProvider.state
+        .map { it.chatId to it.modelChangeMode }
+        .distinctUntilChanged()
+        .mapLatest { (chatId, modelChangeMode) ->
+            ActiveChat(
+                chatId = chatId,
+                modelChangeMode = modelChangeMode,
+                chatModel = chatId?.let { duckAiChatStore.getChatById(it)?.model },
+            )
+        }
+
+    override val effectiveModelId: Flow<String?> = combine(
+        modelManager.modelState,
+        activeChat,
+        recoverySelection,
+    ) { modelState, chat, recovery ->
+        val modelIds = modelState.models.mapTo(HashSet()) { it.id }
+        val recovered = recovery
+            ?.takeIf { chat.modelChangeMode && it.chatId == chat.chatId }
+            ?.modelId
+            ?.takeIf { it in modelIds }
+        recovered ?: chat.chatModel?.takeIf { it in modelIds } ?: modelState.selectedModelId
+    }.distinctUntilChanged()
+
+    override fun onRecoveryModelPicked(chatId: String?, modelId: String) {
+        recoverySelection.value = RecoverySelection(chatId, modelId)
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProvider.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProvider.kt
@@ -44,6 +44,12 @@ interface EffectiveModelProvider {
      * model while that window is open, because the FE syncs the new model back to us asynchronously.
      */
     fun onRecoveryModelPicked(modelId: String)
+
+    /**
+     * Drops the recorded recovery pick when the model-change window closes. Without this the next
+     * window would reapply the previous pick, and the picker's own menu tick would disagree with it.
+     */
+    fun clearRecoveryModelPick()
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -92,5 +98,9 @@ class RealEffectiveModelProvider @Inject constructor(
 
     override fun onRecoveryModelPicked(modelId: String) {
         recoveryModelId.value = modelId
+    }
+
+    override fun clearRecoveryModelPick() {
+        recoveryModelId.value = null
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProvider.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProvider.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 /**
@@ -40,16 +41,16 @@ interface EffectiveModelProvider {
     val effectiveModelId: Flow<String?>
 
     /**
-     * Records the model picked during the FE model-change recovery flow. It wins over the chat's stored
-     * model while that window is open, because the FE syncs the new model back to us asynchronously.
+     * Records the model picked during [chatId]'s FE model-change window. It wins over that chat's stored
+     * model while the window is open, because the FE syncs the new model back to us asynchronously.
      */
-    fun onRecoveryModelPicked(modelId: String)
+    fun onRecoveryModelPicked(chatId: String?, modelId: String)
 
     /**
-     * Drops the recorded recovery pick when the model-change window closes. Without this the next
-     * window would reapply the previous pick, and the picker's own menu tick would disagree with it.
+     * Drops the pick when [chatId]'s window closes. Keyed by chat for two reasons: the next window on the
+     * same chat must not reapply the old pick, and closing one tab's window must not wipe another tab's.
      */
-    fun clearRecoveryModelPick()
+    fun clearRecoveryModelPick(chatId: String?)
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -69,7 +70,9 @@ class RealEffectiveModelProvider @Inject constructor(
         val chatModel: String?,
     )
 
-    private val recoveryModelId = MutableStateFlow<String?>(null)
+    private data class RecoveryPick(val chatId: String?, val modelId: String)
+
+    private val recoveryPick = MutableStateFlow<RecoveryPick?>(null)
 
     // mapLatest: a chatId flip cancels an in-flight lookup, so a slow read can't resolve into a stale chat.
     private val activeChat: Flow<ActiveChat> = nativeInputStateProvider.state
@@ -86,21 +89,22 @@ class RealEffectiveModelProvider @Inject constructor(
     override val effectiveModelId: Flow<String?> = combine(
         modelManager.modelState,
         activeChat,
-        recoveryModelId,
+        recoveryPick,
     ) { modelState, chat, recovery ->
         val modelIds = modelState.models.mapTo(HashSet()) { it.id }
-        // Honoured only while the model-change window is open; it closes per tab, so a stale pick cannot leak.
+        // Honoured only for the chat whose window is open, so a pick cannot leak across tabs.
         val recovered = recovery
-            ?.takeIf { chat.modelChangeMode }
+            ?.takeIf { chat.modelChangeMode && it.chatId == chat.chatId }
+            ?.modelId
             ?.takeIf { it in modelIds }
         recovered ?: chat.chatModel?.takeIf { it in modelIds } ?: modelState.selectedModelId
     }.distinctUntilChanged()
 
-    override fun onRecoveryModelPicked(modelId: String) {
-        recoveryModelId.value = modelId
+    override fun onRecoveryModelPicked(chatId: String?, modelId: String) {
+        recoveryPick.value = RecoveryPick(chatId, modelId)
     }
 
-    override fun clearRecoveryModelPick() {
-        recoveryModelId.value = null
+    override fun clearRecoveryModelPick(chatId: String?) {
+        recoveryPick.update { current -> current?.takeIf { it.chatId != chatId } }
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProvider.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProvider.kt
@@ -22,7 +22,6 @@ import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
-import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,6 +29,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
+import javax.inject.Inject
 
 /**
  * The model whose capabilities the native input controls should reflect for the active tab. Shared so

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -17,7 +17,9 @@
 package com.duckduckgo.duckchat.impl.nativeinput
 
 import android.content.Context
+import android.net.Uri
 import android.view.View
+import android.webkit.ValueCallback
 import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
 import com.duckduckgo.common.utils.plugins.ActivePlugin
 import com.duckduckgo.di.scopes.AppScope
@@ -59,6 +61,21 @@ interface NativeInputHost {
 
     /** The user picked a model during the FE model-change recovery flow. */
     fun changeModelSubmitted(modelId: String)
+
+    /** Ask the host to run the camera capture flow; the activity owns the result plumbing. */
+    fun requestCameraCapture(callback: ValueCallback<Array<Uri>>)
+
+    /** Ask the host to run the file picker for [mimeTypes]. */
+    fun requestFilePicker(callback: ValueCallback<Array<Uri>>, mimeTypes: List<String>)
+
+    /** The user chose to ask about the current page, offered only on the contextual surface. */
+    fun askAboutPage()
+
+    /** The user removed the page-context attachment. */
+    fun pageContextRemoved()
+
+    /** True when the host is the fullscreen edit-message surface, which offers a reduced control set. */
+    fun isEditSurface(): Boolean
 }
 
 interface NativeInputPlugin : ActivePlugin {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -47,6 +47,18 @@ interface NativeInputHost {
      */
     fun toolSelected(tool: String?)
     fun customizeResponsesClicked()
+
+    /** The model menu opened. The host suppresses input teardown while it is up. */
+    fun modelMenuShown()
+
+    /**
+     * The model menu closed. [hasPendingRecoverySelection] is false when the user dismissed it without
+     * picking, which ends the FE model-change window.
+     */
+    fun modelMenuDismissed(hasPendingRecoverySelection: Boolean)
+
+    /** The user picked a model during the FE model-change recovery flow. */
+    fun changeModelSubmitted(modelId: String)
 }
 
 interface NativeInputPlugin : ActivePlugin {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -76,6 +76,13 @@ interface NativeInputHost {
 
     /** True when the host is the fullscreen edit-message surface, which offers a reduced control set. */
     fun isEditSurface(): Boolean
+
+    /**
+     * True when the host is the contextual Duck.ai sheet. Asked of the host rather than read from
+     * `inputContext`, because the sheet shares its per-tab state slot with the omnibar widget and that
+     * slot can briefly carry BROWSER state.
+     */
+    fun isContextualSurface(): Boolean
 }
 
 interface NativeInputPlugin : ActivePlugin {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/AttachmentNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/AttachmentNativeInputPlugin.kt
@@ -37,5 +37,8 @@ class AttachmentNativeInputPlugin @Inject constructor() : NativeInputPlugin {
     override val containerId: Int = R.id.attachButtonContainer
 
     override fun createView(context: Context, host: NativeInputHost): View =
-        AttachmentView(context).also { it.host = host }
+        AttachmentView(context).also {
+            it.host = host
+            it.isEditMode = host.isEditSurface()
+        }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
@@ -40,6 +40,7 @@ class ModelPickerNativeInputPlugin @Inject constructor() : NativeInputPlugin {
         return ModelPickerView(context).also { picker ->
             picker.setHost(host)
             picker.setPickerEnabled(true)
+            picker.isEditMode = host.isEditSurface()
         }
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/OptionsNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/OptionsNativeInputPlugin.kt
@@ -36,5 +36,5 @@ class OptionsNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override val containerId: Int = R.id.optionsButtonContainer
 
-    override fun createView(context: Context, host: NativeInputHost): View = OptionsView(context, host)
+    override fun createView(context: Context, host: NativeInputHost): View = OptionsView(context, host).also { it.isEditMode = host.isEditSurface() }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
@@ -36,5 +36,7 @@ class ReasoningModePickerNativeInputPlugin @Inject constructor() : NativeInputPl
 
     override val containerId: Int = R.id.reasoningModePickerContainer
 
-    override fun createView(context: Context, host: NativeInputHost): View = ReasoningModePickerView(context)
+    override fun createView(context: Context, host: NativeInputHost): View = ReasoningModePickerView(context).also {
+        it.isEditMode = host.isEditSurface()
+    }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StopStreamingNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StopStreamingNativeInputPlugin.kt
@@ -38,5 +38,6 @@ class StopStreamingNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override fun createView(context: Context, host: NativeInputHost): View = StopStreamingView(context).apply {
         onStopClicked = { host.stop() }
+        isEditMode = host.isEditSurface()
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
@@ -33,45 +33,49 @@ import android.widget.ScrollView
 import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.utils.ViewViewModelFactory
+import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.ui.AttachmentViewModel
-import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ImageAttachment
-import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.PageContextAttachment
-import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.SubmittedFile
-import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.SubmittedImage
-import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachmentsContainerView
-import kotlinx.coroutines.CoroutineScope
+import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import org.json.JSONArray
+import javax.inject.Inject
 
 @SuppressLint("ViewConstructor")
+@InjectWith(ViewScope::class)
 class AttachmentView(
     context: Context,
 ) : FrameLayout(context) {
 
+    @Inject lateinit var viewModelFactory: ViewViewModelFactory
+
+    @Inject lateinit var nativeInputStateProvider: NativeInputStateProvider
+
+    @Inject lateinit var faviconManager: FaviconManager
+
     var host: NativeInputHost? = null
-    var onCameraCaptureRequested: ((ValueCallback<Array<Uri>>) -> Unit)? = null
-    var onFilePickerRequested: ((ValueCallback<Array<Uri>>, List<String>) -> Unit)? = null
-    var isContextual: Boolean = false
     var isEditMode: Boolean = false
-    var onAskAboutPage: (() -> Unit)? = null
-    var onPageContextRemoved: (() -> Unit)? = null
 
     private var viewModel: AttachmentViewModel? = null
-    private var faviconManager: FaviconManager? = null
+
+    /** The contextual sheet is the only surface that offers page context. */
+    private val isContextual: Boolean
+        get() = lastNativeInputState?.inputContext == NativeInputState.InputContext.DUCK_AI_CONTEXTUAL
     private var supportsUpload: Boolean = false
     private var nativeInputStateJob: Job? = null
     private var lastNativeInputState: NativeInputState? = null
@@ -87,16 +91,13 @@ class AttachmentView(
         setOnClickListener { showPopupMenu() }
     }
 
-    fun bind(
-        scope: CoroutineScope,
-        factory: ViewViewModelFactory,
-        nativeInputStateProvider: NativeInputStateProvider,
-        faviconManager: FaviconManager,
-    ) {
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
         val owner = findViewTreeViewModelStoreOwner() ?: return
-        val vm = ViewModelProvider(owner, factory)[AttachmentViewModel::class.java]
+        val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        val vm = ViewModelProvider(owner, viewModelFactory)[AttachmentViewModel::class.java]
         viewModel = vm
-        this.faviconManager = faviconManager
         val container = rootView?.findViewById<FrameLayout>(R.id.attachmentsContainer) ?: return
         setupContainerViews(container, vm)
         scope.launch {
@@ -120,29 +121,6 @@ class AttachmentView(
         isVisible = show
         (parent as? View)?.isVisible = show
     }
-
-    fun getImageAttachments(): List<ImageAttachment> = viewModel?.getImageAttachments() ?: emptyList()
-
-    fun getFileAttachments(): List<FileAttachment> = viewModel?.getFileAttachments() ?: emptyList()
-
-    fun getImageAttachmentsJson(): JSONArray? = viewModel?.getImageAttachmentsJson()
-
-    fun getFileAttachmentsJson(): JSONArray? = viewModel?.getFileAttachmentsJson()
-
-    fun clearAttachments() = viewModel?.clearAttachments()
-
-    fun adoptAttachments(
-        images: List<SubmittedImage>,
-        files: List<SubmittedFile>,
-    ) = viewModel?.adopt(images, files)
-
-    fun clearAttachmentsForNewChat() = viewModel?.clearAttachmentsForNewChat()
-
-    fun setPageContext(attachment: PageContextAttachment) = viewModel?.setPageContext(attachment)
-
-    fun clearPageContext() = viewModel?.removePageContext()
-
-    fun getPageContext(): PageContextAttachment? = viewModel?.getPageContext()
 
     private fun buildAttachButton(): ImageView {
         val iconSize = context.resources.getDimensionPixelSize(R.dimen.nativeInputButtonSize)
@@ -266,11 +244,11 @@ class AttachmentView(
         } else if (view.current() != next) {
             view.show(next) {
                 viewModel?.removePageContext()
-                onPageContextRemoved?.invoke()
+                host?.pageContextRemoved()
             }
             view.faviconView()?.let { faviconView ->
                 viewModel?.viewModelScope?.launch {
-                    faviconManager?.loadToViewFromLocalWithRetry(tabId = next.tabId, url = next.url, view = faviconView)
+                    faviconManager.loadToViewFromLocalWithRetry(tabId = next.tabId, url = next.url, view = faviconView)
                 }
             }
         }
@@ -339,7 +317,7 @@ class AttachmentView(
             ) {
                 popup.dismiss()
                 host?.showAttachmentChooser(true)
-                onCameraCaptureRequested?.invoke(buildImagePickerCallback(AttachmentViewModel.ImageSource.CAMERA))
+                host?.requestCameraCapture(buildImagePickerCallback(AttachmentViewModel.ImageSource.CAMERA))
             }
 
             addMenuItem(
@@ -349,7 +327,7 @@ class AttachmentView(
             ) {
                 popup.dismiss()
                 host?.showAttachmentChooser(true)
-                onFilePickerRequested?.invoke(buildImagePickerCallback(AttachmentViewModel.ImageSource.PHOTO_LIBRARY), listOf("image/*"))
+                host?.requestFilePicker(buildImagePickerCallback(AttachmentViewModel.ImageSource.PHOTO_LIBRARY), listOf("image/*"))
             }
         }
 
@@ -361,7 +339,7 @@ class AttachmentView(
             ) {
                 popup.dismiss()
                 host?.showAttachmentChooser(true)
-                onFilePickerRequested?.invoke(buildFilePickerCallback(), supportedFileTypes)
+                host?.requestFilePicker(buildFilePickerCallback(), supportedFileTypes)
             }
         }
 
@@ -372,7 +350,7 @@ class AttachmentView(
                 titleRes = R.string.duckChatContextualAskAboutPage,
             ) {
                 popup.dismiss()
-                onAskAboutPage?.invoke()
+                host?.askAboutPage()
             }
         }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
@@ -75,9 +75,10 @@ class AttachmentView(
 
     /** The contextual sheet is the only surface that offers page context. */
     private val isContextual: Boolean
-        get() = lastNativeInputState?.inputContext == NativeInputState.InputContext.DUCK_AI_CONTEXTUAL
+        get() = host?.isContextualSurface() == true
     private var supportsUpload: Boolean = false
     private var nativeInputStateJob: Job? = null
+    private var attachmentStateJob: Job? = null
     private var lastNativeInputState: NativeInputState? = null
     private var popupWindow: PopupWindow? = null
     private var thumbnailsLayout: LinearLayout? = null
@@ -100,7 +101,8 @@ class AttachmentView(
         viewModel = vm
         val container = rootView?.findViewById<FrameLayout>(R.id.attachmentsContainer) ?: return
         setupContainerViews(container, vm)
-        scope.launch {
+        attachmentStateJob?.cancel()
+        attachmentStateJob = scope.launch {
             vm.attachmentState.collect { state -> applyState(state, container) }
         }
         nativeInputStateJob = nativeInputStateProvider.state
@@ -279,6 +281,8 @@ class AttachmentView(
         super.onDetachedFromWindow()
         nativeInputStateJob?.cancel()
         nativeInputStateJob = null
+        attachmentStateJob?.cancel()
+        attachmentStateJob = null
         lastNativeInputState = null
         dismissPopup()
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -63,13 +63,9 @@ import javax.inject.Inject
 interface ModelPicker {
     var onMenuShown: (() -> Unit)?
     var onMenuDismissed: (() -> Unit)?
-    var onModelSelected: (() -> Unit)?
 
     /** Invoked when the user picks a model during the FE recovery model-change flow. */
     var onChangeModelSubmitted: ((modelId: String) -> Unit)?
-    fun getSelectedModelId(): String?
-    fun isImageGenerationSupported(): Boolean
-    fun isWebSearchSupported(): Boolean
     fun setPickerEnabled(enabled: Boolean)
     fun setHost(host: NativeInputHost)
 
@@ -102,7 +98,6 @@ class ModelPickerView @JvmOverloads constructor(
     private var inputContextJob: Job? = null
     private var commandJob: Job? = null
     private var modelChangeJob: Job? = null
-    private var effectiveModelJob: Job? = null
     private var popupWindow: PopupWindow? = null
     private var lastNativeInputState: NativeInputState? = null
 
@@ -112,23 +107,10 @@ class ModelPickerView @JvmOverloads constructor(
     private lateinit var host: NativeInputHost
     override var onMenuShown: (() -> Unit)? = null
     override var onMenuDismissed: (() -> Unit)? = null
-    override var onModelSelected: (() -> Unit)? = null
     override var onChangeModelSubmitted: ((modelId: String) -> Unit)? = null
 
     init {
         inflate(context, R.layout.view_model_picker, this)
-    }
-
-    override fun getSelectedModelId(): String? = viewModel.getSelectedModelId()
-
-    override fun isImageGenerationSupported(): Boolean {
-        if (!isAttachedToWindow) return true
-        return viewModel.isImageGenerationSupported()
-    }
-
-    override fun isWebSearchSupported(): Boolean {
-        if (!isAttachedToWindow) return true
-        return viewModel.isWebSearchSupported()
     }
 
     private var pickerEnabled = false
@@ -184,13 +166,6 @@ class ModelPickerView @JvmOverloads constructor(
         stateJob?.cancel()
         stateJob = viewModel.state
             .onEach { updateVisibility() }
-            .launchIn(scope)
-
-        // Refresh option tool-visibility whenever the effective (chat-aware / recovery) model
-        // changes, not only on global model changes — otherwise options reflect the wrong model.
-        effectiveModelJob?.cancel()
-        effectiveModelJob = viewModel.effectiveModelId
-            .onEach { onModelSelected?.invoke() }
             .launchIn(scope)
 
         chipLabelJob?.cancel()
@@ -308,8 +283,6 @@ class ModelPickerView @JvmOverloads constructor(
         commandJob = null
         modelChangeJob?.cancel()
         modelChangeJob = null
-        effectiveModelJob?.cancel()
-        effectiveModelJob = null
         lastNativeInputState = null
         dismissPopup()
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -61,11 +61,7 @@ import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 interface ModelPicker {
-    var onMenuShown: (() -> Unit)?
-    var onMenuDismissed: (() -> Unit)?
 
-    /** Invoked when the user picks a model during the FE recovery model-change flow. */
-    var onChangeModelSubmitted: ((modelId: String) -> Unit)?
     fun setPickerEnabled(enabled: Boolean)
     fun setHost(host: NativeInputHost)
 
@@ -105,9 +101,6 @@ class ModelPickerView @JvmOverloads constructor(
     // read synchronously from popup callbacks. Updated by observeInputContext().
     private var lastInputContext: InputContext = InputContext.BROWSER
     private lateinit var host: NativeInputHost
-    override var onMenuShown: (() -> Unit)? = null
-    override var onMenuDismissed: (() -> Unit)? = null
-    override var onChangeModelSubmitted: ((modelId: String) -> Unit)? = null
 
     init {
         inflate(context, R.layout.view_model_picker, this)
@@ -183,7 +176,7 @@ class ModelPickerView @JvmOverloads constructor(
             .onEach { change ->
                 when (change) {
                     is PickerModelChange.ChangeModel -> {
-                        onChangeModelSubmitted?.invoke(change.modelId)
+                        host?.changeModelSubmitted(change.modelId)
                         dismissPopup()
                     }
                 }
@@ -220,7 +213,7 @@ class ModelPickerView @JvmOverloads constructor(
 
         viewModel.menuShowing = true
         viewModel.onPickerShown(currentSurface())
-        onMenuShown?.invoke()
+        host?.modelMenuShown()
         showPopupWindow(state)
     }
 
@@ -268,7 +261,7 @@ class ModelPickerView @JvmOverloads constructor(
     private fun onPopupDismissed() {
         viewModel.menuShowing = false
         popupWindow = null
-        onMenuDismissed?.invoke()
+        host?.modelMenuDismissed(viewModel.hasPendingRecoverySelection())
     }
 
     override fun onDetachedFromWindow() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -95,7 +95,10 @@ class ModelPickerViewModel @Inject constructor(
             nativeInputStateProvider.state.collect { state ->
                 modelChangeMode = state.modelChangeMode
                 pixelSurface = DuckChatPixelSurface.from(state.inputContext)
-                if (!state.modelChangeMode) recoverySelectedModelId.value = null
+                if (!state.modelChangeMode) {
+                    recoverySelectedModelId.value = null
+                    effectiveModelProvider.clearRecoveryModelPick()
+                }
             }
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -26,11 +26,10 @@ import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
-import com.duckduckgo.duckchat.impl.nativeinput.EffectiveModelProvider
 import com.duckduckgo.duckchat.impl.models.ModelProvider
 import com.duckduckgo.duckchat.impl.models.ModelState
-import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.UserTier
+import com.duckduckgo.duckchat.impl.nativeinput.EffectiveModelProvider
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.store.impl.DuckAiChat

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -150,14 +150,6 @@ class ModelPickerViewModel @Inject constructor(
 
     var menuShowing = false
 
-    fun getSelectedModelId(): String? = modelManager.getSelectedModelId()
-
-    fun getSelectedModel(): AIChatModel? = state.value.models.firstOrNull { it.id == effectiveModelId.value }
-
-    fun isImageGenerationSupported(): Boolean = getSelectedModel()?.supportsTool(Tool.IMAGE_GENERATION) ?: true
-
-    fun isWebSearchSupported(): Boolean = getSelectedModel()?.supportsTool(Tool.WEB_SEARCH) ?: true
-
     fun fetchModels() {
         viewModelScope.launch {
             modelManager.fetchModels()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
+import com.duckduckgo.duckchat.impl.nativeinput.EffectiveModelProvider
 import com.duckduckgo.duckchat.impl.models.ModelProvider
 import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.Tool
@@ -63,6 +64,7 @@ class ModelPickerViewModel @Inject constructor(
     private val duckChatPixels: DuckChatPixels,
     private val nativeInputStateProvider: NativeInputStateProvider,
     private val duckAiChatStore: DuckAiChatStore,
+    private val effectiveModelProvider: EffectiveModelProvider,
 ) : ViewModel() {
 
     val state: StateFlow<ModelState> = modelManager.modelState
@@ -99,23 +101,8 @@ class ModelPickerViewModel @Inject constructor(
         }
     }
 
-    /**
-     * The model the chip displays and whose capabilities the options should reflect: a just-picked
-     * recovery model, else the active chat's model (when in the list, e.g. not lost access), else
-     * the global selection. Single source of truth for [chipLabel] and [getSelectedModel].
-     */
-    val effectiveModelId: StateFlow<String?> = combine(
-        modelManager.modelState,
-        nativeInputStateProvider.state,
-        currentChat,
-        recoverySelectedModelId,
-    ) { modelState, nativeState, chat, recoveryId ->
-        val modelIds = modelState.models.mapTo(HashSet()) { it.id }
-        // A just-picked recovery model wins (display, before the chat's model syncs back).
-        recoveryId?.takeIf { it in modelIds }?.let { return@combine it }
-        val activeChat = chat?.takeIf { it.chatId == nativeState.chatId }
-        activeChat?.model?.takeIf { it in modelIds } ?: modelState.selectedModelId
-    }.stateIn(
+    /** Mirrors [EffectiveModelProvider.effectiveModelId] for this view: the model the chip displays. */
+    val effectiveModelId: StateFlow<String?> = effectiveModelProvider.effectiveModelId.stateIn(
         scope = viewModelScope,
         started = SharingStarted.Eagerly,
         initialValue = modelManager.modelState.value.selectedModelId,
@@ -186,6 +173,7 @@ class ModelPickerViewModel @Inject constructor(
                 }
                 duckChatPixels.fireSubmitChangeModel(model.id, pixelSurface)
                 recoverySelectedModelId.value = model.id
+                effectiveModelProvider.onRecoveryModelPicked(model.id)
                 modelChangeChannel.trySend(PickerModelChange.ChangeModel(model.id))
             } else {
                 if (model.id != modelManager.getSelectedModelId()) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -72,6 +72,10 @@ class ModelPickerViewModel @Inject constructor(
 
     private var modelChangeMode: Boolean = false
 
+    // The published chatId, which is the key for the recovery pick. Read from state rather than
+    // currentChat, which can still be resolving when the user picks.
+    private var publishedChatId: String? = null
+
     // The pixel surface for the active tab, tracked from the published input context.
     // Named distinctly from the [PickerSurface] param on [onModelTapped] to avoid shadowing.
     private var pixelSurface: DuckChatPixelSurface = DuckChatPixelSurface.ADDRESS_BAR
@@ -94,10 +98,11 @@ class ModelPickerViewModel @Inject constructor(
         viewModelScope.launch {
             nativeInputStateProvider.state.collect { state ->
                 modelChangeMode = state.modelChangeMode
+                publishedChatId = state.chatId
                 pixelSurface = DuckChatPixelSurface.from(state.inputContext)
                 if (!state.modelChangeMode) {
                     recoverySelectedModelId.value = null
-                    effectiveModelProvider.clearRecoveryModelPick()
+                    effectiveModelProvider.clearRecoveryModelPick(state.chatId)
                 }
             }
         }
@@ -175,7 +180,7 @@ class ModelPickerViewModel @Inject constructor(
                 }
                 duckChatPixels.fireSubmitChangeModel(model.id, pixelSurface)
                 recoverySelectedModelId.value = model.id
-                effectiveModelProvider.onRecoveryModelPicked(model.id)
+                effectiveModelProvider.onRecoveryModelPicked(chatId = publishedChatId, modelId = model.id)
                 modelChangeChannel.trySend(PickerModelChange.ChangeModel(model.id))
             } else {
                 if (model.id != modelManager.getSelectedModelId()) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -314,7 +314,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var editPromptJob: Job? = null
     private var submitAllowed: Boolean = true
     private var modelPickerView: ModelPicker? = null
-    private var optionsView: OptionsView? = null
     private var chatSuggestionsUserEnabled: Boolean = true
     private var isStreaming: Boolean = false
     private var attachmentLimitExceeded: Boolean = false
@@ -745,9 +744,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
                             // before plugins were created.
                             pluginView.setPickerEnabled(viewModel.modelPickerEnabled.value)
                         }
-                        if (pluginView is OptionsView) {
-                            optionsView = pluginView
-                        }
                         wirePluginView(pluginView, scope)
                     }
                 }
@@ -791,16 +787,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
         if (pluginView is StopStreamingView) {
             pluginView.isEditMode = isEditWidget
-        }
-        (pluginView as? ModelPicker)?.let { picker ->
-            picker.onMenuShown = { isModelMenuVisible = true }
-            picker.onMenuDismissed = {
-                isModelMenuVisible = false
-                // FE recovery: dismissing without picking a model reverts the change window so the
-                // chip hides again (nothing changed). A selection keeps the chip until submit.
-                if (!picker.hasPendingRecoverySelection()) viewModel.exitModelChangeMode()
-            }
-            picker.onChangeModelSubmitted = { modelId -> onChangeModelSubmitted?.invoke(modelId) }
         }
     }
 
@@ -851,7 +837,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         editPromptJob?.cancel()
         editPromptJob = null
         modelPickerView = null
-        optionsView = null
         widgetRoot = null
         tearDownChatSuggestions()
     }
@@ -1524,7 +1509,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun getSelectedTool(): String? = viewModel.getSelectedTool()
 
     override fun clearSelectedTool() {
-        optionsView?.clearSelection()
+        viewModel.setSelectedTool(null)
     }
 
     override fun onPromptSubmitted() {
@@ -1635,7 +1620,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         } ?: emptyList()
         viewModel.storePendingPrompt(query, getSelectedModelId(), getResolvedReasoningEffort(), getSelectedTool(), images, files)
         attachmentView?.clearAttachmentsForNewChat()
-        optionsView?.clearSelection()
+        viewModel.setSelectedTool(null)
     }
 
     override fun configure(tabId: String, isDuckAiMode: Boolean, isBottom: Boolean) {
@@ -2053,6 +2038,21 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
         updateSendButtonVisibility()
         updateVoiceButtonVisibility()
+    }
+
+    override fun modelMenuShown() {
+        isModelMenuVisible = true
+    }
+
+    override fun modelMenuDismissed(hasPendingRecoverySelection: Boolean) {
+        isModelMenuVisible = false
+        // FE recovery: dismissing without picking a model reverts the change window so the chip hides
+        // again (nothing changed). A selection keeps the chip until submit.
+        if (!hasPendingRecoverySelection) viewModel.exitModelChangeMode()
+    }
+
+    override fun changeModelSubmitted(modelId: String) {
+        onChangeModelSubmitted?.invoke(modelId)
     }
 
     override fun toolSelected(tool: String?) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -2052,6 +2052,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun isEditSurface(): Boolean = isEditWidget
 
+    override fun isContextualSurface(): Boolean = isContextualWidget
+
     override fun toolSelected(tool: String?) {
         viewModel.setSelectedTool(tool)
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -750,7 +750,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
                         }
                         wirePluginView(pluginView, scope)
                     }
-                    optionsView?.updateCapabilitiesFrom(modelPickerView)
                 }
             }
             launch {
@@ -800,9 +799,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
                 // FE recovery: dismissing without picking a model reverts the change window so the
                 // chip hides again (nothing changed). A selection keeps the chip until submit.
                 if (!picker.hasPendingRecoverySelection()) viewModel.exitModelChangeMode()
-            }
-            picker.onModelSelected = {
-                optionsView?.updateCapabilitiesFrom(picker)
             }
             picker.onChangeModelSubmitted = { modelId -> onChangeModelSubmitted?.invoke(modelId) }
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -84,6 +84,7 @@ import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.pixel.inputScreenPixelsModeParam
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
+import com.duckduckgo.duckchat.impl.ui.AttachmentViewModel
 import com.duckduckgo.duckchat.impl.ui.NativeInputModeWidgetViewModel
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.PageContextAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.edit.EditPromptScreenParams
@@ -374,16 +375,15 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override var isModelMenuVisible: Boolean = false
         private set
 
-    private var pendingCameraCaptureCallback: ((ValueCallback<Array<Uri>>) -> Unit)? = null
-    private var pendingFilePickerCallback: ((ValueCallback<Array<Uri>>, List<String>) -> Unit)? = null
-    private var pendingIsContextual: Boolean = false
-    private var pendingAskAboutPage: (() -> Unit)? = null
-    private var pendingOnPageContextRemoved: (() -> Unit)? = null
+    private var cameraCaptureCallback: ((ValueCallback<Array<Uri>>) -> Unit)? = null
+    private var filePickerCallback: ((ValueCallback<Array<Uri>>, List<String>) -> Unit)? = null
+    private var askAboutPageAction: (() -> Unit)? = null
+    private var pageContextRemovedAction: (() -> Unit)? = null
     private var pendingPageContext: PageContextAttachment? = null
 
     // adoptEditAttachments() can be called (from EditPromptActivity.onCreate) before the widget is
-    // attached and the AttachmentView plugin exists, so the values are held here and applied once
-    // wirePluginView() runs.
+    // attached, when the attachment ViewModel cannot be resolved yet, so the values are held here and
+    // applied by applyPendingAttachmentState().
     private var pendingAdoptedImages: List<SubmittedImage> = emptyList()
     private var pendingAdoptedFiles: List<SubmittedFile> = emptyList()
 
@@ -403,7 +403,13 @@ class NativeInputModeWidget @JvmOverloads constructor(
     // it they'd flip from 4dp→8dp after focusInput and look like a second step.
     private var previewEnterFocus = false
 
-    private var attachmentView: AttachmentView? = null
+    // The attachment plugin's ViewModel, shared through this widget's ViewModelStoreOwner. Submission
+    // needs the staged attachments, and reading them from the ViewModel keeps the widget out of the
+    // plugin's view.
+    private val attachmentViewModel: AttachmentViewModel?
+        get() = findViewTreeViewModelStoreOwner()?.let { owner ->
+            ViewModelProvider(owner, viewModelFactory)[AttachmentViewModel::class.java]
+        }
 
     val inputField: EditText
     private val inputFieldClearText: View
@@ -681,6 +687,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
             duckChatInternal.setInputQuery(currentInputQuery())
         }
         setupPlugins()
+        applyPendingAttachmentState()
         observeModelPickerEnabledSource()
         observeChatIdSource()
         observeInteractionLockSource()
@@ -744,7 +751,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
                             // before plugins were created.
                             pluginView.setPickerEnabled(viewModel.modelPickerEnabled.value)
                         }
-                        wirePluginView(pluginView, scope)
                     }
                 }
             }
@@ -760,44 +766,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
     }
 
-    // This function will be removed with the new plugin architecture
-    private fun wirePluginView(pluginView: View, scope: CoroutineScope) {
-        if (pluginView is AttachmentView) {
-            attachmentView = pluginView
-            pluginView.onCameraCaptureRequested = pendingCameraCaptureCallback
-            pluginView.onFilePickerRequested = pendingFilePickerCallback
-            pluginView.isContextual = pendingIsContextual
-            pluginView.isEditMode = isEditWidget
-            pluginView.onAskAboutPage = pendingAskAboutPage
-            pluginView.onPageContextRemoved = pendingOnPageContextRemoved
-            pluginView.bind(scope, viewModelFactory, nativeInputStateProvider, faviconManager)
-            pendingPageContext?.let { pluginView.setPageContext(it) }
-            if (hasPendingAdoptedAttachments(pendingAdoptedImages, pendingAdoptedFiles)) {
-                pluginView.adoptAttachments(pendingAdoptedImages, pendingAdoptedFiles)
-            }
-        }
-        if (pluginView is OptionsView) {
-            pluginView.isEditMode = isEditWidget
-        }
-        if (pluginView is ModelPickerView) {
-            pluginView.isEditMode = isEditWidget
-        }
-        if (pluginView is ReasoningModePickerView) {
-            pluginView.isEditMode = isEditWidget
-        }
-        if (pluginView is StopStreamingView) {
-            pluginView.isEditMode = isEditWidget
-        }
-    }
-
     override fun bindAttachmentCallbacks(
         onCameraCaptureRequested: (ValueCallback<Array<Uri>>) -> Unit,
         onFilePickerRequested: (ValueCallback<Array<Uri>>, List<String>) -> Unit,
     ) {
-        pendingCameraCaptureCallback = onCameraCaptureRequested
-        pendingFilePickerCallback = onFilePickerRequested
-        attachmentView?.onCameraCaptureRequested = onCameraCaptureRequested
-        attachmentView?.onFilePickerRequested = onFilePickerRequested
+        cameraCaptureCallback = onCameraCaptureRequested
+        filePickerCallback = onFilePickerRequested
     }
 
     override fun onDetachedFromWindow() {
@@ -1355,8 +1329,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun fireSubmissionPixels(hasText: Boolean) {
-        val hasImageAttachment = attachmentView?.getImageAttachments()?.isNotEmpty() == true
-        val hasFileAttachment = attachmentView?.getFileAttachments()?.isNotEmpty() == true
+        val hasImageAttachment = attachmentViewModel?.getImageAttachments()?.isNotEmpty() == true
+        val hasFileAttachment = attachmentViewModel?.getFileAttachments()?.isNotEmpty() == true
         viewModel.fireSubmissionPixels(
             hasText = hasText,
             hasImageAttachment = hasImageAttachment,
@@ -1576,50 +1550,44 @@ class NativeInputModeWidget @JvmOverloads constructor(
             .launchIn(scope)
     }
 
-    override fun getImageAttachmentsJson(): JSONArray? = attachmentView?.getImageAttachmentsJson()
+    override fun getImageAttachmentsJson(): JSONArray? = attachmentViewModel?.getImageAttachmentsJson()
 
-    override fun getFileAttachmentsJson(): JSONArray? = attachmentView?.getFileAttachmentsJson()
+    override fun getFileAttachmentsJson(): JSONArray? = attachmentViewModel?.getFileAttachmentsJson()
 
     override fun setPageContext(title: String, url: String) {
         val attachment = PageContextAttachment(title = title, url = url, tabId = activeTabId)
         pendingPageContext = attachment
-        attachmentView?.setPageContext(attachment)
+        attachmentViewModel?.setPageContext(attachment)
     }
 
     override fun clearPageContext() {
         pendingPageContext = null
-        attachmentView?.clearPageContext()
+        attachmentViewModel?.removePageContext()
     }
 
-    override fun getPageContext(): PageContextAttachment? = attachmentView?.getPageContext()
+    override fun getPageContext(): PageContextAttachment? = attachmentViewModel?.getPageContext()
 
     override fun setContextualAttachmentActions(
         onAskAboutPage: () -> Unit,
         onPageContextRemoved: () -> Unit,
     ) {
-        pendingIsContextual = true
-        pendingAskAboutPage = onAskAboutPage
-        pendingOnPageContextRemoved = onPageContextRemoved
-        attachmentView?.let { view ->
-            view.isContextual = true
-            view.onAskAboutPage = onAskAboutPage
-            view.onPageContextRemoved = onPageContextRemoved
-        }
+        askAboutPageAction = onAskAboutPage
+        pageContextRemovedAction = onPageContextRemoved
     }
 
     override fun clearAttachments() {
-        attachmentView?.clearAttachments()
+        attachmentViewModel?.clearAttachments()
     }
 
     override fun storePendingPrompt(query: String) {
-        val images = attachmentView?.getImageAttachments()?.map {
+        val images = attachmentViewModel?.getImageAttachments()?.map {
             PendingNativeImage(base64Data = it.base64Data, format = it.format)
         } ?: emptyList()
-        val files = attachmentView?.getFileAttachments()?.map {
+        val files = attachmentViewModel?.getFileAttachments()?.map {
             PendingNativeFile(base64Data = it.base64Data, fileName = it.fileName, mimeType = it.mimeType)
         } ?: emptyList()
         viewModel.storePendingPrompt(query, getSelectedModelId(), getResolvedReasoningEffort(), getSelectedTool(), images, files)
-        attachmentView?.clearAttachmentsForNewChat()
+        attachmentViewModel?.clearAttachmentsForNewChat()
         viewModel.setSelectedTool(null)
     }
 
@@ -1642,7 +1610,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun configureForEdit(sessionId: String) {
         isEditWidget = true
-        attachmentView?.isEditMode = true
         doOnAttach {
             viewModel.configureForEdit(sessionId)
             selectChatTab()
@@ -1655,7 +1622,19 @@ class NativeInputModeWidget @JvmOverloads constructor(
     ) {
         pendingAdoptedImages = images
         pendingAdoptedFiles = files
-        attachmentView?.adoptAttachments(images, files)
+        attachmentViewModel?.adopt(images, files)
+    }
+
+    /**
+     * setPageContext / adoptEditAttachments can be called before this widget is attached, when the
+     * ViewModel cannot be resolved yet. Replay whatever was stashed once it can.
+     */
+    private fun applyPendingAttachmentState() {
+        val viewModel = attachmentViewModel ?: return
+        pendingPageContext?.let { viewModel.setPageContext(it) }
+        if (hasPendingAdoptedAttachments(pendingAdoptedImages, pendingAdoptedFiles)) {
+            viewModel.adopt(pendingAdoptedImages, pendingAdoptedFiles)
+        }
     }
 
     override fun isWidgetBottom(): Boolean = nativeInputState?.isBottom ?: false
@@ -2054,6 +2033,24 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun changeModelSubmitted(modelId: String) {
         onChangeModelSubmitted?.invoke(modelId)
     }
+
+    override fun requestCameraCapture(callback: ValueCallback<Array<Uri>>) {
+        cameraCaptureCallback?.invoke(callback)
+    }
+
+    override fun requestFilePicker(callback: ValueCallback<Array<Uri>>, mimeTypes: List<String>) {
+        filePickerCallback?.invoke(callback, mimeTypes)
+    }
+
+    override fun askAboutPage() {
+        askAboutPageAction?.invoke()
+    }
+
+    override fun pageContextRemoved() {
+        pageContextRemovedAction?.invoke()
+    }
+
+    override fun isEditSurface(): Boolean = isEditWidget
 
     override fun toolSelected(tool: String?) {
         viewModel.setSelectedTool(tool)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -43,8 +43,8 @@ import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @InjectWith(ViewScope::class)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
@@ -91,6 +92,7 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
     private var optionsButton: ImageView
     private var selectedToolJob: Job? = null
     private var nativeInputStateJob: Job? = null
+    private var visibleToolsJob: Job? = null
     private var lastNativeInputState: NativeInputState? = null
 
     init {
@@ -105,6 +107,7 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
         super.onAttachedToWindow()
         observeSelectedTool()
         observeNativeInputState()
+        observeVisibleTools()
     }
 
     override fun onDetachedFromWindow() {
@@ -113,6 +116,8 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
         selectedToolJob = null
         nativeInputStateJob?.cancel()
         nativeInputStateJob = null
+        visibleToolsJob?.cancel()
+        visibleToolsJob = null
         lastNativeInputState = null
         dismissPopup()
     }
@@ -123,6 +128,16 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
         selectedToolJob = viewModel.selectedTool
             .onEach { tool -> renderSelection(tool) }
             .launchIn(lifecycleOwner.lifecycleScope)
+    }
+
+    private fun observeVisibleTools() {
+        val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        visibleToolsJob?.cancel()
+        visibleToolsJob = scope.launch {
+            launch { viewModel.visibleTools.collect { tools -> refreshOptionsButtonVisibility(tools) } }
+            // The model stopped supporting the selected tool, so drop it. The host owns the write.
+            launch { viewModel.toolSelectionCleared.collect { host.toolSelected(null) } }
+        }
     }
 
     private fun observeNativeInputState() {
@@ -174,20 +189,6 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
                 host.showReasoningPicker(false)
             }
         }
-    }
-
-    fun updateCapabilitiesFrom(picker: ModelPicker?) {
-        val visibleTools = buildSet {
-            if (picker?.isImageGenerationSupported() ?: true) add(Tool.IMAGE_GENERATION)
-            if (picker?.isWebSearchSupported() ?: true) add(Tool.WEB_SEARCH)
-        }
-
-        if (isAttachedToWindow) {
-            val selectionCleared = viewModel.updateVisibleTools(visibleTools)
-            if (selectionCleared) host.toolSelected(null)
-        }
-
-        refreshOptionsButtonVisibility(visibleTools)
     }
 
     private fun buildOptionsButton(): ImageView {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -175,11 +175,6 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
         host.showReasoningPicker(show)
     }
 
-    fun clearSelection() {
-        if (!isAttachedToWindow) return
-        host.toolSelected(null)
-    }
-
     override fun onVisibilityChanged(changedView: View, visibility: Int) {
         super.onVisibilityChanged(changedView, visibility)
         if (!isAttachedToWindow) return

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModel.kt
@@ -27,11 +27,10 @@ import com.duckduckgo.duckchat.impl.nativeinput.EffectiveModelProvider
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModel.kt
@@ -21,10 +21,14 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
+import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.Tool
+import com.duckduckgo.duckchat.impl.nativeinput.EffectiveModelProvider
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -36,6 +40,8 @@ import javax.inject.Inject
 class OptionsViewModel @Inject constructor(
     nativeInputStateProvider: NativeInputStateProvider,
     private val duckChatPixels: DuckChatPixels,
+    modelManager: DuckAiModelManager,
+    effectiveModelProvider: EffectiveModelProvider,
 ) : ViewModel() {
 
     val selectedTool: StateFlow<Tool?> = nativeInputStateProvider.state
@@ -46,21 +52,28 @@ class OptionsViewModel @Inject constructor(
         .map { DuckChatPixelSurface.from(it.inputContext) }
         .stateIn(viewModelScope, SharingStarted.Eagerly, DuckChatPixelSurface.ADDRESS_BAR)
 
-    private val _visibleTools = MutableStateFlow(Tool.entries.toSet())
-    val visibleTools: StateFlow<Set<Tool>> = _visibleTools.asStateFlow()
+    /**
+     * Tools the effective model supports. An unknown model means every tool is offered, which is the
+     * behaviour the pre-plugin code fell back to when it could not resolve a model.
+     */
+    val visibleTools: StateFlow<Set<Tool>> = combine(
+        modelManager.modelState,
+        effectiveModelProvider.effectiveModelId,
+    ) { modelState, modelId ->
+        modelState.models.firstOrNull { it.id == modelId }
+            ?.let { model -> Tool.entries.filterTo(mutableSetOf()) { model.supportsTool(it) } }
+            ?: Tool.entries.toSet()
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, Tool.entries.toSet())
 
     val shouldShowPickers: Boolean get() = selectedTool.value != Tool.IMAGE_GENERATION
 
     /**
-     * Update the set of tools the menu should display. Returns true if the currently selected tool
-     * is no longer in the visible set (caller is responsible for pushing the cleared selection
-     * through [com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost.toolSelected]).
+     * Emits when the selected tool is no longer supported by the effective model. Deliberately not a
+     * pixel: the user did not deselect it, the model change did.
      */
-    fun updateVisibleTools(tools: Set<Tool>): Boolean {
-        _visibleTools.value = tools
-        val current = selectedTool.value
-        return current != null && current !in tools
-    }
+    val toolSelectionCleared: Flow<Unit> = combine(selectedTool, visibleTools) { selected, visible ->
+        selected != null && selected !in visible
+    }.filter { it }.map { }
 
     fun onToolSelectedByUser(tool: Tool) {
         when (tool) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProviderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProviderTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.nativeinput
+
+import com.duckduckgo.app.tabs.model.TabEntity
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.impl.models.AIChatModel
+import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
+import com.duckduckgo.duckchat.impl.models.ModelState
+import com.duckduckgo.duckchat.store.impl.DuckAiChat
+import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EffectiveModelProviderTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val selectedTabFlow = MutableStateFlow<TabEntity?>(null)
+    private val tabRepository: TabRepository = mock<TabRepository>().also {
+        whenever(it.flowSelectedTab).thenReturn(selectedTabFlow)
+    }
+    private val tabRepositoryProvider = object : BrowserModeDataProvider<TabRepository> {
+        override fun forMode(mode: BrowserMode): TabRepository = tabRepository
+    }
+    private val browserModeStateHolder: BrowserModeStateHolder = mock<BrowserModeStateHolder>().also {
+        whenever(it.currentMode).thenReturn(MutableStateFlow(BrowserMode.REGULAR))
+    }
+    private val store = RealNativeInputStateStore(
+        dagger.Lazy { tabRepositoryProvider },
+        browserModeStateHolder,
+    )
+    private val modelStateFlow = MutableStateFlow(
+        ModelState(
+            models = listOf(model("global-model"), model("chat-model"), model("recovery-model")),
+            selectedModelId = "global-model",
+            selectedModelShortName = "Global",
+        ),
+    )
+    private val modelManager: DuckAiModelManager = mock<DuckAiModelManager>().also {
+        whenever(it.modelState).thenReturn(modelStateFlow)
+    }
+    private val duckAiChatStore: DuckAiChatStore = mock()
+
+    private lateinit var testee: RealEffectiveModelProvider
+
+    @Before
+    fun setUp() {
+        testee = RealEffectiveModelProvider(modelManager, store, duckAiChatStore)
+    }
+
+    @Test
+    fun whenTabHasNoChatThenGlobalSelectionIsEffective() = runTest {
+        publish(NativeInputState.zero())
+
+        assertEquals("global-model", testee.effectiveModelId.first())
+    }
+
+    @Test
+    fun whenActiveChatHasModelThenChatModelIsEffective() = runTest {
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(chat("chat-1", "chat-model"))
+        publish(NativeInputState.zero().copy(chatId = "chat-1"))
+
+        assertEquals("chat-model", testee.effectiveModelId.first())
+    }
+
+    @Test
+    fun whenChatModelIsNotInTheModelListThenGlobalSelectionIsEffective() = runTest {
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(chat("chat-1", "model-we-lost-access-to"))
+        publish(NativeInputState.zero().copy(chatId = "chat-1"))
+
+        assertEquals("global-model", testee.effectiveModelId.first())
+    }
+
+    @Test
+    fun whenRecoveryModelPickedDuringModelChangeModeThenRecoveryModelIsEffective() = runTest {
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(chat("chat-1", "chat-model"))
+        publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = true))
+
+        testee.onRecoveryModelPicked(chatId = "chat-1", modelId = "recovery-model")
+        advanceUntilIdle()
+
+        assertEquals("recovery-model", testee.effectiveModelId.first())
+    }
+
+    @Test
+    fun whenModelChangeModeEndsThenRecoveryModelIsIgnored() = runTest {
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(chat("chat-1", "chat-model"))
+        publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = true))
+        testee.onRecoveryModelPicked(chatId = "chat-1", modelId = "recovery-model")
+        advanceUntilIdle()
+
+        publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = false))
+
+        assertEquals("chat-model", testee.effectiveModelId.first())
+    }
+
+    private fun TestScope.publish(state: NativeInputState) {
+        store.publish(TAB_ID, state)
+        selectedTabFlow.value = TabEntity(tabId = TAB_ID, position = 0)
+        advanceUntilIdle()
+    }
+
+    private fun model(id: String): AIChatModel = AIChatModel(
+        id = id,
+        name = id,
+        displayName = id,
+        shortName = id,
+        accessTier = emptyList(),
+        isAccessible = true,
+    )
+
+    private fun chat(chatId: String, model: String): DuckAiChat = DuckAiChat(
+        chatId = chatId,
+        title = "title",
+        model = model,
+        lastEdit = "2026-08-17T00:00:00.000Z",
+        pinned = false,
+    )
+
+    private companion object {
+        const val TAB_ID = "tab-A"
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProviderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProviderTest.kt
@@ -108,7 +108,7 @@ class EffectiveModelProviderTest {
         whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(chat("chat-1", "chat-model"))
         publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = true))
 
-        testee.onRecoveryModelPicked(chatId = "chat-1", modelId = "recovery-model")
+        testee.onRecoveryModelPicked("recovery-model")
         advanceUntilIdle()
 
         assertEquals("recovery-model", testee.effectiveModelId.first())
@@ -118,7 +118,7 @@ class EffectiveModelProviderTest {
     fun whenModelChangeModeEndsThenRecoveryModelIsIgnored() = runTest {
         whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(chat("chat-1", "chat-model"))
         publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = true))
-        testee.onRecoveryModelPicked(chatId = "chat-1", modelId = "recovery-model")
+        testee.onRecoveryModelPicked("recovery-model")
         advanceUntilIdle()
 
         publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = false))

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProviderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProviderTest.kt
@@ -108,7 +108,7 @@ class EffectiveModelProviderTest {
         whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(chat("chat-1", "chat-model"))
         publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = true))
 
-        testee.onRecoveryModelPicked("recovery-model")
+        testee.onRecoveryModelPicked(chatId = "chat-1", modelId = "recovery-model")
         advanceUntilIdle()
 
         assertEquals("recovery-model", testee.effectiveModelId.first())
@@ -118,7 +118,7 @@ class EffectiveModelProviderTest {
     fun whenModelChangeModeEndsThenRecoveryModelIsIgnored() = runTest {
         whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(chat("chat-1", "chat-model"))
         publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = true))
-        testee.onRecoveryModelPicked("recovery-model")
+        testee.onRecoveryModelPicked(chatId = "chat-1", modelId = "recovery-model")
         advanceUntilIdle()
 
         publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = false))
@@ -130,13 +130,43 @@ class EffectiveModelProviderTest {
     fun whenANewModelChangeWindowOpensThenThePreviousRecoveryPickIsNotReused() = runTest {
         whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(chat("chat-1", "chat-model"))
         publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = true))
-        testee.onRecoveryModelPicked("recovery-model")
+        testee.onRecoveryModelPicked(chatId = "chat-1", modelId = "recovery-model")
         advanceUntilIdle()
         publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = false))
-        testee.clearRecoveryModelPick()
+        testee.clearRecoveryModelPick(chatId = "chat-1")
         advanceUntilIdle()
 
         publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = true))
+
+        assertEquals("chat-model", testee.effectiveModelId.first())
+    }
+
+    @Test
+    fun whenAnotherTabWithoutAnOpenWindowIsSelectedThenThePickSurvives() = runTest {
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(chat("chat-1", "chat-model"))
+        whenever(duckAiChatStore.getChatById("chat-2")).thenReturn(chat("chat-2", "global-model"))
+        publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = true))
+        testee.onRecoveryModelPicked(chatId = "chat-1", modelId = "recovery-model")
+        advanceUntilIdle()
+
+        // The other tab's window is closed, so its clear must not touch chat-1's pick.
+        publish(NativeInputState.zero().copy(chatId = "chat-2", modelChangeMode = false))
+        testee.clearRecoveryModelPick(chatId = "chat-2")
+        advanceUntilIdle()
+        publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = true))
+
+        assertEquals("recovery-model", testee.effectiveModelId.first())
+    }
+
+    @Test
+    fun whenTheWindowBelongsToAnotherChatThenThePickIsNotApplied() = runTest {
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(chat("chat-1", "chat-model"))
+        whenever(duckAiChatStore.getChatById("chat-2")).thenReturn(chat("chat-2", "chat-model"))
+        publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = true))
+        testee.onRecoveryModelPicked(chatId = "chat-1", modelId = "recovery-model")
+        advanceUntilIdle()
+
+        publish(NativeInputState.zero().copy(chatId = "chat-2", modelChangeMode = true))
 
         assertEquals("chat-model", testee.effectiveModelId.first())
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProviderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/EffectiveModelProviderTest.kt
@@ -126,6 +126,21 @@ class EffectiveModelProviderTest {
         assertEquals("chat-model", testee.effectiveModelId.first())
     }
 
+    @Test
+    fun whenANewModelChangeWindowOpensThenThePreviousRecoveryPickIsNotReused() = runTest {
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(chat("chat-1", "chat-model"))
+        publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = true))
+        testee.onRecoveryModelPicked("recovery-model")
+        advanceUntilIdle()
+        publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = false))
+        testee.clearRecoveryModelPick()
+        advanceUntilIdle()
+
+        publish(NativeInputState.zero().copy(chatId = "chat-1", modelChangeMode = true))
+
+        assertEquals("chat-model", testee.effectiveModelId.first())
+    }
+
     private fun TestScope.publish(state: NativeInputState) {
         store.publish(TAB_ID, state)
         selectedTabFlow.value = TabEntity(tabId = TAB_ID, position = 0)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.ModelProvider
 import com.duckduckgo.duckchat.impl.models.ModelState
+import com.duckduckgo.duckchat.impl.nativeinput.RealEffectiveModelProvider
 import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.UserTier
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
@@ -79,6 +80,7 @@ class ModelPickerViewModelTest {
             duckChatPixels = duckChatPixels,
             nativeInputStateProvider = nativeInputStateProvider,
             duckAiChatStore = duckAiChatStore,
+            effectiveModelProvider = RealEffectiveModelProvider(modelManager, nativeInputStateProvider, duckAiChatStore),
         )
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -671,6 +671,25 @@ class ModelPickerViewModelTest {
     }
 
     @Test
+    fun whenANewRecoveryWindowOpensThenTheChipDoesNotShowThePreviousPick() = runTest {
+        stateFlow.value = ModelState(
+            models = listOf(freeModel(id = "new-model", shortName = "New Model")),
+            selectedModelShortName = "Global Model",
+        )
+        nativeInputState.value = nativeInputState.value.copy(chatId = null, modelChangeMode = true)
+        advanceUntilIdle()
+        testee.onModelTapped(freeModel(id = "new-model", shortName = "New Model"), PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+        advanceUntilIdle()
+        nativeInputState.value = nativeInputState.value.copy(modelChangeMode = false)
+        advanceUntilIdle()
+
+        nativeInputState.value = nativeInputState.value.copy(modelChangeMode = true)
+        advanceUntilIdle()
+
+        assertEquals("Global Model", testee.chipLabel.value)
+    }
+
+    @Test
     fun whenNoRecoveryPickThenHasPendingRecoverySelectionFalse() = runTest {
         nativeInputState.value = nativeInputState.value.copy(chatId = "c1", modelChangeMode = true)
         advanceUntilIdle()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -25,9 +25,9 @@ import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.ModelProvider
 import com.duckduckgo.duckchat.impl.models.ModelState
-import com.duckduckgo.duckchat.impl.nativeinput.RealEffectiveModelProvider
 import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.UserTier
+import com.duckduckgo.duckchat.impl.nativeinput.RealEffectiveModelProvider
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerViewModel
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.PickerModelChange
@@ -83,8 +83,6 @@ class ModelPickerViewModelTest {
             effectiveModelProvider = RealEffectiveModelProvider(modelManager, nativeInputStateProvider, duckAiChatStore),
         )
     }
-
-
 
     @Test
     fun whenFetchModelsThenDelegatesToModelManager() = runTest {
@@ -575,12 +573,6 @@ class ModelPickerViewModelTest {
         assertEquals(model.id, testee.effectiveModelId.value)
     }
 
-
-
-
-
-
-
     @Test
     fun whenOngoingChatThenEffectiveModelIsChatModelNotGlobal() = runTest {
         stateFlow.value = ModelState(
@@ -599,7 +591,6 @@ class ModelPickerViewModelTest {
 
         assertEquals("chat-model", testee.effectiveModelId.value)
     }
-
 
     @Test
     fun whenOngoingChatThenChipLabelIsChatModelShortName() = runTest {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -82,19 +82,7 @@ class ModelPickerViewModelTest {
         )
     }
 
-    @Test
-    fun whenGetSelectedModelIdThenDelegatesToModelManager() {
-        whenever(modelManager.getSelectedModelId()).thenReturn("id")
 
-        assertEquals("id", testee.getSelectedModelId())
-    }
-
-    @Test
-    fun whenGetSelectedModelIdAndNoneSelectedThenReturnsNull() {
-        whenever(modelManager.getSelectedModelId()).thenReturn(null)
-
-        assertNull(testee.getSelectedModelId())
-    }
 
     @Test
     fun whenFetchModelsThenDelegatesToModelManager() = runTest {
@@ -571,76 +559,28 @@ class ModelPickerViewModelTest {
     }
 
     @Test
-    fun whenNoModelSelectedThenGetSelectedModelReturnsNull() {
+    fun whenNoModelSelectedThenEffectiveModelIsNull() {
         stateFlow.value = ModelState(models = listOf(freeModel("id1", "model1")), selectedModelId = null)
 
-        assertNull(testee.getSelectedModel())
+        assertNull(testee.effectiveModelId.value)
     }
 
     @Test
-    fun whenModelSelectedThenGetSelectedModelReturnsIt() {
+    fun whenModelSelectedThenEffectiveModelIsIt() {
         val model = freeModel("id1", "model1")
         stateFlow.value = ModelState(models = listOf(model), selectedModelId = "id1")
 
-        assertEquals(model, testee.getSelectedModel())
+        assertEquals(model.id, testee.effectiveModelId.value)
     }
 
-    @Test
-    fun whenSelectedModelSupportsImageGenerationThenIsImageGenerationSupportedIsTrue() {
-        stateFlow.value = ModelState(
-            models = listOf(freeModel("id1", "model1", supportedTools = listOf(Tool.IMAGE_GENERATION))),
-            selectedModelId = "id1",
-        )
 
-        assertTrue(testee.isImageGenerationSupported())
-    }
+
+
+
+
 
     @Test
-    fun whenSelectedModelDoesNotSupportImageGenerationThenIsImageGenerationSupportedIsFalse() {
-        stateFlow.value = ModelState(
-            models = listOf(freeModel("id1", "model1", supportedTools = emptyList())),
-            selectedModelId = "id1",
-        )
-
-        assertFalse(testee.isImageGenerationSupported())
-    }
-
-    @Test
-    fun whenNoModelSelectedThenIsImageGenerationSupportedDefaultsToTrue() {
-        stateFlow.value = ModelState(models = emptyList(), selectedModelId = null)
-
-        assertTrue(testee.isImageGenerationSupported())
-    }
-
-    @Test
-    fun whenSelectedModelSupportsWebSearchThenIsWebSearchSupportedIsTrue() {
-        stateFlow.value = ModelState(
-            models = listOf(freeModel("id1", "model1", supportedTools = listOf(Tool.WEB_SEARCH))),
-            selectedModelId = "id1",
-        )
-
-        assertTrue(testee.isWebSearchSupported())
-    }
-
-    @Test
-    fun whenSelectedModelDoesNotSupportWebSearchThenIsWebSearchSupportedIsFalse() {
-        stateFlow.value = ModelState(
-            models = listOf(freeModel("id1", "model1", supportedTools = emptyList())),
-            selectedModelId = "id1",
-        )
-
-        assertFalse(testee.isWebSearchSupported())
-    }
-
-    @Test
-    fun whenNoModelSelectedThenIsWebSearchSupportedDefaultsToTrue() {
-        stateFlow.value = ModelState(models = emptyList(), selectedModelId = null)
-
-        assertTrue(testee.isWebSearchSupported())
-    }
-
-    @Test
-    fun whenOngoingChatThenCapabilitiesReflectChatModelNotGlobal() = runTest {
+    fun whenOngoingChatThenEffectiveModelIsChatModelNotGlobal() = runTest {
         stateFlow.value = ModelState(
             models = listOf(
                 freeModel(id = "global-model", shortName = "Global", supportedTools = emptyList()),
@@ -655,31 +595,9 @@ class ModelPickerViewModelTest {
         nativeInputState.value = nativeInputState.value.copy(chatId = "c1")
         advanceUntilIdle()
 
-        assertEquals("chat-model", testee.getSelectedModel()?.id)
-        assertTrue(testee.isImageGenerationSupported())
+        assertEquals("chat-model", testee.effectiveModelId.value)
     }
 
-    @Test
-    fun whenRecoveryModelPickedThenCapabilitiesReflectRecoveryModel() = runTest {
-        val recoveryModel = freeModel(id = "recovery-model", shortName = "Recovery", supportedTools = listOf(Tool.WEB_SEARCH))
-        stateFlow.value = ModelState(
-            models = listOf(
-                freeModel(id = "global-model", shortName = "Global", supportedTools = listOf(Tool.IMAGE_GENERATION)),
-                recoveryModel,
-            ),
-            selectedModelId = "global-model",
-            selectedModelShortName = "Global",
-        )
-        nativeInputState.value = nativeInputState.value.copy(chatId = "c1", modelChangeMode = true)
-        advanceUntilIdle()
-
-        testee.onModelTapped(recoveryModel, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
-        advanceUntilIdle()
-
-        assertEquals("recovery-model", testee.getSelectedModel()?.id)
-        assertTrue(testee.isWebSearchSupported())
-        assertFalse(testee.isImageGenerationSupported())
-    }
 
     @Test
     fun whenOngoingChatThenChipLabelIsChatModelShortName() = runTest {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
@@ -39,7 +39,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
@@ -77,7 +77,7 @@ class OptionsViewModelTest {
     private val effectiveModelId = MutableStateFlow<String?>(null)
     private val effectiveModelProvider = object : EffectiveModelProvider {
         override val effectiveModelId: Flow<String?> = this@OptionsViewModelTest.effectiveModelId
-        override fun onRecoveryModelPicked(chatId: String?, modelId: String) = Unit
+        override fun onRecoveryModelPicked(modelId: String) = Unit
     }
     private lateinit var testee: OptionsViewModel
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
@@ -23,11 +23,17 @@ import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.impl.models.AIChatModel
+import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
+import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.Tool
+import com.duckduckgo.duckchat.impl.nativeinput.EffectiveModelProvider
 import com.duckduckgo.duckchat.impl.nativeinput.RealNativeInputStateStore
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -64,11 +70,20 @@ class OptionsViewModelTest {
         browserModeStateHolder,
     )
     private val duckChatPixels: DuckChatPixels = mock()
+    private val modelStateFlow = MutableStateFlow(ModelState())
+    private val modelManager: DuckAiModelManager = mock<DuckAiModelManager>().also {
+        whenever(it.modelState).thenReturn(modelStateFlow)
+    }
+    private val effectiveModelId = MutableStateFlow<String?>(null)
+    private val effectiveModelProvider = object : EffectiveModelProvider {
+        override val effectiveModelId: Flow<String?> = this@OptionsViewModelTest.effectiveModelId
+        override fun onRecoveryModelPicked(chatId: String?, modelId: String) = Unit
+    }
     private lateinit var testee: OptionsViewModel
 
     @Before
     fun setUp() {
-        testee = OptionsViewModel(store, duckChatPixels)
+        testee = OptionsViewModel(store, duckChatPixels, modelManager, effectiveModelProvider)
     }
 
     @Test
@@ -145,20 +160,69 @@ class OptionsViewModelTest {
     }
 
     @Test
-    fun whenVisibleToolsAutoClearsSelectedToolThenNoPixel() = runTest {
+    fun whenSelectedToolStopsBeingSupportedThenSelectionClearedEmitsWithoutPixel() = runTest {
         val tabId = "tab-E"
         store.publish(tabId, NativeInputState.zero().copy(selectedTool = Tool.WEB_SEARCH.rawValue))
         selectedTabFlow.value = tabEntity(tabId)
+        givenModels(model("m1", supportedTools = listOf(Tool.WEB_SEARCH)))
+        effectiveModelId.value = "m1"
         advanceUntilIdle()
         assertEquals(Tool.WEB_SEARCH, testee.selectedTool.value)
 
-        // A model-capability change that removes the selected tool must auto-clear it
-        // (updateVisibleTools returns true) WITHOUT firing a deselect pixel.
-        val selectionCleared = testee.updateVisibleTools(emptySet())
+        givenModels(model("m1", supportedTools = listOf(Tool.IMAGE_GENERATION)))
+        advanceUntilIdle()
 
-        assertTrue(selectionCleared)
+        assertEquals(Unit, testee.toolSelectionCleared.first())
         verifyNoInteractions(duckChatPixels)
     }
+
+    @Test
+    fun whenEffectiveModelSupportsOneToolThenOnlyThatToolIsVisible() = runTest {
+        givenModels(model("m1", supportedTools = listOf(Tool.WEB_SEARCH)))
+        effectiveModelId.value = "m1"
+        advanceUntilIdle()
+
+        assertEquals(setOf(Tool.WEB_SEARCH), testee.visibleTools.value)
+    }
+
+    @Test
+    fun whenEffectiveModelIsUnknownThenAllToolsAreVisible() = runTest {
+        givenModels(model("m1", supportedTools = listOf(Tool.WEB_SEARCH)))
+        effectiveModelId.value = "not-in-the-list"
+        advanceUntilIdle()
+
+        assertEquals(Tool.entries.toSet(), testee.visibleTools.value)
+    }
+
+    @Test
+    fun whenEffectiveModelChangesThenVisibleToolsFollowIt() = runTest {
+        givenModels(
+            model("m1", supportedTools = listOf(Tool.WEB_SEARCH)),
+            model("m2", supportedTools = Tool.entries),
+        )
+        effectiveModelId.value = "m1"
+        advanceUntilIdle()
+        assertEquals(setOf(Tool.WEB_SEARCH), testee.visibleTools.value)
+
+        effectiveModelId.value = "m2"
+        advanceUntilIdle()
+
+        assertEquals(Tool.entries.toSet(), testee.visibleTools.value)
+    }
+
+    private fun givenModels(vararg models: AIChatModel) {
+        modelStateFlow.value = ModelState(models = models.toList(), selectedModelId = models.firstOrNull()?.id)
+    }
+
+    private fun model(id: String, supportedTools: List<Tool>): AIChatModel = AIChatModel(
+        id = id,
+        name = id,
+        displayName = id,
+        shortName = id,
+        accessTier = emptyList(),
+        isAccessible = true,
+        supportedTools = supportedTools,
+    )
 
     private fun tabEntity(tabId: String): TabEntity = TabEntity(tabId = tabId, position = 0)
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
@@ -77,6 +77,7 @@ class OptionsViewModelTest {
     private val effectiveModelProvider = object : EffectiveModelProvider {
         override val effectiveModelId: Flow<String?> = this@OptionsViewModelTest.effectiveModelId
         override fun onRecoveryModelPicked(modelId: String) = Unit
+        override fun clearRecoveryModelPick() = Unit
     }
     private lateinit var testee: OptionsViewModel
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
@@ -76,8 +76,8 @@ class OptionsViewModelTest {
     private val effectiveModelId = MutableStateFlow<String?>(null)
     private val effectiveModelProvider = object : EffectiveModelProvider {
         override val effectiveModelId: Flow<String?> = this@OptionsViewModelTest.effectiveModelId
-        override fun onRecoveryModelPicked(modelId: String) = Unit
-        override fun clearRecoveryModelPick() = Unit
+        override fun onRecoveryModelPicked(chatId: String?, modelId: String) = Unit
+        override fun clearRecoveryModelPick(chatId: String?) = Unit
     }
     private lateinit var testee: OptionsViewModel
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1157893581871903/task/1217549691747336
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/task/1217490861467320
API Proposals URL(s) (if applicable): None

### Description

`NativeInputModeWidget.wirePluginView()` handed dependencies and callbacks straight to concrete plugin views, which is what forced every control migration through the widget, and it is now gone: a shared `EffectiveModelProvider` resolves the effective model, options derives its own tool visibility, the picker's menu events moved onto `NativeInputHost`, and `AttachmentView` injects its own dependencies. The non-obvious part is that submission still needs the staged attachments, so the widget resolves `AttachmentViewModel` through its own `ViewModelStoreOwner` instead of holding the plugin's view, which avoided both an attachment store and a `duckchat-api` change. Because state and the resolved model arrive on separate flows, both options and the picker chip now ignore an answer resolved for a different chat, otherwise a tab switch could clear a tool the arriving chat supports or name the previous tab's model. This PR also touches `:app`, because testing surfaced a Duck.ai tab with no input field at all: the bottom host's offset was measured against a stale layout when the keyboard hid, and it now recomputes when the host itself is laid out (`cc6f3b5037`).

### Steps to test this PR

_Model and tools across tabs_
- [ ] Open a Duck.ai chat and select Web Search, then switch to a second Duck.ai tab and pick a model that does not support it
- [ ] Return to the first tab, confirm the tool list matches that tab's model, and confirm a tool that tab's model does support is not dropped
- [ ] Switch between two Duck.ai tabs on different models and confirm the chip always names the model of the tab you are on
- [ ] Start a model change in one tab and then in a second tab, switch between them, and confirm each keeps its own pick
- [ ] Dismiss the model picker without choosing a model and confirm the chip reverts

_Input position and presence_
- [ ] On a Duck.ai tab, open and close the keyboard, switch tabs, and confirm the input stays flush at the bottom and never disappears

_Attachments_
- [ ] Attach an image from the camera and from the file picker, exceed the attachment limit, remove one, then submit and confirm the prompt carries the attachments
- [ ] In the contextual sheet, confirm page context attaches, can be removed, and that "ask about page" works
- [ ] From the edit-message screen, confirm existing attachments are adopted

### UI changes

No UI changes. Controls render as before, and the `:app` fix restores the input's original resting position.
