### PR TITLE
fix(pir): send the profile with the captcha token

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
@@ -301,6 +301,16 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
         state: State,
         requestData: PirScriptRequestData,
     ): PirScriptRequestData {
+        if (requestData is PirScriptRequestData.SolveCaptcha) {
+            return requestData.copy(
+                userProfile = state.profileQuery,
+                extractedProfile = when (brokerStep) {
+                    is OptOutStep -> brokerStep.profileToOptOut.toParams(state.profileQuery.fullName)
+                    is EmailConfirmationStep -> brokerStep.profileToOptOut.toParams(state.profileQuery.fullName)
+                    is ScanStep -> null
+                },
+            )
+        }
         if (requestData !is UserProfile) {
             return requestData
         }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/PirScriptRequestParams.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/PirScriptRequestParams.kt
@@ -30,6 +30,8 @@ data class ActionRequest(
 sealed class PirScriptRequestData {
     data class SolveCaptcha(
         val token: String,
+        val userProfile: ProfileQuery? = null,
+        val extractedProfile: ExtractedProfileParams? = null,
     ) : PirScriptRequestData()
 
     data class UserProfile(

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
@@ -475,7 +475,43 @@ class ExecuteBrokerStepActionEventHandlerTest {
         val sideEffect = result.sideEffect as PushJsAction
         assertEquals("action-captcha", sideEffect.actionId)
         assertEquals(action, sideEffect.action)
+        val captchaData = sideEffect.requestParamsData as PirScriptRequestData.SolveCaptcha
+        assertEquals("captcha-token", captchaData.token)
+        assertEquals(testProfileQuery, captchaData.userProfile)
+        assertEquals("John Doe", captchaData.extractedProfile?.name)
         assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenScanStepSolveCaptchaActionWithSolutionThenSendsProfileWithoutExtractedProfile() = runTest {
+        val action = BrokerAction.SolveCaptcha(id = "action-captcha", selector = "captcha-input")
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(action),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStep = scanStep,
+            profileQuery = testProfileQuery,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.CAPTCHA_SOLVE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(PirScriptRequestData.SolveCaptcha(token = "captcha-token"))
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as PushJsAction
+        val captchaData = sideEffect.requestParamsData as PirScriptRequestData.SolveCaptcha
+        assertEquals("captcha-token", captchaData.token)
+        assertEquals(testProfileQuery, captchaData.userProfile)
+        assertNull(captchaData.extractedProfile)
     }
 
     @Test

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scripts/RealBrokerActionProcessorTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scripts/RealBrokerActionProcessorTest.kt
@@ -21,7 +21,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
+import com.duckduckgo.pir.impl.models.Address
+import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction
+import com.duckduckgo.pir.impl.scripts.models.ExtractedProfileParams
 import com.duckduckgo.pir.impl.scripts.models.PirError
 import com.duckduckgo.pir.impl.scripts.models.PirError.ActionError.JsActionFailed
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData
@@ -197,6 +200,37 @@ class RealBrokerActionProcessorTest {
             assertEquals(".city", it.getJSONObject("city").getString("selector"))
             assertEquals(".state", it.getJSONObject("state").getString("selector"))
         }
+    }
+
+    @Test
+    fun whenPushSolveCaptchaActionThenPushedJsonCarriesTokenAndProfiles() = runTest {
+        val action = BrokerAction.SolveCaptcha(id = "action-captcha", selector = "#captcha")
+        val requestData = SolveCaptcha(
+            token = "captcha-token",
+            userProfile = ProfileQuery(
+                id = 1L,
+                firstName = "John",
+                lastName = "Doe",
+                city = "TestCity",
+                state = "TS",
+                addresses = listOf(Address(city = "TestCity", state = "TS")),
+                birthYear = 1990,
+                fullName = "John Doe",
+                age = 34,
+                deprecated = false,
+            ),
+            extractedProfile = ExtractedProfileParams(name = "John Doe", profileUrl = "https://example.com/john"),
+        )
+
+        testee.pushAction(action, requestData)
+
+        val eventCaptor = argumentCaptor<SubscriptionEventData>()
+        verify(mockJsMessaging).sendSubscriptionEvent(eventCaptor.capture())
+
+        val pushedData = eventCaptor.firstValue.params.getJSONObject("state").getJSONObject("data")
+        assertEquals("captcha-token", pushedData.getString("token"))
+        assertEquals("John", pushedData.getJSONObject("userProfile").getString("firstName"))
+        assertEquals("John Doe", pushedData.getJSONObject("extractedProfile").getString("name"))
     }
 
     @Test

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scripts/RealBrokerActionProcessorTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scripts/RealBrokerActionProcessorTest.kt
@@ -21,7 +21,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
+import com.duckduckgo.pir.impl.models.Address
+import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction
+import com.duckduckgo.pir.impl.scripts.models.ExtractedProfileParams
 import com.duckduckgo.pir.impl.scripts.models.PirError
 import com.duckduckgo.pir.impl.scripts.models.PirError.ActionError.JsActionFailed
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData
@@ -239,6 +242,34 @@ class RealBrokerActionProcessorTest {
             assertEquals("li", profileMatch.getString("selector"))
             assertEquals(".name", profileMatch.getJSONObject("profile").getJSONObject("name").getString("selector"))
         }
+    fun whenPushSolveCaptchaActionThenPushedJsonCarriesTokenAndProfiles() = runTest {
+        val action = BrokerAction.SolveCaptcha(id = "action-captcha", selector = "#captcha")
+        val requestData = SolveCaptcha(
+            token = "captcha-token",
+            userProfile = ProfileQuery(
+                id = 1L,
+                firstName = "John",
+                lastName = "Doe",
+                city = "TestCity",
+                state = "TS",
+                addresses = listOf(Address(city = "TestCity", state = "TS")),
+                birthYear = 1990,
+                fullName = "John Doe",
+                age = 34,
+                deprecated = false,
+            ),
+            extractedProfile = ExtractedProfileParams(name = "John Doe", profileUrl = "https://example.com/john"),
+        )
+
+        testee.pushAction(action, requestData)
+
+        val eventCaptor = argumentCaptor<SubscriptionEventData>()
+        verify(mockJsMessaging).sendSubscriptionEvent(eventCaptor.capture())
+
+        val pushedData = eventCaptor.firstValue.params.getJSONObject("state").getJSONObject("data")
+        assertEquals("captcha-token", pushedData.getString("token"))
+        assertEquals("John", pushedData.getJSONObject("userProfile").getString("firstName"))
+        assertEquals("John Doe", pushedData.getJSONObject("extractedProfile").getString("name"))
     }
 
     @Test


### PR DESCRIPTION
### Summary

Asana: https://app.asana.com/1/137249556945/task/1217611870578214

This PR:

* sends `userProfile` and `extractedProfile` with the captcha token, because a broker showing one captcha per record needs the profile to pick the right one, and Android sent the token alone.
