### PR TITLE
Increase granularity of single tab burn wide event durations.

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_data_clearing.json5
+++ b/PixelDefinitions/pixels/definitions/wide_data_clearing.json5
@@ -50,7 +50,7 @@
             {
                 "key": "feature.data.ext.total_duration_ms_bucketed",
                 "description": "Duration of the data clearing operation, bucketed using the lower bucket boundary. Does not include process restart duration.",
-                "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                "enum": ["0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000", "300000", "600000"]
             },
             {
                 "key": "feature.data.ext.failure_reason",

--- a/app/src/main/java/com/duckduckgo/app/fire/wideevents/DataClearingWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/wideevents/DataClearingWideEvent.kt
@@ -20,6 +20,8 @@ import com.duckduckgo.app.settings.clear.FireClearOption
 import com.duckduckgo.app.statistics.wideevents.CleanupPolicy.OnProcessStart
 import com.duckduckgo.app.statistics.wideevents.FlowStatus
 import com.duckduckgo.app.statistics.wideevents.WideEventClient
+import com.duckduckgo.app.statistics.wideevents.WideEventDefinition
+import com.duckduckgo.app.statistics.wideevents.WideEventDefinition.Version
 import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -28,6 +30,8 @@ import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 interface DataClearingWideEvent {
     /**
@@ -111,12 +115,14 @@ class DataClearingWideEventImpl @Inject constructor(
             metadata = metadata,
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
             samplingProbability = SAMPLING_PROBABILITY,
+            definition = WideEventDefinition(version = Version(minor = 1, patch = 0)),
         ).getOrNull()
 
         cachedFlowId?.let { flowId ->
             wideEventClient.intervalStart(
                 wideEventId = flowId,
                 key = KEY_TOTAL_DURATION_MS_BUCKETED,
+                buckets = DURATION_BUCKETS,
             )
         }
     }
@@ -230,6 +236,18 @@ class DataClearingWideEventImpl @Inject constructor(
     }
 
     private companion object {
+        val DURATION_BUCKETS = setOf(
+            1.seconds,
+            2.seconds,
+            3.seconds,
+            4.seconds,
+            5.seconds,
+            10.seconds,
+            30.seconds,
+            1.minutes,
+            5.minutes,
+            10.minutes,
+        )
         const val FLOW_NAME = "data-clearing"
         const val SAMPLING_PROBABILITY = 0.05f
         const val KEY_CLEAR_OPTIONS = "clear_options"

--- a/app/src/test/java/com/duckduckgo/app/fire/wideevents/DataClearingWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/wideevents/DataClearingWideEventTest.kt
@@ -22,6 +22,8 @@ import com.duckduckgo.app.settings.clear.FireClearOption
 import com.duckduckgo.app.statistics.wideevents.CleanupPolicy.OnProcessStart
 import com.duckduckgo.app.statistics.wideevents.FlowStatus
 import com.duckduckgo.app.statistics.wideevents.WideEventClient
+import com.duckduckgo.app.statistics.wideevents.WideEventDefinition
+import com.duckduckgo.app.statistics.wideevents.WideEventDefinition.Version
 import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -33,12 +35,28 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.*
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 class DataClearingWideEventTest {
     @get:Rule
     val coroutineRule = CoroutineTestRule()
 
     private val wideEventClient: WideEventClient = mock()
+
+    // Spelled out rather than referencing the production constant, so a wrong constant still fails.
+    private val expectedDurationBuckets = setOf(
+        1.seconds,
+        2.seconds,
+        3.seconds,
+        4.seconds,
+        5.seconds,
+        10.seconds,
+        30.seconds,
+        1.minutes,
+        5.minutes,
+        10.minutes,
+    )
 
     @SuppressLint("DenyListedApi")
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature =
@@ -71,8 +89,13 @@ class DataClearingWideEventTest {
             metadata = mapOf("clear_options" to "tabs,data", "browser_mode" to "regular"),
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
             samplingProbability = 0.05f,
+            definition = WideEventDefinition(version = Version(minor = 1, patch = 0)),
         )
-        verify(wideEventClient).intervalStart(wideEventId = 123L, key = "total_duration_ms_bucketed")
+        verify(wideEventClient).intervalStart(
+            wideEventId = 123L,
+            key = "total_duration_ms_bucketed",
+            buckets = expectedDurationBuckets,
+        )
     }
 
     @Test
@@ -88,6 +111,7 @@ class DataClearingWideEventTest {
             metadata = mapOf("clear_options" to "tabs", "browser_mode" to "fire"),
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
             samplingProbability = 0.05f,
+            definition = WideEventDefinition(version = Version(minor = 1, patch = 0)),
         )
     }
 
@@ -115,6 +139,7 @@ class DataClearingWideEventTest {
             ),
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
             samplingProbability = 0.05f,
+            definition = WideEventDefinition(version = Version(minor = 1, patch = 0)),
         )
     }
 
@@ -137,6 +162,7 @@ class DataClearingWideEventTest {
                 metadata = mapOf("clear_options" to "", "browser_mode" to "regular", "tab_count" to bucket),
                 cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
                 samplingProbability = 0.05f,
+                definition = WideEventDefinition(version = Version(minor = 1, patch = 0)),
             )
         }
     }
@@ -154,6 +180,7 @@ class DataClearingWideEventTest {
             metadata = mapOf("clear_options" to "", "browser_mode" to "regular"),
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
             samplingProbability = 0.05f,
+            definition = WideEventDefinition(version = Version(minor = 1, patch = 0)),
         )
     }
 
@@ -171,6 +198,7 @@ class DataClearingWideEventTest {
             metadata = mapOf("clear_options" to "duckai_chats", "browser_mode" to "regular"),
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
             samplingProbability = 0.05f,
+            definition = WideEventDefinition(version = Version(minor = 1, patch = 0)),
         )
     }
 
@@ -188,8 +216,13 @@ class DataClearingWideEventTest {
             metadata = mapOf("clear_options" to "tabs,data,duckai_chats", "browser_mode" to "regular"),
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
             samplingProbability = 0.05f,
+            definition = WideEventDefinition(version = Version(minor = 1, patch = 0)),
         )
-        verify(wideEventClient).intervalStart(wideEventId = 124L, key = "total_duration_ms_bucketed")
+        verify(wideEventClient).intervalStart(
+            wideEventId = 124L,
+            key = "total_duration_ms_bucketed",
+            buckets = expectedDurationBuckets,
+        )
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1215536646273752
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Add more granular durations between 1 to 5s.

### Steps to test this PR
No behaviour change, only telemetry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a430a18df9ef0b071c8506c2f4a72a84570901ec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->