### PR TITLE
DRM Policy: Add pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/site_permissions.json5
+++ b/PixelDefinitions/pixels/definitions/site_permissions.json5
@@ -1,7 +1,7 @@
 // Site permissions pixels
 {
     "m_site_permissions_auto_granted": {
-        "description": "Fires when a DRM site permission request is granted automatically by the central DRM policy, without showing the permission dialog",
+        "description": "Fires the first time a tab auto-grants DRM for a domain, when the central DRM policy grants the request without showing the permission dialog. A page can issue several DRM requests; only the first is counted, so this is comparable with m_site_permissions_dialog_impresssion",
         "owners": ["0nko"],
         "triggers": ["page_load"],
         "suffixes": ["form_factor"],

--- a/PixelDefinitions/pixels/definitions/site_permissions.json5
+++ b/PixelDefinitions/pixels/definitions/site_permissions.json5
@@ -1,0 +1,24 @@
+// Site permissions pixels
+{
+    "m_site_permissions_auto_granted": {
+        "description": "Fires when a DRM site permission request is granted automatically by the central DRM policy, without showing the permission dialog",
+        "owners": ["0nko"],
+        "triggers": ["page_load"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "type",
+                "type": "string",
+                "description": "Permission type that was auto-granted",
+                "enum": ["drm"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Policy rule that produced the automatic grant",
+                "enum": ["allow_list", "protections_off"]
+            }
+        ]
+    }
+}

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerImpl.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerImpl.kt
@@ -87,7 +87,7 @@ class SitePermissionsManagerImpl @Inject constructor(
                     ?.also { logcat { "Permissions: drm policy decision for $url is $it" } }
             }
         }
-        drmDecision?.let { fireDrmAutoGrantedPixel(it) }
+        drmDecision?.let { fireDrmAutoGrantedPixel(it, tabId, url) }
 
         val sitePermissionsAllowedToAsk = request.resources
             .filter { drmDecision == null || it != PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID }
@@ -179,13 +179,19 @@ class SitePermissionsManagerImpl @Inject constructor(
         return sitePermissionsRepository.isDomainGranted(url, "", LocationPermissionRequest.RESOURCE_LOCATION_PERMISSION)
     }
 
-    private fun fireDrmAutoGrantedPixel(decision: DrmPolicyDecision) {
+    private fun fireDrmAutoGrantedPixel(
+        decision: DrmPolicyDecision,
+        tabId: String,
+        url: String,
+    ) {
         if (decision.action != DrmPolicyAction.GRANT) return
         val reason = when (decision.reason) {
             DrmPolicyReason.ALLOW_LIST -> SitePermissionsPixelValues.ALLOW_LIST
             DrmPolicyReason.PROTECTIONS_OFF -> SitePermissionsPixelValues.PROTECTIONS_OFF
             else -> return
         }
+        if (!drmSessionStore.markAutoGrantReported(tabId, url.extractDomain() ?: url)) return
+
         pixel.fire(
             SitePermissionsPixelName.PERMISSION_AUTO_GRANTED,
             mapOf(

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerImpl.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerImpl.kt
@@ -23,6 +23,7 @@ import android.location.LocationManager
 import android.webkit.PermissionRequest
 import androidx.core.content.ContextCompat
 import androidx.core.location.LocationManagerCompat
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extractDomain
 import com.duckduckgo.di.scopes.AppScope
@@ -32,7 +33,9 @@ import com.duckduckgo.site.permissions.api.SitePermissionsManager.LocationPermis
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissionQueryResponse
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 import com.duckduckgo.site.permissions.impl.drm.DrmPolicyAction
+import com.duckduckgo.site.permissions.impl.drm.DrmPolicyDecision
 import com.duckduckgo.site.permissions.impl.drm.DrmPolicyManager
+import com.duckduckgo.site.permissions.impl.drm.DrmPolicyReason
 import com.duckduckgo.site.permissions.impl.drm.DrmSessionStore
 import com.duckduckgo.site.permissions.impl.feature.DrmPolicyFeature
 import com.duckduckgo.site.permissions.impl.feature.MicrophoneSitePermissionsDomainRecoveryFeature
@@ -54,6 +57,7 @@ class SitePermissionsManagerImpl @Inject constructor(
     private val drmPolicyFeature: DrmPolicyFeature,
     private val drmPolicyManager: DrmPolicyManager,
     private val drmSessionStore: DrmSessionStore,
+    private val pixel: Pixel,
     duckAiHostProvider: DuckAiHostProvider,
 ) : SitePermissionsManager {
 
@@ -83,6 +87,7 @@ class SitePermissionsManagerImpl @Inject constructor(
                     ?.also { logcat { "Permissions: drm policy decision for $url is $it" } }
             }
         }
+        drmDecision?.let { fireDrmAutoGrantedPixel(it) }
 
         val sitePermissionsAllowedToAsk = request.resources
             .filter { drmDecision == null || it != PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID }
@@ -172,6 +177,22 @@ class SitePermissionsManagerImpl @Inject constructor(
         request: String,
     ): Boolean {
         return sitePermissionsRepository.isDomainGranted(url, "", LocationPermissionRequest.RESOURCE_LOCATION_PERMISSION)
+    }
+
+    private fun fireDrmAutoGrantedPixel(decision: DrmPolicyDecision) {
+        if (decision.action != DrmPolicyAction.GRANT) return
+        val reason = when (decision.reason) {
+            DrmPolicyReason.ALLOW_LIST -> SitePermissionsPixelValues.ALLOW_LIST
+            DrmPolicyReason.PROTECTIONS_OFF -> SitePermissionsPixelValues.PROTECTIONS_OFF
+            else -> return
+        }
+        pixel.fire(
+            SitePermissionsPixelName.PERMISSION_AUTO_GRANTED,
+            mapOf(
+                SitePermissionsPixelParameters.PERMISSION_TYPE to SitePermissionsPixelValues.DRM,
+                SitePermissionsPixelParameters.REASON to reason,
+            ),
+        )
     }
 
     private fun isPermissionSupported(permission: String): Boolean =

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsPixelName.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsPixelName.kt
@@ -21,11 +21,13 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 enum class SitePermissionsPixelName(override val pixelName: String) : Pixel.PixelName {
     PERMISSION_DIALOG_IMPRESSION("m_site_permissions_dialog_impresssion"),
     PERMISSION_DIALOG_CLICK("m_site_permissions_dialog_click"),
+    PERMISSION_AUTO_GRANTED("m_site_permissions_auto_granted"),
 }
 
 object SitePermissionsPixelParameters {
     const val PERMISSION_TYPE = "type"
     const val PERMISSION_SELECTION = "selection"
+    const val REASON = "reason"
 }
 
 object SitePermissionsPixelValues {
@@ -38,4 +40,6 @@ object SitePermissionsPixelValues {
     const val ALLOW_ONCE = "allow_once"
     const val DENY_ALWAYS = "deny_always"
     const val DENY_ONCE = "deny_once"
+    const val ALLOW_LIST = "allow_list"
+    const val PROTECTIONS_OFF = "protections_off"
 }

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/drm/DrmSessionStore.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/drm/DrmSessionStore.kt
@@ -24,6 +24,7 @@ import javax.inject.Inject
 @SingleInstanceIn(AppScope::class)
 class DrmSessionStore @Inject constructor() {
     private val sessions = ConcurrentHashMap<String, Boolean>()
+    private val autoGrantsReported = ConcurrentHashMap<String, Boolean>()
 
     fun get(tabId: String, domain: String): Boolean? = sessions[key(tabId, domain)]
 
@@ -31,8 +32,15 @@ class DrmSessionStore @Inject constructor() {
         sessions[key(tabId, domain)] = allowed
     }
 
+    /**
+     * True the first time this tab and domain are auto-granted. A page can issue several DRM requests, and
+     * an automatic grant records no session choice to short-circuit them, so the caller has to count once.
+     */
+    fun markAutoGrantReported(tabId: String, domain: String): Boolean = autoGrantsReported.putIfAbsent(key(tabId, domain), true) == null
+
     fun clear() {
         sessions.clear()
+        autoGrantsReported.clear()
     }
 
     private fun key(tabId: String, domain: String) = "$tabId/$domain"

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/feature/DrmPolicyFeature.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/feature/DrmPolicyFeature.kt
@@ -20,16 +20,19 @@ import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
     featureName = "drmPolicy",
 )
 interface DrmPolicyFeature {
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @InternalAlwaysEnabled
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @InternalAlwaysEnabled
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun centralPolicy(): Toggle
 }
 

--- a/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerTest.kt
+++ b/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerTest.kt
@@ -23,6 +23,7 @@ import android.location.LocationManager
 import android.webkit.PermissionRequest
 import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
@@ -68,6 +69,7 @@ class SitePermissionsManagerTest {
     private val drmPolicyFeature = FakeFeatureToggleFactory.create(DrmPolicyFeature::class.java)
     private val mockDrmPolicyManager: DrmPolicyManager = mock()
     private val drmSessionStore = DrmSessionStore()
+    private val mockPixel: Pixel = mock()
 
     private val testee by lazy {
         SitePermissionsManagerImpl(
@@ -80,6 +82,7 @@ class SitePermissionsManagerTest {
             drmPolicyFeature,
             mockDrmPolicyManager,
             drmSessionStore,
+            mockPixel,
             mockDuckAiHostProvider,
         )
     }
@@ -151,6 +154,51 @@ class SitePermissionsManagerTest {
         verify(permissionRequest, never()).deny()
         verify(mockSitePermissionsRepository, never()).isDomainAllowedToAsk(url, PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
         verify(mockSitePermissionsRepository, never()).isDomainGranted(url, tabId, PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
+        verify(mockPixel).fire(
+            SitePermissionsPixelName.PERMISSION_AUTO_GRANTED,
+            mapOf(
+                SitePermissionsPixelParameters.PERMISSION_TYPE to SitePermissionsPixelValues.DRM,
+                SitePermissionsPixelParameters.REASON to SitePermissionsPixelValues.ALLOW_LIST,
+            ),
+        )
+    }
+
+    @Test
+    fun whenCentralPolicyGrantsBecauseProtectionsOffThenAutoGrantedPixelFiredWithProtectionsOffReason() = runTest {
+        drmPolicyFeature.centralPolicy().setRawStoredState(Toggle.State(true))
+        val resources = arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
+        whenever(mockDrmPolicyManager.decide(url, tabId))
+            .thenReturn(DrmPolicyDecision(DrmPolicyAction.GRANT, DrmPolicyReason.PROTECTIONS_OFF))
+
+        val permissionRequest: PermissionRequest = mock()
+        whenever(permissionRequest.origin).thenReturn(url.toUri())
+        whenever(permissionRequest.resources).thenReturn(resources)
+
+        testee.getSitePermissions(tabId, permissionRequest)
+
+        verify(mockPixel).fire(
+            SitePermissionsPixelName.PERMISSION_AUTO_GRANTED,
+            mapOf(
+                SitePermissionsPixelParameters.PERMISSION_TYPE to SitePermissionsPixelValues.DRM,
+                SitePermissionsPixelParameters.REASON to SitePermissionsPixelValues.PROTECTIONS_OFF,
+            ),
+        )
+    }
+
+    @Test
+    fun whenCentralPolicyGrantsBecauseOfUserChoiceThenAutoGrantedPixelNotFired() = runTest {
+        drmPolicyFeature.centralPolicy().setRawStoredState(Toggle.State(true))
+        val resources = arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
+        whenever(mockDrmPolicyManager.decide(url, tabId))
+            .thenReturn(DrmPolicyDecision(DrmPolicyAction.GRANT, DrmPolicyReason.USER_ALLOW_ALWAYS))
+
+        val permissionRequest: PermissionRequest = mock()
+        whenever(permissionRequest.origin).thenReturn(url.toUri())
+        whenever(permissionRequest.resources).thenReturn(resources)
+
+        testee.getSitePermissions(tabId, permissionRequest)
+
+        verifyZeroInteractions(mockPixel)
     }
 
     @Test
@@ -189,6 +237,7 @@ class SitePermissionsManagerTest {
         assertEquals(listOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID), permissions.userHandled)
         verify(permissionRequest, never()).grant(any())
         verify(permissionRequest, never()).deny()
+        verifyZeroInteractions(mockPixel)
     }
 
     @Test

--- a/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerTest.kt
+++ b/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerTest.kt
@@ -38,8 +38,10 @@ import com.duckduckgo.site.permissions.impl.feature.DrmPolicyFeature
 import com.duckduckgo.site.permissions.impl.feature.MicrophoneSitePermissionsDomainRecoveryFeature
 import com.duckduckgo.site.permissions.store.sitepermissions.SitePermissionsEntity
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
@@ -183,6 +185,38 @@ class SitePermissionsManagerTest {
                 SitePermissionsPixelParameters.REASON to SitePermissionsPixelValues.PROTECTIONS_OFF,
             ),
         )
+    }
+
+    @Test
+    fun whenTheSamePageRequestsDrmTwiceThenAutoGrantedPixelIsFiredOnce() = runTest {
+        drmPolicyFeature.centralPolicy().setRawStoredState(Toggle.State(true))
+        whenever(mockDrmPolicyManager.decide(url, tabId))
+            .thenReturn(DrmPolicyDecision(DrmPolicyAction.GRANT, DrmPolicyReason.ALLOW_LIST))
+        val permissionRequest = givenDrmPermissionRequest()
+
+        testee.getSitePermissions(tabId, permissionRequest)
+        testee.getSitePermissions(tabId, permissionRequest)
+
+        verify(mockPixel).fire(eq(SitePermissionsPixelName.PERMISSION_AUTO_GRANTED), any(), any(), any())
+    }
+
+    @Test
+    fun whenAnotherTabAutoGrantsTheSameDomainThenAutoGrantedPixelIsFiredAgain() = runTest {
+        drmPolicyFeature.centralPolicy().setRawStoredState(Toggle.State(true))
+        val otherTabId = "otherTabId"
+        whenever(mockDrmPolicyManager.decide(eq(url), any()))
+            .thenReturn(DrmPolicyDecision(DrmPolicyAction.GRANT, DrmPolicyReason.ALLOW_LIST))
+        val permissionRequest = givenDrmPermissionRequest()
+
+        testee.getSitePermissions(tabId, permissionRequest)
+        testee.getSitePermissions(otherTabId, permissionRequest)
+
+        verify(mockPixel, times(2)).fire(eq(SitePermissionsPixelName.PERMISSION_AUTO_GRANTED), any(), any(), any())
+    }
+
+    private fun givenDrmPermissionRequest(): PermissionRequest = mock<PermissionRequest>().apply {
+        whenever(origin).thenReturn(url.toUri())
+        whenever(resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1217678542848175?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1207418217763355/task/1216952383692269?focus=true

### Description

This PR adds a pixel to measure the auto-approved DRM permissions.

### Steps to test this PR

_Setup_

Test privacy config URL: https://gist.githubusercontent.com/0nko/6ba6564e43ec35095a08c0e2288bbdde/raw/3eb9c38d461e73739ebc0d84f7c352cb9d7082d1/privacyconfig.json ("foxnews.com" in eme and "reference.dashif.org" in emeBlock)

_Pixel fires for an allow-list grant (test config)_                                                                                                                                                                                                           
- [x] Open `https://www.foxnews.com/video`                                                                                                                                                                                                                 
- [x] Verify the decision log shows `action=GRANT, reason=ALLOW_LIST`                                                                                                                                                                                      
- [x] Verify a pixel is sent: `Pixel sent: m_site_permissions_auto_granted with params: {type=drm, reason=allow_list}`                                                                                                                                     
                                                                                                                                                                                                                                                           
_Pixel fires for a protections-off grant (test config)_                                                                                                                                                                                                       
- [x] Open `https://reference.dashif.org/dash.js/latest/samples/drm/widevine.html` and confirm `reason=BLOCK_LIST`                                                                                             
- [x] Open the privacy dashboard (shield) and switch **Protections OFF**                                                                                                                                                                                   
- [x] Force-stop and reopen the app, reload the page                                                                                                                                                                                                       
- [x] Verify `action=GRANT, reason=PROTECTIONS_OFF` and `Pixel sent: m_site_permissions_auto_granted with params: {type=drm, reason=protections_off}`                                                                                                                                                                                                 
                                                                                                                                                                                                                                                           
_No pixel for user-driven grants_                                                                                                                          
- [x] Turn protections back on                                                                                                                                                                                                                        
- [x] Go to "cnn.com" and open a video article                                                                                                                                                                                           
- [x] Choose **Allow** with "Remember my choice" in the DRM dialog
- [x] Reload and verify `action=GRANT, reason=USER_ALLOW_ALWAYS`                                                                                                                                                                                           
- [x] Verify **no** `m_site_permissions_auto_granted` pixel is sent — the user made this choice, it is not an automatic grant 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry and feature-flag default/annotation tweaks only; DRM grant behavior is unchanged.
> 
> **Overview**
> Adds `m_site_permissions_auto_granted` so DRM grants from the central policy (allow-list or protections-off) can be compared with dialog impressions.
> 
> The pixel fires once per tab/domain via `DrmSessionStore.markAutoGrantReported`. User-driven grants (`USER_ALLOW_ALWAYS`) and non-GRANT decisions are not counted.
> 
> Also switches `drmPolicy` / `centralPolicy` to `@InternalAlwaysEnabled` with a default of `FALSE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee44278ca5cc483bad4af22891ec3ec036eeda8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->