### PR TITLE
chore(pir): bump content-scope-scripts

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -548,8 +548,9 @@
     "webEvents",
     "pageObserver",
     "hover",
-    "trackerProtection"
+    "trackerProtection",
     // only enabled on apple platforms
+    "textSelection"
   ];
   var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
@@ -623,7 +624,8 @@
       "browserUiLock",
       "trackerProtection",
       "tabSuspension",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "textSelection"
     ]
   );
   var platformSupport = {
@@ -644,7 +646,8 @@
       "webTelemetry",
       "pageObserver",
       "hover",
-      "tabSuspension"
+      "tabSuspension",
+      "textSelection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -2063,8 +2063,9 @@
     "webEvents",
     "pageObserver",
     "hover",
-    "trackerProtection"
+    "trackerProtection",
     // only enabled on apple platforms
+    "textSelection"
   ];
   var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
@@ -2167,7 +2168,8 @@
       "browserUiLock",
       "trackerProtection",
       "tabSuspension",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "textSelection"
     ]
   );
   var platformSupport = {
@@ -2188,7 +2190,8 @@
       "webTelemetry",
       "pageObserver",
       "hover",
-      "tabSuspension"
+      "tabSuspension",
+      "textSelection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],
@@ -8108,6 +8111,23 @@
   // src/features/broker-protection/actions/click.js
   init_define_import_meta_trackerLookup();
 
+  // src/features/broker-protection/utils/select-root-element.js
+  init_define_import_meta_trackerLookup();
+  function selectRootElement(elementConfig, userData, root = document) {
+    if (!elementConfig.parent) return root;
+    if (elementConfig.parent.profileMatch) {
+      const extraction = extractProfiles(elementConfig.parent.profileMatch, userData, root);
+      if ("results" in extraction) {
+        const sorted = extraction.results.filter((x2) => x2.result === true).sort((a2, b2) => b2.score - a2.score);
+        const first = sorted[0];
+        if (first && first.element) {
+          return first.element;
+        }
+      }
+    }
+    return PirError.create("`parent` was present on the element, but the configuration is not supported");
+  }
+
   // src/features/broker-protection/actions/build-url-transforms.js
   init_define_import_meta_trackerLookup();
   function transformUrl(action, userData) {
@@ -8200,11 +8220,9 @@
       return new ErrorResponse({ actionID: action.id, message: "No elements provided to click action" });
     }
     for (const element of elements) {
-      let rootElement;
-      try {
-        rootElement = selectRootElement(element, userData, root);
-      } catch (error) {
-        return new ErrorResponse({ actionID: action.id, message: `Could not find root element: ${error.message}` });
+      const rootElement = selectRootElement(element, userData, root);
+      if (PirError.isError(rootElement)) {
+        return new ErrorResponse({ actionID: action.id, message: `Could not find root element: ${rootElement.error.message}` });
       }
       const elements2 = getElements(rootElement, element.selector);
       if (!elements2?.length) {
@@ -8230,20 +8248,6 @@
       }
     }
     return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: null });
-  }
-  function selectRootElement(clickElement, userData, root = document) {
-    if (!clickElement.parent) return root;
-    if (clickElement.parent.profileMatch) {
-      const extraction = extractProfiles(clickElement.parent.profileMatch, userData, root);
-      if ("results" in extraction) {
-        const sorted = extraction.results.filter((x2) => x2.result === true).sort((a2, b2) => b2.score - a2.score);
-        const first = sorted[0];
-        if (first && first.element) {
-          return first.element;
-        }
-      }
-    }
-    throw new Error("`parent` was present on the element, but the configuration is not supported");
   }
   function getComparisonFunction(operator) {
     switch (operator) {
@@ -8604,26 +8608,28 @@
     if (clients.length === 0) {
       return console.log("cannot find clients");
     }
-    if (typeof clients[0].function === "function") {
-      try {
-        clients[0].function(args.token);
-        console.log("called function with path", clients[0].callback);
-      } catch (e) {
-        console.error("could not call function");
-      }
+    const client = args.widgetId === void 0 ? clients[0] : clients.find(({ id }) => Number(id) === args.widgetId);
+    if (!client || typeof client.function !== "function") {
+      return console.log("cannot find a callable reCAPTCHA client for widget", args.widgetId);
+    }
+    try {
+      client.function(args.token);
+      console.log("called function with path", client.callback);
+    } catch (e) {
+      console.error("could not call function");
     }
     function findRecaptchaClients(target) {
       if (typeof target.___grecaptcha_cfg === "undefined") {
         console.log("target.___grecaptcha_cfg not found in ", location.href);
         return [];
       }
-      return Object.entries(target.___grecaptcha_cfg.clients || {}).map(([cid, client]) => {
+      return Object.entries(target.___grecaptcha_cfg.clients || {}).map(([cid, client2]) => {
         const cidNumber = parseInt(cid, 10);
         const data2 = {
           id: cid,
           version: cidNumber >= 1e4 ? "V3" : "V2"
         };
-        const objects = Object.entries(client).filter(([, value]) => value && typeof value === "object");
+        const objects = Object.entries(client2).filter(([, value]) => value && typeof value === "object");
         objects.forEach(([toplevelKey, toplevel]) => {
           const found = Object.entries(toplevel).find(
             ([, value]) => value && typeof value === "object" && "sitekey" in value && "size" in value
@@ -8688,14 +8694,19 @@
       return null;
     }
     /**
-     * @param {HTMLElement} _captchaContainerElement - The element containing the captcha
+     * @param {HTMLElement} captchaContainerElement - The element containing the captcha
      * @param {string} token
      */
-    getSolveCallback(_captchaContainerElement, token) {
+    getSolveCallback(captchaContainerElement, token) {
+      const responseElement = getElementByTagName(captchaContainerElement, __privateGet(this, _config).responseElementName);
+      const callbackArgs = createCaptchaCallbackArgs(responseElement, __privateGet(this, _config).responseElementName, token);
+      if (PirError.isError(callbackArgs)) {
+        return callbackArgs;
+      }
       return stringifyFunction({
         functionBody: captchaCallback,
         functionName: "captchaCallback",
-        args: { token }
+        args: callbackArgs
       });
     }
     /**
@@ -8720,6 +8731,23 @@
     }
   };
   _config = new WeakMap();
+  function createCaptchaCallbackArgs(responseElement, responseElementName, token) {
+    if (!responseElement) {
+      return PirError.create("could not find the reCAPTCHA response element for the matched record");
+    }
+    if (responseElement.id === responseElementName) {
+      return { token, widgetId: 0 };
+    }
+    const prefix = `${responseElementName}-`;
+    if (!responseElement.id.startsWith(prefix)) {
+      return PirError.create("could not resolve a unique reCAPTCHA widget for the matched record");
+    }
+    const widgetId = responseElement.id.slice(prefix.length);
+    if (!/^\d+$/.test(widgetId)) {
+      return PirError.create("could not resolve a unique reCAPTCHA widget for the matched record");
+    }
+    return { token, widgetId: Number(widgetId) };
+  }
 
   // src/features/broker-protection/captcha-services/providers/image.js
   init_define_import_meta_trackerLookup();
@@ -9115,6 +9143,7 @@
   }
 
   // src/features/broker-protection/captcha-services/captcha.service.js
+  var pendingCaptchaContext = null;
   var getCaptchaContainer = (root, selector) => {
     if (!selector) {
       return PirError.create("missing selector");
@@ -9124,6 +9153,9 @@
       return PirError.create(`could not find captcha container with selector ${selector}`);
     }
     return captchaContainer;
+  };
+  var getCaptchaRoot = (action, userData, root) => {
+    return selectRootElement(action, userData ?? {}, root);
   };
   function getSupportingCodeToInject(action) {
     const { id: actionID, actionType, injectCaptchaHandler: captchaType } = action;
@@ -9137,13 +9169,18 @@
     }
     return SuccessResponse.create({ actionID, actionType, response: { code: captchaProvider.getSupportingCodeToInject() } });
   }
-  async function getCaptchaInfo2(action, root = document) {
+  async function getCaptchaInfo2(action, userData, root = document) {
     const { id: actionID, actionType, captchaType, selector } = action;
+    pendingCaptchaContext = null;
     if (!captchaType) {
       return getCaptchaInfo(action, root);
     }
     const createError = ErrorResponse.generateErrorResponseFunction({ actionID, context: `[getCaptchaInfo] captchaType: ${captchaType}` });
-    const captchaContainer = getCaptchaContainer(root, selector);
+    const captchaRoot = getCaptchaRoot(action, userData, root);
+    if (PirError.isError(captchaRoot)) {
+      return createError(captchaRoot.error.message);
+    }
+    const captchaContainer = getCaptchaContainer(captchaRoot, selector);
     if (PirError.isError(captchaContainer)) {
       return createError(captchaContainer.error.message);
     }
@@ -9165,15 +9202,31 @@
       siteKey: captchaIdentifier,
       type: reportedType
     };
+    if (action.parent) {
+      pendingCaptchaContext = { profile: userData, token: null };
+    }
     return SuccessResponse.create({ actionID, actionType, response });
   }
-  function solveCaptcha2(action, token, root = document) {
+  function solveCaptcha2(action, token, userData, root = document) {
     const { id: actionID, actionType, captchaType, selector } = action;
     if (!captchaType) {
       return solveCaptcha(action, token, root);
     }
     const createError = ErrorResponse.generateErrorResponseFunction({ actionID, context: `[solveCaptcha] captchaType: ${captchaType}` });
-    const captchaContainer = getCaptchaContainer(root, selector);
+    const matchingProfile = userData ?? pendingCaptchaContext?.profile ?? null;
+    if (action.parent && !matchingProfile) {
+      return createError("no profile available to scope the captcha solve");
+    }
+    const captchaToken = token ?? pendingCaptchaContext?.token ?? null;
+    if (!captchaToken) {
+      return createError("no token available to solve the captcha");
+    }
+    pendingCaptchaContext = action.parent ? { profile: matchingProfile, token: captchaToken } : null;
+    const captchaRoot = getCaptchaRoot(action, matchingProfile, root);
+    if (PirError.isError(captchaRoot)) {
+      return createError(captchaRoot.error.message);
+    }
+    const captchaContainer = getCaptchaContainer(captchaRoot, selector);
     if (PirError.isError(captchaContainer)) {
       return createError(captchaContainer.error.message);
     }
@@ -9184,17 +9237,22 @@
     if (!captchaSolveProvider.canSolve(captchaContainer)) {
       return createError("cannot solve captcha");
     }
-    const tokenResponse = captchaSolveProvider.injectToken(captchaContainer, token);
+    const callback = captchaSolveProvider.getSolveCallback(captchaContainer, captchaToken);
+    if (PirError.isError(callback)) {
+      return createError(callback.error.message);
+    }
+    const tokenResponse = captchaSolveProvider.injectToken(captchaContainer, captchaToken);
     if (PirError.isError(tokenResponse)) {
       return createError(tokenResponse.error.message);
     }
     if (!tokenResponse.response.injected) {
       return createError("could not inject token");
     }
+    pendingCaptchaContext = null;
     return SuccessResponse.create({
       actionID,
       actionType,
-      response: { callback: { eval: captchaSolveProvider.getSolveCallback(captchaContainer, token) } }
+      response: { callback: { eval: callback } }
     });
   }
 
@@ -9292,9 +9350,9 @@
           return fillForm(action, data(action, inputData, "extractedProfile"), root, userProfile);
         }
         case "getCaptchaInfo":
-          return await getCaptchaInfo2(action, root);
+          return await getCaptchaInfo2(action, profileForMatching(inputData), root);
         case "solveCaptcha":
-          return solveCaptcha2(action, data(action, inputData, "token"), root);
+          return solveCaptcha2(action, data(action, inputData, "token"), profileForMatching(inputData), root);
         case "condition":
           return condition(action, root);
         case "scroll":
@@ -9313,6 +9371,9 @@
         message: `unhandled exception: ${e.message}`
       });
     }
+  }
+  function profileForMatching(inputData) {
+    return inputData?.userProfile ?? inputData?.extractedProfile ?? null;
   }
   function data(action, data2, defaultSource) {
     if (!data2) return null;

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2063,8 +2063,9 @@
     "webEvents",
     "pageObserver",
     "hover",
-    "trackerProtection"
+    "trackerProtection",
     // only enabled on apple platforms
+    "textSelection"
   ];
   var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
@@ -2139,7 +2140,8 @@
       "browserUiLock",
       "trackerProtection",
       "tabSuspension",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "textSelection"
     ]
   );
   var platformSupport = {
@@ -2160,7 +2162,8 @@
       "webTelemetry",
       "pageObserver",
       "hover",
-      "tabSuspension"
+      "tabSuspension",
+      "textSelection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],
@@ -8077,6 +8080,23 @@
   // src/features/broker-protection/actions/click.js
   init_define_import_meta_trackerLookup();
 
+  // src/features/broker-protection/utils/select-root-element.js
+  init_define_import_meta_trackerLookup();
+  function selectRootElement(elementConfig, userData, root = document) {
+    if (!elementConfig.parent) return root;
+    if (elementConfig.parent.profileMatch) {
+      const extraction = extractProfiles(elementConfig.parent.profileMatch, userData, root);
+      if ("results" in extraction) {
+        const sorted = extraction.results.filter((x2) => x2.result === true).sort((a2, b2) => b2.score - a2.score);
+        const first = sorted[0];
+        if (first && first.element) {
+          return first.element;
+        }
+      }
+    }
+    return PirError.create("`parent` was present on the element, but the configuration is not supported");
+  }
+
   // src/features/broker-protection/actions/build-url-transforms.js
   init_define_import_meta_trackerLookup();
   function transformUrl(action, userData) {
@@ -8169,11 +8189,9 @@
       return new ErrorResponse({ actionID: action.id, message: "No elements provided to click action" });
     }
     for (const element of elements) {
-      let rootElement;
-      try {
-        rootElement = selectRootElement(element, userData, root);
-      } catch (error) {
-        return new ErrorResponse({ actionID: action.id, message: `Could not find root element: ${error.message}` });
+      const rootElement = selectRootElement(element, userData, root);
+      if (PirError.isError(rootElement)) {
+        return new ErrorResponse({ actionID: action.id, message: `Could not find root element: ${rootElement.error.message}` });
       }
       const elements2 = getElements(rootElement, element.selector);
       if (!elements2?.length) {
@@ -8199,20 +8217,6 @@
       }
     }
     return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: null });
-  }
-  function selectRootElement(clickElement, userData, root = document) {
-    if (!clickElement.parent) return root;
-    if (clickElement.parent.profileMatch) {
-      const extraction = extractProfiles(clickElement.parent.profileMatch, userData, root);
-      if ("results" in extraction) {
-        const sorted = extraction.results.filter((x2) => x2.result === true).sort((a2, b2) => b2.score - a2.score);
-        const first = sorted[0];
-        if (first && first.element) {
-          return first.element;
-        }
-      }
-    }
-    throw new Error("`parent` was present on the element, but the configuration is not supported");
   }
   function getComparisonFunction(operator) {
     switch (operator) {
@@ -8573,26 +8577,28 @@
     if (clients.length === 0) {
       return console.log("cannot find clients");
     }
-    if (typeof clients[0].function === "function") {
-      try {
-        clients[0].function(args.token);
-        console.log("called function with path", clients[0].callback);
-      } catch (e) {
-        console.error("could not call function");
-      }
+    const client = args.widgetId === void 0 ? clients[0] : clients.find(({ id }) => Number(id) === args.widgetId);
+    if (!client || typeof client.function !== "function") {
+      return console.log("cannot find a callable reCAPTCHA client for widget", args.widgetId);
+    }
+    try {
+      client.function(args.token);
+      console.log("called function with path", client.callback);
+    } catch (e) {
+      console.error("could not call function");
     }
     function findRecaptchaClients(target) {
       if (typeof target.___grecaptcha_cfg === "undefined") {
         console.log("target.___grecaptcha_cfg not found in ", location.href);
         return [];
       }
-      return Object.entries(target.___grecaptcha_cfg.clients || {}).map(([cid, client]) => {
+      return Object.entries(target.___grecaptcha_cfg.clients || {}).map(([cid, client2]) => {
         const cidNumber = parseInt(cid, 10);
         const data2 = {
           id: cid,
           version: cidNumber >= 1e4 ? "V3" : "V2"
         };
-        const objects = Object.entries(client).filter(([, value]) => value && typeof value === "object");
+        const objects = Object.entries(client2).filter(([, value]) => value && typeof value === "object");
         objects.forEach(([toplevelKey, toplevel]) => {
           const found = Object.entries(toplevel).find(
             ([, value]) => value && typeof value === "object" && "sitekey" in value && "size" in value
@@ -8657,14 +8663,19 @@
       return null;
     }
     /**
-     * @param {HTMLElement} _captchaContainerElement - The element containing the captcha
+     * @param {HTMLElement} captchaContainerElement - The element containing the captcha
      * @param {string} token
      */
-    getSolveCallback(_captchaContainerElement, token) {
+    getSolveCallback(captchaContainerElement, token) {
+      const responseElement = getElementByTagName(captchaContainerElement, __privateGet(this, _config).responseElementName);
+      const callbackArgs = createCaptchaCallbackArgs(responseElement, __privateGet(this, _config).responseElementName, token);
+      if (PirError.isError(callbackArgs)) {
+        return callbackArgs;
+      }
       return stringifyFunction({
         functionBody: captchaCallback,
         functionName: "captchaCallback",
-        args: { token }
+        args: callbackArgs
       });
     }
     /**
@@ -8689,6 +8700,23 @@
     }
   };
   _config = new WeakMap();
+  function createCaptchaCallbackArgs(responseElement, responseElementName, token) {
+    if (!responseElement) {
+      return PirError.create("could not find the reCAPTCHA response element for the matched record");
+    }
+    if (responseElement.id === responseElementName) {
+      return { token, widgetId: 0 };
+    }
+    const prefix = `${responseElementName}-`;
+    if (!responseElement.id.startsWith(prefix)) {
+      return PirError.create("could not resolve a unique reCAPTCHA widget for the matched record");
+    }
+    const widgetId = responseElement.id.slice(prefix.length);
+    if (!/^\d+$/.test(widgetId)) {
+      return PirError.create("could not resolve a unique reCAPTCHA widget for the matched record");
+    }
+    return { token, widgetId: Number(widgetId) };
+  }
 
   // src/features/broker-protection/captcha-services/providers/image.js
   init_define_import_meta_trackerLookup();
@@ -9084,6 +9112,7 @@
   }
 
   // src/features/broker-protection/captcha-services/captcha.service.js
+  var pendingCaptchaContext = null;
   var getCaptchaContainer = (root, selector) => {
     if (!selector) {
       return PirError.create("missing selector");
@@ -9093,6 +9122,9 @@
       return PirError.create(`could not find captcha container with selector ${selector}`);
     }
     return captchaContainer;
+  };
+  var getCaptchaRoot = (action, userData, root) => {
+    return selectRootElement(action, userData ?? {}, root);
   };
   function getSupportingCodeToInject(action) {
     const { id: actionID, actionType, injectCaptchaHandler: captchaType } = action;
@@ -9106,13 +9138,18 @@
     }
     return SuccessResponse.create({ actionID, actionType, response: { code: captchaProvider.getSupportingCodeToInject() } });
   }
-  async function getCaptchaInfo2(action, root = document) {
+  async function getCaptchaInfo2(action, userData, root = document) {
     const { id: actionID, actionType, captchaType, selector } = action;
+    pendingCaptchaContext = null;
     if (!captchaType) {
       return getCaptchaInfo(action, root);
     }
     const createError = ErrorResponse.generateErrorResponseFunction({ actionID, context: `[getCaptchaInfo] captchaType: ${captchaType}` });
-    const captchaContainer = getCaptchaContainer(root, selector);
+    const captchaRoot = getCaptchaRoot(action, userData, root);
+    if (PirError.isError(captchaRoot)) {
+      return createError(captchaRoot.error.message);
+    }
+    const captchaContainer = getCaptchaContainer(captchaRoot, selector);
     if (PirError.isError(captchaContainer)) {
       return createError(captchaContainer.error.message);
     }
@@ -9134,15 +9171,31 @@
       siteKey: captchaIdentifier,
       type: reportedType
     };
+    if (action.parent) {
+      pendingCaptchaContext = { profile: userData, token: null };
+    }
     return SuccessResponse.create({ actionID, actionType, response });
   }
-  function solveCaptcha2(action, token, root = document) {
+  function solveCaptcha2(action, token, userData, root = document) {
     const { id: actionID, actionType, captchaType, selector } = action;
     if (!captchaType) {
       return solveCaptcha(action, token, root);
     }
     const createError = ErrorResponse.generateErrorResponseFunction({ actionID, context: `[solveCaptcha] captchaType: ${captchaType}` });
-    const captchaContainer = getCaptchaContainer(root, selector);
+    const matchingProfile = userData ?? pendingCaptchaContext?.profile ?? null;
+    if (action.parent && !matchingProfile) {
+      return createError("no profile available to scope the captcha solve");
+    }
+    const captchaToken = token ?? pendingCaptchaContext?.token ?? null;
+    if (!captchaToken) {
+      return createError("no token available to solve the captcha");
+    }
+    pendingCaptchaContext = action.parent ? { profile: matchingProfile, token: captchaToken } : null;
+    const captchaRoot = getCaptchaRoot(action, matchingProfile, root);
+    if (PirError.isError(captchaRoot)) {
+      return createError(captchaRoot.error.message);
+    }
+    const captchaContainer = getCaptchaContainer(captchaRoot, selector);
     if (PirError.isError(captchaContainer)) {
       return createError(captchaContainer.error.message);
     }
@@ -9153,17 +9206,22 @@
     if (!captchaSolveProvider.canSolve(captchaContainer)) {
       return createError("cannot solve captcha");
     }
-    const tokenResponse = captchaSolveProvider.injectToken(captchaContainer, token);
+    const callback = captchaSolveProvider.getSolveCallback(captchaContainer, captchaToken);
+    if (PirError.isError(callback)) {
+      return createError(callback.error.message);
+    }
+    const tokenResponse = captchaSolveProvider.injectToken(captchaContainer, captchaToken);
     if (PirError.isError(tokenResponse)) {
       return createError(tokenResponse.error.message);
     }
     if (!tokenResponse.response.injected) {
       return createError("could not inject token");
     }
+    pendingCaptchaContext = null;
     return SuccessResponse.create({
       actionID,
       actionType,
-      response: { callback: { eval: captchaSolveProvider.getSolveCallback(captchaContainer, token) } }
+      response: { callback: { eval: callback } }
     });
   }
 
@@ -9261,9 +9319,9 @@
           return fillForm(action, data(action, inputData, "extractedProfile"), root, userProfile);
         }
         case "getCaptchaInfo":
-          return await getCaptchaInfo2(action, root);
+          return await getCaptchaInfo2(action, profileForMatching(inputData), root);
         case "solveCaptcha":
-          return solveCaptcha2(action, data(action, inputData, "token"), root);
+          return solveCaptcha2(action, data(action, inputData, "token"), profileForMatching(inputData), root);
         case "condition":
           return condition(action, root);
         case "scroll":
@@ -9282,6 +9340,9 @@
         message: `unhandled exception: ${e.message}`
       });
     }
+  }
+  function profileForMatching(inputData) {
+    return inputData?.userProfile ?? inputData?.extractedProfile ?? null;
   }
   function data(action, data2, defaultSource) {
     if (!data2) return null;

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1419,8 +1419,9 @@
     "webEvents",
     "pageObserver",
     "hover",
-    "trackerProtection"
+    "trackerProtection",
     // only enabled on apple platforms
+    "textSelection"
   ];
   var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
@@ -1504,7 +1505,8 @@
       "browserUiLock",
       "trackerProtection",
       "tabSuspension",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "textSelection"
     ]
   );
   var platformSupport = {
@@ -1525,7 +1527,8 @@
       "webTelemetry",
       "pageObserver",
       "hover",
-      "tabSuspension"
+      "tabSuspension",
+      "textSelection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -530,8 +530,9 @@
     "webEvents",
     "pageObserver",
     "hover",
-    "trackerProtection"
+    "trackerProtection",
     // only enabled on apple platforms
+    "textSelection"
   ];
   var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
@@ -605,7 +606,8 @@
       "browserUiLock",
       "trackerProtection",
       "tabSuspension",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "textSelection"
     ]
   );
   var platformSupport = {
@@ -626,7 +628,8 @@
       "webTelemetry",
       "pageObserver",
       "hover",
-      "tabSuspension"
+      "tabSuspension",
+      "textSelection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
@@ -530,8 +530,9 @@
     "webEvents",
     "pageObserver",
     "hover",
-    "trackerProtection"
+    "trackerProtection",
     // only enabled on apple platforms
+    "textSelection"
   ];
   var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
@@ -605,7 +606,8 @@
       "browserUiLock",
       "trackerProtection",
       "tabSuspension",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "textSelection"
     ]
   );
   var platformSupport = {
@@ -626,7 +628,8 @@
       "webTelemetry",
       "pageObserver",
       "hover",
-      "tabSuspension"
+      "tabSuspension",
+      "textSelection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -1451,8 +1451,8 @@
     }
   }
   function L(n2, l3, u3, t3, i3, r3, o3, e3, f3, c3, a3) {
-    var s3, h3, p3, v3, y3, _3, g3, m3 = t3 && t3.__k || w, b2 = l3.length;
-    for (f3 = T(u3, l3, m3, f3, b2), s3 = 0; s3 < b2; s3++) null != (p3 = u3.__k[s3]) && (h3 = -1 != p3.__i && m3[p3.__i] || d, p3.__i = s3, _3 = q(n2, p3, h3, i3, r3, o3, e3, f3, c3, a3), v3 = p3.__e, p3.ref && h3.ref != p3.ref && (h3.ref && J(h3.ref, null, p3), a3.push(p3.ref, p3.__c || v3, p3)), null == y3 && null != v3 && (y3 = v3), (g3 = !!(4 & p3.__u)) || h3.__k === p3.__k ? (f3 = j(p3, f3, n2, g3), g3 && h3.__e && (h3.__e = null)) : "function" == typeof p3.type && void 0 !== _3 ? f3 = _3 : v3 && (f3 = v3.nextSibling), p3.__u &= -7);
+    var s3, h3, p3, v3, y3, _3, g3 = t3 && t3.__k || w, m3 = l3.length;
+    for (f3 = T(u3, l3, g3, f3, m3), s3 = 0; s3 < m3; s3++) null != (p3 = u3.__k[s3]) && (h3 = -1 != p3.__i && g3[p3.__i] || d, p3.__i = s3, _3 = q(n2, p3, h3, i3, r3, o3, e3, f3, c3, a3), v3 = p3.__e, p3.ref && h3.ref != p3.ref && (h3.ref && J(h3.ref, null, p3), a3.push(p3.ref, p3.__c || v3, p3)), null == y3 && null != v3 && (y3 = v3), 4 & p3.__u ? (f3 = j(p3, f3, n2), h3.__e && (h3.__e = null)) : "function" == typeof p3.type && void 0 !== _3 ? f3 = _3 : v3 && (f3 = v3.nextSibling), p3.__u &= -7);
     return u3.__e = y3, f3;
   }
   function T(n2, l3, u3, t3, i3) {
@@ -1461,13 +1461,13 @@
     if (s3) for (r3 = 0; r3 < a3; r3++) null != (e3 = u3[r3]) && 0 == (2 & e3.__u) && (e3.__e == t3 && (t3 = $(e3)), K(e3, e3));
     return t3;
   }
-  function j(n2, l3, u3, t3) {
-    var i3, r3;
+  function j(n2, l3, u3) {
+    var t3, i3;
     if ("function" == typeof n2.type) {
-      for (i3 = n2.__k, r3 = 0; i3 && r3 < i3.length; r3++) i3[r3] && (i3[r3].__ = n2, l3 = j(i3[r3], l3, u3, t3));
+      for (t3 = n2.__k, i3 = 0; t3 && i3 < t3.length; i3++) t3[i3] && (t3[i3].__ = n2, l3 = j(t3[i3], l3, u3));
       return l3;
     }
-    n2.__e != l3 && (t3 && (l3 && n2.type && !l3.parentNode && (l3 = $(n2)), u3.insertBefore(n2.__e, l3 || null)), l3 = n2.__e);
+    n2.__e != l3 && (l3 && n2.type && !l3.parentNode && (l3 = $(n2)), l3 = u3.insertBefore(n2.__e, l3 || null));
     do {
       l3 = l3 && l3.nextSibling;
     } while (null != l3 && 8 == l3.nodeType);
@@ -1513,35 +1513,35 @@
     };
   }
   function q(n2, u3, t3, i3, r3, o3, e3, f3, c3, a3) {
-    var s3, h3, p3, v3, y3, d3, _3, k3, x3, M, $2, I2, P2, A3, H2, T3, j3 = u3.type;
+    var s3, h3, p3, v3, y3, d3, _3, k3, x3, M, I2, P2, A3, H2, T3, j3, F = u3.type;
     if (void 0 !== u3.constructor) return null;
     128 & t3.__u && (c3 = !!(32 & t3.__u), o3 = [f3 = u3.__e = t3.__e]), (s3 = l.__b) && s3(u3);
-    n: if ("function" == typeof j3) {
+    n: if ("function" == typeof F) {
       h3 = e3.length;
       try {
-        if (x3 = u3.props, M = j3.prototype && j3.prototype.render, $2 = (s3 = j3.contextType) && i3[s3.__c], I2 = s3 ? $2 ? $2.props.value : s3.__ : i3, t3.__c ? k3 = (p3 = u3.__c = t3.__c).__ = p3.__E : (M ? u3.__c = p3 = new j3(x3, I2) : (u3.__c = p3 = new C(x3, I2), p3.constructor = j3, p3.render = Q), $2 && $2.sub(p3), p3.state || (p3.state = {}), p3.__n = i3, v3 = p3.__d = true, p3.__h = [], p3._sb = []), M && null == p3.__s && (p3.__s = p3.state), M && null != j3.getDerivedStateFromProps && (p3.__s == p3.state && (p3.__s = m({}, p3.__s)), m(p3.__s, j3.getDerivedStateFromProps(x3, p3.__s))), y3 = p3.props, d3 = p3.state, p3.__v = u3, v3) M && null == j3.getDerivedStateFromProps && null != p3.componentWillMount && p3.componentWillMount(), M && null != p3.componentDidMount && p3.__h.push(p3.componentDidMount);
+        if (x3 = u3.props, M = F.prototype && F.prototype.render, I2 = (s3 = F.contextType) && i3[s3.__c], P2 = s3 ? I2 ? I2.props.value : s3.__ : i3, t3.__c ? k3 = (p3 = u3.__c = t3.__c).__ = p3.__E : (M ? u3.__c = p3 = new F(x3, P2) : (u3.__c = p3 = new C(x3, P2), p3.constructor = F, p3.render = Q), I2 && I2.sub(p3), p3.state || (p3.state = {}), p3.__n = i3, v3 = p3.__d = true, p3.__h = [], p3._sb = []), M && null == p3.__s && (p3.__s = p3.state), M && null != F.getDerivedStateFromProps && (p3.__s == p3.state && (p3.__s = m({}, p3.__s)), m(p3.__s, F.getDerivedStateFromProps(x3, p3.__s))), y3 = p3.props, d3 = p3.state, p3.__v = u3, v3) M && null == F.getDerivedStateFromProps && null != p3.componentWillMount && p3.componentWillMount(), M && null != p3.componentDidMount && p3.__h.push(p3.componentDidMount);
         else {
-          if (M && null == j3.getDerivedStateFromProps && x3 !== y3 && null != p3.componentWillReceiveProps && p3.componentWillReceiveProps(x3, I2), u3.__v == t3.__v || !p3.__e && null != p3.shouldComponentUpdate && false === p3.shouldComponentUpdate(x3, p3.__s, I2)) {
+          if (M && null == F.getDerivedStateFromProps && x3 !== y3 && null != p3.componentWillReceiveProps && p3.componentWillReceiveProps(x3, P2), u3.__v == t3.__v || !p3.__e && null != p3.shouldComponentUpdate && false === p3.shouldComponentUpdate(x3, p3.__s, P2)) {
             u3.__v != t3.__v && (p3.props = x3, p3.state = p3.__s, p3.__d = false), u3.__e = t3.__e, u3.__k = t3.__k, u3.__k.some(function(n3) {
               n3 && (n3.__ = u3);
-            }), w.push.apply(p3.__h, p3._sb), p3._sb = [], p3.__h.length && e3.push(p3);
+            }), w.push.apply(p3.__h, p3._sb), p3._sb = [], p3.__h.length && e3.push(p3), f3 = $(t3);
             break n;
           }
-          null != p3.componentWillUpdate && p3.componentWillUpdate(x3, p3.__s, I2), M && null != p3.componentDidUpdate && p3.__h.push(function() {
+          null != p3.componentWillUpdate && p3.componentWillUpdate(x3, p3.__s, P2), M && null != p3.componentDidUpdate && p3.__h.push(function() {
             p3.componentDidUpdate(y3, d3, _3);
           });
         }
-        if (p3.context = I2, p3.props = x3, p3.__P = n2, p3.__e = false, P2 = l.__r, A3 = 0, M) p3.state = p3.__s, p3.__d = false, P2 && P2(u3), s3 = p3.render(p3.props, p3.state, p3.context), w.push.apply(p3.__h, p3._sb), p3._sb = [];
+        if (p3.context = P2, p3.props = x3, p3.__P = n2, p3.__e = false, A3 = l.__r, H2 = 0, M) p3.state = p3.__s, p3.__d = false, A3 && A3(u3), s3 = p3.render(p3.props, p3.state, p3.context), w.push.apply(p3.__h, p3._sb), p3._sb = [];
         else do {
-          p3.__d = false, P2 && P2(u3), s3 = p3.render(p3.props, p3.state, p3.context), p3.state = p3.__s;
-        } while (p3.__d && ++A3 < 25);
-        p3.state = p3.__s, null != p3.getChildContext && (i3 = m(m({}, i3), p3.getChildContext())), M && !v3 && null != p3.getSnapshotBeforeUpdate && (_3 = p3.getSnapshotBeforeUpdate(y3, d3)), H2 = null != s3 && s3.type === S && null == s3.key ? E(s3.props.children) : s3, f3 = L(n2, g(H2) ? H2 : [H2], u3, t3, i3, r3, o3, e3, f3, c3, a3), p3.base = u3.__e, u3.__u &= -161, p3.__h.length && e3.push(p3), k3 && (p3.__E = p3.__ = null);
+          p3.__d = false, A3 && A3(u3), s3 = p3.render(p3.props, p3.state, p3.context), p3.state = p3.__s;
+        } while (p3.__d && ++H2 < 25);
+        p3.state = p3.__s, null != p3.getChildContext && (i3 = m(m({}, i3), p3.getChildContext())), M && !v3 && null != p3.getSnapshotBeforeUpdate && (_3 = p3.getSnapshotBeforeUpdate(y3, d3)), T3 = null != s3 && s3.type === S && null == s3.key ? E(s3.props.children) : s3, f3 = L(n2, g(T3) ? T3 : [T3], u3, t3, i3, r3, o3, e3, f3, c3, a3), p3.base = u3.__e, u3.__u &= -161, p3.__h.length && e3.push(p3), k3 && (p3.__E = p3.__ = null);
       } catch (n3) {
         if (e3.length = h3, u3.__v = null, c3 || null != o3) {
           if (n3.then) {
             for (u3.__u |= c3 ? 160 : 128; f3 && 8 == f3.nodeType && f3.nextSibling; ) f3 = f3.nextSibling;
             null != o3 && (o3[o3.indexOf(f3)] = null), u3.__e = f3;
-          } else if (null != o3) for (T3 = o3.length; T3--; ) b(o3[T3]);
+          } else if (null != o3) for (j3 = o3.length; j3--; ) b(o3[j3]);
         } else u3.__e = t3.__e;
         null == u3.__k && (u3.__k = t3.__k || []), n3.then || B(u3), l.__e(n3, u3, t3);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^16.23.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.8.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.13.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -61,7 +61,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9bb13ba44c2e73f97ebe45c8ce77c238578f3ce5",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#22bfc22f43a4e13cad055bcad96d6f024092db07",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^16.23.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.8.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.13.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
### Summary

Asana: https://app.asana.com/1/137249556945/task/1217611870578208

This PR bumps content-scope-scripts to `16.13.0` so Android receives matched-record CAPTCHA support.

## Test plan

* [ ] Install the internal debug app with this branch, paste the PropertyRecord JSON into PIR Broker Config, run Scan for a test profile, and confirm Android returns the matched record.
* [ ] Run Opt out for that matched record and confirm PropertyRecord shows the success page for the same person.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Vendor bump of injected content-scope scripts, including broker-protection CAPTCHA and click-root matching. Wrong widget targeting or parent scoping could break opt-out flows.
> 
> **Overview**
> Bumps `@duckduckgo/content-scope-scripts` from `16.8.0` to `16.13.0` so Android PIR can solve CAPTCHAs on a **matched record** rather than the first widget on the page.
> 
> Broker protection now scopes `getCaptchaInfo` / `solveCaptcha` with `selectRootElement` and profile matching, picks a reCAPTCHA client by `widgetId`, and keeps pending profile/token context across those actions. `selectRootElement` returns `PirError` instead of throwing.
> 
> Also registers `textSelection` as a platform-specific feature (Apple-oriented) in the bundled scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0fce2e5bdc75e350deb5e4395502d2810c70e0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->