### PR TITLE
Only auto-open in custom tabs for trusted callers

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2866,7 +2866,10 @@ class BrowserTabFragment :
             }
 
             is Command.OpenAppLink -> {
-                openAppLink(it.appLink)
+                val launched = openAppLink(it.appLink)
+                if (it.finishCustomTabOnLaunch && launched) {
+                    finishCustomTab()
+                }
             }
 
             is Command.HandleNonHttpAppLink -> {
@@ -3421,8 +3424,8 @@ class BrowserTabFragment :
         appLinksSnackBar?.show()
     }
 
-    private fun openAppLink(appLink: SpecialUrlDetector.UrlType.AppLink) {
-        appLinksLauncher.openAppLink(context = context, appLink = appLink, viewModel = viewModel)
+    private fun openAppLink(appLink: SpecialUrlDetector.UrlType.AppLink): Boolean {
+        return appLinksLauncher.openAppLink(context = context, appLink = appLink, viewModel = viewModel)
     }
 
     private fun dismissAppLinkSnackBar() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -511,6 +511,7 @@ class BrowserTabFragment :
     private val customTabToolbarColor get() = requireArguments().getInt(CUSTOM_TAB_TOOLBAR_COLOR_ARG)
     private val tabDisplayedInCustomTabScreen get() = requireArguments().getBoolean(TAB_DISPLAYED_IN_CUSTOM_TAB_SCREEN_ARG)
     private val customTabClientPackage get() = requireArguments().getString(CLIENT_PACKAGE_ARG)
+    private val customTabReferrerPackage get() = requireArguments().getString(REFERRER_PACKAGE_ARG)
 
     private val isLaunchedFromExternalApp get() = requireArguments().getBoolean(LAUNCH_FROM_EXTERNAL_EXTRA)
 
@@ -1218,7 +1219,7 @@ class BrowserTabFragment :
         }
 
         if (savedInstanceState == null) {
-            viewModel.setIsCustomTab(tabDisplayedInCustomTabScreen, customTabClientPackage)
+            viewModel.setIsCustomTab(tabDisplayedInCustomTabScreen, customTabClientPackage, customTabReferrerPackage)
             messageFromPreviousTab?.let {
                 processMessage(it)
             }
@@ -5496,6 +5497,7 @@ class BrowserTabFragment :
         private const val SKIP_HOME_ARG = "SKIP_HOME_ARG"
         private const val LAUNCH_FROM_EXTERNAL_EXTRA = "LAUNCH_FROM_EXTERNAL_EXTRA"
         private const val CLIENT_PACKAGE_ARG = "CLIENT_PACKAGE_ARG"
+        private const val REFERRER_PACKAGE_ARG = "REFERRER_PACKAGE_ARG"
 
         const val ADD_SAVED_SITE_FRAGMENT_TAG = "ADD_SAVED_SITE"
         private const val PDF_VIEWER_FRAGMENT_TAG = "PDF_VIEWER"
@@ -5909,6 +5911,7 @@ class BrowserTabFragment :
             toolbarColor: Int,
             isExternal: Boolean,
             clientPackage: String? = null,
+            referrerPackage: String? = null,
         ): BrowserTabFragment {
             val fragment = BrowserTabFragment()
             val args = Bundle()
@@ -5919,6 +5922,9 @@ class BrowserTabFragment :
             args.putBoolean(LAUNCH_FROM_EXTERNAL_EXTRA, isExternal)
             clientPackage?.let {
                 args.putString(CLIENT_PACKAGE_ARG, it)
+            }
+            referrerPackage?.let {
+                args.putString(REFERRER_PACKAGE_ARG, it)
             }
             query.let {
                 args.putString(URL_EXTRA_ARG, query)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -778,8 +778,10 @@ class BrowserTabViewModel @Inject constructor(
     private var refreshTriggerJob: Job? = null
     private var brokenSiteReportTriggerJob: Job? = null
 
-    /** Non-null while this tab is displayed inside a Custom Tab. Captures the verified
-     * calling package (when known) used by [handleAppLink]'s trusted-caller carve-out. */
+    /** Non-null while this tab is displayed inside a Custom Tab. [clientPackage] is the verified
+     * calling package (when known), used by [handleAppLink]'s trusted-caller launch carve-out.
+     * [referrerPackage] is the best-effort, non-verified android-app:// referrer, used only for the
+     * lower-stakes prompt-skip decision in [appLinkClicked], never the launch carve-out. */
     private data class CustomTabContext(val clientPackage: String?, val referrerPackage: String?)
     private var customTab: CustomTabContext? = null
 
@@ -3919,11 +3921,12 @@ class BrowserTabViewModel @Inject constructor(
         when {
             inCustomTab && !customTabsFeature.handleTrustedCallers().isEnabled() -> command.value = OpenAppLink(appLink)
             inCustomTab && appLinksHandler.isTrustedCaller(appLink, callerPackage) -> {
-                command.value = OpenAppLink(appLink)
-                // The handoff opened another app, leaving a stale custom tab behind; finish it.
-                if (customTabsFeature.closeTabAfterTrustedCallerNavigation().isEnabled()) {
-                    command.value = FinishCustomTab
-                }
+                // The handoff opens another app, leaving a stale custom tab behind; close it, but only once
+                // the app has actually launched, so a failed launch doesn't strand the user on a closed tab.
+                command.value = OpenAppLink(
+                    appLink,
+                    finishCustomTabOnLaunch = customTabsFeature.closeTabAfterTrustedCallerNavigation().isEnabled(),
+                )
             }
             inCustomTab && appLinksHandler.isAlwaysTriggerDomain(appLink) -> command.value = OpenAppLink(appLink)
             appSettingsPreferencesStore.showAppLinksPrompt -> command.value = ShowAppLinkPrompt(appLink)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -781,7 +781,7 @@ class BrowserTabViewModel @Inject constructor(
     /** Non-null while this tab is displayed inside a Custom Tab. [clientPackage] is the verified
      * calling package (when known), used by [handleAppLink]'s trusted-caller launch carve-out.
      * [referrerPackage] is the best-effort, non-verified android-app:// referrer, used only for the
-     * lower-stakes prompt-skip decision in [appLinkClicked], never the launch carve-out. */
+     * prompt-skip decision in [appLinkClicked], never the launch carve-out. */
     private data class CustomTabContext(val clientPackage: String?, val referrerPackage: String?)
     private var customTab: CustomTabContext? = null
 
@@ -3915,8 +3915,6 @@ class BrowserTabViewModel @Inject constructor(
 
     private fun appLinkClicked(appLink: AppLink) {
         val inCustomTab = customTab != null
-        // Falls back to the referrer, which is acceptable here (prompt-skip only) but must never reach the
-        // launch carve-out in handleAppLink, which requires the verified session package.
         val callerPackage = customTab?.clientPackage ?: customTab?.referrerPackage
         when {
             inCustomTab && !customTabsFeature.handleTrustedCallers().isEnabled() -> command.value = OpenAppLink(appLink)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -178,6 +178,7 @@ import com.duckduckgo.app.browser.commands.Command.WebViewCompatWebShareRequest
 import com.duckduckgo.app.browser.commands.Command.WebViewError
 import com.duckduckgo.app.browser.commands.NavigationCommand
 import com.duckduckgo.app.browser.customtabs.CustomTabPixelNames
+import com.duckduckgo.app.browser.customtabs.CustomTabsFeature
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.AdditionalDefaultBrowserPrompts
 import com.duckduckgo.app.browser.duckplayer.DUCK_PLAYER_FEATURE_NAME
 import com.duckduckgo.app.browser.duckplayer.DUCK_PLAYER_PAGE_FEATURE_NAME
@@ -525,6 +526,7 @@ class BrowserTabViewModel @Inject constructor(
     private val sitePermissionsManager: SitePermissionsManager,
     private val cameraHardwareChecker: CameraHardwareChecker,
     private val androidBrowserConfig: AndroidBrowserConfigFeature,
+    private val customTabsFeature: CustomTabsFeature,
     private val faviconsFetchingPrompt: FaviconsFetchingPrompt,
     private val subscriptions: Subscriptions,
     private val sslCertificatesFeature: SSLCertificatesFeature,
@@ -778,7 +780,7 @@ class BrowserTabViewModel @Inject constructor(
 
     /** Non-null while this tab is displayed inside a Custom Tab. Captures the verified
      * calling package (when known) used by [handleAppLink]'s trusted-caller carve-out. */
-    private data class CustomTabContext(val clientPackage: String?)
+    private data class CustomTabContext(val clientPackage: String?, val referrerPackage: String?)
     private var customTab: CustomTabContext? = null
 
     private var alreadyShownKeyboard: Boolean = false
@@ -1022,8 +1024,8 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    fun setIsCustomTab(isCustomTab: Boolean, clientPackage: String? = null) {
-        this.customTab = if (isCustomTab) CustomTabContext(clientPackage) else null
+    fun setIsCustomTab(isCustomTab: Boolean, clientPackage: String? = null, referrerPackage: String? = null) {
+        this.customTab = if (isCustomTab) CustomTabContext(clientPackage, referrerPackage) else null
     }
 
     fun onViewReady() {
@@ -3910,11 +3912,22 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun appLinkClicked(appLink: AppLink) {
-        command.value = when {
-            // When in custom tab, always open the app link directly, without prompting.
-            customTab != null -> OpenAppLink(appLink)
-            appSettingsPreferencesStore.showAppLinksPrompt -> ShowAppLinkPrompt(appLink)
-            else -> OpenAppLink(appLink)
+        val inCustomTab = customTab != null
+        // Falls back to the referrer, which is acceptable here (prompt-skip only) but must never reach the
+        // launch carve-out in handleAppLink, which requires the verified session package.
+        val callerPackage = customTab?.clientPackage ?: customTab?.referrerPackage
+        when {
+            inCustomTab && !customTabsFeature.handleTrustedCallers().isEnabled() -> command.value = OpenAppLink(appLink)
+            inCustomTab && appLinksHandler.isTrustedCaller(appLink, callerPackage) -> {
+                command.value = OpenAppLink(appLink)
+                // The handoff opened another app, leaving a stale custom tab behind; finish it.
+                if (customTabsFeature.closeTabAfterTrustedCallerNavigation().isEnabled()) {
+                    command.value = FinishCustomTab
+                }
+            }
+            inCustomTab && appLinksHandler.isAlwaysTriggerDomain(appLink) -> command.value = OpenAppLink(appLink)
+            appSettingsPreferencesStore.showAppLinksPrompt -> command.value = ShowAppLinkPrompt(appLink)
+            else -> command.value = OpenAppLink(appLink)
         }
         appLinksHandler.setUserQueryState(false)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
@@ -40,8 +40,11 @@ interface AppLinksHandler {
     fun isUserQuery(): Boolean
 
     // True when the app link resolves back to the app that opened the custom tab (e.g. an OAuth/login flow
-    // returning to its host app).
-    fun isTrustedCaller(appLink: AppLink, clientPackage: String?): Boolean
+    // returning to its host app). [callerPackage] may be the verified Custom Tabs client package (safe to
+    // gate the launch carve-out on) or a best-effort, spoofable referrer fallback (prompt-skip decisions
+    // only). This is a plain equality check, so the caller must pass a verified value for any security-
+    // sensitive gate.
+    fun isTrustedCaller(appLink: AppLink, callerPackage: String?): Boolean
 
     fun isAlwaysTriggerDomain(appLink: AppLink): Boolean
 }
@@ -122,9 +125,9 @@ class DuckDuckGoAppLinksHandler @Inject constructor(
         return isAUserQuery
     }
 
-    override fun isTrustedCaller(appLink: AppLink, clientPackage: String?): Boolean {
+    override fun isTrustedCaller(appLink: AppLink, callerPackage: String?): Boolean {
         val targetPackage = appLink.appIntent?.component?.packageName ?: appLink.appIntent?.`package`
-        return targetPackage != null && clientPackage == targetPackage
+        return targetPackage != null && callerPackage == targetPackage
     }
 
     override fun isAlwaysTriggerDomain(appLink: AppLink): Boolean {

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
@@ -38,6 +38,12 @@ interface AppLinksHandler {
     fun updatePreviousUrl(urlString: String?)
     fun setUserQueryState(state: Boolean)
     fun isUserQuery(): Boolean
+
+    // True when the app link resolves back to the app that opened the custom tab (e.g. an OAuth/login flow
+    // returning to its host app).
+    fun isTrustedCaller(appLink: AppLink, clientPackage: String?): Boolean
+
+    fun isAlwaysTriggerDomain(appLink: AppLink): Boolean
 }
 
 @ContributesBinding(AppScope::class)
@@ -67,15 +73,13 @@ class DuckDuckGoAppLinksHandler @Inject constructor(
         }
 
         val urlString = appLink.uriString
-        val isAlwaysTriggerDomain = alwaysTriggerList.contains(urlString.extractDomain())
+        val isAlwaysTriggerDomain = isAlwaysTriggerDomain(appLink)
 
         // HTTP navigations shouldn't launch apps unless started with a user gesture. That is unless
         // the "trusted-caller" carve-out applies - if an app opens a Custom Tab, App Links that
         // point back to that same app should be allowed even without user interaction.
         if (!isAlwaysTriggerDomain && androidBrowserConfigFeature.customTabEndlessLoopFix().isEnabled()) {
-            val targetPackage = appLink.appIntent?.component?.packageName ?: appLink.appIntent?.`package`
-            val isTrustedCaller = targetPackage != null && clientPackage == targetPackage
-            if (!hasGesture && !isTrustedCaller) {
+            if (!hasGesture && !isTrustedCaller(appLink, clientPackage)) {
                 return false
             }
         }
@@ -116,5 +120,14 @@ class DuckDuckGoAppLinksHandler @Inject constructor(
 
     override fun isUserQuery(): Boolean {
         return isAUserQuery
+    }
+
+    override fun isTrustedCaller(appLink: AppLink, clientPackage: String?): Boolean {
+        val targetPackage = appLink.appIntent?.component?.packageName ?: appLink.appIntent?.`package`
+        return targetPackage != null && clientPackage == targetPackage
+    }
+
+    override fun isAlwaysTriggerDomain(appLink: AppLink): Boolean {
+        return alwaysTriggerList.contains(appLink.uriString.extractDomain())
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
@@ -39,13 +39,19 @@ interface AppLinksHandler {
     fun setUserQueryState(state: Boolean)
     fun isUserQuery(): Boolean
 
-    // True when the app link resolves back to the app that opened the custom tab (e.g. an OAuth/login flow
-    // returning to its host app). [callerPackage] may be the verified Custom Tabs client package (safe to
-    // gate the launch carve-out on) or a best-effort, spoofable referrer fallback (prompt-skip decisions
-    // only). This is a plain equality check, so the caller must pass a verified value for any security-
-    // sensitive gate.
+    /**
+     * True when the app link resolves back to the app that opened the custom tab
+     *
+     * @param appLink the app link being evaluated.
+     * @param callerPackage package that launched the custom tab (if any).
+     */
     fun isTrustedCaller(appLink: AppLink, callerPackage: String?): Boolean
 
+    /**
+     * True when the app link's domain always launches its app, bypassing the usual user-gesture and prompt requirements.
+     *
+     * @param appLink the app link being evaluated.
+     */
     fun isAlwaysTriggerDomain(appLink: AppLink): Boolean
 }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksLauncher.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksLauncher.kt
@@ -33,19 +33,20 @@ import logcat.logcat
 import javax.inject.Inject
 
 interface AppLinksLauncher {
-    fun openAppLink(context: Context?, appLink: AppLink, viewModel: BrowserTabViewModel)
+    fun openAppLink(context: Context?, appLink: AppLink, viewModel: BrowserTabViewModel): Boolean
 }
 
 @ContributesBinding(AppScope::class)
 class DuckDuckGoAppLinksLauncher @Inject constructor() : AppLinksLauncher {
 
-    override fun openAppLink(context: Context?, appLink: AppLink, viewModel: BrowserTabViewModel) {
-        if (context == null) return
-        appLink.appIntent?.let {
+    override fun openAppLink(context: Context?, appLink: AppLink, viewModel: BrowserTabViewModel): Boolean {
+        if (context == null) return false
+        val launched = appLink.appIntent?.let {
             configureIntent(it, context)
             startActivityOrQuietlyFail(context, it)
-        }
+        } ?: false
         viewModel.clearPreviousUrl()
+        return launched
     }
 
     private fun configureIntent(
@@ -63,13 +64,16 @@ class DuckDuckGoAppLinksLauncher @Inject constructor() : AppLinksLauncher {
         intent.putExtra(EXTRA_APPLICATION_ID, context.packageName)
     }
 
-    private fun startActivityOrQuietlyFail(context: Context, intent: Intent) {
-        try {
+    private fun startActivityOrQuietlyFail(context: Context, intent: Intent): Boolean {
+        return try {
             context.startActivity(intent)
+            true
         } catch (exception: ActivityNotFoundException) {
             logcat(ERROR) { "Activity not found: ${exception.asLog()}" }
+            false
         } catch (exception: SecurityException) {
             showToast(context, R.string.unableToOpenLink)
+            false
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -229,6 +229,7 @@ sealed class Command {
 
     class OpenAppLink(
         val appLink: AppLink,
+        val finishCustomTabOnLaunch: Boolean = false,
     ) : Command()
 
     class ExtractUrlFromCloakedAmpLink(

--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
@@ -102,7 +102,8 @@ class CustomTabActivity : DuckDuckGoActivity() {
     ) {
         val tabId = "${CustomTabViewModel.CUSTOM_TAB_NAME_PREFIX}${UUID.randomUUID()}"
         val clientPackage = intent.getStringExtra(CLIENT_PACKAGE_EXTRA)
-        val newFragment = BrowserTabFragment.newInstanceForCustomTab(tabId, null, true, toolbarColor, isExternal, clientPackage)
+        val referrerPackage = intent.getStringExtra(REFERRER_PACKAGE_EXTRA)
+        val newFragment = BrowserTabFragment.newInstanceForCustomTab(tabId, null, true, toolbarColor, isExternal, clientPackage, referrerPackage)
         val transaction = supportFragmentManager.beginTransaction()
         transaction.hide(currentFragment)
         transaction.add(R.id.fragmentTabContainer, newFragment, tabId)
@@ -129,6 +130,7 @@ class CustomTabActivity : DuckDuckGoActivity() {
             toolbarColor = viewState.toolbarColor,
             isExternal = intent.getBooleanExtra(LAUNCH_FROM_EXTERNAL_EXTRA, false),
             clientPackage = intent.getStringExtra(CLIENT_PACKAGE_EXTRA),
+            referrerPackage = intent.getStringExtra(REFERRER_PACKAGE_EXTRA),
         )
         val transaction = supportFragmentManager.beginTransaction()
         transaction.replace(R.id.fragmentTabContainer, fragment, viewState.tabId)
@@ -143,6 +145,7 @@ class CustomTabActivity : DuckDuckGoActivity() {
             toolbarColor: Int?,
             isExternal: Boolean,
             clientPackage: String? = null,
+            referrerPackage: String? = null,
         ): Intent {
             return Intent(context, CustomTabActivity::class.java).apply {
                 addFlags(flags)
@@ -154,10 +157,14 @@ class CustomTabActivity : DuckDuckGoActivity() {
                 if (clientPackage != null) {
                     putExtra(CLIENT_PACKAGE_EXTRA, clientPackage)
                 }
+                if (referrerPackage != null) {
+                    putExtra(REFERRER_PACKAGE_EXTRA, referrerPackage)
+                }
             }
         }
         private const val LAUNCH_FROM_EXTERNAL_EXTRA = "LAUNCH_FROM_EXTERNAL_EXTRA"
         private const val CLIENT_PACKAGE_EXTRA = "CLIENT_PACKAGE_EXTRA"
+        private const val REFERRER_PACKAGE_EXTRA = "REFERRER_PACKAGE_EXTRA"
     }
 
     private fun configureOnBackPressedListener() {

--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabsFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabsFeature.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.customtabs
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "customTabs",
+)
+interface CustomTabsFeature {
+
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun self(): Toggle
+
+    /**
+     * When enabled, app links in a custom tab honor the "Open Links in Apps" setting except when the link
+     * returns to the app that opened the tab (a trusted caller) or is an always-trigger domain. When disabled,
+     * the legacy behavior applies: every app link in a custom tab opens directly, without prompting.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun handleTrustedCallers(): Toggle
+
+    /**
+     * When enabled, a custom tab is closed after handing off a trusted-caller navigation (e.g. an
+     * OAuth/login flow returning to the app that opened the tab), so the user doesn't return to a stale tab.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun closeTabAfterTrustedCallerNavigation(): Toggle
+}

--- a/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherActivity.kt
@@ -88,11 +88,14 @@ class IntentDispatcherActivity : DuckDuckGoActivity() {
     }
 
     private fun showCustomTab(intentText: String?, toolbarColor: Int?, isExternal: Boolean) {
-        // The verified calling package (non-null only when the launcher bound the
-        // CustomTabsService). Carried forward as an intent extra so BrowserTabViewModel can
-        // apply the trusted-caller carve-out in handleAppLink.
+        // The verified calling package: non-null only when the launcher bound the CustomTabsService, so it is
+        // safe to gate security-sensitive behavior (the gesture-less app-link launch carve-out) on it.
         val clientPackage = CustomTabsSessionToken.getSessionTokenFromIntent(intent)
             ?.let { customTabsSessionRegistry.lookupClientPackage(it) }
+        // Best-effort caller identity from the android-app:// referrer, available even when the launcher never
+        // bound the service (e.g. apps that open a login Custom Tab without a session). The launcher can set the
+        // referrer, so this is used only for the low-stakes prompt-skip decision, never the launch carve-out.
+        val referrerPackage = referrer?.takeIf { it.scheme == "android-app" }?.host
 
         // As customizations we only support the toolbar color at the moment.
         startActivity(
@@ -103,6 +106,7 @@ class IntentDispatcherActivity : DuckDuckGoActivity() {
                 toolbarColor = toolbarColor,
                 isExternal = isExternal,
                 clientPackage = clientPackage,
+                referrerPackage = referrerPackage,
             ),
         )
 

--- a/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherActivity.kt
@@ -88,8 +88,9 @@ class IntentDispatcherActivity : DuckDuckGoActivity() {
     }
 
     private fun showCustomTab(intentText: String?, toolbarColor: Int?, isExternal: Boolean) {
-        // The verified calling package: non-null only when the launcher bound the CustomTabsService, so it is
-        // safe to gate security-sensitive behavior (the gesture-less app-link launch carve-out) on it.
+        // The verified calling package (non-null only when the launcher bound the
+        // CustomTabsService). Carried forward as an intent extra so BrowserTabViewModel can
+        // apply the trusted-caller carve-out in handleAppLink.
         val clientPackage = CustomTabsSessionToken.getSessionTokenFromIntent(intent)
             ?.let { customTabsSessionRegistry.lookupClientPackage(it) }
         // Best-effort caller identity from the android-app:// referrer, available even when the launcher never

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -106,6 +106,7 @@ import com.duckduckgo.app.browser.commands.Command.ShowKeyboard
 import com.duckduckgo.app.browser.commands.NavigationCommand
 import com.duckduckgo.app.browser.commands.NavigationCommand.Navigate
 import com.duckduckgo.app.browser.customtabs.CustomTabPixelNames
+import com.duckduckgo.app.browser.customtabs.CustomTabsFeature
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.AdditionalDefaultBrowserPrompts
 import com.duckduckgo.app.browser.duckplayer.DUCK_PLAYER_FEATURE_NAME
 import com.duckduckgo.app.browser.duckplayer.DUCK_PLAYER_PAGE_FEATURE_NAME
@@ -630,6 +631,7 @@ class BrowserTabViewModelTest {
     private val protectionTogglePlugin = FakePrivacyProtectionTogglePlugin()
     private val protectionTogglePluginPoint = FakePluginPoint(protectionTogglePlugin)
     private var fakeAndroidConfigBrowserFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+    private val fakeCustomTabsFeature = FakeFeatureToggleFactory.create(CustomTabsFeature::class.java)
     private val mockAutocompleteTabsFeature: AutocompleteTabsFeature = mock()
     private val fakeCustomHeadersPlugin = FakeCustomHeadersProvider(emptyMap())
     private val mockToggleReports: ToggleReports = mock()
@@ -752,6 +754,8 @@ class BrowserTabViewModelTest {
             fakeAutocompleteHistoryDeleteFeature.self().setRawStoredState(State(enable = true))
 
             fakeRememberDesktopModeFeature.self().setRawStoredState(State(enable = true))
+
+            fakeCustomTabsFeature.handleTrustedCallers().setRawStoredState(State(enable = true))
 
             whenever(mockDuckChatJSHelper.enrichPageContextIfPossible(any(), any())).thenAnswer { it.getArgument<String>(1) }
             whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
@@ -984,6 +988,7 @@ class BrowserTabViewModelTest {
                 sitePermissionsManager = mockSitePermissionsManager,
                 cameraHardwareChecker = cameraHardwareChecker,
                 androidBrowserConfig = fakeAndroidConfigBrowserFeature,
+                customTabsFeature = fakeCustomTabsFeature,
                 faviconsFetchingPrompt = mockFaviconFetchingPrompt,
                 subscriptions = subscriptions,
                 sslCertificatesFeature = mockSSLCertificatesFeature,
@@ -5409,6 +5414,158 @@ class BrowserTabViewModelTest {
         appLinkCaptor.lastValue.invoke()
         assertCommandIssued<Command.OpenAppLink>()
         verify(mockAppLinksHandler).setUserQueryState(false)
+    }
+
+    @Test
+    fun whenAppLinkClickedInCustomTabAndTrustedCallerThenOpenAppLinkDirectlyEvenWhenPromptEnabled() {
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
+        whenever(ctaViewModelMockSettingsStore.showAppLinksPrompt).thenReturn(true)
+        whenever(mockAppLinksHandler.isTrustedCaller(eq(urlType), eq("com.example.app"))).thenReturn(true)
+        testee.setIsCustomTab(isCustomTab = true, clientPackage = "com.example.app")
+        testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
+        verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), any(), any(), any(), appLinkCaptor.capture())
+        appLinkCaptor.lastValue.invoke()
+        assertCommandIssued<Command.OpenAppLink>()
+    }
+
+    @Test
+    fun whenAppLinkClickedInCustomTabAndNotTrustedCallerAndPromptEnabledThenShowAppLinkPrompt() {
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
+        whenever(ctaViewModelMockSettingsStore.showAppLinksPrompt).thenReturn(true)
+        whenever(mockAppLinksHandler.isTrustedCaller(eq(urlType), eq("com.example.app"))).thenReturn(false)
+        testee.setIsCustomTab(isCustomTab = true, clientPackage = "com.example.app")
+        testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
+        verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), any(), any(), any(), appLinkCaptor.capture())
+        appLinkCaptor.lastValue.invoke()
+        assertCommandIssued<Command.ShowAppLinkPrompt>()
+    }
+
+    @Test
+    fun whenAppLinkClickedInCustomTabAndHandleTrustedCallersDisabledThenAlwaysOpenDirectlyEvenWhenPromptEnabled() {
+        fakeCustomTabsFeature.handleTrustedCallers().setRawStoredState(State(enable = false))
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
+        whenever(ctaViewModelMockSettingsStore.showAppLinksPrompt).thenReturn(true)
+        whenever(mockAppLinksHandler.isTrustedCaller(eq(urlType), eq("com.example.app"))).thenReturn(false)
+        testee.setIsCustomTab(isCustomTab = true, clientPackage = "com.example.app")
+        testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
+        verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), any(), any(), any(), appLinkCaptor.capture())
+        appLinkCaptor.lastValue.invoke()
+        assertCommandIssued<Command.OpenAppLink>()
+        assertCommandNotIssued<Command.ShowAppLinkPrompt>()
+        assertCommandNotIssued<Command.FinishCustomTab>()
+    }
+
+    @Test
+    fun whenAppLinkClickedInCustomTabWithNoSessionButMatchingReferrerThenOpenDirectlyWithoutPrompt() {
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
+        whenever(ctaViewModelMockSettingsStore.showAppLinksPrompt).thenReturn(true)
+        whenever(mockAppLinksHandler.isTrustedCaller(eq(urlType), eq("com.example.app"))).thenReturn(true)
+        testee.setIsCustomTab(isCustomTab = true, clientPackage = null, referrerPackage = "com.example.app")
+        testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
+        verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), anyOrNull(), any(), any(), appLinkCaptor.capture())
+        appLinkCaptor.lastValue.invoke()
+        assertCommandIssued<Command.OpenAppLink>()
+        assertCommandNotIssued<Command.ShowAppLinkPrompt>()
+    }
+
+    @Test
+    fun whenAppLinkClickedInCustomTabWithNoSessionAndNoReferrerThenHonorPromptSetting() {
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
+        whenever(ctaViewModelMockSettingsStore.showAppLinksPrompt).thenReturn(true)
+        whenever(mockAppLinksHandler.isTrustedCaller(eq(urlType), anyOrNull())).thenReturn(false)
+        testee.setIsCustomTab(isCustomTab = true, clientPackage = null, referrerPackage = null)
+        testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
+        verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), anyOrNull(), any(), any(), appLinkCaptor.capture())
+        appLinkCaptor.lastValue.invoke()
+        assertCommandIssued<Command.ShowAppLinkPrompt>()
+    }
+
+    @Test
+    fun whenHandleAppLinkCalledInCustomTabThenVerifiedClientPackageForwardedToHandlerNotReferrer() {
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
+        testee.setIsCustomTab(isCustomTab = true, clientPackage = null, referrerPackage = "com.example.app")
+        testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = false)
+        // The launch carve-out must receive only the verified (session) package, never the referrer fallback.
+        verify(mockAppLinksHandler).handleAppLink(eq(true), eq(urlType), eq(false), eq(null), any(), any(), appLinkCaptor.capture())
+    }
+
+    @Test
+    fun whenAppLinkClickedInCustomTabAndHandleTrustedCallersDisabledThenCloseTabFeatureIsInertEvenForTrustedCaller() {
+        fakeCustomTabsFeature.handleTrustedCallers().setRawStoredState(State(enable = false))
+        fakeCustomTabsFeature.closeTabAfterTrustedCallerNavigation().setRawStoredState(State(enable = true))
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
+        whenever(mockAppLinksHandler.isTrustedCaller(eq(urlType), eq("com.example.app"))).thenReturn(true)
+        testee.setIsCustomTab(isCustomTab = true, clientPackage = "com.example.app")
+        testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
+        verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), any(), any(), any(), appLinkCaptor.capture())
+        appLinkCaptor.lastValue.invoke()
+        assertCommandIssued<Command.OpenAppLink>()
+        assertCommandNotIssued<Command.FinishCustomTab>()
+    }
+
+    @Test
+    fun whenAppLinkClickedInCustomTabAndTrustedCallerAndCloseTabFeatureEnabledThenFinishCustomTabAfterOpen() {
+        fakeCustomTabsFeature.closeTabAfterTrustedCallerNavigation().setRawStoredState(State(enable = true))
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
+        whenever(mockAppLinksHandler.isTrustedCaller(eq(urlType), eq("com.example.app"))).thenReturn(true)
+        testee.setIsCustomTab(isCustomTab = true, clientPackage = "com.example.app")
+        testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
+        verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), any(), any(), any(), appLinkCaptor.capture())
+        appLinkCaptor.lastValue.invoke()
+        assertCommandIssued<Command.OpenAppLink>()
+        assertCommandIssued<Command.FinishCustomTab>()
+    }
+
+    @Test
+    fun whenAppLinkClickedInCustomTabAndTrustedCallerButCloseTabFeatureDisabledThenDoNotFinishCustomTab() {
+        fakeCustomTabsFeature.closeTabAfterTrustedCallerNavigation().setRawStoredState(State(enable = false))
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
+        whenever(mockAppLinksHandler.isTrustedCaller(eq(urlType), eq("com.example.app"))).thenReturn(true)
+        testee.setIsCustomTab(isCustomTab = true, clientPackage = "com.example.app")
+        testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
+        verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), any(), any(), any(), appLinkCaptor.capture())
+        appLinkCaptor.lastValue.invoke()
+        assertCommandIssued<Command.OpenAppLink>()
+        assertCommandNotIssued<Command.FinishCustomTab>()
+    }
+
+    @Test
+    fun whenAppLinkClickedInCustomTabAndAlwaysTriggerDomainAndCloseTabFeatureEnabledThenDoNotFinishCustomTab() {
+        fakeCustomTabsFeature.closeTabAfterTrustedCallerNavigation().setRawStoredState(State(enable = true))
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
+        whenever(mockAppLinksHandler.isTrustedCaller(eq(urlType), eq("com.example.app"))).thenReturn(false)
+        whenever(mockAppLinksHandler.isAlwaysTriggerDomain(eq(urlType))).thenReturn(true)
+        testee.setIsCustomTab(isCustomTab = true, clientPackage = "com.example.app")
+        testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
+        verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), any(), any(), any(), appLinkCaptor.capture())
+        appLinkCaptor.lastValue.invoke()
+        assertCommandIssued<Command.OpenAppLink>()
+        assertCommandNotIssued<Command.FinishCustomTab>()
+    }
+
+    @Test
+    fun whenAppLinkClickedInCustomTabAndAlwaysTriggerDomainThenOpenAppLinkDirectlyEvenWhenPromptEnabled() {
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
+        whenever(ctaViewModelMockSettingsStore.showAppLinksPrompt).thenReturn(true)
+        whenever(mockAppLinksHandler.isTrustedCaller(eq(urlType), eq("com.example.app"))).thenReturn(false)
+        whenever(mockAppLinksHandler.isAlwaysTriggerDomain(eq(urlType))).thenReturn(true)
+        testee.setIsCustomTab(isCustomTab = true, clientPackage = "com.example.app")
+        testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
+        verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), any(), any(), any(), appLinkCaptor.capture())
+        appLinkCaptor.lastValue.invoke()
+        assertCommandIssued<Command.OpenAppLink>()
+    }
+
+    @Test
+    fun whenAppLinkClickedInCustomTabAndNotTrustedCallerAndPromptDisabledThenOpenAppLink() {
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
+        whenever(ctaViewModelMockSettingsStore.showAppLinksPrompt).thenReturn(false)
+        whenever(mockAppLinksHandler.isTrustedCaller(eq(urlType), eq("com.example.app"))).thenReturn(false)
+        testee.setIsCustomTab(isCustomTab = true, clientPackage = "com.example.app")
+        testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
+        verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), any(), any(), any(), appLinkCaptor.capture())
+        appLinkCaptor.lastValue.invoke()
+        assertCommandIssued<Command.OpenAppLink>()
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5450,9 +5450,10 @@ class BrowserTabViewModelTest {
         testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
         verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), any(), any(), any(), appLinkCaptor.capture())
         appLinkCaptor.lastValue.invoke()
-        assertCommandIssued<Command.OpenAppLink>()
+        assertCommandIssued<Command.OpenAppLink> {
+            assertFalse(finishCustomTabOnLaunch)
+        }
         assertCommandNotIssued<Command.ShowAppLinkPrompt>()
-        assertCommandNotIssued<Command.FinishCustomTab>()
     }
 
     @Test
@@ -5499,12 +5500,13 @@ class BrowserTabViewModelTest {
         testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
         verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), any(), any(), any(), appLinkCaptor.capture())
         appLinkCaptor.lastValue.invoke()
-        assertCommandIssued<Command.OpenAppLink>()
-        assertCommandNotIssued<Command.FinishCustomTab>()
+        assertCommandIssued<Command.OpenAppLink> {
+            assertFalse(finishCustomTabOnLaunch)
+        }
     }
 
     @Test
-    fun whenAppLinkClickedInCustomTabAndTrustedCallerAndCloseTabFeatureEnabledThenFinishCustomTabAfterOpen() {
+    fun whenAppLinkClickedInCustomTabAndTrustedCallerAndCloseTabFeatureEnabledThenOpenAppLinkRequestsFinishOnLaunch() {
         fakeCustomTabsFeature.closeTabAfterTrustedCallerNavigation().setRawStoredState(State(enable = true))
         val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
         whenever(mockAppLinksHandler.isTrustedCaller(eq(urlType), eq("com.example.app"))).thenReturn(true)
@@ -5512,12 +5514,13 @@ class BrowserTabViewModelTest {
         testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
         verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), any(), any(), any(), appLinkCaptor.capture())
         appLinkCaptor.lastValue.invoke()
-        assertCommandIssued<Command.OpenAppLink>()
-        assertCommandIssued<Command.FinishCustomTab>()
+        assertCommandIssued<Command.OpenAppLink> {
+            assertTrue(finishCustomTabOnLaunch)
+        }
     }
 
     @Test
-    fun whenAppLinkClickedInCustomTabAndTrustedCallerButCloseTabFeatureDisabledThenDoNotFinishCustomTab() {
+    fun whenAppLinkClickedInCustomTabAndTrustedCallerButCloseTabFeatureDisabledThenOpenAppLinkDoesNotRequestFinish() {
         fakeCustomTabsFeature.closeTabAfterTrustedCallerNavigation().setRawStoredState(State(enable = false))
         val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
         whenever(mockAppLinksHandler.isTrustedCaller(eq(urlType), eq("com.example.app"))).thenReturn(true)
@@ -5525,12 +5528,13 @@ class BrowserTabViewModelTest {
         testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
         verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), any(), any(), any(), appLinkCaptor.capture())
         appLinkCaptor.lastValue.invoke()
-        assertCommandIssued<Command.OpenAppLink>()
-        assertCommandNotIssued<Command.FinishCustomTab>()
+        assertCommandIssued<Command.OpenAppLink> {
+            assertFalse(finishCustomTabOnLaunch)
+        }
     }
 
     @Test
-    fun whenAppLinkClickedInCustomTabAndAlwaysTriggerDomainAndCloseTabFeatureEnabledThenDoNotFinishCustomTab() {
+    fun whenAppLinkClickedInCustomTabAndAlwaysTriggerDomainAndCloseTabFeatureEnabledThenOpenAppLinkDoesNotRequestFinish() {
         fakeCustomTabsFeature.closeTabAfterTrustedCallerNavigation().setRawStoredState(State(enable = true))
         val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
         whenever(mockAppLinksHandler.isTrustedCaller(eq(urlType), eq("com.example.app"))).thenReturn(false)
@@ -5539,8 +5543,9 @@ class BrowserTabViewModelTest {
         testee.handleAppLink(urlType, isForMainFrame = true, hasGesture = true)
         verify(mockAppLinksHandler).handleAppLink(any(), eq(urlType), any(), any(), any(), any(), appLinkCaptor.capture())
         appLinkCaptor.lastValue.invoke()
-        assertCommandIssued<Command.OpenAppLink>()
-        assertCommandNotIssued<Command.FinishCustomTab>()
+        assertCommandIssued<Command.OpenAppLink> {
+            assertFalse(finishCustomTabOnLaunch)
+        }
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/applinks/DuckDuckGoAppLinksHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/applinks/DuckDuckGoAppLinksHandlerTest.kt
@@ -521,4 +521,37 @@ class DuckDuckGoAppLinksHandlerTest {
         )
         verify(mockCallback).invoke()
     }
+
+    @Test
+    fun whenTrustedCallerViaComponentPackageMatchesClientThenReturnTrue() {
+        val appIntent = Intent().setComponent(ComponentName("com.example.app", "com.example.app.MainActivity"))
+        assertTrue(testee.isTrustedCaller(AppLink(uriString = "example.com", appIntent = appIntent), "com.example.app"))
+    }
+
+    @Test
+    fun whenTrustedCallerViaIntentPackageMatchesClientThenReturnTrue() {
+        val appIntent = Intent().setPackage("com.example.app")
+        assertTrue(testee.isTrustedCaller(AppLink(uriString = "example.com", appIntent = appIntent), "com.example.app"))
+    }
+
+    @Test
+    fun whenTargetPackageDoesNotMatchClientThenReturnFalse() {
+        val appIntent = Intent().setPackage("com.example.app")
+        assertFalse(testee.isTrustedCaller(AppLink(uriString = "example.com", appIntent = appIntent), "com.different.app"))
+    }
+
+    @Test
+    fun whenTargetPackageIsNullThenReturnFalse() {
+        assertFalse(testee.isTrustedCaller(AppLink(uriString = "example.com", appIntent = null), "com.example.app"))
+    }
+
+    @Test
+    fun whenDomainInAlwaysTriggerListThenIsAlwaysTriggerDomainReturnsTrue() {
+        assertTrue(testee.isAlwaysTriggerDomain(AppLink(uriString = "https://app.digid.nl/path")))
+    }
+
+    @Test
+    fun whenDomainNotInAlwaysTriggerListThenIsAlwaysTriggerDomainReturnsFalse() {
+        assertFalse(testee.isAlwaysTriggerDomain(AppLink(uriString = "https://example.com/path")))
+    }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/applinks/DuckDuckGoAppLinksLauncherTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/applinks/DuckDuckGoAppLinksLauncherTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.applinks
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.browser.BrowserTabViewModel
+import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.AppLink
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class DuckDuckGoAppLinksLauncherTest {
+
+    private val mockContext: Context = mock()
+    private val mockViewModel: BrowserTabViewModel = mock()
+    private val testee = DuckDuckGoAppLinksLauncher()
+
+    @Before
+    fun setup() {
+        whenever(mockContext.packageName).thenReturn("com.duckduckgo.test")
+    }
+
+    @Test
+    fun whenAppLinkLaunchesSuccessfullyThenReturnsTrue() {
+        val appLink = AppLink(uriString = "example.com", appIntent = Intent())
+        assertTrue(testee.openAppLink(mockContext, appLink, mockViewModel))
+        verify(mockViewModel).clearPreviousUrl()
+    }
+
+    @Test
+    fun whenStartActivityThrowsActivityNotFoundThenReturnsFalse() {
+        doThrow(ActivityNotFoundException()).whenever(mockContext).startActivity(any())
+        val appLink = AppLink(uriString = "example.com", appIntent = Intent())
+        assertFalse(testee.openAppLink(mockContext, appLink, mockViewModel))
+        verify(mockViewModel).clearPreviousUrl()
+    }
+
+    @Test
+    fun whenAppIntentIsNullThenReturnsFalseAndDoesNotStartActivity() {
+        val appLink = AppLink(uriString = "example.com", appIntent = null)
+        assertFalse(testee.openAppLink(mockContext, appLink, mockViewModel))
+        verify(mockContext, never()).startActivity(any())
+        verify(mockViewModel).clearPreviousUrl()
+    }
+
+    @Test
+    fun whenContextIsNullThenReturnsFalse() {
+        val appLink = AppLink(uriString = "example.com", appIntent = Intent())
+        assertFalse(testee.openAppLink(null, appLink, mockViewModel))
+        verifyNoInteractions(mockViewModel)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1217644628446912?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

### Steps to test this PR

_Pre-requisites_
- [x] Make DDG the default browser
- [x] Install the blink app
- [x] Install the YouTube app
- [x] Go to settings > permissions > Open Links in Apps, and make sure "Ask Every Time" is selected

_Flags on -> opens trusted caller with no prompt_
- [x] Open the Blink app and login (credentials and instructions in linked Asana task)
- [x] No prompt to open in app is shown after login and Blink app opens normally
- [x] Open DDG app, no residual custom tab remains

_Flags on -> asks on other cases_

- [x] Open dev settings -> custom tabs 
- [x] Load mkbhd.com
- [x] Scroll down to the "videos" section and click on a video
- [x] Check snackbar asking whether to open in app is shown

_Flags off -> opens trusted caller with no prompt_
- [x] Disable `customTabs` > `handleTrustedCallers` and `customTabs` > `closeTabAfterTrustedCallerNavigation`
- [x] Install the blink app and login (credentials in linked Asana task)
- [x] No prompt to open in app is shown after login and Blink app opens normally
- [x] Open DDG app, no residual custom tab remains

_Flags off -> asks on other cases_
- [x] Disable `customTabs` > `handleTrustedCallers` and `customTabs` > `closeTabAfterTrustedCallerNavigation`
- [x] Install the YouTube app
- [x] Open dev settings -> custom tabs 
- [x] Load mkbhd.com
- [x] Scroll down to the "videos" section and click on a video
- [x] Check snackbar isn't shown and YouTube app is launched

### UI changes
n/a

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 697c7721fcf69d333d8c5b4aa5ef1a9c6e6e4385. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->