### PR TITLE
[DO NOT MERGE YET] Set Metro as the default DI

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,4 +28,4 @@ com.squareup.anvil.trackSourceFiles=true
 android.lint.useK2Uast=false
 
 # DI framework: AnvilDagger (default) or Metro
-ddg.di=AnvilDagger
+ddg.di=Metro

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,5 +27,5 @@ com.squareup.anvil.trackSourceFiles=true
 # Run Android Lint with the K1 UAST engine instead of K2.
 android.lint.useK2Uast=false
 
-# DI framework: AnvilDagger (default) or Metro
+# DI framework: AnvilDagger or Metro (default)
 ddg.di=Metro


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217192951849245?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description
Sets Metro as the default DI framework.

⚠️ Should only be merged after 5.295.0 is fully rolled out!

### Steps to test this PR
Should already be covered by all the CI checks we run alongside Anvil.

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the default dependency-injection stack for the whole app, so local and any un-overridden builds now compile and wire with Metro instead of Anvil/Dagger.
> 
> **Overview**
> Flips `ddg.di` in `gradle.properties` so **Metro is the default DI framework** instead of AnvilDagger.
> 
> CI still passes `-Pddg.di` per matrix, so this mainly affects local builds and any jobs that do not override the property. Intended to land only after 5.293.0 is fully rolled out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afa85c4c2b9fe7f43eaa50d13125655596650ad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->