### PR TITLE
Restore native input focus after attaching a file

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -38,6 +38,9 @@ interface NativeInputHost {
     fun showModelPicker(showing: Boolean)
     fun showReasoningPicker(showing: Boolean)
 
+    /** Return focus and the keyboard to the input field after a plugin handed control to another screen. */
+    fun restoreInputFocus()
+
     fun attachmentChanged(hasAttachments: Boolean, limitExceeded: Boolean, supportsUpload: Boolean)
 
     /**

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
@@ -409,11 +409,13 @@ class AttachmentView(
     private fun buildImagePickerCallback(source: AttachmentViewModel.ImageSource): ValueCallback<Array<Uri>> = ValueCallback { uris ->
         val list = uris?.toList()
         if (!list.isNullOrEmpty()) viewModel?.onImagesPicked(list, source)
+        host?.restoreInputFocus()
     }
 
     private fun buildFilePickerCallback(): ValueCallback<Array<Uri>> = ValueCallback { uris ->
         val list = uris?.toList()
         if (!list.isNullOrEmpty()) viewModel?.onFilesPicked(list)
+        host?.restoreInputFocus()
     }
 }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -2044,6 +2044,15 @@ class NativeInputModeWidget @JvmOverloads constructor(
         onAttachmentChooserStateChanged?.invoke(showing)
     }
 
+    override fun restoreInputFocus() {
+        // Picker results are delivered in onActivityResult, before the host activity resumes, and the IME
+        // ignores a show request until then. Posting runs this once that transaction completes.
+        post {
+            requestInputFocus()
+            showKeyboard()
+        }
+    }
+
     override fun attachmentChanged(
         hasAttachments: Boolean,
         limitExceeded: Boolean,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1157893581871903/task/1217314046325775
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

### Description

Attaching an image or a file to the native input left the input field unfocused, so the user had to tap it again before they could send the message.

The attachment menu hands control to the camera or the file picker and the result comes back through the `ValueCallback` built in `AttachmentView`. That callback added the attachment to state and stopped there, so nothing ever returned focus or the keyboard to the input field. Cancelling the picker left the same state.

This adds `restoreInputFocus()` to `NativeInputHost` and calls it from both picker callbacks, so it covers image attachments, camera capture, file attachments, and the cancelled-picker case. `NativeInputModeWidget` implements it by posting `requestInputFocus()` and `showKeyboard()`: picker results are delivered in `onActivityResult`, which runs before the host activity resumes, and the IME ignores a show request until then, so the post is what makes the keyboard actually come back.

Both attachment entry points route through `AttachmentView`, so the browser omnibar and the contextual sheet are both fixed by the same two call sites. Edit mode is unaffected, the attach button is hidden there.

No unit test: the existing tests around this widget cover pure functions extracted out of the views, and there is no branching logic here to extract. The behaviour worth testing is IME timing, which a JVM test cannot exercise.

### Steps to test this PR

_Attaching an image from the omnibar_
- [ ] Open the browser and tap the omnibar so the native input is focused and the keyboard is up
- [ ] Tap the attach button, choose `Attach photo`, and pick an image
- [ ] Check the thumbnail appears AND the input field is still focused with the keyboard up
- [ ] Type a prompt without tapping the field first and send it

_Camera capture_
- [ ] Repeat the above choosing `Take photo` instead, and confirm focus returns after the capture

_Cancelling the picker_
- [ ] Tap the attach button, open the picker, then press back without picking anything
- [ ] Check the input field is focused again with the keyboard up

_Contextual sheet_
- [ ] Open Duck.ai from a page so the contextual input is shown
- [ ] Attach an image and confirm focus and the keyboard return the same way

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes|No UI changes|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-focus change on the native input host after pickers; no auth, data, or attachment-handling logic changes. IME timing is the main behavioral risk and is not unit-tested.
> 
> **Overview**
> After attaching (or cancelling) a photo, camera capture, or file, the native chat input now gets focus and the keyboard back so users can type and send without tapping the field again.
> 
> Adds `restoreInputFocus()` on `NativeInputHost`. Image and file picker callbacks in `AttachmentView` always call it. `NativeInputModeWidget` posts `requestInputFocus()` plus `showKeyboard()` so the IME show runs after `onActivityResult` and the activity resume. Same path covers omnibar and contextual sheet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec342077c578c71b04cfcd6cab3e86106d3befa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->