### PR TITLE
fix: Preserve password settings when device auth enrollment cannot open

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementDisabledMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementDisabledMode.kt
@@ -101,8 +101,6 @@ class AutofillManagementDisabledMode : DuckDuckGoFragment() {
                 Intent(ACTION_FINGERPRINT_ENROLL).safeLaunchSettingsActivity(tryFallback = true)
             }
         }
-
-        requireActivity().finish()
     }
 
     /**

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementDisabledModeTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementDisabledModeTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.ui.credential.management.viewing
+
+import android.os.Bundle
+import android.provider.Settings.ACTION_BIOMETRIC_ENROLL
+import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.autofill.impl.R
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
+import dagger.android.AndroidInjector
+import dagger.android.HasAndroidInjector
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import com.duckduckgo.mobile.android.R as CommonR
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [30])
+class AutofillManagementDisabledModeTest {
+
+    private val appBuildConfig: AppBuildConfig = mock()
+    private val edgeToEdgeProvider: EdgeToEdgeProvider = mock()
+
+    @Test
+    fun whenSetUpInSettingsClickedThenBiometricEnrollmentIsLaunchedAndActivityRemainsOpen() {
+        whenever(appBuildConfig.manufacturer).thenReturn("Google")
+        whenever(appBuildConfig.sdkInt).thenReturn(30)
+        whenever(edgeToEdgeProvider.isEnabled(any())).thenReturn(false)
+        val activity = Robolectric.buildActivity(TestActivity::class.java).setup().get()
+        val fragment = AutofillManagementDisabledMode().apply {
+            appBuildConfig = this@AutofillManagementDisabledModeTest.appBuildConfig
+            edgeToEdgeProvider = this@AutofillManagementDisabledModeTest.edgeToEdgeProvider
+            edgeToEdgeHandler = EdgeToEdgeHandler()
+        }
+        activity.supportFragmentManager.beginTransaction()
+            .add(TestActivity.CONTAINER_ID, fragment)
+            .commitNow()
+
+        fragment.requireView().findViewById<android.view.View>(R.id.disabled_cta).performClick()
+
+        assertEquals(ACTION_BIOMETRIC_ENROLL, shadowOf(activity).nextStartedActivity.action)
+        assertFalse(activity.isFinishing)
+    }
+}
+
+class TestActivity : AppCompatActivity(), HasAndroidInjector {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setTheme(CommonR.style.Theme_DuckDuckGo_Light)
+        super.onCreate(savedInstanceState)
+        setContentView(FrameLayout(this).apply { id = CONTAINER_ID })
+    }
+
+    override fun androidInjector(): AndroidInjector<Any> = AndroidInjector { }
+
+    companion object {
+        const val CONTAINER_ID = 1
+    }
+}


### PR DESCRIPTION
Task/Issue URL: 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

Update the existing CTA handler in `AutofillManagementDisabledMode` so launching the enrollment intent no longer unconditionally finishes the host activity. Keeping the activity alive lets Android Settings appear normally on capable devices and leaves the disabled-state explanation available when enrollment is unavailable or returns immediately; the activity's existing lifecycle checks can refresh capability state when the user comes back. Add a Robolectric regression test around the production fragment and CTA that verifies the appropriate settings intent is launched while the host activity remains open, including the API 30 path matching the report.

On BlueStacks and other devices without usable biometric or device-credential enrollment, the Passwords/Autofill disabled-state CTA launches Android's biometric enrollment activity, which can return immediately without changing any settings. `AutofillManagementDisabledMode` then unconditionally finishes its host activity, leaving the user outside the screen with no progress and no useful recovery path. A maintainer confirmed this dismissal as an app-side bug while noting that supporting Sync or password storage without device authentication is a separate, harder security problem. This plan fixes only the confirmed navigation defect and keeps the existing authentication requirement intact.

Fixes #8365

### Steps to test this PR

- [ ]
- [ ]
- On API 30 with a non-special-cased manufacturer, tapping **Set up in Settings** launches `ACTION_BIOMETRIC_ENROLL` and does not finish the host activity. - When the launched enrollment activity returns immediately without enrolling authentication, the Passwords/Autofill disabled screen remains available instead of navigating the user away. - Existing manufacturer and older-API intent selection and fallback behavior remain unchanged; the regression test should assert only the affected API 30 navigation contract rather than duplicate every intent-routing branch.

### UI changes

| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small navigation fix in autofill UI with no changes to auth requirements, credential storage, or enrollment intent selection.
> 
> **Overview**
> Fixes a navigation bug on the Passwords/Autofill **disabled** screen when users tap **Set up in Settings** to open device authentication enrollment.
> 
> **`AutofillManagementDisabledMode`** no longer calls `requireActivity().finish()` after starting the enrollment/settings intent. The host activity stays open so users can return to the disabled-state explanation when enrollment is unavailable or returns immediately (e.g. BlueStacks), instead of being dismissed with no recovery path. Manufacturer-specific intent routing and settings fallbacks are unchanged.
> 
> Adds a Robolectric regression test on API 30 that verifies `ACTION_BIOMETRIC_ENROLL` is started and the host activity is not finishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f62a58f88a4e3f0502485978547b4f07567622e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->