### PR TITLE
Reopen progress bar gate at navigation request, not commit

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1567,6 +1567,8 @@ class BrowserTabViewModel @Inject constructor(
                 }
 
                 site?.nextUrl = urlToNavigate
+                // Submitted query/URL loads bypass WebView, open the gate here
+                hasCompletedPageLoad = false
                 command.value = NavigationCommand.Navigate(urlToNavigate, getUrlHeaders(urlToNavigate))
             }
         }
@@ -1652,6 +1654,8 @@ class BrowserTabViewModel @Inject constructor(
 
     override fun willOverrideUrl(newUrl: String) {
         site?.nextUrl = newUrl
+        // Link tap: shouldOverrideUrlLoading fires here, well before pageStarted, open the gate now
+        hasCompletedPageLoad = false
         logcat { "SSLError: willOverride is $newUrl" }
         navigationAwareLoginDetector.onEvent(NavigationEvent.Redirect(newUrl))
         val previousSiteStillLoading = currentLoadingViewState().isLoading

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1916,6 +1916,37 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenWillOverrideUrlAfterCompletionThenProgressEventsFlowWithoutWaitingForCommit() {
+        fakeProgressBarUpgradeFeature.behaviourUpdate().setRawStoredState(State(enable = true))
+        setBrowserShowing(true)
+        testee.progressChanged(50, WebViewNavigationState(mockStack, 50))
+        testee.progressChanged(100, WebViewNavigationState(mockStack, 100))
+        assertEquals(false, loadingViewState().isLoading)
+
+        // willOverrideUrl fires from shouldOverrideUrlLoading, well before pageStarted (commit)
+        testee.willOverrideUrl("http://example.com/next")
+
+        testee.progressChanged(10, WebViewNavigationState(mockStack, 10))
+        assertEquals(true, loadingViewState().isLoading)
+    }
+
+    @Test
+    fun whenUserSubmittedQueryAfterCompletionThenProgressEventsFlowWithoutWaitingForCommit() {
+        fakeProgressBarUpgradeFeature.behaviourUpdate().setRawStoredState(State(enable = true))
+        setBrowserShowing(true)
+        testee.progressChanged(50, WebViewNavigationState(mockStack, 50))
+        testee.progressChanged(100, WebViewNavigationState(mockStack, 100))
+        assertEquals(false, loadingViewState().isLoading)
+
+        // App-initiated loads never reach shouldOverrideUrlLoading, so willOverrideUrl never fires
+        whenever(mockOmnibarConverter.convertQueryToUrl("foo", null)).thenReturn("foo.com")
+        testee.onUserSubmittedQuery("foo")
+
+        testee.progressChanged(10, WebViewNavigationState(mockStack, 10))
+        assertEquals(true, loadingViewState().isLoading)
+    }
+
+    @Test
     fun whenProgressBarUpgradeEnabledThenRawProgressPassedThrough() {
         fakeProgressBarUpgradeFeature.behaviourUpdate().setRawStoredState(State(enable = true))
         setBrowserShowing(true)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202630464207380/task/1215451088826768?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Reopens the progress-bar gate at navigation request instead of at WebView commit, so tapping a link or submitting a query shows loading feedback immediately instead of after the DNS/TLS/TTFB round trip.

| tap→commit | bar start, fixed | bar start, today | delta | url |
| --- | --- | --- | --- | --- |
| 276ms | 26ms | 293ms | **267ms** | [devblogs.microsoft.com](http://devblogs.microsoft.com/) |
| 277ms | 33ms | 299ms | **266ms** | [openrouter.ai](http://openrouter.ai/) |
| 445ms | 39ms | 469ms | **430ms** | go.dev |
| 961ms | 28ms | 981ms | **953ms** | [news.ycombinator.com/item](http://news.ycombinator.com/item) |
| 739ms | 28ms | 756ms | **728ms** | grapheneos.social |
| 1069ms | 30ms | 1092ms | **1062ms** | [engines.egr.uh.edu](http://engines.egr.uh.edu/) |
| 320ms | 20ms | 346ms | **326ms** | [news.ycombinator.com/newcomments](http://news.ycombinator.com/newcomments) |

### Steps to test this PR

> [!NOTE]
> Prerequisites:
> - [ ] Install Internal Debug.
> - [ ] In Settings → Feature Flag Inventory, confirm `behaviourUpdate` is ON.

- [ ] Open a page → tap a link → confirm the progress bar starts animating right at the tap, not after a pause once the destination page appears.
- [ ] From the omnibar, submit a typed query or URL → confirm the progress bar starts immediately on submit.

### UI changes

https://github.com/user-attachments/assets/2f5d5235-42a9-4d42-9b45-a83265015128


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small timing change to loading-state bookkeeping in the browser tab VM, covered by unit tests and gated behind the existing progress bar behaviour-update feature flag.
> 
> **Overview**
> **Reopens the progress-bar “completed load” gate when navigation is requested**, not only when the WebView commits (`pageStarted`), so loading UI can react immediately after a link tap or omnibar submit.
> 
> `BrowserTabViewModel` now sets `hasCompletedPageLoad = false` in **`willOverrideUrl`** (link taps via `shouldOverrideUrlLoading`) and when issuing **`Navigate`** from **`onUserSubmittedQuery`**, matching the existing behaviour-upgrade path that ignores late progress until a new load starts. Tests cover both entry points so progress updates resume without waiting for commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b49f0118f122883f404365efd19f35a84f29ba8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->