### PR TITLE
PIR: Add support for executeScript action

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -113,7 +113,8 @@
                     "solveCaptcha",
                     "condition",
                     "getEmailData",
-                    "generateEmail"
+                    "generateEmail",
+                    "executeScript"
                 ]
             },
             {
@@ -463,7 +464,8 @@
                     "solveCaptcha",
                     "condition",
                     "getEmailData",
-                    "generateEmail"
+                    "generateEmail",
+                    "executeScript"
                 ]
             }
         ]
@@ -623,7 +625,8 @@
                     "solveCaptcha",
                     "condition",
                     "getEmailData",
-                    "generateEmail"
+                    "generateEmail",
+                    "executeScript"
                 ]
             },
             {
@@ -708,7 +711,8 @@
                     "solveCaptcha",
                     "condition",
                     "getEmailData",
-                    "generateEmail"
+                    "generateEmail",
+                    "executeScript"
                 ]
             },
             {

--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakePirMessagingInterface.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakePirMessagingInterface.kt
@@ -154,6 +154,14 @@ class FakePirMessagingInterface(moshi: Moshi) : JsMessaging {
                 """.trimIndent()
             }
 
+            is BrokerAction.ExecuteScript -> """
+                {
+                    "actionID": "${action.id}",
+                    "actionType": "executeScript",
+                    "response": null
+                }
+            """.trimIndent()
+
             is BrokerAction.FillForm -> """
                 {
                     "actionID": "${action.id}",

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandler.kt
@@ -84,7 +84,7 @@ class BrokerActionFailedEventHandler @Inject constructor(
         }
 
         // Silenced script failures still need diagnostics, but must not stop the broker step.
-        if (currentAction is BrokerAction.ExecuteScript && currentAction.failSilently) {
+        if (currentAction is BrokerAction.ExecuteScript && currentAction.failSilently && error is PirError.ActionError.JsActionFailed) {
             emitBrokerActionFailedPixel(state, error)
             return Next(
                 nextState = state.copy(

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandler.kt
@@ -83,6 +83,18 @@ class BrokerActionFailedEventHandler @Inject constructor(
             return handleConditionNotMet(state)
         }
 
+        // Silenced script failures still need diagnostics, but must not stop the broker step.
+        if (currentAction is BrokerAction.ExecuteScript && currentAction.failSilently) {
+            emitBrokerActionFailedPixel(state, error)
+            return Next(
+                nextState = state.copy(
+                    currentActionIndex = state.currentActionIndex + 1,
+                    actionRetryCount = 0,
+                ),
+                nextEvent = ExecuteBrokerStepAction(UserProfile(userProfile = state.profileQuery)),
+            )
+        }
+
         // If failure is on Any captcha action, we proceed to next action
         return if (shouldRetryFailedAction(state, event, currentAction)) {
             Next(
@@ -159,7 +171,8 @@ class BrokerActionFailedEventHandler @Inject constructor(
         event: BrokerActionFailed,
         currentAction: BrokerAction,
     ): Boolean {
-        if (!event.allowRetry) {
+        // Scripts can have non-idempotent side effects, so never retry them.
+        if (!event.allowRetry || currentAction is BrokerAction.ExecuteScript) {
             return false
         }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/JsActionSuccessEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/JsActionSuccessEventHandler.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ClickResponse
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ConditionResponse
+import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ExecuteScriptResponse
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ExpectationResponse
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ExtractedResponse
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.FillFormResponse
@@ -137,7 +138,7 @@ class JsActionSuccessEventHandler @Inject constructor(
                 )
             }
 
-            is FillFormResponse, is ClickResponse, is ExpectationResponse, is ExtractedResponse -> {
+            is FillFormResponse, is ClickResponse, is ExpectationResponse, is ExtractedResponse, is ExecuteScriptResponse -> {
                 Next(
                     nextState = baseSuccessState.copy(
                         currentActionIndex = baseSuccessState.currentActionIndex + 1,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/di/PirModule.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/di/PirModule.kt
@@ -42,6 +42,7 @@ import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ClickResponse
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ConditionResponse
+import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ExecuteScriptResponse
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ExpectationResponse
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ExtractedResponse
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.FillFormResponse
@@ -146,6 +147,7 @@ class PirModule {
                     .withSubtype(BrokerAction.Extract::class.java, "extract")
                     .withSubtype(BrokerAction.Expectation::class.java, "expectation")
                     .withSubtype(BrokerAction.Click::class.java, "click")
+                    .withSubtype(BrokerAction.ExecuteScript::class.java, "executeScript")
                     .withSubtype(BrokerAction.FillForm::class.java, "fillForm")
                     .withSubtype(BrokerAction.Navigate::class.java, "navigate")
                     .withSubtype(BrokerAction.GetCaptchaInfo::class.java, "getCaptchaInfo")
@@ -165,6 +167,7 @@ class PirModule {
                     .withSubtype(GetCaptchaInfoResponse::class.java, "getCaptchaInfo")
                     .withSubtype(SolveCaptchaResponse::class.java, "solveCaptcha")
                     .withSubtype(ClickResponse::class.java, "click")
+                    .withSubtype(ExecuteScriptResponse::class.java, "executeScript")
                     .withSubtype(ExpectationResponse::class.java, "expectation")
                     .withSubtype(FillFormResponse::class.java, "fillForm")
                     .withSubtype(ConditionResponse::class.java, "condition"),

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.pir.impl.scripts.models
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.Click
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.Condition
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.EmailConfirmation
+import com.duckduckgo.pir.impl.scripts.models.BrokerAction.ExecuteScript
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.Expectation
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.Expectation.ExpectationSelector
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.Extract
@@ -89,6 +90,11 @@ sealed class BrokerAction(
             val right: String,
         )
     }
+
+    data class ExecuteScript(
+        override val id: String,
+        val script: String,
+    ) : BrokerAction(id)
 
     data class Expectation(
         override val id: String,
@@ -178,6 +184,7 @@ fun BrokerAction.asActionType(): String {
         is Extract -> "extract"
         is Expectation -> "expectation"
         is Click -> "click"
+        is ExecuteScript -> "executeScript"
         is FillForm -> "fillForm"
         is GetCaptchaInfo -> "getCaptchaInfo"
         is SolveCaptcha -> "solveCaptcha"

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.pir.impl.scripts.models
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.Click
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.Condition
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.EmailConfirmation
+import com.duckduckgo.pir.impl.scripts.models.BrokerAction.ExecuteScript
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.Expectation
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.Expectation.ExpectationSelector
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.Extract
@@ -91,6 +92,11 @@ sealed class BrokerAction(
             val right: String,
         )
     }
+
+    data class ExecuteScript(
+        override val id: String,
+        val script: String,
+    ) : BrokerAction(id)
 
     data class Expectation(
         override val id: String,
@@ -180,6 +186,7 @@ fun BrokerAction.asActionType(): String {
         is Extract -> "extract"
         is Expectation -> "expectation"
         is Click -> "click"
+        is ExecuteScript -> "executeScript"
         is FillForm -> "fillForm"
         is GetCaptchaInfo -> "getCaptchaInfo"
         is SolveCaptcha -> "solveCaptcha"

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
@@ -96,6 +96,7 @@ sealed class BrokerAction(
     data class ExecuteScript(
         override val id: String,
         val script: String,
+        val failSilently: Boolean = false,
     ) : BrokerAction(id)
 
     data class Expectation(

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/PirScriptResponseParams.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/PirScriptResponseParams.kt
@@ -120,6 +120,12 @@ sealed class PirSuccessResponse(
         val meta: AdditionalData? = null,
     ) : PirSuccessResponse(actionID, actionType)
 
+    data class ExecuteScriptResponse(
+        override val actionID: String,
+        override val actionType: String,
+        val meta: AdditionalData? = null,
+    ) : PirSuccessResponse(actionID, actionType)
+
     data class ExpectationResponse(
         override val actionID: String,
         override val actionType: String,

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealBrokerStepsParserTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealBrokerStepsParserTest.kt
@@ -20,9 +20,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.EmailConfirmationStep
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.OptOutStep
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.ScanStep
-import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions
-import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.OptOutStepActions
-import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.ScanStepActions
+import com.duckduckgo.pir.impl.di.PirModule
 import com.duckduckgo.pir.impl.models.AddressCityState
 import com.duckduckgo.pir.impl.models.Broker
 import com.duckduckgo.pir.impl.models.ExtractedProfile
@@ -33,8 +31,6 @@ import com.duckduckgo.pir.impl.scripts.models.BrokerAction
 import com.duckduckgo.pir.impl.scripts.models.ElementSelector
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -84,25 +80,7 @@ class RealBrokerStepsParserTest {
 
     @Before
     fun setUp() {
-        moshi = Moshi.Builder()
-            .add(
-                PolymorphicJsonAdapterFactory.of(BrokerAction::class.java, "actionType")
-                    .withSubtype(BrokerAction.Extract::class.java, "extract")
-                    .withSubtype(BrokerAction.Expectation::class.java, "expectation")
-                    .withSubtype(BrokerAction.Click::class.java, "click")
-                    .withSubtype(BrokerAction.FillForm::class.java, "fillForm")
-                    .withSubtype(BrokerAction.Navigate::class.java, "navigate")
-                    .withSubtype(BrokerAction.GetCaptchaInfo::class.java, "getCaptchaInfo")
-                    .withSubtype(BrokerAction.SolveCaptcha::class.java, "solveCaptcha")
-                    .withSubtype(BrokerAction.EmailConfirmation::class.java, "emailConfirmation")
-                    .withSubtype(BrokerAction.Condition::class.java, "condition"),
-            ).add(
-                PolymorphicJsonAdapterFactory.of(BrokerStepActions::class.java, "stepType")
-                    .withSubtype(ScanStepActions::class.java, "scan")
-                    .withSubtype(OptOutStepActions::class.java, "optOut"),
-            )
-            .add(KotlinJsonAdapterFactory())
-            .build()
+        moshi = PirModule().providePirMoshi(Moshi.Builder().build())
 
         testee = RealBrokerStepsParser(
             dispatcherProvider = coroutineRule.testDispatcherProvider,
@@ -136,6 +114,37 @@ class RealBrokerStepsParserTest {
         assertEquals("scan", scanStep.step.stepType)
         assertEquals("automated", scanStep.step.scanType)
         assertEquals(1, scanStep.step.actions.size)
+    }
+
+    @Test
+    fun whenParseStepWithExecuteScriptActionThenReturnExecuteScriptAction() = runTest {
+        val actionId = "execute-script-1"
+        val script = "document.querySelector('#target').click();"
+        val scanJson = """
+            {
+                "stepType": "scan",
+                "scanType": "automated",
+                "actions": [
+                    {
+                        "actionType": "navigate",
+                        "id": "nav-1",
+                        "url": "https://testbroker.com/search"
+                    },
+                    {
+                        "actionType": "executeScript",
+                        "id": "$actionId",
+                        "script": "$script"
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val result = testee.parseStep(testBroker, scanJson, null)
+
+        val actions = result.filterIsInstance<ScanStep>().single().step.actions
+        assertEquals(2, actions.size)
+        val executeScript = actions.filterIsInstance<BrokerAction.ExecuteScript>().single { it.id == actionId }
+        assertEquals(script, executeScript.script)
     }
 
     @Test

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealBrokerStepsParserTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealBrokerStepsParserTest.kt
@@ -459,4 +459,37 @@ class RealBrokerStepsParserTest {
 
         assertNull(result)
     }
+
+    @Test
+    fun whenParseExecuteScriptThenPreserveScriptAndDefaultFailSilentlyToFalse() = runTest {
+        val script = "const value = \"quoted\";\nroot.body.textContent = userProfile.firstName;"
+        val encodedScript = moshi.adapter(String::class.java).toJson(script)
+        listOf("", ", \"failSilently\": false", ", \"failSilently\": true").forEach { flag ->
+            val step = """
+                {
+                    "stepType": "scan", "scanType": "automated",
+                    "actions": [{"actionType": "executeScript", "id": "script-1", "script": $encodedScript $flag}]
+                }
+            """.trimIndent()
+
+            val result = testee.parseStep(testBroker, step, null).single() as ScanStep
+
+            assertEquals(
+                BrokerAction.ExecuteScript("script-1", script, failSilently = flag.contains("true")),
+                result.step.actions.single(),
+            )
+        }
+    }
+
+    @Test
+    fun whenParseExecuteScriptWithoutScriptThenRejectStep() = runTest {
+        val json = """
+            {
+                "stepType": "scan", "scanType": "automated",
+                "actions": [{"actionType": "executeScript", "id": "script-1"}]
+            }
+        """.trimIndent()
+
+        assertTrue(testee.parseStep(testBroker, json, null).isEmpty())
+    }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealPirActionsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealPirActionsRunnerTest.kt
@@ -29,11 +29,15 @@ import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngineFactory
 import com.duckduckgo.pir.impl.models.Broker
 import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.scripts.BrokerActionProcessor
+import com.duckduckgo.pir.impl.scripts.models.BrokerAction
 import com.duckduckgo.pir.impl.scripts.models.PirError
+import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
@@ -592,5 +596,28 @@ class RealPirActionsRunnerTest {
         val eventCaptor = argumentCaptor<Event>()
         verify(mockEngine, times(2)).dispatch(eventCaptor.capture())
         assertTrue(eventCaptor.allValues.none { it is Event.LoadUrlComplete })
+    }
+
+    @Test
+    fun whenExecuteScriptDoesNotRespondThenNativeTimeoutFiresAfterSixtySeconds() = runTest {
+        val deferred = async { testee.execute(testProfileQuery, testScanStep) }
+        yield()
+        val action = BrokerAction.ExecuteScript("script-1", "return new Promise(() => {});")
+        val request = PirScriptRequestData.UserProfile(testProfileQuery)
+        sideEffectFlow.emit(SideEffect.PushJsAction(action.id, action, 0L, request))
+        runCurrent()
+
+        advanceTimeBy(59_999)
+        runCurrent()
+        verify(mockEngine, never()).dispatch(any<Event.BrokerActionFailed>())
+
+        advanceTimeBy(1)
+        runCurrent()
+        verify(mockEngine).dispatch(
+            Event.BrokerActionFailed(PirError.ActionError.JsActionFailed(action.id, "Local timeout"), allowRetry = true),
+        )
+        verify(mockBrokerActionProcessor, times(1)).pushAction(action, request)
+        sideEffectFlow.emit(SideEffect.CompleteExecution)
+        deferred.await()
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandlerTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.ScanSt
 import com.duckduckgo.pir.impl.common.PirJob.RunType
 import com.duckduckgo.pir.impl.common.PirRunStateHandler
 import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerOptOutConditionNotFound
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerStepActionFailed
 import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerStepInvalidEvent
 import com.duckduckgo.pir.impl.common.actions.BrokerActionFailedEventHandler.Companion.MAX_RETRY_COUNT_OPTOUT
 import com.duckduckgo.pir.impl.common.actions.BrokerActionFailedEventHandler.Companion.MAX_RETRY_COUNT_SCAN
@@ -48,7 +49,10 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.isA
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -533,5 +537,73 @@ class BrokerActionFailedEventHandlerTest {
         testee.invoke(state, event)
 
         verify(mockPirRunStateHandler).handleState(any())
+    }
+
+    @Test
+    fun whenExecuteScriptFailsThenNeverRetryAndRecordFailureForEveryRunType() = runTest {
+        RunType.entries.forEach { runType ->
+            val action = BrokerAction.ExecuteScript("script-1", "throw new Error('failed')")
+            val state = executeScriptState(action, runType)
+            val error = PirError.ActionError.JsActionFailed(action.id, "executeScript failed: Error: failed")
+
+            val result = testee.invoke(state, BrokerActionFailed(error, allowRetry = true))
+
+            assertEquals(state, result.nextState)
+            assertEquals(BrokerStepCompleted(false, Failure(error)), result.nextEvent)
+            assertNull(result.sideEffect)
+        }
+        verify(mockPirRunStateHandler, times(RunType.entries.size)).handleState(
+            isA<BrokerStepActionFailed>(),
+        )
+    }
+
+    @Test
+    fun whenExecuteScriptFailureIsSilencedThenRecordErrorAndAdvanceForEveryRunType() = runTest {
+        RunType.entries.forEach { runType ->
+            val action = BrokerAction.ExecuteScript("script-1", "throw new Error('failed')", failSilently = true)
+            val state = executeScriptState(action, runType).copy(actionRetryCount = 2)
+            val error = PirError.ActionError.JsActionFailed(action.id, "executeScript failed: Error: failed")
+
+            val result = testee.invoke(state, BrokerActionFailed(error, allowRetry = true))
+
+            assertEquals(state.copy(currentActionIndex = 1, actionRetryCount = 0), result.nextState)
+            assertEquals(ExecuteBrokerStepAction(PirScriptRequestData.UserProfile(testProfileQuery)), result.nextEvent)
+            assertNull(result.sideEffect)
+        }
+        val captor = argumentCaptor<BrokerStepActionFailed>()
+        verify(mockPirRunStateHandler, times(RunType.entries.size)).handleState(captor.capture())
+        captor.allValues.forEach {
+            assertEquals("script-1", it.actionID)
+            assertEquals("executeScript", it.actionType)
+            assertEquals("executeScript failed: Error: failed", it.errorMessage)
+            assertEquals(testCurrentTimeInMillis, it.completionTimeInMillis)
+        }
+    }
+
+    @Test
+    fun whenSilencedExecuteScriptFailsWithoutRetryPermissionThenStillAdvance() = runTest {
+        val action = BrokerAction.ExecuteScript("script-1", "", failSilently = true)
+        val state = executeScriptState(action, RunType.OPTOUT)
+
+        val result = testee.invoke(state, BrokerActionFailed(testError, allowRetry = false))
+
+        assertEquals(1, result.nextState.currentActionIndex)
+        assertEquals(ExecuteBrokerStepAction(PirScriptRequestData.UserProfile(testProfileQuery)), result.nextEvent)
+        verify(mockPirRunStateHandler).handleState(isA<BrokerStepActionFailed>())
+    }
+
+    private fun executeScriptState(action: BrokerAction.ExecuteScript, runType: RunType): State {
+        val actions = listOf(action, testClickAction)
+        val step = if (runType == RunType.OPTOUT || runType == RunType.EMAIL_CONFIRMATION) {
+            OptOutStep(testBroker, OptOutStepActions(stepType = "optOut", actions = actions, optOutType = "form"), testExtractedProfile)
+        } else {
+            testScanStep(actions = actions).copy(broker = testBroker)
+        }
+        return State(
+            runType = runType,
+            brokerStep = step,
+            profileQuery = testProfileQuery,
+            stageStatus = PirStageStatus(PirStage.OTHER, 0L),
+        )
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandlerTest.kt
@@ -581,14 +581,37 @@ class BrokerActionFailedEventHandlerTest {
     }
 
     @Test
-    fun whenSilencedExecuteScriptFailsWithoutRetryPermissionThenStillAdvance() = runTest {
+    fun whenUnrecoverableErrorDuringSilencedExecuteScriptThenFailStep() = runTest {
         val action = BrokerAction.ExecuteScript("script-1", "", failSilently = true)
         val state = executeScriptState(action, RunType.OPTOUT)
+        val errors = listOf(
+            PirError.JsError.ParsingErrorObjectFailed,
+            PirError.ActionError.ClientError(action.id, "Client error"),
+            PirError.ActionError.EmailError(action.id, 500, "Email service error"),
+            PirError.ActionError.CaptchaServiceError(action.id, 500, "Captcha service error"),
+        )
 
-        val result = testee.invoke(state, BrokerActionFailed(testError, allowRetry = false))
+        errors.forEach { error ->
+            val result = testee.invoke(state, BrokerActionFailed(error, allowRetry = false))
 
-        assertEquals(1, result.nextState.currentActionIndex)
+            assertEquals(state, result.nextState)
+            assertEquals(BrokerStepCompleted(false, Failure(error)), result.nextEvent)
+            assertNull(result.sideEffect)
+        }
+        verify(mockPirRunStateHandler, times(errors.size)).handleState(isA<BrokerStepActionFailed>())
+    }
+
+    @Test
+    fun whenSilencedExecuteScriptTimesOutThenRecordErrorAndAdvance() = runTest {
+        val action = BrokerAction.ExecuteScript("script-1", "return new Promise(() => {});", failSilently = true)
+        val state = executeScriptState(action, RunType.OPTOUT)
+        val error = PirError.ActionError.JsActionFailed(action.id, "Local timeout")
+
+        val result = testee.invoke(state, BrokerActionFailed(error, allowRetry = true))
+
+        assertEquals(state.copy(currentActionIndex = 1, actionRetryCount = 0), result.nextState)
         assertEquals(ExecuteBrokerStepAction(PirScriptRequestData.UserProfile(testProfileQuery)), result.nextEvent)
+        assertNull(result.sideEffect)
         verify(mockPirRunStateHandler).handleState(isA<BrokerStepActionFailed>())
     }
 

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/JsActionSuccessEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/JsActionSuccessEventHandlerTest.kt
@@ -48,6 +48,7 @@ import com.duckduckgo.pir.impl.scripts.models.BrokerAction
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ClickResponse
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ConditionResponse
+import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ExecuteScriptResponse
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ExpectationResponse
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ExtractedResponse
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.FillFormResponse
@@ -695,5 +696,27 @@ class JsActionSuccessEventHandlerTest {
                 ),
             ),
         )
+    }
+
+    @Test
+    fun whenExecuteScriptSucceedsThenRecordSuccessAndAdvance() = runTest {
+        val action = BrokerAction.ExecuteScript("script-1", "root.body.textContent = 'done'")
+        val step = testScanStep.copy(step = testScanStep.step.copy(actions = listOf(action)))
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStep = step,
+            profileQuery = testProfileQuery,
+            actionRetryCount = 2,
+            stageStatus = PirStageStatus(PirStage.OTHER, 0L),
+        )
+        val response = ExecuteScriptResponse(action.id, "executeScript")
+
+        val result = testee.invoke(state, JsActionSuccess(response))
+
+        assertEquals(state.copy(currentActionIndex = 1, actionRetryCount = 0), result.nextState)
+        assertEquals(ExecuteBrokerStepAction(UserProfile(testProfileQuery)), result.nextEvent)
+        assertNull(result.sideEffect)
+        verify(mockPirRunStateHandler).handleState(BrokerScanActionSucceeded(testBroker1, testProfileQueryId, response))
+        verifyNoMoreInteractions(mockPirRunStateHandler)
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scripts/RealBrokerActionProcessorTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scripts/RealBrokerActionProcessorTest.kt
@@ -21,24 +21,14 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
+import com.duckduckgo.pir.impl.di.PirModule
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction
 import com.duckduckgo.pir.impl.scripts.models.PirError
 import com.duckduckgo.pir.impl.scripts.models.PirError.ActionError.JsActionFailed
-import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData
-import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.SolveCaptcha
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ClickResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ConditionResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ExpectationResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ExtractedResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.FillFormResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.GetCaptchaInfoResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.NavigateResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.SolveCaptchaResponse
+import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ExecuteScriptResponse
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -57,37 +47,7 @@ import org.mockito.kotlin.whenever
 class RealBrokerActionProcessorTest {
     private lateinit var testee: RealBrokerActionProcessor
     private val mockJsMessaging: JsMessaging = mock()
-    private val moshi = Moshi.Builder()
-        .add(
-            PolymorphicJsonAdapterFactory.of(PirScriptRequestData::class.java, "data")
-                .withSubtype(SolveCaptcha::class.java, "solveCaptcha")
-                .withSubtype(UserProfile::class.java, "userProfile"),
-        )
-        .add(
-            PolymorphicJsonAdapterFactory.of(BrokerAction::class.java, "actionType")
-                .withSubtype(BrokerAction.Extract::class.java, "extract")
-                .withSubtype(BrokerAction.Expectation::class.java, "expectation")
-                .withSubtype(BrokerAction.Click::class.java, "click")
-                .withSubtype(BrokerAction.FillForm::class.java, "fillForm")
-                .withSubtype(BrokerAction.Navigate::class.java, "navigate")
-                .withSubtype(BrokerAction.GetCaptchaInfo::class.java, "getCaptchaInfo")
-                .withSubtype(BrokerAction.SolveCaptcha::class.java, "solveCaptcha")
-                .withSubtype(BrokerAction.EmailConfirmation::class.java, "emailConfirmation")
-                .withSubtype(BrokerAction.Condition::class.java, "condition"),
-        )
-        .add(
-            PolymorphicJsonAdapterFactory.of(PirSuccessResponse::class.java, "actionType")
-                .withSubtype(NavigateResponse::class.java, "navigate")
-                .withSubtype(ExtractedResponse::class.java, "extract")
-                .withSubtype(GetCaptchaInfoResponse::class.java, "getCaptchaInfo")
-                .withSubtype(SolveCaptchaResponse::class.java, "solveCaptcha")
-                .withSubtype(ClickResponse::class.java, "click")
-                .withSubtype(ExpectationResponse::class.java, "expectation")
-                .withSubtype(FillFormResponse::class.java, "fillForm")
-                .withSubtype(ConditionResponse::class.java, "condition"),
-        )
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    private val moshi = PirModule().providePirMoshi(Moshi.Builder().build())
     private val mockWebView: WebView = mock()
     private val mockActionResultListener: BrokerActionProcessor.ActionResultListener = mock()
 
@@ -197,6 +157,36 @@ class RealBrokerActionProcessorTest {
             assertEquals(".city", it.getJSONObject("city").getString("selector"))
             assertEquals(".state", it.getJSONObject("state").getString("selector"))
         }
+    }
+
+    @Test
+    fun whenProcessJsCallbackWithExecuteScriptSuccessThenCallsOnSuccess() = runTest {
+        val callback = registerAndGetCallback()
+
+        val successJson = """
+            {
+                "result": {
+                    "success": {
+                        "actionID": "action-1",
+                        "actionType": "executeScript",
+                        "response": null
+                    }
+                }
+            }
+        """.trimIndent()
+
+        callback.process(
+            featureName = PIRScriptConstants.SCRIPT_FEATURE_NAME,
+            method = PIRScriptConstants.RECEIVED_METHOD_NAME_COMPLETED,
+            id = null,
+            data = JSONObject(successJson),
+        )
+
+        val successCaptor = argumentCaptor<PirSuccessResponse>()
+        verify(mockActionResultListener).onSuccess(successCaptor.capture())
+        assertTrue(successCaptor.firstValue is ExecuteScriptResponse)
+        assertEquals("action-1", successCaptor.firstValue.actionID)
+        assertEquals("executeScript", successCaptor.firstValue.actionType)
     }
 
     @Test

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scripts/RealBrokerActionProcessorTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scripts/RealBrokerActionProcessorTest.kt
@@ -21,24 +21,14 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
+import com.duckduckgo.pir.impl.di.PirModule
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction
 import com.duckduckgo.pir.impl.scripts.models.PirError
 import com.duckduckgo.pir.impl.scripts.models.PirError.ActionError.JsActionFailed
-import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData
-import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.SolveCaptcha
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ClickResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ConditionResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ExpectationResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ExtractedResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.FillFormResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.GetCaptchaInfoResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.NavigateResponse
-import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.SolveCaptchaResponse
+import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.ExecuteScriptResponse
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -58,37 +48,7 @@ import org.mockito.kotlin.whenever
 class RealBrokerActionProcessorTest {
     private lateinit var testee: RealBrokerActionProcessor
     private val mockJsMessaging: JsMessaging = mock()
-    private val moshi = Moshi.Builder()
-        .add(
-            PolymorphicJsonAdapterFactory.of(PirScriptRequestData::class.java, "data")
-                .withSubtype(SolveCaptcha::class.java, "solveCaptcha")
-                .withSubtype(UserProfile::class.java, "userProfile"),
-        )
-        .add(
-            PolymorphicJsonAdapterFactory.of(BrokerAction::class.java, "actionType")
-                .withSubtype(BrokerAction.Extract::class.java, "extract")
-                .withSubtype(BrokerAction.Expectation::class.java, "expectation")
-                .withSubtype(BrokerAction.Click::class.java, "click")
-                .withSubtype(BrokerAction.FillForm::class.java, "fillForm")
-                .withSubtype(BrokerAction.Navigate::class.java, "navigate")
-                .withSubtype(BrokerAction.GetCaptchaInfo::class.java, "getCaptchaInfo")
-                .withSubtype(BrokerAction.SolveCaptcha::class.java, "solveCaptcha")
-                .withSubtype(BrokerAction.EmailConfirmation::class.java, "emailConfirmation")
-                .withSubtype(BrokerAction.Condition::class.java, "condition"),
-        )
-        .add(
-            PolymorphicJsonAdapterFactory.of(PirSuccessResponse::class.java, "actionType")
-                .withSubtype(NavigateResponse::class.java, "navigate")
-                .withSubtype(ExtractedResponse::class.java, "extract")
-                .withSubtype(GetCaptchaInfoResponse::class.java, "getCaptchaInfo")
-                .withSubtype(SolveCaptchaResponse::class.java, "solveCaptcha")
-                .withSubtype(ClickResponse::class.java, "click")
-                .withSubtype(ExpectationResponse::class.java, "expectation")
-                .withSubtype(FillFormResponse::class.java, "fillForm")
-                .withSubtype(ConditionResponse::class.java, "condition"),
-        )
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    private val moshi = PirModule().providePirMoshi(Moshi.Builder().build())
     private val mockWebView: WebView = mock()
     private val mockActionResultListener: BrokerActionProcessor.ActionResultListener = mock()
 
@@ -239,6 +199,33 @@ class RealBrokerActionProcessorTest {
             assertEquals("li", profileMatch.getString("selector"))
             assertEquals(".name", profileMatch.getJSONObject("profile").getJSONObject("name").getString("selector"))
         }
+    fun whenProcessJsCallbackWithExecuteScriptSuccessThenCallsOnSuccess() = runTest {
+        val callback = registerAndGetCallback()
+
+        val successJson = """
+            {
+                "result": {
+                    "success": {
+                        "actionID": "action-1",
+                        "actionType": "executeScript",
+                        "response": null
+                    }
+                }
+            }
+        """.trimIndent()
+
+        callback.process(
+            featureName = PIRScriptConstants.SCRIPT_FEATURE_NAME,
+            method = PIRScriptConstants.RECEIVED_METHOD_NAME_COMPLETED,
+            id = null,
+            data = JSONObject(successJson),
+        )
+
+        val successCaptor = argumentCaptor<PirSuccessResponse>()
+        verify(mockActionResultListener).onSuccess(successCaptor.capture())
+        assertTrue(successCaptor.firstValue is ExecuteScriptResponse)
+        assertEquals("action-1", successCaptor.firstValue.actionID)
+        assertEquals("executeScript", successCaptor.firstValue.actionType)
     }
 
     @Test

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scripts/RealBrokerActionProcessorTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scripts/RealBrokerActionProcessorTest.kt
@@ -199,6 +199,9 @@ class RealBrokerActionProcessorTest {
             assertEquals("li", profileMatch.getString("selector"))
             assertEquals(".name", profileMatch.getJSONObject("profile").getJSONObject("name").getString("selector"))
         }
+    }
+
+    @Test
     fun whenProcessJsCallbackWithExecuteScriptSuccessThenCallsOnSuccess() = runTest {
         val callback = registerAndGetCallback()
 
@@ -362,5 +365,54 @@ class RealBrokerActionProcessorTest {
         val errorCaptor = argumentCaptor<PirError>()
         verify(mockActionResultListener).onError(errorCaptor.capture())
         assertEquals(PirError.JsError.ParsingErrorObjectFailed, errorCaptor.firstValue)
+    }
+
+    @Test
+    fun whenPushExecuteScriptThenForwardOpaqueScriptAndUserProfile() {
+        val script = "const anchor = root.createElement(\"a\");\nanchor.textContent = userProfile.firstName;"
+        val profile = com.duckduckgo.pir.impl.models.ProfileQuery(
+            id = 1L, firstName = "John", lastName = "Doe", city = "New York", state = "NY",
+            addresses = emptyList(), birthYear = 1990, fullName = "John Doe", age = 36, deprecated = false,
+        )
+        val action = BrokerAction.ExecuteScript("script-1", script, failSilently = true)
+
+        testee.pushAction(action, UserProfile(userProfile = profile))
+
+        val captor = argumentCaptor<SubscriptionEventData>()
+        verify(mockJsMessaging).sendSubscriptionEvent(captor.capture())
+        assertEquals(PIRScriptConstants.SCRIPT_FEATURE_NAME, captor.firstValue.featureName)
+        assertEquals(PIRScriptConstants.SUBSCRIBED_METHOD_NAME_RECEIVED, captor.firstValue.subscriptionName)
+        val state = captor.firstValue.params.getJSONObject("state")
+        val pushedAction = state.getJSONObject("action")
+        assertEquals("executeScript", pushedAction.getString("actionType"))
+        assertEquals(action.id, pushedAction.getString("id"))
+        assertEquals(script, pushedAction.getString("script"))
+        assertTrue(pushedAction.getBoolean("failSilently"))
+        val userProfile = state.getJSONObject("data").getJSONObject("userProfile")
+        assertEquals(profile.firstName, userProfile.getString("firstName"))
+        assertEquals(profile.lastName, userProfile.getString("lastName"))
+        assertEquals(profile.city, userProfile.getString("city"))
+        assertEquals(profile.state, userProfile.getString("state"))
+        assertEquals(profile.birthYear, userProfile.getInt("birthYear"))
+    }
+
+    @Test
+    fun whenExecuteScriptFailsThenForwardSanitizedMessageUnmodified() {
+        val callback = registerAndGetCallback()
+        val message = "executeScript failed: TypeError: " + "x".repeat(468)
+        val data = JSONObject().put(
+            "result",
+            JSONObject().put("error", JSONObject().put("actionID", "script-1").put("message", message)),
+        )
+
+        callback.process(
+            PIRScriptConstants.SCRIPT_FEATURE_NAME,
+            PIRScriptConstants.RECEIVED_METHOD_NAME_COMPLETED,
+            null,
+            data,
+        )
+
+        verify(mockActionResultListener).onError(JsActionFailed("script-1", message))
+        org.mockito.kotlin.verifyNoMoreInteractions(mockActionResultListener)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217806727201845
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1217897464444079
API Proposals URL(s) (if applicable): None

### Description

Adds `executeScript` support to PIR broker rules in line with the approved tech design. Android forwards the script and existing user profile to C-S-S, handles its success response, and advances to the next action. Script failures are never retried; `failSilently` defaults to false and, when enabled, records the failure before continuing. The existing 60-second native timeout still applies.

### Steps to test this PR

1. Settings → PIR dev settings → Broker Config.
2. Select PropertyRecord and paste in this config:

<details><summary>Broker config</summary>
<p>

```json
{
  "name": "PropertyRecord",
  "url": "propertyrecord.com",
  "version": "0.8.0",
  "addedDatetime": 1775736000000,
  "optOutUrl": "https://dashboard.propertyrecord.com/opt-out",
  "steps": [
    {
      "stepType": "scan",
      "scanType": "templatedUrl",
      "actions": [
        {
          "actionType": "navigate",
          "id": "4e3682bd-cc48-4ebe-9172-0ea3b89fe503",
          "url": "https://www.propertyrecord.com/"
        },
        {
          "actionType": "expectation",
          "expectations": [
            {
              "type": "element",
              "selector": "//a[@title='Remove My Info']"
            }
          ],
          "id": "65e32379-fb7b-42d5-9817-00ba4075c36a"
        },
        {
          "actionType": "click",
          "elements": [
            {
              "type": "button",
              "selector": "//a[@title='Remove My Info']"
            }
          ],
          "id": "7562499b-cff9-4fb2-a87e-92432a49f827"
        },
        {
          "actionType": "expectation",
          "expectations": [
            {
              "type": "element",
              "selector": "//h1[contains(text(), 'Remove My Information')]"
            }
          ],
          "id": "bd6730a0-3381-43b4-8317-1e27f9df05d6"
        },
        {
          "actionType": "fillForm",
          "selector": "form#backgroundCheckForm",
          "dataSource": "userProfile",
          "elements": [
            {
              "type": "fullName",
              "selector": ".//input[@name='name']"
            },
            {
              "type": "cityState",
              "selector": ".//input[@name='cityState']"
            }
          ],
          "id": "8fde207e-9e1e-476e-9e6d-184a72d279d4"
        },
        {
          "actionType": "executeScript",
          "id": "d7d9b7bf-ba8a-4ed4-9086-73ec1655fa6f",
          "_comment": "Injects an anchor to the records URL. The next click follows this anchor instead of submitting the form, so the records request carries the opt-out page as referer and returns 200 instead of 403.",
          "script": "const { firstName, lastName, city, state } = userProfile;\n\nconst records = new URL(\"/opt-out/records\", root.location.origin);\nrecords.search = new URLSearchParams({\n  name: `${firstName} ${lastName}`,\n  city: city.toLowerCase(),\n  state,\n  cityState: `${city}, ${state}`,\n}).toString();\n\nconst anchor = root.createElement(\"a\");\nanchor.id = \"pir-probe-anchor\";\nanchor.href = records.toString();\nanchor.style.cssText = \"position: fixed; top: 0; left: 0;\";\n\nroot.body.appendChild(anchor);\n"
        },
        {
          "actionType": "click",
          "elements": [
            {
              "type": "button",
              "selector": "a#pir-probe-anchor"
            }
          ],
          "id": "d0030ece-5888-40ae-8b93-3f9f157da3cd"
        },
        {
          "actionType": "expectation",
          "expectations": [
            {
              "type": "element",
              "selector": "//div[contains(text(), 'Search Results')]"
            }
          ],
          "id": "441dce5c-d29f-4f01-847e-405795aae7d1"
        },
        {
          "actionType": "condition",
          "_comment": "Click Use Original when the site offers a spelling correction.",
          "expectations": [
            {
              "type": "element",
              "selector": "#spellcheck-original",
              "failSilently": true
            }
          ],
          "actions": [
            {
              "actionType": "click",
              "elements": [
                {
                  "type": "button",
                  "selector": "#spellcheck-original"
                }
              ],
              "id": "433039ee-c3e7-44c4-9056-e7ad09abe618"
            }
          ],
          "id": "9cbacc8a-2afa-46bb-b72a-d39f46ec9046"
        },
        {
          "actionType": "expectation",
          "expectations": [
            {
              "type": "element",
              "selector": "//div[contains(text(), 'Search Results')]"
            }
          ],
          "id": "55c7fe04-dead-5857-b038-f67ca8d062bc"
        },
        {
          "actionType": "extract",
          "id": "8b02aa75-9acb-4f22-9ed5-efda7fd0b2fa",
          "selector": "//ul[@id='people-search-results']/li",
          "noResultsSelector": "//h3[contains(text(), 'No results found')]",
          "profile": {
            "name": {
              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(concat(' ', normalize-space(@class), ' '), ' !text-black-900 ') and contains(concat(' ', normalize-space(@class), ' '), ' text-lg ')]"
            },
            "addressCityState": {
              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
            },
            "age": {
              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(.,'Years Old') or contains(.,'Deceased')]"
            },
            "addressCityStateList": {
              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Locations Include']/following-sibling::div",
              "findElements": true
            },
            "relativesList": {
              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Possible Relatives']/following-sibling::div",
              "findElements": true
            },
            "profileUrl": {
              "identifierType": "hash"
            }
          }
        }
      ]
    },
    {
      "stepType": "optOut",
      "optOutType": "formOptOut",
      "actions": [
        {
          "actionType": "navigate",
          "id": "9e7126b9-7101-4953-b132-2e5c9668275b",
          "url": "https://www.propertyrecord.com/"
        },
        {
          "actionType": "click",
          "elements": [
            {
              "type": "button",
              "selector": "//a[@title='Remove My Info']"
            }
          ],
          "id": "ce2f0fa7-f9c1-4df3-9e6a-102d27353ea8"
        },
        {
          "actionType": "expectation",
          "expectations": [
            {
              "type": "element",
              "selector": "//h1[contains(text(), 'Remove My Information')]"
            }
          ],
          "id": "54ca8a38-6900-408d-98ce-151d929ca948"
        },
        {
          "actionType": "fillForm",
          "selector": "form#backgroundCheckForm",
          "dataSource": "userProfile",
          "elements": [
            {
              "type": "fullName",
              "selector": ".//input[@name='name']"
            },
            {
              "type": "cityState",
              "selector": ".//input[@name='cityState']"
            }
          ],
          "id": "37b5dae9-35dc-464a-a044-f2e0332efcbc"
        },
        {
          "actionType": "executeScript",
          "id": "21ca1a9a-c41d-4a1b-85b7-644be77c4919",
          "_comment": "Injects an anchor to the records URL. The next click follows this anchor instead of submitting the form, so the records request carries the opt-out page as referer and returns 200 instead of 403.",
          "script": "const { firstName, lastName, city, state } = userProfile;\n\nconst records = new URL(\"/opt-out/records\", root.location.origin);\nrecords.search = new URLSearchParams({\n  name: `${firstName} ${lastName}`,\n  city: city.toLowerCase(),\n  state,\n  cityState: `${city}, ${state}`,\n}).toString();\n\nconst anchor = root.createElement(\"a\");\nanchor.id = \"pir-probe-anchor\";\nanchor.href = records.toString();\nanchor.style.cssText = \"position: fixed; top: 0; left: 0;\";\n\nroot.body.appendChild(anchor);\n"
        },
        {
          "actionType": "click",
          "elements": [
            {
              "type": "button",
              "selector": "a#pir-probe-anchor"
            }
          ],
          "id": "ee4a70fa-f0da-4f6b-a5d0-db42a0bca5a0"
        },
        {
          "actionType": "expectation",
          "expectations": [
            {
              "type": "element",
              "selector": "//div[contains(text(), 'Search Results')]"
            }
          ],
          "id": "848b3be4-8d48-440e-8ce0-b640281d8872"
        },
        {
          "actionType": "condition",
          "_comment": "Click Use Original when the site offers a spelling correction.",
          "expectations": [
            {
              "type": "element",
              "selector": "#spellcheck-original",
              "failSilently": true
            }
          ],
          "actions": [
            {
              "actionType": "click",
              "elements": [
                {
                  "type": "button",
                  "selector": "#spellcheck-original"
                }
              ],
              "id": "672b570b-75d7-42f5-9abb-e767b3901b1e"
            }
          ],
          "id": "8d2d1ab8-54d9-434d-92f1-27175a57b93b"
        },
        {
          "actionType": "expectation",
          "expectations": [
            {
              "type": "element",
              "selector": "//div[contains(text(), 'Search Results')]"
            }
          ],
          "id": "f9597066-25f4-5675-b7d5-7f3a2a461f93"
        },
        {
          "actionType": "getCaptchaInfo",
          "id": "2393aa3b-3997-48d6-89fa-715acfe5f6e2",
          "captchaType": "recaptcha2",
          "selector": ".g-recaptcha",
          "parent": {
            "profileMatch": {
              "selector": "//ul[@id='people-search-results']/li",
              "profile": {
                "name": {
                  "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(concat(' ', normalize-space(@class), ' '), ' !text-black-900 ') and contains(concat(' ', normalize-space(@class), ' '), ' text-lg ')]"
                },
                "addressCityState": {
                  "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
                },
                "age": {
                  "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(.,'Years Old') or contains(.,'Deceased')]"
                },
                "addressCityStateList": {
                  "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Locations Include']/following-sibling::div",
                  "findElements": true
                },
                "relativesList": {
                  "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Possible Relatives']/following-sibling::div",
                  "findElements": true
                },
                "profileUrl": {
                  "identifierType": "hash"
                }
              }
            }
          }
        },
        {
          "actionType": "solveCaptcha",
          "id": "3fbe6cca-2c24-4d45-a8e0-05a523e6726d",
          "captchaType": "recaptcha2",
          "selector": ".g-recaptcha",
          "parent": {
            "profileMatch": {
              "selector": "//ul[@id='people-search-results']/li",
              "profile": {
                "name": {
                  "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(concat(' ', normalize-space(@class), ' '), ' !text-black-900 ') and contains(concat(' ', normalize-space(@class), ' '), ' text-lg ')]"
                },
                "addressCityState": {
                  "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
                },
                "age": {
                  "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(.,'Years Old') or contains(.,'Deceased')]"
                },
                "addressCityStateList": {
                  "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Locations Include']/following-sibling::div",
                  "findElements": true
                },
                "relativesList": {
                  "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Possible Relatives']/following-sibling::div",
                  "findElements": true
                },
                "profileUrl": {
                  "identifierType": "hash"
                }
              }
            }
          }
        },
        {
          "actionType": "click",
          "elements": [
            {
              "type": "button",
              "selector": ".//button[contains(normalize-space(.), 'Remove My Info')]",
              "parent": {
                "profileMatch": {
                  "selector": "//ul[@id='people-search-results']/li",
                  "profile": {
                    "name": {
                      "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(concat(' ', normalize-space(@class), ' '), ' !text-black-900 ') and contains(concat(' ', normalize-space(@class), ' '), ' text-lg ')]"
                    },
                    "addressCityState": {
                      "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
                    },
                    "age": {
                      "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(.,'Years Old') or contains(.,'Deceased')]"
                    },
                    "addressCityStateList": {
                      "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Locations Include']/following-sibling::div",
                      "findElements": true
                    },
                    "relativesList": {
                      "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Possible Relatives']/following-sibling::div",
                      "findElements": true
                    },
                    "profileUrl": {
                      "identifierType": "hash"
                    }
                  }
                }
              }
            }
          ],
          "id": "f47133ae-dc60-42ea-a1c7-be42d843ec6e"
        },
        {
          "actionType": "expectation",
          "expectations": [
            {
              "type": "element",
              "selector": "//h3[normalize-space(.)='Success: Information Removed']",
              "failSilently": true
            }
          ],
          "id": "aeb7b984-95cb-42fc-a50b-537c332df23a",
          "_comment": "This fail-silent check adds one action interval for PropertyRecord to finish the POST navigation before the required success check."
        },
        {
          "actionType": "expectation",
          "expectations": [
            {
              "type": "element",
              "selector": "//h3[normalize-space(.)='Success: Information Removed']"
            }
          ],
          "id": "eb466716-5675-48c0-adc8-9823099c1c61"
        }
      ]
    }
  ],
  "schedulingConfig": {
    "retryError": 48,
    "confirmOptOutScan": 72,
    "maintenanceScan": 120,
    "maxAttempts": -1
  },
  "removedAt": null
}
```

</p>
</details> 

(You can also use any of the other configs from https://dub.duckduckgo.com/duckduckgo/dbp-api/pull/489, just make sure you manually inline `scriptPath` → `script`.)

3. Settings → PIR dev settings → PIR Scan.
4. Fill in name, city, state, birth year with a sample profile.
5. Select PropertyRecord and press Debug Scan.
6. Profile should be extracted. Logcat should show `executeScript` working.

<!-- CURSOR_SUMMARY -→
---

> [!NOTE]
> **High Risk**
> Introduces execution of broker-supplied scripts in the PIR WebView with access to user profile data; misconfiguration or malicious broker rules could cause unintended page behavior, though retries are disabled and errors can be silenced only for JS failures.
> 
> **Overview**
> Adds **`executeScript`** to PIR broker flows so scan/opt-out rules can run custom JavaScript in the broker WebView, with Android wiring through content-scope-scripts.
> 
> The dependency **`@duckduckgo/content-scope-scripts`** is bumped to a branch that implements the action (runs `action.script` with `userProfile` and `root`, returns success or a sanitized error, and skips JS-layer retries). Android models **`BrokerAction.ExecuteScript`** (`script`, optional **`failSilently`**, default false), parses it from broker JSON, and forwards script + user profile to the injected script. Success advances the step like click/fill; failures are **never retried** (non-idempotent). With **`failSilently`**, JS failures and the existing **60s** local timeout are recorded and the runner continues; otherwise the broker step fails. Moshi, success/failure handlers, integration fakes, and tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad1f4275ea131853c08c4ed57e262ba00c407540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->