### PR TITLE
Implement HostnameResolver for the Suggest redirect feature

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnAppModule.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnAppModule.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.mobile.android.vpn.di
 
 import android.content.Context
 import android.content.res.Resources
-import android.net.ConnectivityManager
 import androidx.room.Room
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -40,13 +39,6 @@ import javax.inject.Qualifier
 @Module
 @ContributesTo(AppScope::class)
 object VpnAppModule {
-
-    @SingleInstanceIn(AppScope::class)
-    @Provides
-    fun providesConnectivityManager(context: Context): ConnectivityManager {
-        return context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-    }
-
     @Provides
     fun provideVpnDatabaseCallbackProvider(
         context: Context,

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -367,7 +367,7 @@ class BrowserModule {
     ): HostnameResolver {
         val lookupTimeout = HostnameResolver.LOOKUP_TIMEOUT_MS.milliseconds
         val dnsLookup = if (appBuildConfig.sdkInt >= 29) {
-            @Suppress("NewApi")
+            @Suppress("NewApi") // we use appBuildConfig
             DnsLookupApi29Impl(dispatcherProvider, DnsResolver.getInstance())
         } else {
             DnsLookupPreApi29Impl(dispatcherProvider)

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -19,6 +19,8 @@ package com.duckduckgo.app.browser.di
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.net.DnsResolver
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
@@ -49,6 +51,10 @@ import com.duckduckgo.app.browser.menu.BrowserMenuHighlightPlugin
 import com.duckduckgo.app.browser.menu.TopInContextSection
 import com.duckduckgo.app.browser.pageloadpixel.PageLoadedPixelDao
 import com.duckduckgo.app.browser.pageloadpixel.firstpaint.PagePaintedPixelDao
+import com.duckduckgo.app.browser.suggestredirect.DnsLookupApi29Impl
+import com.duckduckgo.app.browser.suggestredirect.DnsLookupPreApi29Impl
+import com.duckduckgo.app.browser.suggestredirect.HostnameResolver
+import com.duckduckgo.app.browser.suggestredirect.HostnameResolverImpl
 import com.duckduckgo.app.browser.tabpreview.FileBasedWebViewPreviewGenerator
 import com.duckduckgo.app.browser.tabpreview.FileBasedWebViewPreviewPersister
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewGenerator
@@ -74,6 +80,7 @@ import com.duckduckgo.app.surrogates.ResourceSurrogates
 import com.duckduckgo.app.tabs.ui.GridViewColumnCalculator
 import com.duckduckgo.app.trackerdetection.CloakedCnameDetector
 import com.duckduckgo.app.trackerdetection.db.WebTrackersBlockedDao
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
@@ -103,6 +110,7 @@ import dagger.multibindings.IntoSet
 import kotlinx.coroutines.CoroutineScope
 import javax.inject.Named
 import javax.inject.Qualifier
+import kotlin.time.Duration.Companion.milliseconds
 
 @Module
 @ContributesTo(AppScope::class)
@@ -348,6 +356,23 @@ class BrowserModule {
     @Provides
     fun provideSiteErrorCodeHandler(): HttpCodeSiteErrorHandler {
         return HttpCodeSiteErrorHandlerImpl()
+    }
+
+    @SingleInstanceIn(AppScope::class)
+    @Provides
+    fun provideHostnameResolver(
+        appBuildConfig: AppBuildConfig,
+        connectivityManager: ConnectivityManager,
+        dispatcherProvider: DispatcherProvider,
+    ): HostnameResolver {
+        val lookupTimeout = HostnameResolver.LOOKUP_TIMEOUT_MS.milliseconds
+        val dnsLookup = if (appBuildConfig.sdkInt >= 29) {
+            @Suppress("NewApi")
+            DnsLookupApi29Impl(dispatcherProvider, DnsResolver.getInstance())
+        } else {
+            DnsLookupPreApi29Impl(dispatcherProvider)
+        }
+        return HostnameResolverImpl(lookupTimeout, connectivityManager, dispatcherProvider, dnsLookup)
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/suggestredirect/DnsLookup.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/suggestredirect/DnsLookup.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.suggestredirect
+
+import android.net.DnsResolver
+import android.net.DnsResolver.Callback
+import android.net.DnsResolver.DnsException
+import android.net.Network
+import android.os.CancellationSignal
+import androidx.annotation.RequiresApi
+import com.duckduckgo.app.browser.suggestredirect.DnsLookup.LookupResult
+import com.duckduckgo.common.utils.DispatcherProvider
+import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import java.net.InetAddress
+import java.net.UnknownHostException
+import kotlin.coroutines.resume
+
+interface DnsLookup {
+    /**
+     * @return a [LookupResult.Success] containing the resolved IP addresses for [hostname]
+     * when the lookup succeeds, or [LookupResult.Failure] with its cause when it fails.
+     */
+    suspend fun lookup(network: Network, hostname: String): LookupResult
+
+    sealed class LookupResult {
+        data class Success(val addresses: List<InetAddress>) : LookupResult()
+        data class Failure(val cause: Throwable) : LookupResult()
+    }
+}
+
+@RequiresApi(29)
+class DnsLookupApi29Impl(
+    private val dispatcherProvider: DispatcherProvider,
+    private val dnsResolver: DnsResolver,
+) : DnsLookup {
+    override suspend fun lookup(network: Network, hostname: String): LookupResult = suspendCancellableCoroutine { continuation ->
+        val cancellationSignal = CancellationSignal()
+        continuation.invokeOnCancellation { cancellationSignal.cancel() }
+        val dnsResolverCallback = object : Callback<List<InetAddress>> {
+            override fun onAnswer(answer: List<InetAddress>, rcode: Int) {
+                if (!continuation.isActive) {
+                    return
+                }
+                continuation.resume(
+                    if (rcode == 0) {
+                        LookupResult.Success(answer)
+                    } else {
+                        LookupResult.Failure(RuntimeException("RCode was $rcode"))
+                    },
+                )
+            }
+
+            override fun onError(error: DnsException) {
+                if (!continuation.isActive) {
+                    return
+                }
+                continuation.resume(LookupResult.Failure(error))
+            }
+        }
+        dnsResolver.query(
+            network,
+            hostname,
+            DnsResolver.FLAG_NO_RETRY,
+            dispatcherProvider.io().asExecutor(),
+            cancellationSignal,
+            dnsResolverCallback,
+        )
+    }
+}
+
+class DnsLookupPreApi29Impl(private val dispatcherProvider: DispatcherProvider) : DnsLookup {
+    override suspend fun lookup(network: Network, hostname: String): LookupResult {
+        return try {
+            val addresses = withContext(dispatcherProvider.io()) {
+                runInterruptible { network.getAllByName(hostname) }
+            }
+            LookupResult.Success(addresses.toList())
+        } catch (throwable: UnknownHostException) {
+            LookupResult.Failure(throwable)
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/suggestredirect/HostnameResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/suggestredirect/HostnameResolver.kt
@@ -17,10 +17,10 @@
 package com.duckduckgo.app.browser.suggestredirect
 
 import android.net.ConnectivityManager
+import androidx.core.util.PatternsCompat
 import com.duckduckgo.app.browser.suggestredirect.DnsLookup.LookupResult.Failure
 import com.duckduckgo.app.browser.suggestredirect.DnsLookup.LookupResult.Success
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.wireguard.config.InetAddresses
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.time.Duration
@@ -47,8 +47,12 @@ class HostnameResolverImpl(
     private val dnsLookup: DnsLookup,
 ) : HostnameResolver {
     override suspend fun resolves(hostname: String): Boolean {
-        // isHostname() accepts all-numeric labels, so IPv4 literals must be rejected separately.
-        if (!InetAddresses.isHostname(hostname) || IPV4_LITERAL.matches(hostname)) {
+        if (PatternsCompat.IP_ADDRESS.toRegex().matches(hostname)) {
+            // An IP address is already resolved, so it's not resolvable
+            return false
+        }
+
+        if (!PatternsCompat.DOMAIN_NAME.toRegex().matches(hostname)) {
             return false
         }
 
@@ -64,9 +68,5 @@ class HostnameResolverImpl(
             is Success -> result.addresses.isNotEmpty()
             is Failure -> false
         }
-    }
-
-    private companion object {
-        val IPV4_LITERAL = Regex("""\d{1,3}(\.\d{1,3}){3}""")
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/suggestredirect/HostnameResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/suggestredirect/HostnameResolver.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.suggestredirect
+
+import android.net.ConnectivityManager
+import com.duckduckgo.app.browser.suggestredirect.DnsLookup.LookupResult.Failure
+import com.duckduckgo.app.browser.suggestredirect.DnsLookup.LookupResult.Success
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.wireguard.config.InetAddresses
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration
+
+interface HostnameResolver {
+    /**
+     * @return
+     * - `true` when [hostname] resolves to at least one IP address on the active
+     * network within the lookup timeout.
+     * - `false` on failure, timeout, no connectivity or syntactically invalid
+     * hostnames (including IPv4/IPv6 literals).
+     */
+    suspend fun resolves(hostname: String): Boolean
+
+    companion object {
+        const val LOOKUP_TIMEOUT_MS = 2_000L
+    }
+}
+
+class HostnameResolverImpl(
+    private val lookupTimeout: Duration,
+    private val connectivityManager: ConnectivityManager,
+    private val dispatcherProvider: DispatcherProvider,
+    private val dnsLookup: DnsLookup,
+) : HostnameResolver {
+    override suspend fun resolves(hostname: String): Boolean {
+        // isHostname() accepts all-numeric labels, so IPv4 literals must be rejected separately.
+        if (!InetAddresses.isHostname(hostname) || IPV4_LITERAL.matches(hostname)) {
+            return false
+        }
+
+        val network = withContext(dispatcherProvider.io()) {
+            connectivityManager.activeNetwork
+        } ?: return false
+
+        val result = withTimeoutOrNull(lookupTimeout) {
+            dnsLookup.lookup(network, hostname)
+        } ?: return false
+
+        return when (result) {
+            is Success -> result.addresses.isNotEmpty()
+            is Failure -> false
+        }
+    }
+
+    private companion object {
+        val IPV4_LITERAL = Regex("""\d{1,3}(\.\d{1,3}){3}""")
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/di/SystemComponentsModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/SystemComponentsModule.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.di
 import android.content.Context
 import android.content.pm.PackageManager
 import android.location.LocationManager
+import android.net.ConnectivityManager
 import com.duckduckgo.app.fire.FireAnimationLoader
 import com.duckduckgo.app.fire.LottieFireAnimationLoader
 import com.duckduckgo.app.global.shortcut.AppShortcutCreator
@@ -52,6 +53,11 @@ object SystemComponentsModule {
     @SingleInstanceIn(AppScope::class)
     @Provides
     fun locationManager(context: Context): LocationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+
+    @SingleInstanceIn(AppScope::class)
+    @Provides
+    fun connectivityManager(context: Context): ConnectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
     @SingleInstanceIn(AppScope::class)
     @Provides

--- a/app/src/test/java/com/duckduckgo/app/browser/suggestredirect/DnsLookupApi29ImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/suggestredirect/DnsLookupApi29ImplTest.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.suggestredirect
+
+import android.net.DnsResolver
+import android.net.DnsResolver.DnsException
+import android.net.Network
+import android.os.CancellationSignal
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.browser.suggestredirect.DnsLookup.LookupResult
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.annotation.Config
+import java.net.InetAddress
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+/**
+ * Robolectric is required in this test to provide a functioning [android.os.CancellationSignal]
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class DnsLookupApi29ImplTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val network: Network = mock()
+    private val dnsResolver: DnsResolver = mock()
+    private val hostname: String = "example.com"
+
+    private val testee: DnsLookup = DnsLookupApi29Impl(
+        coroutineRule.testDispatcherProvider,
+        dnsResolver,
+    )
+
+    @Test
+    fun `when lookup is answered with a zero RCode, then returns success`() = runTest {
+        val resolvedAddresses = listOf(mock<InetAddress>())
+        stubLookupCall(network, hostname) { callback ->
+            callback.onAnswer(resolvedAddresses, RCODE_NOERROR)
+        }
+
+        val result = testee.lookup(network, hostname)
+
+        assertIs<LookupResult.Success>(result)
+        assertEquals(resolvedAddresses, result.addresses)
+    }
+
+    @Test
+    fun `when lookup is answered with a non-zero RCode, then returns failure`() = runTest {
+        stubLookupCall(network, hostname) { callback ->
+            callback.onAnswer(emptyList(), RCODE_NXDOMAIN)
+        }
+
+        val result = testee.lookup(network, hostname)
+
+        assertIs<LookupResult.Failure>(result)
+    }
+
+    @Test
+    fun `when lookup fails with DnsException, then returns failure`() = runTest {
+        val error = DnsException(1, null)
+        stubLookupCall(network, hostname) { callback ->
+            callback.onError(error)
+        }
+        val result = testee.lookup(network, hostname)
+
+        assertIs<LookupResult.Failure>(result)
+        assertEquals(error, result.cause)
+    }
+
+    @Test
+    fun `when error arrives after answer, then it is ignored`() = runTest {
+        val resolvedAddresses = listOf(mock<InetAddress>())
+        stubLookupCall(network, hostname) { callback ->
+            callback.onAnswer(resolvedAddresses, RCODE_NOERROR)
+            callback.onError(DnsException(1, null))
+        }
+
+        val result = testee.lookup(network, hostname)
+
+        assertIs<LookupResult.Success>(result)
+        assertEquals(resolvedAddresses, result.addresses)
+    }
+
+    @Test
+    fun `when answer arrives after error, then it is ignored`() = runTest {
+        val error = DnsException(1, null)
+        stubLookupCall(network, hostname) { callback ->
+            callback.onError(error)
+            callback.onAnswer(listOf(mock<InetAddress>()), RCODE_NOERROR)
+        }
+
+        val result = testee.lookup(network, hostname)
+
+        assertIs<LookupResult.Failure>(result)
+        assertEquals(error, result.cause)
+    }
+
+    @Test
+    fun `when canceled, then the underlying query is canceled`() = runTest {
+        val job = launch { testee.lookup(network, hostname) }
+        yield()
+
+        val cancellationSignalCaptor = argumentCaptor<CancellationSignal>()
+        verify(dnsResolver).query(
+            eq(network),
+            eq(hostname),
+            any(),
+            any(),
+            cancellationSignalCaptor.capture(),
+            any(),
+        )
+        assertFalse(cancellationSignalCaptor.firstValue.isCanceled)
+        job.cancelAndJoin()
+        assertTrue(cancellationSignalCaptor.firstValue.isCanceled)
+    }
+
+    private fun stubLookupCall(
+        network: Network,
+        @Suppress("SameParameterValue") hostname: String,
+        block: (DnsResolver.Callback<List<InetAddress>>) -> Unit,
+    ) {
+        whenever(
+            dnsResolver.query(
+                eq(network),
+                eq(hostname),
+                any(),
+                any(),
+                any(),
+                any(),
+            ),
+        )
+            .thenAnswer { invocation ->
+                val callback = invocation.getArgument<DnsResolver.Callback<List<InetAddress>>>(5)
+                block.invoke(callback)
+            }
+    }
+
+    @OptIn(ExperimentalContracts::class)
+    private inline fun <reified T> assertIs(value: Any?) {
+        contract {
+            returns() implies (value is T)
+        }
+        assertTrue("Expected ${T::class.simpleName} but was ${value?.let { it::class.simpleName }}", value is T)
+    }
+
+    companion object {
+        private const val RCODE_NOERROR = 0 // Success
+        private const val RCODE_NXDOMAIN = 3 // Non-existent domain
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/suggestredirect/DnsLookupPreApi29ImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/suggestredirect/DnsLookupPreApi29ImplTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.suggestredirect
+
+import android.net.Network
+import com.duckduckgo.app.browser.suggestredirect.DnsLookup.LookupResult
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.net.InetAddress
+import java.net.UnknownHostException
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+class DnsLookupPreApi29ImplTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val network: Network = mock()
+    private val hostname: String = "example.com"
+
+    private val testee: DnsLookup = DnsLookupPreApi29Impl(coroutineRule.testDispatcherProvider)
+
+    @Test
+    fun `when lookup succeeds, then returns success`() = runTest {
+        val resolvedAddresses = arrayOf(mock<InetAddress>())
+        whenever(network.getAllByName(hostname))
+            .thenReturn(resolvedAddresses)
+
+        val result = testee.lookup(network, hostname)
+
+        assertIs<LookupResult.Success>(result)
+        assertEquals(resolvedAddresses.toList(), result.addresses)
+    }
+
+    @Test
+    fun `when lookup fails, then returns failure`() = runTest {
+        whenever(network.getAllByName(hostname))
+            .thenThrow(UnknownHostException())
+
+        val result = testee.lookup(network, hostname)
+
+        assertIs<LookupResult.Failure>(result)
+        assertIs<UnknownHostException>(result.cause)
+    }
+
+    @OptIn(ExperimentalContracts::class)
+    private inline fun <reified T> assertIs(value: Any?) {
+        contract {
+            returns() implies (value is T)
+        }
+        assertTrue("Expected ${T::class.simpleName} but was ${value?.let { it::class.simpleName }}", value is T)
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/suggestredirect/HostnameResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/suggestredirect/HostnameResolverTest.kt
@@ -56,7 +56,6 @@ class HostnameResolverTest {
             "exa mple.com",
             "-example.com",
             "example-.com",
-            "under_score.com",
             "example..com",
         ).forEach { invalidHostname ->
             assertFalse("Expected resolves(\"$invalidHostname\") to be false", testee.resolves(invalidHostname))

--- a/app/src/test/java/com/duckduckgo/app/browser/suggestredirect/HostnameResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/suggestredirect/HostnameResolverTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.suggestredirect
+
+import android.net.ConnectivityManager
+import android.net.Network
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import java.net.InetAddress
+import kotlin.time.Duration.Companion.seconds
+
+class HostnameResolverTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val connectivityManager: ConnectivityManager = mock()
+    private val dnsLookup: DnsLookup = mock()
+    private val network: Network = mock()
+    private val hostname: String = "example.com"
+
+    private val testee: HostnameResolver = HostnameResolverImpl(
+        2.seconds,
+        connectivityManager,
+        coroutineRule.testDispatcherProvider,
+        dnsLookup,
+    )
+
+    @Test
+    fun `when hostname is syntactically invalid, then returns false and performs no lookups`() = runTest {
+        listOf(
+            "",
+            "exa mple.com",
+            "-example.com",
+            "example-.com",
+            "under_score.com",
+            "example..com",
+        ).forEach { invalidHostname ->
+            assertFalse("Expected resolves(\"$invalidHostname\") to be false", testee.resolves(invalidHostname))
+        }
+        verifyNoInteractions(connectivityManager, dnsLookup)
+    }
+
+    @Test
+    fun `when hostname is an IPv4 literal, then returns false and performs no lookups`() = runTest {
+        listOf(
+            "192.168.0.1",
+            "8.8.8.8",
+            "255.255.255.255",
+        ).forEach { ipv4Literal ->
+            assertFalse("Expected resolves(\"$ipv4Literal\") to be false", testee.resolves(ipv4Literal))
+        }
+        verifyNoInteractions(connectivityManager, dnsLookup)
+    }
+
+    @Test
+    fun `when hostname is an IPv6 literal, then returns false and performs no lookups`() = runTest {
+        listOf(
+            "::1",
+            "2001:db8::1",
+            "fe80::1%eth0",
+            "[2001:db8::1]",
+        ).forEach { ipv6Literal ->
+            assertFalse("Expected resolves(\"$ipv6Literal\") to be false", testee.resolves(ipv6Literal))
+        }
+        verifyNoInteractions(connectivityManager, dnsLookup)
+    }
+
+    @Test
+    fun `when active network is null, then returns false and performs no lookups`() = runTest {
+        whenever(connectivityManager.activeNetwork).thenReturn(null)
+
+        assertFalse(testee.resolves(hostname))
+        verifyNoInteractions(dnsLookup)
+    }
+
+    @Test
+    fun `when lookup is answered with at least one address, then returns true`() = runTest {
+        whenever(connectivityManager.activeNetwork).thenReturn(network)
+        whenever(dnsLookup.lookup(eq(network), eq(hostname)))
+            .thenReturn(DnsLookup.LookupResult.Success(listOf(mock<InetAddress>())))
+
+        assertTrue(testee.resolves(hostname))
+    }
+
+    @Test
+    fun `when lookup is answered with no addresses, then returns false`() = runTest {
+        whenever(connectivityManager.activeNetwork).thenReturn(network)
+        whenever(dnsLookup.lookup(eq(network), eq(hostname)))
+            .thenReturn(DnsLookup.LookupResult.Success(emptyList()))
+
+        assertFalse(testee.resolves(hostname))
+    }
+
+    @Test
+    fun `when lookup fails, then returns false`() = runTest {
+        whenever(connectivityManager.activeNetwork).thenReturn(network)
+        whenever(dnsLookup.lookup(eq(network), eq(hostname)))
+            .thenReturn(DnsLookup.LookupResult.Failure(RuntimeException("Lookup failed!")))
+
+        assertFalse(testee.resolves(hostname))
+    }
+
+    @Test
+    fun `when no response arrives within the lookup timeout, then returns false`() = runTest {
+        whenever(connectivityManager.activeNetwork).thenReturn(network)
+        whenever(dnsLookup.lookup(eq(network), eq(hostname)))
+            .doSuspendableAnswer {
+                delay(3.seconds) // Wait longer than lookupTimeout (2 seconds)
+                DnsLookup.LookupResult.Success(listOf(mock()))
+            }
+
+        assertFalse(testee.resolves(hostname))
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216807998862658/task/1217615568331049?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1216807998862658/task/1217494645371352?focus=true

### Description
This PR adds the `HostnameResolver` implementation for the Suggest redirect feature, together with unit tests for it and integration tests for the two `DnsLookup` implementations (one for API 29+ and one for API 28), which are dependencies of the main component.

The `HostnameResolver` component is wired up to DI but is not yet used in the app. The third PR, which culminates this feature's implementation will make use of it.

### UI changes
N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces DNS lookups against the active network and relocates the app-scoped ConnectivityManager binding. The resolver is unused in product code, so runtime impact is limited until a follow-up.
> 
> **Overview**
> Adds a `HostnameResolver` that reports whether a hostname resolves on the active network within 2s, for the upcoming Suggest redirect feature. It is wired in DI but not used yet.
> 
> Lookups skip IP literals and invalid domains. API 29+ uses `DnsResolver` with cancellation; older APIs use `Network.getAllByName`. `ConnectivityManager` is now provided from `SystemComponentsModule` instead of the VPN module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5543f1ada581d6d18be737086b3ff30afbf628d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->