### PR TITLE
Add onboarding password import experiment toggle and manager

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPasswordImportExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPasswordImportExperimentManager.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import com.duckduckgo.app.onboarding.OnboardingPasswordImportExperimentManager.OnboardingPasswordImportVariant
+import com.duckduckgo.app.onboarding.OnboardingPasswordImportToggles.OnboardingPasswordImportCohorts
+import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+interface OnboardingPasswordImportExperimentManager {
+
+    suspend fun enroll(): OnboardingPasswordImportVariant?
+
+    enum class OnboardingPasswordImportVariant {
+        CONTROL,
+        TREATMENT,
+    }
+}
+
+@ContributesBinding(AppScope::class, boundType = OnboardingPasswordImportExperimentManager::class)
+@SingleInstanceIn(AppScope::class)
+class OnboardingPasswordImportExperimentManagerImpl @Inject constructor(
+    private val toggles: OnboardingPasswordImportToggles,
+    private val onboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles,
+    private val appBuildConfig: AppBuildConfig,
+    private val dispatcherProvider: DispatcherProvider,
+    private val onboardingPrivacyConfigPersistedGate: OnboardingPrivacyConfigPersistedGate,
+) : OnboardingPasswordImportExperimentManager {
+
+    override suspend fun enroll(): OnboardingPasswordImportVariant? = withContext(dispatcherProvider.io()) {
+        if (onboardingPrivacyConfigPersistedGate.awaitPersisted() && checkPrerequisites()) {
+            val toggle = toggles.passwordImportExperimentAug25()
+            toggle.enroll()
+            when {
+                toggle.isEnrolledAndEnabled(OnboardingPasswordImportCohorts.TREATMENT) -> OnboardingPasswordImportVariant.TREATMENT
+                toggle.isEnrolledAndEnabled(OnboardingPasswordImportCohorts.CONTROL) -> OnboardingPasswordImportVariant.CONTROL
+                else -> null
+            }
+        } else {
+            null
+        }
+    }
+
+    /**
+     * Checked before enrolling, so users who could never reach the step are kept out of the experiment: it exists
+     * only in the config-driven onboarding, and only for new installs.
+     */
+    private suspend fun checkPrerequisites() =
+        toggles.self().isEnabled() &&
+            onboardingBrandDesignUpdateToggles.configDrivenDialogs().isEnabled() &&
+            !appBuildConfig.isAppReinstall()
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPasswordImportToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPasswordImportToggles.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
+
+/**
+ * Feature toggles for the experiment offering a password import step in the new-user onboarding.
+ */
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "onboardingPasswordImport",
+)
+interface OnboardingPasswordImportToggles {
+
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun self(): Toggle
+
+    /** Assigns the cohort deciding whether the password-import step is part of the onboarding plan. */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun passwordImportExperimentAug25(): Toggle
+
+    enum class OnboardingPasswordImportCohorts(override val cohortName: String) : CohortName {
+        CONTROL("control"),
+        TREATMENT("treatment"),
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217538403444758
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1211724162604201/task/1217143698674642
API Proposals URL(s) (if applicable): None

### Description

Adds the remote feature and the enrolment manager for the experiment that offers a password import step during new-user onboarding. 

### Steps to test this PR

_Nothing is wired up yet, so this is a review-and-build check_
- [ ] CI passes

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes|No UI changes|
