### PR TITLE
Update PIR broker bundle - 2026-08-24

### DIFF
--- a/pir/pir-impl/src/main/assets/brokers/courtrec.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/courtrec.com.json
@@ -1,7 +1,7 @@
 {
   "name": "CourtRec",
   "url": "courtrec.com",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "parent": "propertyrecord.com",
   "addedDatetime": 1775829600000,
   "optOutUrl": "https://dashboard.courtrec.com/opt-out",
@@ -12,72 +12,48 @@
       "actions": [
         {
           "actionType": "navigate",
-          "id": "228c9575-c719-4586-94de-259ee950bab2",
-          "url": "https://www.courtrec.com/"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//a[@title='Remove My Info']"
-            }
-          ],
-          "id": "175fc808-0308-457d-875b-69118ed7e60e"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "//a[@title='Remove My Info']"
-            }
-          ],
-          "id": "db22d4ff-e40f-49ba-bfb8-a1b8ff5ab701"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//h1[contains(text(), 'Remove My Information')]"
-            }
-          ],
-          "id": "5a229e1d-e84d-4005-88a4-d88dca619018"
-        },
-        {
-          "actionType": "fillForm",
-          "selector": "form#backgroundCheckForm",
-          "dataSource": "userProfile",
-          "elements": [
-            {
-              "type": "fullName",
-              "selector": ".//input[@name='name']"
-            },
-            {
-              "type": "cityState",
-              "selector": ".//input[@name='cityState']"
-            }
-          ],
-          "id": "4e8c5bda-3d7f-4164-ac9f-318036ee0fc9"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "button[type='submit']"
-            }
-          ],
+          "_comment": "Forwarding page source: https://github.com/duckduckgo/privacy-test-pages/blob/main/pir/opt-out/index.html",
+          "url": "https://privacy-test-pages.site/pir/opt-out/?name=${firstName}%20${lastName}&city=${city|downcase}&state=${state|upcase}&cityState=${city},%20${state|upcase}&to=https%3A%2F%2Fdashboard.courtrec.com%2Fopt-out%2Frecords",
           "id": "f1a05523-08e8-4094-a4d6-c30f972ae7cb"
         },
         {
-          "actionType": "condition",
-          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "#spellcheck-original"
+              "selector": "#forward"
+            }
+          ],
+          "id": "a9cee5d4-1987-44ba-b53b-0bdf43fddafb"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "#forward"
+            }
+          ],
+          "id": "2d54e0e4-03a5-4f7c-9bf0-8c1ac4c525d0"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "0d2257f5-439d-4d4d-94a0-9a711cb6f0b1"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Click Use Original when the site offers a spelling correction.",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original",
+              "failSilently": true
             }
           ],
           "actions": [
@@ -111,7 +87,7 @@
           "noResultsSelector": "//h3[contains(text(), 'No results found')]",
           "profile": {
             "name": {
-              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(concat(' ', normalize-space(@class), ' '), ' !text-black-900 ') and contains(concat(' ', normalize-space(@class), ' '), ' text-lg ')]"
             },
             "addressCityState": {
               "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"

--- a/pir/pir-impl/src/main/assets/brokers/propertyrec.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/propertyrec.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PropertyRec",
   "url": "propertyrec.com",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "parent": "propertyrecord.com",
   "addedDatetime": 1775829600000,
   "optOutUrl": "https://dashboard.propertyrec.com/opt-out",
@@ -12,53 +12,48 @@
       "actions": [
         {
           "actionType": "navigate",
-          "_comment": "All other child sites go to the homepage first and click the opt-out link, but this one pops the page up in a new window, so we'll go to the opt-out page directly instead",
-          "id": "3591978e-66c7-4bc8-864c-4a0c4741d182",
-          "url": "https://dashboard.propertyrec.com/opt-out/"
+          "_comment": "Forwarding page source: https://github.com/duckduckgo/privacy-test-pages/blob/main/pir/opt-out/index.html",
+          "url": "https://privacy-test-pages.site/pir/opt-out/?name=${firstName}%20${lastName}&city=${city|downcase}&state=${state|upcase}&cityState=${city},%20${state|upcase}&to=https%3A%2F%2Fdashboard.propertyrec.com%2Fopt-out%2Frecords",
+          "id": "5d160b1d-d825-4b7a-aaa2-d43972edb7ca"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "//h1[contains(text(), 'Remove My Information')]"
+              "selector": "#forward"
             }
           ],
-          "id": "3e44df56-fc5d-49d3-a408-0bc059c5d2c8"
-        },
-        {
-          "actionType": "fillForm",
-          "selector": "form#backgroundCheckForm",
-          "dataSource": "userProfile",
-          "elements": [
-            {
-              "type": "fullName",
-              "selector": ".//input[@name='name']"
-            },
-            {
-              "type": "cityState",
-              "selector": ".//input[@name='cityState']"
-            }
-          ],
-          "id": "790f6a0e-2236-4502-8627-726c214094bd"
+          "id": "4edbc6b7-c114-4fb4-bdbd-c2aa4662a452"
         },
         {
           "actionType": "click",
           "elements": [
             {
               "type": "button",
-              "selector": "button[type='submit']"
+              "selector": "#forward"
             }
           ],
-          "id": "5d160b1d-d825-4b7a-aaa2-d43972edb7ca"
+          "id": "7a62b3ac-8b18-4ff5-a4b2-1af852a8f04e"
         },
         {
-          "actionType": "condition",
-          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "#spellcheck-original"
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "3e9357ec-536b-48d6-a1a2-8ebfac5693b2"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Click Use Original when the site offers a spelling correction.",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original",
+              "failSilently": true
             }
           ],
           "actions": [
@@ -92,7 +87,7 @@
           "noResultsSelector": "//h3[contains(text(), 'No results found')]",
           "profile": {
             "name": {
-              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(concat(' ', normalize-space(@class), ' '), ' !text-black-900 ') and contains(concat(' ', normalize-space(@class), ' '), ' text-lg ')]"
             },
             "addressCityState": {
               "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"

--- a/pir/pir-impl/src/main/assets/brokers/propertyrecord.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/propertyrecord.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PropertyRecord",
   "url": "propertyrecord.com",
-  "version": "0.4.0",
+  "version": "0.7.0",
   "addedDatetime": 1775736000000,
   "optOutUrl": "https://dashboard.propertyrecord.com/opt-out",
   "steps": [
@@ -11,72 +11,48 @@
       "actions": [
         {
           "actionType": "navigate",
-          "id": "4e3682bd-cc48-4ebe-9172-0ea3b89fe503",
-          "url": "https://www.propertyrecord.com/"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//a[@title='Remove My Info']"
-            }
-          ],
-          "id": "65e32379-fb7b-42d5-9817-00ba4075c36a"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "//a[@title='Remove My Info']"
-            }
-          ],
-          "id": "7562499b-cff9-4fb2-a87e-92432a49f827"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//h1[contains(text(), 'Remove My Information')]"
-            }
-          ],
-          "id": "bd6730a0-3381-43b4-8317-1e27f9df05d6"
-        },
-        {
-          "actionType": "fillForm",
-          "selector": "form#backgroundCheckForm",
-          "dataSource": "userProfile",
-          "elements": [
-            {
-              "type": "fullName",
-              "selector": ".//input[@name='name']"
-            },
-            {
-              "type": "cityState",
-              "selector": ".//input[@name='cityState']"
-            }
-          ],
-          "id": "8fde207e-9e1e-476e-9e6d-184a72d279d4"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "button[type='submit']"
-            }
-          ],
+          "_comment": "Forwarding page source: https://github.com/duckduckgo/privacy-test-pages/blob/main/pir/opt-out/index.html",
+          "url": "https://privacy-test-pages.site/pir/opt-out/?name=${firstName}%20${lastName}&city=${city|downcase}&state=${state|upcase}&cityState=${city},%20${state|upcase}&to=https%3A%2F%2Fdashboard.propertyrecord.com%2Fopt-out%2Frecords",
           "id": "d0030ece-5888-40ae-8b93-3f9f157da3cd"
         },
         {
-          "actionType": "condition",
-          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "#spellcheck-original"
+              "selector": "#forward"
+            }
+          ],
+          "id": "f3c33407-a4a5-4989-88ab-b9ec69c59065"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "#forward"
+            }
+          ],
+          "id": "1116b900-277d-42cb-8fdb-7f7e4dc95c56"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "887cead7-38bf-4f93-9f98-402659ffac91"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Click Use Original when the site offers a spelling correction.",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original",
+              "failSilently": true
             }
           ],
           "actions": [
@@ -110,7 +86,7 @@
           "noResultsSelector": "//h3[contains(text(), 'No results found')]",
           "profile": {
             "name": {
-              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(concat(' ', normalize-space(@class), ' '), ' !text-black-900 ') and contains(concat(' ', normalize-space(@class), ' '), ' text-lg ')]"
             },
             "addressCityState": {
               "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
@@ -139,62 +115,47 @@
       "actions": [
         {
           "actionType": "navigate",
-          "id": "9e7126b9-7101-4953-b132-2e5c9668275b",
-          "url": "https://www.propertyrecord.com/"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "//a[@title='Remove My Info']"
-            }
-          ],
-          "id": "ce2f0fa7-f9c1-4df3-9e6a-102d27353ea8"
+          "url": "https://privacy-test-pages.site/pir/opt-out/?name=${firstName}%20${lastName}&city=${city|downcase}&state=${state|upcase}&cityState=${city},%20${state|upcase}&to=https%3A%2F%2Fdashboard.propertyrecord.com%2Fopt-out%2Frecords",
+          "id": "ee4a70fa-f0da-4f6b-a5d0-db42a0bca5a0"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "//h1[contains(text(), 'Remove My Information')]"
+              "selector": "#forward"
             }
           ],
-          "id": "54ca8a38-6900-408d-98ce-151d929ca948"
-        },
-        {
-          "actionType": "fillForm",
-          "selector": "form#backgroundCheckForm",
-          "dataSource": "userProfile",
-          "elements": [
-            {
-              "type": "fullName",
-              "selector": ".//input[@name='name']"
-            },
-            {
-              "type": "cityState",
-              "selector": ".//input[@name='cityState']"
-            }
-          ],
-          "id": "37b5dae9-35dc-464a-a044-f2e0332efcbc"
+          "id": "926cad35-d4e1-4d14-a2e9-56bf37c90862"
         },
         {
           "actionType": "click",
           "elements": [
             {
               "type": "button",
-              "selector": "button[type='submit']"
+              "selector": "#forward"
             }
           ],
-          "id": "ee4a70fa-f0da-4f6b-a5d0-db42a0bca5a0"
+          "id": "2c4e1be5-1b9e-43f6-8f40-c581c5eeaa6f"
         },
         {
-          "actionType": "condition",
-          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "#spellcheck-original"
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "e5b89938-508a-4264-9a9b-47c9ab6789a9"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Click Use Original when the site offers a spelling correction.",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original",
+              "failSilently": true
             }
           ],
           "actions": [
@@ -222,6 +183,72 @@
           "id": "848b3be4-8d48-440e-8ce0-b640281d8872"
         },
         {
+          "actionType": "getCaptchaInfo",
+          "id": "2393aa3b-3997-48d6-89fa-715acfe5f6e2",
+          "captchaType": "recaptcha2",
+          "selector": ".g-recaptcha",
+          "parent": {
+            "profileMatch": {
+              "selector": "//ul[@id='people-search-results']/li",
+              "profile": {
+                "name": {
+                  "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(concat(' ', normalize-space(@class), ' '), ' !text-black-900 ') and contains(concat(' ', normalize-space(@class), ' '), ' text-lg ')]"
+                },
+                "addressCityState": {
+                  "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
+                },
+                "age": {
+                  "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(.,'Years Old') or contains(.,'Deceased')]"
+                },
+                "addressCityStateList": {
+                  "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Locations Include']/following-sibling::div",
+                  "findElements": true
+                },
+                "relativesList": {
+                  "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Possible Relatives']/following-sibling::div",
+                  "findElements": true
+                },
+                "profileUrl": {
+                  "identifierType": "hash"
+                }
+              }
+            }
+          }
+        },
+        {
+          "actionType": "solveCaptcha",
+          "id": "3fbe6cca-2c24-4d45-a8e0-05a523e6726d",
+          "captchaType": "recaptcha2",
+          "selector": ".g-recaptcha",
+          "parent": {
+            "profileMatch": {
+              "selector": "//ul[@id='people-search-results']/li",
+              "profile": {
+                "name": {
+                  "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(concat(' ', normalize-space(@class), ' '), ' !text-black-900 ') and contains(concat(' ', normalize-space(@class), ' '), ' text-lg ')]"
+                },
+                "addressCityState": {
+                  "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
+                },
+                "age": {
+                  "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(.,'Years Old') or contains(.,'Deceased')]"
+                },
+                "addressCityStateList": {
+                  "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Locations Include']/following-sibling::div",
+                  "findElements": true
+                },
+                "relativesList": {
+                  "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Possible Relatives']/following-sibling::div",
+                  "findElements": true
+                },
+                "profileUrl": {
+                  "identifierType": "hash"
+                }
+              }
+            }
+          }
+        },
+        {
           "actionType": "click",
           "elements": [
             {
@@ -232,7 +259,7 @@
                   "selector": "//ul[@id='people-search-results']/li",
                   "profile": {
                     "name": {
-                      "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+                      "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(concat(' ', normalize-space(@class), ' '), ' !text-black-900 ') and contains(concat(' ', normalize-space(@class), ' '), ' text-lg ')]"
                     },
                     "addressCityState": {
                       "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
@@ -262,9 +289,20 @@
           "actionType": "expectation",
           "expectations": [
             {
-              "type": "text",
-              "selector": "body",
-              "expect": "Success: Information Removed"
+              "type": "element",
+              "selector": "//h3[normalize-space(.)='Success: Information Removed']",
+              "failSilently": true
+            }
+          ],
+          "id": "aeb7b984-95cb-42fc-a50b-537c332df23a",
+          "_comment": "This fail-silent check adds one action interval for PropertyRecord to finish the POST navigation before the required success check."
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h3[normalize-space(.)='Success: Information Removed']"
             }
           ],
           "id": "eb466716-5675-48c0-adc8-9823099c1c61"

--- a/pir/pir-impl/src/main/assets/brokers/propertyrecs.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/propertyrecs.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PropertyRecs",
   "url": "propertyrecs.com",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "parent": "propertyrecord.com",
   "addedDatetime": 1775829600000,
   "optOutUrl": "https://dashboard.propertyrecs.com/opt-out",
@@ -12,72 +12,48 @@
       "actions": [
         {
           "actionType": "navigate",
-          "id": "7ae4f835-bf67-468e-bc85-98723d0ff766",
-          "url": "https://www.propertyrecs.com/"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//a[@title='Remove My Info']"
-            }
-          ],
-          "id": "23414895-7813-4fab-a80f-8a8ba36a5185"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "//a[@title='Remove My Info']"
-            }
-          ],
-          "id": "59002bbe-7c2e-4cdc-934f-df2cff270a89"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//h1[contains(text(), 'Remove My Information')]"
-            }
-          ],
-          "id": "1ddc81f1-7048-4e1b-b601-8a7b89f1e19d"
-        },
-        {
-          "actionType": "fillForm",
-          "selector": "form#backgroundCheckForm",
-          "dataSource": "userProfile",
-          "elements": [
-            {
-              "type": "fullName",
-              "selector": ".//input[@name='name']"
-            },
-            {
-              "type": "cityState",
-              "selector": ".//input[@name='cityState']"
-            }
-          ],
-          "id": "cff3b925-7d91-4950-80a3-b3ad0cdc2c10"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "button[type='submit']"
-            }
-          ],
+          "_comment": "Forwarding page source: https://github.com/duckduckgo/privacy-test-pages/blob/main/pir/opt-out/index.html",
+          "url": "https://privacy-test-pages.site/pir/opt-out/?name=${firstName}%20${lastName}&city=${city|downcase}&state=${state|upcase}&cityState=${city},%20${state|upcase}&to=https%3A%2F%2Fdashboard.propertyrecs.com%2Fopt-out%2Frecords",
           "id": "cc9429c8-881e-43f3-8a1b-db214144aa09"
         },
         {
-          "actionType": "condition",
-          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "#spellcheck-original"
+              "selector": "#forward"
+            }
+          ],
+          "id": "0a34d435-70fd-4a65-944c-fe34dffe0838"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "#forward"
+            }
+          ],
+          "id": "8859d273-3cc1-44de-b601-02353934db19"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "4fac1c67-c966-4da9-9e39-42ab6fb5e7cb"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Click Use Original when the site offers a spelling correction.",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original",
+              "failSilently": true
             }
           ],
           "actions": [
@@ -111,7 +87,7 @@
           "noResultsSelector": "//h3[contains(text(), 'No results found')]",
           "profile": {
             "name": {
-              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(concat(' ', normalize-space(@class), ' '), ' !text-black-900 ') and contains(concat(' ', normalize-space(@class), ' '), ' text-lg ')]"
             },
             "addressCityState": {
               "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"

--- a/pir/pir-impl/src/main/assets/brokers/publicrecords.info.json
+++ b/pir/pir-impl/src/main/assets/brokers/publicrecords.info.json
@@ -1,7 +1,7 @@
 {
   "name": "PublicRecordsInfo",
   "url": "publicrecords.info",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "parent": "propertyrecord.com",
   "addedDatetime": 1775829600000,
   "optOutUrl": "https://dashboard.publicrecords.info/opt-out",
@@ -12,72 +12,48 @@
       "actions": [
         {
           "actionType": "navigate",
-          "id": "19677c91-451c-49c2-b1fa-67ab45717b47",
-          "url": "https://www.publicrecords.info/"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//a[@title='Remove My Info']"
-            }
-          ],
-          "id": "6915ac9f-f899-4718-a9d2-943de410cf45"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "//a[@title='Remove My Info']"
-            }
-          ],
-          "id": "171052b7-e18d-4db5-90db-11aed7ce776c"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//h1[contains(text(), 'Remove My Information')]"
-            }
-          ],
-          "id": "cebf9b17-b872-4f50-923e-683447603cce"
-        },
-        {
-          "actionType": "fillForm",
-          "selector": "form#backgroundCheckForm",
-          "dataSource": "userProfile",
-          "elements": [
-            {
-              "type": "fullName",
-              "selector": ".//input[@name='name']"
-            },
-            {
-              "type": "cityState",
-              "selector": ".//input[@name='cityState']"
-            }
-          ],
-          "id": "62e6a0f9-cb99-4c7e-b287-2738b1ab2452"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "button[type='submit']"
-            }
-          ],
+          "_comment": "Forwarding page source: https://github.com/duckduckgo/privacy-test-pages/blob/main/pir/opt-out/index.html",
+          "url": "https://privacy-test-pages.site/pir/opt-out/?name=${firstName}%20${lastName}&city=${city|downcase}&state=${state|upcase}&cityState=${city},%20${state|upcase}&to=https%3A%2F%2Fdashboard.publicrecords.info%2Fopt-out%2Frecords",
           "id": "7ae485fd-ed88-482b-85d9-ddb2606143f6"
         },
         {
-          "actionType": "condition",
-          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "#spellcheck-original"
+              "selector": "#forward"
+            }
+          ],
+          "id": "42f9473b-625e-494a-8b7c-e18d03141e24"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "#forward"
+            }
+          ],
+          "id": "9029478a-9754-4ba6-8dee-b506c9f46651"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "2a722625-d079-460d-992d-71e3e24177b7"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Click Use Original when the site offers a spelling correction.",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original",
+              "failSilently": true
             }
           ],
           "actions": [
@@ -111,7 +87,7 @@
           "noResultsSelector": "//h3[contains(text(), 'No results found')]",
           "profile": {
             "name": {
-              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(concat(' ', normalize-space(@class), ' '), ' !text-black-900 ') and contains(concat(' ', normalize-space(@class), ' '), ' text-lg ')]"
             },
             "addressCityState": {
               "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"

--- a/pir/pir-impl/src/main/assets/brokers/publicrecords.us.json
+++ b/pir/pir-impl/src/main/assets/brokers/publicrecords.us.json
@@ -1,7 +1,7 @@
 {
   "name": "PublicRecordsUs",
   "url": "publicrecords.us",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "parent": "propertyrecord.com",
   "addedDatetime": 1775829600000,
   "optOutUrl": "https://dashboard.publicrecords.us/opt-out",
@@ -12,72 +12,48 @@
       "actions": [
         {
           "actionType": "navigate",
-          "id": "695fb2f0-b2e4-4127-ab75-252a4b8430c0",
-          "url": "https://www.publicrecords.us/"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//a[@title='Remove My Info']"
-            }
-          ],
-          "id": "7c5df98e-3636-470d-b397-c1c7f52fe788"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "//a[@title='Remove My Info']"
-            }
-          ],
-          "id": "41fea052-1cfe-4cd0-ae37-fb90fef82949"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//h1[contains(text(), 'Remove My Information')]"
-            }
-          ],
-          "id": "61914e4e-4587-46e7-8682-73c82642af21"
-        },
-        {
-          "actionType": "fillForm",
-          "selector": "form#backgroundCheckForm",
-          "dataSource": "userProfile",
-          "elements": [
-            {
-              "type": "fullName",
-              "selector": ".//input[@name='name']"
-            },
-            {
-              "type": "cityState",
-              "selector": ".//input[@name='cityState']"
-            }
-          ],
-          "id": "9d03c424-e97a-4ee6-9b17-114afe7dc41a"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "button[type='submit']"
-            }
-          ],
+          "_comment": "Forwarding page source: https://github.com/duckduckgo/privacy-test-pages/blob/main/pir/opt-out/index.html",
+          "url": "https://privacy-test-pages.site/pir/opt-out/?name=${firstName}%20${lastName}&city=${city|downcase}&state=${state|upcase}&cityState=${city},%20${state|upcase}&to=https%3A%2F%2Fdashboard.publicrecords.us%2Fopt-out%2Frecords",
           "id": "492b18f5-23a0-45ae-b215-75b03dbc9a2e"
         },
         {
-          "actionType": "condition",
-          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "#spellcheck-original"
+              "selector": "#forward"
+            }
+          ],
+          "id": "203d00e8-e089-4c08-9f91-baf8e08b83fe"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "#forward"
+            }
+          ],
+          "id": "69e6018f-0cb2-4cc9-81d0-548bff5ce716"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "eb08bbc0-dd52-41e4-8802-ba535b002678"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Click Use Original when the site offers a spelling correction.",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original",
+              "failSilently": true
             }
           ],
           "actions": [
@@ -111,7 +87,7 @@
           "noResultsSelector": "//h3[contains(text(), 'No results found')]",
           "profile": {
             "name": {
-              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(concat(' ', normalize-space(@class), ' '), ' !text-black-900 ') and contains(concat(' ', normalize-space(@class), ' '), ' text-lg ')]"
             },
             "addressCityState": {
               "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"

--- a/pir/pir-impl/src/main/assets/brokers/vehiclehistory.us.json
+++ b/pir/pir-impl/src/main/assets/brokers/vehiclehistory.us.json
@@ -1,7 +1,7 @@
 {
   "name": "VehicleHistory",
   "url": "vehiclehistory.us",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "parent": "propertyrecord.com",
   "addedDatetime": 1775829600000,
   "optOutUrl": "https://dashboard.vehiclehistory.us/opt-out",
@@ -12,72 +12,48 @@
       "actions": [
         {
           "actionType": "navigate",
-          "id": "b5e5aedd-72ff-497d-baa9-3fd3bb4715e1",
-          "url": "https://www.vehiclehistory.us/"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//a[@title='Remove My Info']"
-            }
-          ],
-          "id": "44e75eae-a288-472b-b392-f664a3e44e5b"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "//a[@title='Remove My Info']"
-            }
-          ],
-          "id": "24f92a0c-cb34-432c-9d84-ec6069f83406"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//h1[contains(text(), 'Remove My Information')]"
-            }
-          ],
-          "id": "44fe39d2-88c9-4119-b915-172d752d1e2a"
-        },
-        {
-          "actionType": "fillForm",
-          "selector": "form#backgroundCheckForm",
-          "dataSource": "userProfile",
-          "elements": [
-            {
-              "type": "fullName",
-              "selector": ".//input[@name='name']"
-            },
-            {
-              "type": "cityState",
-              "selector": ".//input[@name='cityState']"
-            }
-          ],
-          "id": "85072b72-6a48-4635-a29b-158b85040051"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "button[type='submit']"
-            }
-          ],
+          "_comment": "Forwarding page source: https://github.com/duckduckgo/privacy-test-pages/blob/main/pir/opt-out/index.html",
+          "url": "https://privacy-test-pages.site/pir/opt-out/?name=${firstName}%20${lastName}&city=${city|downcase}&state=${state|upcase}&cityState=${city},%20${state|upcase}&to=https%3A%2F%2Fdashboard.vehiclehistory.us%2Fopt-out%2Frecords",
           "id": "227207ce-699d-46ee-8693-0f42015c602c"
         },
         {
-          "actionType": "condition",
-          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "#spellcheck-original"
+              "selector": "#forward"
+            }
+          ],
+          "id": "85b6a83b-4a92-4f96-a56b-37ac873a1978"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "#forward"
+            }
+          ],
+          "id": "9fece957-82ee-4692-8ff1-f4c22f19767a"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "40869691-c488-4091-b524-47264ebdbcaf"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Click Use Original when the site offers a spelling correction.",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original",
+              "failSilently": true
             }
           ],
           "actions": [
@@ -111,7 +87,7 @@
           "noResultsSelector": "//h3[contains(text(), 'No results found')]",
           "profile": {
             "name": {
-              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(concat(' ', normalize-space(@class), ' '), ' !text-black-900 ') and contains(concat(' ', normalize-space(@class), ' '), ' text-lg ')]"
             },
             "addressCityState": {
               "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217760327196990

## PIR Broker Bundle Update

Automated update of PIR broker JSON files from the remote bundle.

### Changes

**Updated (7):**
- courtrec.com.json (0.3.0 → 0.6.0)
- propertyrec.com.json (0.3.0 → 0.6.0)
- propertyrecord.com.json (0.4.0 → 0.7.0)
- propertyrecs.com.json (0.3.0 → 0.6.0)
- publicrecords.info.json (0.3.0 → 0.6.0)
- publicrecords.us.json (0.3.0 → 0.6.0)
- vehiclehistory.us.json (0.3.0 → 0.6.0)

### Checklist

- [x] Verify broker changes look correct
- [x] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live PIR scan and opt-out automation for a family of data brokers, including new recaptcha steps and navigation via an external forwarding page. Broken selectors or URLs would fail real opt-outs.
> 
> **Overview**
> Updates the **PropertyRecord** family (parent plus six children) so scan/opt-out no longer fill the on-site search form. Flows now navigate a templated `privacy-test-pages` forwarding URL with name/city/state, click `#forward`, and wait for Search Results.
> 
> Name extraction selectors are updated for the new `!text-black-900` / `text-lg` classes. Spellcheck “Use Original” is `failSilently`.
> 
> On the parent opt-out, **reCAPTCHA v2** is solved before “Remove My Info”, and success is checked on an `h3` with a fail-silent wait so the POST can finish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 040e39677cde8f2c9d9818c826da9109224b1b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->