### PR TITLE
Target16: Odd padding in fullscreen landscape videos

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -41,6 +41,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
+import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
 import androidx.core.view.postDelayed
 import androidx.lifecycle.Lifecycle
@@ -890,7 +891,11 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 SystemBarStyle.light(toolbarColor, toolbarColor)
             }
             enableEdgeToEdge(statusBarStyle = barStyle, navigationBarStyle = barStyle)
-            edgeToEdgeHandler.applyStatusBarAndHorizontalInsets(binding.root, installScrim = false)
+            edgeToEdgeHandler.applyStatusBarAndHorizontalInsets(
+                binding.root,
+                installScrim = false,
+                isFullScreen = { isFullScreen() },
+            )
             edgeToEdgeHandler.applyNavigationBarInsets(binding.navigationBarMockup.root)
             edgeToEdgeHandler.applyNavigationBarInsets(binding.bottomMockupToolbar.appBarLayoutMockup)
             applyDisplayCutoutMode(resources.configuration.orientation)
@@ -1216,6 +1221,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
     override fun toggleFullScreen() {
         super.toggleFullScreen()
+
+        // Fullscreen state is owned here, so re-apply insets to pick up the new state.
+        ViewCompat.requestApplyInsets(binding.root)
 
         if (swipingTabsFeature.isEnabled) {
             viewModel.onFullScreenModeChanged(isFullScreen())

--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
@@ -24,6 +24,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.view.ViewCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -35,6 +36,7 @@ import com.duckduckgo.app.browser.databinding.ActivityCustomTabBinding
 import com.duckduckgo.app.global.intentText
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.getColorFromAttr
+import com.duckduckgo.common.ui.view.isFullScreen
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
@@ -73,7 +75,11 @@ class CustomTabActivity : DuckDuckGoActivity() {
                 SystemBarStyle.light(toolbarColor, toolbarColor)
             }
             enableEdgeToEdge(statusBarStyle = barStyle, navigationBarStyle = barStyle)
-            edgeToEdgeHandler.applyStatusBarAndHorizontalInsets(binding.root, installScrim = false)
+            edgeToEdgeHandler.applyStatusBarAndHorizontalInsets(
+                binding.root,
+                installScrim = false,
+                isFullScreen = { isFullScreen() },
+            )
             applyDisplayCutoutMode(resources.configuration.orientation)
         }
 
@@ -109,6 +115,13 @@ class CustomTabActivity : DuckDuckGoActivity() {
         transaction.addToBackStack(tabId)
         transaction.commit()
         newFragment.messageFromPreviousTab = message
+    }
+
+    override fun toggleFullScreen() {
+        super.toggleFullScreen()
+
+        // Fullscreen state is owned here, so re-apply insets to pick up the new state.
+        ViewCompat.requestApplyInsets(binding.root)
     }
 
     override fun onStart() {

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
@@ -23,6 +23,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.annotation.ColorInt
+import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.doOnAttach
@@ -46,18 +47,33 @@ class EdgeToEdgeHandler @Inject constructor() {
     /**
      * Pads [view]'s top (status bar + cutout) and left/right (side system bars + cutout) edges.
      *
+     * While [isFullScreen] reports true (e.g. a fullscreen video) no padding is reserved, so the content spans the
+     * whole display (including the cutout) instead of leaving a letterbox bar beside the notch. [isFullScreen] is
+     * evaluated on every inset dispatch; the caller — which owns the fullscreen state — forces a re-evaluation on
+     * entering/exiting fullscreen with [ViewCompat.requestApplyInsets].
+     *
      * @param view The view to pad, typically the screen's root.
      * @param installScrim When true (default), a status-bar scrim (see [installStatusBarScrim]) is drawn behind
      *   the transparent status bar. Pass false for screens that colour their own system bars (e.g. via SystemBarStyle).
+     * @param isFullScreen Reports whether the screen is currently in immersive fullscreen. Defaults to never; supply
+     *   it only for screens that host fullscreen video.
      */
-    fun applyStatusBarAndHorizontalInsets(view: View, installScrim: Boolean = true) {
+    fun applyStatusBarAndHorizontalInsets(
+        view: View,
+        installScrim: Boolean = true,
+        isFullScreen: () -> Boolean = { false },
+    ) {
         val initialLeft = view.paddingLeft
         val initialTop = view.paddingTop
         val initialRight = view.paddingRight
         ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
-            val windowInsets = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout() or WindowInsetsCompat.Type.ime(),
-            )
+            val windowInsets = if (isFullScreen()) {
+                Insets.NONE
+            } else {
+                insets.getInsets(
+                    WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout() or WindowInsetsCompat.Type.ime(),
+                )
+            }
             v.updatePadding(
                 left = initialLeft + windowInsets.left,
                 top = initialTop + windowInsets.top,

--- a/common/common-utils/src/test/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandlerTest.kt
+++ b/common/common-utils/src/test/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandlerTest.kt
@@ -95,6 +95,75 @@ class EdgeToEdgeHandlerTest {
         assertEquals(1, scrims)
     }
 
+    @Test
+    fun whenNotFullScreenThenReservesStatusBarAndHorizontalInsetsAsPadding() {
+        testee.applyStatusBarAndHorizontalInsets(anchor, installScrim = false, isFullScreen = { false })
+
+        dispatchStatusBarAndCutout(statusBarTop = 63, cutoutLeft = 48, cutoutRight = 24)
+
+        assertEquals(48, anchor.paddingLeft)
+        assertEquals(63, anchor.paddingTop)
+        assertEquals(24, anchor.paddingRight)
+    }
+
+    @Test
+    fun whenFullScreenThenReservesNoPadding() {
+        testee.applyStatusBarAndHorizontalInsets(anchor, installScrim = false, isFullScreen = { true })
+
+        dispatchStatusBarAndCutout(statusBarTop = 63, cutoutLeft = 48, cutoutRight = 24)
+
+        assertEquals(0, anchor.paddingLeft)
+        assertEquals(0, anchor.paddingTop)
+        assertEquals(0, anchor.paddingRight)
+    }
+
+    @Test
+    fun whenFullScreenDefaultThenReservesInsets() {
+        testee.applyStatusBarAndHorizontalInsets(anchor, installScrim = false)
+
+        dispatchStatusBarAndCutout(statusBarTop = 63, cutoutLeft = 48)
+
+        assertEquals(48, anchor.paddingLeft)
+        assertEquals(63, anchor.paddingTop)
+    }
+
+    @Test
+    fun whenFullScreenTogglesThenPaddingDropsAndRestoresWithoutAccumulating() {
+        var fullScreen = false
+        testee.applyStatusBarAndHorizontalInsets(anchor, installScrim = false, isFullScreen = { fullScreen })
+
+        dispatchStatusBarAndCutout(statusBarTop = 63, cutoutLeft = 48, cutoutRight = 24)
+        assertEquals(48, anchor.paddingLeft)
+        assertEquals(63, anchor.paddingTop)
+        assertEquals(24, anchor.paddingRight)
+
+        // Entering fullscreen: the caller flips its state and re-dispatches insets.
+        fullScreen = true
+        dispatchStatusBarAndCutout(statusBarTop = 63, cutoutLeft = 48, cutoutRight = 24)
+        assertEquals(0, anchor.paddingLeft)
+        assertEquals(0, anchor.paddingTop)
+        assertEquals(0, anchor.paddingRight)
+
+        // Exiting fullscreen restores the original insets, not double them.
+        fullScreen = false
+        dispatchStatusBarAndCutout(statusBarTop = 63, cutoutLeft = 48, cutoutRight = 24)
+        assertEquals(48, anchor.paddingLeft)
+        assertEquals(63, anchor.paddingTop)
+        assertEquals(24, anchor.paddingRight)
+    }
+
+    private fun dispatchStatusBarAndCutout(
+        statusBarTop: Int,
+        cutoutLeft: Int = 0,
+        cutoutRight: Int = 0,
+    ) {
+        val insets = WindowInsetsCompat.Builder()
+            .setInsets(WindowInsetsCompat.Type.statusBars(), Insets.of(0, statusBarTop, 0, 0))
+            .setInsets(WindowInsetsCompat.Type.displayCutout(), Insets.of(cutoutLeft, 0, cutoutRight, 0))
+            .build()
+        ViewCompat.dispatchApplyWindowInsets(anchor, insets)
+    }
+
     private fun scrim(): View = content.findViewWithTag(NAVIGATION_BAR_SCRIM_TAG)
 
     private fun dispatchInsets(

--- a/common/common-utils/src/test/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandlerTest.kt
+++ b/common/common-utils/src/test/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandlerTest.kt
@@ -118,7 +118,7 @@ class EdgeToEdgeHandlerTest {
     }
 
     @Test
-    fun whenFullScreenDefaultThenReservesInsets() {
+    fun whenFullScreenCallbackIsOmittedThenReservesInsets() {
         testee.applyStatusBarAndHorizontalInsets(anchor, installScrim = false)
 
         dispatchStatusBarAndCutout(statusBarTop = 63, cutoutLeft = 48)
@@ -137,14 +137,12 @@ class EdgeToEdgeHandlerTest {
         assertEquals(63, anchor.paddingTop)
         assertEquals(24, anchor.paddingRight)
 
-        // Entering fullscreen: the caller flips its state and re-dispatches insets.
         fullScreen = true
         dispatchStatusBarAndCutout(statusBarTop = 63, cutoutLeft = 48, cutoutRight = 24)
         assertEquals(0, anchor.paddingLeft)
         assertEquals(0, anchor.paddingTop)
         assertEquals(0, anchor.paddingRight)
 
-        // Exiting fullscreen restores the original insets, not double them.
         fullScreen = false
         dispatchStatusBarAndCutout(statusBarTop = 63, cutoutLeft = 48, cutoutRight = 24)
         assertEquals(48, anchor.paddingLeft)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1217357976062047?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
This PR fixes the odd gray bar/padding shown at the top of fullscreen landscape videos after the Android 16 target bump.
- In `EdgeToEdgeHandler.applyStatusBarAndHorizontalInsets`, no status-bar/cutout inset padding is reserved while the screen is in immersive fullscreen (detected via the status bar being hidden), so the content spans the whole display including the cutout.
- The inset listener re-fires on bar hide/show, so the padding is dropped on entering fullscreen and restored on exit.
- Applies to any edge-to-edge screen using this handler on its root (browser and custom tabs); non-fullscreen screens are unaffected.

### Steps to test this PR
Test on Android 16 up and Android 15 below
- [x] Open a new tab > load a youtube video
- [x] While playing, select fullscreen
- [x] Verify that experience is trully full screen and no awkward margin
- [x] Smoke test other features (different omnibar placement, custom tabs)

### UI changes
| Before  | After |
| ------ | ----- |
<img width="766" height="356" alt="Screenshot 2026-08-20 at 17 28 50" src="https://github.com/user-attachments/assets/8eef356b-8548-450a-9cbb-5ac07e65948a" />|<img width="760" height="349" alt="Screenshot 2026-08-20 at 17 29 15" src="https://github.com/user-attachments/assets/ed9fcfcd-1d8b-4fd3-ba00-a3515e17c0d8" />|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only insets handling for fullscreen video; no auth, data, or security changes. Wrong callback wiring could mis-pad other screens, but the default is unchanged.
> 
> **Overview**
> Removes the gray letterbox/cutout padding on landscape fullscreen video after the Android 16 edge-to-edge change.
> 
> `applyStatusBarAndHorizontalInsets` now takes an `isFullScreen` callback. While true, status-bar and cutout insets are not applied as padding so content can fill the display including the notch. Browser and custom tab activities pass their fullscreen state and call `ViewCompat.requestApplyInsets` on toggle so padding drops on enter and restores on exit without accumulating. Other screens keep the default (never fullscreen).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e19e5c2c4f32d6f56f8da668386ce4f85e0b0865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->