### PR TITLE
Add duck.ai entry point pixel

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -439,6 +439,52 @@
             }
         ]
     },
+    "m_aichat_entry_point": {
+        "description": "Fires when an active user action enters Duck.ai, with the initiating surface and navigation context.",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The surface that initiated the Duck.ai entry.",
+                "enum": [
+                    "address_bar_prompt",
+                    "address_bar_icon",
+                    "address_bar_shortcut_chip",
+                    "address_bar_editing_state",
+                    "suggestion_ask_ai",
+                    "browsing_menu_ntp",
+                    "browsing_menu_webpage",
+                    "tab_switcher",
+                    "chat_history_new_chat",
+                    "chat_history_open_chat",
+                    "voice",
+                    "onboarding",
+                    "direct_url",
+                    "serp",
+                    "icon_shortcut",
+                    "contextual_chat",
+                    "widget_quick_actions",
+                    "widget_favorite",
+                    "system_search",
+                    "digital_assistant",
+                    "deep_link_other",
+                    "paid_settings"
+                ]
+            },
+            { "key": "duck_ai_enabled", "type": "boolean", "description": "Whether Duck.ai is enabled by feature and user settings." },
+            {
+                "key": "input_screen_enabled",
+                "type": "boolean",
+                "description": "Whether the Search and Duck.ai input capability is enabled."
+            },
+            { "key": "opens_new_tab", "type": "boolean", "description": "Whether this entry opens a new browser tab." },
+            { "key": "has_prompt", "type": "boolean", "description": "Whether a non-blank prompt is automatically submitted on entry." }
+        ]
+    },
     "m_aichat_duck_ai_direct_navigation_count": {
         "description": "User navigated directly to the Duck.ai URL by typing it in the omnibar",
         "owners": ["malmstein"],
@@ -451,6 +497,11 @@
                 "type": "string",
                 "description": "Whether the Duck.ai global setting is enabled",
                 "enum": ["true", "false"]
+            },
+            {
+                "key": "input_screen_enabled",
+                "type": "boolean",
+                "description": "Whether the Search and Duck.ai input capability is enabled."
             }
         ]
     },
@@ -466,6 +517,11 @@
                 "type": "string",
                 "description": "Whether the Duck.ai global setting is enabled",
                 "enum": ["true", "false"]
+            },
+            {
+                "key": "input_screen_enabled",
+                "type": "boolean",
+                "description": "Whether the Search and Duck.ai input capability is enabled."
             }
         ]
     },

--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -494,9 +494,8 @@
             "appVersion",
             {
                 "key": "duck_ai_enabled",
-                "type": "string",
-                "description": "Whether the Duck.ai global setting is enabled",
-                "enum": ["true", "false"]
+                "type": "boolean",
+                "description": "Whether the Duck.ai global setting is enabled"
             },
             {
                 "key": "input_screen_enabled",
@@ -514,9 +513,8 @@
             "appVersion",
             {
                 "key": "duck_ai_enabled",
-                "type": "string",
-                "description": "Whether the Duck.ai global setting is enabled",
-                "enum": ["true", "false"]
+                "type": "boolean",
+                "description": "Whether the Duck.ai global setting is enabled"
             },
             {
                 "key": "input_screen_enabled",

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -888,7 +888,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt"
-            line="45"
+            line="46"
             column="1"/>
     </issue>
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -41,6 +41,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
+import androidx.core.net.toUri
 import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
 import androidx.core.view.postDelayed
@@ -61,7 +62,10 @@ import com.duckduckgo.app.browser.databinding.IncludeOmnibarToolbarMockupBinding
 import com.duckduckgo.app.browser.databinding.IncludeOmnibarToolbarMockupBottomBinding
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.ui.DefaultBrowserBottomSheetDialog
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.ui.DefaultBrowserBottomSheetDialog.EventListener
+import com.duckduckgo.app.browser.mode.AppShortcutDuckAi
 import com.duckduckgo.app.browser.mode.BrowserLaunchSource
+import com.duckduckgo.app.browser.mode.DuckAiPinShortcut
+import com.duckduckgo.app.browser.mode.SearchWidgetDuckAi
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.browser.omnibar.applyAddressBarRebrandRadius
@@ -127,6 +131,7 @@ import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.downloads.api.DownloadsScreens.DownloadsScreenNoParams
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.viewmodel.DuckChatSharedViewModel
 import com.duckduckgo.feedback.api.FeedbackScreenNoParams
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -151,6 +156,12 @@ import logcat.asLog
 import logcat.logcat
 import javax.inject.Inject
 import com.duckduckgo.mobile.android.R as CommonR
+
+private fun BrowserLaunchSource.toDuckChatEntryPoint(): DuckChatEntryPoint? = when (this) {
+    AppShortcutDuckAi, DuckAiPinShortcut -> DuckChatEntryPoint.ICON_SHORTCUT
+    SearchWidgetDuckAi -> DuckChatEntryPoint.WIDGET_QUICK_ACTIONS
+    else -> null
+}
 
 // open class so that we can test BrowserApplicationStateInfo
 @HasMemberInjections
@@ -813,6 +824,11 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
         if (intent.getBooleanExtra(OPEN_DUCK_CHAT, false)) {
             val sourceTabId = intent.getStringExtra(SOURCE_TAB_ID_EXTRA)
+            intent.getStringExtra(DUCK_CHAT_ENTRY_POINT_EXTRA)?.let { source ->
+                runCatching { DuckChatEntryPoint.valueOf(source) }
+                    .getOrNull()
+                    ?.let { duckChat.reportDuckChatEntry(it, opensNewTab = true, hasPrompt = false) }
+            }
             launchDuckAi(url = intent.getStringExtra(DUCK_CHAT_URL), sourceTabId = sourceTabId)
             return
         }
@@ -838,6 +854,13 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 lifecycleScope.launch { viewModel.onOpenShortcut(sharedText) }
             } else if (intent.getBooleanExtra(LAUNCH_FROM_FAVORITES_WIDGET, false)) {
                 logcat { "Favorite clicked from widget $sharedText" }
+                if (duckChat.isDuckChatUrl(sharedText.toUri())) {
+                    duckChat.reportDuckChatEntry(
+                        DuckChatEntryPoint.WIDGET_FAVORITE,
+                        opensNewTab = true,
+                        hasPrompt = hasAutoSubmittedPrompt(sharedText),
+                    )
+                }
                 lifecycleScope.launch { viewModel.onOpenFavoriteFromWidget(query = sharedText) }
             } else if (intent.getBooleanExtra(OPEN_IN_CURRENT_TAB_EXTRA, false)) {
                 logcat(WARN) { "open in current tab requested" }
@@ -854,6 +877,13 @@ open class BrowserActivity : DuckDuckGoActivity() {
             } else {
                 val isExternal = intent.getBooleanExtra(LAUNCH_FROM_EXTERNAL_EXTRA, false)
                 val interstitialScreen = intent.getBooleanExtra(LAUNCH_FROM_INTERSTITIAL_EXTRA, false)
+                if (isExternal && duckChat.isDuckChatUrl(sharedText.toUri())) {
+                    duckChat.reportDuckChatEntry(
+                        DuckChatEntryPoint.DEEP_LINK_OTHER,
+                        opensNewTab = true,
+                        hasPrompt = hasAutoSubmittedPrompt(sharedText),
+                    )
+                }
                 logcat(WARN) { "opening in new tab requested for $sharedText isExternal $isExternal interstitial $interstitialScreen" }
                 if (!interstitialScreen) {
                     logcat(WARN) { "not launching from interstitial screen" }
@@ -1066,6 +1096,11 @@ open class BrowserActivity : DuckDuckGoActivity() {
         }
     }
 
+    private fun hasAutoSubmittedPrompt(url: String): Boolean = runCatching {
+        val uri = url.toUri()
+        uri.getQueryParameter("prompt") == "1" && !uri.getQueryParameter("q").isNullOrBlank()
+    }.getOrDefault(false)
+
     fun closeDuckChatFullScreen() {
         isDuckChatVisible = false
         currentTab?.closeCurrentTab()
@@ -1151,6 +1186,11 @@ open class BrowserActivity : DuckDuckGoActivity() {
                             finish()
                         }
                         is NewUserBrowserOnboardingViewModel.Command.OpenDuckAiOnboardingDemo -> {
+                            duckChat.reportDuckChatEntry(
+                                DuckChatEntryPoint.ONBOARDING,
+                                opensNewTab = true,
+                                hasPrompt = hasAutoSubmittedPrompt(command.url),
+                            )
                             launchDuckAi(url = command.url)
                         }
                     }
@@ -1260,6 +1300,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             intent.putExtra(LAUNCH_FROM_INTERSTITIAL_EXTRA, interstitialScreen)
             intent.putExtra(OPEN_EXISTING_TAB_ID_EXTRA, openExistingTabId)
             intent.putExtra(OPEN_DUCK_CHAT, openDuckChat)
+            intent.putExtra(DUCK_CHAT_ENTRY_POINT_EXTRA, launchSource.toDuckChatEntryPoint()?.name)
             intent.putExtra(CLOSE_DUCK_CHAT, closeDuckChat)
             intent.putExtra(DUCK_CHAT_URL, duckChatUrl)
             intent.putExtra(DUCK_CHAT_SESSION_ACTIVE, duckChatSessionActive)
@@ -1295,6 +1336,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         const val LAUNCH_SOURCE_PIXEL_VALUE = "LAUNCH_SOURCE_PIXEL_VALUE"
 
         private const val OPEN_DUCK_CHAT = "OPEN_DUCK_CHAT_EXTRA"
+        private const val DUCK_CHAT_ENTRY_POINT_EXTRA = "DUCK_CHAT_ENTRY_POINT_EXTRA"
         private const val CLOSE_DUCK_CHAT = "CLOSE_DUCK_CHAT_EXTRA"
         private const val DUCK_CHAT_URL = "DUCK_CHAT_URL"
         private const val DUCK_CHAT_SESSION_ACTIVE = "DUCK_CHAT_SESSION_ACTIVE"

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -338,6 +338,7 @@ import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatContextual
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatHistoryNoParams
 import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InteractionLock
@@ -824,7 +825,7 @@ class BrowserTabFragment :
                 viewModel.openNewDuckChat(omnibar.viewMode)
             }
             onMenuItemClicked(contentView.findViewById(com.duckduckgo.duckchat.impl.R.id.chatMenuPopupNewVoiceChat)) {
-                duckChat.openVoiceDuckChat()
+                duckChat.openVoiceDuckChat(DuckChatEntryPoint.VOICE)
             }
             onMenuItemClicked(contentView.findViewById(com.duckduckgo.duckchat.impl.R.id.chatMenuPopupNewTab)) {
                 browserActivity?.launchNewTab(browserMode = BrowserMode.REGULAR)
@@ -1080,7 +1081,7 @@ class BrowserTabFragment :
                             if (nativeInputManager.isNativeInputEnabled()) {
                                 nativeInputManager.handleDuckAiVoiceResult(result.query)
                             } else {
-                                duckChat.openDuckChatWithAutoPrompt(result.query)
+                                duckChat.openDuckChatWithAutoPrompt(result.query, DuckChatEntryPoint.VOICE)
                             }
                         }
                     }
@@ -1445,7 +1446,9 @@ class BrowserTabFragment :
                     )
                 },
                 onChatSuggestionSelected = { chatUrl -> viewModel.openDuckAiChatById(chatUrl) },
-                onDuckAiQuerySubmitted = { query -> viewModel.openDuckAiQuery(query, autoPrompt = true) },
+                onDuckAiQuerySubmitted = { query, entryPoint ->
+                    viewModel.openDuckAiQuery(query, autoPrompt = true, entryPoint = entryPoint)
+                },
                 onChatUrlSuggestionClicked = { suggestion -> viewModel.userSelectedAutocomplete(suggestion, firePixel = false) },
                 onChatHistoryShortcutClicked = {
                     pixel.fire(DuckChatPixelName.DUCK_CHAT_SETTINGS_SIDEBAR_TAPPED)
@@ -1870,7 +1873,7 @@ class BrowserTabFragment :
             onMenuItemClicked(duckAiNewVoiceChatMenuItem) {
                 pixel.fire(DuckChatPixelName.DUCK_CHAT_VOICE_ENTRY_TAPPED_COUNT)
                 pixel.fire(DuckChatPixelName.DUCK_CHAT_VOICE_ENTRY_TAPPED_DAILY, type = Daily())
-                duckChat.openVoiceDuckChat()
+                duckChat.openVoiceDuckChat(DuckChatEntryPoint.VOICE)
             }
             onMenuItemClicked(duckChatHistoryMenuItem) {
                 pixel.fire(DuckChatPixelName.DUCK_CHAT_SETTINGS_SIDEBAR_TAPPED)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -376,6 +376,9 @@ import com.duckduckgo.downloads.store.DownloadStatus
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
+import com.duckduckgo.duckchat.api.DuckChatInputModeState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.contextual.PageContextJSHelper
 import com.duckduckgo.duckchat.impl.contextual.RealPageContextJSHelper.Companion.PAGE_CONTEXT_FEATURE_NAME
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
@@ -540,6 +543,7 @@ class BrowserTabViewModel @Inject constructor(
     private val duckChat: DuckChat,
     private val duckAiHostProvider: DuckAiHostProvider,
     private val duckAiFeatureState: DuckAiFeatureState,
+    private val duckChatInputModeState: DuckChatInputModeState,
     private val duckPlayerJSHelper: DuckPlayerJSHelper,
     private val refreshPixelSender: RefreshPixelSender,
     private val privacyProtectionTogglePlugin: PluginPoint<PrivacyProtectionTogglePlugin>,
@@ -1532,7 +1536,9 @@ class BrowserTabViewModel @Inject constructor(
         val verticalParameter = extractVerticalParameter(url)
         var urlToNavigate = queryUrlConverter.convertQueryToUrl(trimmedInput, verticalParameter, queryOrigin)
 
-        if (queryOrigin is QueryOrigin.FromUser && isTypedDuckAiUrl(urlToNavigate)) {
+        val isDuckAiDirectNavigation =
+            submissionSource == QuerySubmissionSource.USER && queryOrigin is QueryOrigin.FromUser && isTypedDuckAiUrl(urlToNavigate)
+        if (isDuckAiDirectNavigation) {
             fireDuckAiDirectNavigationPixel()
         }
 
@@ -1562,6 +1568,13 @@ class BrowserTabViewModel @Inject constructor(
             }
 
             else -> {
+                if (isDuckAiDirectNavigation) {
+                    duckChat.reportDuckChatEntry(
+                        DuckChatEntryPoint.DIRECT_URL,
+                        opensNewTab = false,
+                        hasPrompt = hasAutoSubmittedPrompt(urlToNavigate),
+                    )
+                }
                 if (type is SpecialUrlDetector.UrlType.ExtractedAmpLink) {
                     logcat { "AMP link detection: Using extracted URL: ${type.extractedUrl}" }
                     urlToNavigate = type.extractedUrl
@@ -1645,8 +1658,17 @@ class BrowserTabViewModel @Inject constructor(
         return host == duckAiHost || host == "www.$duckAiHost"
     }
 
+    private fun hasAutoSubmittedPrompt(url: String): Boolean = runCatching {
+        val uri = url.toUri()
+        uri.getQueryParameter("prompt") == "1" && !uri.getQueryParameter(QUERY).isNullOrBlank()
+    }.getOrDefault(false)
+
     private fun fireDuckAiDirectNavigationPixel() {
-        val params = mapOf("duck_ai_enabled" to duckChat.isEnabled().toString())
+        val inputScreenEnabled = duckChatInputModeState.inputModeCapability.value == NativeInputState.InputMode.SEARCH_AND_DUCK_AI
+        val params = mapOf(
+            "duck_ai_enabled" to duckChat.isEnabled().toString(),
+            "input_screen_enabled" to inputScreenEnabled.toString(),
+        )
         pixel.fire(AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT, parameters = params)
         pixel.fire(AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_DAILY, parameters = params, type = Daily())
     }
@@ -4036,9 +4058,9 @@ class BrowserTabViewModel @Inject constructor(
     private fun openDuckChatForUrl(uri: Uri) {
         val queryParameter = uri.getQueryParameter(QUERY)
         if (queryParameter != null) {
-            duckChat.openDuckChatWithPrefill(queryParameter)
+            duckChat.openDuckChatWithPrefill(queryParameter, DuckChatEntryPoint.DIRECT_URL)
         } else {
-            duckChat.openDuckChat()
+            duckChat.openDuckChat(DuckChatEntryPoint.DIRECT_URL)
         }
     }
 
@@ -5625,7 +5647,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun onUserTappedDuckAiPromptAutocomplete(prompt: String) {
-        openDuckAiQuery(prompt, autoPrompt = true)
+        openDuckAiQuery(prompt, autoPrompt = true, entryPoint = DuckChatEntryPoint.SUGGESTION_ASK_AI)
 
         viewModelScope.launch {
             val params = duckChat.createWasUsedBeforePixelParams()
@@ -5639,12 +5661,22 @@ class BrowserTabViewModel @Inject constructor(
      * selected. The query opens in a new tab so the current tab is preserved; on the NTP we
      * reuse the empty tab instead of spawning another.
      */
-    fun openDuckAiQuery(query: String, autoPrompt: Boolean) {
+    fun openDuckAiQuery(
+        query: String,
+        autoPrompt: Boolean,
+        entryPoint: DuckChatEntryPoint,
+    ) {
+        val duckAiUrl = duckChat.getDuckChatUrl(query, autoPrompt)
+        val hasPrompt = hasAutoSubmittedPrompt(duckAiUrl)
         browserInteractionsPlugins.getPlugins().forEach { it.onInputSubmitted() }
-        if (autoPrompt && query.isNotBlank()) {
+        if (hasPrompt) {
             browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted() }
         }
-        navigateToDuckAi(duckChat.getDuckChatUrl(query, autoPrompt))
+        navigateToDuckAi(
+            url = duckAiUrl,
+            entryPoint = entryPoint,
+            hasPrompt = hasPrompt,
+        )
     }
 
     /**
@@ -5654,7 +5686,7 @@ class BrowserTabViewModel @Inject constructor(
      */
     fun openDuckAiChatById(chatUrl: String) {
         browserInteractionsPlugins.getPlugins().forEach { it.onChatSelected() }
-        navigateToDuckAi(chatUrl)
+        navigateToDuckAi(chatUrl, DuckChatEntryPoint.CHAT_HISTORY_OPEN_CHAT, hasPrompt = false)
     }
 
     /**
@@ -5668,8 +5700,14 @@ class BrowserTabViewModel @Inject constructor(
         browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted() }
     }
 
-    private fun navigateToDuckAi(url: String) {
-        if (!currentBrowserViewState().browserShowing) {
+    private fun navigateToDuckAi(
+        url: String,
+        entryPoint: DuckChatEntryPoint,
+        hasPrompt: Boolean,
+    ) {
+        val opensNewTab = currentBrowserViewState().browserShowing
+        duckChat.reportDuckChatEntry(entryPoint, opensNewTab = opensNewTab, hasPrompt = hasPrompt)
+        if (!opensNewTab) {
             submitQuery(url, QueryOrigin.FromUser, QuerySubmissionSource.INTERNAL_NAVIGATION)
         } else {
             command.value = OpenInNewTab(query = url, sourceTabId = tabId)
@@ -5685,6 +5723,12 @@ class BrowserTabViewModel @Inject constructor(
             }
         } else {
             val url = duckChat.getDuckChatUrl("", false)
+            val entryPoint = if (viewMode == ViewMode.NewTab) {
+                DuckChatEntryPoint.BROWSING_MENU_NTP
+            } else {
+                DuckChatEntryPoint.BROWSING_MENU_WEBPAGE
+            }
+            duckChat.reportDuckChatEntry(entryPoint, opensNewTab = true, hasPrompt = false)
             command.value = OpenInNewTab(url, tabId)
             pixel.fire(DuckChatPixelName.DUCK_CHAT_SETTINGS_NEW_CHAT_TAB_TAPPED)
         }
@@ -5776,6 +5820,11 @@ class BrowserTabViewModel @Inject constructor(
                     if (submittedAiPrompt) {
                         browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted() }
                     }
+                    duckChat.reportDuckChatEntry(
+                        DuckChatEntryPoint.ADDRESS_BAR_ICON,
+                        opensNewTab = false,
+                        hasPrompt = submittedAiPrompt,
+                    )
                     submitQuery(url, QueryOrigin.FromUser, QuerySubmissionSource.INTERNAL_NAVIGATION)
                 } else {
                     // The typed-URL branch above: genuinely a URL submission, not a Duck.ai one.

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -84,6 +84,7 @@ import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.contentscopescripts.api.contentscopeExperiments.ContentScopeExperiments
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.subscriptions.api.Subscriptions
@@ -300,11 +301,12 @@ class BrowserWebViewClient @Inject constructor(
 
                 is SpecialUrlDetector.UrlType.ShouldLaunchDuckChatLink -> {
                     runCatching {
+                        val entryPoint = duckChatEntryPointFor(webView.originalUrl)
                         val query = url.getQueryParameter(QUERY)
                         if (query != null) {
-                            duckChat.openDuckChatWithPrefill(query)
+                            duckChat.openDuckChatWithPrefill(query, entryPoint)
                         } else {
-                            duckChat.openDuckChat()
+                            duckChat.openDuckChat(entryPoint)
                         }
                     }.isSuccess
                 }
@@ -350,6 +352,18 @@ class BrowserWebViewClient @Inject constructor(
 
                 is SpecialUrlDetector.UrlType.SearchQuery -> false
                 is SpecialUrlDetector.UrlType.Web -> {
+                    if (
+                        isForMainFrame &&
+                        hasGestureInNavigation &&
+                        duckChat.isDuckChatUrl(url) &&
+                        webView.originalUrl?.toUri()?.let(duckChat::isDuckChatUrl) != true
+                    ) {
+                        duckChat.reportDuckChatEntry(
+                            entryPoint = duckChatEntryPointFor(webView.originalUrl),
+                            opensNewTab = false,
+                            hasPrompt = url.getQueryParameter("prompt") == "1" && !url.getQueryParameter(QUERY).isNullOrBlank(),
+                        )
+                    }
                     shouldOverrideWebRequest(url, webView, isForMainFrame)
                 }
 
@@ -428,6 +442,13 @@ class BrowserWebViewClient @Inject constructor(
             return false
         }
     }
+
+    private fun duckChatEntryPointFor(initiatingUrl: String?): DuckChatEntryPoint =
+        if (initiatingUrl?.let(duckDuckGoUrlDetector::isDuckDuckGoQueryUrl) == true) {
+            DuckChatEntryPoint.SERP
+        } else {
+            DuckChatEntryPoint.DIRECT_URL
+        }
 
     private fun shouldOverrideWebRequest(
         url: Uri,

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -57,6 +57,7 @@ import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.api.NativeInputEventListener
@@ -91,7 +92,7 @@ class NativeInputCallbacks(
         filesJson: JSONArray?,
     ) -> Unit,
     val onChatSuggestionSelected: (String) -> Unit,
-    val onDuckAiQuerySubmitted: (query: String) -> Unit = {},
+    val onDuckAiQuerySubmitted: (query: String, entryPoint: DuckChatEntryPoint) -> Unit = { _, _ -> },
     /** User picked a model in the native picker (→ submitChangeModelAction). */
     val onChangeModelSubmitted: (modelId: String) -> Unit = {},
     val onCustomizeResponsesClicked: () -> Unit = {},
@@ -220,6 +221,7 @@ class RealNativeInputManager @Inject constructor(
     private var navBarTabCountLiveData: LiveData<Int>? = null
     private var navBarTabCountObserver: Observer<Int>? = null
     private var lastCallbacks: NativeInputCallbacks? = null
+    private var nextDuckAiEntryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT
 
     /** True while an enter morph from [attachWidget] still owns [NativeInputLayoutCoordinator]'s animating flag. */
     private var pendingEnterOwnsAnimating = false
@@ -355,12 +357,17 @@ class RealNativeInputManager @Inject constructor(
     override fun handleDuckAiVoiceResult(query: String) {
         val widget = widgetFrom(rootView)
         if (widget != null) {
-            if (!widget.isChatTabSelected()) {
-                widget.selectChatTab()
+            nextDuckAiEntryPoint = DuckChatEntryPoint.VOICE
+            try {
+                if (!widget.isChatTabSelected()) {
+                    widget.selectChatTab()
+                }
+                widget.submitMessage(query)
+            } finally {
+                nextDuckAiEntryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT
             }
-            widget.submitMessage(query)
         } else {
-            duckChat.openDuckChatWithAutoPrompt(query)
+            duckChat.openDuckChatWithAutoPrompt(query, DuckChatEntryPoint.VOICE)
         }
     }
 
@@ -743,7 +750,9 @@ class RealNativeInputManager @Inject constructor(
                     }
                     isExiting = false
                     nativeInputEventListener.onChatPromptSubmitted()
-                    callbacks.onDuckAiQuerySubmitted(query)
+                    val entryPoint = nextDuckAiEntryPoint
+                    nextDuckAiEntryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT
+                    callbacks.onDuckAiQuerySubmitted(query, entryPoint)
                 }
             },
         )
@@ -943,7 +952,7 @@ class RealNativeInputManager @Inject constructor(
         }
         widget.onVoiceChatClick = {
             hideNativeInput(animate = false)
-            duckChat.openVoiceDuckChat()
+            duckChat.openVoiceDuckChat(DuckChatEntryPoint.VOICE)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -109,6 +110,7 @@ class OnboardingActivity : DuckDuckGoActivity() {
         lifecycleScope.launch {
             viewModel.onOnboardingDone(extendedOnboardingFlow = DUCK_AI_FOCUSED)
             val duckChatUrl = duckChat.getDuckChatUrl(prompt, autoPrompt = true) + "&flow=mobile-app-onboarding"
+            duckChat.reportDuckChatEntry(DuckChatEntryPoint.ONBOARDING, opensNewTab = true, hasPrompt = prompt.isNotBlank())
             startActivity(BrowserActivity.intent(this@OnboardingActivity, launchSource = Onboarding, duckChatUrl = duckChatUrl, openDuckChat = true))
             finish()
         }

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -90,6 +90,7 @@ import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.common.utils.text.TextChangedWatcher
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.impl.dialogs.EditSavedSiteDialogFragment
 import com.duckduckgo.voice.api.VoiceSearchAvailability
@@ -436,7 +437,7 @@ class SystemSearchActivity : DuckDuckGoActivity() {
                     }
 
                     is VoiceSearchLauncher.VoiceRecognitionResult.DuckAiResult -> {
-                        viewModel.onDuckAiRequested(result.query)
+                        viewModel.onDuckAiRequested(result.query, DuckChatEntryPoint.VOICE)
                     }
                 }
             } else if (it is VoiceSearchLauncher.Event.VoiceSearchDisabled) {
@@ -451,7 +452,7 @@ class SystemSearchActivity : DuckDuckGoActivity() {
 
     fun configureDuckAi() {
         duckAi.setOnClickListener {
-            viewModel.onDuckAiRequested(omnibarTextInput.text.toString())
+            viewModel.onDuckAiRequested(omnibarTextInput.text.toString(), DuckChatEntryPoint.SYSTEM_SEARCH)
         }
     }
 
@@ -572,7 +573,7 @@ class SystemSearchActivity : DuckDuckGoActivity() {
             SystemSearchViewModel.Command.ExitSearch -> finish()
 
             LaunchDuckAiVoiceChat -> {
-                duckChat.openVoiceDuckChat()
+                duckChat.openVoiceDuckChat(DuckChatEntryPoint.DIGITAL_ASSISTANT)
                 finish()
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -47,6 +47,7 @@ import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite
@@ -323,8 +324,8 @@ class SystemSearchViewModel @Inject constructor(
         voiceSearchState.tryEmit(Unit)
     }
 
-    fun onDuckAiRequested(query: String) {
-        duckChat.openDuckChatWithAutoPrompt(query)
+    fun onDuckAiRequested(query: String, entryPoint: DuckChatEntryPoint) {
+        duckChat.openDuckChatWithAutoPrompt(query, entryPoint)
         command.value = Command.ExitSearch
     }
 
@@ -382,7 +383,7 @@ class SystemSearchViewModel @Inject constructor(
             }
 
             is AutoCompleteSuggestion.AutoCompleteDuckAIPrompt -> {
-                onDuckAiRequested(suggestion.phrase)
+                onDuckAiRequested(suggestion.phrase, DuckChatEntryPoint.SUGGESTION_ASK_AI)
             }
 
             is AutoCompleteSuggestion.AutoCompleteDeviceAppSuggestion -> {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -70,6 +70,7 @@ import com.duckduckgo.common.utils.extensions.combine
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.remote.messaging.api.RemoteMessageModel
 import com.duckduckgo.savedsites.api.SavedSitesRepository
@@ -702,6 +703,7 @@ class TabSwitcherViewModel @Inject constructor(
             pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN_TAB_SWITCHER_FAB, parameters = params)
 
             val url = duckChat.getDuckChatUrl("", false)
+            duckChat.reportDuckChatEntry(DuckChatEntryPoint.TAB_SWITCHER, opensNewTab = true, hasPrompt = false)
             tabRepository.add(url, true)
             command.value = Command.Close
         }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -308,6 +308,9 @@ import com.duckduckgo.downloads.store.DownloadStatus
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
+import com.duckduckgo.duckchat.api.DuckChatInputModeState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.contextual.PageContextJSHelper
 import com.duckduckgo.duckchat.impl.contextual.RealPageContextJSHelper.Companion.PAGE_CONTEXT_FEATURE_NAME
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
@@ -533,8 +536,10 @@ class BrowserTabViewModelTest {
     private val mockStandardizedLeadingIconToggle: StandardizedLeadingIconFeatureToggle = mock()
 
     private val mockDuckAiFeatureState: DuckAiFeatureState = mock()
+    private val mockDuckChatInputModeState: DuckChatInputModeState = mock()
 
     private val mockDuckAiFeatureStateInputScreenFlow = MutableStateFlow(false)
+    private val mockInputModeCapability = MutableStateFlow(NativeInputState.InputMode.SEARCH_ONLY)
 
     private val mockDuckAiContextualModeFlow = MutableStateFlow(false)
 
@@ -705,6 +710,7 @@ class BrowserTabViewModelTest {
     private val exampleUrl = "http://example.com"
     private val shortExampleUrl = "example.com"
     private val duckChatURL = "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5"
+    private val duckChatAutoPromptURL = "$duckChatURL&prompt=1"
 
     private val selectedTab = TabEntity("TAB_ID", exampleUrl, position = 0, sourceTabId = "TAB_ID_SOURCE")
     private val flowSelectedTab = MutableStateFlow(selectedTab)
@@ -838,6 +844,7 @@ class BrowserTabViewModelTest {
             whenever(mockDuckAiFeatureState.showPopupMenuShortcut).thenReturn(MutableStateFlow(false))
             whenever(mockDuckAiFeatureState.showInputScreen).thenReturn(mockDuckAiFeatureStateInputScreenFlow)
             whenever(mockDuckAiFeatureState.showContextualMode).thenReturn(mockDuckAiContextualModeFlow)
+            whenever(mockDuckChatInputModeState.inputModeCapability).thenReturn(mockInputModeCapability)
             whenever(mockVpnMenuStateProvider.getVpnMenuState()).thenReturn(flowOf(VpnMenuState.Hidden))
             whenever(nonHttpAppLinkChecker.isPermitted(anyOrNull())).thenReturn(true)
             runBlocking { whenever(mockAddressBarTrackersAnimationManager.isFeatureEnabled()).thenReturn(false) }
@@ -1004,6 +1011,7 @@ class BrowserTabViewModelTest {
                 duckChat = mockDuckChat,
                 duckAiHostProvider = mockDuckAiHostProvider,
                 duckAiFeatureState = mockDuckAiFeatureState,
+                duckChatInputModeState = mockDuckChatInputModeState,
                 duckPlayerJSHelper =
                 DuckPlayerJSHelper(
                     mockDuckPlayer,
@@ -6494,7 +6502,7 @@ class BrowserTabViewModelTest {
         val handled = testee.handleDuckChatUrlInCustomTab("https://duck.ai/?q=hello".toUri())
 
         assertTrue(handled)
-        verify(mockDuckChat).openDuckChatWithPrefill("hello")
+        verify(mockDuckChat).openDuckChatWithPrefill("hello", DuckChatEntryPoint.DIRECT_URL)
         assertTrue(captureCommands().allValues.contains(Command.FinishCustomTab))
     }
 
@@ -6506,7 +6514,7 @@ class BrowserTabViewModelTest {
         val handled = testee.handleDuckChatUrlInCustomTab("https://duck.ai/".toUri())
 
         assertTrue(handled)
-        verify(mockDuckChat).openDuckChat()
+        verify(mockDuckChat).openDuckChat(DuckChatEntryPoint.DIRECT_URL)
         assertTrue(captureCommands().allValues.contains(Command.FinishCustomTab))
     }
 
@@ -6518,8 +6526,8 @@ class BrowserTabViewModelTest {
         val handled = testee.handleDuckChatUrlInCustomTab("https://duck.ai/?q=hello".toUri())
 
         assertFalse(handled)
-        verify(mockDuckChat, never()).openDuckChat()
-        verify(mockDuckChat, never()).openDuckChatWithPrefill(any())
+        verify(mockDuckChat, never()).openDuckChat(any())
+        verify(mockDuckChat, never()).openDuckChatWithPrefill(any(), any())
     }
 
     @Test
@@ -6530,8 +6538,8 @@ class BrowserTabViewModelTest {
         val handled = testee.handleDuckChatUrlInCustomTab("https://duck.ai/?q=hello".toUri())
 
         assertFalse(handled)
-        verify(mockDuckChat, never()).openDuckChat()
-        verify(mockDuckChat, never()).openDuckChatWithPrefill(any())
+        verify(mockDuckChat, never()).openDuckChat(any())
+        verify(mockDuckChat, never()).openDuckChatWithPrefill(any(), any())
     }
 
     @Test
@@ -8274,12 +8282,57 @@ class BrowserTabViewModelTest {
 
         verify(mockPixel).fire(
             AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT,
-            parameters = mapOf("duck_ai_enabled" to "true"),
+            parameters = mapOf("duck_ai_enabled" to "true", "input_screen_enabled" to "false"),
         )
         verify(mockPixel).fire(
             AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_DAILY,
-            parameters = mapOf("duck_ai_enabled" to "true"),
+            parameters = mapOf("duck_ai_enabled" to "true", "input_screen_enabled" to "false"),
             type = Daily(),
+        )
+        verify(mockDuckChat).reportDuckChatEntry(DuckChatEntryPoint.DIRECT_URL, opensNewTab = false, hasPrompt = false)
+    }
+
+    @Test
+    fun whenTypedDuckAiUrlWithNonBlankQueryAndPromptSubmittedThenReportsDirectUrlEntryWithPrompt() {
+        val typedUrl = "https://duck.ai/chat?duckai=5&q=Hello&prompt=1"
+        whenever(mockOmnibarConverter.convertQueryToUrl(typedUrl, null, FromUser)).thenReturn(typedUrl)
+
+        testee.onUserSubmittedQuery(typedUrl, queryOrigin = FromUser)
+
+        verify(mockDuckChat).reportDuckChatEntry(DuckChatEntryPoint.DIRECT_URL, opensNewTab = false, hasPrompt = true)
+    }
+
+    @Test
+    fun whenTypedDuckAiUrlWithPromptButNoQuerySubmittedThenReportsDirectUrlEntryWithoutPrompt() {
+        val typedUrl = "https://duck.ai/chat?duckai=5&prompt=1"
+        whenever(mockOmnibarConverter.convertQueryToUrl(typedUrl, null, FromUser)).thenReturn(typedUrl)
+
+        testee.onUserSubmittedQuery(typedUrl, queryOrigin = FromUser)
+
+        verify(mockDuckChat).reportDuckChatEntry(DuckChatEntryPoint.DIRECT_URL, opensNewTab = false, hasPrompt = false)
+    }
+
+    @Test
+    fun whenTypedDuckAiUrlWithQueryButNoPromptParameterSubmittedThenReportsDirectUrlEntryWithoutPrompt() {
+        val typedUrl = "https://duck.ai/chat?duckai=5&q=Hello"
+        whenever(mockOmnibarConverter.convertQueryToUrl(typedUrl, null, FromUser)).thenReturn(typedUrl)
+
+        testee.onUserSubmittedQuery(typedUrl, queryOrigin = FromUser)
+
+        verify(mockDuckChat).reportDuckChatEntry(DuckChatEntryPoint.DIRECT_URL, opensNewTab = false, hasPrompt = false)
+    }
+
+    @Test
+    fun whenTypedDuckAiUrlSubmittedWithInputScreenEnabledThenDirectNavigationPixelCarriesCapability() {
+        mockInputModeCapability.value = NativeInputState.InputMode.SEARCH_AND_DUCK_AI
+        whenever(mockOmnibarConverter.convertQueryToUrl("duck.ai", null, FromUser)).thenReturn("https://duck.ai/")
+        whenever(mockDuckChat.isEnabled()).thenReturn(true)
+
+        testee.onUserSubmittedQuery("duck.ai", queryOrigin = FromUser)
+
+        verify(mockPixel).fire(
+            AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT,
+            parameters = mapOf("duck_ai_enabled" to "true", "input_screen_enabled" to "true"),
         )
     }
 
@@ -8292,7 +8345,7 @@ class BrowserTabViewModelTest {
 
         verify(mockPixel).fire(
             AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT,
-            parameters = mapOf("duck_ai_enabled" to "true"),
+            parameters = mapOf("duck_ai_enabled" to "true", "input_screen_enabled" to "false"),
         )
     }
 
@@ -8305,11 +8358,11 @@ class BrowserTabViewModelTest {
 
         verify(mockPixel).fire(
             AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT,
-            parameters = mapOf("duck_ai_enabled" to "false"),
+            parameters = mapOf("duck_ai_enabled" to "false", "input_screen_enabled" to "false"),
         )
         verify(mockPixel).fire(
             AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_DAILY,
-            parameters = mapOf("duck_ai_enabled" to "false"),
+            parameters = mapOf("duck_ai_enabled" to "false", "input_screen_enabled" to "false"),
             type = Daily(),
         )
     }
@@ -8819,31 +8872,50 @@ class BrowserTabViewModelTest {
             assertCommandIssued<Command.OpenInNewTab> {
                 assertEquals(duckChatURL, query)
             }
-            verify(mockDuckChat, never()).openDuckChatWithAutoPrompt(any())
+            verify(mockDuckChat, never()).openDuckChatWithAutoPrompt(any(), any())
         }
 
     @Test
     fun whenOpenDuckAiQueryOnBrowserTabThenOpensInNewTab() = runTest {
         setBrowserShowing(true)
+        whenever(mockDuckChat.getDuckChatUrl(eq("hello"), eq(true), any())).thenReturn(duckChatAutoPromptURL)
 
-        testee.openDuckAiQuery(query = "hello", autoPrompt = true)
+        testee.openDuckAiQuery(query = "hello", autoPrompt = true, entryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT)
 
         assertCommandIssued<Command.OpenInNewTab> {
-            assertEquals(duckChatURL, query)
+            assertEquals(duckChatAutoPromptURL, query)
         }
         verify(mockDuckChat).getDuckChatUrl(eq("hello"), eq(true), any())
-        verify(mockDuckChat, never()).openDuckChatWithAutoPrompt(any())
+        verify(mockDuckChat).reportDuckChatEntry(DuckChatEntryPoint.ADDRESS_BAR_PROMPT, opensNewTab = true, hasPrompt = true)
+        verify(mockDuckChat, never()).openDuckChatWithAutoPrompt(any(), any())
     }
 
     @Test
     fun whenOpenDuckAiQueryOnNtpThenStaysInTab() = runTest {
         setBrowserShowing(false)
-        whenever(mockOmnibarConverter.convertQueryToUrl(duckChatURL, null)).thenReturn(duckChatURL)
+        whenever(mockDuckChat.getDuckChatUrl(eq("hello"), eq(true), any())).thenReturn(duckChatAutoPromptURL)
+        whenever(mockOmnibarConverter.convertQueryToUrl(duckChatAutoPromptURL, null)).thenReturn(duckChatAutoPromptURL)
 
-        testee.openDuckAiQuery(query = "hello", autoPrompt = true)
+        testee.openDuckAiQuery(query = "hello", autoPrompt = true, entryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT)
 
         assertCommandNotIssued<Command.OpenInNewTab>()
         verify(mockDuckChat).getDuckChatUrl(eq("hello"), eq(true), any())
+        verify(mockDuckChat).reportDuckChatEntry(DuckChatEntryPoint.ADDRESS_BAR_PROMPT, opensNewTab = false, hasPrompt = true)
+    }
+
+    @Test
+    fun whenOpenDuckAiQueryWithBangOnlyThenReportsNoPrompt() = runTest {
+        setBrowserShowing(true)
+        val bangOnlyUrl = "https://duck.ai/chat"
+        whenever(mockDuckChat.getDuckChatUrl(eq("!ai"), eq(true), any())).thenReturn(bangOnlyUrl)
+
+        testee.openDuckAiQuery(query = "!ai", autoPrompt = true, entryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT)
+
+        verify(mockDuckChat).reportDuckChatEntry(
+            DuckChatEntryPoint.ADDRESS_BAR_PROMPT,
+            opensNewTab = true,
+            hasPrompt = false,
+        )
     }
 
     @Test
@@ -8856,6 +8928,7 @@ class BrowserTabViewModelTest {
         assertCommandIssued<Command.OpenInNewTab> {
             assertEquals(chatUrl, query)
         }
+        verify(mockDuckChat).reportDuckChatEntry(DuckChatEntryPoint.CHAT_HISTORY_OPEN_CHAT, opensNewTab = true, hasPrompt = false)
     }
 
     @Test
@@ -8873,9 +8946,10 @@ class BrowserTabViewModelTest {
     fun whenOpenDuckAiQueryThenFiresOnInputSubmittedOnBrowserInteractionsPlugins() = runTest {
         val plugin: BrowserInteractionsPlugin = mock()
         whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
-        whenever(mockOmnibarConverter.convertQueryToUrl(duckChatURL, null)).thenReturn(duckChatURL)
+        whenever(mockDuckChat.getDuckChatUrl(eq("hello"), eq(true), any())).thenReturn(duckChatAutoPromptURL)
+        whenever(mockOmnibarConverter.convertQueryToUrl(duckChatAutoPromptURL, null)).thenReturn(duckChatAutoPromptURL)
 
-        testee.openDuckAiQuery(query = "hello", autoPrompt = true)
+        testee.openDuckAiQuery(query = "hello", autoPrompt = true, entryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT)
 
         // Preserve the pre-return-session behavior: one callback is explicit and one comes from
         // reusing the NTP tab. The new AI classifier must still fire exactly once without a URL.
@@ -8891,7 +8965,7 @@ class BrowserTabViewModelTest {
         whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
         setBrowserShowing(true)
 
-        testee.openDuckAiQuery(query = "", autoPrompt = false)
+        testee.openDuckAiQuery(query = "", autoPrompt = false, entryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT)
 
         verify(plugin).onInputSubmitted()
         verify(plugin, never()).onAiPromptSubmitted()
@@ -8903,7 +8977,7 @@ class BrowserTabViewModelTest {
         whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
         setBrowserShowing(true)
 
-        testee.openDuckAiQuery(query = "prefill", autoPrompt = false)
+        testee.openDuckAiQuery(query = "prefill", autoPrompt = false, entryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT)
 
         verify(plugin).onInputSubmitted()
         verify(plugin, never()).onAiPromptSubmitted()
@@ -8914,8 +8988,9 @@ class BrowserTabViewModelTest {
         val plugin: BrowserInteractionsPlugin = mock()
         whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
         setBrowserShowing(true)
+        whenever(mockDuckChat.getDuckChatUrl(eq("hello"), eq(true), any())).thenReturn(duckChatAutoPromptURL)
 
-        testee.openDuckAiQuery(query = "hello", autoPrompt = true)
+        testee.openDuckAiQuery(query = "hello", autoPrompt = true, entryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT)
 
         verify(plugin).onInputSubmitted()
         verify(plugin).onAiPromptSubmitted()
@@ -9101,7 +9176,7 @@ class BrowserTabViewModelTest {
             "https://duckduckgo.com/?q=example&ia=chat&duckai=5",
         )
         testee.onUserSubmittedQuery("https://duckduckgo.com/?q=example&ia=chat&duckai=5")
-        mockDuckChat.openDuckChatWithPrefill("example")
+        mockDuckChat.openDuckChatWithPrefill("example", DuckChatEntryPoint.DIRECT_URL)
     }
 
     @Test
@@ -9109,7 +9184,7 @@ class BrowserTabViewModelTest {
         whenever(mockSpecialUrlDetector.determineType(anyString())).thenReturn(SpecialUrlDetector.UrlType.ShouldLaunchDuckChatLink)
         whenever(mockOmnibarConverter.convertQueryToUrl("https://duckduckgo.com/?ia=chat", null)).thenReturn("https://duckduckgo.com/?ia=chat")
         testee.onUserSubmittedQuery("https://duckduckgo.com/?ia=chat")
-        mockDuckChat.openDuckChat()
+        mockDuckChat.openDuckChat(DuckChatEntryPoint.DIRECT_URL)
     }
 
     @Test
@@ -10977,7 +11052,7 @@ class BrowserTabViewModelTest {
             val command = commandCaptor.lastValue as Command.OpenInNewTab
             assertTrue(command.query == duckChatURL)
 
-            verify(mockDuckChat, never()).openDuckChat()
+            verify(mockDuckChat, never()).openDuckChat(any())
             verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_SETTINGS_NEW_CHAT_TAB_TAPPED)
         }
 
@@ -11323,7 +11398,7 @@ class BrowserTabViewModelTest {
         val command = commandCaptor.lastValue as Navigate
         assertEquals(duckAIUrl, command.url)
 
-        verify(mockDuckChat, never()).openDuckChat()
+        verify(mockDuckChat, never()).openDuckChat(any())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -85,6 +85,7 @@ import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.contentscopescripts.api.contentscopeExperiments.ContentScopeExperiments
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.subscriptions.api.Subscriptions
@@ -574,7 +575,7 @@ class BrowserWebViewClientTest {
         whenever(webResourceRequest.url).thenReturn("https://duckduckgo.com/?q=example&ia=chat&duckai=5".toUri())
         assertTrue(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
 
-        verify(mockDuckChat).openDuckChatWithPrefill("example")
+        verify(mockDuckChat).openDuckChatWithPrefill("example", DuckChatEntryPoint.DIRECT_URL)
     }
 
     @Test
@@ -583,7 +584,38 @@ class BrowserWebViewClientTest {
         whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
         whenever(webResourceRequest.url).thenReturn("https://duckduckgo.com/?ia=chat".toUri())
         assertTrue(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
-        verify(mockDuckChat).openDuckChat()
+        verify(mockDuckChat).openDuckChat(DuckChatEntryPoint.DIRECT_URL)
+    }
+
+    @Test
+    fun whenDuckChatLinkIsLaunchedFromSerpThenSourceIsSerp() {
+        val serpWebView: WebView = mock()
+        whenever(serpWebView.originalUrl).thenReturn("https://duckduckgo.com/?q=privacy")
+        whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoQueryUrl(any())).thenReturn(true)
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.ShouldLaunchDuckChatLink)
+        whenever(webResourceRequest.url).thenReturn("https://duck.ai/".toUri())
+
+        testee.shouldOverrideUrlLoading(serpWebView, webResourceRequest)
+
+        verify(mockDuckChat).openDuckChat(DuckChatEntryPoint.SERP)
+    }
+
+    @Test
+    fun whenInPageDuckChatLinkNavigatesInPlaceThenDirectUrlEntryIsReported() {
+        val pageWebView: WebView = mock()
+        whenever(pageWebView.originalUrl).thenReturn("https://example.com/page")
+        whenever(pageWebView.url).thenReturn("https://example.com/page")
+        whenever(webResourceRequest.url).thenReturn("https://duck.ai/?q=prefill".toUri())
+        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+        whenever(webResourceRequest.hasGesture()).thenReturn(true)
+        whenever(mockDuckChat.isDuckChatUrl("https://duck.ai/?q=prefill".toUri())).thenReturn(true)
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.Web("https://duck.ai/?q=prefill"))
+
+        testee.shouldOverrideUrlLoading(pageWebView, webResourceRequest)
+
+        verify(mockDuckChat).reportDuckChatEntry(DuckChatEntryPoint.DIRECT_URL, opensNewTab = false, hasPrompt = false)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.NativeInputEventListener
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
@@ -348,6 +349,90 @@ class RealNativeInputManagerTest {
         }
     }
 
+    @Test
+    fun whenBlankDuckAiVoiceResultFollowedByTypedSubmissionThenTypedSubmissionUsesAddressBarPromptEntryPoint() {
+        val entryPoints = mutableListOf<DuckChatEntryPoint>()
+        val widget = showVoiceTestWidget { _, entryPoint -> entryPoints += entryPoint }
+
+        testee.handleDuckAiVoiceResult("")
+        widget.submitMessage("typed query")
+
+        assertEquals(listOf(DuckChatEntryPoint.ADDRESS_BAR_PROMPT), entryPoints)
+    }
+
+    @Test
+    fun whenWhitespaceDuckAiVoiceResultFollowedByTypedSubmissionThenTypedSubmissionUsesAddressBarPromptEntryPoint() {
+        val entryPoints = mutableListOf<DuckChatEntryPoint>()
+        val widget = showVoiceTestWidget { _, entryPoint -> entryPoints += entryPoint }
+
+        testee.handleDuckAiVoiceResult("   ")
+        widget.submitMessage("typed query")
+
+        assertEquals(listOf(DuckChatEntryPoint.ADDRESS_BAR_PROMPT), entryPoints)
+    }
+
+    @Test
+    fun whenNonBlankDuckAiVoiceResultThenSubmissionUsesVoiceEntryPoint() {
+        val entryPoints = mutableListOf<DuckChatEntryPoint>()
+        showVoiceTestWidget { _, entryPoint -> entryPoints += entryPoint }
+
+        testee.handleDuckAiVoiceResult("voice query")
+
+        assertEquals(listOf(DuckChatEntryPoint.VOICE), entryPoints)
+    }
+
+    @Test
+    fun whenTypedSubmissionFollowsSuccessfulDuckAiVoiceSubmissionThenTypedSubmissionUsesAddressBarPromptEntryPoint() {
+        val entryPoints = mutableListOf<DuckChatEntryPoint>()
+        val onSubmitted = { _: String, entryPoint: DuckChatEntryPoint -> entryPoints += entryPoint }
+        showVoiceTestWidget(onSubmitted)
+        testee.handleDuckAiVoiceResult("voice query")
+
+        val widget = showVoiceTestWidget(onSubmitted)
+        widget.selectChatTab()
+        widget.submitMessage("typed query")
+
+        assertEquals(
+            listOf(DuckChatEntryPoint.VOICE, DuckChatEntryPoint.ADDRESS_BAR_PROMPT),
+            entryPoints,
+        )
+    }
+
+    private fun showVoiceTestWidget(onDuckAiQuerySubmitted: (String, DuckChatEntryPoint) -> Unit): TestNativeInputWidget {
+        whenever(duckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(MutableStateFlow(true))
+        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(MutableStateFlow(true))
+        whenever(duckAiFeatureState.showVoiceSearchToggle).thenReturn(MutableStateFlow(false))
+        whenever(duckAiFeatureState.showVoiceChatEntry).thenReturn(MutableStateFlow(false))
+        whenever(omnibar.viewMode).thenReturn(Omnibar.ViewMode.NewTab)
+        whenever(omnibar.getText()).thenReturn("")
+        testee.init(omnibar, rootView, lifecycleOwner)
+        if (rootView.findViewById<View?>(R.id.includeNewBrowserTab) == null) {
+            rootView.addView(FrameLayout(context).apply { id = R.id.includeNewBrowserTab })
+        }
+
+        val widget = TestNativeInputWidget(context).apply { id = R.id.inputModeWidget }
+        val widgetView = FrameLayout(context).apply { addView(widget) }
+        val layoutInflater: LayoutInflater = mock()
+        whenever(layoutInflater.inflate(any<Int>(), any<ViewGroup>(), any<Boolean>())).thenReturn(widgetView)
+        testee.showNativeInput(
+            tabId = "tab",
+            layoutInflater = layoutInflater,
+            lifecycleOwner = lifecycleOwner,
+            tabs = mock<LiveData<List<TabEntity>>>(),
+            currentTabUrl = emptyFlow(),
+            callbacks = NativeInputCallbacks(
+                onSearchTextChanged = {},
+                onSearchSubmitted = {},
+                onDuckAiChatSubmitted = { _, _, _, _, _, _ -> },
+                onChatSuggestionSelected = {},
+                onDuckAiQuerySubmitted = onDuckAiQuerySubmitted,
+                onClearAutocomplete = {},
+                onStopTapped = {},
+            ),
+        )
+        return widget
+    }
+
     private fun showNativeInput() {
         testee.showNativeInput(
             tabId = "tab",
@@ -369,6 +454,37 @@ class RealNativeInputManagerTest {
     private class FakeLifecycleOwner : LifecycleOwner {
         private val registry = LifecycleRegistry(this).apply { currentState = Lifecycle.State.RESUMED }
         override val lifecycle: Lifecycle get() = registry
+    }
+
+    private class TestNativeInputWidget(
+        context: Context,
+        delegate: NativeInputWidget = mock(),
+    ) : View(context), NativeInputWidget by delegate {
+        private var chatTabSelected = false
+        private var onChatSubmitted: ((String) -> Unit)? = null
+
+        override var text: String = ""
+
+        override fun bindInputEvents(
+            onSearchTextChanged: (String) -> Unit,
+            onSearchSubmitted: (String) -> Unit,
+            onChatSubmitted: (String) -> Unit,
+            onInputTextEmptyChanged: (isEmpty: Boolean) -> Unit,
+        ) {
+            this.onChatSubmitted = onChatSubmitted
+        }
+
+        override fun selectChatTab() {
+            chatTabSelected = true
+        }
+
+        override fun isChatTabSelected(): Boolean = chatTabSelected
+
+        override fun submitMessage(message: String?) {
+            message?.trim()?.takeIf { it.isNotEmpty() }?.let { onChatSubmitted?.invoke(it) }
+        }
+
+        override fun asView(): View = this
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -48,6 +48,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.InstantSchedulersRule
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.history.api.NavigationHistory
@@ -691,8 +692,8 @@ class SystemSearchViewModelTest {
     @Test
     fun onDuckAiTappedThenDuckChatOpenedWithQuery() {
         val query = "What is DuckDuckGo?"
-        testee.onDuckAiRequested(query)
-        verify(mockDuckChat).openDuckChatWithAutoPrompt(query)
+        testee.onDuckAiRequested(query, DuckChatEntryPoint.SYSTEM_SEARCH)
+        verify(mockDuckChat).openDuckChatWithAutoPrompt(query, DuckChatEntryPoint.SYSTEM_SEARCH)
     }
 
     @Test

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -32,19 +32,32 @@ interface DuckChat {
     fun isEnabled(): Boolean
 
     /**
-     * Opens the DuckChat WebView with optional pre-filled [String] query.
+     * Opens Duck.ai from [entryPoint].
      */
-    fun openDuckChat()
+    fun openDuckChat(entryPoint: DuckChatEntryPoint)
 
     /**
-     * Auto-prompts the DuckChat WebView with the provided [String] query.
+     * Opens Duck.ai from [entryPoint] and automatically submits [query].
      */
-    fun openDuckChatWithAutoPrompt(query: String)
+    fun openDuckChatWithAutoPrompt(query: String, entryPoint: DuckChatEntryPoint)
 
     /**
-     * Opens Duck Chat with a prefilled [String] query.
+     * Opens Duck.ai from [entryPoint] with [query] prefilled but not submitted.
      */
-    fun openDuckChatWithPrefill(query: String)
+    fun openDuckChatWithPrefill(query: String, entryPoint: DuckChatEntryPoint)
+
+    /**
+     * Records a Duck.ai entry performed through navigation that bypasses the open methods.
+     *
+     * @param entryPoint the surface that initiated the entry.
+     * @param opensNewTab whether the entry opens a new browser tab.
+     * @param hasPrompt whether a non-blank prompt is automatically submitted on entry.
+     */
+    fun reportDuckChatEntry(
+        entryPoint: DuckChatEntryPoint,
+        opensNewTab: Boolean,
+        hasPrompt: Boolean,
+    )
 
     /**
      * Returns the Duck Chat URL to be used
@@ -138,7 +151,7 @@ interface DuckChat {
     /**
      * Opens Duck.ai directly in voice mode (duck.ai/?mode=voice-mode).
      */
-    fun openVoiceDuckChat()
+    fun openVoiceDuckChat(entryPoint: DuckChatEntryPoint)
 
     /**
      * Returns `true` if a voice session is currently active on the tab with the given [tabId].

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatEntryPoint.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatEntryPoint.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.api
+
+/** The user-visible surface that initiated an entry into Duck.ai. */
+enum class DuckChatEntryPoint {
+    ADDRESS_BAR_PROMPT,
+    ADDRESS_BAR_ICON,
+    ADDRESS_BAR_SHORTCUT_CHIP,
+    ADDRESS_BAR_EDITING_STATE,
+    SUGGESTION_ASK_AI,
+    BROWSING_MENU_NTP,
+    BROWSING_MENU_WEBPAGE,
+    TAB_SWITCHER,
+    CHAT_HISTORY_NEW_CHAT,
+    CHAT_HISTORY_OPEN_CHAT,
+    VOICE,
+    ONBOARDING,
+    DIRECT_URL,
+    SERP,
+    ICON_SHORTCUT,
+    CONTEXTUAL_CHAT,
+    WIDGET_QUICK_ACTIONS,
+    WIDGET_FAVORITE,
+    SYSTEM_SEARCH,
+    DIGITAL_ASSISTANT,
+    DEEP_LINK_OTHER,
+    PAID_SETTINGS,
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -26,7 +26,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.di.IsMainProcess
-import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browsermode.api.BrowserMode
@@ -45,8 +44,7 @@ import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.feature.AIChatImageUploadFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
-import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
-import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.repository.AddressBarPickerAttributionRepository
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
@@ -59,6 +57,7 @@ import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
+import dagger.Lazy
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -462,7 +461,7 @@ class RealDuckChat @Inject constructor(
     private val context: Context,
     @IsMainProcess private val isMainProcess: Boolean,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
-    private val pixel: Pixel,
+    private val duckChatPixels: Lazy<DuckChatPixels>,
     private val imageUploadFeature: AIChatImageUploadFeature,
     private val browserNav: BrowserNav,
     private val deviceSyncState: DeviceSyncState,
@@ -800,19 +799,12 @@ class RealDuckChat @Inject constructor(
         opensNewTab: Boolean,
         hasPrompt: Boolean,
     ) {
-        val parameters = mapOf(
-            DuckChatPixelParameters.ENTRY_SOURCE to entryPoint.toPixelValue(),
-            DuckChatPixelParameters.DUCK_AI_ENABLED to isEnabled().toString(),
-            DuckChatPixelParameters.INPUT_SCREEN_ENABLED to
-                (inputModeCapability.value == NativeInputState.InputMode.SEARCH_AND_DUCK_AI).toString(),
-            DuckChatPixelParameters.OPENS_NEW_TAB to opensNewTab.toString(),
-            DuckChatPixelParameters.HAS_PROMPT to hasPrompt.toString(),
-        )
-        pixel.fire(DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_COUNT, parameters = parameters)
-        pixel.fire(
-            DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_DAILY,
-            parameters = parameters,
-            type = Pixel.PixelType.Daily(),
+        duckChatPixels.get().reportDuckChatEntry(
+            entryPoint = entryPoint,
+            opensNewTab = opensNewTab,
+            hasPrompt = hasPrompt,
+            duckAiEnabled = isEnabled(),
+            inputScreenEnabled = inputModeCapability.value == NativeInputState.InputMode.SEARCH_AND_DUCK_AI,
         )
     }
 
@@ -1141,29 +1133,4 @@ class RealDuckChat @Inject constructor(
         private const val ORIGIN_QUERY_NAME = "origin"
         private const val ORIGIN_VALUE_ADDRESS_BAR_PICKER = "funnel_addressbar_android__aitoggle"
     }
-}
-
-private fun DuckChatEntryPoint.toPixelValue(): String = when (this) {
-    DuckChatEntryPoint.ADDRESS_BAR_PROMPT -> "address_bar_prompt"
-    DuckChatEntryPoint.ADDRESS_BAR_ICON -> "address_bar_icon"
-    DuckChatEntryPoint.ADDRESS_BAR_SHORTCUT_CHIP -> "address_bar_shortcut_chip"
-    DuckChatEntryPoint.ADDRESS_BAR_EDITING_STATE -> "address_bar_editing_state"
-    DuckChatEntryPoint.SUGGESTION_ASK_AI -> "suggestion_ask_ai"
-    DuckChatEntryPoint.BROWSING_MENU_NTP -> "browsing_menu_ntp"
-    DuckChatEntryPoint.BROWSING_MENU_WEBPAGE -> "browsing_menu_webpage"
-    DuckChatEntryPoint.TAB_SWITCHER -> "tab_switcher"
-    DuckChatEntryPoint.CHAT_HISTORY_NEW_CHAT -> "chat_history_new_chat"
-    DuckChatEntryPoint.CHAT_HISTORY_OPEN_CHAT -> "chat_history_open_chat"
-    DuckChatEntryPoint.VOICE -> "voice"
-    DuckChatEntryPoint.ONBOARDING -> "onboarding"
-    DuckChatEntryPoint.DIRECT_URL -> "direct_url"
-    DuckChatEntryPoint.SERP -> "serp"
-    DuckChatEntryPoint.ICON_SHORTCUT -> "icon_shortcut"
-    DuckChatEntryPoint.CONTEXTUAL_CHAT -> "contextual_chat"
-    DuckChatEntryPoint.WIDGET_QUICK_ACTIONS -> "widget_quick_actions"
-    DuckChatEntryPoint.WIDGET_FAVORITE -> "widget_favorite"
-    DuckChatEntryPoint.SYSTEM_SEARCH -> "system_search"
-    DuckChatEntryPoint.DIGITAL_ASSISTANT -> "digital_assistant"
-    DuckChatEntryPoint.DEEP_LINK_OTHER -> "deep_link_other"
-    DuckChatEntryPoint.PAID_SETTINGS -> "paid_settings"
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -38,12 +38,15 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.DuckChatSettingsNoParams
 import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.feature.AIChatImageUploadFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters
 import com.duckduckgo.duckchat.impl.repository.AddressBarPickerAttributionRepository
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
@@ -179,7 +182,7 @@ interface DuckChatInternal : DuckChat {
     /**
      * Opens DuckChat with a new session.
      */
-    fun openNewDuckChatSession()
+    fun openNewDuckChatSession(entryPoint: DuckChatEntryPoint)
 
     /** Single source of truth for the Duck.ai chat URL shape. */
     fun buildChatUrl(chatId: String): String
@@ -717,13 +720,15 @@ class RealDuckChat @Inject constructor(
 
     override fun keepSessionIntervalInMinutes() = keepSessionAliveInMinutes
 
-    override fun openDuckChat() {
+    override fun openDuckChat(entryPoint: DuckChatEntryPoint) {
         logcat { "Duck.ai: openDuckChat" }
+        reportDuckChatEntry(entryPoint, opensNewTab = true, hasPrompt = false)
         openDuckChat(emptyMap())
     }
 
-    override fun openDuckChatWithAutoPrompt(query: String) {
+    override fun openDuckChatWithAutoPrompt(query: String, entryPoint: DuckChatEntryPoint) {
         logcat { "Duck.ai: openDuckChatWithAutoPrompt query $query" }
+        reportDuckChatEntry(entryPoint, opensNewTab = true, hasPrompt = stripBang(query).isNotEmpty())
         val parameters = addChatParameters(query, autoPrompt = true, sidebar = false)
         openDuckChat(parameters, forceNewSession = true)
     }
@@ -732,8 +737,9 @@ class RealDuckChat @Inject constructor(
         addressBarPickerAttributionRepository.onPickerDuckAiSelected()
     }
 
-    override fun openDuckChatWithPrefill(query: String) {
+    override fun openDuckChatWithPrefill(query: String, entryPoint: DuckChatEntryPoint) {
         logcat { "Duck.ai: openDuckChatWithPrefill query $query" }
+        reportDuckChatEntry(entryPoint, opensNewTab = true, hasPrompt = false)
         val parameters = addChatParameters(query, autoPrompt = false, sidebar = false)
         openDuckChat(parameters, forceNewSession = true)
     }
@@ -777,14 +783,37 @@ class RealDuckChat @Inject constructor(
         return query.replace(bangPattern, "").trim()
     }
 
-    override fun openVoiceDuckChat() {
+    override fun openVoiceDuckChat(entryPoint: DuckChatEntryPoint) {
         logcat { "Duck.ai: openVoiceDuckChat" }
+        reportDuckChatEntry(entryPoint, opensNewTab = true, hasPrompt = false)
         val parameters = mapOf(MODE_QUERY_NAME to VOICE_MODE_QUERY_VALUE)
         openDuckChat(parameters, forceNewSession = true)
     }
 
-    override fun openNewDuckChatSession() {
+    override fun openNewDuckChatSession(entryPoint: DuckChatEntryPoint) {
+        reportDuckChatEntry(entryPoint, opensNewTab = true, hasPrompt = false)
         openDuckChat(emptyMap(), forceNewSession = true)
+    }
+
+    override fun reportDuckChatEntry(
+        entryPoint: DuckChatEntryPoint,
+        opensNewTab: Boolean,
+        hasPrompt: Boolean,
+    ) {
+        val parameters = mapOf(
+            DuckChatPixelParameters.ENTRY_SOURCE to entryPoint.toPixelValue(),
+            DuckChatPixelParameters.DUCK_AI_ENABLED to isEnabled().toString(),
+            DuckChatPixelParameters.INPUT_SCREEN_ENABLED to
+                (inputModeCapability.value == NativeInputState.InputMode.SEARCH_AND_DUCK_AI).toString(),
+            DuckChatPixelParameters.OPENS_NEW_TAB to opensNewTab.toString(),
+            DuckChatPixelParameters.HAS_PROMPT to hasPrompt.toString(),
+        )
+        pixel.fire(DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_COUNT, parameters = parameters)
+        pixel.fire(
+            DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_DAILY,
+            parameters = parameters,
+            type = Pixel.PixelType.Daily(),
+        )
     }
 
     private fun openDuckChat(
@@ -1112,4 +1141,29 @@ class RealDuckChat @Inject constructor(
         private const val ORIGIN_QUERY_NAME = "origin"
         private const val ORIGIN_VALUE_ADDRESS_BAR_PICKER = "funnel_addressbar_android__aitoggle"
     }
+}
+
+private fun DuckChatEntryPoint.toPixelValue(): String = when (this) {
+    DuckChatEntryPoint.ADDRESS_BAR_PROMPT -> "address_bar_prompt"
+    DuckChatEntryPoint.ADDRESS_BAR_ICON -> "address_bar_icon"
+    DuckChatEntryPoint.ADDRESS_BAR_SHORTCUT_CHIP -> "address_bar_shortcut_chip"
+    DuckChatEntryPoint.ADDRESS_BAR_EDITING_STATE -> "address_bar_editing_state"
+    DuckChatEntryPoint.SUGGESTION_ASK_AI -> "suggestion_ask_ai"
+    DuckChatEntryPoint.BROWSING_MENU_NTP -> "browsing_menu_ntp"
+    DuckChatEntryPoint.BROWSING_MENU_WEBPAGE -> "browsing_menu_webpage"
+    DuckChatEntryPoint.TAB_SWITCHER -> "tab_switcher"
+    DuckChatEntryPoint.CHAT_HISTORY_NEW_CHAT -> "chat_history_new_chat"
+    DuckChatEntryPoint.CHAT_HISTORY_OPEN_CHAT -> "chat_history_open_chat"
+    DuckChatEntryPoint.VOICE -> "voice"
+    DuckChatEntryPoint.ONBOARDING -> "onboarding"
+    DuckChatEntryPoint.DIRECT_URL -> "direct_url"
+    DuckChatEntryPoint.SERP -> "serp"
+    DuckChatEntryPoint.ICON_SHORTCUT -> "icon_shortcut"
+    DuckChatEntryPoint.CONTEXTUAL_CHAT -> "contextual_chat"
+    DuckChatEntryPoint.WIDGET_QUICK_ACTIONS -> "widget_quick_actions"
+    DuckChatEntryPoint.WIDGET_FAVORITE -> "widget_favorite"
+    DuckChatEntryPoint.SYSTEM_SEARCH -> "system_search"
+    DuckChatEntryPoint.DIGITAL_ASSISTANT -> "digital_assistant"
+    DuckChatEntryPoint.DEEP_LINK_OTHER -> "deep_link_other"
+    DuckChatEntryPoint.PAID_SETTINGS -> "paid_settings"
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -799,7 +799,7 @@ class RealDuckChat @Inject constructor(
         opensNewTab: Boolean,
         hasPrompt: Boolean,
     ) {
-        duckChatPixels.get().reportDuckChatEntry(
+        duckChatPixels.get().sendDuckChatEntryPixel(
             entryPoint = entryPoint,
             opensNewTab = opensNewTab,
             hasPrompt = hasPrompt,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -86,6 +86,7 @@ import com.duckduckgo.downloads.api.DownloadStateListener
 import com.duckduckgo.downloads.api.DownloadsFileActions
 import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.duckchat.api.DuckChatContextual
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatHistoryNoParams
 import com.duckduckgo.duckchat.api.viewmodel.DuckChatSharedViewModel
 import com.duckduckgo.duckchat.impl.DuckChatInternal
@@ -528,7 +529,7 @@ class DuckChatContextualFragment :
             onPageContextRemoved = { viewModel.removePageContext() },
             onVoiceChatRequested = {
                 viewModel.onContextualClose()
-                duckChat.openVoiceDuckChat()
+                duckChat.openVoiceDuckChat(DuckChatEntryPoint.VOICE)
             },
             onVoiceSearchRequested = {
                 activity?.hideKeyboard()
@@ -721,6 +722,10 @@ class DuckChatContextualFragment :
         }
     }
 
+    private fun openDuckAiWithPrompt(query: String) {
+        duckChat.openDuckChatWithAutoPrompt(query, DuckChatEntryPoint.CONTEXTUAL_CHAT)
+    }
+
     private fun observeViewModel() {
         viewModel.commands
             .onEach { command ->
@@ -781,7 +786,7 @@ class DuckChatContextualFragment :
 
                     is DuckChatContextualViewModel.Command.OpenDuckAiWithPrompt -> {
                         viewModel.onContextualClose()
-                        duckChat.openDuckChatWithAutoPrompt(command.query)
+                        openDuckAiWithPrompt(command.query)
                     }
 
                     is DuckChatContextualViewModel.Command.FocusInput -> {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.toChatIdOrNull
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
@@ -748,6 +749,7 @@ class DuckChatContextualViewModel @Inject constructor(
     fun onFullModeRequested() {
         logcat { "Duck.ai: request fullmode url $fullModeUrl" }
         val currentState = _viewState.value
+        val hasPrompt = currentState.sheetMode != SheetMode.INPUT
         val chatUrl = if (currentState.sheetMode == SheetMode.INPUT) {
             duckChat.getDuckChatUrl("", false, sidebar = false)
         } else {
@@ -758,6 +760,7 @@ class DuckChatContextualViewModel @Inject constructor(
         viewModelScope.launch {
             commandChannel.trySend(Command.OpenFullscreenMode(chatUrl))
         }
+        duckChatInternal.reportDuckChatEntry(DuckChatEntryPoint.CONTEXTUAL_CHAT, opensNewTab = true, hasPrompt = hasPrompt)
         duckChatPixels.reportContextualSheetExpanded()
     }
 
@@ -903,6 +906,7 @@ class DuckChatContextualViewModel @Inject constructor(
         duckChatPixels.reportContextualRecentChatSelected()
         val url = duckChatInternal.buildChatUrl(chatId)
         val sourceTabId = _viewState.value.tabId
+        duckChatInternal.reportDuckChatEntry(DuckChatEntryPoint.CHAT_HISTORY_OPEN_CHAT, opensNewTab = true, hasPrompt = false)
         commandChannel.trySend(Command.OpenChatUrl(url = url, sourceTabId = sourceTabId))
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckChatContextual
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
@@ -93,6 +94,7 @@ class RealDuckChatContextual @Inject constructor(
 
     private fun openNewChatTab(activity: Activity, sourceTabId: String) {
         val url = duckChatInternal.getDuckChatUrl(query = "", autoPrompt = false)
+        duckChatInternal.reportDuckChatEntry(DuckChatEntryPoint.CONTEXTUAL_CHAT, opensNewTab = true, hasPrompt = false)
         browserNav.openInNewTab(activity, url, sourceTabId).also { activity.startActivity(it) }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.ChatState
@@ -176,7 +177,11 @@ class RealDuckChatJSHelper @Inject constructor(
             METHOD_OPEN_AI_CHAT -> {
                 val payload = extractPayload(data)
                 dataStore.updateUserPreferences(payload)
-                duckChat.openNewDuckChatSession()
+                val entryPoint = when {
+                    mode == Mode.CONTEXTUAL -> DuckChatEntryPoint.CONTEXTUAL_CHAT
+                    else -> DuckChatEntryPoint.DIRECT_URL
+                }
+                duckChat.openNewDuckChatSession(entryPoint)
                 null
             }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.dataclearing.api.plugin.ClearableData
 import com.duckduckgo.dataclearing.api.plugin.DataClearingTrigger
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.history.ChatHistoryUiState.Loaded
 import com.duckduckgo.duckchat.impl.history.ChatHistoryUiState.Mode
@@ -101,6 +102,7 @@ class ChatHistoryViewModel @Inject constructor(
             // Open the chat as a new tab anchored to the tab the user was on, so closing it returns there.
             viewModelScope.launch {
                 val sourceTabId = tabRepository.getSelectedTab()?.tabId
+                duckChat.reportDuckChatEntry(DuckChatEntryPoint.CHAT_HISTORY_OPEN_CHAT, opensNewTab = true, hasPrompt = false)
                 navigationChannel.trySend(NavigationEvent.OpenChat(url = duckChat.buildChatUrl(chatId), sourceTabId = sourceTabId))
             }
         }
@@ -133,13 +135,13 @@ class ChatHistoryViewModel @Inject constructor(
             DuckChatPixelName.DUCK_CHAT_HISTORY_EMPTY_CTA_TAPPED_COUNT,
             DuckChatPixelName.DUCK_CHAT_HISTORY_EMPTY_CTA_TAPPED_DAILY,
         )
-        duckChat.openDuckChat()
+        duckChat.openDuckChat(DuckChatEntryPoint.CHAT_HISTORY_NEW_CHAT)
     }
 
     /** Toolbar "New chat" action. Kept separate from [onOpenDuckAiClicked] so the two surfaces stay independently instrumentable. */
     fun onNewChatRequested() {
         pixel.fireCountAndDaily(DuckChatPixelName.DUCK_CHAT_HISTORY_NEW_CHAT_TAPPED_COUNT, DuckChatPixelName.DUCK_CHAT_HISTORY_NEW_CHAT_TAPPED_DAILY)
-        duckChat.openDuckChat()
+        duckChat.openDuckChat(DuckChatEntryPoint.CHAT_HISTORY_NEW_CHAT)
     }
 
     fun onFireIconClicked() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/metric/nativeinput/MetricsNativeInputEventListener.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/metric/nativeinput/MetricsNativeInputEventListener.kt
@@ -17,7 +17,9 @@
 package com.duckduckgo.duckchat.impl.metric.nativeinput
 
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.NativeInputEventListener
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.metric.nativeinput.discovery.InputScreenDiscoveryFunnel
 import com.duckduckgo.duckchat.impl.metric.nativeinput.usage.InputScreenSessionUsageMetric
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
@@ -27,6 +29,7 @@ import javax.inject.Inject
 @ContributesBinding(AppScope::class)
 class MetricsNativeInputEventListener @Inject constructor(
     private val duckChatPixels: DuckChatPixels,
+    private val duckChatInputModeState: DuckChatInputModeState,
     private val sessionUsageMetric: InputScreenSessionUsageMetric,
     private val discoveryFunnel: InputScreenDiscoveryFunnel,
 ) : NativeInputEventListener {
@@ -34,7 +37,8 @@ class MetricsNativeInputEventListener @Inject constructor(
     override fun onNativeInputShown(landscape: Boolean) {
         discoveryFunnel.onNativeInputActive()
         discoveryFunnel.onInputScreenOpened()
-        duckChatPixels.fireOmnibarShown()
+        val toggleVisible = duckChatInputModeState.inputModeCapability.value == NativeInputState.InputMode.SEARCH_AND_DUCK_AI
+        duckChatPixels.fireOmnibarShown(toggleVisible)
         duckChatPixels.fireOmnibarTextAreaFocused(landscape = landscape)
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -1047,6 +1047,8 @@ class RealDuckChatPixels @Inject constructor(
 
 enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_OPEN("aichat_open"),
+    DUCK_CHAT_ENTRY_POINT_COUNT("m_aichat_entry_point_count"),
+    DUCK_CHAT_ENTRY_POINT_DAILY("m_aichat_entry_point_daily"),
     DUCK_CHAT_OPEN_BROWSER_MENU("aichat_open_browser_menu"),
     DUCK_CHAT_OPEN_NEW_TAB_MENU("aichat_open_new_tab_menu"),
     DUCK_CHAT_OPEN_TAB_SWITCHER_FAB("aichat_open_tab_switcher_fab"),
@@ -1338,6 +1340,11 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
 }
 
 object DuckChatPixelParameters {
+    const val ENTRY_SOURCE = "source"
+    const val DUCK_AI_ENABLED = "duck_ai_enabled"
+    const val INPUT_SCREEN_ENABLED = "input_screen_enabled"
+    const val OPENS_NEW_TAB = "opens_new_tab"
+    const val HAS_PROMPT = "has_prompt"
     const val WAS_USED_BEFORE = "was_used_before"
     const val SUGGESTION_ID = "suggestionId"
     const val PAGE_TYPE = "pageType"
@@ -1382,6 +1389,8 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
     override fun names(): List<Pair<String, Set<PixelParameter>>> {
         return listOf(
             DUCK_CHAT_OPEN.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_DAILY.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_OPEN_BROWSER_MENU.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_OPEN_NEW_TAB_MENU.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_OPEN_TAB_SWITCHER_FAB.pixelName to PixelParameter.removeAtb(),

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -23,9 +23,9 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
-import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.ModelTier
 import com.duckduckgo.duckchat.impl.ReportMetric
 import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_CREATE_NEW_CHAT
@@ -140,6 +140,14 @@ enum class DuckChatPixelSurface(val value: String) {
 interface DuckChatPixels {
     fun sendReportMetricPixel(reportMetric: ReportMetric, modelTier: ModelTier? = null, source: String? = null)
     fun reportOpen()
+
+    fun reportDuckChatEntry(
+        entryPoint: DuckChatEntryPoint,
+        opensNewTab: Boolean,
+        hasPrompt: Boolean,
+        duckAiEnabled: Boolean,
+        inputScreenEnabled: Boolean,
+    )
     fun reportContextualSheetOpened()
     fun reportContextualSheetDismissed()
     fun reportContextualSheetSessionRestored()
@@ -244,7 +252,7 @@ interface DuckChatPixels {
     fun fireRecentChatDeleteConfirmed()
     fun fireRecentChatDeleteCancelled()
     fun fireCustomizeResponsesSelected(surface: DuckChatPixelSurface)
-    fun fireOmnibarShown()
+    fun fireOmnibarShown(toggleVisible: Boolean)
     fun fireOmnibarTextAreaFocused(landscape: Boolean)
     fun fireOmnibarQuerySubmitted(query: String, defaultMode: ToggleSelection?)
     fun fireOmnibarModeSwitched(directionToSearch: Boolean, hadText: Boolean)
@@ -260,7 +268,6 @@ interface DuckChatPixels {
 class RealDuckChatPixels @Inject constructor(
     private val pixel: Pixel,
     private val duckChatFeatureRepository: DuckChatFeatureRepository,
-    private val duckChatInternal: DuckChatInternal,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val statisticsUpdater: StatisticsUpdater,
@@ -281,6 +288,26 @@ class RealDuckChatPixels @Inject constructor(
 
     private fun surfaceParams(surface: DuckChatPixelSurface): Map<String, String> =
         mapOf(DuckChatPixelParameters.SURFACE to surface.value)
+
+    override fun reportDuckChatEntry(
+        entryPoint: DuckChatEntryPoint,
+        opensNewTab: Boolean,
+        hasPrompt: Boolean,
+        duckAiEnabled: Boolean,
+        inputScreenEnabled: Boolean,
+    ) {
+        fireCountAndDaily(
+            DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_COUNT,
+            DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_DAILY,
+            mapOf(
+                DuckChatPixelParameters.ENTRY_SOURCE to entryPoint.toPixelValue(),
+                DuckChatPixelParameters.DUCK_AI_ENABLED to duckAiEnabled.toString(),
+                DuckChatPixelParameters.INPUT_SCREEN_ENABLED to inputScreenEnabled.toString(),
+                DuckChatPixelParameters.OPENS_NEW_TAB to opensNewTab.toString(),
+                DuckChatPixelParameters.HAS_PROMPT to hasPrompt.toString(),
+            ),
+        )
+    }
 
     override fun reportContextualSuggestionSelected(
         suggestionId: String,
@@ -962,10 +989,10 @@ class RealDuckChatPixels @Inject constructor(
         DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_CANCELLED_DAILY,
     )
 
-    override fun fireOmnibarShown() = fireCountAndDaily(
+    override fun fireOmnibarShown(toggleVisible: Boolean) = fireCountAndDaily(
         DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_COUNT,
         DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_DAILY,
-        mapOf(DuckChatPixelParameters.TOGGLE_VISIBLE to (duckChatInternal.resolvedTogglePosition() != null).toString()),
+        mapOf(DuckChatPixelParameters.TOGGLE_VISIBLE to toggleVisible.toString()),
     )
 
     override fun fireOmnibarTextAreaFocused(landscape: Boolean) {
@@ -1637,3 +1664,5 @@ internal fun ToggleSelection.pixelValue(): String = when (this) {
     ToggleSelection.SEARCH -> "search"
     ToggleSelection.DUCK_AI -> "duck_ai"
 }
+
+private fun DuckChatEntryPoint.toPixelValue(): String = name.lowercase()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -141,7 +141,7 @@ interface DuckChatPixels {
     fun sendReportMetricPixel(reportMetric: ReportMetric, modelTier: ModelTier? = null, source: String? = null)
     fun reportOpen()
 
-    fun reportDuckChatEntry(
+    fun sendDuckChatEntryPixel(
         entryPoint: DuckChatEntryPoint,
         opensNewTab: Boolean,
         hasPrompt: Boolean,
@@ -289,7 +289,7 @@ class RealDuckChatPixels @Inject constructor(
     private fun surfaceParams(surface: DuckChatPixelSurface): Map<String, String> =
         mapOf(DuckChatPixelParameters.SURFACE to surface.value)
 
-    override fun reportDuckChatEntry(
+    override fun sendDuckChatEntryPixel(
         entryPoint: DuckChatEntryPoint,
         opensNewTab: Boolean,
         hasPrompt: Boolean,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/subscription/DuckAiPaidSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/subscription/DuckAiPaidSettingsActivity.kt
@@ -40,6 +40,7 @@ import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatSettingsNoParams
 import com.duckduckgo.duckchat.impl.R.string
 import com.duckduckgo.duckchat.impl.databinding.ActivityDuckAiPaidSettingsBinding
@@ -168,7 +169,7 @@ class DuckAiPaidSettingsActivity : DuckDuckGoActivity() {
             }
 
             OpenDuckAi -> {
-                duckChat.openDuckChat()
+                duckChat.openDuckChat(DuckChatEntryPoint.PAID_SETTINGS)
             }
 
             OpenDuckChatSettings -> {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InteractionLock
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
@@ -434,7 +435,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     }
 
     fun openNewChat() {
-        duckChatInternal.openNewDuckChatSession()
+        duckChatInternal.openNewDuckChatSession(DuckChatEntryPoint.ADDRESS_BAR_EDITING_STATE)
     }
 
     fun setDuckAiMode(isDuckAiMode: Boolean) {

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
@@ -42,7 +42,6 @@ class RealDuckChatPixelsAttachmentsTest {
     private val testee = RealDuckChatPixels(
         pixel = pixel,
         duckChatFeatureRepository = duckChatFeatureRepository,
-        duckChatInternal = mock(),
         appCoroutineScope = coroutineTestRule.testScope,
         dispatcherProvider = coroutineTestRule.testDispatcherProvider,
         statisticsUpdater = statisticsUpdater,

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
@@ -42,7 +42,6 @@ class RealDuckChatPixelsPickerTest {
     private val testee = RealDuckChatPixels(
         pixel = pixel,
         duckChatFeatureRepository = duckChatFeatureRepository,
-        duckChatInternal = mock(),
         appCoroutineScope = coroutineTestRule.testScope,
         dispatcherProvider = coroutineTestRule.testDispatcherProvider,
         statisticsUpdater = statisticsUpdater,

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
@@ -43,7 +43,6 @@ class RealDuckChatPixelsToolsTest {
     private val testee = RealDuckChatPixels(
         pixel = pixel,
         duckChatFeatureRepository = duckChatFeatureRepository,
-        duckChatInternal = mock(),
         appCoroutineScope = coroutineTestRule.testScope,
         dispatcherProvider = coroutineTestRule.testDispatcherProvider,
         statisticsUpdater = statisticsUpdater,

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -26,7 +26,6 @@ import androidx.lifecycle.Lifecycle.State.CREATED
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
-import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browsermode.api.BrowserMode
@@ -40,7 +39,7 @@ import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.feature.AIChatImageUploadFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
-import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.repository.AddressBarPickerAttributionRepository
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
@@ -52,6 +51,7 @@ import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 import com.duckduckgo.sync.api.DeviceSyncState
 import com.squareup.moshi.Moshi
+import dagger.Lazy
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -97,7 +97,7 @@ class RealDuckChatTest {
     private val dispatcherProvider = coroutineRule.testDispatcherProvider
     private val mockGlobalActivityStarter: GlobalActivityStarter = mock()
     private val mockContext: Context = mock()
-    private val mockPixel: Pixel = mock()
+    private val mockDuckChatPixels: DuckChatPixels = mock()
     private val mockIntent: Intent = mock()
     private val mockBrowserNav: BrowserNav = mock()
     private val imageUploadFeature: AIChatImageUploadFeature = FakeFeatureToggleFactory.create(AIChatImageUploadFeature::class.java)
@@ -141,7 +141,7 @@ class RealDuckChatTest {
                 mockContext,
                 true,
                 coroutineRule.testScope,
-                mockPixel,
+                Lazy { mockDuckChatPixels },
                 imageUploadFeature,
                 mockBrowserNav,
                 mockDeviceSyncState,
@@ -625,25 +625,19 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun whenDuckChatEntryReportedThenCountAndDailyCarryBoundedContext() = runTest {
+    fun whenDuckChatEntryReportedThenDelegatesBoundedContextToDuckChatPixels() = runTest {
         testee.reportDuckChatEntry(
             entryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT,
             opensNewTab = false,
             hasPrompt = true,
         )
 
-        val parameters = mapOf(
-            "source" to "address_bar_prompt",
-            "duck_ai_enabled" to "true",
-            "input_screen_enabled" to "true",
-            "opens_new_tab" to "false",
-            "has_prompt" to "true",
-        )
-        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_COUNT, parameters = parameters)
-        verify(mockPixel).fire(
-            DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_DAILY,
-            parameters = parameters,
-            type = Pixel.PixelType.Daily(),
+        verify(mockDuckChatPixels).reportDuckChatEntry(
+            entryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT,
+            opensNewTab = false,
+            hasPrompt = true,
+            duckAiEnabled = true,
+            inputScreenEnabled = true,
         )
     }
 
@@ -651,37 +645,13 @@ class RealDuckChatTest {
     fun whenContextualPromptOpensFullscreenThenContextualEntryIsReportedExactlyOnce() = runTest {
         testee.openDuckChatWithAutoPrompt("contextual prompt", DuckChatEntryPoint.CONTEXTUAL_CHAT)
 
-        val parameters = mapOf(
-            "source" to "contextual_chat",
-            "duck_ai_enabled" to "true",
-            "input_screen_enabled" to "true",
-            "opens_new_tab" to "true",
-            "has_prompt" to "true",
+        verify(mockDuckChatPixels, times(1)).reportDuckChatEntry(
+            entryPoint = DuckChatEntryPoint.CONTEXTUAL_CHAT,
+            opensNewTab = true,
+            hasPrompt = true,
+            duckAiEnabled = true,
+            inputScreenEnabled = true,
         )
-        verify(mockPixel, times(1)).fire(DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_COUNT, parameters = parameters)
-        verify(mockPixel, times(1)).fire(
-            DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_DAILY,
-            parameters = parameters,
-            type = Pixel.PixelType.Daily(),
-        )
-    }
-
-    @Test
-    fun everyDuckChatEntryPointMapsToItsLowerSnakeCaseWireValue() = runTest {
-        DuckChatEntryPoint.entries.forEach { entryPoint ->
-            clearInvocations(mockPixel)
-
-            testee.reportDuckChatEntry(entryPoint, opensNewTab = true, hasPrompt = false)
-
-            val parameters = argumentCaptor<Map<String, String>>()
-            verify(mockPixel).fire(
-                eq(DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_COUNT),
-                parameters.capture(),
-                eq(emptyMap()),
-                eq(Pixel.PixelType.Count),
-            )
-            assertEquals(entryPoint.name.lowercase(), parameters.firstValue["source"])
-        }
     }
 
     @Test
@@ -695,27 +665,28 @@ class RealDuckChatTest {
         testee.openDuckChatWithPrefill("prefill", DuckChatEntryPoint.DIRECT_URL)
         testee.openVoiceDuckChat(DuckChatEntryPoint.VOICE)
 
-        val parameters = argumentCaptor<Map<String, String>>()
-        verify(mockPixel, times(8)).fire(
-            eq(DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_COUNT),
-            parameters.capture(),
-            eq(emptyMap()),
-            eq(Pixel.PixelType.Count),
+        val entryPoints = argumentCaptor<DuckChatEntryPoint>()
+        val hasPrompts = argumentCaptor<Boolean>()
+        verify(mockDuckChatPixels, times(8)).reportDuckChatEntry(
+            entryPoint = entryPoints.capture(),
+            opensNewTab = eq(true),
+            hasPrompt = hasPrompts.capture(),
+            duckAiEnabled = eq(true),
+            inputScreenEnabled = eq(true),
         )
         assertEquals(
             listOf(
-                "chat_history_new_chat" to "false",
-                "suggestion_ask_ai" to "true",
-                "system_search" to "false",
-                "digital_assistant" to "false",
-                "direct_url" to "false",
-                "address_bar_prompt" to "true",
-                "direct_url" to "false",
-                "voice" to "false",
+                DuckChatEntryPoint.CHAT_HISTORY_NEW_CHAT to false,
+                DuckChatEntryPoint.SUGGESTION_ASK_AI to true,
+                DuckChatEntryPoint.SYSTEM_SEARCH to false,
+                DuckChatEntryPoint.DIGITAL_ASSISTANT to false,
+                DuckChatEntryPoint.DIRECT_URL to false,
+                DuckChatEntryPoint.ADDRESS_BAR_PROMPT to true,
+                DuckChatEntryPoint.DIRECT_URL to false,
+                DuckChatEntryPoint.VOICE to false,
             ),
-            parameters.allValues.map { it.getValue("source") to it.getValue("has_prompt") },
+            entryPoints.allValues.zip(hasPrompts.allValues),
         )
-        assertTrue(parameters.allValues.all { it["opens_new_tab"] == "true" })
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -632,7 +632,7 @@ class RealDuckChatTest {
             hasPrompt = true,
         )
 
-        verify(mockDuckChatPixels).reportDuckChatEntry(
+        verify(mockDuckChatPixels).sendDuckChatEntryPixel(
             entryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT,
             opensNewTab = false,
             hasPrompt = true,
@@ -645,7 +645,7 @@ class RealDuckChatTest {
     fun whenContextualPromptOpensFullscreenThenContextualEntryIsReportedExactlyOnce() = runTest {
         testee.openDuckChatWithAutoPrompt("contextual prompt", DuckChatEntryPoint.CONTEXTUAL_CHAT)
 
-        verify(mockDuckChatPixels, times(1)).reportDuckChatEntry(
+        verify(mockDuckChatPixels, times(1)).sendDuckChatEntryPixel(
             entryPoint = DuckChatEntryPoint.CONTEXTUAL_CHAT,
             opensNewTab = true,
             hasPrompt = true,
@@ -667,7 +667,7 @@ class RealDuckChatTest {
 
         val entryPoints = argumentCaptor<DuckChatEntryPoint>()
         val hasPrompts = argumentCaptor<Boolean>()
-        verify(mockDuckChatPixels, times(8)).reportDuckChatEntry(
+        verify(mockDuckChatPixels, times(8)).sendDuckChatEntryPixel(
             entryPoint = entryPoints.capture(),
             opensNewTab = eq(true),
             hasPrompt = hasPrompts.capture(),

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -34,11 +34,13 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatSettingsNoParams
 import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.feature.AIChatImageUploadFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.repository.AddressBarPickerAttributionRepository
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
@@ -74,7 +76,9 @@ import org.mockito.Mockito.spy
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -610,7 +614,7 @@ class RealDuckChatTest {
 
     @Test
     fun whenOpenDuckChatCalledThenOpenDuckChat() = runTest {
-        testee.openDuckChat()
+        testee.openDuckChat(DuckChatEntryPoint.PAID_SETTINGS)
 
         verify(mockBrowserNav).openDuckChat(
             mockContext,
@@ -621,10 +625,104 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun whenDuckChatEntryReportedThenCountAndDailyCarryBoundedContext() = runTest {
+        testee.reportDuckChatEntry(
+            entryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT,
+            opensNewTab = false,
+            hasPrompt = true,
+        )
+
+        val parameters = mapOf(
+            "source" to "address_bar_prompt",
+            "duck_ai_enabled" to "true",
+            "input_screen_enabled" to "true",
+            "opens_new_tab" to "false",
+            "has_prompt" to "true",
+        )
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_COUNT, parameters = parameters)
+        verify(mockPixel).fire(
+            DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_DAILY,
+            parameters = parameters,
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenContextualPromptOpensFullscreenThenContextualEntryIsReportedExactlyOnce() = runTest {
+        testee.openDuckChatWithAutoPrompt("contextual prompt", DuckChatEntryPoint.CONTEXTUAL_CHAT)
+
+        val parameters = mapOf(
+            "source" to "contextual_chat",
+            "duck_ai_enabled" to "true",
+            "input_screen_enabled" to "true",
+            "opens_new_tab" to "true",
+            "has_prompt" to "true",
+        )
+        verify(mockPixel, times(1)).fire(DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_COUNT, parameters = parameters)
+        verify(mockPixel, times(1)).fire(
+            DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_DAILY,
+            parameters = parameters,
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun everyDuckChatEntryPointMapsToItsLowerSnakeCaseWireValue() = runTest {
+        DuckChatEntryPoint.entries.forEach { entryPoint ->
+            clearInvocations(mockPixel)
+
+            testee.reportDuckChatEntry(entryPoint, opensNewTab = true, hasPrompt = false)
+
+            val parameters = argumentCaptor<Map<String, String>>()
+            verify(mockPixel).fire(
+                eq(DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_COUNT),
+                parameters.capture(),
+                eq(emptyMap()),
+                eq(Pixel.PixelType.Count),
+            )
+            assertEquals(entryPoint.name.lowercase(), parameters.firstValue["source"])
+        }
+    }
+
+    @Test
+    fun publicOpenMethodsReportTheirNavigationAndPromptTruthTable() = runTest {
+        testee.openDuckChat(DuckChatEntryPoint.CHAT_HISTORY_NEW_CHAT)
+        testee.openDuckChatWithAutoPrompt("prompt", DuckChatEntryPoint.SUGGESTION_ASK_AI)
+        testee.openDuckChatWithAutoPrompt("", DuckChatEntryPoint.SYSTEM_SEARCH)
+        testee.openDuckChatWithAutoPrompt("  ", DuckChatEntryPoint.DIGITAL_ASSISTANT)
+        testee.openDuckChatWithAutoPrompt("!ai", DuckChatEntryPoint.DIRECT_URL)
+        testee.openDuckChatWithAutoPrompt("!ai prompt", DuckChatEntryPoint.ADDRESS_BAR_PROMPT)
+        testee.openDuckChatWithPrefill("prefill", DuckChatEntryPoint.DIRECT_URL)
+        testee.openVoiceDuckChat(DuckChatEntryPoint.VOICE)
+
+        val parameters = argumentCaptor<Map<String, String>>()
+        verify(mockPixel, times(8)).fire(
+            eq(DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_COUNT),
+            parameters.capture(),
+            eq(emptyMap()),
+            eq(Pixel.PixelType.Count),
+        )
+        assertEquals(
+            listOf(
+                "chat_history_new_chat" to "false",
+                "suggestion_ask_ai" to "true",
+                "system_search" to "false",
+                "digital_assistant" to "false",
+                "direct_url" to "false",
+                "address_bar_prompt" to "true",
+                "direct_url" to "false",
+                "voice" to "false",
+            ),
+            parameters.allValues.map { it.getValue("source") to it.getValue("has_prompt") },
+        )
+        assertTrue(parameters.allValues.all { it["opens_new_tab"] == "true" })
+    }
+
+    @Test
     fun whenOpenDuckChatCalledWithCustomHostThenUrlUsesCustomHost() = runTest {
         whenever(mockDuckAiHostProvider.getHost()).thenReturn("staging.duck.ai")
 
-        testee.openDuckChat()
+        testee.openDuckChat(DuckChatEntryPoint.PAID_SETTINGS)
 
         verify(mockBrowserNav).openDuckChat(
             mockContext,
@@ -639,7 +737,7 @@ class RealDuckChatTest {
         val thirtyMinutesAgo = System.currentTimeMillis() - (30 * 60 * 1000L)
         whenever(mockDuckChatFeatureRepository.lastSessionTimestamp()).thenReturn(thirtyMinutesAgo)
 
-        testee.openDuckChat()
+        testee.openDuckChat(DuckChatEntryPoint.PAID_SETTINGS)
 
         verify(mockBrowserNav).openDuckChat(
             mockContext,
@@ -651,7 +749,7 @@ class RealDuckChatTest {
 
     @Test
     fun whenOpenVoiceDuckChatCalledThenOpenDuckChatWithVoiceModeUrl() = runTest {
-        testee.openVoiceDuckChat()
+        testee.openVoiceDuckChat(DuckChatEntryPoint.VOICE)
 
         verify(mockBrowserNav).openDuckChat(
             mockContext,
@@ -666,7 +764,7 @@ class RealDuckChatTest {
         val thirtyMinutesAgo = System.currentTimeMillis() - (30 * 60 * 1000L)
         whenever(mockDuckChatFeatureRepository.lastSessionTimestamp()).thenReturn(thirtyMinutesAgo)
 
-        testee.openVoiceDuckChat()
+        testee.openVoiceDuckChat(DuckChatEntryPoint.VOICE)
 
         verify(mockBrowserNav).openDuckChat(
             mockContext,
@@ -678,7 +776,7 @@ class RealDuckChatTest {
 
     @Test
     fun whenOpenDuckChatCalledWithQueryThenDuckChatOpenedWithQuery() = runTest {
-        testee.openDuckChatWithPrefill(query = "example")
+        testee.openDuckChatWithPrefill(query = "example", entryPoint = DuckChatEntryPoint.DIRECT_URL)
 
         verify(mockBrowserNav).openDuckChat(
             mockContext,
@@ -694,7 +792,7 @@ class RealDuckChatTest {
         duckChatFeature.keepSession().setRawStoredState(State(enable = false))
         testee.onPrivacyConfigDownloaded()
 
-        testee.openDuckChatWithPrefill(query = "example !ai")
+        testee.openDuckChatWithPrefill(query = "example !ai", entryPoint = DuckChatEntryPoint.DIRECT_URL)
 
         verify(mockBrowserNav).openDuckChat(
             mockContext,
@@ -710,7 +808,7 @@ class RealDuckChatTest {
         duckChatFeature.keepSession().setRawStoredState(State(enable = false))
         testee.onPrivacyConfigDownloaded()
 
-        testee.openDuckChatWithPrefill(query = "example !g")
+        testee.openDuckChatWithPrefill(query = "example !g", entryPoint = DuckChatEntryPoint.DIRECT_URL)
 
         verify(mockBrowserNav).openDuckChat(
             mockContext,
@@ -725,7 +823,7 @@ class RealDuckChatTest {
         duckChatFeature.self().setRawStoredState(State(enable = true, settings = SETTINGS_JSON))
         testee.onPrivacyConfigDownloaded()
 
-        testee.openDuckChatWithPrefill(query = "!ai !image")
+        testee.openDuckChatWithPrefill(query = "!ai !image", entryPoint = DuckChatEntryPoint.DIRECT_URL)
 
         verify(mockBrowserNav).openDuckChat(
             mockContext,
@@ -769,7 +867,7 @@ class RealDuckChatTest {
 
     @Test
     fun whenOpenDuckChatCalledWithQueryAndAutoPromptThenDuckChatOpenedWithQueryAndAutoPrompt() = runTest {
-        testee.openDuckChatWithAutoPrompt(query = "example")
+        testee.openDuckChatWithAutoPrompt(query = "example", entryPoint = DuckChatEntryPoint.SUGGESTION_ASK_AI)
 
         verify(mockBrowserNav).openDuckChat(
             mockContext,
@@ -857,7 +955,7 @@ class RealDuckChatTest {
         testee.onPrivacyConfigDownloaded()
         coroutineRule.testScope.advanceUntilIdle()
 
-        testee.openDuckChat()
+        testee.openDuckChat(DuckChatEntryPoint.PAID_SETTINGS)
 
         verify(mockBrowserNav).openDuckChat(
             mockContext,
@@ -873,7 +971,7 @@ class RealDuckChatTest {
         testee.onPrivacyConfigDownloaded()
         coroutineRule.testScope.advanceUntilIdle()
 
-        testee.openDuckChatWithPrefill(query = "example")
+        testee.openDuckChatWithPrefill(query = "example", entryPoint = DuckChatEntryPoint.DIRECT_URL)
 
         verify(mockBrowserNav).openDuckChat(
             mockContext,
@@ -889,7 +987,7 @@ class RealDuckChatTest {
         testee.onPrivacyConfigDownloaded()
         coroutineRule.testScope.advanceUntilIdle()
 
-        testee.openVoiceDuckChat()
+        testee.openVoiceDuckChat(DuckChatEntryPoint.VOICE)
 
         verify(mockBrowserNav).openDuckChat(
             mockContext,

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -21,6 +21,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.contextual.suggestions.ContextualSuggestedPrompt
@@ -1232,12 +1233,24 @@ class DuckChatContextualViewModelTest {
         }
 
     @Test
-    fun `when full mode requested then expanded pixel is fired`() = runTest {
+    fun `when full mode requested then expanded pixel and entry point are fired`() = runTest {
         testee.onFullModeRequested()
 
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
 
         verify(duckChatPixels).reportContextualSheetExpanded()
+        verify(duckChatInternal).reportDuckChatEntry(DuckChatEntryPoint.CONTEXTUAL_CHAT, opensNewTab = true, hasPrompt = false)
+    }
+
+    @Test
+    fun `when full mode requested with a prompt already sent then entry point reports hasPrompt true`() = runTest {
+        testee.onPromptSent("hello")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onFullModeRequested()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatInternal).reportDuckChatEntry(DuckChatEntryPoint.CONTEXTUAL_CHAT, opensNewTab = true, hasPrompt = true)
     }
 
     @Test
@@ -1604,12 +1617,14 @@ class DuckChatContextualViewModelTest {
         testee.onSheetOpened("tab-1")
         verify(duckChatPixels).reportContextualSheetOpened()
         verify(duckChatPixels).reportContextualAskAboutPageShown()
+        verify(duckChatInternal, never()).reportDuckChatEntry(any(), any(), any())
     }
 
     @Test
     fun `when reopenSheet called then contextual opened pixel is fired`() = runTest {
         testee.onSheetReopened()
         verify(duckChatPixels).reportContextualSheetOpened()
+        verify(duckChatInternal, never()).reportDuckChatEntry(any(), any(), any())
     }
 
     @Test
@@ -2367,6 +2382,12 @@ class DuckChatContextualViewModelTest {
             assertEquals("tab-1", command.sourceTabId)
             cancelAndIgnoreRemainingEvents()
         }
+
+        verify(duckChatInternal, times(1)).reportDuckChatEntry(
+            DuckChatEntryPoint.CHAT_HISTORY_OPEN_CHAT,
+            opensNewTab = true,
+            hasPrompt = false,
+        )
     }
 
     @Test
@@ -2611,9 +2632,14 @@ class DuckChatContextualViewModelTest {
         }
 
         override fun isEnabled(): Boolean = true
-        override fun openDuckChat() = Unit
-        override fun openDuckChatWithAutoPrompt(query: String) = Unit
-        override fun openDuckChatWithPrefill(query: String) = Unit
+        override fun openDuckChat(entryPoint: com.duckduckgo.duckchat.api.DuckChatEntryPoint) = Unit
+        override fun openDuckChatWithAutoPrompt(query: String, entryPoint: com.duckduckgo.duckchat.api.DuckChatEntryPoint) = Unit
+        override fun openDuckChatWithPrefill(query: String, entryPoint: com.duckduckgo.duckchat.api.DuckChatEntryPoint) = Unit
+        override fun reportDuckChatEntry(
+            entryPoint: com.duckduckgo.duckchat.api.DuckChatEntryPoint,
+            opensNewTab: Boolean,
+            hasPrompt: Boolean,
+        ) = Unit
         override fun getDuckChatUrl(
             query: String,
             autoPrompt: Boolean,
@@ -2638,7 +2664,7 @@ class DuckChatContextualViewModelTest {
         override suspend fun isStandaloneMigrationCompleted(): Boolean = true
         override suspend fun setChatSuggestionsUserSetting(enabled: Boolean) = Unit
         override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = flowOf(true)
-        override fun openVoiceDuckChat() { }
+        override fun openVoiceDuckChat(entryPoint: com.duckduckgo.duckchat.api.DuckChatEntryPoint) { }
         override fun isVoiceChatSessionActive(tabId: String): Boolean = false
         override val activeVoiceChatSessions: Flow<Set<String>> = flowOf(emptySet())
         override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = emptyFlow()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
@@ -1192,12 +1193,13 @@ class RealDuckChatJSHelperTest {
                 method,
                 id,
                 data,
+                mode = Mode.CONTEXTUAL,
                 pageContext = viewModel.updatedPageContext,
             ),
         )
 
         verify(mockDataStore).updateUserPreferences(payloadString)
-        verify(mockDuckChat).openNewDuckChatSession()
+        verify(mockDuckChat).openNewDuckChatSession(DuckChatEntryPoint.CONTEXTUAL_CHAT)
     }
 
     @Test
@@ -1212,11 +1214,12 @@ class RealDuckChatJSHelperTest {
                 method,
                 id,
                 null,
+                mode = Mode.CONTEXTUAL,
                 pageContext = viewModel.updatedPageContext,
             ),
         )
         verify(mockDataStore).updateUserPreferences(null)
-        verify(mockDuckChat).openNewDuckChatSession()
+        verify(mockDuckChat).openNewDuckChatSession(DuckChatEntryPoint.CONTEXTUAL_CHAT)
     }
 
     @Test
@@ -1232,11 +1235,42 @@ class RealDuckChatJSHelperTest {
                 method,
                 id,
                 data,
+                mode = Mode.CONTEXTUAL,
                 pageContext = viewModel.updatedPageContext,
             ),
         )
         verify(mockDataStore).updateUserPreferences(null)
-        verify(mockDuckChat).openNewDuckChatSession()
+        verify(mockDuckChat).openNewDuckChatSession(DuckChatEntryPoint.CONTEXTUAL_CHAT)
+    }
+
+    @Test
+    fun whenOpenAIChatFromOtherWebpageThenOpenDuckChatWithDirectUrlEntryPoint() = runTest {
+        assertNull(
+            testee.processJsCallbackMessage(
+                "aiChat",
+                "openAIChat",
+                "123",
+                null,
+                mode = Mode.FULL,
+            ),
+        )
+
+        verify(mockDuckChat).openNewDuckChatSession(DuckChatEntryPoint.DIRECT_URL)
+    }
+
+    @Test
+    fun whenOpenAIChatFromContextualThenOpenDuckChatWithContextualEntryPoint() = runTest {
+        assertNull(
+            testee.processJsCallbackMessage(
+                "aiChat",
+                "openAIChat",
+                "123",
+                null,
+                mode = Mode.CONTEXTUAL,
+            ),
+        )
+
+        verify(mockDuckChat).openNewDuckChatSession(DuckChatEntryPoint.CONTEXTUAL_CHAT)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.duckchat.impl.messaging.fakes
 
 import android.net.Uri
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -44,17 +45,19 @@ class FakeDuckChat(
 
     override fun isEnabled(): Boolean = enabled
 
-    override fun openDuckChat() {
+    override fun openDuckChat(entryPoint: DuckChatEntryPoint) {
         openDuckChatCalls.add(Unit)
     }
 
-    override fun openDuckChatWithAutoPrompt(query: String) {
+    override fun openDuckChatWithAutoPrompt(query: String, entryPoint: DuckChatEntryPoint) {
         openDuckChatWithAutoPromptCalls.add(query)
     }
 
-    override fun openDuckChatWithPrefill(query: String) {
+    override fun openDuckChatWithPrefill(query: String, entryPoint: DuckChatEntryPoint) {
         openDuckChatWithPrefillCalls.add(query)
     }
+
+    override fun reportDuckChatEntry(entryPoint: DuckChatEntryPoint, opensNewTab: Boolean, hasPrompt: Boolean) { }
 
     override fun getDuckChatUrl(
         query: String,
@@ -118,7 +121,7 @@ class FakeDuckChat(
 
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = chatSuggestionsUserSettingEnabled
 
-    override fun openVoiceDuckChat() { }
+    override fun openVoiceDuckChat(entryPoint: DuckChatEntryPoint) { }
     override fun isVoiceChatSessionActive(tabId: String): Boolean = false
     override val activeVoiceChatSessions: Flow<Set<String>> = MutableStateFlow(emptySet())
     override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = emptyFlow()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.duckchat.impl.messaging.fakes
 
 import android.net.Uri
 import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
@@ -63,13 +64,15 @@ class FakeDuckChatInternal(
     var openDuckChatCalls: Int = 0
         private set
 
-    override fun openDuckChat() {
+    override fun openDuckChat(entryPoint: DuckChatEntryPoint) {
         openDuckChatCalls += 1
     }
 
-    override fun openDuckChatWithAutoPrompt(query: String) { }
+    override fun openDuckChatWithAutoPrompt(query: String, entryPoint: DuckChatEntryPoint) { }
 
-    override fun openDuckChatWithPrefill(query: String) { }
+    override fun openDuckChatWithPrefill(query: String, entryPoint: DuckChatEntryPoint) { }
+
+    override fun reportDuckChatEntry(entryPoint: DuckChatEntryPoint, opensNewTab: Boolean, hasPrompt: Boolean) { }
 
     override fun getDuckChatUrl(query: String, autoPrompt: Boolean, sidebar: Boolean): String {
         return "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5"
@@ -148,7 +151,7 @@ class FakeDuckChatInternal(
 
     override fun closeDuckChat() { }
 
-    override fun openNewDuckChatSession() { }
+    override fun openNewDuckChatSession(entryPoint: DuckChatEntryPoint) { }
 
     override fun observeCloseEvent(lifecycleOwner: LifecycleOwner, onClose: () -> Unit) { }
 
@@ -214,7 +217,7 @@ class FakeDuckChatInternal(
 
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = chatSuggestionsUserSettingEnabled
 
-    override fun openVoiceDuckChat() { }
+    override fun openVoiceDuckChat(entryPoint: DuckChatEntryPoint) { }
     override fun isVoiceChatSessionActive(tabId: String): Boolean = false
     override val activeVoiceChatSessions: Flow<Set<String>> = MutableStateFlow(emptySet())
     override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = emptyFlow()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/metric/nativeinput/MetricsNativeInputEventListenerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/metric/nativeinput/MetricsNativeInputEventListenerTest.kt
@@ -16,25 +16,36 @@
 
 package com.duckduckgo.duckchat.impl.metric.nativeinput
 
+import com.duckduckgo.duckchat.api.DuckChatInputModeState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.metric.nativeinput.discovery.InputScreenDiscoveryFunnel
 import com.duckduckgo.duckchat.impl.metric.nativeinput.usage.InputScreenSessionUsageMetric
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 
 class MetricsNativeInputEventListenerTest {
 
     private val duckChatPixels: DuckChatPixels = mock()
+    private val duckChatInputModeState: DuckChatInputModeState = mock()
+    private val inputModeCapability = MutableStateFlow(NativeInputState.InputMode.SEARCH_ONLY)
     private val sessionUsageMetric: InputScreenSessionUsageMetric = mock()
     private val discoveryFunnel: InputScreenDiscoveryFunnel = mock()
 
     private val testee = MetricsNativeInputEventListener(
         duckChatPixels = duckChatPixels,
+        duckChatInputModeState = duckChatInputModeState,
         sessionUsageMetric = sessionUsageMetric,
         discoveryFunnel = discoveryFunnel,
     )
+
+    init {
+        whenever(duckChatInputModeState.inputModeCapability).thenReturn(inputModeCapability)
+    }
 
     @Test
     fun whenSearchSubmittedThenUsageAndDiscoveryMetricsAreUpdated() {
@@ -43,5 +54,23 @@ class MetricsNativeInputEventListenerTest {
         verify(sessionUsageMetric).onSearchSubmitted()
         verify(discoveryFunnel).onSearchSubmitted()
         verifyNoInteractions(duckChatPixels)
+    }
+
+    @Test
+    fun whenNativeInputShownWithToggleCapabilityThenOmnibarShownReportsToggleVisible() {
+        inputModeCapability.value = NativeInputState.InputMode.SEARCH_AND_DUCK_AI
+
+        testee.onNativeInputShown(landscape = false)
+
+        verify(duckChatPixels).fireOmnibarShown(toggleVisible = true)
+    }
+
+    @Test
+    fun whenNativeInputShownWithSearchOnlyCapabilityThenOmnibarShownReportsToggleNotVisible() {
+        inputModeCapability.value = NativeInputState.InputMode.SEARCH_ONLY
+
+        testee.onNativeInputShown(landscape = false)
+
+        verify(duckChatPixels).fireOmnibarShown(toggleVisible = false)
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -376,8 +376,8 @@ class RealDuckChatPixelsTest {
     }
 
     @Test
-    fun `when reportDuckChatEntry then fires count and daily with bounded entry context`() = runTest {
-        testee.reportDuckChatEntry(
+    fun `when sendDuckChatEntryPixel then fires count and daily with bounded entry context`() = runTest {
+        testee.sendDuckChatEntryPixel(
             entryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT,
             opensNewTab = false,
             hasPrompt = true,
@@ -403,7 +403,7 @@ class RealDuckChatPixelsTest {
         DuckChatEntryPoint.entries.forEach { entryPoint ->
             clearInvocations(mockPixel)
 
-            testee.reportDuckChatEntry(entryPoint, opensNewTab = true, hasPrompt = false, duckAiEnabled = true, inputScreenEnabled = true)
+            testee.sendDuckChatEntryPixel(entryPoint, opensNewTab = true, hasPrompt = false, duckAiEnabled = true, inputScreenEnabled = true)
             advanceUntilIdle()
 
             val parameters = argumentCaptor<Map<String, String>>()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -19,8 +19,8 @@ package com.duckduckgo.duckchat.impl.pixel
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
-import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.ReportMetric
 import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_ACCEPT_TERMS_AND_CONDITIONS
 import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_CREATE_NEW_CHAT
@@ -55,6 +55,8 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SETTING_AUTOMATIC_PAGE_CONTENT_DISABLED_DAILY
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SETTING_AUTOMATIC_PAGE_CONTENT_ENABLED_COUNT
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SETTING_AUTOMATIC_PAGE_CONTENT_ENABLED_DAILY
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_COUNT
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_ENTRY_POINT_DAILY
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_KEYBOARD_RETURN_PRESSED
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_OPEN
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_OPEN_HISTORY
@@ -68,9 +70,13 @@ import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -88,7 +94,6 @@ class RealDuckChatPixelsTest {
     private val statisticsUpdater: StatisticsUpdater = mock()
     private val duckAiMetricCollector: DuckAiMetricCollector = mock()
     private val mockTermsOfServiceHandler: DuckChatTermsOfServiceHandler = mock()
-    private val mockDuckChatInternal: DuckChatInternal = mock()
 
     private lateinit var testee: RealDuckChatPixels
 
@@ -99,7 +104,6 @@ class RealDuckChatPixelsTest {
         testee = RealDuckChatPixels(
             pixel = mockPixel,
             duckChatFeatureRepository = mockDuckChatFeatureRepository,
-            duckChatInternal = mockDuckChatInternal,
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             statisticsUpdater = statisticsUpdater,
@@ -372,6 +376,48 @@ class RealDuckChatPixelsTest {
     }
 
     @Test
+    fun `when reportDuckChatEntry then fires count and daily with bounded entry context`() = runTest {
+        testee.reportDuckChatEntry(
+            entryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT,
+            opensNewTab = false,
+            hasPrompt = true,
+            duckAiEnabled = true,
+            inputScreenEnabled = true,
+        )
+
+        advanceUntilIdle()
+
+        val params = mapOf(
+            "source" to "address_bar_prompt",
+            "duck_ai_enabled" to "true",
+            "input_screen_enabled" to "true",
+            "opens_new_tab" to "false",
+            "has_prompt" to "true",
+        )
+        verify(mockPixel).fire(DUCK_CHAT_ENTRY_POINT_COUNT, params)
+        verify(mockPixel).fire(DUCK_CHAT_ENTRY_POINT_DAILY, params, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `every DuckChatEntryPoint maps to its lower snake case wire value`() = runTest {
+        DuckChatEntryPoint.entries.forEach { entryPoint ->
+            clearInvocations(mockPixel)
+
+            testee.reportDuckChatEntry(entryPoint, opensNewTab = true, hasPrompt = false, duckAiEnabled = true, inputScreenEnabled = true)
+            advanceUntilIdle()
+
+            val parameters = argumentCaptor<Map<String, String>>()
+            verify(mockPixel).fire(
+                eq(DUCK_CHAT_ENTRY_POINT_COUNT),
+                parameters.capture(),
+                eq(emptyMap()),
+                eq(Pixel.PixelType.Count),
+            )
+            assertEquals(entryPoint.name.lowercase(), parameters.firstValue["source"])
+        }
+    }
+
+    @Test
     fun `when reportContextualSuggestionsCatalogLoadFailed then fires count and daily`() = runTest {
         testee.reportContextualSuggestionsCatalogLoadFailed()
 
@@ -458,9 +504,7 @@ class RealDuckChatPixelsTest {
 
     @Test
     fun whenFireOmnibarShownWithToggleVisibleThenParamsReflectIt() = runTest {
-        whenever(mockDuckChatInternal.resolvedTogglePosition()).thenReturn(ToggleSelection.SEARCH)
-
-        testee.fireOmnibarShown()
+        testee.fireOmnibarShown(toggleVisible = true)
 
         advanceUntilIdle()
 
@@ -475,9 +519,7 @@ class RealDuckChatPixelsTest {
 
     @Test
     fun whenFireOmnibarShownWithNoToggleThenParamsReflectIt() = runTest {
-        whenever(mockDuckChatInternal.resolvedTogglePosition()).thenReturn(null)
-
-        testee.fireOmnibarShown()
+        testee.fireOmnibarShown(toggleVisible = false)
 
         advanceUntilIdle()
 

--- a/new-tab-page/new-tab-page-impl/build.gradle
+++ b/new-tab-page/new-tab-page-impl/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     ksp project(':anvil-ksp')
     implementation project(":new-tab-page-api")
     implementation project(':browser-api')
+    implementation project(':duckchat-api')
     implementation project(':browser-mode-api')
     implementation project(':common-utils')
     implementation project(':saved-sites-api')

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/NewTabShortcuts.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/NewTabShortcuts.kt
@@ -21,6 +21,8 @@ import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.newtabpage.api.NewTabPageShortcutPlugin
@@ -38,6 +40,7 @@ import javax.inject.Inject
 class AIChatNewTabShortcutPlugin @Inject constructor(
     private val browserNav: BrowserNav,
     private val setting: AIChatNewTabShortcutSetting,
+    private val duckChat: DuckChat,
 ) : NewTabPageShortcutPlugin {
 
     inner class AIChatShortcut() : NewTabShortcut {
@@ -51,6 +54,7 @@ class AIChatNewTabShortcutPlugin @Inject constructor(
     }
 
     override fun onClick(context: Context) {
+        duckChat.reportDuckChatEntry(DuckChatEntryPoint.ADDRESS_BAR_SHORTCUT_CHIP, opensNewTab = false, hasPrompt = false)
         context.startActivity(browserNav.openInCurrentTab(context, AI_CHAT_URL))
     }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -71,6 +71,7 @@ import com.duckduckgo.downloads.api.DownloadsFileActions
 import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
@@ -606,7 +607,7 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
     }
 
     private fun goToDuckAI() {
-        duckChat.openDuckChat()
+        duckChat.openDuckChat(DuckChatEntryPoint.PAID_SETTINGS)
     }
 
     private fun computeUserSettings(id: String) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1217295011063283?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1217382844057496?focus=true
API Proposals URL(s) (if applicable): https://app.asana.com/1/137249556945/project/1212810093780571/task/1217532302535418?focus=true

### Description

Adds Duck.ai entry-point count/daily pixels with five bounded parameters: `source`, `duck_ai_enabled`, `input_screen_enabled`, `opens_new_tab`, and `has_prompt`.

Every public `DuckChat.open*` method requires a `DuckChatEntryPoint` and reports automatically. Navigation paths that bypass those methods call `DuckChat.reportDuckChatEntry` beside the navigation. Restored tabs and selecting an existing tab are passive and do not report.

### Steps to test this PR

Install the internal build; filter Logcat for `Pixel sent:` and `m_aichat_entry_point`. Expect a count event for each action and at most one daily event per day. For every event, verify exactly `source`, `duck_ai_enabled`, `input_screen_enabled`, `opens_new_tab`, and `has_prompt`.

| source | Testing steps | opens_new_tab | has_prompt |
| --- | --- | --- | --- |
| `address_bar_prompt` | **NTP:** **Settings > AI Features > Search & Duck.ai**; select Duck.ai in the address bar, enter `entry test`, submit.<br>**Loaded page:** repeat after opening `https://example.com/`. | NTP: `false`<br>Loaded page: `true` | `true` |
| `address_bar_icon` | **Settings > AI Features > Duck.ai Shortcuts > Address Bar** on and **Search Only** selected. Open an NTP without focusing the bar; tap its Duck.ai icon. | `false` | `false` |
| `suggestion_ask_ai` | Keep Search selected, focus the address bar, type `entry test`, and tap **Ask Duck.ai**. Repeat from an NTP and from `https://example.com/`. | NTP: `false`<br>Loaded page: `true` | `true` |
| `browsing_menu_ntp` | On an NTP, open **⋮ > New Chat**. | `true` | `false` |
| `browsing_menu_webpage` | Open `https://example.com/`, then **⋮ > New Chat**. | `true` | `false` |
| `tab_switcher` | Open the tab switcher and tap its Duck.ai toolbar/FAB button, not an existing Duck.ai tab card. | `true` | `false` |
| `chat_history_new_chat` | With `useNativeStorageChatData` enabled, open **⋮ > Chats**, then tap toolbar **New**; if history is empty, tap **Open Duck.ai**. | `true` | `false` |
| `chat_history_open_chat` | Create a saved chat, open **⋮ > Chats**, and tap its row. Also check an address-bar recent-chat suggestion: NTP reuses the tab; a loaded page opens a new tab. | History/contextual row: `true`<br>Address-bar row: NTP `false`, loaded page `true` | `false` |
| `voice` | **Settings > AI Features > Duck.ai Shortcuts > Voice Chat** on; open **⋮ > Voice Chat**. | `true` | `false` |
| `onboarding` | Clear app data/reinstall, choose the Duck.ai onboarding flow, enter/select a nonblank demo prompt, and continue into Duck.ai. | `true` | `true` |
| `direct_url` | 1. Type and submit `https://duck.ai/`.<br>2. Type and submit `https://duck.ai/chat?duckai=5&q=Hello%20from%20entry%20test&prompt=1`.<br>3. Open `https://duckduckgo.com/duckduckgo-help-pages/duckai/` and tap **Navigate there directly**. | Normal typed/intercepted navigation: `false`;<br>custom-tab handoff: `true` | Plain URL/link: `false`<br>Auto-submit URL: `true` |
| `serp` | Open `https://duckduckgo.com/?q=duck.ai`, then tap the result that opens `https://duck.ai/`. | `false` for normal same-tab navigation | `false` |
| `icon_shortcut` | **Settings > AI Features > Duck.ai Shortcuts > Browser Menu** on; relaunch if needed, long-press the DuckDuckGo app icon, then tap **Duck.ai**. | `true` | `false` |
| `contextual_chat` | Enable `contextualModeKillSwitch` plus completed standalone migration or `contextualMode`; open contextual mode from a loaded page, then use the contextual FE handoff that emits `openAIChat` into full-screen Duck.ai. | `true` | `false` |
| `widget_quick_actions` | Open Duck.ai once, add the **Search and Duck.ai** or **Search and Favorites** widget to the Home screen, then tap the Duck.ai icon in the widget. | `true` | `false` |
| `widget_favorite` | Add `https://duck.ai/` as a Favorite, add the **Search and Favorites** widget, then tap that Duck.ai favorite. | `true` | `false` |
| `system_search` | Set **Settings > AI Features > Search & Duck.ai**; add a DuckDuckGo search widget, tap its search field (not its Duck.ai quick-action icon), enter `entry test`, then tap the Duck.ai icon inside System Search. | `true` | `true` |
| `digital_assistant` | Android **Settings > Apps > Default apps > Digital assistant app > DuckDuckGo**; invoke the assistant gesture/power-key shortcut. | `true` | `false` |
| `deep_link_other` | With the app closed, run `adb shell am start -W -a android.intent.action.VIEW -d 'https://duck.ai/' -p '<applicationId>'`. | `true` | `false` |
| `paid_settings` | From the **Settings** main screen, under **DuckDuckGo Subscription**, tap **Duck.ai**, then **Open Duck.ai**. | `true` | `false` |
| `address_bar_shortcut_chip` | NTP **Customize > Shortcuts**; enable **Duck.ai**, return to the NTP, tap the Duck.ai chip. | `false` with the selected NTP;<br>`true` only in the no-selected-tab fallback | `false` |
| `address_bar_editing_state` | **Settings > AI Features > Search Only** and **Duck.ai Shortcuts > Address Bar** on. Focus an empty address bar, then tap the Duck.ai icon shown in the editing field. | `true` | `false` |



### UI changes
No UI changes



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public DuckChat open APIs now require an entry point, so every Duck.ai launch path is retouched. Risk is telemetry/API-contract, not auth or data handling.
> 
> **Overview**
> Adds **`m_aichat_entry_point`** count/daily pixels so every user-initiated Duck.ai open reports `source`, `duck_ai_enabled`, `input_screen_enabled`, `opens_new_tab`, and `has_prompt`.
> 
> Public `DuckChat.open*` methods now take a `DuckChatEntryPoint` and fire automatically. Paths that navigate without those methods (typed URLs, SERP/in-page links, widgets, shortcuts, onboarding, NTP chip, tab switcher, menus) call `reportDuckChatEntry` next to the navigation. Restored/selected existing tabs stay silent.
> 
> Also converts direct-navigation `duck_ai_enabled` to a boolean, adds `input_screen_enabled` there, and derives omnibar `toggle_visible` from input-mode capability instead of toggle position.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dad76c93d8f94fd3a891139b92f79f2239880b5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->