### PR TITLE
Subscription Onboarding: Product Review Welcome Screens

### DIFF
--- a/subscriptions/subscriptions-impl/build.gradle
+++ b/subscriptions/subscriptions-impl/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     implementation "com.android.billingclient:billing:_"
     implementation "com.android.billingclient:billing-ktx:_"
     implementation "com.squareup.logcat:logcat:_"
+    implementation 'nl.dionsegijn:konfetti:1.2.5'
 
     implementation Google.dagger
     implementation AndroidX.core.ktx

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/OnboardingConfetti.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/OnboardingConfetti.kt
@@ -22,11 +22,6 @@ import nl.dionsegijn.konfetti.models.Shape
 import nl.dionsegijn.konfetti.models.Size
 import com.duckduckgo.mobile.android.R as CommonR
 
-/**
- * Streams a short burst of brand-coloured confetti from the top centre of this view. The parameters
- * mirror the celebration used in App Tracking Protection's `DeviceShieldTrackerActivity` so both
- * celebrations look identical.
- */
 fun KonfettiView.launchOnboardingConfetti() {
     val resources = context.resources
     val magenta = ResourcesCompat.getColor(resources, CommonR.color.magenta, null)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/OnboardingConfetti.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/OnboardingConfetti.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding.welcome
+
+import androidx.core.content.res.ResourcesCompat
+import nl.dionsegijn.konfetti.KonfettiView
+import nl.dionsegijn.konfetti.models.Shape
+import nl.dionsegijn.konfetti.models.Size
+import com.duckduckgo.mobile.android.R as CommonR
+
+/**
+ * Streams a short burst of brand-coloured confetti from the top centre of this view. The parameters
+ * mirror the celebration used in App Tracking Protection's `DeviceShieldTrackerActivity` so both
+ * celebrations look identical.
+ */
+fun KonfettiView.launchOnboardingConfetti() {
+    val resources = context.resources
+    val magenta = ResourcesCompat.getColor(resources, CommonR.color.magenta, null)
+    val blue = ResourcesCompat.getColor(resources, CommonR.color.blue30, null)
+    val purple = ResourcesCompat.getColor(resources, CommonR.color.purple, null)
+    val green = ResourcesCompat.getColor(resources, CommonR.color.green, null)
+    val yellow = ResourcesCompat.getColor(resources, CommonR.color.yellow, null)
+
+    val displayWidth = resources.displayMetrics.widthPixels
+
+    build()
+        .addColors(magenta, blue, purple, green, yellow)
+        .setDirection(0.0, 359.0)
+        .setSpeed(4f, 9f)
+        .setFadeOutEnabled(true)
+        .setTimeToLive(1500L)
+        .addShapes(Shape.Rectangle(1f))
+        .addSizes(Size(8))
+        .setPosition(displayWidth / 2f, displayWidth / 2f, -50f, -50f)
+        .streamFor(60, 2000L)
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeFragment.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeFragment.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.subscriptions.impl.R
 import com.duckduckgo.subscriptions.impl.databinding.FragmentSubscriptionOnboardingWelcomeBinding
+import com.duckduckgo.subscriptions.impl.onboarding.welcome.SubscriptionOnboardingWelcomeViewModel.Command
 import com.duckduckgo.subscriptions.impl.onboarding.welcome.SubscriptionOnboardingWelcomeViewModel.ViewState
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -56,8 +57,17 @@ class SubscriptionOnboardingWelcomeFragment : DuckDuckGoFragment(R.layout.fragme
             .onEach { render(it) }
             .launchIn(viewLifecycleOwner.lifecycleScope)
 
-        if (savedInstanceState == null) {
-            binding.subscriptionOnboardingWelcomeKonfetti.doOnLayout {
+        viewModel.commands
+            .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+            .onEach { processCommand(it) }
+            .launchIn(viewLifecycleOwner.lifecycleScope)
+
+        viewModel.onScreenShown()
+    }
+
+    private fun processCommand(command: Command) {
+        when (command) {
+            Command.LaunchConfetti -> binding.subscriptionOnboardingWelcomeKonfetti.doOnLayout {
                 binding.subscriptionOnboardingWelcomeKonfetti.launchOnboardingConfetti()
             }
         }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeFragment.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeFragment.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.subscriptions.impl.onboarding.welcome
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.doOnLayout
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.flowWithLifecycle
@@ -54,6 +55,12 @@ class SubscriptionOnboardingWelcomeFragment : DuckDuckGoFragment(R.layout.fragme
             .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
             .onEach { render(it) }
             .launchIn(viewLifecycleOwner.lifecycleScope)
+
+        if (savedInstanceState == null) {
+            binding.subscriptionOnboardingWelcomeKonfetti.doOnLayout {
+                binding.subscriptionOnboardingWelcomeKonfetti.launchOnboardingConfetti()
+            }
+        }
     }
 
     private fun render(viewState: ViewState) {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeViewModel.kt
@@ -17,15 +17,23 @@
 package com.duckduckgo.subscriptions.impl.onboarding.welcome
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
 import com.duckduckgo.subscriptions.impl.onboarding.welcome.SubscriptionOnboardingWelcomeStepPlugin.Companion.WELCOME_STEP_ID
+import com.duckduckgo.subscriptions.impl.store.SubscriptionOnboardingStepStore
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
@@ -33,6 +41,8 @@ import javax.inject.Inject
 class SubscriptionOnboardingWelcomeViewModel @Inject constructor(
     private val controller: SubscriptionOnboardingController,
     private val currentTimeProvider: CurrentTimeProvider,
+    private val stepStore: SubscriptionOnboardingStepStore,
+    private val dispatcherProvider: DispatcherProvider,
 ) : ViewModel() {
 
     data class ViewState(
@@ -40,8 +50,17 @@ class SubscriptionOnboardingWelcomeViewModel @Inject constructor(
         val freeTrialDayLabels: List<String> = emptyList(),
     )
 
+    sealed interface Command {
+        data object LaunchConfetti : Command
+    }
+
     private val _viewState = MutableStateFlow(buildViewState())
     val viewState: StateFlow<ViewState> = _viewState.asStateFlow()
+
+    private val _commands = Channel<Command>(1, DROP_OLDEST)
+    val commands: Flow<Command> = _commands.receiveAsFlow()
+
+    private var confettiRequested = false
 
     private fun buildViewState(): ViewState {
         val startDate = currentTimeProvider.localDateTimeNow().toLocalDate()
@@ -49,6 +68,17 @@ class SubscriptionOnboardingWelcomeViewModel @Inject constructor(
             formattedBillingDate = startDate.plusDays(FREE_TRIAL_DAYS.toLong()).format(DATE_FORMATTER),
             freeTrialDayLabels = (0 until FREE_TRIAL_DAYS).map { startDate.plusDays(it.toLong()).dayOfMonth.toString() },
         )
+    }
+
+    fun onScreenShown() {
+        if (confettiRequested) return
+        confettiRequested = true
+
+        viewModelScope.launch(dispatcherProvider.io()) {
+            if (!stepStore.isCompleted(WELCOME_STEP_ID)) {
+                _commands.send(Command.LaunchConfetti)
+            }
+        }
     }
 
     fun onPrimaryCtaClicked() {

--- a/subscriptions/subscriptions-impl/src/main/res/layout/content_subscription_onboarding_feature_info_idtr.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/content_subscription_onboarding_feature_info_idtr.xml
@@ -86,6 +86,7 @@
         app:featureInfoTitle="@string/subscriptionOnboardingFeatureInfoItrItem8Title" />
 
     <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/subscriptionOnboardingFeatureInfoLegalFooter"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/keyline_4"

--- a/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_features_summary.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_features_summary.xml
@@ -75,7 +75,8 @@
                     app:leadingIcon="@drawable/vpn_color_24"
                     app:primaryText="@string/subscriptionOnboardingFeature1Title"
                     app:secondaryText="@string/subscriptionOnboardingFeature1Description"
-                    app:trailingIcon="@drawable/ic_chevron_right_24" />
+                    app:trailingIcon="@drawable/ic_chevron_right_24"
+                    app:trailingIconSize="small" />
 
                 <com.duckduckgo.common.ui.view.divider.HorizontalDivider
                     android:id="@+id/onboardingSubscriptionFeaturesDivider1"
@@ -89,7 +90,8 @@
                     app:leadingIcon="@drawable/identity_theft_restoration_color_24"
                     app:primaryText="@string/subscriptionOnboardingFeature2Title"
                     app:secondaryText="@string/subscriptionOnboardingFeature2Description"
-                    app:trailingIcon="@drawable/ic_chevron_right_24" />
+                    app:trailingIcon="@drawable/ic_chevron_right_24"
+                    app:trailingIconSize="small" />
 
                 <com.duckduckgo.common.ui.view.divider.HorizontalDivider
                     android:id="@+id/onboardingSubscriptionFeaturesDivider2"
@@ -103,7 +105,8 @@
                     app:leadingIcon="@drawable/ai_general_color_24"
                     app:primaryText="@string/subscriptionOnboardingFeature3Title"
                     app:secondaryText="@string/subscriptionOnboardingFeature3Description"
-                    app:trailingIcon="@drawable/ic_chevron_right_24" />
+                    app:trailingIcon="@drawable/ic_chevron_right_24"
+                    app:trailingIconSize="small" />
 
                 <com.duckduckgo.common.ui.view.divider.HorizontalDivider
                     android:id="@+id/onboardingSubscriptionFeaturesDivider3"
@@ -117,7 +120,8 @@
                     app:leadingIcon="@drawable/identity_blocked_pir_color_24"
                     app:primaryText="@string/subscriptionOnboardingFeature4Title"
                     app:secondaryText="@string/subscriptionOnboardingFeature4Description"
-                    app:trailingIcon="@drawable/ic_chevron_right_24" />
+                    app:trailingIcon="@drawable/ic_chevron_right_24"
+                    app:trailingIconSize="small" />
 
             </LinearLayout>
 

--- a/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_features_summary.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_features_summary.xml
@@ -74,7 +74,8 @@
                     android:layout_height="wrap_content"
                     app:leadingIcon="@drawable/vpn_color_24"
                     app:primaryText="@string/subscriptionOnboardingFeature1Title"
-                    app:secondaryText="@string/subscriptionOnboardingFeature1Description" />
+                    app:secondaryText="@string/subscriptionOnboardingFeature1Description"
+                    app:trailingIcon="@drawable/ic_chevron_right_24" />
 
                 <com.duckduckgo.common.ui.view.divider.HorizontalDivider
                     android:id="@+id/onboardingSubscriptionFeaturesDivider1"
@@ -87,7 +88,8 @@
                     android:layout_height="wrap_content"
                     app:leadingIcon="@drawable/identity_theft_restoration_color_24"
                     app:primaryText="@string/subscriptionOnboardingFeature2Title"
-                    app:secondaryText="@string/subscriptionOnboardingFeature2Description" />
+                    app:secondaryText="@string/subscriptionOnboardingFeature2Description"
+                    app:trailingIcon="@drawable/ic_chevron_right_24" />
 
                 <com.duckduckgo.common.ui.view.divider.HorizontalDivider
                     android:id="@+id/onboardingSubscriptionFeaturesDivider2"
@@ -100,7 +102,8 @@
                     android:layout_height="wrap_content"
                     app:leadingIcon="@drawable/ai_general_color_24"
                     app:primaryText="@string/subscriptionOnboardingFeature3Title"
-                    app:secondaryText="@string/subscriptionOnboardingFeature3Description" />
+                    app:secondaryText="@string/subscriptionOnboardingFeature3Description"
+                    app:trailingIcon="@drawable/ic_chevron_right_24" />
 
                 <com.duckduckgo.common.ui.view.divider.HorizontalDivider
                     android:id="@+id/onboardingSubscriptionFeaturesDivider3"
@@ -113,7 +116,8 @@
                     android:layout_height="wrap_content"
                     app:leadingIcon="@drawable/identity_blocked_pir_color_24"
                     app:primaryText="@string/subscriptionOnboardingFeature4Title"
-                    app:secondaryText="@string/subscriptionOnboardingFeature4Description" />
+                    app:secondaryText="@string/subscriptionOnboardingFeature4Description"
+                    app:trailingIcon="@drawable/ic_chevron_right_24" />
 
             </LinearLayout>
 

--- a/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_welcome.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_welcome.xml
@@ -224,4 +224,15 @@
         app:daxButtonSize="large"
         app:layout_constraintBottom_toBottomOf="parent" />
 
+    <nl.dionsegijn.konfetti.KonfettiView
+        android:id="@+id/subscriptionOnboardingWelcomeKonfetti"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:clickable="false"
+        android:focusable="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
@@ -92,7 +92,7 @@
     <string name="subscriptionOnboardingFeatureInfoItrTitle">Identity Theft Restoration</string>
     <string name="subscriptionOnboardingFeatureInfoItrDescription">If your identity is stolen in the future, we\'ll help restore it. A personal case manager handles calls and paperwork so you don\'t have to.</string>
     <string name="subscriptionOnboardingFeatureInfoItrItem1Title">Recover financial losses</string>
-    <string name="subscriptionOnboardingFeatureInfoItrItem1Description">We\'ll work with financial institutions to help reverse any fraudulent transactions, and we\'ll reimburse certain out-of-pocket expenses*** in the event that you become a victim of identity theft or fraud.</string>
+    <string name="subscriptionOnboardingFeatureInfoItrItem1Description">We\'ll work with financial institutions to help reverse any fraudulent transactions, and we\'ll reimburse certain out-of-pocket expenses* in the event that you become a victim of identity theft or fraud.</string>
     <string name="subscriptionOnboardingFeatureInfoItrItem2Title">Fix your credit report</string>
     <string name="subscriptionOnboardingFeatureInfoItrItem2Description">We\'ll help fix errors in your credit report that result from fraudulent activity, and assist you in freezing your credit report until your identity is restored.</string>
     <string name="subscriptionOnboardingFeatureInfoItrItem3Title">Replace and cancel lost wallet items</string>
@@ -107,7 +107,7 @@
     <string name="subscriptionOnboardingFeatureInfoItrItem7Description">We\'ll help you report fraudulent activity to police and legal authorities.</string>
     <string name="subscriptionOnboardingFeatureInfoItrItem8Title">Medical ID theft assistance</string>
     <string name="subscriptionOnboardingFeatureInfoItrItem8Description">If fraudulent medical claims occur, we\'ll help inform healthcare and insurance providers, and help ensure medical records are corrected — with in-house medical staff if required.</string>
-    <string name="subscriptionOnboardingFeatureInfoItrLegalFooter">The Identity Expense Reimbursement and the Unauthorized Electronic Fund Transfer Reimbursement benefits are underwritten and administered by American Bankers Insurance Company of Florida, an Assurant company, under group or blanket policies issued to Generali Global Assistance, Inc., dba Iris® Powered by Generali for the benefit of its Members. Please refer to the actual policies for terms, conditions, and exclusions of coverage. Coverage may not be available in all jurisdictions. Review the Summary of Benefits.</string>
+    <string name="subscriptionOnboardingFeatureInfoItrLegalFooter">*The Identity Expense Reimbursement and the Unauthorized Electronic Fund Transfer Reimbursement benefits are underwritten and administered by American Bankers Insurance Company of Florida, an Assurant company, under group or blanket policies issued to Generali Global Assistance, Inc., dba Iris® Powered by Generali for the benefit of its Members. Please refer to the actual policies for terms, conditions, and exclusions of coverage. Coverage may not be available in all jurisdictions. Review the Summary of Benefits.</string>
 
     <!-- Feature detail: Duck.ai -->
     <string name="subscriptionOnboardingFeatureInfoDuckAiTitle">Chat privately with advanced AI models</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
@@ -98,7 +98,7 @@
     <string name="subscriptionOnboardingFeatureInfoItrItem3Title">Replace and cancel lost wallet items</string>
     <string name="subscriptionOnboardingFeatureInfoItrItem3Description">Losing your wallet shouldn\'t be so stressful. Should you need to, we\'ll help you cancel and replace your driver\'s license, bank cards, passport, and social security card.</string>
     <string name="subscriptionOnboardingFeatureInfoItrItem4Title">Get help from a personal case manager</string>
-    <string name="subscriptionOnboardingFeatureInfoItrItem4Description">With servers across the US and Europe, you get the closest connection to maximize speed and stability and can choose to connect to any of our servers worldwide.</string>
+    <string name="subscriptionOnboardingFeatureInfoItrItem4Description">They\'ll help to resolve issues and work directly with credit card companies or banks, deal with paperwork and call centers, handle follow-ups, and provide guidance throughout.</string>
     <string name="subscriptionOnboardingFeatureInfoItrItem5Title">Rapid and reliable response</string>
     <string name="subscriptionOnboardingFeatureInfoItrItem5Description">We treat every stolen identity as an emergency. Call 24/7 to request assistance, and count on an answer from an expert advisor in less than 30 seconds.</string>
     <string name="subscriptionOnboardingFeatureInfoItrItem6Title">Emergency cash and travel arrangements</string>

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeViewModelTest.kt
@@ -16,21 +16,32 @@
 
 package com.duckduckgo.subscriptions.impl.onboarding.welcome
 
+import app.cash.turbine.test
+import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
 import com.duckduckgo.subscriptions.impl.onboarding.welcome.SubscriptionOnboardingWelcomeStepPlugin.Companion.WELCOME_STEP_ID
+import com.duckduckgo.subscriptions.impl.onboarding.welcome.SubscriptionOnboardingWelcomeViewModel.Command.LaunchConfetti
+import com.duckduckgo.subscriptions.impl.store.SubscriptionOnboardingStepStore
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 class SubscriptionOnboardingWelcomeViewModelTest {
 
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
     private val controller: SubscriptionOnboardingController = mock()
+    private val stepStore: SubscriptionOnboardingStepStore = mock()
 
     private fun viewModelStartingOn(date: LocalDate): SubscriptionOnboardingWelcomeViewModel {
         val timeProvider = object : CurrentTimeProvider {
@@ -38,7 +49,7 @@ class SubscriptionOnboardingWelcomeViewModelTest {
             override fun currentTimeMillis(): Long = 0
             override fun localDateTimeNow(): LocalDateTime = date.atStartOfDay()
         }
-        return SubscriptionOnboardingWelcomeViewModel(controller, timeProvider)
+        return SubscriptionOnboardingWelcomeViewModel(controller, timeProvider, stepStore, coroutineRule.testDispatcherProvider)
     }
 
     @Test
@@ -89,5 +100,44 @@ class SubscriptionOnboardingWelcomeViewModelTest {
         viewModelStartingOn(LocalDate.of(2026, 5, 7)).onPrimaryCtaClicked()
 
         verify(controller).onStepFinished(WELCOME_STEP_ID, COMPLETED)
+    }
+
+    @Test
+    fun whenScreenShownAndWelcomeStepNotCompletedThenLaunchesConfetti() = runTest {
+        whenever(stepStore.isCompleted(WELCOME_STEP_ID)).thenReturn(false)
+        val viewModel = viewModelStartingOn(LocalDate.of(2026, 5, 7))
+
+        viewModel.commands.test {
+            viewModel.onScreenShown()
+
+            assertEquals(LaunchConfetti, awaitItem())
+        }
+    }
+
+    @Test
+    fun whenScreenShownAndWelcomeStepAlreadyCompletedThenDoesNotLaunchConfetti() = runTest {
+        whenever(stepStore.isCompleted(WELCOME_STEP_ID)).thenReturn(true)
+        val viewModel = viewModelStartingOn(LocalDate.of(2026, 5, 7))
+
+        viewModel.commands.test {
+            viewModel.onScreenShown()
+
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun whenScreenShownAgainThenDoesNotLaunchConfettiTwice() = runTest {
+        whenever(stepStore.isCompleted(WELCOME_STEP_ID)).thenReturn(false)
+        val viewModel = viewModelStartingOn(LocalDate.of(2026, 5, 7))
+
+        viewModel.commands.test {
+            viewModel.onScreenShown()
+            assertEquals(LaunchConfetti, awaitItem())
+
+            viewModel.onScreenShown()
+
+            expectNoEvents()
+        }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217713262961059?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Applied changes requested in product/copy review

### Steps to test this PR (_Optional as it was verified in product review_)

_Pre steps_
- [x] Apply patch on https://app.asana.com/1/137249556945/project/1201807753394693/task/1216636588501791?focus=true

_Confetti in Welcome Screen_
- [x] Fresh install from branch
- [x] Purchase a test subscription
- [x] Subscription onbaording is launched
- [x] Verify a confetti animation is displayed in welcome screen
- [x] Go to next step and then go back to welcome screen
- [x] Verify confetti animation is not displayed

_Chevron added_
- [ ] Go to next step again (features list)
- [ ] Verify list items have a chevron

_Copy changes_
- [x] Go to Identity Theft Restoration
- [x] Verify that in the first item, there is only one asterisk after expenses
- [x] Verify in the footnote, an asterisk was also added
- [x] Verify fourth item description is updated with suggested new copy -> https://app.asana.com/1/137249556945/task/1217499353778336/comment/1217606702250324?focus=true

### UI changes
- See https://app.asana.com/1/137249556945/project/72649045549333/task/1217488667544918?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only onboarding polish plus a small third-party animation library; no auth, billing, or data-handling changes.
> 
> **Overview**
> Applies product-review tweaks to subscription onboarding: confetti on first welcome, chevrons on the features list, and Identity Theft Restoration copy fixes.
> 
> The welcome screen now plays a one-shot Konfetti animation when the step is not yet completed, gated via `SubscriptionOnboardingStepStore` so returning to the screen does not replay it.
> 
> Feature summary rows get trailing chevrons. ITR copy uses a single asterisk, a matching legal footnote, and a corrected case-manager description (replacing misplaced VPN text).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f71ca66490ba888ca6b72cc70841f5c3613c65d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->