### PR TITLE
Fix Maestro tests for native search-only input

### DIFF
--- a/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
+++ b/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
@@ -13,7 +13,7 @@ tags:
         - runFlow: ../shared/skip_all_onboarding.yaml
 
         - tapOn:
-            id: "omnibarTextInput"
+            id: "omnibarTextInput|inputField"
         - inputText: "fill.dev/form/login-simple"
         - pressKey: enter
 

--- a/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
+++ b/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
@@ -14,7 +14,7 @@ tags:
       - runFlow: ../shared/skip_all_onboarding.yaml
 
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - tapOn:

--- a/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
@@ -20,7 +20,7 @@ tags:
       - assertVisible:
             text: "Search engine"
       - tapOn:
-            id: "omnibarTextInput"
+            id: "omnibarTextInput|inputField"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - assertVisible:

--- a/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
@@ -14,7 +14,7 @@ tags:
       - runFlow: ../shared/skip_all_onboarding.yaml
 
       - tapOn:
-            id: "omnibarTextInput"
+            id: "omnibarTextInput|inputField"
       - inputText: "https://www.search-company.site/"
       - pressKey: Enter
       - assertVisible:

--- a/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
@@ -26,7 +26,7 @@ tags:
             - tapOn:
                   text: "add bookmark"
             - tapOn:
-                  id: "omnibarTextInput"
+                  id: "omnibarTextInput|inputField"
             - inputText: "https://www.search-company.site/"
             - pressKey: Enter
             - assertVisible:

--- a/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
@@ -14,7 +14,7 @@ tags:
             - runFlow: ../shared/skip_all_onboarding.yaml
 
             - tapOn:
-                  id: "omnibarTextInput"
+                  id: "omnibarTextInput|inputField"
             - inputText: "https://privacy-test-pages.site/"
             - pressKey: Enter
             - assertVisible:

--- a/.maestro/browsing/visit_site.yaml
+++ b/.maestro/browsing/visit_site.yaml
@@ -16,7 +16,7 @@ tags:
       - assertVisible:
           text: "Search"
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - assertVisible:

--- a/.maestro/browsing/visit_site.yaml
+++ b/.maestro/browsing/visit_site.yaml
@@ -22,7 +22,7 @@ tags:
       - assertVisible:
           text: ".*Privacy Test Pages.*"
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - eraseText
       - assertVisible:
           text: "Search"

--- a/.maestro/favorites/favorites_bookmarks_add.yaml
+++ b/.maestro/favorites/favorites_bookmarks_add.yaml
@@ -14,7 +14,7 @@ tags:
       - runFlow: ../shared/skip_all_onboarding.yaml
 
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - tapOn:

--- a/.maestro/favorites/favorites_bookmarks_delete.yaml
+++ b/.maestro/favorites/favorites_bookmarks_delete.yaml
@@ -14,7 +14,7 @@ tags:
       - runFlow: ../shared/skip_all_onboarding.yaml
 
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - tapOn:

--- a/.maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml
+++ b/.maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml
@@ -12,7 +12,7 @@ tags:
                 clearState: true
             - runFlow: ../shared/skip_all_onboarding.yaml
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - inputText: "https://www.search-company.site/#ad-id-5"
             - pressKey: Enter
             - assertVisible:
@@ -61,7 +61,7 @@ tags:
             - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
             - runFlow: ../shared/browser_screen/confirm_fire_dialog.yaml
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - pasteText
             - pressKey: Enter
             - assertVisible:

--- a/.maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml
+++ b/.maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml
@@ -54,9 +54,9 @@ tags:
             - action: back
             - action: back
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - copyTextFrom:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - action: back
             - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
             - runFlow: ../shared/browser_screen/confirm_fire_dialog.yaml

--- a/.maestro/privacy_tests/6_-_Multi-tab.yaml
+++ b/.maestro/privacy_tests/6_-_Multi-tab.yaml
@@ -10,7 +10,7 @@ tags:
                 clearState: true
             - runFlow: ../shared/skip_all_onboarding.yaml
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - inputText: "https://www.search-company.site/#ad-id-5"
             - pressKey: Enter
             - assertVisible:
@@ -62,9 +62,9 @@ tags:
             - tapOn:
                 id: "com.duckduckgo.mobile.android:id/close"
             - assertVisible:
-                id: "com.duckduckgo.mobile.android:id/omnibarTextInput"
+                id: "inputModeWidget|omnibarTextInput"
             - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - inputText: "https://www.publisher-company.site/product.html?p=200"
             - pressKey: Enter
             - assertVisible:

--- a/.maestro/security_tests/1_-_AddressBarSpoof,_basicauth.yaml
+++ b/.maestro/security_tests/1_-_AddressBarSpoof,_basicauth.yaml
@@ -10,7 +10,7 @@ tags:
                 clearState: true
             - runFlow: ../shared/skip_all_onboarding.yaml
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             # Test 1 - using line-separator (U+2028) character
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-2028.html"
             - pressKey: Enter

--- a/.maestro/security_tests/1_-_AddressBarSpoof,_basicauth.yaml
+++ b/.maestro/security_tests/1_-_AddressBarSpoof,_basicauth.yaml
@@ -18,10 +18,10 @@ tags:
             - tapOn: "run"
             - assertVisible: "Example Domain"
             - copyTextFrom:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - eraseText
             # Test 2 - using paragraph-separator (U+2029) character
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-2029.html"
@@ -29,10 +29,10 @@ tags:
             - tapOn: "run"
             - assertVisible: "Example Domain"
             - copyTextFrom:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - eraseText
             # Test 3 - using repeated space character
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-whitespace.html"
@@ -40,5 +40,5 @@ tags:
             - tapOn: "run"
             - assertVisible: "Example Domain"
             - copyTextFrom:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}

--- a/.maestro/security_tests/2_-_AddressBarSpoof,_aboutblank.yaml
+++ b/.maestro/security_tests/2_-_AddressBarSpoof,_aboutblank.yaml
@@ -20,7 +20,7 @@ tags:
                 notVisible: "Not DDG."  # Spoofed content not visible
                 timeout: 10000
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - copyTextFrom:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - assertTrue: ${maestro.copiedText == "about:blank" || maestro.copiedText == "https://duckduckgo.com/"}

--- a/.maestro/security_tests/2_-_AddressBarSpoof,_aboutblank.yaml
+++ b/.maestro/security_tests/2_-_AddressBarSpoof,_aboutblank.yaml
@@ -10,7 +10,7 @@ tags:
                 clearState: true
             - runFlow: ../shared/skip_all_onboarding.yaml
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-about-blank-rewrite.html"
             - pressKey: Enter
 

--- a/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
+++ b/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
@@ -20,7 +20,7 @@ tags:
             - assertVisible: "Open in another app"
             - tapOn: "Cancel"
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - copyTextFrom:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - assertTrue: ${maestro.copiedText.indexOf("duckduckgo.com") == -1}

--- a/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
+++ b/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
@@ -11,7 +11,7 @@ tags:
             - runFlow: ../shared/skip_all_onboarding.yaml
             # Test 1
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-open-b64-html.html"
             - pressKey: Enter
 

--- a/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
+++ b/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
@@ -11,7 +11,7 @@ tags:
             - runFlow: ../shared/skip_all_onboarding.yaml
             # Test 1
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-download-url.html"
             - pressKey: Enter
 

--- a/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
+++ b/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
@@ -22,7 +22,7 @@ tags:
                 timeout: 10000
             - tapOn: "Save to Downloads"
             - copyTextFrom:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - assertTrue: ${maestro.copiedText == "Search"} # Downloads should occur in empty origin.
             - pressKey: Back
             # Download Cancel Flow:
@@ -33,7 +33,7 @@ tags:
             - tapOn: "Cancel"
             # Should redirect back to the last page.
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - copyTextFrom:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - assertTrue: ${maestro.copiedText.indexOf("https://staticcdn.duckduckgo.com") == -1}

--- a/.maestro/security_tests/6_-_AddressBarSpoof,_formaction.yaml
+++ b/.maestro/security_tests/6_-_AddressBarSpoof,_formaction.yaml
@@ -11,7 +11,7 @@ tags:
             - runFlow: ../shared/skip_all_onboarding.yaml
             # Test 1
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-form-action.html"
             - pressKey: Enter
 

--- a/.maestro/security_tests/6_-_AddressBarSpoof,_formaction.yaml
+++ b/.maestro/security_tests/6_-_AddressBarSpoof,_formaction.yaml
@@ -18,7 +18,7 @@ tags:
             - tapOn: "run"
             # Should do nothing - the navigation should be prevented.
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - copyTextFrom:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-form-action.html"}

--- a/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
+++ b/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
@@ -11,7 +11,7 @@ tags:
             - runFlow: ../shared/skip_all_onboarding.yaml
             # Test 1
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-page-rewrite.html"
             - pressKey: Enter
 

--- a/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
+++ b/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
@@ -21,7 +21,7 @@ tags:
             - assertNotVisible: "DDG."
             # Now check the address bar hasn't been updated too early resulting in spoofed content
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - copyTextFrom:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-page-rewrite.html"}

--- a/.maestro/security_tests/8_-_AddressBarSpoof,_aboutblankemptyaddress.yaml
+++ b/.maestro/security_tests/8_-_AddressBarSpoof,_aboutblankemptyaddress.yaml
@@ -19,6 +19,6 @@ tags:
       - tapOn: "run"
 
       - copyTextFrom:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
 
       - assertTrue: ${maestro.copiedText == "about:blank" }

--- a/.maestro/security_tests/8_-_AddressBarSpoof,_aboutblankemptyaddress.yaml
+++ b/.maestro/security_tests/8_-_AddressBarSpoof,_aboutblankemptyaddress.yaml
@@ -12,7 +12,7 @@ tags:
       - runFlow: ../shared/skip_all_onboarding.yaml
 
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "http://privacy-test-pages.site/security/address-bar-spoofing/spoof-about-blank-emptyaddress.html"
       - pressKey: Enter
 

--- a/.maestro/tabs/open_multiple_tabs.yaml
+++ b/.maestro/tabs/open_multiple_tabs.yaml
@@ -14,7 +14,7 @@ tags:
             - runFlow: ../shared/skip_all_onboarding.yaml
 
             - tapOn:
-                id: "omnibarTextInput"
+                id: "omnibarTextInput|inputField"
             - inputText: "https://privacy-test-pages.site"
             - pressKey: Enter
             - runFlow: ../shared/browser_screen/click_on_tabs_button.yaml
@@ -24,7 +24,7 @@ tags:
                 text: "Privacy Test Pages - Home"
             - tapOn: "New Tab"
             - assertVisible:
-                id: "omnibarTextInput"
+                id: "inputModeWidget|omnibarTextInput"
             - inputText: "https://www.search-company.site"
             - pressKey: Enter
             - assertVisible:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1217765551469786?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Updates the affected Maestro flows to work with both the legacy Omnibar and the native search-only input.

### Steps to test this PR

Check [cloud run](https://app.maestro.dev/project/proj_01htg54rdtfwx8rgbzv03cxkpf/maestro-test/app/app_01hkqhj1thevwtn9ym8a2ctn2r/upload/mupload_01m0ss8szff4rtxbfxdm813vyj?sort=name)

NOTE: We're only interested in omnibarTextInput related failures, as this is being tested on an internalRelease to force the `nativeInputSearch` toggle on

_Maestro tests, run locally or on Maestro Cloud_

- [ ] To run locally, run:
  ```bash
  maestro test --include-tags "autofillNoAuthTests,privacyTest,securityTest,releaseTest" .maestro
  ```
- [ ] Verify the updated tests pass

### UI changes

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only selector updates; no production or security-sensitive code changes.
> 
> **Overview**
> Updates Maestro flows so they work with both the legacy omnibar (`omnibarTextInput`) and the native search-only input (`inputField`).
> 
> Selectors now use Maestro’s `|` OR syntax for tap, copy, and visibility checks. New-tab empty-state asserts also accept `inputModeWidget` alongside the old omnibar id.
> 
> Covers autofill, bookmarks, browsing, favorites, privacy, security, and tabs tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 988e81b6ee90548a369e51ef50f529bad949f4c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->