### PR TITLE
fix(pir): forward CAPTCHA parent scope

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
@@ -64,12 +64,14 @@ sealed class BrokerAction(
         override val id: String,
         val selector: String,
         val captchaType: String? = null,
+        val parent: ParentElement? = null,
     ) : BrokerAction(id)
 
     data class SolveCaptcha(
         override val id: String,
         val selector: String,
         val captchaType: String? = null,
+        val parent: ParentElement? = null,
     ) : BrokerAction(id)
 
     data class Click(

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scripts/RealBrokerActionProcessorTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scripts/RealBrokerActionProcessorTest.kt
@@ -50,6 +50,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -196,6 +197,47 @@ class RealBrokerActionProcessorTest {
             assertTrue(it.getBoolean("findElements"))
             assertEquals(".city", it.getJSONObject("city").getString("selector"))
             assertEquals(".state", it.getJSONObject("state").getString("selector"))
+        }
+    }
+
+    @Test
+    fun whenPushCaptchaActionsThenProfileMatchParentIsForwarded() = runTest {
+        val actions = listOf("getCaptchaInfo", "solveCaptcha")
+
+        actions.forEach { actionType ->
+            val actionJson = """
+                {
+                    "actionType": "$actionType",
+                    "id": "$actionType-1",
+                    "selector": ".g-recaptcha",
+                    "parent": {
+                        "profileMatch": {
+                            "selector": "li",
+                            "profile": {
+                                "name": {
+                                    "selector": ".name"
+                                }
+                            }
+                        }
+                    }
+                }
+            """.trimIndent()
+            val action = moshi.adapter(BrokerAction::class.java).fromJson(actionJson)!!
+
+            testee.pushAction(action, UserProfile())
+        }
+
+        val eventCaptor = argumentCaptor<SubscriptionEventData>()
+        verify(mockJsMessaging, times(actions.size)).sendSubscriptionEvent(eventCaptor.capture())
+
+        eventCaptor.allValues.forEach { event ->
+            val profileMatch = event.params
+                .getJSONObject("state")
+                .getJSONObject("action")
+                .getJSONObject("parent")
+                .getJSONObject("profileMatch")
+            assertEquals("li", profileMatch.getString("selector"))
+            assertEquals(".name", profileMatch.getJSONObject("profile").getJSONObject("name").getString("selector"))
         }
     }
 


### PR DESCRIPTION
### Summary

Asana: https://app.asana.com/1/137249556945/task/1217675906074658

This PR:

* adds `parent` to both Android CAPTCHA action models, because Android drops broker fields that the Kotlin models do not declare.
* passes the matched-row scope to content-scope-scripts for `getCaptchaInfo` and `solveCaptcha`. Android only forwards the field, while content-scope-scripts handles the matching and CAPTCHA logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9077e55ba2104f39b9d68e39eb83a0a977d9f233. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
