### PR TITLE
Add sync Exchange v2.1 feature flag

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -96,6 +96,12 @@ interface SyncFeature {
     fun canShowV2ConnectCode(): Toggle
 
     /**
+     * Global switch for the v2.1 exchange protocol.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun canUseExchangeV2Point1(): Toggle
+
+    /**
      * When enabled, the sync barcode scanner only attempts to decode QR codes. Sync codes are
      * always encoded as QR, so other formats only add noise (and false-positive decodes) to
      * the scanner.

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/ExchangeProtocolVersion.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/ExchangeProtocolVersion.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange
+
+sealed class ExchangeProtocolVersion : Comparable<ExchangeProtocolVersion> {
+
+    sealed class Supported : ExchangeProtocolVersion() {
+        abstract val major: Int
+        abstract val minor: Int
+
+        final override fun toString() = if (minor == 0) "$major" else "$major.$minor"
+    }
+
+    data class V1(
+        override val minor: Int,
+    ) : Supported() {
+        override val major get() = MAJOR
+
+        companion object {
+            const val MAJOR = 1
+        }
+    }
+
+    data class V2(
+        override val minor: Int,
+    ) : Supported() {
+        override val major get() = MAJOR
+
+        companion object {
+            const val MAJOR = 2
+        }
+    }
+
+    data class Unsupported(
+        val rawVersion: String,
+    ) : ExchangeProtocolVersion() {
+        override fun toString() = rawVersion
+    }
+
+    override fun compareTo(other: ExchangeProtocolVersion): Int = when {
+        this is Supported && other is Supported -> compareValuesBy(this, other, Supported::major, Supported::minor)
+        this is Unsupported && other is Unsupported -> rawVersion.compareTo(other.rawVersion)
+        this is Supported -> -1
+        else -> 1
+    }
+
+    companion object {
+        val V1_0 = V1(minor = 0)
+        val V2_0 = V2(minor = 0)
+        val V2_1 = V2(minor = 1)
+
+        fun parse(rawVersion: String): Result<ExchangeProtocolVersion> = runCatching {
+            val components = rawVersion.split('.').map { it.toInt() }
+            val major = components[0]
+            val minor = components.getOrNull(1) ?: 0
+            when (major) {
+                V1.MAJOR -> V1(minor)
+                V2.MAJOR -> V2(minor)
+                else -> Unsupported(rawVersion)
+            }
+        }
+
+        fun parseOrUnsupported(rawVersion: String): ExchangeProtocolVersion = parse(rawVersion).getOrElse { Unsupported(rawVersion) }
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.sync.impl.exchange.v2
 
 import android.util.Base64
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.Json
 import com.squareup.moshi.Moshi
@@ -34,7 +35,7 @@ import javax.inject.Inject
  * The outer `code2` value is URL-safe + no-padding base64 (the fragment isn't safe for `+`/`/`/`=`).
  */
 interface ExchangeV2QrCode {
-    fun buildLinkingCode(channelId: String, publicKeyBase64Url: String, version: String = "2"): String
+    fun buildLinkingCode(channelId: String, publicKeyBase64Url: String, version: ExchangeProtocolVersion.V2): String
     fun parse(text: String): ExchangeV2CodeParseResult
 }
 
@@ -43,7 +44,7 @@ sealed interface ExchangeV2CodeParseResult {
     data class LinkingV2(
         val channelId: String,
         val publicKey: String,
-        val version: String,
+        val version: ExchangeProtocolVersion.V2,
     ) : ExchangeV2CodeParseResult
 
     /** v1 linking code (legacy <code=...>); fall back to v1 stack. */
@@ -59,9 +60,9 @@ sealed interface ExchangeV2CodeParseResult {
 @ContributesBinding(AppScope::class)
 class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
 
-    override fun buildLinkingCode(channelId: String, publicKeyBase64Url: String, version: String): String {
+    override fun buildLinkingCode(channelId: String, publicKeyBase64Url: String, version: ExchangeProtocolVersion.V2): String {
         val payload = linkingCodeAdapter.toJson(
-            V2LinkingCodePayload(version = version, channelId = channelId, publicKey = publicKeyBase64Url),
+            V2LinkingCodePayload(version = version.toString(), channelId = channelId, publicKey = publicKeyBase64Url),
         )
         val encoded = Base64.encodeToString(
             payload.toByteArray(Charsets.UTF_8),
@@ -97,10 +98,10 @@ class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
         }
 
         // Accept any same-major (2.x) version per Transport TD 1214486492252757 §Versioning.
-        val version = json.optString("version")
+        val version = ExchangeProtocolVersion.parseOrUnsupported(json.optString("version"))
         val channelId = json.optString("channel_id")
         val publicKey = json.optString("public_key")
-        if (majorVersion(version) == 2 && channelId.isNotEmpty() && publicKey.isNotEmpty()) {
+        if (version is ExchangeProtocolVersion.V2 && channelId.isNotEmpty() && publicKey.isNotEmpty()) {
             return ExchangeV2CodeParseResult.LinkingV2(
                 channelId = channelId,
                 publicKey = publicKey,
@@ -128,9 +129,6 @@ class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
             .firstOrNull { it.startsWith("$PARAM_V2=") || it.startsWith("$PARAM_V1=") }
             ?.substringAfter('=')
     }
-
-    /** Major component of a "major.minor" version string (e.g. "2.1" → 2), or null if unparseable. */
-    private fun majorVersion(version: String): Int? = version.substringBefore(".").toIntOrNull()
 
     companion object {
         private const val URL_PREFIX = "https://duckduckgo.com/sync/pairing/"

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -21,8 +21,10 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncDeviceIds
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.crypto.RsaKeyPair
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Host
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.SameAccountAbort
@@ -116,6 +118,7 @@ class RealExchangeV2Runner @Inject constructor(
     private val qrCode: ExchangeV2QrCode,
     private val recoveryCodeProvider: RecoveryCodeProvider,
     private val syncDeviceIds: SyncDeviceIds,
+    private val syncFeature: SyncFeature,
     @AppCoroutineScope private val appScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
 ) : ExchangeV2Runner {
@@ -220,6 +223,7 @@ class RealExchangeV2Runner @Inject constructor(
                 _linkingCode = qrCode.buildLinkingCode(
                     channelId = ownChannelId!!,
                     publicKeyBase64Url = keyPair.publicKeyBase64,
+                    version = if (syncFeature.canUseExchangeV2Point1().isEnabled()) ExchangeProtocolVersion.V2_1 else ExchangeProtocolVersion.V2_0,
                 )
                 // Presenter waits to receive hello before transitioning out of Bootstrapped.
                 session = smFactory.create(

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.PEER_RECOVERY_CODE_UNAVAILABLE
 import com.duckduckgo.sync.impl.AccountErrorCodes.RECOVERY_CODE_PREPARATION_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.SESSION_TIMEOUT
 import com.duckduckgo.sync.impl.AccountErrorCodes.UNEXPECTED_EVENT
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -171,7 +172,7 @@ class RealSyncCodeDispatcherTest {
     @Test fun `v2 flag on, v2 LinkingV2 - returns V2InProgress and does NOT call parseSyncAuthCode`() {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
 
         val decision = dispatcher.route("v2-link-url")
@@ -476,7 +477,7 @@ class RealSyncCodeDispatcherTest {
     @Test fun `v2 flag on, LinkingV2 - ignores stale terminal events from prior sessions in the replay cache`() = runTest {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         val staleJoinerDone = ExchangeV2Event.Transition(
             timestampMs = 1L,
@@ -508,7 +509,7 @@ class RealSyncCodeDispatcherTest {
     @Test fun `v2 flag on, LinkingV2 - runner_startScan deferred until Flow is collected (cold)`() = runTest {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
 
         val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
@@ -523,7 +524,7 @@ class RealSyncCodeDispatcherTest {
         // Spec 1214802412121967: the v2 wire `secret` is base64url; v1 login decodes as standard base64.
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
         val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o"
@@ -671,7 +672,7 @@ class RealSyncCodeDispatcherTest {
     @Test fun `Scanner maps a version-too-new SessionError to UpgradeRequired`() = runTest {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
         flow.test {
@@ -689,7 +690,7 @@ class RealSyncCodeDispatcherTest {
     @Test fun `Scanner - Host_Aborted with UserDeniedHost maps to Failed PAIRING_CANCELLED`() = runTest {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
         flow.test {
@@ -711,7 +712,7 @@ class RealSyncCodeDispatcherTest {
     @Test fun `Scanner - Host_Aborted with HostUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
         flow.test {
@@ -989,7 +990,7 @@ class RealSyncCodeDispatcherTest {
             ExchangeV2CodeParseResult.LinkingV2(
                 channelId = "c",
                 publicKey = "k",
-                version = "2",
+                version = ExchangeProtocolVersion.V2_0,
             ),
         )
         val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
@@ -1026,7 +1027,7 @@ class RealSyncCodeDispatcherTest {
             ExchangeV2CodeParseResult.LinkingV2(
                 channelId = "peer-channel",
                 publicKey = "k",
-                version = "2",
+                version = ExchangeProtocolVersion.V2_0,
             ),
         )
         val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
@@ -1064,7 +1065,7 @@ class RealSyncCodeDispatcherTest {
     @Test fun `Scanner emits Failed when runner reaches Aborted (hello during negotiating)`() = runTest {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
         decision.outcomes.test {
@@ -1101,7 +1102,7 @@ class RealSyncCodeDispatcherTest {
     private fun startLinking(): kotlinx.coroutines.flow.Flow<DispatchOutcome> {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         return (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/ExchangeProtocolVersionTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/ExchangeProtocolVersionTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange
+
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion.Unsupported
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion.V1
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion.V2
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(TestParameterInjector::class)
+class ExchangeProtocolVersionTest {
+
+    enum class ParseSuccessCase(
+        val rawVersion: String,
+        val expected: ExchangeProtocolVersion,
+    ) {
+        MajorOnlyV1("1", V1(minor = 0)),
+        MajorMinorV1("1.0", V1(minor = 0)),
+        HigherMinorV1("1.5", V1(minor = 5)),
+        MajorOnlyV2("2", V2(minor = 0)),
+        MajorMinorV2("2.1", V2(minor = 1)),
+        PatchComponentIgnored("2.1.7", V2(minor = 1)),
+        UnknownMajor("3", Unsupported("3")),
+        UnknownMajorWithMinor("3.2", Unsupported("3.2")),
+        ZeroMajor("0", Unsupported("0")),
+        DoubleDigitMajor("10.2", Unsupported("10.2")),
+    }
+
+    @Test
+    fun `parses valid version strings`(
+        @TestParameter case: ParseSuccessCase,
+    ) {
+        assertEquals(case.expected, ExchangeProtocolVersion.parse(case.rawVersion).getOrThrow())
+    }
+
+    @Test
+    fun `parsing malformed input returns failure`(
+        @TestParameter("", "abc", "1.x", "2..1", ".", "1.", " 1") rawVersion: String,
+    ) {
+        assertTrue(ExchangeProtocolVersion.parse(rawVersion).isFailure)
+    }
+
+    enum class OrderingCase(
+        val lower: ExchangeProtocolVersion,
+        val higher: ExchangeProtocolVersion,
+    ) {
+        MinorWithinV1(V1(minor = 0), V1(minor = 1)),
+        MinorWithinV2(V2(minor = 0), V2(minor = 1)),
+        MajorBeatsMinor(V1(minor = 9), V2(minor = 0)),
+        SupportedBelowUnsupported(V2(minor = 9), Unsupported("0")),
+        UnsupportedByRawVersion(Unsupported("3"), Unsupported("4")),
+    }
+
+    @Test
+    fun `orders versions`(
+        @TestParameter case: OrderingCase,
+    ) {
+        assertTrue(case.lower < case.higher)
+        assertTrue(case.higher > case.lower)
+    }
+
+    enum class EqualityCase(
+        val first: ExchangeProtocolVersion,
+        val second: ExchangeProtocolVersion,
+    ) {
+        SameV1(V1(minor = 3), V1(minor = 3)),
+        SameV2(V2(minor = 0), V2(minor = 0)),
+        SameUnsupported(Unsupported("3.2"), Unsupported("3.2")),
+    }
+
+    @Test
+    fun `equal versions compare as equal`(@TestParameter case: EqualityCase) {
+        assertEquals(0, case.first.compareTo(case.second))
+        assertEquals(case.first, case.second)
+    }
+
+    enum class ToStringCase(
+        val version: ExchangeProtocolVersion,
+        val expected: String,
+    ) {
+        ZeroMinorOmitted(V2(minor = 0), "2"),
+        NonZeroMinorIncluded(V2(minor = 1), "2.1"),
+        UnsupportedKeepsRawVersion(Unsupported("3.2.1"), "3.2.1"),
+    }
+
+    @Test
+    fun `renders version string`(
+        @TestParameter case: ToStringCase,
+    ) {
+        assertEquals(case.expected, case.version.toString())
+    }
+
+    @Test
+    fun `parsing the rendered form of a supported version round-trips`(
+        @TestParameter("1", "1.5", "2", "2.1") rawVersion: String,
+    ) {
+        val parsed = ExchangeProtocolVersion.parse(rawVersion).getOrThrow()
+        val reParsed = ExchangeProtocolVersion.parse(parsed.toString()).getOrThrow()
+
+        assertEquals(parsed, reParsed)
+    }
+
+    @Test
+    fun `parseOrUnsupported returns parsed version for valid input`(
+        @TestParameter case: ParseSuccessCase,
+    ) {
+        assertEquals(case.expected, ExchangeProtocolVersion.parseOrUnsupported(case.rawVersion))
+    }
+
+    @Test
+    fun `parseOrUnsupported falls back to Unsupported with raw version for malformed input`(
+        @TestParameter("", "abc", "1.x", "2..1", ".", "1.", " 1") rawVersion: String,
+    ) {
+        assertEquals(Unsupported(rawVersion), ExchangeProtocolVersion.parseOrUnsupported(rawVersion))
+    }
+
+    @Test
+    fun `predefined constants carry expected versions`() {
+        assertEquals(V1(minor = 0), ExchangeProtocolVersion.V1_0)
+        assertEquals(V2(minor = 0), ExchangeProtocolVersion.V2_0)
+        assertEquals(V2(minor = 1), ExchangeProtocolVersion.V2_1)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.sync.impl.exchange.v2
 
 import android.util.Base64
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -33,7 +34,7 @@ class RealExchangeV2QrCodeTest {
     // ---- parse: LinkingV2 ----
 
     @Test fun `parse identifies a well-formed v2 linking URL`() {
-        val url = qrCode.buildLinkingCode(channelId = "abc", publicKeyBase64Url = "pubkey", version = "2")
+        val url = qrCode.buildLinkingCode(channelId = "abc", publicKeyBase64Url = "pubkey", version = ExchangeProtocolVersion.V2_0)
 
         val result = qrCode.parse(url)
 
@@ -41,11 +42,11 @@ class RealExchangeV2QrCodeTest {
         result as ExchangeV2CodeParseResult.LinkingV2
         assertEquals("abc", result.channelId)
         assertEquals("pubkey", result.publicKey)
-        assertEquals("2", result.version)
+        assertEquals(ExchangeProtocolVersion.V2_0, result.version)
     }
 
     @Test fun `parse tolerates leading whitespace and prefix text before the URL`() {
-        val url = qrCode.buildLinkingCode("c", "k")
+        val url = qrCode.buildLinkingCode("c", "k", version = ExchangeProtocolVersion.V2_0)
         val noisy = "   Linking code: $url"
 
         val result = qrCode.parse(noisy)
@@ -133,7 +134,7 @@ class RealExchangeV2QrCodeTest {
         parsed as ExchangeV2CodeParseResult.LinkingV2
         assertEquals("chan", parsed.channelId)
         assertEquals("pub", parsed.publicKey)
-        assertEquals("2.1", parsed.version)
+        assertEquals(ExchangeProtocolVersion.V2_1, parsed.version)
     }
 
     @Test fun `parse rejects a v2 code with an empty public_key`() {
@@ -149,7 +150,7 @@ class RealExchangeV2QrCodeTest {
     // ---- buildLinkingCode round-trip ----
 
     @Test fun `buildLinkingCode emits a URL parse can decode back to its inputs`() {
-        val built = qrCode.buildLinkingCode(channelId = "chan-123", publicKeyBase64Url = "pubkey-456")
+        val built = qrCode.buildLinkingCode(channelId = "chan-123", publicKeyBase64Url = "pubkey-456", version = ExchangeProtocolVersion.V2_0)
 
         val parsed = qrCode.parse(built) as ExchangeV2CodeParseResult.LinkingV2
 
@@ -158,20 +159,20 @@ class RealExchangeV2QrCodeTest {
     }
 
     @Test fun `buildLinkingCode produces the documented URL shape`() {
-        val built = qrCode.buildLinkingCode(channelId = "c", publicKeyBase64Url = "k")
+        val built = qrCode.buildLinkingCode(channelId = "c", publicKeyBase64Url = "k", version = ExchangeProtocolVersion.V2_0)
         assertTrue("expected URL prefix, got: $built", built.startsWith("https://duckduckgo.com/sync/pairing/#&code2="))
     }
 
     @Test fun `buildLinkingCode emits the expected compact JSON shape`() {
         // Field order is not contractual (codes are parse-only, never byte-compared); this pins the current serializer output.
-        val built = qrCode.buildLinkingCode(channelId = "c", publicKeyBase64Url = "k", version = "2")
+        val built = qrCode.buildLinkingCode(channelId = "c", publicKeyBase64Url = "k", version = ExchangeProtocolVersion.V2_0)
         val fragment = built.substringAfter("code2=")
         val decoded = String(Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP))
         assertEquals("""{"channel_id":"c","public_key":"k","version":"2"}""", decoded)
     }
 
     @Test fun `buildLinkingCode does not escape forward slashes (defense-in-depth)`() {
-        val built = qrCode.buildLinkingCode(channelId = "chan/123", publicKeyBase64Url = "pub/key+raw")
+        val built = qrCode.buildLinkingCode(channelId = "chan/123", publicKeyBase64Url = "pub/key+raw", version = ExchangeProtocolVersion.V2_0)
         val fragment = built.substringAfter("code2=")
         val decoded = String(Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP))
         assertFalse("linking JSON must not contain escaped slashes (\\/): $decoded", decoded.contains("\\/"))
@@ -180,7 +181,7 @@ class RealExchangeV2QrCodeTest {
     }
 
     @Test fun `buildLinkingCode honours custom version`() {
-        val built = qrCode.buildLinkingCode("c", "k", version = "2.1")
+        val built = qrCode.buildLinkingCode("c", "k", version = ExchangeProtocolVersion.V2_1)
         val fragment = built.substringAfter("code2=")
         val decoded = Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
         assertTrue(String(decoded).contains("\"version\":\"2.1\""))

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -18,10 +18,14 @@ package com.duckduckgo.sync.impl.exchange.v2
 
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncDeviceIds
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.crypto.RsaKeyPair
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
@@ -44,6 +48,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -62,6 +67,7 @@ class RealExchangeV2RunnerTest {
     private val qrCode: ExchangeV2QrCode = mock()
     private val recoveryCodeProvider: RecoveryCodeProvider = mock()
     private val syncDeviceIds: SyncDeviceIds = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
 
     private fun newRunner(): RealExchangeV2Runner =
         RealExchangeV2Runner(
@@ -74,13 +80,14 @@ class RealExchangeV2RunnerTest {
             qrCode = qrCode,
             recoveryCodeProvider = recoveryCodeProvider,
             syncDeviceIds = syncDeviceIds,
+            syncFeature = syncFeature,
             appScope = coroutineTestRule.testScope,
             dispatchers = coroutineTestRule.testDispatcherProvider,
         )
 
     @Before fun stubWireDeps() {
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "peer-channel", publicKey = "peer-pubkey", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "peer-channel", publicKey = "peer-pubkey", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(qrCode.buildLinkingCode(any(), any(), any())).thenReturn("https://duckduckgo.com/sync/pairing/#&code2=fake")
         whenever(jweCrypto.generateRsaKeyPair(any())).thenReturn(RsaKeyPair(publicKeyBase64 = "own-pub", privateKeyBase64 = "own-priv"))
@@ -254,6 +261,22 @@ class RealExchangeV2RunnerTest {
             any(),
             any(),
         )
+    }
+
+    @Test fun `startPresent builds a v2_0 linking code when the v2_1 exchange flag is disabled`() {
+        syncFeature.canUseExchangeV2Point1().setRawStoredState(State(enable = false))
+        val runner = newRunner()
+        runner.startPresent()
+
+        verify(qrCode).buildLinkingCode(any(), any(), eq(ExchangeProtocolVersion.V2_0))
+    }
+
+    @Test fun `startPresent builds a v2_1 linking code when the v2_1 exchange flag is enabled`() {
+        syncFeature.canUseExchangeV2Point1().setRawStoredState(State(enable = true))
+        val runner = newRunner()
+        runner.startPresent()
+
+        verify(qrCode).buildLinkingCode(any(), any(), eq(ExchangeProtocolVersion.V2_1))
     }
 
     // ---- Auto role election ----

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -46,6 +46,7 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncAuthCode.Unknown
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -164,7 +165,7 @@ internal class EnterCodeViewModelTest {
         val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
         whenever(qrCode.parse(pastedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
@@ -404,7 +405,7 @@ internal class EnterCodeViewModelTest {
         val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
         whenever(qrCode.parse(pastedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(
@@ -435,7 +436,7 @@ internal class EnterCodeViewModelTest {
         val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
         whenever(qrCode.parse(pastedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.sync.impl.SyncAuthCode.Connect
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncCodeType
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -613,7 +614,7 @@ class SyncConnectViewModelTest {
             com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult.LinkingV2(
                 channelId = "chan",
                 publicKey = "pk",
-                version = "2",
+                version = ExchangeProtocolVersion.V2_0,
             ),
         )
         val recoveryJson = org.json.JSONObject().apply {
@@ -831,7 +832,7 @@ class SyncConnectViewModelTest {
         whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
         val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(qrCode.parse(scannedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(
@@ -883,7 +884,7 @@ class SyncConnectViewModelTest {
         whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
         val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(qrCode.parse(scannedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -110,7 +111,7 @@ class SyncLoginViewModelTest {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
         val scanned = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(qrCode.parse(scanned)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
@@ -130,7 +131,7 @@ class SyncLoginViewModelTest {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
         val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(qrCode.parse(scannedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(
@@ -169,7 +170,7 @@ class SyncLoginViewModelTest {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
         val scanned = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(qrCode.parse(scanned)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -54,6 +54,7 @@ import com.duckduckgo.sync.impl.SyncAuthCode.Exchange
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.encodeB64
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -775,7 +776,7 @@ class SyncWithAnotherDeviceViewModelTest {
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
         val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(qrCode.parse(scannedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
 
         testee.commands().test {
@@ -834,7 +835,7 @@ class SyncWithAnotherDeviceViewModelTest {
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
         val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(qrCode.parse(scannedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -158,6 +158,7 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.syncFaviconsPromptCta.setOnClickListener {
             viewModel.resetFaviconsPrompt()
         }
+        binding.checkLinkingCodeCta.setOnClickListener { viewModel.onCheckLinkingCodeClicked() }
         binding.testSyncWarningToggle.setOnCheckedChangeListener(testSyncWarningListener)
         binding.clearHistoryBookmarkAddedDialogPromo.setOnClickListener { viewModel.onClearHistoryBookmarkAddedDialogPromoClicked() }
         binding.clearHistoryBookmarkScreenPromo.setOnClickListener { viewModel.onClearHistoryBookmarkScreenPromoClicked() }
@@ -348,6 +349,7 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.recoveryCodeDecodedTextView.text = decodeStandardBase64(viewState.recoveryCode, emptyPlaceholder = "(not signed in)")
         binding.thirdPartyRecoveryCodeTextView.text = viewState.thirdPartyRecoveryCode.ifEmpty { "(no 3party credential yet)" }
         binding.thirdPartyRecoveryCodeDecodedTextView.text = decodeThirdPartyRecoveryCode(viewState.thirdPartyRecoveryCode)
+        binding.checkLinkingCodeResultTextView.text = viewState.checkLinkingCodeResult
         binding.connectedDevicesList.removeAllViews()
         binding.blockStoreFeatureFlag.text = viewState.blockStoreFeatureFlagText
         binding.blockStoreAvailability.text = viewState.blockStoreAvailabilityText
@@ -367,6 +369,9 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         }
         binding.canShowV2ConnectCodeToggle.quietlySetIsChecked(viewState.canShowV2ConnectCodeEnabled) { _, enabled ->
             viewModel.onCanShowV2ConnectCodeFlagChanged(enabled)
+        }
+        binding.canUseExchangeV2Point1.quietlySetIsChecked(viewState.canUseExchangeV2Point1) { _, enabled ->
+            viewModel.onCanUseExchangeV2Point1FlagChanged(enabled)
         }
         binding.accessCredentialsTextView.text = viewState.accessCredentialsText
         binding.scopedTokenResultTextView.text = viewState.scopedTokenResult

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -480,11 +480,19 @@ constructor(
         }
     }
 
-    private fun fetchV1LinkingCode(): String =
-        when (val result = syncAccountRepository.getConnectQR()) {
-            is Success -> describeQrCode(result.data.qrCode)
-            is Error -> "Failed to fetch v1 connect code: $result"
+    private fun fetchV1LinkingCode(): String {
+        val signedIn = syncAccountRepository.isSignedIn()
+        val result = if (signedIn) {
+            syncAccountRepository.generateExchangeInvitationCode()
+        } else {
+            syncAccountRepository.getConnectQR()
         }
+        val label = if (signedIn) "invitation" else "connect"
+        return when (result) {
+            is Success -> describeQrCode(result.data.qrCode)
+            is Error -> "Failed to fetch v1 $label code: $result"
+        }
+    }
 
     private suspend fun fetchV2LinkingCode(): String {
         val outcome = syncCodeDispatcher.presentV2().firstOrNull { it is DispatchOutcome.LinkingCodeReady || it is DispatchOutcome.Failed }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.internal.ui
 import android.annotation.SuppressLint
 import android.app.KeyguardManager
 import android.content.Context
+import android.util.Base64
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
@@ -37,16 +38,20 @@ import com.duckduckgo.sync.impl.DeviceInfoMigrator
 import com.duckduckgo.sync.impl.DeviceInfoSessionResult
 import com.duckduckgo.sync.impl.DeviceInfoUpdater
 import com.duckduckgo.sync.impl.DeviceV2
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncApi
 import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncDeviceIds
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
 import com.duckduckgo.sync.impl.autorestore.SyncRecoveryPersistentStorageKey
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
 import com.duckduckgo.sync.impl.getOrNull
 import com.duckduckgo.sync.impl.internal.SyncInternalEnvDataStore
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore
@@ -65,6 +70,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
@@ -95,6 +101,8 @@ constructor(
     private val deviceFieldDecryptor: DeviceFieldDecryptor,
     private val deviceInfoMigrator: DeviceInfoMigrator,
     private val syncDeviceIds: SyncDeviceIds,
+    private val exchangeV2QrCode: ExchangeV2QrCode,
+    private val syncCodeDispatcher: SyncCodeDispatcher,
     @field:SuppressLint("StaticFieldLeak") private val context: Context,
 ) : ViewModel() {
 
@@ -131,6 +139,8 @@ constructor(
         val blockStoreCurrentValueText: String = "Loading...",
         val canUseV2ConnectFlowEnabled: Boolean = false,
         val canShowV2ConnectCodeEnabled: Boolean = false,
+        val canUseExchangeV2Point1: Boolean = false,
+        val checkLinkingCodeResult: String = "",
         val accessCredentialsText: String = "",
         val scopedTokenResult: String = "",
         val v2StoreFieldsText: String = "",
@@ -258,6 +268,15 @@ constructor(
     }
 
     @SuppressLint("DenyListedApi")
+    fun onCanUseExchangeV2Point1FlagChanged(enabled: Boolean) {
+        viewModelScope.launch(dispatchers.io()) {
+            logcat { "Sync-ScopedToken: setting canUseExchangeV2Point1 flag = $enabled" }
+            setRawToggleState(syncFeature.canUseExchangeV2Point1(), enabled)
+            updateViewState()
+        }
+    }
+
+    @SuppressLint("DenyListedApi")
     private fun setRawToggleState(
         toggle: Toggle,
         enabled: Boolean,
@@ -329,6 +348,7 @@ constructor(
                 environment = syncEnvDataStore.syncEnvironmentUrl,
                 canUseV2ConnectFlowEnabled = syncFeature.canUseV2ConnectFlow().isEnabled(),
                 canShowV2ConnectCodeEnabled = syncFeature.canShowV2ConnectCode().isEnabled(),
+                canUseExchangeV2Point1 = syncFeature.canUseExchangeV2Point1().isEnabled(),
                 v2StoreFieldsText = buildV2StoreFieldsText(),
                 // Clear per-session dev-tool results once signed out so stale keys aren't shown.
                 keysText = if (accountInfo.isSignedIn) viewState.value.keysText else "",
@@ -362,6 +382,23 @@ constructor(
         viewModelScope.launch(dispatchers.io()) {
             val recoveryCode = syncAccountRepository.getRecoveryCode().getOrNull() ?: return@launch
             command.send(ShowQR(recoveryCode.qrCode))
+        }
+    }
+
+    private fun describeQrCode(rawCode: String): String {
+        val decodedPayload = runCatching {
+            String(Base64.decode(rawCode, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP), Charsets.UTF_8)
+        }.getOrDefault(rawCode)
+        return when (val parsed = exchangeV2QrCode.parse(rawCode)) {
+            is ExchangeV2CodeParseResult.LinkingV1 -> "v1 linking code\n$decodedPayload"
+
+            is ExchangeV2CodeParseResult.LinkingV2 -> {
+                "v2 linking code\nversion ${parsed.version}\nchannel_id: ${parsed.channelId}\npublic_key: ${parsed.publicKey}"
+            }
+
+            is ExchangeV2CodeParseResult.RecoveryCode -> "recovery code\n${parsed.rawJson}"
+
+            is ExchangeV2CodeParseResult.Unknown -> decodedPayload
         }
     }
 
@@ -431,6 +468,30 @@ constructor(
                     }
                 }
             }
+        }
+    }
+
+    fun onCheckLinkingCodeClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            val useV2 = syncFeature.canUseV2ConnectFlow().isEnabled() && syncFeature.canShowV2ConnectCode().isEnabled()
+            viewState.update { it.copy(checkLinkingCodeResult = "Fetching ${if (useV2) "v2" else "v1"} linking code…") }
+            val result = if (useV2) fetchV2LinkingCode() else fetchV1LinkingCode()
+            viewState.update { it.copy(checkLinkingCodeResult = result) }
+        }
+    }
+
+    private fun fetchV1LinkingCode(): String =
+        when (val result = syncAccountRepository.getConnectQR()) {
+            is Success -> describeQrCode(result.data.qrCode)
+            is Error -> "Failed to fetch v1 connect code: $result"
+        }
+
+    private suspend fun fetchV2LinkingCode(): String {
+        val outcome = syncCodeDispatcher.presentV2().firstOrNull { it is DispatchOutcome.LinkingCodeReady || it is DispatchOutcome.Failed }
+        return when (outcome) {
+            is DispatchOutcome.LinkingCodeReady -> describeQrCode(outcome.linkingCode)
+            is DispatchOutcome.Failed -> "Failed to fetch v2 linking code: ${outcome.reason}"
+            else -> "v2 session ended without a linking code"
         }
     }
 

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -112,6 +112,13 @@
             app:showSwitch="true"
             app:primaryText="canShowV2ConnectCode (display, requires canUseV2ConnectFlow)" />
 
+        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+            android:id="@+id/canUseExchangeV2Point1"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="canUseExchangeV2.1"
+            app:showSwitch="true" />
+
         <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
             android:id="@+id/openV2PairingDebugButton"
             android:layout_width="wrap_content"
@@ -694,6 +701,28 @@
                 android:layout_height="wrap_content"
                 android:ellipsize="end"
                 android:maxLines="5"
+                app:typography="body2" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Check linking code" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/checkLinkingCodeCta"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/sync_internal_check_linking_code_cta"
+                app:daxButtonSize="large" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/checkLinkingCodeResultTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginTop="@dimen/keyline_2"
+                android:layout_marginEnd="@dimen/keyline_4"
                 app:typography="body2" />
 
             <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem

--- a/sync/sync-internal/src/main/res/values/donottranslate.xml
+++ b/sync/sync-internal/src/main/res/values/donottranslate.xml
@@ -31,6 +31,7 @@
     <string name="sync_internal_recovery_code">Recovery code</string>
     <string name="sync_internal_recovery_code_cta">Copy Recovery code</string>
     <string name="sync_internal_favicons_prompt_cta">Reset Favicons Prompt</string>
+    <string name="sync_internal_check_linking_code_cta">Check linking code</string>
     <string name="userIdSectionHeader">User ID</string>
     <string name="deviceIdSectionHeader">Device Id</string>
     <string name="deviceNameSectionHeader">Device Name</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1217367677188793
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1217626160385687
API Proposals URL(s) (if applicable): N/A

### Description

Adds a feature flag for the v2.1 exchange protocol and makes the device that presents a v2 linking QR code advertise the protocol version based on that flag.

- Adds the `canUseExchangeV2Point1` feature flag to `SyncFeature`. It is off by default, so nothing changes in the pairing flows until it is enabled.
- When the flag is enabled, the linking QR code presented by the host device advertises protocol version 2.1.
- Scanning behavior is unchanged: any 2.x linking code is accepted regardless of the flag.
- Introduces `ExchangeProtocolVersion`, a typed representation of the protocol version used when building and parsing linking codes. Versions are comparable, a missing minor component defaults to 0, any patch component is ignored, and unknown majors or malformed values are kept as an unsupported raw string instead of failing the parse.

Internal settings additions:
- A "canUseExchangeV2.1" toggle to override the new flag.
- A "Check linking code" section with a button that fetches the current linking code (v2 if the v2 connect flow flags are enabled, v1 otherwise) and prints its decoded contents, including the advertised version, channel id and public key.

### Steps to test this PR

_Advertise v2.1 in the linking code_
- [ ] Open Sync Internal Settings.
- [ ] Enable the "canUseV2ConnectFlow" toggle.
- [ ] Enable the "canShowV2ConnectCode" toggle.
- [ ] Enable the "canUseExchangeV2.1" toggle.
- [ ] Scroll down and tap "Create account" if you haven't already.
- [ ] Tap "Check linking code".
- [ ] Verify the result shows a v2 linking code with version 2.1.

_Default version stays 2_
- [ ] Disable the "canUseExchangeV2.1" toggle.
- [ ] Tap "Check linking code".
- [ ] Verify the result shows a v2 linking code with version 2.

_v1 linking code fallback_
- [ ] Disable the "canUseV2ConnectFlow" toggle.
- [ ] Disable the "canShowV2ConnectCode" toggle.
- [ ] Tap "Check linking code".
- [ ] Verify the result shows a v1 linking code.

_Pairing still works with the flag enabled_
- [ ] Enable the v2 connect flow flags and the "canUseExchangeV2.1" toggle.
- [ ] Pair the device with another device by scanning its QR code.
- [ ] Verify pairing completes successfully.

### UI changes
N/A

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync pairing protocol advertisement behind a default-off flag, but mis-flag rollout or version parsing could affect cross-device pairing compatibility.
> 
> **Overview**
> Introduces **typed exchange protocol versions** and a **feature-flagged v2.1 advertisement** when a device presents a v2 pairing QR code. Default behavior stays **version 2** until `canUseExchangeV2Point1` is enabled.
> 
> **`ExchangeProtocolVersion`** replaces raw version strings when building and parsing v2 linking codes: supported majors 1/2 with minor (patch ignored), comparison, and malformed/unknown majors as `Unsupported` without failing parse. **`ExchangeV2Runner.startPresent`** embeds **2.1** or **2** in the QR payload based on the new flag; scanning still accepts any **2.x** linking code. Hello/wire envelope versioning is unchanged (still `"2"`).
> 
> **Internal sync settings** add a **canUseExchangeV2.1** toggle and a **Check linking code** tool that fetches the current v1 or v2 linking code and shows decoded type, version, channel id, and public key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec9a178408ef37a503df10a98a662ce374715796. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->