### PR TITLE
UnifiedInput: Submit button background should always be blue

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/drawable/background_duck_ai_send_button.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/background_duck_ai_send_button.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+   ~ Copyright (c) 2026 DuckDuckGo
+   ~
+   ~ Licensed under the Apache License, Version 2.0 (the "License");
+   ~ you may not use this file except in compliance with the License.
+   ~ You may obtain a copy of the License at
+   ~
+   ~     http://www.apache.org/licenses/LICENSE-2.0
+   ~
+   ~ Unless required by applicable law or agreed to in writing, software
+   ~ distributed under the License is distributed on an "AS IS" BASIS,
+   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   ~ See the License for the specific language governing permissions and
+   ~ limitations under the License.
+   -->
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?android:attr/colorControlHighlight">
+    <item android:id="@android:id/mask">
+        <shape android:shape="oval">
+            <solid android:color="?attr/daxColorBlack" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="?attr/daxColorRebrandAccentBlue" />
+        </shape>
+    </item>
+</ripple>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_buttons.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_buttons.xml
@@ -62,10 +62,11 @@
         android:layout_width="@dimen/nativeInputButtonSize"
         android:layout_height="@dimen/nativeInputButtonSize"
         android:layout_marginStart="@dimen/keyline_1"
-        android:background="@drawable/selectable_circular_container_ripple"
+        android:background="@drawable/background_duck_ai_send_button"
         android:importantForAccessibility="no"
         android:scaleType="centerInside"
         android:src="@drawable/ic_arrow_right_24"
+        app:tint="?attr/daxColorButtonPrimaryText"
         android:visibility="gone" />
 
 </LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_floating_buttons.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_floating_buttons.xml
@@ -15,6 +15,7 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:clipToPadding="false"
@@ -36,10 +37,11 @@
         android:layout_width="36dp"
         android:layout_height="36dp"
         android:layout_marginStart="8dp"
-        android:background="@drawable/selectable_circular_container_ripple"
+        android:background="@drawable/background_duck_ai_send_button"
         android:importantForAccessibility="no"
         android:scaleType="centerInside"
         android:src="@drawable/ic_arrow_right_24"
-        android:visibility="gone" />
+        android:visibility="gone"
+        app:tint="?attr/daxColorButtonPrimaryText" />
 
 </LinearLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1217235426248461?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description
Update the submit icons color according to https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?node-id=25898-48622&m=dev

### Steps to test this PR
- [ ] Open unified input > duck.ai from the address bar and type something
- [ ] Verify that submit icon is blue
- [ ] Verify that back button and voice chat icon (wave) is NOT blue (did not change)
- [ ] Open a website and launch the contextual sheet
- [ ] Verify that submit icon is blue
- [ ] Choose a suggested prompt
- [ ] Type something in the input
- [ ] Verify that submit icon is blue
- [ ] Open a duck.ai chat tab tab and  Type something in the input
- [ ] Verify that submit icon is blue
- [ ] Change theme to Dark and verify the same things above

### UI changes
| Figma Light  | Figma Dark |
| ------ | ----- |
<img width="419" height="213" alt="Screenshot 2026-08-20 at 16 04 56" src="https://github.com/user-attachments/assets/6d4e0c6a-c927-4729-ac00-d4f9ffeea521" />|<img width="422" height="204" alt="Screenshot 2026-08-20 at 16 05 01" src="https://github.com/user-attachments/assets/1704834e-98e7-4b3f-b551-15909780029e" />|


| Before  | After |
| ------ | ----- |
<img width="355" height="142" alt="Screenshot 2026-08-20 at 16 02 24" src="https://github.com/user-attachments/assets/e0b65d83-563e-43a3-92fb-ef3200f7817d" />|<img width="354" height="149" alt="Screenshot 2026-08-20 at 16 01 48" src="https://github.com/user-attachments/assets/ef496529-7103-4df0-a482-96211eefe808" />|
<img width="352" height="148" alt="Screenshot 2026-08-20 at 16 02 14" src="https://github.com/user-attachments/assets/c54c58c0-8733-4b2b-a0b1-344248518e07" />|<img width="354" height="143" alt="Screenshot 2026-08-20 at 16 02 01" src="https://github.com/user-attachments/assets/85d3d49c-55b3-49d9-8018-b5fcbad01d6b" />|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6b028faff1e45e2ce0b0e5c0b3dbd129b7c47794. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->