### PR TITLE
Wait for async results in HttpsUpgradesTest

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/espresso/JsObjectIdlingResource.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/JsObjectIdlingResource.kt
@@ -28,6 +28,8 @@ class JsObjectIdlingResource(
     private val objectName: String,
     private val timeoutMillis: Long = DEFAULT_TIMEOUT_MILLIS,
     private val failOnTimeout: Boolean = true,
+    // Defaults to waiting for the object to exist; pass an expression to wait for a specific state instead
+    private val condition: String = "typeof $objectName !== 'undefined'",
 ) : IdlingResource {
 
     @Volatile
@@ -54,15 +56,15 @@ class JsObjectIdlingResource(
             isIdle = true
             callback?.onTransitionToIdle()
             if (failOnTimeout) {
-                // fail test if the object is not found within the timeout if opted-in
-                throw AssertionError("JS object '$objectName' did not appear within ${timeoutMillis}ms.")
+                // fail test if the condition is not met within the timeout if opted-in
+                throw AssertionError("JS condition '$condition' was not met within ${timeoutMillis}ms.")
             }
-            logcat { "JsObjectIdlingResource: '$objectName' did not appear within ${timeoutMillis}ms; proceeding" }
+            logcat { "JsObjectIdlingResource: '$condition' was not met within ${timeoutMillis}ms; proceeding" }
             return
         }
 
         webView.evaluateJavascript(
-            "(typeof $objectName !== 'undefined')",
+            "($condition)",
         ) { result ->
             if (result == "true") {
                 isIdle = true

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/GpcTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/GpcTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.espresso.privacy
 
+import android.view.View
 import android.webkit.WebView
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.IdlingResource
@@ -38,6 +39,7 @@ import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.sameInstance
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -66,19 +68,25 @@ class GpcTest {
             webView = it.findViewById(R.id.browserWebView)
         }
 
-        WebViewIdlingResource(webView!!).track()
+        val testWebView = webView!!
+
+        // The top frame header test calls window.open, so a second tab (and WebView) exists while the
+        // test runs; match this tab's WebView explicitly instead of relying on there being only one.
+        val testWebViewMatcher = sameInstance<View>(testWebView)
+
+        WebViewIdlingResource(testWebView).track()
 
         // asserts we have injected css by querying the duckduckgo object
-        JsObjectIdlingResource(webView!!, "window.navigator.duckduckgo").track()
+        JsObjectIdlingResource(testWebView, "window.navigator.duckduckgo").track()
 
-        onWebView()
+        onWebView(testWebViewMatcher)
             .withElement(findElement(ID, "start"))
             .check(webMatches(getText(), containsString("Start test")))
             .perform(webClick())
 
-        WebViewIdlingResource(webView!!).track()
+        WebViewIdlingResource(testWebView).track()
 
-        val results = onWebView()
+        val results = onWebView(testWebViewMatcher)
             .perform(script(SCRIPT))
             .get()
 

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/HttpsUpgradesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/HttpsUpgradesTest.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.mode.InAppNavigation
 import com.duckduckgo.common.utils.isHttps
+import com.duckduckgo.espresso.JsObjectIdlingResource
 import com.duckduckgo.espresso.PrivacyTest
 import com.duckduckgo.espresso.WebViewIdlingResource
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
@@ -80,7 +81,9 @@ class HttpsUpgradesTest {
             .check(webMatches(getText(), containsString("Start test")))
             .perform(webClick())
 
-        val idlingResourceForScript = WebViewIdlingResource(testWebView)
+        // The page loads before its tests finish, so page progress alone does not mean the results are
+        // populated: upgrade-navigation resolves only once the popup it opens posts its URL back.
+        val idlingResourceForScript = JsObjectIdlingResource(testWebView, RESULTS_OBJECT, condition = RESULTS_POPULATED)
         IdlingRegistry.getInstance().register(idlingResourceForScript)
 
         val results = onWebView(testWebViewMatcher)
@@ -105,6 +108,13 @@ class HttpsUpgradesTest {
     companion object {
         const val SCRIPT = "return results.results;"
         val compatibleIds = listOf("upgrade-navigation")
+
+        // The page declares `results` with const, so it is a global binding rather than a window property
+        private const val RESULTS_OBJECT = "results"
+        private val RESULTS_POPULATED = compatibleIds.joinToString(
+            separator = " && ",
+            prefix = "typeof $RESULTS_OBJECT !== 'undefined' && ",
+        ) { "!!$RESULTS_OBJECT.results?.find(r => r.id === '$it')?.value" }
     }
 
     data class TestJson(val status: Int, val value: List<HttpsUpgradeTest>)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217673990175146
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

> [!NOTE]
> Stacked on #9549. Review that one first, this PR targets its branch so a single Privacy Tests run covers both fixes.

### Description

`HttpsUpgradesTest.whenProtectionsAreEnabledHttpsUpgradedCorrectly` fails with `java.lang.AssertionError: Url for upgrade-navigation should be https`. Seen in [this run](https://github.com/duckduckgo/Android/actions/runs/32343711433).

This is a different bug from #9534 and #9549, which were both about `AmbiguousViewMatcherException`. Now that the matcher is pinned, the test no longer throws when the popup tab is open, so it proceeds and reads results that are not ready yet.

The only gate between the click and the read was `WebViewIdlingResource`, which is idle once `webView.progress == 100`. The top frame never navigates while the page's tests run, so progress was already 100 and that gate opened immediately. Meanwhile the page fills each entry asynchronously: `runTests()` pushes `{id, value}` up front and `upgrade-navigation` only resolves once the popup it opens postMessages its URL back (retried on a 500ms interval). Reading before that gives no value, and `it.value?.toUri()?.isHttps ?: false` is then false.

Evidence that the results are still being filled after the gate opens, logged from an instrumented local run 10s after the click:

```
{"id":"upgrade-navigation","value":"https://good.third-party.site/..."},
{"id":"upgrade-iframe","value":"http://..."},
{"id":"upgrade-subrequest","value":"http://..."},
{"id":"upgrade-websocket"}   <- still no value
```

Whether the read wins the race is pure timing, which is why this test passed, flaked and failed on consecutive CI runs with no change on either side.

This PR gates the read on the asserted results being populated. Two properties worth noting:

- a truthy but `http` value still satisfies the condition, so a genuine https-upgrade regression fails the assertion exactly as it does today rather than being masked by the wait
- a result that never arrives now fails naming the unmet condition, instead of the misleading "should be https"

`JsObjectIdlingResource` takes the condition as an optional argument defaulting to its current object-exists check, so `GpcTest`, `FingerprintProtectionTest` and `RequestBlocklistTest` are unaffected.

The condition uses the bare `results` identifier rather than `window.results` because the page declares it with `const`, which creates a global binding and not a window property.

### Steps to test this PR

_HttpsUpgradesTest passes_
- [x] Check the Privacy Tests workflow on this PR is green (it runs the `@PrivacyTest` suite, including this test and GpcTest from #9549)
- [x] Optionally, run it locally against an API 34 emulator, since Espresso 3.6.1 cannot inject events on API 36+: `./gradlew :app:connectedPlayDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.duckduckgo.espresso.privacy.HttpsUpgradesTest`

Note on local verification: the race does not reproduce on a local emulator. The host is fast enough, and `frame.html` is served from the WebView cache, that the handshake always completes inside the Espresso click round-trip, so the read is already populated and the new gate is a no-op of a few ms. Network throttling does not widen the window for the same caching reason. Local runs therefore only confirm the fix is green and cheap when timing is good; the protection itself shows on the slower CI runner.

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Instrumented-test-only change; no production, auth, or data-handling code is modified.
> 
> **Overview**
> Stops `HttpsUpgradesTest` from reading results as soon as the page hits 100% progress. The `upgrade-navigation` case only fills in after a popup posts its URL back, so the old `WebViewIdlingResource` gate often opened too early and the https assertion failed on empty values.
> 
> `JsObjectIdlingResource` now accepts an optional JS `condition` (default still “object exists”). The test waits until `results` has a truthy value for the asserted ids, so a real http upgrade still fails the assertion rather than being hidden by the wait. Other privacy tests keep the default object-exists check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42193ef179a1804feb799227e231c9d422d965b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->