### PR TITLE
Pin GpcTest interactions to the tab's WebView

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/GpcTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/GpcTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.espresso.privacy
 
+import android.view.View
 import android.webkit.WebView
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.IdlingResource
@@ -38,6 +39,7 @@ import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.sameInstance
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -66,19 +68,25 @@ class GpcTest {
             webView = it.findViewById(R.id.browserWebView)
         }
 
-        WebViewIdlingResource(webView!!).track()
+        val testWebView = webView!!
+
+        // The top frame header test calls window.open, so a second tab (and WebView) exists while the
+        // test runs; match this tab's WebView explicitly instead of relying on there being only one.
+        val testWebViewMatcher = sameInstance<View>(testWebView)
+
+        WebViewIdlingResource(testWebView).track()
 
         // asserts we have injected css by querying the duckduckgo object
-        JsObjectIdlingResource(webView!!, "window.navigator.duckduckgo").track()
+        JsObjectIdlingResource(testWebView, "window.navigator.duckduckgo").track()
 
-        onWebView()
+        onWebView(testWebViewMatcher)
             .withElement(findElement(ID, "start"))
             .check(webMatches(getText(), containsString("Start test")))
             .perform(webClick())
 
-        WebViewIdlingResource(webView!!).track()
+        WebViewIdlingResource(testWebView).track()
 
-        val results = onWebView()
+        val results = onWebView(testWebViewMatcher)
             .perform(script(SCRIPT))
             .get()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217673990175146
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

### Description

`GpcTest.whenProtectionsAreEnableGpcSetCorrectly` fails with `AmbiguousViewMatcherException`: the matcher `an instance of android.webkit.WebView and webView.getSettings().getJavaScriptEnabled() is <true>` matched two `DuckDuckGoWebView`s, both with `res-name=browserWebView` and both visible. See the failure in [this run](https://github.com/duckduckgo/Android/actions/runs/32133443253).

Same root cause as #9534. The `top frame header` case on `privacy-test-pages.site/privacy-protections/gpc/` calls `window.open(...)`, and `BrowserChromeClient.onCreateWindow` forces `isGesture = true` under instrumentation, so the popup always becomes a real tab. Its fragment sits in the tab pager alongside the original one, and Espresso's default web matcher selects purely on type and id, so whenever it resolved inside that window the test failed.

Both interactions now match the `WebView` instance the test already captured, which is the one holding the page's `results` object, and the idling resources are built from that same instance. How many tabs exist at that moment no longer matters.

`HttpsUpgradesTest` needed no change, #9534 already covers it.

### Steps to test this PR

_GpcTest passes_
- [x] Check the Privacy Tests workflow on this PR is green (it runs the `@PrivacyTest` suite, including this test)
- [x] Optionally, run it locally against an API 34 emulator, since Espresso 3.6.1 cannot inject events on API 36+: `./gradlew :app:connectedPlayDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.duckduckgo.espresso.privacy.GpcTest`
- [x] While the test runs, note the second tab that appears when the test page opens its popup, and that the assertions still read the original tab

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Instrumentation-test-only change; no production, auth, or data-handling code is modified.
> 
> **Overview**
> Fixes flaky `GpcTest.whenProtectionsAreEnableGpcSetCorrectly` when the GPC test page’s `window.open` creates a second tab.
> 
> Espresso now matches the captured original `WebView` via `sameInstance` instead of the default type/id matcher, and idling resources use that same instance so extra tabs no longer cause `AmbiguousViewMatcherException`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dd3c2b6775c098886a0412606cfe126f105a49e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->