### PR TITLE
Contextual/DuckAi: Chat in progress mode updates 

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualEntryPromptStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualEntryPromptStore.kt
@@ -27,7 +27,8 @@ import javax.inject.Inject
  * straight into the chat (WEBVIEW) and auto-submit it, rather than reopening the initial input state.
  *
  * [serializedPageContext] is the page context the dialog had attached at submit time, so "Ask about
- * page" keeps its context across the hand-off.
+ * page" keeps its context across the hand-off. When it is null the dialog had no context attached
+ * (never available, or the user removed it), and the sheet must not auto-attach one on hand-off.
  */
 data class ContextualEntryPrompt(
     val tabId: String,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -111,6 +111,11 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
     // is ready (onWebAppReady). Held between opening the sheet and that ready signal.
     private var pendingEntryPrompt: NativeInputPrompt? = null
 
+    // The page context the entry dialog had attached to [pendingEntryPrompt] at hand-off (null if none).
+    // Frozen so the first webview prompt reflects the dialog's choice, regardless of the sheet's own
+    // native-input auto-attach that may run before the web app is ready.
+    private var pendingEntryPageContext: String? = null
+
     private var hidingSheetForNewChat = false
 
     sealed class Command {
@@ -156,6 +161,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         val contextUrl: String = "",
         val contextTitle: String = "",
         val tabId: String = "",
+        val userRemovedContext: Boolean = false,
         val isFireButtonEnabled: Boolean = false,
         val recentChats: List<ChatHistoryItem> = emptyList(),
     )
@@ -293,30 +299,25 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         tabId: String,
         entry: ContextualEntryPrompt,
     ) {
+        // Freeze the prompt and the dialog's attachment decision (a page context, or none). The first
+        // webview prompt carries exactly this; the sheet's own native-input attachment state must not add
+        // to or remove from it.
         pendingEntryPrompt = entry.prompt
+        pendingEntryPageContext = entry.serializedPageContext
+        val handedOffWithoutContext = entry.serializedPageContext == null
         val chatUrl = duckChat.getDuckChatUrl("", false, sidebar = true)
         withContext(dispatchers.main()) {
             setSheetUrl(chatUrl)
-            entry.serializedPageContext?.let { attachProvidedPageContext(it) }
             _viewState.update {
-                it.copy(showFullscreen = hasChatId(chatUrl), tabId = tabId)
+                it.copy(
+                    showFullscreen = hasChatId(chatUrl),
+                    tabId = tabId,
+                    showContext = false,
+                    userRemovedContext = handedOffWithoutContext,
+                )
             }
             commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_EXPANDED))
             commandChannel.trySend(Command.LoadUrl(chatUrl))
-        }
-    }
-
-    private fun attachProvidedPageContext(serializedPageContext: String) {
-        if (!isContextValid(serializedPageContext)) return
-        currentPageContext = serializedPageContext
-        pageContextState = pageContextState.copy(attachedPage = serializedPageContext)
-        val json = JSONObject(serializedPageContext)
-        _viewState.update {
-            it.copy(
-                showContext = true,
-                contextTitle = json.optString("title"),
-                contextUrl = json.optString("url"),
-            )
         }
     }
 
@@ -327,14 +328,17 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
      */
     fun onWebAppReady() {
         val entry = pendingEntryPrompt ?: return
+        val entryPageContext = pendingEntryPageContext
         pendingEntryPrompt = null
-        onPromptSent(
+        pendingEntryPageContext = null
+        submitPrompt(
             prompt = entry.prompt,
             modelId = entry.modelId,
             reasoningEffort = entry.reasoningEffort,
             selectedTool = entry.selectedTool,
             imagesJson = entry.imagesJson,
             filesJson = entry.filesJson,
+            pageContextSerialized = entryPageContext,
         )
     }
 
@@ -347,8 +351,22 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         imagesJson: JSONArray? = null,
         filesJson: JSONArray? = null,
     ) {
+        val attachedContext = pageContextState.attachedPage.takeIf { _viewState.value.showContext }
+        submitPrompt(prompt, followUpPrefill, modelId, reasoningEffort, selectedTool, imagesJson, filesJson, attachedContext)
+    }
+
+    private fun submitPrompt(
+        prompt: String,
+        followUpPrefill: String? = null,
+        modelId: String? = null,
+        reasoningEffort: String? = null,
+        selectedTool: String? = null,
+        imagesJson: JSONArray? = null,
+        filesJson: JSONArray? = null,
+        pageContextSerialized: String?,
+    ) {
         viewModelScope.launch(dispatchers.io()) {
-            val contextPrompt = generateContextPrompt(prompt, modelId, reasoningEffort, selectedTool, imagesJson, filesJson)
+            val contextPrompt = generateContextPrompt(prompt, modelId, reasoningEffort, selectedTool, imagesJson, filesJson, pageContextSerialized)
             val prefillText = followUpPrefill?.takeIf { it.isNotEmpty() }
             val prefillEvent = prefillText?.let { generatePrefillEvent(it) }
             withContext(dispatchers.main()) {
@@ -435,20 +453,12 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         selectedTool: String? = null,
         imagesJson: JSONArray? = null,
         filesJson: JSONArray? = null,
+        pageContextSerialized: String?,
     ): SubscriptionEventData {
-        val viewState = _viewState.value
         val pageContext =
-            if (viewState.showContext) {
-                pageContextState.attachedPage
-                    .takeIf { it.isNotBlank() }
-                    ?.let { runCatching { JSONObject(it) }.getOrNull() }
-                    ?: run {
-                        logcat { "Duck.ai: no pageContext available, skipping pageContext in prompt" }
-                        null
-                    }
-            } else {
-                null
-            }
+            pageContextSerialized
+                ?.takeIf { it.isNotBlank() }
+                ?.let { runCatching { JSONObject(it) }.getOrNull() }
 
         if (pageContext == null) {
             duckChatPixels.reportContextualPromptSubmittedWithoutContextNative()
@@ -505,7 +515,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         }
 
         val params = JSONObject().apply {
-            if (duckChatInternal.isAutomaticContextAttachmentEnabled()) {
+            if (duckChatInternal.isAutomaticContextAttachmentEnabled() && _viewState.value.showContext) {
                 put("pageContext", pageContext)
             } else {
                 put("pageContext", null)
@@ -550,7 +560,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
     fun removePageContext() {
         logcat { "Duck.ai Contextual: removePageContext" }
         _viewState.update { current ->
-            current.copy(showContext = false)
+            current.copy(showContext = false, userRemovedContext = true)
         }
         duckChatPixels.reportContextualPageContextRemovedNative()
     }
@@ -571,6 +581,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         _viewState.update { current ->
             current.copy(
                 showContext = true,
+                userRemovedContext = false,
                 contextTitle = json.optString("title"),
                 contextUrl = json.optString("url"),
             )
@@ -635,14 +646,35 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
             val url = json.optString("url")
 
             logcat { "Duck.ai: onPageContextReceived for url $url" }
-            _viewState.update { current ->
-                current.copy(
+            val current = _viewState.value
+            val allowsAutomaticContextAttachment = duckChatInternal.isAutomaticContextAttachmentEnabled()
+
+            val urlChanged = current.contextUrl.isNotEmpty() && url != current.contextUrl
+            val remainsUserRemoved = current.userRemovedContext && !urlChanged
+            val dropStaleAttachment = !allowsAutomaticContextAttachment && current.showContext && urlChanged
+
+            val showContext = when {
+                allowsAutomaticContextAttachment -> !remainsUserRemoved
+                dropStaleAttachment -> false
+                else -> current.showContext
+            }
+            val newlyAutoAttached = showContext && !current.showContext
+            if (showContext) {
+                pageContextState = pageContextState.copy(attachedPage = pageContext)
+            }
+            _viewState.update {
+                it.copy(
                     contextTitle = title,
                     contextUrl = url,
                     tabId = tabId,
+                    showContext = showContext,
+                    userRemovedContext = remainsUserRemoved,
                 )
             }
-            if (duckChatInternal.isAutomaticContextAttachmentEnabled() || duckChatInternal.areMultipleContentAttachmentsEnabled()) {
+            if (newlyAutoAttached) {
+                duckChatPixels.reportContextualPageContextAutoAttached()
+            }
+            if (allowsAutomaticContextAttachment || duckChatInternal.areMultipleContentAttachmentsEnabled()) {
                 val pageContextEvent = generatePageContextEventData()
                 viewModelScope.launch(dispatchers.main()) {
                     _subscriptionEventDataChannel.trySend(pageContextEvent)
@@ -727,6 +759,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
                     it.copy(
                         showFullscreen = true,
                         showContext = false,
+                        userRemovedContext = false,
                     )
                 }
                 val subscriptionEvent = duckChatJSHelper.onNativeAction(NativeAction.NEW_CHAT)

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_webview.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_webview.xml
@@ -54,11 +54,10 @@
             android:background="@drawable/selectable_item_rounded_corner_background"
             android:contentDescription="@string/browserMenuChatHistory"
             android:scaleType="center"
-            android:layout_marginEnd="@dimen/keyline_2"
             app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/contextualTitle"
-            app:srcCompat="@drawable/ic_expand_24" />
+            app:srcCompat="@drawable/ic_open_in_24" />
 
         <ImageView
             android:id="@+id/contextualNewChat"
@@ -70,7 +69,7 @@
             android:visibility="gone"
             tools:visibility="visible"
             app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
-            app:layout_constraintStart_toEndOf="@+id/contextualFullScreen"
+            app:layout_constraintStart_toEndOf="@+id/contextualClose"
             app:layout_constraintTop_toTopOf="@id/contextualTitle"
             app:srcCompat="@drawable/ic_chats_24" />
 
@@ -79,7 +78,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/keyline_4"
-            android:drawableStart="@drawable/ic_duck_ai_color_24"
+            android:drawableStart="@drawable/ic_ai_chat_color_24"
             android:drawablePadding="@dimen/keyline_2"
             android:gravity="center"
             android:text="@string/duck_chat_title"
@@ -98,7 +97,7 @@
             android:visibility="gone"
             tools:visibility="visible"
             app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
-            app:layout_constraintEnd_toStartOf="@+id/contextualClose"
+            app:layout_constraintEnd_toStartOf="@+id/contextualFullScreen"
             app:layout_constraintTop_toTopOf="@id/contextualTitle"
             app:srcCompat="@drawable/ic_fire_24" />
 
@@ -111,7 +110,7 @@
             android:contentDescription="@string/browserMenuChatHistory"
             android:scaleType="center"
             app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/contextualTitle"
             app:srcCompat="@drawable/ic_close_24_small" />
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
@@ -107,4 +107,20 @@ class DuckChatContextualEntryViewModelTest {
         verify(store).store(captor.capture())
         assertNull(captor.firstValue.serializedPageContext)
     }
+
+    @Test
+    fun whenContextRemovedThenPromptStoredWithNullContext() = runTest {
+        viewModel.start("tab-1")
+        viewModel.onPageContextReceived(validContext)
+        viewModel.onContextRemoved()
+
+        viewModel.commands.test {
+            viewModel.onPromptSubmitted(samplePrompt)
+            assertEquals(DuckChatContextualEntryViewModel.Command.HandOffToSheet, awaitItem())
+        }
+
+        val captor = argumentCaptor<ContextualEntryPrompt>()
+        verify(store).store(captor.capture())
+        assertNull(captor.firstValue.serializedPageContext)
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -183,6 +183,147 @@ class DuckChatContextualWebViewViewModelTest {
     }
 
     @Test
+    fun `onPageContextReceived auto-attaches the current context when automatic attachment is enabled`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("Page Title", testee.viewState.value.contextTitle)
+        verify(duckChatPixels).reportContextualPageContextAutoAttached()
+    }
+
+    @Test
+    fun `onPageContextReceived does not auto-attach when automatic attachment is disabled`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+
+        assertFalse(testee.viewState.value.showContext)
+        verify(duckChatPixels, never()).reportContextualPageContextAutoAttached()
+    }
+
+    @Test
+    fun `onPageContextReceived does not re-attach context the user removed`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        testee.removePageContext()
+        testee.onPageContextReceived("tab-1", serializedPageData)
+
+        assertFalse(testee.viewState.value.showContext)
+    }
+
+    @Test
+    fun `native input auto-attach during hand-off does not add context to the first prompt`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.subscriptionEventDataFlow.test {
+            // The entry dialog handed off no context, so the sheet must not auto-attach the current page...
+            testee.onPageContextReceived("tab-1", serializedPageData)
+            assertEquals("submitAIChatPageContext", awaitItem().subscriptionName)
+            assertFalse(testee.viewState.value.showContext)
+
+            // ...and the first prompt is frozen to the entry dialog's (empty) attachment, so it carries none.
+            testee.onWebAppReady()
+            val promptEvent = awaitItem()
+            assertEquals("submitAIChatNativePrompt", promptEvent.subscriptionName)
+            assertTrue(promptEvent.params.isNull("pageContext"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `first prompt from a with-context entry hand-off carries the entry page context`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = serializedPageData))
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.subscriptionEventDataFlow.test {
+            testee.onWebAppReady()
+
+            val promptEvent = awaitItem()
+            assertEquals("submitAIChatNativePrompt", promptEvent.subscriptionName)
+            assertEquals("Page Title", promptEvent.params.getJSONObject("pageContext").getString("title"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `no-context entry hand-off does not re-attach the current page while it stays put`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+
+        // A repeated report for the same page still must not auto-attach.
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+    }
+
+    @Test
+    fun `no-context entry hand-off re-attaches after the user navigates to a new page`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+
+        val otherPageData =
+            """
+            {
+                "title": "Other Page",
+                "url": "https://other.example.com",
+                "content": "Other extracted DOM text...",
+                "truncated": false,
+                "fullContentLength": 4321
+            }
+            """.trimIndent()
+        testee.onPageContextReceived("tab-1", otherPageData)
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("Other Page", testee.viewState.value.contextTitle)
+    }
+
+    @Test
+    fun `no-context entry hand-off re-attaches when the user manually attaches`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+
+        testee.addPageContext()
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("Page Title", testee.viewState.value.contextTitle)
+    }
+
+    @Test
     fun `onNewChatRequestedFromPopup resets chat and hands off to the entry dialog`() = runTest {
         testee.onSheetOpened("tab-1")
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217157779879515?focus=true 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
- Visual updates only -> Updates order of top icons and replaces icon for contextual sheet

### Steps to test this PR
QA optional

### UI changes
FIGMA


| Figma  | Before | After |
| ---- | ---- |---- |
<img width="413" height="925" alt="Screenshot 2026-08-21 at 16 13 02" src="https://github.com/user-attachments/assets/085d9f07-d9a5-48ff-aa9e-f90c64cd868a" />|<img width="342" height="745" alt="Screenshot 2026-08-21 at 16 11 55" src="https://github.com/user-attachments/assets/1b69eb27-7280-438b-8b2d-27f4a505695f" />|<img width="338" height="748" alt="Screenshot 2026-08-21 at 16 24 46" src="https://github.com/user-attachments/assets/9e7f62dc-cd31-418a-a337-d36f63e24a89" />|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what page context is sent on the first contextual chat prompt and when auto-attachment runs, which affects AI query content but is localized to contextual Duck AI hand-off logic with broad test coverage.
> 
> **Overview**
> Beyond the **contextual sheet toolbar** reshuffle (close on the left, open-in-fullscreen on the right, updated title/chat icons), this PR changes how **page context** is carried from the entry dialog into the in-progress WebView.
> 
> The first auto-submitted prompt after hand-off now uses a **frozen** `serializedPageContext` from `ContextualEntryPrompt` (or none if the user removed context or never had it). The sheet no longer calls `attachProvidedPageContext` on open, so native auto-attach during load cannot add context to that first prompt. `userRemovedContext` blocks re-auto-attach on the same URL; navigation to a new page or manual attach can restore it. `onPageContextReceived` and `generatePageContextEventData` tie visibility and JS events to `showContext` and the automatic-attachment flag.
> 
> Tests cover null-context hand-off, with-context hand-off, user removal, and auto-attach behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407e8d16d4d1d882dd0bf618f355e0009a0e7df2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->