### PR TITLE
Add UI and logic for displaying redirect suggestion on the BAD_URL error page

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -40,6 +40,8 @@ import android.print.PrintDocumentAdapter
 import android.print.PrintManager
 import android.provider.MediaStore
 import android.text.Spanned
+import android.text.SpannedString
+import android.text.TextUtils
 import android.view.ContextMenu
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
@@ -179,6 +181,7 @@ import com.duckduckgo.app.browser.print.PrintDocumentAdapterFactory
 import com.duckduckgo.app.browser.print.PrintInjector
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.browser.shortcut.ShortcutBuilder
+import com.duckduckgo.app.browser.suggestredirect.RedirectSuggestion
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewGenerator
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
 import com.duckduckgo.app.browser.ui.dialogs.AutomaticFireproofDialogOptions
@@ -293,6 +296,7 @@ import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.ui.store.BrowserAppTheme
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
 import com.duckduckgo.common.ui.view.DaxDialog
+import com.duckduckgo.common.ui.view.addClickableLink
 import com.duckduckgo.common.ui.view.dialog.ActionBottomSheetDialog
 import com.duckduckgo.common.ui.view.dialog.CustomAlertDialogBuilder
 import com.duckduckgo.common.ui.view.dialog.DaxAlertDialog
@@ -2374,6 +2378,7 @@ class BrowserTabFragment :
         newBrowserTab.newTabRootLayout.gone()
         sslErrorView.gone()
         maliciousWarningView.gone()
+        renderRedirectSuggestion(viewModel.browserViewState.value?.redirectSuggestion)
         hidePdf()
         omnibar.setViewMode(ViewMode.Error)
         webView?.onPause()
@@ -2387,6 +2392,21 @@ class BrowserTabFragment :
         errorView.errorLayout.show()
 
         browserNavigationBarIntegration.configureBrowserViewMode()
+    }
+
+    private fun renderRedirectSuggestion(suggestion: RedirectSuggestion?) {
+        if (suggestion == null) {
+            errorView.redirectSuggestionMessage.gone()
+            return
+        }
+        // Use expandTemplate(), getString() would otherwise strip the annotation altogether
+        val message = SpannedString(TextUtils.expandTemplate(getText(R.string.webViewErrorRedirectSuggestionMessage), suggestion.domain))
+        with(errorView.redirectSuggestionMessage) {
+            addClickableLink("redirect_link", message) {
+                viewModel.onRedirectSuggestionClicked(suggestion.url)
+            }
+            show()
+        }
     }
 
     private fun showDuckAI(browserViewState: BrowserViewState) {
@@ -6105,6 +6125,7 @@ class BrowserTabFragment :
                 val browserShowing = viewState.browserShowing
                 val browserShowingChanged = viewState.browserShowing != lastSeenBrowserViewState?.browserShowing
                 val errorChanged = viewState.browserError != lastSeenBrowserViewState?.browserError
+                val redirectSuggestionChanged = viewState.redirectSuggestion != lastSeenBrowserViewState?.redirectSuggestion
                 val sslErrorChanged = viewState.sslError != lastSeenBrowserViewState?.sslError
 
                 lastSeenBrowserViewState = viewState
@@ -6132,6 +6153,8 @@ class BrowserTabFragment :
                             showHome()
                         }
                     }
+                } else if (redirectSuggestionChanged) {
+                    renderRedirectSuggestion(viewState.redirectSuggestion)
                 }
 
                 omnibar.renderBrowserViewState(viewState)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1314,6 +1314,7 @@ class BrowserTabFragment :
                 errorView.yetiIcon.isSaveEnabled = false
                 errorView.errorTitle.isSaveEnabled = false
                 errorView.errorMessage.isSaveEnabled = false
+                errorView.redirectSuggestionMessage.isSaveEnabled = false
 
                 omnibar.disableViewStateSaving()
                 sslErrorView.disableViewStateSaving()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -4568,7 +4568,10 @@ class BrowserTabViewModel @Inject constructor(
             command.value = WebViewError(errorType, url)
             suggestRedirectJob.cancel() // Cancel previous in-flight job as the new errorType might not be BAD_URL
         }
-        if (errorType == BAD_URL && suggestRedirectOnUnresolvedErrorFeature.suggestRedirect().isEnabled()) {
+        if (errorType == BAD_URL &&
+            suggestRedirectOnUnresolvedErrorFeature.self().isEnabled() &&
+            suggestRedirectOnUnresolvedErrorFeature.suggestRedirect().isEnabled()
+        ) {
             suggestRedirectJob += viewModelScope.launch {
                 suggestRedirectEvaluator.suggestRedirect(url)?.let { suggestion ->
                     browserViewState.value = currentBrowserViewState().copy(redirectSuggestion = suggestion)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -5797,6 +5797,11 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
+    fun onRedirectSuggestionClicked(url: String) {
+        resetBrowserError()
+        command.value = NavigationCommand.Navigate(url, getUrlHeaders(url))
+    }
+
     private fun trackersCount(): String =
         siteLiveData.value?.trackerCount?.takeIf { it > 0 }?.toString() ?: ""
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -63,6 +63,7 @@ import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.AppLink
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.NonHttpAppLink
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.ShouldLaunchDuckChatLink
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.ShouldLaunchSubscriptionLink
+import com.duckduckgo.app.browser.WebViewErrorResponse.BAD_URL
 import com.duckduckgo.app.browser.WebViewErrorResponse.LOADING
 import com.duckduckgo.app.browser.WebViewErrorResponse.OMITTED
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
@@ -222,6 +223,8 @@ import com.duckduckgo.app.browser.progressbar.ProgressBarUpgradeFeature
 import com.duckduckgo.app.browser.refreshpixels.RefreshPixelSender
 import com.duckduckgo.app.browser.santize.NonHttpAppLinkChecker
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
+import com.duckduckgo.app.browser.suggestredirect.SuggestRedirectEvaluator
+import com.duckduckgo.app.browser.suggestredirect.SuggestRedirectOnUnresolvedErrorFeature
 import com.duckduckgo.app.browser.tabs.TabManager
 import com.duckduckgo.app.browser.uilock.BROWSER_UI_LOCK_FEATURE_NAME
 import com.duckduckgo.app.browser.uilock.BrowserUiLockFeature
@@ -591,6 +594,8 @@ class BrowserTabViewModel @Inject constructor(
     private val adBlockingOmnibarAnimationProvider: AdBlockingOmnibarAnimationProvider,
     private val newTabPageModalPresenterRegistry: NewTabPageModalPresenterRegistry,
     private val newTabPageModalTrigger: NewTabPageModalTrigger,
+    private val suggestRedirectOnUnresolvedErrorFeature: SuggestRedirectOnUnresolvedErrorFeature,
+    private val suggestRedirectEvaluator: SuggestRedirectEvaluator,
 ) : ViewModel(),
     WebViewClientListener,
     EditSavedSiteListener,
@@ -742,6 +747,7 @@ class BrowserTabViewModel @Inject constructor(
     private var autoCompleteJob = ConflatedJob()
     private var serpLogoJob = ConflatedJob()
     private var pdfDownloadJob = ConflatedJob()
+    private var suggestRedirectJob = ConflatedJob()
 
     private var site: Site? = null
         set(value) {
@@ -1588,10 +1594,12 @@ class BrowserTabViewModel @Inject constructor(
                 queryOrFullUrl = if (isDuckChatUrl) "" else trimmedInput,
                 forceExpand = true,
             )
+        suggestRedirectJob.cancel()
         browserViewState.value =
             currentBrowserViewState().copy(
                 browserShowing = true,
                 browserError = OMITTED,
+                redirectSuggestion = null,
                 sslError = NONE,
                 maliciousSiteBlocked = false,
                 maliciousSiteStatus = null,
@@ -1943,6 +1951,7 @@ class BrowserTabViewModel @Inject constructor(
             duckChat.endVoiceChatSession(tabId)
         }
         pdfDownloadJob.cancel()
+        suggestRedirectJob.cancel()
         site = null
         onSiteChanged()
         webNavigationState = null
@@ -4451,14 +4460,16 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun resetBrowserError() {
-        browserViewState.value = currentBrowserViewState().copy(browserError = OMITTED)
+        suggestRedirectJob.cancel()
+        browserViewState.value = currentBrowserViewState().copy(browserError = OMITTED, redirectSuggestion = null)
         // Catches the race where pageFinished fired while browserError was still LOADING.
         onDuckAiOnboardingPageFinishedIfApplicable()
     }
 
     fun refreshBrowserError() {
+        suggestRedirectJob.cancel()
         if (currentBrowserViewState().browserError != OMITTED && currentBrowserViewState().browserError != LOADING) {
-            browserViewState.value = currentBrowserViewState().copy(browserError = LOADING)
+            browserViewState.value = currentBrowserViewState().copy(browserError = LOADING, redirectSuggestion = null)
         }
         if (currentBrowserViewState().sslError != NONE) {
             browserViewState.value = currentBrowserViewState().copy(browserShowing = true, sslError = NONE)
@@ -4548,12 +4559,21 @@ class BrowserTabViewModel @Inject constructor(
             browserViewState.value =
                 currentBrowserViewState().copy(
                     browserError = errorType,
+                    redirectSuggestion = null,
                     showPrivacyShield = HighlightableButton.Visible(enabled = false),
                 )
             if (androidBrowserConfig.errorPagePixel().isEnabled()) {
                 pixel.enqueueFire(AppPixelName.ERROR_PAGE_SHOWN)
             }
             command.value = WebViewError(errorType, url)
+            suggestRedirectJob.cancel() // Cancel previous in-flight job as the new errorType might not be BAD_URL
+        }
+        if (errorType == BAD_URL && suggestRedirectOnUnresolvedErrorFeature.suggestRedirect().isEnabled()) {
+            suggestRedirectJob += viewModelScope.launch {
+                suggestRedirectEvaluator.suggestRedirect(url)?.let { suggestion ->
+                    browserViewState.value = currentBrowserViewState().copy(redirectSuggestion = suggestion)
+                }
+            }
         }
         if (androidBrowserConfig.errorCodePixel().isEnabled()) {
             pixel.enqueueFire(AppPixelName.ERROR_CODE_PIXEL, mapOf("error_code" to errorCode))

--- a/app/src/main/java/com/duckduckgo/app/browser/suggestredirect/SuggestRedirectEvaluator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/suggestredirect/SuggestRedirectEvaluator.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.suggestredirect
+
+import android.net.Uri
+import androidx.core.net.toUri
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.toTldPlusOne
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+data class RedirectSuggestion(
+    val domain: String,
+    val url: String,
+)
+
+interface SuggestRedirectEvaluator {
+    /**
+     * Decides whether the error page for a failed [url] due to unresolved host should suggest
+     * redirecting to the "www." prefixed variant of its host.
+     *
+     * @return the suggestion to offer when [url] points at a bare domain (no "www." prefix)
+     * whose "www." variant resolves; `null` otherwise.
+     */
+    suspend fun suggestRedirect(url: String): RedirectSuggestion?
+}
+
+@ContributesBinding(AppScope::class)
+class RealSuggestRedirectEvaluator @Inject constructor(
+    private val hostnameResolver: HostnameResolver,
+    private val dispatcherProvider: DispatcherProvider,
+) : SuggestRedirectEvaluator {
+    override suspend fun suggestRedirect(url: String): RedirectSuggestion? = withContext(dispatcherProvider.io()) {
+        val uri = url.toUri()
+        val hostname = uri.host ?: return@withContext null
+
+        if (hostname.startsWith(WWW_PREFIX)) {
+            return@withContext null
+        }
+
+        if (hostname != hostname.toTldPlusOne()) {
+            // Non-registrable (eTLD+1) domains are rejected (e.g. localhost, a.b.domain.com)
+            return@withContext null
+        }
+
+        val suggestedDomain = "${WWW_PREFIX}$hostname"
+        if (!hostnameResolver.resolves(suggestedDomain)) {
+            return@withContext null
+        }
+
+        return@withContext RedirectSuggestion(
+            domain = suggestedDomain,
+            url = uri.replaceHost(suggestedDomain).toString(),
+        )
+    }
+
+    private fun Uri.replaceHost(host: String): Uri {
+        val authority = if (this.port != -1) "$host:${this.port}" else host
+        return this.buildUpon().encodedAuthority(authority).build()
+    }
+
+    companion object {
+        private const val WWW_PREFIX = "www."
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/viewstate/BrowserViewState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/viewstate/BrowserViewState.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.browser.SSLErrorType
 import com.duckduckgo.app.browser.SpecialUrlDetector
 import com.duckduckgo.app.browser.WebViewErrorResponse
 import com.duckduckgo.app.browser.omnibar.QueryOrigin
+import com.duckduckgo.app.browser.suggestredirect.RedirectSuggestion
 import com.duckduckgo.app.global.model.MaliciousSiteStatus
 import com.duckduckgo.browser.ui.browsermenu.VpnMenuState
 import com.duckduckgo.savedsites.api.models.SavedSite
@@ -55,6 +56,7 @@ data class BrowserViewState(
     val isPrinting: Boolean = false,
     val showAutofill: Boolean = false,
     val browserError: WebViewErrorResponse = WebViewErrorResponse.OMITTED,
+    val redirectSuggestion: RedirectSuggestion? = null,
     val sslError: SSLErrorType = SSLErrorType.NONE,
     val maliciousSiteBlocked: Boolean = false,
     val maliciousSiteStatus: MaliciousSiteStatus? = null,

--- a/app/src/main/res/layout/include_error_view.xml
+++ b/app/src/main/res/layout/include_error_view.xml
@@ -71,5 +71,22 @@
             app:textType="secondary"
             tools:text="@string/webViewErrorBadUrl" />
 
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/redirect_suggestion_message"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="40dp"
+            android:layout_marginEnd="40dp"
+            android:gravity="center"
+            android:paddingBottom="@dimen/keyline_5"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/error_message"
+            app:typography="body1"
+            app:textType="secondary"
+            tools:text="@string/webViewErrorRedirectSuggestionMessage"
+            tools:visibility="visible" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -24,6 +24,7 @@
     <string name="webViewErrorNoConnection">The internet connection appears to be offline.</string>
     <string name="webViewErrorBadUrl">A server with the specified hostname could not be found.</string>
     <string name="webViewErrorSslProtocol"><![CDATA[The certificate for this server is invalid. You might be connecting to a server that is pretending to be <b>%1$s</b> which could put your confidential information at risk.]]></string>
+    <string name="webViewErrorRedirectSuggestionMessage" instruction="Shown when a domain fails to load, offering a link to the www. version of the address. ^1 is the suggested address and is displayed as a tappable link.">Did you mean <annotation type="redirect_link">^1</annotation>?</string>
 
     <!-- Broken Sites-->
     <string name="brokenSitesLoginHint">What site are you signing in to? (required)</string>

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -8452,6 +8452,26 @@ class BrowserTabViewModelTest {
         }
 
     @Test
+    fun whenRedirectSuggestionClickedThenResetsBrowserErrorResetAndNavigateCommandIssuedWithSuggestedUrl() =
+        runTest {
+            testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+
+            testee.onRedirectSuggestionClicked("http://www.example.com")
+
+            assertEquals(OMITTED, browserViewState().browserError)
+            assertCommandIssued<Navigate> {
+                assertEquals("http://www.example.com", url)
+            }
+        }
+
+    @Test
+    fun whenRedirectSuggestionClickedThenSearchCountNotIncremented() =
+        runTest {
+            testee.onRedirectSuggestionClicked("http://www.example.com")
+
+            verify(mockSearchCountDao, never()).incrementSearchCount()
+        }
+    @Test
     fun whenUserSelectedAutocompleteWithAutoCompleteSwitchToTabSuggestionThenSwitchToTabCommandSentWithTabId() =
         runTest {
             val tabId = "tabId"

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -8485,7 +8485,10 @@ class BrowserTabViewModelTest {
 
     @Test
     fun givenSuggestRedirectEnabledWhenBadUrlErrorReceivedAndRedirectShouldBeSuggestedThenRedirectSuggestionSetInViewState() = runTest {
-        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        fakeSuggestRedirectFeature.apply {
+            self().setRawStoredState(State(enable = true))
+            suggestRedirect().setRawStoredState(State(enable = true))
+        }
         val redirectSuggestion = RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com/path?q=1")
         whenever(mockSuggestRedirectEvaluator.suggestRedirect("http://example.com/path?q=1"))
             .thenReturn(redirectSuggestion)
@@ -8508,7 +8511,10 @@ class BrowserTabViewModelTest {
 
     @Test
     fun givenSuggestRedirectEnabledWhenBadUrlErrorReceivedAndRedirectShouldNotBeSuggestedThenRedirectSuggestionNotSetInViewState() = runTest {
-        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        fakeSuggestRedirectFeature.apply {
+            self().setRawStoredState(State(enable = true))
+            suggestRedirect().setRawStoredState(State(enable = true))
+        }
         whenever(mockSuggestRedirectEvaluator.suggestRedirect(any()))
             .thenReturn(null)
 
@@ -8519,7 +8525,10 @@ class BrowserTabViewModelTest {
 
     @Test
     fun givenSuggestRedirectEnabledWhenNonBadUrlErrorReceivedThenRedirectSuggestionNotSetInViewState() = runTest {
-        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        fakeSuggestRedirectFeature.apply {
+            self().setRawStoredState(State(enable = true))
+            suggestRedirect().setRawStoredState(State(enable = true))
+        }
         whenever(mockSuggestRedirectEvaluator.suggestRedirect(any()))
             .thenReturn(RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com"))
 
@@ -8530,7 +8539,10 @@ class BrowserTabViewModelTest {
 
     @Test
     fun givenSuggestRedirectEvaluationInFlightWhenBrowserErrorResetThenRedirectSuggestionNotSetInViewState() = runTest {
-        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        fakeSuggestRedirectFeature.apply {
+            self().setRawStoredState(State(enable = true))
+            suggestRedirect().setRawStoredState(State(enable = true))
+        }
         whenever(mockSuggestRedirectEvaluator.suggestRedirect(any()))
             .doSuspendableAnswer {
                 delay(1.seconds)
@@ -8547,7 +8559,10 @@ class BrowserTabViewModelTest {
 
     @Test
     fun givenSuggestRedirectEvaluationInFlightWhenNewErrorReceivedThenPreviousRedirectSuggestionNotSetInViewState() = runTest {
-        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        fakeSuggestRedirectFeature.apply {
+            self().setRawStoredState(State(enable = true))
+            suggestRedirect().setRawStoredState(State(enable = true))
+        }
         whenever(mockSuggestRedirectEvaluator.suggestRedirect(any()))
             .doSuspendableAnswer {
                 delay(1.seconds)
@@ -8564,7 +8579,10 @@ class BrowserTabViewModelTest {
 
     @Test
     fun givenSuggestRedirectEvaluationInFlightWhenBrowserErrorRefreshedThenRedirectSuggestionNotSetInViewState() = runTest {
-        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        fakeSuggestRedirectFeature.apply {
+            self().setRawStoredState(State(enable = true))
+            suggestRedirect().setRawStoredState(State(enable = true))
+        }
         whenever(mockSuggestRedirectEvaluator.suggestRedirect(any())).doSuspendableAnswer {
             delay(1.seconds)
             RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com")
@@ -8581,7 +8599,10 @@ class BrowserTabViewModelTest {
     @Test
     fun givenSuggestRedirectEvaluationInFlightWhenUserSubmittedQueryThenRedirectSuggestionNotSetInViewState() = runTest {
         whenever(mockOmnibarConverter.convertQueryToUrl("http://another-site.com", null)).thenReturn("http://another-site.com")
-        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        fakeSuggestRedirectFeature.apply {
+            self().setRawStoredState(State(enable = true))
+            suggestRedirect().setRawStoredState(State(enable = true))
+        }
         whenever(mockSuggestRedirectEvaluator.suggestRedirect(any())).doSuspendableAnswer {
             delay(1.seconds)
             RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com")
@@ -8598,7 +8619,10 @@ class BrowserTabViewModelTest {
     @Test
     fun givenSuggestRedirectEvaluationInFlightWhenUserNavigatesHomeThenRedirectSuggestionNotSetInViewState() =
         runTest {
-            fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+            fakeSuggestRedirectFeature.apply {
+                self().setRawStoredState(State(enable = true))
+                suggestRedirect().setRawStoredState(State(enable = true))
+            }
             whenever(mockSuggestRedirectEvaluator.suggestRedirect(any())).doSuspendableAnswer {
                 delay(1.seconds)
                 RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com")
@@ -8615,7 +8639,10 @@ class BrowserTabViewModelTest {
 
     @Test
     fun givenSuggestRedirectEvaluationInFlightWhenOmittedErrorReceivedThenRedirectSuggestionStillSetInViewState() = runTest {
-        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        fakeSuggestRedirectFeature.apply {
+            self().setRawStoredState(State(enable = true))
+            suggestRedirect().setRawStoredState(State(enable = true))
+        }
         val redirectSuggestion = RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com")
         whenever(mockSuggestRedirectEvaluator.suggestRedirect(any())).doSuspendableAnswer {
             delay(1.seconds)

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -74,6 +74,7 @@ import com.duckduckgo.app.browser.SSLErrorType.NONE
 import com.duckduckgo.app.browser.SSLErrorType.UNTRUSTED_HOST
 import com.duckduckgo.app.browser.SSLErrorType.WRONG_HOST
 import com.duckduckgo.app.browser.WebViewErrorResponse.BAD_URL
+import com.duckduckgo.app.browser.WebViewErrorResponse.CONNECTION
 import com.duckduckgo.app.browser.WebViewErrorResponse.LOADING
 import com.duckduckgo.app.browser.WebViewErrorResponse.OMITTED
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
@@ -149,6 +150,9 @@ import com.duckduckgo.app.browser.progressbar.ProgressBarUpgradeFeature
 import com.duckduckgo.app.browser.refreshpixels.RefreshPixelSender
 import com.duckduckgo.app.browser.santize.NonHttpAppLinkChecker
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
+import com.duckduckgo.app.browser.suggestredirect.RedirectSuggestion
+import com.duckduckgo.app.browser.suggestredirect.SuggestRedirectEvaluator
+import com.duckduckgo.app.browser.suggestredirect.SuggestRedirectOnUnresolvedErrorFeature
 import com.duckduckgo.app.browser.tabs.TabManager
 import com.duckduckgo.app.browser.trafficquality.AndroidFeaturesHeaderPlugin.Companion.X_DUCKDUCKGO_ANDROID_HEADER
 import com.duckduckgo.app.browser.uilock.BROWSER_UI_LOCK_FEATURE_NAME
@@ -357,6 +361,7 @@ import com.duckduckgo.subscriptions.api.SubscriptionsJSHelper
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
 import com.duckduckgo.voice.api.VoiceSearchAvailabilityPixelLogger
 import dagger.Lazy
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -401,6 +406,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
@@ -416,6 +422,7 @@ import java.time.LocalDateTime
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.time.Duration.Companion.seconds
 import com.duckduckgo.mobile.android.R as CommonR
 
 @SuppressLint("DenyListedApi")
@@ -719,6 +726,8 @@ class BrowserTabViewModelTest {
     private val fakeAutocompleteHistoryDeleteFeature = FakeFeatureToggleFactory.create(AutocompleteHistoryDeleteFeature::class.java)
     private val mockDesktopModeSettings: DesktopModeSettings = mock()
     private val fakeRememberDesktopModeFeature = FakeFeatureToggleFactory.create(RememberDesktopModeFeature::class.java)
+    private val fakeSuggestRedirectFeature = FakeFeatureToggleFactory.create(SuggestRedirectOnUnresolvedErrorFeature::class.java)
+    private val mockSuggestRedirectEvaluator: SuggestRedirectEvaluator = mock()
     private val mockInlinePdfHandler: InlinePdfHandler = mock()
     private val mockPdfDownloadTooltipDataStore: PdfDownloadTooltipDataStore = mock()
     private val mockCachedFileDownloader: CachedFileDownloader = mock()
@@ -1058,6 +1067,8 @@ class BrowserTabViewModelTest {
                 adBlockingOmnibarAnimationProvider = mockAdBlockingOmnibarAnimationProvider,
                 newTabPageModalPresenterRegistry = NewTabPageModalPresenterRegistry(),
                 newTabPageModalTrigger = mockNewTabPageModalTrigger,
+                suggestRedirectOnUnresolvedErrorFeature = fakeSuggestRedirectFeature,
+                suggestRedirectEvaluator = mockSuggestRedirectEvaluator,
             )
 
         testee.loadData("abc", null, false, false)
@@ -8452,7 +8463,7 @@ class BrowserTabViewModelTest {
         }
 
     @Test
-    fun whenRedirectSuggestionClickedThenResetsBrowserErrorResetAndNavigateCommandIssuedWithSuggestedUrl() =
+    fun whenRedirectSuggestionClickedThenBrowserErrorResetAndNavigateCommandIssuedWithSuggestedUrl() =
         runTest {
             testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
 
@@ -8471,6 +8482,154 @@ class BrowserTabViewModelTest {
 
             verify(mockSearchCountDao, never()).incrementSearchCount()
         }
+
+    @Test
+    fun givenSuggestRedirectEnabledWhenBadUrlErrorReceivedAndRedirectShouldBeSuggestedThenRedirectSuggestionSetInViewState() = runTest {
+        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        val redirectSuggestion = RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com/path?q=1")
+        whenever(mockSuggestRedirectEvaluator.suggestRedirect("http://example.com/path?q=1"))
+            .thenReturn(redirectSuggestion)
+
+        testee.onReceivedError(BAD_URL, "http://example.com/path?q=1", "ERROR_HOST_LOOKUP")
+
+        assertEquals(redirectSuggestion, browserViewState().redirectSuggestion)
+    }
+
+    @Test
+    fun givenSuggestRedirectDisabledWhenBadUrlErrorReceivedThenRedirectSuggestionNotSetInViewState() = runTest {
+        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = false))
+        whenever(mockSuggestRedirectEvaluator.suggestRedirect(any()))
+            .thenReturn(RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com"))
+
+        testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+
+        assertNull(browserViewState().redirectSuggestion)
+    }
+
+    @Test
+    fun givenSuggestRedirectEnabledWhenBadUrlErrorReceivedAndRedirectShouldNotBeSuggestedThenRedirectSuggestionNotSetInViewState() = runTest {
+        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        whenever(mockSuggestRedirectEvaluator.suggestRedirect(any()))
+            .thenReturn(null)
+
+        testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+
+        assertNull(browserViewState().redirectSuggestion)
+    }
+
+    @Test
+    fun givenSuggestRedirectEnabledWhenNonBadUrlErrorReceivedThenRedirectSuggestionNotSetInViewState() = runTest {
+        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        whenever(mockSuggestRedirectEvaluator.suggestRedirect(any()))
+            .thenReturn(RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com"))
+
+        testee.onReceivedError(CONNECTION, "http://example.com", "ERROR_CONNECT")
+
+        assertNull(browserViewState().redirectSuggestion)
+    }
+
+    @Test
+    fun givenSuggestRedirectEvaluationInFlightWhenBrowserErrorResetThenRedirectSuggestionNotSetInViewState() = runTest {
+        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        whenever(mockSuggestRedirectEvaluator.suggestRedirect(any()))
+            .doSuspendableAnswer {
+                delay(1.seconds)
+                RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com")
+            }
+
+        testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+        testee.resetBrowserError()
+        @OptIn(ExperimentalCoroutinesApi::class)
+        advanceUntilIdle()
+
+        assertNull(browserViewState().redirectSuggestion)
+    }
+
+    @Test
+    fun givenSuggestRedirectEvaluationInFlightWhenNewErrorReceivedThenPreviousRedirectSuggestionNotSetInViewState() = runTest {
+        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        whenever(mockSuggestRedirectEvaluator.suggestRedirect(any()))
+            .doSuspendableAnswer {
+                delay(1.seconds)
+                RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com")
+            }
+
+        testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+        testee.onReceivedError(CONNECTION, "http://example.com", "ERROR_CONNECT")
+        @OptIn(ExperimentalCoroutinesApi::class)
+        advanceUntilIdle()
+
+        assertNull(browserViewState().redirectSuggestion)
+    }
+
+    @Test
+    fun givenSuggestRedirectEvaluationInFlightWhenBrowserErrorRefreshedThenRedirectSuggestionNotSetInViewState() = runTest {
+        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        whenever(mockSuggestRedirectEvaluator.suggestRedirect(any())).doSuspendableAnswer {
+            delay(1.seconds)
+            RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com")
+        }
+
+        testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+        testee.refreshBrowserError()
+        @OptIn(ExperimentalCoroutinesApi::class)
+        advanceUntilIdle()
+
+        assertNull(browserViewState().redirectSuggestion)
+    }
+
+    @Test
+    fun givenSuggestRedirectEvaluationInFlightWhenUserSubmittedQueryThenRedirectSuggestionNotSetInViewState() = runTest {
+        whenever(mockOmnibarConverter.convertQueryToUrl("http://another-site.com", null)).thenReturn("http://another-site.com")
+        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        whenever(mockSuggestRedirectEvaluator.suggestRedirect(any())).doSuspendableAnswer {
+            delay(1.seconds)
+            RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com")
+        }
+
+        testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+        testee.onUserSubmittedQuery("http://another-site.com")
+        @OptIn(ExperimentalCoroutinesApi::class)
+        advanceUntilIdle()
+
+        assertNull(browserViewState().redirectSuggestion)
+    }
+
+    @Test
+    fun givenSuggestRedirectEvaluationInFlightWhenUserNavigatesHomeThenRedirectSuggestionNotSetInViewState() =
+        runTest {
+            fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+            whenever(mockSuggestRedirectEvaluator.suggestRedirect(any())).doSuspendableAnswer {
+                delay(1.seconds)
+                RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com")
+            }
+            setupNavigation(isBrowsing = true)
+
+            testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+            testee.onUserPressedBack()
+            @OptIn(ExperimentalCoroutinesApi::class)
+            advanceUntilIdle()
+
+            assertNull(browserViewState().redirectSuggestion)
+        }
+
+    @Test
+    fun givenSuggestRedirectEvaluationInFlightWhenOmittedErrorReceivedThenRedirectSuggestionStillSetInViewState() = runTest {
+        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = true))
+        val redirectSuggestion = RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com")
+        whenever(mockSuggestRedirectEvaluator.suggestRedirect(any())).doSuspendableAnswer {
+            delay(1.seconds)
+            redirectSuggestion
+        }
+
+        testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+        testee.onReceivedError(OMITTED, "http://example.com", "ERROR_UNKNOWN")
+        @OptIn(ExperimentalCoroutinesApi::class)
+        advanceUntilIdle()
+
+        assertEquals(redirectSuggestion, browserViewState().redirectSuggestion)
+    }
+
     @Test
     fun whenUserSelectedAutocompleteWithAutoCompleteSwitchToTabSuggestionThenSwitchToTabCommandSentWithTabId() =
         runTest {

--- a/app/src/test/java/com/duckduckgo/app/browser/suggestredirect/SuggestRedirectEvaluatorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/suggestredirect/SuggestRedirectEvaluatorTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.suggestredirect
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class SuggestRedirectEvaluatorTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val hostnameResolver: HostnameResolver = mock()
+
+    private val testee: SuggestRedirectEvaluator = RealSuggestRedirectEvaluator(hostnameResolver, coroutineRule.testDispatcherProvider)
+
+    @Test
+    fun `when URL has no host, then returns null and performs no lookups`() = runTest {
+        listOf(
+            "",
+            "   ",
+            "not a url",
+            "example.com", // Missing scheme in the URL
+        ).forEach { url ->
+            assertNull("Expected suggestRedirect(\"$url\") to be null", testee.suggestRedirect(url))
+        }
+        verifyNoInteractions(hostnameResolver)
+    }
+
+    @Test
+    fun `when host already has a www prefix, then returns null and performs no lookups`() = runTest {
+        assertNull(testee.suggestRedirect("https://www.example.com"))
+        verifyNoInteractions(hostnameResolver)
+    }
+
+    @Test
+    fun `when host is not a registrable domain, then returns null and performs no lookups`() = runTest {
+        listOf(
+            "https://localhost",
+            "https://a.b.example.com",
+            "https://.com",
+            "https://com",
+            "https://127.0.0.1",
+            "https://62.62.62.62",
+            "https://::1",
+            "https://2001:db8::1",
+            "https://fe80::1%eth0",
+            "https://[2001:db8::1]",
+        ).forEach { url ->
+            assertNull("Expected suggestRedirect(\"$url\") to be null", testee.suggestRedirect(url))
+        }
+        verifyNoInteractions(hostnameResolver)
+    }
+
+    @Test
+    fun `when www variant of the host resolves, then returns the suggestion`() = runTest {
+        whenever(hostnameResolver.resolves("www.example.com")).thenReturn(true)
+
+        assertEquals(
+            RedirectSuggestion(domain = "www.example.com", url = "https://www.example.com"),
+            testee.suggestRedirect("https://example.com"),
+        )
+    }
+
+    @Test
+    fun `when www variant of the host does not resolve, then returns null`() = runTest {
+        whenever(hostnameResolver.resolves("www.example.com")).thenReturn(false)
+
+        assertNull(testee.suggestRedirect("https://example.com"))
+    }
+
+    @Test
+    fun `when redirect is suggested, then the suggested URL keeps the original scheme, path and query`() = runTest {
+        whenever(hostnameResolver.resolves("www.example.com")).thenReturn(true)
+
+        assertEquals(
+            RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com/path?q=1"),
+            testee.suggestRedirect("http://example.com/path?q=1"),
+        )
+    }
+
+    @Test
+    fun `when redirect is suggested, then the suggested URL keeps the original port`() = runTest {
+        whenever(hostnameResolver.resolves("www.example.com")).thenReturn(true)
+
+        assertEquals(
+            RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com:8080/path"),
+            testee.suggestRedirect("http://example.com:8080/path"),
+        )
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216807998862658/task/1217666997020568?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216807998862658/task/1217494645371353?focus=true

### Description
This PR completes the changes for displaying a redirect suggestion on `BAD_URL` error page. The feature is behind a feature flag, which is disabled by default at the moment.

### Steps to test this PR
1. Make sure the feature flag `suggestRedirct` is enabled.
2. Perform the following steps using both a normal tab and a custom tab:
    1. Navigate to `airnow.gov/test`
    2. Verify that the redirect suggestion is displayed with only `www.airnow.gov` underlined
    3. Tap on the underlined link
    4. Verify that the browser navigated to `www.airnow.gov/test`, loading successfully (minus the expected page not found)
3. On a normal tab:
    1. Try to navigate to `airnow.gov`
    2. Verify that the `BAD_URL` error page together with the redirect suggestion is displayed
    3. Turn on airplane mode
    4. Tap on the redirect link
    5. Verify that the offline error page is displayed and that the redirect suggestion is no longer displayed
    6. Turn off airplane mode
    7. Try to navigate again to the current page, which should be `www.airnow.gov`
    8. Verify that it loads successfully

### UI changes
https://github.com/user-attachments/assets/f39eee57-aede-409d-b807-a065a091f9f8



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error-page navigation and async host lookups on failed loads; risk is moderate because mis-suggestions or stale async results could send users to the wrong host, though feature-flag gating and job cancellation limit exposure.
> 
> **Overview**
> When a page fails with a **BAD_URL** (host not found) error and the feature flag is on, the browser now evaluates whether a `www.` variant of the bare registrable domain resolves and, if so, shows a **“Did you mean …?”** line on the error UI with a tappable link to that URL (path, query, port preserved).
> 
> **BrowserTabViewModel** drives this via `redirectSuggestion` on `BrowserViewState`, async evaluation through `SuggestRedirectEvaluator`, and clears or cancels in-flight work when the user navigates, goes home, resets/refreshes the error, or gets a different error type. Tapping the link clears the error state and issues navigation to the suggested URL.
> 
> **BrowserTabFragment** renders the new `redirect_suggestion_message` view and reacts when the suggestion changes while an error is shown. **SuggestRedirectEvaluator** encapsulates the www-prefix + DNS lookup rules. Unit tests cover the evaluator and view-model gating, race cancellation, and click handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb16d8f16afc4c7a591e05198c0df755397d76ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->