### PR TITLE
Contextual/DuckAi: Fix auto-attach in chat in progress

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualEntryPromptStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualEntryPromptStore.kt
@@ -27,7 +27,8 @@ import javax.inject.Inject
  * straight into the chat (WEBVIEW) and auto-submit it, rather than reopening the initial input state.
  *
  * [serializedPageContext] is the page context the dialog had attached at submit time, so "Ask about
- * page" keeps its context across the hand-off.
+ * page" keeps its context across the hand-off. When it is null the dialog had no context attached
+ * (never available, or the user removed it), and the sheet must not auto-attach one on hand-off.
  */
 data class ContextualEntryPrompt(
     val tabId: String,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -156,6 +156,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         val contextUrl: String = "",
         val contextTitle: String = "",
         val tabId: String = "",
+        val userRemovedContext: Boolean = false,
         val isFireButtonEnabled: Boolean = false,
         val recentChats: List<ChatHistoryItem> = emptyList(),
     )
@@ -314,6 +315,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         _viewState.update {
             it.copy(
                 showContext = true,
+                userRemovedContext = false,
                 contextTitle = json.optString("title"),
                 contextUrl = json.optString("url"),
             )
@@ -550,7 +552,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
     fun removePageContext() {
         logcat { "Duck.ai Contextual: removePageContext" }
         _viewState.update { current ->
-            current.copy(showContext = false)
+            current.copy(showContext = false, userRemovedContext = true)
         }
         duckChatPixels.reportContextualPageContextRemovedNative()
     }
@@ -571,6 +573,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         _viewState.update { current ->
             current.copy(
                 showContext = true,
+                userRemovedContext = false,
                 contextTitle = json.optString("title"),
                 contextUrl = json.optString("url"),
             )
@@ -635,14 +638,35 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
             val url = json.optString("url")
 
             logcat { "Duck.ai: onPageContextReceived for url $url" }
-            _viewState.update { current ->
-                current.copy(
+            val current = _viewState.value
+            val allowsAutomaticContextAttachment = duckChatInternal.isAutomaticContextAttachmentEnabled()
+
+            val urlChanged = current.contextUrl.isNotEmpty() && url != current.contextUrl
+            val remainsUserRemoved = current.userRemovedContext && !urlChanged
+            val dropStaleAttachment = !allowsAutomaticContextAttachment && current.showContext && urlChanged
+
+            val showContext = when {
+                allowsAutomaticContextAttachment -> !remainsUserRemoved
+                dropStaleAttachment -> false
+                else -> current.showContext
+            }
+            val newlyAutoAttached = showContext && !current.showContext
+            if (showContext) {
+                pageContextState = pageContextState.copy(attachedPage = pageContext)
+            }
+            _viewState.update {
+                it.copy(
                     contextTitle = title,
                     contextUrl = url,
                     tabId = tabId,
+                    showContext = showContext,
+                    userRemovedContext = remainsUserRemoved,
                 )
             }
-            if (duckChatInternal.isAutomaticContextAttachmentEnabled() || duckChatInternal.areMultipleContentAttachmentsEnabled()) {
+            if (newlyAutoAttached) {
+                duckChatPixels.reportContextualPageContextAutoAttached()
+            }
+            if (allowsAutomaticContextAttachment || duckChatInternal.areMultipleContentAttachmentsEnabled()) {
                 val pageContextEvent = generatePageContextEventData()
                 viewModelScope.launch(dispatchers.main()) {
                     _subscriptionEventDataChannel.trySend(pageContextEvent)
@@ -727,6 +751,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
                     it.copy(
                         showFullscreen = true,
                         showContext = false,
+                        userRemovedContext = false,
                     )
                 }
                 val subscriptionEvent = duckChatJSHelper.onNativeAction(NativeAction.NEW_CHAT)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -304,11 +304,17 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         // to or remove from it.
         pendingEntryPrompt = entry.prompt
         pendingEntryPageContext = entry.serializedPageContext
+        val handedOffWithoutContext = entry.serializedPageContext == null
         val chatUrl = duckChat.getDuckChatUrl("", false, sidebar = true)
         withContext(dispatchers.main()) {
             setSheetUrl(chatUrl)
             _viewState.update {
-                it.copy(showFullscreen = hasChatId(chatUrl), tabId = tabId)
+                it.copy(
+                    showFullscreen = hasChatId(chatUrl),
+                    tabId = tabId,
+                    showContext = false,
+                    userRemovedContext = handedOffWithoutContext,
+                )
             }
             commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_EXPANDED))
             commandChannel.trySend(Command.LoadUrl(chatUrl))

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -111,6 +111,11 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
     // is ready (onWebAppReady). Held between opening the sheet and that ready signal.
     private var pendingEntryPrompt: NativeInputPrompt? = null
 
+    // The page context the entry dialog had attached to [pendingEntryPrompt] at hand-off (null if none).
+    // Frozen so the first webview prompt reflects the dialog's choice, regardless of the sheet's own
+    // native-input auto-attach that may run before the web app is ready.
+    private var pendingEntryPageContext: String? = null
+
     private var hidingSheetForNewChat = false
 
     sealed class Command {
@@ -294,31 +299,19 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         tabId: String,
         entry: ContextualEntryPrompt,
     ) {
+        // Freeze the prompt and the dialog's attachment decision (a page context, or none). The first
+        // webview prompt carries exactly this; the sheet's own native-input attachment state must not add
+        // to or remove from it.
         pendingEntryPrompt = entry.prompt
+        pendingEntryPageContext = entry.serializedPageContext
         val chatUrl = duckChat.getDuckChatUrl("", false, sidebar = true)
         withContext(dispatchers.main()) {
             setSheetUrl(chatUrl)
-            entry.serializedPageContext?.let { attachProvidedPageContext(it) }
             _viewState.update {
                 it.copy(showFullscreen = hasChatId(chatUrl), tabId = tabId)
             }
             commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_EXPANDED))
             commandChannel.trySend(Command.LoadUrl(chatUrl))
-        }
-    }
-
-    private fun attachProvidedPageContext(serializedPageContext: String) {
-        if (!isContextValid(serializedPageContext)) return
-        currentPageContext = serializedPageContext
-        pageContextState = pageContextState.copy(attachedPage = serializedPageContext)
-        val json = JSONObject(serializedPageContext)
-        _viewState.update {
-            it.copy(
-                showContext = true,
-                userRemovedContext = false,
-                contextTitle = json.optString("title"),
-                contextUrl = json.optString("url"),
-            )
         }
     }
 
@@ -329,14 +322,17 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
      */
     fun onWebAppReady() {
         val entry = pendingEntryPrompt ?: return
+        val entryPageContext = pendingEntryPageContext
         pendingEntryPrompt = null
-        onPromptSent(
+        pendingEntryPageContext = null
+        submitPrompt(
             prompt = entry.prompt,
             modelId = entry.modelId,
             reasoningEffort = entry.reasoningEffort,
             selectedTool = entry.selectedTool,
             imagesJson = entry.imagesJson,
             filesJson = entry.filesJson,
+            pageContextSerialized = entryPageContext,
         )
     }
 
@@ -349,8 +345,22 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         imagesJson: JSONArray? = null,
         filesJson: JSONArray? = null,
     ) {
+        val attachedContext = pageContextState.attachedPage.takeIf { _viewState.value.showContext }
+        submitPrompt(prompt, followUpPrefill, modelId, reasoningEffort, selectedTool, imagesJson, filesJson, attachedContext)
+    }
+
+    private fun submitPrompt(
+        prompt: String,
+        followUpPrefill: String? = null,
+        modelId: String? = null,
+        reasoningEffort: String? = null,
+        selectedTool: String? = null,
+        imagesJson: JSONArray? = null,
+        filesJson: JSONArray? = null,
+        pageContextSerialized: String?,
+    ) {
         viewModelScope.launch(dispatchers.io()) {
-            val contextPrompt = generateContextPrompt(prompt, modelId, reasoningEffort, selectedTool, imagesJson, filesJson)
+            val contextPrompt = generateContextPrompt(prompt, modelId, reasoningEffort, selectedTool, imagesJson, filesJson, pageContextSerialized)
             val prefillText = followUpPrefill?.takeIf { it.isNotEmpty() }
             val prefillEvent = prefillText?.let { generatePrefillEvent(it) }
             withContext(dispatchers.main()) {
@@ -437,20 +447,12 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         selectedTool: String? = null,
         imagesJson: JSONArray? = null,
         filesJson: JSONArray? = null,
+        pageContextSerialized: String?,
     ): SubscriptionEventData {
-        val viewState = _viewState.value
         val pageContext =
-            if (viewState.showContext) {
-                pageContextState.attachedPage
-                    .takeIf { it.isNotBlank() }
-                    ?.let { runCatching { JSONObject(it) }.getOrNull() }
-                    ?: run {
-                        logcat { "Duck.ai: no pageContext available, skipping pageContext in prompt" }
-                        null
-                    }
-            } else {
-                null
-            }
+            pageContextSerialized
+                ?.takeIf { it.isNotBlank() }
+                ?.let { runCatching { JSONObject(it) }.getOrNull() }
 
         if (pageContext == null) {
             duckChatPixels.reportContextualPromptSubmittedWithoutContextNative()
@@ -507,7 +509,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         }
 
         val params = JSONObject().apply {
-            if (duckChatInternal.isAutomaticContextAttachmentEnabled()) {
+            if (duckChatInternal.isAutomaticContextAttachmentEnabled() && _viewState.value.showContext) {
                 put("pageContext", pageContext)
             } else {
                 put("pageContext", null)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
@@ -107,4 +107,20 @@ class DuckChatContextualEntryViewModelTest {
         verify(store).store(captor.capture())
         assertNull(captor.firstValue.serializedPageContext)
     }
+
+    @Test
+    fun whenContextRemovedThenPromptStoredWithNullContext() = runTest {
+        viewModel.start("tab-1")
+        viewModel.onPageContextReceived(validContext)
+        viewModel.onContextRemoved()
+
+        viewModel.commands.test {
+            viewModel.onPromptSubmitted(samplePrompt)
+            assertEquals(DuckChatContextualEntryViewModel.Command.HandOffToSheet, awaitItem())
+        }
+
+        val captor = argumentCaptor<ContextualEntryPrompt>()
+        verify(store).store(captor.capture())
+        assertNull(captor.firstValue.serializedPageContext)
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -226,12 +226,12 @@ class DuckChatContextualWebViewViewModelTest {
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
 
         testee.subscriptionEventDataFlow.test {
-            // The sheet's native input auto-attaches the page before the web app is ready...
+            // The entry dialog handed off no context, so the sheet must not auto-attach the current page...
             testee.onPageContextReceived("tab-1", serializedPageData)
             assertEquals("submitAIChatPageContext", awaitItem().subscriptionName)
-            assertTrue(testee.viewState.value.showContext)
+            assertFalse(testee.viewState.value.showContext)
 
-            // ...but the first prompt is frozen to the entry dialog's (empty) attachment, so it carries none.
+            // ...and the first prompt is frozen to the entry dialog's (empty) attachment, so it carries none.
             testee.onWebAppReady()
             val promptEvent = awaitItem()
             assertEquals("submitAIChatNativePrompt", promptEvent.subscriptionName)
@@ -258,6 +258,69 @@ class DuckChatContextualWebViewViewModelTest {
             assertEquals("Page Title", promptEvent.params.getJSONObject("pageContext").getString("title"))
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `no-context entry hand-off does not re-attach the current page while it stays put`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+
+        // A repeated report for the same page still must not auto-attach.
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+    }
+
+    @Test
+    fun `no-context entry hand-off re-attaches after the user navigates to a new page`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+
+        val otherPageData =
+            """
+            {
+                "title": "Other Page",
+                "url": "https://other.example.com",
+                "content": "Other extracted DOM text...",
+                "truncated": false,
+                "fullContentLength": 4321
+            }
+            """.trimIndent()
+        testee.onPageContextReceived("tab-1", otherPageData)
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("Other Page", testee.viewState.value.contextTitle)
+    }
+
+    @Test
+    fun `no-context entry hand-off re-attaches when the user manually attaches`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        assertFalse(testee.viewState.value.showContext)
+
+        testee.addPageContext()
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("Page Title", testee.viewState.value.contextTitle)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -215,6 +215,52 @@ class DuckChatContextualWebViewViewModelTest {
     }
 
     @Test
+    fun `native input auto-attach during hand-off does not add context to the first prompt`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = null))
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.subscriptionEventDataFlow.test {
+            // The sheet's native input auto-attaches the page before the web app is ready...
+            testee.onPageContextReceived("tab-1", serializedPageData)
+            assertEquals("submitAIChatPageContext", awaitItem().subscriptionName)
+            assertTrue(testee.viewState.value.showContext)
+
+            // ...but the first prompt is frozen to the entry dialog's (empty) attachment, so it carries none.
+            testee.onWebAppReady()
+            val promptEvent = awaitItem()
+            assertEquals("submitAIChatNativePrompt", promptEvent.subscriptionName)
+            assertTrue(promptEvent.params.isNull("pageContext"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `first prompt from a with-context entry hand-off carries the entry page context`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1"))
+            .thenReturn(ContextualEntryPrompt("tab-1", prompt, serializedPageContext = serializedPageData))
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.subscriptionEventDataFlow.test {
+            testee.onWebAppReady()
+
+            val promptEvent = awaitItem()
+            assertEquals("submitAIChatNativePrompt", promptEvent.subscriptionName)
+            assertEquals("Page Title", promptEvent.params.getJSONObject("pageContext").getString("title"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `onNewChatRequestedFromPopup resets chat and hands off to the entry dialog`() = runTest {
         testee.onSheetOpened("tab-1")
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -183,6 +183,38 @@ class DuckChatContextualWebViewViewModelTest {
     }
 
     @Test
+    fun `onPageContextReceived auto-attaches the current context when automatic attachment is enabled`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("Page Title", testee.viewState.value.contextTitle)
+        verify(duckChatPixels).reportContextualPageContextAutoAttached()
+    }
+
+    @Test
+    fun `onPageContextReceived does not auto-attach when automatic attachment is disabled`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+
+        assertFalse(testee.viewState.value.showContext)
+        verify(duckChatPixels, never()).reportContextualPageContextAutoAttached()
+    }
+
+    @Test
+    fun `onPageContextReceived does not re-attach context the user removed`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+
+        testee.onPageContextReceived("tab-1", serializedPageData)
+        testee.removePageContext()
+        testee.onPageContextReceived("tab-1", serializedPageData)
+
+        assertFalse(testee.viewState.value.showContext)
+    }
+
+    @Test
     fun `onNewChatRequestedFromPopup resets chat and hands off to the entry dialog`() = runTest {
         testee.onSheetOpened("tab-1")
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217584535708602?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

### Steps to test this PR

_Enable auto attach feature + contextualRedesign (FF)_
- [x] Load a website
- [x] Select Ask About Page
- [x] Select a suggested prompt / send any prompt
- [x] Verify that the chat in progress / webview sheet shows and has context attached (which is the current page)
- [x] Close the sheet and navigate to another site and reopen the sheet
- [x] Verify that the attached context is correct and updated.
- [x] Remove the attached context and close the sheet. 
- [x] Reopen and verify that context is NOT reattached.
- [x] Navigate to a new site on the same tab
- [x] Reopen and verify that new context is re-attached
- [x] Do this a few times and quickly / different tabs and verify everything looks as expected - pay attention to native input (state should be the consistent).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hand-off and auto-attach logic for page context in contextual chat, affecting what the web app receives on first prompt and on reopen; behavior is well covered by new tests but touches core contextual UX.
> 
> **Overview**
> Fixes **contextual Duck.ai** page-context behavior when auto-attach is on and the user moves from the entry dialog into the chat-in-progress sheet.
> 
> **Entry → sheet hand-off:** The first submitted prompt now uses the **frozen** page context from the entry dialog (`serializedPageContext`), not whatever the sheet’s native input might auto-attach before the web app is ready. A null hand-off means the user had no context (or removed it); the sheet sets `userRemovedContext` and must not auto-attach on that path.
> 
> **Auto-attach while the sheet is open:** `onPageContextReceived` can show the context chip and sync `attachedPage` when automatic attachment is enabled. If the user removed context, it stays off until they **navigate to a different URL** or **manually attach** again. Page-context events to the web app only send data when `showContext` is true.
> 
> **Prompt submission:** `submitPrompt` / `generateContextPrompt` take an explicit page context string instead of inferring it only from view state, so entry hand-off and follow-up prompts stay consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5d49365dde2370f0bcba7bc9918f7a5ca31916d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->