### PR TITLE
Stop DaxSwitch logging a failed ColorStateList inflation

### DIFF
--- a/android-design-system/design-system/src/main/res/values/widgets.xml
+++ b/android-design-system/design-system/src/main/res/values/widgets.xml
@@ -523,6 +523,10 @@
         <item name="trackTint">@color/switch_track_tint</item>
         <item name="thumbTint">@color/switch_thumb_tint</item>
         <item name="android:thumb">@drawable/switch_thumb</item>
+        <!-- The inherited Material3 tints resolve M3-only theme attributes our MaterialComponents
+             themes don't define, which makes every switch log a failed ColorStateList inflation. -->
+        <item name="thumbIconTint">@android:color/transparent</item>
+        <item name="trackDecorationTint">@android:color/transparent</item>
     </style>
 
     <!-- Slider -->


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217697838823340
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

### Description

`Widget.DuckDuckGo.v3.Switch` inherits the Material3 switch style, so `MaterialSwitch` read `thumbIconTint` and `trackDecorationTint` from Material3 color state lists that point at `?attr/colorSurfaceContainerHighest` and `?attr/colorOutline`. Our themes are MaterialComponents and define neither, so every switch construction threw inside `ColorStateListInflaterCompat` and `ResourcesCompat` logged the exception plus the full theme inheritance dump; only successful inflations are cached, so it never stopped. Opening Settings logged 82 warnings, 668 KB of that screen's 785 KB of logcat, reported externally as heat and battery drain (#9551). Overriding both tints with transparent stops the Material3 lists being read: `thumbIconTint` is inert because we never set a `thumbIcon`, and `trackDecorationTint` was already rendering nothing.

### Steps to test this PR

_No more ColorStateList warnings_
- [x] Run `adb logcat -c`, then open Settings in the app
- [x] Run `adb logcat -d | grep -c "Failed to inflate ColorStateList"`, expect 0 (on develop this is 82)

_Switches look unchanged_
- [x] Open Settings, Accessibility and toggle a switch on
- [x] Check the on and off switches in light and dark theme against develop, they should be identical

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes|No UI changes|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny style-only override of unused switch tints; no logic, auth, or data-handling changes. Appearance should stay the same.
> 
> **Overview**
> Stops `MaterialSwitch` from repeatedly failing to inflate Material3 `ColorStateList`s on every switch, which flooded logcat (dozens of warnings per Settings open) and was reported as extra heat/battery use.
> 
> `Widget.DuckDuckGo.v3.Switch` now overrides `thumbIconTint` and `trackDecorationTint` to transparent so inherited M3 attributes (`colorSurfaceContainerHighest`, `colorOutline`) are never resolved against MaterialComponents themes. Appearance is unchanged: no thumb icon is set, and track decoration already rendered as nothing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdccb6fc24892b8641a0c0a434d734f758b7a89c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->