### PR TITLE
Quick Win: Android: Improve PageLoadWideEvent reporting to recover 21.6% unknown events

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_page_load.json5
+++ b/PixelDefinitions/pixels/definitions/wide_page_load.json5
@@ -80,17 +80,17 @@
             },
             {
                 "key": "feature.data.ext.is_tab_in_foreground_on_finish",
-                "description": "Whether the tab was in foreground when page finished loading",
+                "description": "Whether the tab was in foreground when page finished loading. Reported by the caller at finish, so it is absent on a cancelled load.",
                 "type": "boolean"
             },
             {
                 "key": "feature.data.ext.active_requests_on_load_start",
-                "description": "Number of active network requests when page load started",
+                "description": "Number of active network requests when page load started. Reported by the caller at finish, so it is absent on a cancelled load.",
                 "type": "number"
             },
             {
                 "key": "feature.data.ext.concurrent_requests_on_finish",
-                "description": "Number of concurrent network requests when page finished loading",
+                "description": "Number of concurrent network requests when page finished loading. Reported by the caller at finish, so it is absent on a cancelled load.",
                 "type": "number"
             },
             {
@@ -142,6 +142,11 @@
                 "key": "feature.data.ext.failure_reason",
                 "description": "Failure reason auto-attached by the wide event client when the flow finishes with FlowStatus.Failure. Mirrors error_code for page-load failures.",
                 "type": "string"
+            },
+            {
+                "key": "feature.data.ext.cancellation_reason",
+                "description": "Why a load ended without finishing. Only present on CANCELLED loads, which are loads superseded by another main frame load in the same tab before they finished. superseded_same_url covers a reload or restart; superseded_different_url covers a redirect hop and the user navigating away - WebView does not distinguish them.",
+                "enum": ["superseded_same_url", "superseded_different_url"]
             }
         ]
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -770,6 +770,9 @@ class BrowserTabViewModel @Inject constructor(
     private var accessibilityObserver: Job? = null
     private var isProcessingTrackingLink = false
     private var isLinkOpenedInNewTab = false
+
+    // Needed for PageLoadWideEvent: it identifies which page load the progress events belong to.
+    private var pageLoadNavigationId: Long? = null
     private var hasExitedFixedProgress = false
     private var hasCompletedPageLoad = false
 
@@ -2285,7 +2288,6 @@ class BrowserTabViewModel @Inject constructor(
 
         isProcessingTrackingLink = false
         isLinkOpenedInNewTab = false
-        hasExitedFixedProgress = false
         hasCompletedPageLoad = false
 
         automaticSavedLoginsMonitor.clearAutoSavedLoginId(tabId)
@@ -2528,6 +2530,11 @@ class BrowserTabViewModel @Inject constructor(
         logcat { "showPrivacyShield=false, showSearchIcon=true, showClearButton=true" }
     }
 
+    override fun onMainFrameLoadStarted(navigationId: Long) {
+        pageLoadNavigationId = navigationId
+        hasExitedFixedProgress = false
+    }
+
     override fun pageRefreshed(refreshedUrl: String) {
         logcat { "pageRefreshed URL: $url refreshedUrl $refreshedUrl" }
         if (url == null || refreshedUrl == url) {
@@ -2570,11 +2577,10 @@ class BrowserTabViewModel @Inject constructor(
         }
 
         // Track the first time we escape from max progress threshold for Wide Events
-        val currentUrl = webViewNavigationState.currentUrl
         val progressThreshold = if (progressBarUpgradeFeature.behaviourUpdate().isEnabled()) UPGRADED_PROGRESS_THRESHOLD else FIXED_PROGRESS
-        if (!hasExitedFixedProgress && currentUrl != null && newProgress > progressThreshold) {
+        if (!hasExitedFixedProgress && newProgress > progressThreshold) {
             hasExitedFixedProgress = true
-            pageLoadWideEvent.onProgressChanged(tabId, currentUrl)
+            pageLoadNavigationId?.let { pageLoadWideEvent.onProgressChanged(tabId, it) }
         }
 
         loadingViewState.value = progress.copy(isLoading = isLoading, progress = reportedProgress, url = site?.url ?: "")

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -149,6 +149,14 @@ class BrowserWebViewClient @Inject constructor(
     // WebView clears hasGesture() on redirect hops, but the App Link rules assume Chromium's per-navigation gesture flag.
     private var mainFrameGestureOriginUrl: String? = null
     private var start: Long? = null
+
+    // Needed for PageLoadWideEvent: it identifies the page load the wide event is currently measuring,
+    // so every callback reports against the flow that load opened and no later one can claim them.
+    private var navigationId: Long? = null
+
+    // Needed for PageLoadWideEvent: it identifies the url the measured load started with, so a main frame error
+    // can be told apart from one reported against some other url.
+    private var navigationUrl: String? = null
     private var lastInterceptedAppSchemeUrl: String? = null
     private var pageCommitVisibleFired: Boolean = false
     private var recompositeScheduled: Boolean = false
@@ -177,6 +185,7 @@ class BrowserWebViewClient @Inject constructor(
 
     private var currentLoadOperationId: String? = null
     private var parallelRequestsOnStart = 0
+    private var parallelRequestsOnMeasuredLoadStart = 0
 
     init {
         appCoroutineScope.launch {
@@ -496,8 +505,10 @@ class BrowserWebViewClient @Inject constructor(
         if (webView.url == url) {
             val navigationList = webView.safeCopyBackForwardList() ?: return
             webViewClientListener?.onPageCommitVisible(WebViewNavigationState(navigationList), url)
-            webViewClientListener?.getCurrentTabId()?.let { tabId ->
-                pageLoadWideEvent.onPageVisible(tabId, url, webView.progress)
+            navigationId?.let { loadNavigationId ->
+                webViewClientListener?.getCurrentTabId()?.let { tabId ->
+                    pageLoadWideEvent.onPageVisible(tabId, loadNavigationId, webView.progress)
+                }
             }
         }
     }
@@ -546,15 +557,15 @@ class BrowserWebViewClient @Inject constructor(
         var wideEventNavigation: Pair<String, Long>? = null
         url?.let {
             // See https://app.asana.com/0/0/1206159443951489/f (WebView limitations)
-            if (it != ABOUT_BLANK && start == null) {
-                start = currentTimeProvider.elapsedRealtime()
-                webViewClientListener?.getCurrentTabId()?.let { tabId ->
-                    val navigationId = wideEventNavigationIdCounter.incrementAndGet()
-                    pageLoadWideEvent.onPageStarted(tabId, it, navigationId)
-                    wideEventNavigation = tabId to navigationId
+            if (it != ABOUT_BLANK) {
+                if (start == null) {
+                    start = currentTimeProvider.elapsedRealtime()
+                    incrementAndTrackLoad() // increment the request counter
+                    requestInterceptor.onPageStarted(url)
                 }
-                incrementAndTrackLoad() // increment the request counter
-                requestInterceptor.onPageStarted(url)
+                // A page start arriving while another load is in flight opens its own measured load, so a redirect
+                // chain is measured from its last hop.
+                wideEventNavigation = startWideEventPageLoad(it)
             }
 
             handleMediaPlayback(webView, it)
@@ -587,6 +598,56 @@ class BrowserWebViewClient @Inject constructor(
         lastPageStarted = url
         browserAutofillConfigurator.configureAutofillForCurrentPage(webView, url, browserMode)
         loginDetector.onEvent(WebNavigationEvent.OnPageStarted(webView))
+    }
+
+    private fun startWideEventPageLoad(url: String): Pair<String, Long>? {
+        val loadNavigationId = wideEventNavigationIdCounter.incrementAndGet()
+        val replacedNavigationId = navigationId
+        navigationId = loadNavigationId
+        navigationUrl = url
+        parallelRequestsOnMeasuredLoadStart = otherPageLoadsInFlight()
+        logcat { "Page load measured as navigationId=$loadNavigationId: url=$url, replacing=$replacedNavigationId" }
+        webViewClientListener?.onMainFrameLoadStarted(loadNavigationId)
+        val tabId = webViewClientListener?.getCurrentTabId() ?: return null
+        pageLoadWideEvent.onPageStarted(tabId, url, loadNavigationId)
+        return tabId to loadNavigationId
+    }
+
+    private fun endMeasuredPageLoad() {
+        navigationId = null
+        navigationUrl = null
+    }
+
+    private fun reportMeasuredLoadFailed(url: String?, errorDescription: String) {
+        failedNavigationIdFor(url)?.let { reportMeasuredLoadEnded(it, errorDescription) }
+    }
+
+    private fun reportMeasuredLoadFinished() {
+        navigationId?.let { reportMeasuredLoadEnded(it, errorDescription = null) }
+    }
+
+    private fun reportMeasuredLoadEnded(loadNavigationId: Long, errorDescription: String?) {
+        endMeasuredPageLoad()
+        val tabId = webViewClientListener?.getCurrentTabId() ?: return
+        pageLoadWideEvent.onPageLoadFinished(
+            tabId = tabId,
+            navigationId = loadNavigationId,
+            errorDescription = errorDescription,
+            isTabInForegroundOnFinish = webViewClientListener?.isTabInForeground() ?: true,
+            activeRequestsOnLoadStart = parallelRequestsOnMeasuredLoadStart,
+            concurrentRequestsOnFinish = otherPageLoadsInFlight(),
+        )
+    }
+
+    private fun otherPageLoadsInFlight(): Int = (parallelRequestCounter.get() - 1).coerceAtLeast(0)
+
+    private fun failedNavigationIdFor(url: String?): Long? {
+        val currentNavigationId = navigationId ?: return null
+        if (url == null || url != navigationUrl) {
+            logcat { "Ignoring load failure for $url: navigationId=$currentNavigationId is measuring $navigationUrl" }
+            return null
+        }
+        return currentNavigationId
     }
 
     override fun doUpdateVisitedHistory(
@@ -685,18 +746,9 @@ class BrowserWebViewClient @Inject constructor(
             printInjector.injectPrint(webView)
 
             if (url != null && url != ABOUT_BLANK) {
+                reportMeasuredLoadFinished()
                 start?.let { safeStart ->
                     val concurrentRequestsOnFinish = decrementLoadCountAndGet()
-                    webViewClientListener?.getCurrentTabId()?.let { tabId ->
-                        pageLoadWideEvent.onPageLoadFinished(
-                            tabId = tabId,
-                            url = url,
-                            errorDescription = null,
-                            isTabInForegroundOnFinish = webViewClientListener?.isTabInForeground() ?: true,
-                            activeRequestsOnLoadStart = parallelRequestsOnStart,
-                            concurrentRequestsOnFinish = concurrentRequestsOnFinish,
-                        )
-                    }
 
                     // TODO (cbarreiro - 22/05/2024): Extract to plugins
                     pageLoadedHandler.onPageLoaded(
@@ -790,20 +842,15 @@ class BrowserWebViewClient @Inject constructor(
             pixel.fire(WEB_RENDERER_GONE_KILLED)
         }
 
+        // Not url-scoped, and not gated on the cycle: a dead renderer ends whatever load it was running.
+        navigationId?.let { loadNavigationId ->
+            reportMeasuredLoadEnded(
+                loadNavigationId = loadNavigationId,
+                errorDescription = if (didCrash) "ERROR_RENDERER_CRASHED" else "ERROR_RENDERER_KILLED",
+            )
+        }
         if (this.start != null) {
-            val concurrentRequestsOnFinish = decrementLoadCountAndGet()
-            view?.url?.let { url ->
-                webViewClientListener?.getCurrentTabId()?.let { tabId ->
-                    pageLoadWideEvent.onPageLoadFinished(
-                        tabId = tabId,
-                        url = url,
-                        errorDescription = if (didCrash) "ERROR_RENDERER_CRASHED" else "ERROR_RENDERER_KILLED",
-                        isTabInForegroundOnFinish = webViewClientListener?.isTabInForeground() ?: true,
-                        activeRequestsOnLoadStart = parallelRequestsOnStart,
-                        concurrentRequestsOnFinish = concurrentRequestsOnFinish,
-                    )
-                }
-            }
+            decrementLoadCountAndGet()
             this.start = null
         }
 
@@ -921,22 +968,15 @@ class BrowserWebViewClient @Inject constructor(
 
             val parsedError = parseErrorResponse(webResourceError)
             if (request?.isForMainFrame == true) {
+                // Reported for every main-frame error, not just ones shown to the user. Otherwise, other failures
+                // never close properly and later get marked Unknown, making failed loads look like abandoned ones.
+                reportMeasuredLoadFailed(
+                    url = request.url?.toString(),
+                    errorDescription = webResourceError.errorCode.asStringErrorCode(),
+                )
                 if (parsedError != OMITTED) {
                     if (this.start != null) {
-                        // Trigger Wide Event failure for main frame errors
-                        val concurrentRequestsOnFinish = decrementLoadCountAndGet()
-                        request.url?.toString()?.let { url ->
-                            webViewClientListener?.getCurrentTabId()?.let { tabId ->
-                                pageLoadWideEvent.onPageLoadFinished(
-                                    tabId = tabId,
-                                    url = url,
-                                    errorDescription = webResourceError.errorCode.asStringErrorCode(),
-                                    isTabInForegroundOnFinish = webViewClientListener?.isTabInForeground() ?: true,
-                                    activeRequestsOnLoadStart = parallelRequestsOnStart,
-                                    concurrentRequestsOnFinish = concurrentRequestsOnFinish,
-                                )
-                            }
-                        }
+                        decrementLoadCountAndGet()
                         this.start = null
                     }
                 }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -39,6 +39,13 @@ interface WebViewClientListener {
 
     fun pageRefreshed(refreshedUrl: String)
 
+    /**
+     * Called synchronously when a main-frame load starts, with the id identifying that load for
+     * [com.duckduckgo.app.browser.pageload.PageLoadWideEvent]. A redirect hop starts a load of its own, so this fires
+     * more than once per navigation. Progress reported from here until the next call belongs to [navigationId].
+     */
+    fun onMainFrameLoadStarted(navigationId: Long)
+
     fun progressChanged(
         newProgress: Int,
         webViewNavigationState: WebViewNavigationState,

--- a/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.pixels.remoteconfig.OptimizeTrackerEvaluationRCWrapper
 import com.duckduckgo.app.statistics.wideevents.CleanupPolicy
 import com.duckduckgo.app.statistics.wideevents.FlowStatus
 import com.duckduckgo.app.statistics.wideevents.WideEventClient
+import com.duckduckgo.app.statistics.wideevents.WideEventDefinition
 import com.duckduckgo.autoconsent.api.Autoconsent
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
@@ -38,7 +39,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 import logcat.logcat
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
@@ -58,7 +58,8 @@ interface PageLoadWideEvent {
     /**
      * Called when a page starts loading.
      * Starting a load ends whatever load was previously tracked for this tab, whether or not [url] is tracked: the
-     * previous flow can no longer receive events, so leaving it open would only emit an abandoned event on cleanup.
+     * previous flow can no longer receive events, and is completed as cancelled so the load it was measuring stays
+     * countable as one that was superseded, rather than being dropped or left to age into an unaccounted outcome.
      * @param tabId The unique identifier for the tab
      * @param url The URL of the page being loaded
      * @param navigationId Identifies this load for every measurement reported against it later. Must be unique for the
@@ -146,8 +147,7 @@ class RealPageLoadWideEvent @Inject constructor(
                 if (!isFeatureEnabled()) return@launch
 
                 activeFlows.remove(tabId)?.let { previous ->
-                    logcat { "Cancelling previous flow for tabId=$tabId, flowId=${previous.flowId} (${previous.url} → $url)" }
-                    wideEventClient.flowAbort(previous.flowId)
+                    reportSupersededLoad(tabId, previous, supersedingUrl = url)
                 }
 
                 if (!shouldTrackUrl(url)) return@launch
@@ -155,6 +155,7 @@ class RealPageLoadWideEvent @Inject constructor(
                 val result = wideEventClient.flowStart(
                     name = PAGE_LOAD_FEATURE_NAME,
                     cleanupPolicy = CleanupPolicy.OnTimeout(CLEANUP_TIMEOUT),
+                    definition = WideEventDefinition(version = DEFINITION_VERSION),
                 )
 
                 result.onSuccess { flowId ->
@@ -270,8 +271,6 @@ class RealPageLoadWideEvent @Inject constructor(
                 },
             )
 
-            val optimizations = contentScopeOptimizations.current()
-
             val flowStatus = if (isSuccess) {
                 FlowStatus.Success
             } else {
@@ -280,21 +279,41 @@ class RealPageLoadWideEvent @Inject constructor(
             wideEventClient.flowFinish(
                 wideEventId = flowId,
                 status = flowStatus,
-                metadata = mapOf(
-                    KEY_WEBVIEW_VERSION to webViewVersionProvider.getMajorVersion(),
-                    KEY_CPM_ENABLED to autoconsent.isAutoconsentEnabled().toString(),
-                    KEY_TRACKER_OPTIMIZATION_ENABLED to optimizeTrackerEvaluationRCWrapper.enabled.toString(),
+                metadata = loadConditions() + mapOf(
                     KEY_IS_TAB_IN_FOREGROUND_ON_FINISH to isTabInForegroundOnFinish.toString(),
                     KEY_ACTIVE_REQUESTS_ON_LOAD_START to activeRequestsOnLoadStart.toString(),
                     KEY_CONCURRENT_REQUESTS_ON_FINISH to concurrentRequestsOnFinish.toString(),
-                    KEY_CONTENT_SCOPE_INJECTION_OPTIMIZED to optimizations.injectionOptimized.toString(),
-                    KEY_CONTENT_SCOPE_MESSAGING_OPTIMIZED to optimizations.messagingOptimized.toString(),
-                    KEY_CONTENT_SCOPE_EXPERIMENTS_CACHED to optimizations.experimentsCached.toString(),
                 ),
             )
 
             logcat { "Page load finished: tabId=$tabId, flowId=$flowId, outcome=$outcome" }
         }
+    }
+
+    private suspend fun reportSupersededLoad(tabId: String, previous: PageLoadState, supersedingUrl: String) {
+        if (previous.isStale()) {
+            logcat { "Leaving stale flow ${previous.flowId} for tabId=$tabId to the cleanup policy" }
+            return
+        }
+        val reason = if (previous.url == supersedingUrl) REASON_SUPERSEDED_SAME_URL else REASON_SUPERSEDED_DIFFERENT_URL
+        logcat { "Cancelling flow ${previous.flowId} for tabId=$tabId as $reason (${previous.url} → $supersedingUrl)" }
+        wideEventClient.flowFinish(
+            wideEventId = previous.flowId,
+            status = FlowStatus.Cancelled,
+            metadata = loadConditions() + mapOf(KEY_CANCELLATION_REASON to reason),
+        )
+    }
+
+    private suspend fun loadConditions(): Map<String, String> {
+        val optimizations = contentScopeOptimizations.current()
+        return mapOf(
+            KEY_WEBVIEW_VERSION to webViewVersionProvider.getMajorVersion(),
+            KEY_CPM_ENABLED to autoconsent.isAutoconsentEnabled().toString(),
+            KEY_TRACKER_OPTIMIZATION_ENABLED to optimizeTrackerEvaluationRCWrapper.enabled.toString(),
+            KEY_CONTENT_SCOPE_INJECTION_OPTIMIZED to optimizations.injectionOptimized.toString(),
+            KEY_CONTENT_SCOPE_MESSAGING_OPTIMIZED to optimizations.messagingOptimized.toString(),
+            KEY_CONTENT_SCOPE_EXPERIMENTS_CACHED to optimizations.experimentsCached.toString(),
+        )
     }
 
     private fun shouldTrackUrl(url: String): Boolean {
@@ -362,10 +381,10 @@ class RealPageLoadWideEvent @Inject constructor(
         if (state.isStale()) return null
         return state
     }
-
-    private suspend fun isFeatureEnabled(): Boolean = withContext(dispatchers.io()) {
-        androidBrowserConfigFeature.get().sendPageLoadWideEvent().isEnabled()
-    }
+    private suspend fun isFeatureEnabled(): Boolean = true
+    //     private suspend fun isFeatureEnabled(): Boolean = withContext(dispatchers.io()) {
+    //     androidBrowserConfigFeature.get().sendPageLoadWideEvent().isEnabled()
+    // }
 
     private inner class PageLoadState(
         val flowId: Long,
@@ -396,6 +415,7 @@ class RealPageLoadWideEvent @Inject constructor(
 
         val CONTENT_SCOPE_BUCKETS_MS: List<Long> = listOf(5, 10, 25, 50, 100, 200, 400, 800, 1600, 3200, 6400)
         const val PAGE_LOAD_FEATURE_NAME = "page-load"
+        val DEFINITION_VERSION = WideEventDefinition.Version(minor = 0, patch = 1)
         const val STEP_PAGE_START = "page_start"
         const val STEP_PAGE_VISIBLE = "page_visible"
         const val STEP_PAGE_ESCAPED_FIXED_PROGRESS = "page_escaped_fixed_progress"
@@ -419,6 +439,9 @@ class RealPageLoadWideEvent @Inject constructor(
         const val KEY_IS_TAB_IN_FOREGROUND_ON_FINISH = "is_tab_in_foreground_on_finish"
         const val KEY_ACTIVE_REQUESTS_ON_LOAD_START = "active_requests_on_load_start"
         const val KEY_CONCURRENT_REQUESTS_ON_FINISH = "concurrent_requests_on_finish"
+        const val KEY_CANCELLATION_REASON = "cancellation_reason"
+        const val REASON_SUPERSEDED_SAME_URL = "superseded_same_url"
+        const val REASON_SUPERSEDED_DIFFERENT_URL = "superseded_different_url"
         const val FIXED_PROGRESS_THRESHOLD = 50
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import logcat.logcat
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
@@ -381,10 +382,10 @@ class RealPageLoadWideEvent @Inject constructor(
         if (state.isStale()) return null
         return state
     }
-    private suspend fun isFeatureEnabled(): Boolean = true
-    //     private suspend fun isFeatureEnabled(): Boolean = withContext(dispatchers.io()) {
-    //     androidBrowserConfigFeature.get().sendPageLoadWideEvent().isEnabled()
-    // }
+
+    private suspend fun isFeatureEnabled(): Boolean = withContext(dispatchers.io()) {
+        androidBrowserConfigFeature.get().sendPageLoadWideEvent().isEnabled()
+    }
 
     private inner class PageLoadState(
         val flowId: Long,

--- a/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
@@ -49,38 +49,40 @@ import kotlin.time.Duration.Companion.seconds
 /**
  * Tracks page load events as Wide Event flows with multi-phase tracking.
  * Manages flow lifecycle: page_start → page_visible → page_escaped_max_progress → page_finish
+ *
+ * A flow is identified by the navigationId it was started with, never by url: callers report against a load after the
+ * point where its url can still change under them (redirects) or where the load can already have been replaced, so a
+ * url-keyed flow both loses the events of its own load and can be claimed by a later one.
  */
 interface PageLoadWideEvent {
     /**
      * Called when a page starts loading.
+     * Starting a load ends whatever load was previously tracked for this tab, whether or not [url] is tracked: the
+     * previous flow can no longer receive events, so leaving it open would only emit an abandoned event on cleanup.
      * @param tabId The unique identifier for the tab
      * @param url The URL of the page being loaded
-     * @param navigationId Identifies this navigation for the measurements that are reported against it later. Must be
-     * unique for the lifetime of the process, and the same value must be passed to [onContentScopeExperimentsResolved]
-     * and [onJsInjectionComplete] for this navigation.
+     * @param navigationId Identifies this load for every measurement reported against it later. Must be unique for the
+     * lifetime of the process, and the same value must be passed to every other callback for this load.
      */
     fun onPageStarted(tabId: String, url: String, navigationId: Long)
 
     /**
      * Called when a page becomes visible to the user.
      * @param tabId The unique identifier for the tab
-     * @param url The URL of the page being loaded
+     * @param navigationId The id given to [onPageStarted] for the load this belongs to
      * @param progress The current page load progress (0-100)
      */
-    fun onPageVisible(tabId: String, url: String, progress: Int)
+    fun onPageVisible(tabId: String, navigationId: Long, progress: Int)
 
     /**
      * Called when page progress changes and escapes the max progress threshold state.
      * @param tabId The unique identifier for the tab
-     * @param url The URL of the page being loaded
+     * @param navigationId The id given to [onPageStarted] for the load this belongs to
      */
-    fun onProgressChanged(tabId: String, url: String)
+    fun onProgressChanged(tabId: String, navigationId: Long)
 
     /**
      * Called once the active content scope experiments have been resolved, which page start awaits before it can inject.
-     *
-     * Attributed by [navigationId] rather than by url, because callers defer this past the point where their navigation
-     * can end: a later load of the same url in the same tab would otherwise be able to claim the measurement.
      * @param tabId The unique identifier for the tab
      * @param navigationId The id given to [onPageStarted] for the navigation that triggered the injection
      */
@@ -97,7 +99,7 @@ interface PageLoadWideEvent {
     /**
      * Called when a page finishes loading (either successfully or with an error).
      * @param tabId The unique identifier for the tab
-     * @param url The URL of the page that finished loading
+     * @param navigationId The id given to [onPageStarted] for the load that finished
      * @param errorDescription Optional error description. If null, indicates successful load.
      * @param isTabInForegroundOnFinish Whether the tab was in the foreground when finished
      * @param activeRequestsOnLoadStart Number of parallel requests when page load started
@@ -105,7 +107,7 @@ interface PageLoadWideEvent {
      */
     fun onPageLoadFinished(
         tabId: String,
-        url: String,
+        navigationId: Long,
         errorDescription: String? = null,
         isTabInForegroundOnFinish: Boolean,
         activeRequestsOnLoadStart: Int,
@@ -138,19 +140,17 @@ class RealPageLoadWideEvent @Inject constructor(
     private val activeFlows = ConcurrentHashMap<String, PageLoadState>()
 
     override fun onPageStarted(tabId: String, url: String, navigationId: Long) {
-        if (!shouldTrackUrl(url)) return
         val startedAt = currentTimeProvider.elapsedRealtime()
         coroutineScope.launch {
             mutex.withLock {
                 if (!isFeatureEnabled()) return@launch
-                if (isInProgress(tabId, url)) return@launch
 
-                val existingState = activeFlows[tabId]
-                if (existingState != null && existingState.url != url) {
-                    logcat { "Cancelling previous flow for tabId=$tabId (${existingState.url} → $url)" }
-                    activeFlows.remove(tabId)
-                    wideEventClient.flowAbort(existingState.flowId)
+                activeFlows.remove(tabId)?.let { previous ->
+                    logcat { "Cancelling previous flow for tabId=$tabId, flowId=${previous.flowId} (${previous.url} → $url)" }
+                    wideEventClient.flowAbort(previous.flowId)
                 }
+
+                if (!shouldTrackUrl(url)) return@launch
 
                 val result = wideEventClient.flowStart(
                     name = PAGE_LOAD_FEATURE_NAME,
@@ -190,22 +190,22 @@ class RealPageLoadWideEvent @Inject constructor(
         }
     }
 
-    override fun onPageVisible(tabId: String, url: String, progress: Int) {
-        updateWideEventAsync(tabId, url) { flowId ->
+    override fun onPageVisible(tabId: String, navigationId: Long, progress: Int) {
+        updateWideEventAsync(tabId, navigationId, onceForStep = STEP_PAGE_VISIBLE) { state ->
             wideEventClient.intervalEnd(
-                wideEventId = flowId,
+                wideEventId = state.flowId,
                 key = KEY_ELAPSED_TIME_TO_VISIBLE,
             )
 
             wideEventClient.flowStep(
-                wideEventId = flowId,
+                wideEventId = state.flowId,
                 stepName = STEP_PAGE_VISIBLE,
                 metadata = mapOf(
                     KEY_PROGRESS to (progress >= FIXED_PROGRESS_THRESHOLD).toString(),
                 ),
             )
 
-            logcat { "Page visible recorded: flowId=$flowId, progress=$progress" }
+            logcat { "Page visible recorded: flowId=${state.flowId}, progress=$progress" }
         }
     }
 
@@ -227,30 +227,31 @@ class RealPageLoadWideEvent @Inject constructor(
         )
     }
 
-    override fun onProgressChanged(tabId: String, url: String) {
-        updateWideEventAsync(tabId, url) { flowId ->
+    override fun onProgressChanged(tabId: String, navigationId: Long) {
+        updateWideEventAsync(tabId, navigationId, onceForStep = STEP_PAGE_ESCAPED_FIXED_PROGRESS) { state ->
             wideEventClient.intervalEnd(
-                wideEventId = flowId,
+                wideEventId = state.flowId,
                 key = KEY_ELAPSED_TIME_TO_ESCAPED_FIXED_PROGRESS,
             )
             wideEventClient.flowStep(
-                wideEventId = flowId,
+                wideEventId = state.flowId,
                 stepName = STEP_PAGE_ESCAPED_FIXED_PROGRESS,
             )
-            logcat { "Exited max progress threshold: flowId=$flowId" }
+            logcat { "Exited max progress threshold: flowId=${state.flowId}" }
         }
     }
 
     override fun onPageLoadFinished(
         tabId: String,
-        url: String,
+        navigationId: Long,
         errorDescription: String?,
         isTabInForegroundOnFinish: Boolean,
         activeRequestsOnLoadStart: Int,
         concurrentRequestsOnFinish: Int,
     ) {
-        updateWideEventAsync(tabId, url) { flowId ->
-            popActiveFlowId(tabId)
+        updateWideEventAsync(tabId, navigationId) { state ->
+            val flowId = state.flowId
+            activeFlows.remove(tabId)
             val isSuccess = errorDescription == null
             val outcome = if (isSuccess) "success" else "error"
 
@@ -296,11 +297,6 @@ class RealPageLoadWideEvent @Inject constructor(
         }
     }
 
-    private fun isInProgress(tabId: String, url: String): Boolean {
-        val state = activeFlows[tabId] ?: return false
-        return state.url == url && !state.isStale()
-    }
-
     private fun shouldTrackUrl(url: String): Boolean {
         if (url.isBlank()) return false
         if (url == ABOUT_BLANK) return false
@@ -320,31 +316,14 @@ class RealPageLoadWideEvent @Inject constructor(
         key: String,
     ) {
         val measuredAt = currentTimeProvider.elapsedRealtime()
-        coroutineScope.launch {
-            mutex.withLock {
-                if (!isFeatureEnabled()) return@withLock
-                val state = activeFlows[tabId] ?: return@withLock
-                // Matched on the navigation rather than the url: callers defer these measurements past the point where
-                // their navigation can end, and a later load of the same url in this tab must not claim them.
-                if (state.navigationId != navigationId) {
-                    logcat { "Dropping $key from navigation $navigationId, tabId=$tabId is on ${state.navigationId}" }
-                    return@withLock
-                }
-                if (state.isStale()) return@withLock
-                // First value wins, so a callback repeated for this navigation cannot overwrite the measurement already
-                // taken for it.
-                if (!state.recordedMeasurementKeys.add(key)) {
-                    logcat { "Ignoring repeat $key measurement for flowId=${state.flowId}" }
-                    return@withLock
-                }
-                val bucket = lowerBoundBucket(measuredAt - state.startedAt)
-                wideEventClient.flowStep(
-                    wideEventId = state.flowId,
-                    stepName = stepName,
-                    metadata = mapOf(key to bucket),
-                )
-                logcat { "Recorded $key=$bucket for flowId=${state.flowId}" }
-            }
+        updateWideEventAsync(tabId, navigationId, onceForStep = stepName) { state ->
+            val bucket = lowerBoundBucket(measuredAt - state.startedAt)
+            wideEventClient.flowStep(
+                wideEventId = state.flowId,
+                stepName = stepName,
+                metadata = mapOf(key to bucket),
+            )
+            logcat { "Recorded $key=$bucket for flowId=${state.flowId}" }
         }
     }
 
@@ -353,36 +332,39 @@ class RealPageLoadWideEvent @Inject constructor(
 
     private fun updateWideEventAsync(
         tabId: String,
-        url: String,
-        operation: suspend (Long) -> Unit,
+        navigationId: Long,
+        onceForStep: String? = null,
+        operation: suspend (PageLoadState) -> Unit,
     ) {
         coroutineScope.launch {
             mutex.withLock {
-                if (isFeatureEnabled() && isInProgress(tabId, url)) {
-                    getActiveFlowId(tabId)?.let { flowId -> operation(flowId) }
+                if (!isFeatureEnabled()) return@withLock
+                val state = activeFlowFor(tabId, navigationId) ?: return@withLock
+                if (onceForStep != null && !state.recordedSteps.add(onceForStep)) {
+                    logcat { "Ignoring repeat $onceForStep for flowId=${state.flowId}" }
+                    return@withLock
                 }
+                operation(state)
             }
         }
     }
 
-    private suspend fun isFeatureEnabled(): Boolean = withContext(dispatchers.io()) {
-        androidBrowserConfigFeature.get().sendPageLoadWideEvent().isEnabled()
-    }
-
-    private fun getActiveFlowId(tabId: String): Long? {
+    private fun activeFlowFor(tabId: String, navigationId: Long): PageLoadState? {
         val state = activeFlows[tabId]
         if (state == null) {
             logcat { "No active flow found for tabId=$tabId" }
+            return null
         }
-        return state?.flowId
+        if (state.navigationId != navigationId) {
+            logcat { "Dropping event from navigation $navigationId, tabId=$tabId is on ${state.navigationId}" }
+            return null
+        }
+        if (state.isStale()) return null
+        return state
     }
 
-    private fun popActiveFlowId(tabId: String): Long? {
-        val state = activeFlows.remove(tabId)
-        if (state == null) {
-            logcat { "No active flow found to pop for tabId=$tabId" }
-        }
-        return state?.flowId
+    private suspend fun isFeatureEnabled(): Boolean = withContext(dispatchers.io()) {
+        androidBrowserConfigFeature.get().sendPageLoadWideEvent().isEnabled()
     }
 
     private inner class PageLoadState(
@@ -392,7 +374,7 @@ class RealPageLoadWideEvent @Inject constructor(
         val startedAt: Long,
         val createdAt: Long = currentTimeProvider.currentTimeMillis(),
     ) {
-        val recordedMeasurementKeys: MutableSet<String> = mutableSetOf()
+        val recordedSteps: MutableSet<String> = mutableSetOf()
 
         fun isStale(): Boolean =
             currentTimeProvider.currentTimeMillis() - createdAt > CLEANUP_TIMEOUT.inWholeMilliseconds

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -11370,19 +11370,34 @@ class BrowserTabViewModelTest {
         whenever(mockStack.currentItem).thenReturn(mockWebHistoryItem)
         setBrowserShowing(true)
         loadUrl(testUrl)
+        testee.onMainFrameLoadStarted(11L)
 
         testee.progressChanged(60, WebViewNavigationState(mockStack, 60))
 
         val tabIdCaptor = argumentCaptor<String>()
-        val urlCaptor = argumentCaptor<String>()
+        val navigationIdCaptor = argumentCaptor<Long>()
 
         verify(mockPageLoadWideEvent).onProgressChanged(
             tabIdCaptor.capture(),
-            urlCaptor.capture(),
+            navigationIdCaptor.capture(),
         )
 
         assertNotNull(tabIdCaptor.firstValue)
-        assertEquals(testUrl, urlCaptor.firstValue)
+        assertEquals(11L, navigationIdCaptor.firstValue)
+    }
+
+    @Test
+    fun whenProgressExceedsFixedProgressBeforeAPageLoadStartedThenManagerNotCalled() {
+        val testUrl = "https://example.com"
+        val mockWebHistoryItem: WebHistoryItem = mock()
+        whenever(mockWebHistoryItem.url).thenReturn(testUrl)
+        whenever(mockStack.currentItem).thenReturn(mockWebHistoryItem)
+        setBrowserShowing(true)
+        loadUrl(testUrl)
+
+        testee.progressChanged(60, WebViewNavigationState(mockStack, 60))
+
+        verify(mockPageLoadWideEvent, never()).onProgressChanged(any(), any())
     }
 
     @Test
@@ -11393,6 +11408,7 @@ class BrowserTabViewModelTest {
         whenever(mockStack.currentItem).thenReturn(mockWebHistoryItem)
         setBrowserShowing(true)
         loadUrl(testUrl)
+        testee.onMainFrameLoadStarted(11L)
 
         // First time - should trigger call
         testee.progressChanged(60, WebViewNavigationState(mockStack, 60))
@@ -11414,6 +11430,7 @@ class BrowserTabViewModelTest {
         whenever(mockStack.currentItem).thenReturn(mockWebHistoryItem)
         setBrowserShowing(true)
         loadUrl(testUrl)
+        testee.onMainFrameLoadStarted(11L)
 
         // Progress below FIXED_PROGRESS (50) - should NOT call manager
         testee.progressChanged(30, WebViewNavigationState(mockStack, 30))
@@ -11434,16 +11451,41 @@ class BrowserTabViewModelTest {
         // First page load
         whenever(mockStack.currentItem).thenReturn(mockWebHistoryItem1)
         loadUrl(firstUrl)
+        testee.onMainFrameLoadStarted(11L)
         testee.progressChanged(60, WebViewNavigationState(mockStack, 60))
-        verify(mockPageLoadWideEvent).onProgressChanged(any(), eq(firstUrl))
+        verify(mockPageLoadWideEvent).onProgressChanged(any(), eq(11L))
 
-        // New page load - resets hasExitedFixedProgress flag
+        // New page load
         whenever(mockStack.currentItem).thenReturn(mockWebHistoryItem2)
         loadUrl(secondUrl)
+        testee.onMainFrameLoadStarted(12L)
         testee.progressChanged(70, WebViewNavigationState(mockStack, 70))
 
-        // Verify second call with new URL
-        verify(mockPageLoadWideEvent).onProgressChanged(any(), eq(secondUrl))
+        // Verify the second load is reported against its own navigation, not the one before it
+        verify(mockPageLoadWideEvent).onProgressChanged(any(), eq(12L))
+    }
+
+    @Test
+    fun whenProgressExceedsFixedProgressAfterSameHostRedirectThenReportedAgainstTheNewLoad() {
+        val firstUrl = "https://example.com/first"
+        val redirectedUrl = "https://example.com/second"
+        val mockWebHistoryItem: WebHistoryItem = mock()
+        whenever(mockWebHistoryItem.url).thenReturn(firstUrl)
+        whenever(mockStack.currentItem).thenReturn(mockWebHistoryItem)
+        setBrowserShowing(true)
+        loadUrl(firstUrl)
+
+        testee.onMainFrameLoadStarted(11L)
+        testee.progressChanged(60, WebViewNavigationState(mockStack, 60))
+        verify(mockPageLoadWideEvent).onProgressChanged(any(), eq(11L))
+
+        // A redirect within the same host compares as UrlUpdated rather than NewPage, so nothing url-driven runs
+        // between the two loads: the page start is the only signal that a new flow is being measured.
+        whenever(mockWebHistoryItem.url).thenReturn(redirectedUrl)
+        testee.onMainFrameLoadStarted(12L)
+        testee.progressChanged(70, WebViewNavigationState(mockStack, 70))
+
+        verify(mockPageLoadWideEvent).onProgressChanged(any(), eq(12L))
     }
 
     @Test
@@ -11454,6 +11496,7 @@ class BrowserTabViewModelTest {
         whenever(mockStack.currentItem).thenReturn(mockWebHistoryItem)
         setBrowserShowing(true)
         loadUrl(testUrl)
+        testee.onMainFrameLoadStarted(11L)
 
         testee.progressChanged(50, WebViewNavigationState(mockStack, 50))
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -104,6 +104,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doNothing
@@ -452,13 +453,14 @@ class BrowserWebViewClientTest {
         testee.onPageStarted(mockWebView, url, null)
         testee.onRenderProcessGone(mockWebView, detail)
 
+        val navigationId = startedNavigationId()
         val tabIdCaptor = argumentCaptor<String>()
-        val urlCaptor = argumentCaptor<String>()
+        val navigationIdCaptor = argumentCaptor<Long>()
         val errorCaptor = argumentCaptor<String>()
 
         verify(pageLoadWideEvent).onPageLoadFinished(
             tabId = tabIdCaptor.capture(),
-            url = urlCaptor.capture(),
+            navigationId = navigationIdCaptor.capture(),
             errorDescription = errorCaptor.capture(),
             isTabInForegroundOnFinish = any(),
             activeRequestsOnLoadStart = any(),
@@ -466,7 +468,7 @@ class BrowserWebViewClientTest {
         )
 
         assertEquals(tabId, tabIdCaptor.firstValue)
-        assertEquals(url, urlCaptor.firstValue)
+        assertEquals(navigationId, navigationIdCaptor.firstValue)
         assertEquals("ERROR_RENDERER_CRASHED", errorCaptor.firstValue)
     }
 
@@ -486,13 +488,14 @@ class BrowserWebViewClientTest {
         testee.onPageStarted(mockWebView, url, null)
         testee.onRenderProcessGone(mockWebView, detail)
 
+        val navigationId = startedNavigationId()
         val tabIdCaptor = argumentCaptor<String>()
-        val urlCaptor = argumentCaptor<String>()
+        val navigationIdCaptor = argumentCaptor<Long>()
         val errorCaptor = argumentCaptor<String>()
 
         verify(pageLoadWideEvent).onPageLoadFinished(
             tabId = tabIdCaptor.capture(),
-            url = urlCaptor.capture(),
+            navigationId = navigationIdCaptor.capture(),
             errorDescription = errorCaptor.capture(),
             isTabInForegroundOnFinish = any(),
             activeRequestsOnLoadStart = any(),
@@ -500,7 +503,7 @@ class BrowserWebViewClientTest {
         )
 
         assertEquals(tabId, tabIdCaptor.firstValue)
-        assertEquals(url, urlCaptor.firstValue)
+        assertEquals(navigationId, navigationIdCaptor.firstValue)
         assertEquals("ERROR_RENDERER_KILLED", errorCaptor.firstValue)
     }
 
@@ -1278,9 +1281,10 @@ class BrowserWebViewClientTest {
         testee.onPageStarted(mockWebView, requestUrl, null)
         testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
 
+        val navigationId = startedNavigationId()
         verify(pageLoadWideEvent).onPageLoadFinished(
             tabId = eq(tabId),
-            url = eq(requestUrl),
+            navigationId = eq(navigationId),
             errorDescription = any(),
             isTabInForegroundOnFinish = eq(true),
             activeRequestsOnLoadStart = any(),
@@ -1289,7 +1293,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenOnReceivedErrorWithOmittedErrorThenPageLoadMonitorOnPageLoadFinishedIsNotCalled() {
+    fun whenErrorArrivesWithNoLoadInFlightThenNothingIsReported() {
         val mockWebView = getImmediatelyInvokedMockWebView()
         val requestUrl = "https://example.com"
         val tabId = "test-tab-789"
@@ -1304,12 +1308,93 @@ class BrowserWebViewClientTest {
 
         verify(pageLoadWideEvent, never()).onPageLoadFinished(
             tabId = any(),
-            url = any(),
-            errorDescription = any(),
+            navigationId = any(),
+            errorDescription = anyOrNull(),
             isTabInForegroundOnFinish = any(),
             activeRequestsOnLoadStart = any(),
             concurrentRequestsOnFinish = any(),
         )
+    }
+
+    @Test
+    fun whenMainFrameErrorHasNoErrorScreenThenTheLoadIsStillReportedAsFailed() {
+        val mockWebView = pageLoadMockWebView()
+        whenever(webResourceError.errorCode).thenReturn(ERROR_UNKNOWN)
+        whenever(webResourceError.description).thenReturn("some transient error")
+        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+        whenever(webResourceRequest.url).thenReturn(EXAMPLE_URL.toUri())
+        whenever(listener.isTabInForeground()).thenReturn(true)
+
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
+
+        // ERROR_UNKNOWN parses to OMITTED, so the user is shown no error screen. The load still failed, and measuring
+        // only the errors that get a screen is what left the rest to be swept as Unknown.
+        val navigationId = startedNavigationId()
+        verify(pageLoadWideEvent).onPageLoadFinished(
+            tabId = eq(TAB_ID),
+            navigationId = eq(navigationId),
+            errorDescription = eq("ERROR_UNKNOWN"),
+            isTabInForegroundOnFinish = any(),
+            activeRequestsOnLoadStart = any(),
+            concurrentRequestsOnFinish = any(),
+        )
+    }
+
+    @Test
+    fun whenMainFrameErrorIsForAUrlTheLoadNeverStartedThenTheLoadIsNotFailed() {
+        val mockWebView = pageLoadMockWebView()
+        whenever(mockWebView.progress).thenReturn(100)
+        whenever(webResourceError.errorCode).thenReturn(ERROR_UNKNOWN)
+        whenever(webResourceError.description).thenReturn("some transient error")
+        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+        // A main frame error carries the url of the request that failed, which is not always the page being measured -
+        // a page navigating the main frame somewhere it cannot go reports against that url instead.
+        whenever(webResourceRequest.url).thenReturn("https://other.example.org/elsewhere".toUri())
+        whenever(listener.isTabInForeground()).thenReturn(true)
+
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
+
+        verify(pageLoadWideEvent, never()).onPageLoadFinished(
+            tabId = any(),
+            navigationId = any(),
+            errorDescription = anyOrNull(),
+            isTabInForegroundOnFinish = any(),
+            activeRequestsOnLoadStart = any(),
+            concurrentRequestsOnFinish = any(),
+        )
+
+        // And the page's own finish still reports, which failing it would have suppressed.
+        testee.onPageFinished(mockWebView, EXAMPLE_URL)
+        val navigationId = startedNavigationId()
+        verify(pageLoadWideEvent).onPageLoadFinished(
+            tabId = eq(TAB_ID),
+            navigationId = eq(navigationId),
+            errorDescription = isNull(),
+            isTabInForegroundOnFinish = any(),
+            activeRequestsOnLoadStart = any(),
+            concurrentRequestsOnFinish = any(),
+        )
+    }
+
+    @Test
+    fun whenMainFrameErrorHasNoErrorScreenThenTheCycleStillCompletes() {
+        val mockWebView = pageLoadMockWebView()
+        whenever(mockWebView.progress).thenReturn(100)
+        whenever(webResourceError.errorCode).thenReturn(ERROR_UNKNOWN)
+        whenever(webResourceError.description).thenReturn("some transient error")
+        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+        whenever(webResourceRequest.url).thenReturn(EXAMPLE_URL.toUri())
+        whenever(listener.isTabInForeground()).thenReturn(true)
+
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
+        testee.onPageFinished(mockWebView, EXAMPLE_URL)
+
+        // Ending the measured load must not end the cycle: an aborted navigation is followed by the one that replaced
+        // it, and the page load pixel and the history entry still belong to that cycle.
+        verify(pageLoadedHandler).onPageLoaded(any(), anyOrNull(), any(), any(), any(), any(), any())
     }
 
     @Test
@@ -1603,20 +1688,17 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenPageStartedAgainMidLoadThenOnlyTheNavigationThatStartedTheFlowReportsMeasurements() {
-        val mockWebView = getImmediatelyInvokedMockWebView()
-        val tabId = "test-tab-123"
-        whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
-        whenever(mockWebView.settings).thenReturn(mock())
-        whenever(listener.getCurrentTabId()).thenReturn(tabId)
+    fun whenPageStartedAgainMidLoadThenEachPageStartReportsItsOwnMeasurements() {
+        val mockWebView = pageLoadMockWebView()
 
         testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
-        // A hop within the same load does not start a flow, so its deferred measurements have no navigation to land on.
-        testee.onPageStarted(mockWebView, "$EXAMPLE_URL/redirected", null)
+        testee.onPageStarted(mockWebView, SECOND_URL, null)
 
-        verify(pageLoadWideEvent, times(1)).onPageStarted(any(), any(), any())
-        verify(pageLoadWideEvent, times(1)).onContentScopeExperimentsResolved(any(), any())
-        verify(pageLoadWideEvent, times(1)).onJsInjectionComplete(any(), any())
+        val navigationIds = startedNavigationIds(2)
+        verify(pageLoadWideEvent).onContentScopeExperimentsResolved(TAB_ID, navigationIds[0])
+        verify(pageLoadWideEvent).onJsInjectionComplete(TAB_ID, navigationIds[0])
+        verify(pageLoadWideEvent).onContentScopeExperimentsResolved(TAB_ID, navigationIds[1])
+        verify(pageLoadWideEvent).onJsInjectionComplete(TAB_ID, navigationIds[1])
     }
 
     @Test
@@ -1682,9 +1764,133 @@ class BrowserWebViewClientTest {
         whenever(mockWebView.url).thenReturn(EXAMPLE_URL)
         whenever(mockWebView.progress).thenReturn(progress)
         whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
+        whenever(mockWebView.settings).thenReturn(mock())
         whenever(listener.getCurrentTabId()).thenReturn(tabId)
+
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
         testee.onPageCommitVisible(mockWebView, EXAMPLE_URL)
-        verify(pageLoadWideEvent).onPageVisible(tabId, EXAMPLE_URL, progress)
+
+        val navigationId = startedNavigationId()
+        verify(pageLoadWideEvent).onPageVisible(tabId, navigationId, progress)
+    }
+
+    @Test
+    fun whenPageVisibleBeforeAnyPageStartedThenManagerNotCalled() {
+        val mockWebView = getImmediatelyInvokedMockWebView()
+        whenever(mockWebView.url).thenReturn(EXAMPLE_URL)
+        whenever(mockWebView.progress).thenReturn(42)
+        whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
+        whenever(listener.getCurrentTabId()).thenReturn("test-tab-456")
+
+        testee.onPageCommitVisible(mockWebView, EXAMPLE_URL)
+
+        verify(pageLoadWideEvent, never()).onPageVisible(any(), any(), any())
+    }
+
+    @Test
+    fun whenPageStartedWhileLoadInFlightThenReplacementGetsItsOwnLoad() {
+        val mockWebView = pageLoadMockWebView()
+
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        testee.onPageStarted(mockWebView, SECOND_URL, null)
+
+        val navigationIds = startedNavigationIds(2)
+        verify(pageLoadWideEvent).onPageStarted(TAB_ID, EXAMPLE_URL, navigationIds[0])
+        verify(pageLoadWideEvent).onPageStarted(TAB_ID, SECOND_URL, navigationIds[1])
+        assertNotEquals(navigationIds[0], navigationIds[1])
+    }
+
+    @Test
+    fun whenLoadInFlightIsReplacedThenFinishIsReportedAgainstTheReplacement() {
+        val mockWebView = pageLoadMockWebView()
+        whenever(mockWebView.progress).thenReturn(100)
+        whenever(listener.isTabInForeground()).thenReturn(true)
+
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        testee.onPageStarted(mockWebView, SECOND_URL, null)
+        testee.onPageFinished(mockWebView, SECOND_URL)
+
+        // Reporting the interrupted load's id here is what stretched its duration across both pages.
+        val replacementNavigationId = startedNavigationIds(2).last()
+        verify(pageLoadWideEvent).onPageLoadFinished(
+            tabId = eq(TAB_ID),
+            navigationId = eq(replacementNavigationId),
+            errorDescription = isNull(),
+            isTabInForegroundOnFinish = any(),
+            activeRequestsOnLoadStart = any(),
+            concurrentRequestsOnFinish = any(),
+        )
+    }
+
+    @Test
+    fun whenAFailureForAnotherUrlEndsTheCycleThenTheLoadCanStillReportItsFinish() {
+        val mockWebView = pageLoadMockWebView()
+        whenever(mockWebView.progress).thenReturn(100)
+        // BAD_URL, so this error gets an error screen and takes the cycle down with it.
+        whenever(webResourceError.errorCode).thenReturn(ERROR_HOST_LOOKUP)
+        whenever(webResourceError.description).thenReturn("net::ERR_NAME_NOT_RESOLVED")
+        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+        whenever(webResourceRequest.url).thenReturn("https://other.example.org/elsewhere".toUri())
+        whenever(listener.isTabInForeground()).thenReturn(true)
+
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
+        testee.onPageFinished(mockWebView, EXAMPLE_URL)
+
+        // The measured load outlives the cycle: tying it to `start` left this flow with nothing able to end it, and it
+        // was swept as Unknown five minutes later.
+        val navigationId = startedNavigationId()
+        verify(pageLoadWideEvent).onPageLoadFinished(
+            tabId = eq(TAB_ID),
+            navigationId = eq(navigationId),
+            errorDescription = isNull(),
+            isTabInForegroundOnFinish = any(),
+            activeRequestsOnLoadStart = any(),
+            concurrentRequestsOnFinish = any(),
+        )
+    }
+
+    @Test
+    fun whenErrorArrivesForAnAlreadyReplacedLoadThenTheReplacementIsNotClosedWithIt() {
+        val mockWebView = pageLoadMockWebView()
+        whenever(webResourceError.errorCode).thenReturn(ERROR_HOST_LOOKUP)
+        whenever(webResourceError.description).thenReturn("net::ERR_NAME_NOT_RESOLVED")
+        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+        whenever(webResourceRequest.url).thenReturn(EXAMPLE_URL.toUri())
+        whenever(listener.isTabInForeground()).thenReturn(true)
+
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        testee.onPageStarted(mockWebView, SECOND_URL, null)
+        testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
+
+        verify(pageLoadWideEvent, never()).onPageLoadFinished(
+            tabId = any(),
+            navigationId = any(),
+            errorDescription = anyOrNull(),
+            isTabInForegroundOnFinish = any(),
+            activeRequestsOnLoadStart = any(),
+            concurrentRequestsOnFinish = any(),
+        )
+    }
+
+    private fun pageLoadMockWebView(): WebView {
+        val mockWebView = getImmediatelyInvokedMockWebView()
+        whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
+        whenever(mockWebView.settings).thenReturn(mock())
+        whenever(listener.getCurrentTabId()).thenReturn(TAB_ID)
+        return mockWebView
+    }
+
+    /**
+     * The id [BrowserWebViewClient] assigned to the load it is timing. Read back from the listener rather than asserted
+     * as a literal, because the counter behind it is static and keeps counting across tests.
+     */
+    private fun startedNavigationId(): Long = startedNavigationIds(1).single()
+
+    private fun startedNavigationIds(count: Int): List<Long> {
+        val captor = argumentCaptor<Long>()
+        verify(listener, times(count)).onMainFrameLoadStarted(captor.capture())
+        return captor.allValues
     }
 
     @Test
@@ -1700,13 +1906,14 @@ class BrowserWebViewClientTest {
         testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
         testee.onPageFinished(mockWebView, EXAMPLE_URL)
 
+        val navigationId = startedNavigationId()
         val tabIdCaptor = argumentCaptor<String>()
-        val urlCaptor = argumentCaptor<String>()
+        val navigationIdCaptor = argumentCaptor<Long>()
         val foregroundCaptor = argumentCaptor<Boolean>()
 
         verify(pageLoadWideEvent).onPageLoadFinished(
             tabId = tabIdCaptor.capture(),
-            url = urlCaptor.capture(),
+            navigationId = navigationIdCaptor.capture(),
             errorDescription = isNull(),
             isTabInForegroundOnFinish = foregroundCaptor.capture(),
             activeRequestsOnLoadStart = any(),
@@ -1714,7 +1921,7 @@ class BrowserWebViewClientTest {
         )
 
         assertEquals(tabId, tabIdCaptor.firstValue)
-        assertEquals(EXAMPLE_URL, urlCaptor.firstValue)
+        assertEquals(navigationId, navigationIdCaptor.firstValue)
         assertEquals(true, foregroundCaptor.firstValue)
     }
 
@@ -1734,7 +1941,7 @@ class BrowserWebViewClientTest {
         val foregroundCaptor = argumentCaptor<Boolean>()
         verify(pageLoadWideEvent).onPageLoadFinished(
             tabId = any(),
-            url = any(),
+            navigationId = any(),
             errorDescription = isNull(),
             isTabInForegroundOnFinish = foregroundCaptor.capture(),
             activeRequestsOnLoadStart = any(),
@@ -1752,8 +1959,8 @@ class BrowserWebViewClientTest {
         testee.onPageFinished(mockWebView, EXAMPLE_URL)
         verify(pageLoadWideEvent, never()).onPageLoadFinished(
             tabId = any(),
-            url = any(),
-            errorDescription = any(),
+            navigationId = any(),
+            errorDescription = anyOrNull(),
             isTabInForegroundOnFinish = any(),
             activeRequestsOnLoadStart = any(),
             concurrentRequestsOnFinish = any(),
@@ -1774,8 +1981,8 @@ class BrowserWebViewClientTest {
 
         verify(pageLoadWideEvent, never()).onPageLoadFinished(
             tabId = any(),
-            url = any(),
-            errorDescription = any(),
+            navigationId = any(),
+            errorDescription = anyOrNull(),
             isTabInForegroundOnFinish = any(),
             activeRequestsOnLoadStart = any(),
             concurrentRequestsOnFinish = any(),
@@ -1796,8 +2003,8 @@ class BrowserWebViewClientTest {
 
         verify(pageLoadWideEvent, never()).onPageLoadFinished(
             tabId = any(),
-            url = any(),
-            errorDescription = any(),
+            navigationId = any(),
+            errorDescription = anyOrNull(),
             isTabInForegroundOnFinish = any(),
             activeRequestsOnLoadStart = any(),
             concurrentRequestsOnFinish = any(),
@@ -1821,13 +2028,14 @@ class BrowserWebViewClientTest {
         testee.onPageStarted(mockWebView, errorUrl, null)
         testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
 
+        val navigationId = startedNavigationId()
         val tabIdCaptor = argumentCaptor<String>()
-        val urlCaptor = argumentCaptor<String>()
+        val navigationIdCaptor = argumentCaptor<Long>()
         val errorCaptor = argumentCaptor<String>()
 
         verify(pageLoadWideEvent).onPageLoadFinished(
             tabId = tabIdCaptor.capture(),
-            url = urlCaptor.capture(),
+            navigationId = navigationIdCaptor.capture(),
             errorDescription = errorCaptor.capture(),
             isTabInForegroundOnFinish = any(),
             activeRequestsOnLoadStart = any(),
@@ -1835,7 +2043,7 @@ class BrowserWebViewClientTest {
         )
 
         assertEquals(tabId, tabIdCaptor.firstValue)
-        assertEquals(errorUrl, urlCaptor.firstValue)
+        assertEquals(navigationId, navigationIdCaptor.firstValue)
         assertEquals("ERROR_HOST_LOOKUP", errorCaptor.firstValue)
     }
 
@@ -1856,8 +2064,8 @@ class BrowserWebViewClientTest {
 
         verify(pageLoadWideEvent, never()).onPageLoadFinished(
             tabId = any(),
-            url = any(),
-            errorDescription = any(),
+            navigationId = any(),
+            errorDescription = anyOrNull(),
             isTabInForegroundOnFinish = any(),
             activeRequestsOnLoadStart = any(),
             concurrentRequestsOnFinish = any(),
@@ -2220,6 +2428,8 @@ class BrowserWebViewClientTest {
 
     companion object {
         const val EXAMPLE_URL = "https://example.com"
+        const val SECOND_URL = "https://www.example.com"
+        const val TAB_ID = "test-tab-page-load"
         const val DDG_URL = "https://duckduckgo.com"
         const val EXAMPLE_SERP_URL = "https://duckduckgo.com/?q=test"
         const val DUCK_AI_URL = "https://duck.ai/?q=test"

--- a/app/src/test/java/com/duckduckgo/app/browser/pageload/PageLoadWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pageload/PageLoadWideEventTest.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.pixels.remoteconfig.OptimizeTrackerEvaluationRCWrapper
 import com.duckduckgo.app.statistics.wideevents.CleanupPolicy
 import com.duckduckgo.app.statistics.wideevents.FlowStatus
 import com.duckduckgo.app.statistics.wideevents.WideEventClient
+import com.duckduckgo.app.statistics.wideevents.WideEventDefinition
 import com.duckduckgo.autoconsent.api.Autoconsent
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.browser.feature.toggles.AndroidBrowserConfigFeature
@@ -100,6 +101,7 @@ class PageLoadWideEventTest {
             flowEntryPoint = null,
             metadata = emptyMap(),
             cleanupPolicy = CleanupPolicy.OnTimeout(5.minutes),
+            definition = WideEventDefinition(version = WideEventDefinition.Version(minor = 0, patch = 1)),
         )
         verify(wideEventClient).flowStep(
             wideEventId = 123L,
@@ -576,7 +578,7 @@ class PageLoadWideEventTest {
     }
 
     @Test
-    fun `when onPageStarted called with different url then aborts previous flow`() = runTest {
+    fun `when onPageStarted called with different url then cancels previous flow`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(800L))
             .thenReturn(Result.success(900L))
@@ -585,15 +587,63 @@ class PageLoadWideEventTest {
         pageLoadWideEvent.onPageStarted("tab_8", "https://espn.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
-        // Start second page load with different URL - should abort first flow
+        // Start second page load with different URL - should cancel first flow
         pageLoadWideEvent.onPageStarted("tab_8", "https://twitter.com", 2L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
-        // Verify first flow was aborted
-        verify(wideEventClient).flowAbort(800L)
+        verify(wideEventClient).flowFinish(
+            wideEventId = 800L,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf(
+                "webview_version" to "120",
+                "cpm_enabled" to "true",
+                "tracker_optimization_enabled_v3" to "true",
+                "content_scope_injection_optimized" to "true",
+                "content_scope_messaging_optimized" to "true",
+                "content_scope_experiments_cached" to "true",
+                "cancellation_reason" to "superseded_different_url",
+            ),
+        )
 
         // Verify second flow was started
         verify(wideEventClient, times(2)).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `when a load is replaced by one of the same url then it is cancelled as a restart`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .thenReturn(Result.success(801L))
+            .thenReturn(Result.success(802L))
+
+        pageLoadWideEvent.onPageStarted("tab_same", "https://reddit.com", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        // A restart of the load rather than a navigation away from it, which the reason has to keep apart.
+        pageLoadWideEvent.onPageStarted("tab_same", "https://reddit.com", 2L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(eq(801L), eq(FlowStatus.Cancelled), any())
+        assertEquals("superseded_same_url", capturedFlowFinishMetadata(801L)["cancellation_reason"])
+    }
+
+    @Test
+    fun `when the load being replaced is already past the cleanup timeout then it is left to the cleanup policy`() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis())
+            .thenReturn(1000L)
+            .thenReturn(1000L + 6.minutes.inWholeMilliseconds)
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .thenReturn(Result.success(910L))
+            .thenReturn(Result.success(911L))
+
+        pageLoadWideEvent.onPageStarted("tab_stale", "https://reddit.com", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        pageLoadWideEvent.onPageStarted("tab_stale", "https://ebay.com", 2L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        // Cancelled means superseded while it was still being measured. A load this old was not, so its outcome is
+        // genuinely unaccounted for and the cleanup policy owns it.
+        verify(wideEventClient, times(2)).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+        verify(wideEventClient, never()).flowFinish(eq(910L), any(), any())
+        verify(wideEventClient, never()).flowAbort(any())
     }
 
     @Test
@@ -648,6 +698,7 @@ class PageLoadWideEventTest {
             flowEntryPoint = null,
             metadata = emptyMap(),
             cleanupPolicy = CleanupPolicy.OnTimeout(5.minutes),
+            definition = WideEventDefinition(version = WideEventDefinition.Version(minor = 0, patch = 1)),
         )
     }
 
@@ -709,7 +760,7 @@ class PageLoadWideEventTest {
     }
 
     @Test
-    fun `when a new load starts in a tab then the previous flow is aborted even if untracked`() = runTest {
+    fun `when a new load starts in a tab then the previous flow is cancelled even if untracked`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(123L))
 
@@ -719,7 +770,8 @@ class PageLoadWideEventTest {
         pageLoadWideEvent.onPageStarted("tab_1", "https://untracked-site.com", 2L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
-        verify(wideEventClient).flowAbort(123L)
+        assertEquals("superseded_different_url", capturedFlowFinishMetadata(123L)["cancellation_reason"])
+        verify(wideEventClient).flowFinish(eq(123L), eq(FlowStatus.Cancelled), any())
         verify(wideEventClient, times(1)).flowStart(any(), anyOrNull(), any(), any(), any(), any())
     }
 
@@ -740,7 +792,7 @@ class PageLoadWideEventTest {
     }
 
     @Test
-    fun `when an untracked load starts before the flow it replaces exists then that flow is still aborted`() = runTest {
+    fun `when an untracked load starts before the flow it replaces exists then that flow is still cancelled`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(123L))
 
@@ -750,7 +802,7 @@ class PageLoadWideEventTest {
         pageLoadWideEvent.onPageStarted("tab_race", "https://untracked-site.com", 2L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
-        verify(wideEventClient).flowAbort(123L)
+        verify(wideEventClient).flowFinish(eq(123L), eq(FlowStatus.Cancelled), any())
     }
 
     @Test
@@ -774,8 +826,10 @@ class PageLoadWideEventTest {
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
         finishPageLoad("tab_r", 3L)
 
-        // The abandoned reddit load sends nothing, rather than an event whose duration spans it and ebay together.
-        verify(wideEventClient).flowAbort(73L)
+        // The abandoned reddit load is reported as superseded, rather than as an event whose duration spans it and
+        // ebay together, or as nothing at all.
+        verify(wideEventClient).flowFinish(eq(73L), eq(FlowStatus.Cancelled), any())
+        verify(wideEventClient, never()).intervalEnd(eq(73L), eq("elapsed_time_to_finish_ms_bucketed"))
         verify(wideEventClient).intervalEnd(74L, "elapsed_time_to_finish_ms_bucketed")
         verify(wideEventClient).flowFinish(eq(74L), eq(FlowStatus.Success), any())
 

--- a/app/src/test/java/com/duckduckgo/app/browser/pageload/PageLoadWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pageload/PageLoadWideEventTest.kt
@@ -220,7 +220,7 @@ class PageLoadWideEventTest {
 
         pageLoadWideEvent.onPageStarted("tab_cs", "https://reddit.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
-        finishPageLoad("tab_cs", "https://reddit.com")
+        finishPageLoad("tab_cs", 1L)
         // The same url loads again in this tab while the first navigation's deferred callback is still pending, so the
         // late measurement arrives with a live flow in place for the same tab and url.
         pageLoadWideEvent.onPageStarted("tab_cs", "https://reddit.com", 2L)
@@ -249,7 +249,7 @@ class PageLoadWideEventTest {
 
         pageLoadWideEvent.onPageStarted("tab_cs", "https://reddit.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
-        finishPageLoad("tab_cs", "https://reddit.com")
+        finishPageLoad("tab_cs", 1L)
         pageLoadWideEvent.onJsInjectionComplete("tab_cs", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
@@ -277,7 +277,7 @@ class PageLoadWideEventTest {
 
         pageLoadWideEvent.onPageStarted("tab_cs", "https://reddit.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
-        finishPageLoad("tab_cs", "https://reddit.com")
+        finishPageLoad("tab_cs", 1L)
 
         val metadata = capturedFlowFinishMetadata(781L)
         assertEquals("true", metadata["content_scope_injection_optimized"])
@@ -285,10 +285,10 @@ class PageLoadWideEventTest {
         assertEquals("true", metadata["content_scope_experiments_cached"])
     }
 
-    private fun finishPageLoad(tabId: String, url: String) {
+    private fun finishPageLoad(tabId: String, navigationId: Long) {
         pageLoadWideEvent.onPageLoadFinished(
             tabId = tabId,
-            url = url,
+            navigationId = navigationId,
             errorDescription = null,
             isTabInForegroundOnFinish = true,
             activeRequestsOnLoadStart = 0,
@@ -310,7 +310,7 @@ class PageLoadWideEventTest {
 
         pageLoadWideEvent.onPageStarted("tab_2", "https://twitter.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
-        pageLoadWideEvent.onPageVisible("tab_2", "https://twitter.com", 50)
+        pageLoadWideEvent.onPageVisible("tab_2", 1L, 50)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         verify(wideEventClient).intervalEnd(456L, "elapsed_time_to_visible_ms_bucketed")
@@ -324,7 +324,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when onPageVisible called with unknown tab then does nothing`() = runTest {
-        pageLoadWideEvent.onPageVisible("unknown_tab", "https://unknown.com", 50)
+        pageLoadWideEvent.onPageVisible("unknown_tab", 1L, 50)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         verify(wideEventClient, never()).intervalEnd(any(), any())
@@ -338,7 +338,7 @@ class PageLoadWideEventTest {
 
         pageLoadWideEvent.onPageStarted("tab_3", "https://reddit.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
-        pageLoadWideEvent.onProgressChanged("tab_3", "https://reddit.com")
+        pageLoadWideEvent.onProgressChanged("tab_3", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         verify(wideEventClient).intervalEnd(789L, "elapsed_time_to_escaped_fixed_progress_ms_bucketed")
@@ -350,7 +350,7 @@ class PageLoadWideEventTest {
 
     @Test
     fun `when onProgressChanged called with unknown tab then does nothing`() = runTest {
-        pageLoadWideEvent.onProgressChanged("unknown_tab", "https://unknown.com")
+        pageLoadWideEvent.onProgressChanged("unknown_tab", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         verify(wideEventClient, never()).intervalEnd(any(), any())
@@ -366,7 +366,7 @@ class PageLoadWideEventTest {
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
         pageLoadWideEvent.onPageLoadFinished(
             tabId = "tab_4",
-            url = "https://espn.com",
+            navigationId = 1L,
             errorDescription = null,
             isTabInForegroundOnFinish = true,
             activeRequestsOnLoadStart = 5,
@@ -407,7 +407,7 @@ class PageLoadWideEventTest {
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
         pageLoadWideEvent.onPageLoadFinished(
             tabId = "tab_5",
-            url = "https://wikipedia.org",
+            navigationId = 1L,
             errorDescription = "ERROR_HOST_LOOKUP",
             isTabInForegroundOnFinish = false,
             activeRequestsOnLoadStart = 3,
@@ -445,7 +445,7 @@ class PageLoadWideEventTest {
     fun `when onPageLoadFinished called with unknown tab then does nothing`() = runTest {
         pageLoadWideEvent.onPageLoadFinished(
             tabId = "unknown_tab",
-            url = "https://unknown.com",
+            navigationId = 1L,
             errorDescription = null,
             isTabInForegroundOnFinish = true,
             activeRequestsOnLoadStart = 0,
@@ -464,13 +464,13 @@ class PageLoadWideEventTest {
 
         pageLoadWideEvent.onPageStarted("tab_9", "https://github.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
-        pageLoadWideEvent.onPageVisible("tab_9", "https://github.com", 50)
+        pageLoadWideEvent.onPageVisible("tab_9", 1L, 50)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
-        pageLoadWideEvent.onProgressChanged("tab_9", "https://github.com")
+        pageLoadWideEvent.onProgressChanged("tab_9", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
         pageLoadWideEvent.onPageLoadFinished(
             tabId = "tab_9",
-            url = "https://github.com",
+            navigationId = 1L,
             errorDescription = null,
             isTabInForegroundOnFinish = true,
             activeRequestsOnLoadStart = 0,
@@ -492,9 +492,9 @@ class PageLoadWideEventTest {
         pageLoadWideEvent.onPageStarted("tab_b", "https://weather.com", 2L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
-        pageLoadWideEvent.onPageVisible("tab_a", "https://ebay.com", 30)
+        pageLoadWideEvent.onPageVisible("tab_a", 1L, 30)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
-        pageLoadWideEvent.onPageVisible("tab_b", "https://weather.com", 40)
+        pageLoadWideEvent.onPageVisible("tab_b", 2L, 40)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         verify(wideEventClient).flowStep(
@@ -534,17 +534,17 @@ class PageLoadWideEventTest {
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Page becomes visible
-        pageLoadWideEvent.onPageVisible("tab_complete", "https://duckduckgo.com", 45)
+        pageLoadWideEvent.onPageVisible("tab_complete", 1L, 45)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Page escapes fixed progress
-        pageLoadWideEvent.onProgressChanged("tab_complete", "https://duckduckgo.com")
+        pageLoadWideEvent.onProgressChanged("tab_complete", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
         // Page finishes
         pageLoadWideEvent.onPageLoadFinished(
             tabId = "tab_complete",
-            url = "https://duckduckgo.com",
+            navigationId = 1L,
             errorDescription = null,
             isTabInForegroundOnFinish = true,
             activeRequestsOnLoadStart = 7,
@@ -597,19 +597,21 @@ class PageLoadWideEventTest {
     }
 
     @Test
-    fun `when onPageStarted called with same url then does not start duplicate flow`() = runTest {
+    fun `when the same url loads again in a tab then it gets its own flow`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(1000L))
+            .thenReturn(Result.success(1001L))
 
-        // Start page load twice with same URL
         pageLoadWideEvent.onPageStarted("tab_10", "https://reddit.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        finishPageLoad("tab_10", 1L)
         pageLoadWideEvent.onPageStarted("tab_10", "https://reddit.com", 2L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        pageLoadWideEvent.onPageVisible("tab_10", 2L, 80)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
-        // Verify flowStart was only called once and flowAbort was never called
-        verify(wideEventClient, times(1)).flowStart(any(), anyOrNull(), any(), any(), any(), any())
-        verify(wideEventClient, never()).flowAbort(any())
+        verify(wideEventClient, times(2)).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+        verify(wideEventClient).flowStep(1001L, "page_visible", true, mapOf("progress" to "true"))
     }
 
     @Test
@@ -650,99 +652,138 @@ class PageLoadWideEventTest {
     }
 
     @Test
-    fun `when onPageVisible called with untracked url then does nothing`() = runTest {
-        // Start with a tracked URL
+    fun `when a load redirects then its events still reach the flow it started`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
             .thenReturn(Result.success(123L))
-        pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com", 1L)
-        coroutineRule.testScope.testScheduler.advanceUntilIdle()
 
-        // Clear invocations from setup
-        clearInvocations(wideEventClient)
-
-        // Call onPageVisible with untracked URL
-        pageLoadWideEvent.onPageVisible("tab_1", "https://untracked-example.com", 50)
-        coroutineRule.testScope.testScheduler.advanceUntilIdle()
-
-        // Verify no wide event operations were performed
-        verify(wideEventClient, never()).flowStep(any(), any(), any(), any())
-        verify(wideEventClient, never()).intervalEnd(any(), any())
-    }
-
-    @Test
-    fun `when onProgressChanged called with untracked url then does nothing`() = runTest {
-        // Start with a tracked URL
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
-            .thenReturn(Result.success(123L))
-        pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com", 1L)
-        coroutineRule.testScope.testScheduler.advanceUntilIdle()
-
-        // Clear invocations from setup
-        clearInvocations(wideEventClient)
-
-        // Call onProgressChanged with untracked URL
-        pageLoadWideEvent.onProgressChanged("tab_1", "https://untracked-example.com")
-        coroutineRule.testScope.testScheduler.advanceUntilIdle()
-
-        // Verify no wide event operations were performed
-        verify(wideEventClient, never()).flowStep(any(), any(), any(), any())
-        verify(wideEventClient, never()).intervalEnd(any(), any())
-    }
-
-    @Test
-    fun `when onPageLoadFinished called with success and untracked url then does nothing`() = runTest {
-        // Start with a tracked URL
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
-            .thenReturn(Result.success(123L))
-        pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com", 1L)
-        coroutineRule.testScope.testScheduler.advanceUntilIdle()
-
-        // Clear invocations from setup
-        clearInvocations(wideEventClient)
-
-        // Call onPageLoadFinished with untracked URL (e.g., redirect scenario)
-        pageLoadWideEvent.onPageLoadFinished(
-            tabId = "tab_1",
-            url = "https://untracked-redirect.com",
-            errorDescription = null,
-            isTabInForegroundOnFinish = true,
-            activeRequestsOnLoadStart = 5,
-            concurrentRequestsOnFinish = 2,
-        )
-        coroutineRule.testScope.testScheduler.advanceUntilIdle()
-
-        // Verify no wide event operations were performed
-        verify(wideEventClient, never()).flowStep(any(), any(), any(), any())
-        verify(wideEventClient, never()).intervalEnd(any(), any())
-        verify(wideEventClient, never()).flowFinish(any(), any(), any())
-    }
-
-    @Test
-    fun `when onPageLoadFinished called with error and untracked url then does nothing`() = runTest {
-        // Start with a tracked URL
-        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
-            .thenReturn(Result.success(123L))
+        // https://espn.com redirects to https://www.espn.com/, so every callback after the redirect carries a url the
+        // flow was not started with. They belong to the same load, and to the same navigationId.
         pageLoadWideEvent.onPageStarted("tab_1", "https://espn.com", 1L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        pageLoadWideEvent.onPageVisible("tab_1", 1L, 60)
+        pageLoadWideEvent.onProgressChanged("tab_1", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        finishPageLoad("tab_1", 1L)
 
-        // Clear invocations from setup
+        verify(wideEventClient).intervalEnd(123L, "elapsed_time_to_visible_ms_bucketed")
+        verify(wideEventClient).intervalEnd(123L, "elapsed_time_to_escaped_fixed_progress_ms_bucketed")
+        verify(wideEventClient).intervalEnd(123L, "elapsed_time_to_finish_ms_bucketed")
+        verify(wideEventClient).flowFinish(eq(123L), eq(FlowStatus.Success), any())
+    }
+
+    @Test
+    fun `when events arrive from a load the flow did not start then they are dropped`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .thenReturn(Result.success(123L))
+        pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
         clearInvocations(wideEventClient)
 
-        // Call onPageLoadFinished with error and untracked URL
-        pageLoadWideEvent.onPageLoadFinished(
-            tabId = "tab_1",
-            url = "https://untracked-error.com",
-            errorDescription = "ERR_CONNECTION_REFUSED",
-            isTabInForegroundOnFinish = true,
-            activeRequestsOnLoadStart = 3,
-            concurrentRequestsOnFinish = 0,
-        )
+        pageLoadWideEvent.onPageVisible("tab_1", 2L, 50)
+        pageLoadWideEvent.onProgressChanged("tab_1", 2L)
         coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        finishPageLoad("tab_1", 2L)
 
-        // Verify no wide event operations were performed
         verify(wideEventClient, never()).flowStep(any(), any(), any(), any())
         verify(wideEventClient, never()).intervalEnd(any(), any())
         verify(wideEventClient, never()).flowFinish(any(), any(), any())
+    }
+
+    @Test
+    fun `when a page becomes visible twice in one load then the first is kept`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .thenReturn(Result.success(123L))
+
+        pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        pageLoadWideEvent.onPageVisible("tab_1", 1L, 10)
+        pageLoadWideEvent.onPageVisible("tab_1", 1L, 90)
+        pageLoadWideEvent.onProgressChanged("tab_1", 1L)
+        pageLoadWideEvent.onProgressChanged("tab_1", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        // The interval only ends once, so the progress reported alongside it has to be the one it was measured against.
+        verify(wideEventClient, times(1)).flowStep(eq(123L), eq("page_visible"), any(), any())
+        verify(wideEventClient).flowStep(123L, "page_visible", true, mapOf("progress" to "false"))
+        verify(wideEventClient, times(1)).flowStep(eq(123L), eq("page_escaped_fixed_progress"), any(), any())
+    }
+
+    @Test
+    fun `when a new load starts in a tab then the previous flow is aborted even if untracked`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .thenReturn(Result.success(123L))
+
+        pageLoadWideEvent.onPageStarted("tab_1", "https://reddit.com", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        // Left open it would be swept by the cleanup policy and sent as an Unknown load with no duration.
+        pageLoadWideEvent.onPageStarted("tab_1", "https://untracked-site.com", 2L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowAbort(123L)
+        verify(wideEventClient, times(1)).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `when a page becomes visible before its flow exists then the measurement still lands`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .thenReturn(Result.success(123L))
+
+        // Queued together, so flowStart has not run when the commit-visible callback arrives - the ordinary ordering
+        // for a cached page, since flowStart goes to disk. Gating these callbacks on an activeFlows hit outside the
+        // lock would drop them.
+        pageLoadWideEvent.onPageStarted("tab_early", "https://reddit.com", 1L)
+        pageLoadWideEvent.onPageVisible("tab_early", 1L, 80)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).intervalEnd(123L, "elapsed_time_to_visible_ms_bucketed")
+        verify(wideEventClient).flowStep(123L, "page_visible", true, mapOf("progress" to "true"))
+    }
+
+    @Test
+    fun `when an untracked load starts before the flow it replaces exists then that flow is still aborted`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .thenReturn(Result.success(123L))
+
+        // Both starts are queued before either reaches the lock, which is what a tracked load redirecting off its
+        // domain looks like: the second start arrives while the flow it has to end is still being created.
+        pageLoadWideEvent.onPageStarted("tab_race", "https://reddit.com", 1L)
+        pageLoadWideEvent.onPageStarted("tab_race", "https://untracked-site.com", 2L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowAbort(123L)
+    }
+
+    @Test
+    fun `when a load is replaced mid flight then each load is measured on its own`() = runTest {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .thenReturn(Result.success(73L))
+            .thenReturn(Result.success(74L))
+            .thenReturn(Result.success(75L))
+
+        // reddit.com starts loading and the user navigates away to ebay.com before it finishes.
+        pageLoadWideEvent.onPageStarted("tab_r", "https://reddit.com", 1L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        pageLoadWideEvent.onPageStarted("tab_r", "https://ebay.com", 2L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        finishPageLoad("tab_r", 2L)
+
+        // Within the cleanup timeout, reddit.com loads again in the same tab.
+        pageLoadWideEvent.onPageStarted("tab_r", "https://reddit.com", 3L)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        pageLoadWideEvent.onPageVisible("tab_r", 3L, 70)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+        finishPageLoad("tab_r", 3L)
+
+        // The abandoned reddit load sends nothing, rather than an event whose duration spans it and ebay together.
+        verify(wideEventClient).flowAbort(73L)
+        verify(wideEventClient).intervalEnd(74L, "elapsed_time_to_finish_ms_bucketed")
+        verify(wideEventClient).flowFinish(eq(74L), eq(FlowStatus.Success), any())
+
+        // The reload is measured in full instead of being swallowed by the flow the first attempt left behind.
+        verify(wideEventClient).flowStep(75L, "page_visible", true, mapOf("progress" to "true"))
+        verify(wideEventClient).intervalEnd(75L, "elapsed_time_to_visible_ms_bucketed")
+        verify(wideEventClient).intervalEnd(75L, "elapsed_time_to_finish_ms_bucketed")
+        verify(wideEventClient).flowFinish(eq(75L), eq(FlowStatus.Success), any())
     }
 
     private class FakeContentScopeOptimizations : ContentScopeOptimizations {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1217240546184827?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

The page load wide event was ending a large share of flows at the five-minute cleanup as `Unknown`instead of at a real outcome. Five separate causes:

- **Flows are keyed by** **`navigationId`, not url.** A redirect changed the url under the flow, so its finish no longer matched and was dropped.
- **A start for an untracked url now ends the tab's open flow**, instead of leaving it to the cleanup policy.
- **Every main-frame error reports a failure.** Reporting was gated on the error having a user-facing error screen, so most failures were indistinguishable from abandoned loads.
- **The measured load ends independently of the page load cycle**, so a terminal callback for an already-replaced load no longer orphans the flow that replaced it.
- **The fixed-progress gate resets per load**, closing its interval on same-host redirects (which compare as `UrlUpdated`, so the previous url-driven reset never ran).

Failures are matched strictly on the load's url, because marking a load failed also suppresses its finish — an error reported against a different url is declined rather than guessed at.

No pixel definition change: `error_code` is already a free-form string documented as any WebViewClient error constant.

**Known limitation, deliberate.** Every main-frame page start opens its own measured load, including a redirect hop, so a redirecting load is measured from its last hop: `elapsed_time_to_finish` excludes the redirect leg the user also waited through, and aborts count hops rather than loads the user abandoned. Confirmed on device — `reddit.com/` → `reddit.com/?rdt=…` drops 505 ms. Spanning a chain with one flow is possible via `WebResourceRequest.isRedirect`, but it would move the content-scope and JS-injection steps onto the document the redirect left behind and change which urls are sampled. Both are decisions about what the metric should mean, so they are out of scope here.

### Steps to test this PR

**Setup - IMPORTANT**:

- [x]  Replace the current`isFeatureEnabled()` function in `PageLoadWideEvent.kt` with `private suspend fun isFeatureEnabled(): Boolean = true `so you can see events.
- [x] Only sites in `PageLoadedSites.perfSites` are tracked (`bbc.co.uk`, `reddit.com`, `foxnews.com`, `amazon.com`, `apnews.com`, …). Any other domain logs nothing.
- [x] Use this grep for easy checks:
`adb logcat -v time | grep -E ￼'Page load measured as navigationId|Page load flow started|Cancelling previous flow|Page visible recorded|Exited max progress threshold|Recorded elapsed_time|Page load finished|Ignoring repeat|Ignoring load failure|Dropping event from navigation|No active flow found|Failed to start page load￼flow'`

_Successful load reaches a terminal outcome_

- [x] Load https://www.bbc.com/news. Expect `Page load measured as navigationId [...]` `Page load finished [...]`  Flow id should match for the above logs. If https://www.bbc.com/news redirects to https://www.bbc.co.uk/news you should see 2 events, one for each page loaded.
- [x]  Check the wide event pixel as well. Open another logcat console and filter by `wide_page-load_c`

_Multiple_ _page_ _loads_, where one is cancelled should not record the cancelled one

- [x]  Load https://www.reddit.com/  and, before it finishes, navigate away to ebay.com in the same tab. Let ebay.com finish. Within 5 minutes, load reddit.com again in that same tab.
- [x]  Expect to see Page load finished only for ebay.com and for the second load of reddit. The fist one should be cancelled.
- [x]  Check the wide event pixel as well. Open another logcat console and filter by wide_page-load_c. A wide event should not be sent for the cancelled page load.

_Cancelling a load_
- [ ] Load bbc.com/news and before it finished loading load foxnews.com
- [ ] Notice 2 wide event pixels containing:
`wide_page-load_c with params: {... feature.status=CANCELLED, ..., feature.data.ext.cancellation_reason=superseded_different_url, ...}`
`wide_page-load_c with params: {... feature.status=SUCCESS, ...}`

- [ ] Load bbc.com/news and before it finished loading do a pull to refresh 
- [ ] Notice 2 wide event pixels containing:
`wide_page-load_c with params: {... feature.status=CANCELLED, ..., feature.data.ext.cancellation_reason=superseded_same_url, ...}`
`wide_page-load_c with params: {... feature.status=SUCCESS, ...}`

### NO UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Telemetry-only, but it rewires page-load flow identity, cancellation, and error matching in WebView navigation. Mis-attribution would distort success/failure/cancel rates without affecting browsing itself.
> 
> **Overview**
> Stops page-load wide events from aging out as **Unknown** by identifying each measured load with `navigationId` instead of URL, so redirects, replacements, and late callbacks no longer steal or drop another load’s events.
> 
> `BrowserWebViewClient` now opens a new measured load on every main-frame `onPageStarted` (including redirect hops), ends it independently of the page-load cycle, and reports **every** main-frame error as a failure when the URL matches the load being measured. Superseded in-flight flows finish as **Cancelled** with `cancellation_reason` (`superseded_same_url` / `superseded_different_url`), including when the replacement URL is untracked. Progress-threshold tracking resets per load via `onMainFrameLoadStarted`.
> 
> Pixel definition patch 0.1 documents the new cancellation field and that finish-only metadata is absent on cancelled loads. Redirect chains are still measured from the last hop by design.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0435b9645ebb32549e52fc91d5a58cfdbc53ed38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->