### PR TITLE
Refactor Exchange v2 envelope handling

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -96,6 +96,12 @@ interface SyncFeature {
     fun canShowV2ConnectCode(): Toggle
 
     /**
+     * Global switch for the v2.1 exchange protocol.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun canUseExchangeV2Point1(): Toggle
+
+    /**
      * When enabled, the sync barcode scanner only attempts to decode QR codes. Sync codes are
      * always encoded as QR, so other formats only add noise (and false-positive decodes) to
      * the scanner.

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/ExchangeProtocolVersion.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/ExchangeProtocolVersion.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange
+
+sealed class ExchangeProtocolVersion : Comparable<ExchangeProtocolVersion> {
+
+    sealed class Supported : ExchangeProtocolVersion() {
+        abstract val major: Int
+        abstract val minor: Int
+
+        final override fun toString() = if (minor == 0) "$major" else "$major.$minor"
+    }
+
+    data class V1(
+        override val minor: Int,
+    ) : Supported() {
+        override val major get() = MAJOR
+
+        companion object {
+            const val MAJOR = 1
+        }
+    }
+
+    data class V2(
+        override val minor: Int,
+    ) : Supported() {
+        override val major get() = MAJOR
+
+        companion object {
+            const val MAJOR = 2
+        }
+    }
+
+    data class Unsupported(
+        val rawVersion: String,
+    ) : ExchangeProtocolVersion() {
+        override fun toString() = rawVersion
+    }
+
+    override fun compareTo(other: ExchangeProtocolVersion): Int = when {
+        this is Supported && other is Supported -> compareValuesBy(this, other, Supported::major, Supported::minor)
+        this is Unsupported && other is Unsupported -> rawVersion.compareTo(other.rawVersion)
+        this is Supported -> -1
+        else -> 1
+    }
+
+    companion object {
+        val V1_0 = V1(minor = 0)
+        val V2_0 = V2(minor = 0)
+        val V2_1 = V2(minor = 1)
+
+        fun parse(rawVersion: String): Result<ExchangeProtocolVersion> = runCatching {
+            val components = rawVersion.split('.').map { it.toInt() }
+            val major = components[0]
+            val minor = components.getOrNull(1) ?: 0
+            when (major) {
+                V1.MAJOR -> V1(minor)
+                V2.MAJOR -> V2(minor)
+                else -> Unsupported(rawVersion)
+            }
+        }
+
+        fun parseOrUnsupported(rawVersion: String): ExchangeProtocolVersion = parse(rawVersion).getOrElse { Unsupported(rawVersion) }
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
@@ -51,10 +51,10 @@ interface ExchangeV2Channel {
     fun createChannel(channelId: String): Result<Unit>
 
     /**
-     * Encrypt [messageJson] and send it to [peerChannelId]. Sender's kid is [ownChannelId].
+     * Encrypt [message] and send it to [peerChannelId]. Sender's kid is [ownChannelId].
      */
     fun sendMessage(
-        messageJson: String,
+        message: ExchangeV2Message,
         peerChannelId: String,
         peerPublicKeyBase64: String,
         ownChannelId: String,
@@ -85,13 +85,13 @@ class RealExchangeV2Channel @Inject constructor(
     }
 
     override fun sendMessage(
-        messageJson: String,
+        message: ExchangeV2Message,
         peerChannelId: String,
         peerPublicKeyBase64: String,
         ownChannelId: String,
     ): Result<Unit> {
         val sealed = runCatching {
-            envelope.seal(messageJson, peerPublicKeyBase64, ownChannelId)
+            envelope.seal(message, peerPublicKeyBase64, ownChannelId)
         }.getOrElse {
             logcat(ERROR) { "Sync-ExchangeV2: seal failed: ${it.message}" }
             return Result.Error(reason = "Failed to seal envelope: ${it.message}")

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Envelope.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Envelope.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl.exchange.v2
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.ExchangeEnvelope
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
@@ -35,10 +36,10 @@ import javax.inject.Inject
 interface ExchangeV2Envelope {
 
     /**
-     * Build an outbound envelope encrypting [messageJson] to the recipient's [peerPublicKeyBase64].
+     * Build an outbound envelope encrypting [message] to the recipient's [peerPublicKeyBase64].
      * [senderChannelId] is written as the JWE `kid` header so the recipient knows the sender.
      */
-    fun seal(messageJson: String, peerPublicKeyBase64: String, senderChannelId: String): ExchangeEnvelope
+    fun seal(message: ExchangeV2Message, peerPublicKeyBase64: String, senderChannelId: String): ExchangeEnvelope
 
     /**
      * Decrypt an inbound envelope with our ephemeral private key, returning the inner message JSON.
@@ -49,8 +50,8 @@ interface ExchangeV2Envelope {
 }
 
 /** Thrown when an envelope requires a protocol version we don't support. */
-class EnvelopeVersionTooNew(val version: String) : RuntimeException(
-    "Envelope requires protocol v$version; we only support v$OUR_MAJOR",
+class EnvelopeVersionTooNew(val version: ExchangeProtocolVersion) : RuntimeException(
+    "Envelope requires protocol v$version; we only support up to v${ExchangeProtocolVersion.V2.MAJOR}",
 )
 
 /**
@@ -62,34 +63,37 @@ class EnvelopeDecryptFailure(val seq: Int, cause: Throwable) : RuntimeException(
     cause,
 )
 
-const val OUR_MAJOR: Int = 2
-const val OUR_VERSION_STRING: String = "2"
-
 @ContributesBinding(AppScope::class)
 class RealExchangeV2Envelope @Inject constructor(
     private val jweCrypto: SyncJweCrypto,
 ) : ExchangeV2Envelope {
 
-    override fun seal(messageJson: String, peerPublicKeyBase64: String, senderChannelId: String): ExchangeEnvelope {
+    override fun seal(message: ExchangeV2Message, peerPublicKeyBase64: String, senderChannelId: String): ExchangeEnvelope {
         val jwe = jweCrypto.jweEncryptRsaOaep(
-            plaintext = messageJson.toByteArray(Charsets.UTF_8),
+            plaintext = message.rawJson.toByteArray(Charsets.UTF_8),
             recipientPublicKeyBase64 = peerPublicKeyBase64,
             kid = senderChannelId,
         )
-        return ExchangeEnvelope(version = OUR_VERSION_STRING, payload = jwe)
+        return ExchangeEnvelope(version = message.protocolVersion.toString(), payload = jwe)
     }
 
     override fun open(envelope: ExchangeEnvelope, ownPrivateKeyBase64: String): String {
-        val major = parseMajor(envelope.version)
-        if (major > OUR_MAJOR) throw EnvelopeVersionTooNew(envelope.version)
-        if (major < OUR_MAJOR) throw IllegalArgumentException("Obsolete envelope version ${envelope.version}")
-        val decrypted = jweCrypto.jweDecryptRsaOaep(envelope.payload, ownPrivateKeyBase64)
-        return String(decrypted, Charsets.UTF_8)
-    }
+        val protocol = ExchangeProtocolVersion.parse(envelope.version).getOrElse {
+            throw IllegalArgumentException("Malformed envelope version: ${envelope.version}")
+        }
+        return when (protocol) {
+            is ExchangeProtocolVersion.V2 -> {
+                val decrypted = jweCrypto.jweDecryptRsaOaep(envelope.payload, ownPrivateKeyBase64)
+                String(decrypted, Charsets.UTF_8)
+            }
 
-    private fun parseMajor(version: String): Int {
-        val majorPart = version.substringBefore('.')
-        return majorPart.toIntOrNull()
-            ?: throw IllegalArgumentException("Malformed envelope version: $version")
+            is ExchangeProtocolVersion.V1 -> {
+                throw IllegalArgumentException("Obsolete envelope version $protocol")
+            }
+
+            else -> {
+                throw EnvelopeVersionTooNew(protocol)
+            }
+        }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Message.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Message.kt
@@ -16,15 +16,37 @@
 
 package com.duckduckgo.sync.impl.exchange.v2
 
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import org.json.JSONObject
+
 /**
  * Wire messages exchanged over the v2 /sync/v2/exchange/{channelId} channel.
  *
- * Spec: Asana 1215056232572322 (Exchange V2 Message Sequence State Machine).
- * Each subtype carries its raw JSON for replay/inspection.
+ * Each message is a JSON object identified by its `type` field, carried inside an encrypted relay
+ * envelope. The envelope is not a message type itself: it holds `version` (the protocol version
+ * required to process it) and `payload` (the JWE compact serialization of the encrypted message
+ * JSON, whose `kid` header is the sender's channel ID).
+ *
+ * Spec: Asana 1215056232572321 (Exchange V2 Messages), 1215056232572322 (Exchange V2 Message
+ * Sequence State Machine).
  */
 sealed interface ExchangeV2Message {
+    /**
+     * The message JSON exactly as it goes on (or came off) the wire, before envelope encryption.
+     * Kept verbatim so a received message can be re-read or logged without lossy reserialization,
+     * including any fields this version of the client doesn't model.
+     */
     val rawJson: String
+
+    /** Value of the message's `type` field, which identifies the message on the wire. */
     val messageType: String
+
+    /**
+     * Lowest protocol version a receiver needs in order to process this message — what goes into
+     * `envelope.version`. A property of the message, not of the sending device, and unrelated to
+     * the version negotiated for the session.
+     */
+    val protocolVersion: ExchangeProtocolVersion.V2
 
     /**
      * Sent by the Scanner to the Presenter's relay channel to open the session.
@@ -33,115 +55,305 @@ sealed interface ExchangeV2Message {
      *  it as the address for replies.
      * @param publicKey Scanner's session public key (base64url-encoded SPKI DER); used to
      *  encrypt all subsequent messages addressed to the Scanner.
-     * @param version Sender's minimum protocol version (e.g. "2", "2.1").
+     * @param version The version the sender speaks (e.g. "2", "2.1"; defaults to "2"). Not a
+     *  minimum requirement on the receiver — that is `envelope.version`. It lets the peer adjust
+     *  its capabilities, and is the input to capability negotiation.
      */
-    data class Hello(
+    @ConsistentCopyVisibility
+    data class Hello private constructor(
         override val rawJson: String,
-        val channelId: String = "",
-        val publicKey: String = "",
-        val version: String = "2",
+        val channelId: String,
+        val publicKey: String,
+        val version: ExchangeProtocolVersion,
     ) : ExchangeV2Message {
         override val messageType: String = TYPE
+        override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
             const val TYPE = "hello"
+
+            private val DEFAULT_VERSION = ExchangeProtocolVersion.V2_0
+
+            private const val FIELD_CHANNEL_ID = "channel_id"
+            private const val FIELD_PUBLIC_KEY = "public_key"
+            private const val FIELD_VERSION = "version"
+
+            fun create(
+                channelId: String,
+                publicKey: String,
+                version: ExchangeProtocolVersion,
+            ) = Hello(
+                rawJson = buildMessageJson(TYPE) {
+                    put(FIELD_CHANNEL_ID, channelId)
+                    put(FIELD_PUBLIC_KEY, publicKey)
+                    put(FIELD_VERSION, version.toString())
+                },
+                channelId = channelId,
+                publicKey = publicKey,
+                version = version,
+            )
+
+            fun fromJson(rawJson: String): Hello {
+                val json = JSONObject(rawJson)
+                val rawVersion = json.optString(FIELD_VERSION, "")
+                return Hello(
+                    rawJson = rawJson,
+                    channelId = json.optString(FIELD_CHANNEL_ID, ""),
+                    publicKey = json.optString(FIELD_PUBLIC_KEY, ""),
+                    // Spec: an absent version means the sender speaks 2.
+                    version = if (rawVersion.isBlank()) DEFAULT_VERSION else ExchangeProtocolVersion.parseOrUnsupported(rawVersion),
+                )
+            }
         }
     }
 
     /**
-     * Sender has a sync account. Carries [userId] for same-account detection, [kind] (ddg
-     * or 3party) for cross-kind role election, and human-readable [name] for the user UI.
+     * Sent by either device during negotiation to declare it has a sync account.
+     *
+     * @param userId Identifies the sender's account. If both sides send the same [userId] the
+     *  session must be aborted — the devices are already on the same account.
+     * @param name Human-readable device name shown to the peer.
+     * @param kind Device kind, "ddg" or "3party"; drives cross-kind role election.
      */
-    data class RecoveryCodeAvailable(
+    @ConsistentCopyVisibility
+    data class RecoveryCodeAvailable private constructor(
         override val rawJson: String,
         val userId: String,
         val name: String,
         val kind: String,
     ) : ExchangeV2Message {
         override val messageType: String = TYPE
+        override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
             const val TYPE = "recovery_code_available"
+
+            private const val FIELD_USER_ID = "user_id"
+            private const val FIELD_NAME = "name"
+            private const val FIELD_KIND = "kind"
+
+            fun create(
+                userId: String,
+                name: String,
+                kind: String,
+            ) = RecoveryCodeAvailable(
+                rawJson = buildMessageJson(TYPE) {
+                    put(FIELD_USER_ID, userId)
+                    put(FIELD_NAME, name)
+                    put(FIELD_KIND, kind)
+                },
+                userId = userId,
+                name = name,
+                kind = kind,
+            )
+
+            // NOTE: a recovery_code_available semantically must carry a user_id (the sender has
+            // an account), but we currently accept a missing/blank one as userId="" rather than
+            // rejecting it — downstream this affects same-account detection and role election.
+            // Hardening (reject or drop as malformed) is tracked separately in Asana
+            // 1215414930715623; left lenient here for forward-compat.
+            fun fromJson(rawJson: String): RecoveryCodeAvailable {
+                val json = JSONObject(rawJson)
+                return RecoveryCodeAvailable(
+                    rawJson = rawJson,
+                    userId = json.optString(FIELD_USER_ID, ""),
+                    name = json.optString(FIELD_NAME, ""),
+                    kind = json.optString(FIELD_KIND, ""),
+                )
+            }
         }
     }
 
     /**
-     * Sender has no sync account. Carries [kind] and [name]; user_id is implied null.
+     * Sent by either device during negotiation to declare it has no sync account. No user_id
+     * accompanies it.
+     *
+     * @param name Human-readable device name shown to the peer.
+     * @param kind Device kind, "ddg" or "3party"; drives cross-kind role election.
      */
-    data class RecoveryCodeRequest(
+    @ConsistentCopyVisibility
+    data class RecoveryCodeRequest private constructor(
         override val rawJson: String,
         val name: String,
         val kind: String,
     ) : ExchangeV2Message {
         override val messageType: String = TYPE
+        override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
             const val TYPE = "recovery_code_request"
-        }
-    }
 
-    data class RecoveryCodeAwaitingConfirmation(
-        override val rawJson: String,
-    ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+            private const val FIELD_NAME = "name"
+            private const val FIELD_KIND = "kind"
 
-        companion object {
-            const val TYPE = "recovery_code_awaiting_confirmation"
-        }
-    }
+            fun create(
+                name: String,
+                kind: String,
+            ) = RecoveryCodeRequest(
+                rawJson = buildMessageJson(TYPE) {
+                    put(FIELD_NAME, name)
+                    put(FIELD_KIND, kind)
+                },
+                name = name,
+                kind = kind,
+            )
 
-    data class RecoveryCodeConfirmed(
-        override val rawJson: String,
-    ) : ExchangeV2Message {
-        override val messageType: String = TYPE
-
-        companion object {
-            const val TYPE = "recovery_code_confirmed"
-        }
-    }
-
-    data class RecoveryCodeDenied(
-        override val rawJson: String,
-    ) : ExchangeV2Message {
-        override val messageType: String = TYPE
-
-        companion object {
-            const val TYPE = "recovery_code_denied"
-        }
-    }
-
-    data class RecoveryCodeUnavailable(
-        override val rawJson: String,
-    ) : ExchangeV2Message {
-        override val messageType: String = TYPE
-
-        companion object {
-            const val TYPE = "recovery_code_unavailable"
+            fun fromJson(rawJson: String): RecoveryCodeRequest {
+                val json = JSONObject(rawJson)
+                return RecoveryCodeRequest(
+                    rawJson = rawJson,
+                    name = json.optString(FIELD_NAME, ""),
+                    kind = json.optString(FIELD_KIND, ""),
+                )
+            }
         }
     }
 
     /**
-     * Sent by the Host carrying the actual recovery code. Terminal happy-path message.
+     * Sent by the Host to signal it is currently prompting its user.
+     *
+     * The Joiner already confirmed locally before entering the message loop, so no action is
+     * required. A UI may use it to show a hint such as "Check the other device".
+     */
+    @ConsistentCopyVisibility
+    data class RecoveryCodeAwaitingConfirmation private constructor(
+        override val rawJson: String,
+    ) : ExchangeV2Message {
+        override val messageType: String = TYPE
+        override val protocolVersion get() = ExchangeProtocolVersion.V2_0
+
+        companion object {
+            const val TYPE = "recovery_code_awaiting_confirmation"
+
+            fun create() = RecoveryCodeAwaitingConfirmation(buildMessageJson(TYPE))
+
+            fun fromJson(rawJson: String) = RecoveryCodeAwaitingConfirmation(rawJson)
+        }
+    }
+
+    /**
+     * Sent by the Host after its user approved, signaling the recovery code is about to follow.
+     *
+     * The Joiner must accept [RecoveryCodeResponse] regardless of whether this message was seen
+     * first.
+     */
+    @ConsistentCopyVisibility
+    data class RecoveryCodeConfirmed private constructor(
+        override val rawJson: String,
+    ) : ExchangeV2Message {
+        override val messageType: String = TYPE
+        override val protocolVersion get() = ExchangeProtocolVersion.V2_0
+
+        companion object {
+            const val TYPE = "recovery_code_confirmed"
+
+            fun create() = RecoveryCodeConfirmed(buildMessageJson(TYPE))
+
+            fun fromJson(rawJson: String) = RecoveryCodeConfirmed(rawJson)
+        }
+    }
+
+    /**
+     * Sent by the Host when its user declined to share the recovery code. The Joiner must abort the
+     * session on receiving this.
+     */
+    @ConsistentCopyVisibility
+    data class RecoveryCodeDenied private constructor(
+        override val rawJson: String,
+    ) : ExchangeV2Message {
+        override val messageType: String = TYPE
+        override val protocolVersion get() = ExchangeProtocolVersion.V2_0
+
+        companion object {
+            const val TYPE = "recovery_code_denied"
+
+            fun create() = RecoveryCodeDenied(buildMessageJson(TYPE))
+
+            fun fromJson(rawJson: String) = RecoveryCodeDenied(rawJson)
+        }
+    }
+
+    /**
+     * Sent by the Host when it cannot supply a recovery code (e.g. no account exists and creation
+     * failed). The Joiner must abort the session on receiving this.
+     */
+    @ConsistentCopyVisibility
+    data class RecoveryCodeUnavailable private constructor(
+        override val rawJson: String,
+    ) : ExchangeV2Message {
+        override val messageType: String = TYPE
+        override val protocolVersion get() = ExchangeProtocolVersion.V2_0
+
+        companion object {
+            const val TYPE = "recovery_code_unavailable"
+
+            fun create() = RecoveryCodeUnavailable(buildMessageJson(TYPE))
+
+            fun fromJson(rawJson: String) = RecoveryCodeUnavailable(rawJson)
+        }
+    }
+
+    /**
+     * Sent by the Host carrying the actual recovery code. Terminal message of a successful pairing
+     * exchange.
      *
      * @param recoveryCode base64url-encoded recovery code payload.
      */
-    data class RecoveryCodeResponse(
+    @ConsistentCopyVisibility
+    data class RecoveryCodeResponse private constructor(
         override val rawJson: String,
-        val recoveryCode: String = "",
+        val recoveryCode: String,
     ) : ExchangeV2Message {
         override val messageType: String = TYPE
+        override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
             const val TYPE = "recovery_code_response"
+            private const val FIELD_RECOVERY_CODE = "recovery_code"
+
+            fun create(recoveryCode: String) = RecoveryCodeResponse(
+                rawJson = buildMessageJson(TYPE) { put(FIELD_RECOVERY_CODE, recoveryCode) },
+                recoveryCode = recoveryCode,
+            )
+
+            fun fromJson(rawJson: String): RecoveryCodeResponse {
+                val json = JSONObject(rawJson)
+                return RecoveryCodeResponse(
+                    rawJson = rawJson,
+                    recoveryCode = json.optString(FIELD_RECOVERY_CODE, ""),
+                )
+            }
         }
     }
 
     /**
      * Forward-compatibility variant: a message whose type field doesn't match any known
      * value. The SM drops these without changing state per the spec's forward-compat rule.
+     *
+     * Inbound only — we never send a type we don't know so there is no `create`.
      */
-    data class Unknown(
+    @ConsistentCopyVisibility
+    data class Unknown private constructor(
         override val rawJson: String,
         override val messageType: String,
-    ) : ExchangeV2Message
+    ) : ExchangeV2Message {
+        /** Inert: we only ever receive these, so this is never written to an envelope. */
+        override val protocolVersion get() = ExchangeProtocolVersion.V2_0
+
+        companion object {
+            fun fromJson(rawJson: String, messageType: String) = Unknown(rawJson, messageType)
+        }
+    }
+
+    companion object {
+        internal const val FIELD_TYPE = "type"
+    }
 }
+
+private fun buildMessageJson(
+    type: String,
+    fields: JSONObject.() -> Unit = {},
+): String = JSONObject().apply {
+    put(ExchangeV2Message.FIELD_TYPE, type)
+    fields()
+}.toString()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Message.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Message.kt
@@ -59,8 +59,7 @@ sealed interface ExchangeV2Message {
      *  minimum requirement on the receiver — that is `envelope.version`. It lets the peer adjust
      *  its capabilities, and is the input to capability negotiation.
      */
-    @ConsistentCopyVisibility
-    data class Hello private constructor(
+    data class Hello(
         override val rawJson: String,
         val channelId: String,
         val publicKey: String,
@@ -115,8 +114,7 @@ sealed interface ExchangeV2Message {
      * @param name Human-readable device name shown to the peer.
      * @param kind Device kind, "ddg" or "3party"; drives cross-kind role election.
      */
-    @ConsistentCopyVisibility
-    data class RecoveryCodeAvailable private constructor(
+    data class RecoveryCodeAvailable(
         override val rawJson: String,
         val userId: String,
         val name: String,
@@ -171,8 +169,7 @@ sealed interface ExchangeV2Message {
      * @param name Human-readable device name shown to the peer.
      * @param kind Device kind, "ddg" or "3party"; drives cross-kind role election.
      */
-    @ConsistentCopyVisibility
-    data class RecoveryCodeRequest private constructor(
+    data class RecoveryCodeRequest(
         override val rawJson: String,
         val name: String,
         val kind: String,
@@ -215,8 +212,7 @@ sealed interface ExchangeV2Message {
      * The Joiner already confirmed locally before entering the message loop, so no action is
      * required. A UI may use it to show a hint such as "Check the other device".
      */
-    @ConsistentCopyVisibility
-    data class RecoveryCodeAwaitingConfirmation private constructor(
+    data class RecoveryCodeAwaitingConfirmation(
         override val rawJson: String,
     ) : ExchangeV2Message {
         override val messageType: String = TYPE
@@ -237,8 +233,7 @@ sealed interface ExchangeV2Message {
      * The Joiner must accept [RecoveryCodeResponse] regardless of whether this message was seen
      * first.
      */
-    @ConsistentCopyVisibility
-    data class RecoveryCodeConfirmed private constructor(
+    data class RecoveryCodeConfirmed(
         override val rawJson: String,
     ) : ExchangeV2Message {
         override val messageType: String = TYPE
@@ -257,8 +252,7 @@ sealed interface ExchangeV2Message {
      * Sent by the Host when its user declined to share the recovery code. The Joiner must abort the
      * session on receiving this.
      */
-    @ConsistentCopyVisibility
-    data class RecoveryCodeDenied private constructor(
+    data class RecoveryCodeDenied(
         override val rawJson: String,
     ) : ExchangeV2Message {
         override val messageType: String = TYPE
@@ -277,8 +271,7 @@ sealed interface ExchangeV2Message {
      * Sent by the Host when it cannot supply a recovery code (e.g. no account exists and creation
      * failed). The Joiner must abort the session on receiving this.
      */
-    @ConsistentCopyVisibility
-    data class RecoveryCodeUnavailable private constructor(
+    data class RecoveryCodeUnavailable(
         override val rawJson: String,
     ) : ExchangeV2Message {
         override val messageType: String = TYPE
@@ -299,8 +292,7 @@ sealed interface ExchangeV2Message {
      *
      * @param recoveryCode base64url-encoded recovery code payload.
      */
-    @ConsistentCopyVisibility
-    data class RecoveryCodeResponse private constructor(
+    data class RecoveryCodeResponse(
         override val rawJson: String,
         val recoveryCode: String,
     ) : ExchangeV2Message {
@@ -332,8 +324,7 @@ sealed interface ExchangeV2Message {
      *
      * Inbound only — we never send a type we don't know so there is no `create`.
      */
-    @ConsistentCopyVisibility
-    data class Unknown private constructor(
+    data class Unknown(
         override val rawJson: String,
         override val messageType: String,
     ) : ExchangeV2Message {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2MessageParser.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2MessageParser.kt
@@ -29,52 +29,20 @@ interface ExchangeV2MessageParser {
 class JsonExchangeV2MessageParser @Inject constructor() : ExchangeV2MessageParser {
 
     override fun parse(rawJson: String): ExchangeV2Message {
-        val json = runCatching { JSONObject(rawJson) }.getOrNull()
-            ?: return ExchangeV2Message.Unknown(rawJson = rawJson, messageType = "")
-        return when (val type = json.optString(FIELD_TYPE, "")) {
-            ExchangeV2Message.Hello.TYPE -> ExchangeV2Message.Hello(
-                rawJson = rawJson,
-                channelId = json.optString(FIELD_CHANNEL_ID, ""),
-                publicKey = json.optString(FIELD_PUBLIC_KEY, ""),
-                version = json.optString(FIELD_VERSION, DEFAULT_VERSION),
-            )
-            // NOTE: a recovery_code_available semantically must carry a user_id (the sender has
-            // an account), but we currently accept a missing/blank one as userId="" rather than
-            // rejecting it — downstream this affects same-account detection and role election.
-            // Hardening (reject or drop as malformed) is tracked separately in Asana
-            // 1215414930715623; left lenient here for forward-compat.
-            ExchangeV2Message.RecoveryCodeAvailable.TYPE -> ExchangeV2Message.RecoveryCodeAvailable(
-                rawJson = rawJson,
-                userId = json.optString(FIELD_USER_ID, ""),
-                name = json.optString(FIELD_NAME, ""),
-                kind = json.optString(FIELD_KIND, ""),
-            )
-            ExchangeV2Message.RecoveryCodeRequest.TYPE -> ExchangeV2Message.RecoveryCodeRequest(
-                rawJson = rawJson,
-                name = json.optString(FIELD_NAME, ""),
-                kind = json.optString(FIELD_KIND, ""),
-            )
-            ExchangeV2Message.RecoveryCodeAwaitingConfirmation.TYPE -> ExchangeV2Message.RecoveryCodeAwaitingConfirmation(rawJson)
-            ExchangeV2Message.RecoveryCodeConfirmed.TYPE -> ExchangeV2Message.RecoveryCodeConfirmed(rawJson)
-            ExchangeV2Message.RecoveryCodeDenied.TYPE -> ExchangeV2Message.RecoveryCodeDenied(rawJson)
-            ExchangeV2Message.RecoveryCodeUnavailable.TYPE -> ExchangeV2Message.RecoveryCodeUnavailable(rawJson)
-            ExchangeV2Message.RecoveryCodeResponse.TYPE -> ExchangeV2Message.RecoveryCodeResponse(
-                rawJson = rawJson,
-                recoveryCode = json.optString(FIELD_RECOVERY_CODE, ""),
-            )
-            else -> ExchangeV2Message.Unknown(rawJson = rawJson, messageType = type)
-        }
-    }
-
-    companion object {
-        private const val FIELD_TYPE = "type"
-        private const val FIELD_USER_ID = "user_id"
-        private const val FIELD_NAME = "name"
-        private const val FIELD_KIND = "kind"
-        private const val FIELD_CHANNEL_ID = "channel_id"
-        private const val FIELD_PUBLIC_KEY = "public_key"
-        private const val FIELD_VERSION = "version"
-        private const val FIELD_RECOVERY_CODE = "recovery_code"
-        private const val DEFAULT_VERSION = "2"
+        val type = runCatching { JSONObject(rawJson).optString(ExchangeV2Message.FIELD_TYPE, "") }
+            .getOrElse { return ExchangeV2Message.Unknown.fromJson(rawJson, messageType = "") }
+        return runCatching {
+            when (type) {
+                ExchangeV2Message.Hello.TYPE -> ExchangeV2Message.Hello.fromJson(rawJson)
+                ExchangeV2Message.RecoveryCodeAvailable.TYPE -> ExchangeV2Message.RecoveryCodeAvailable.fromJson(rawJson)
+                ExchangeV2Message.RecoveryCodeRequest.TYPE -> ExchangeV2Message.RecoveryCodeRequest.fromJson(rawJson)
+                ExchangeV2Message.RecoveryCodeAwaitingConfirmation.TYPE -> ExchangeV2Message.RecoveryCodeAwaitingConfirmation.fromJson(rawJson)
+                ExchangeV2Message.RecoveryCodeConfirmed.TYPE -> ExchangeV2Message.RecoveryCodeConfirmed.fromJson(rawJson)
+                ExchangeV2Message.RecoveryCodeDenied.TYPE -> ExchangeV2Message.RecoveryCodeDenied.fromJson(rawJson)
+                ExchangeV2Message.RecoveryCodeUnavailable.TYPE -> ExchangeV2Message.RecoveryCodeUnavailable.fromJson(rawJson)
+                ExchangeV2Message.RecoveryCodeResponse.TYPE -> ExchangeV2Message.RecoveryCodeResponse.fromJson(rawJson)
+                else -> ExchangeV2Message.Unknown.fromJson(rawJson, messageType = type)
+            }
+        }.getOrElse { ExchangeV2Message.Unknown.fromJson(rawJson, messageType = type) }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.sync.impl.exchange.v2
 
 import android.util.Base64
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.Json
 import com.squareup.moshi.Moshi
@@ -34,7 +35,7 @@ import javax.inject.Inject
  * The outer `code2` value is URL-safe + no-padding base64 (the fragment isn't safe for `+`/`/`/`=`).
  */
 interface ExchangeV2QrCode {
-    fun buildLinkingCode(channelId: String, publicKeyBase64Url: String, version: String = "2"): String
+    fun buildLinkingCode(channelId: String, publicKeyBase64Url: String, version: ExchangeProtocolVersion.V2): String
     fun parse(text: String): ExchangeV2CodeParseResult
 }
 
@@ -43,7 +44,7 @@ sealed interface ExchangeV2CodeParseResult {
     data class LinkingV2(
         val channelId: String,
         val publicKey: String,
-        val version: String,
+        val version: ExchangeProtocolVersion.V2,
     ) : ExchangeV2CodeParseResult
 
     /** v1 linking code (legacy <code=...>); fall back to v1 stack. */
@@ -59,9 +60,9 @@ sealed interface ExchangeV2CodeParseResult {
 @ContributesBinding(AppScope::class)
 class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
 
-    override fun buildLinkingCode(channelId: String, publicKeyBase64Url: String, version: String): String {
+    override fun buildLinkingCode(channelId: String, publicKeyBase64Url: String, version: ExchangeProtocolVersion.V2): String {
         val payload = linkingCodeAdapter.toJson(
-            V2LinkingCodePayload(version = version, channelId = channelId, publicKey = publicKeyBase64Url),
+            V2LinkingCodePayload(version = version.toString(), channelId = channelId, publicKey = publicKeyBase64Url),
         )
         val encoded = Base64.encodeToString(
             payload.toByteArray(Charsets.UTF_8),
@@ -97,10 +98,10 @@ class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
         }
 
         // Accept any same-major (2.x) version per Transport TD 1214486492252757 §Versioning.
-        val version = json.optString("version")
+        val version = ExchangeProtocolVersion.parseOrUnsupported(json.optString("version"))
         val channelId = json.optString("channel_id")
         val publicKey = json.optString("public_key")
-        if (majorVersion(version) == 2 && channelId.isNotEmpty() && publicKey.isNotEmpty()) {
+        if (version is ExchangeProtocolVersion.V2 && channelId.isNotEmpty() && publicKey.isNotEmpty()) {
             return ExchangeV2CodeParseResult.LinkingV2(
                 channelId = channelId,
                 publicKey = publicKey,
@@ -128,9 +129,6 @@ class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
             .firstOrNull { it.startsWith("$PARAM_V2=") || it.startsWith("$PARAM_V1=") }
             ?.substringAfter('=')
     }
-
-    /** Major component of a "major.minor" version string (e.g. "2.1" → 2), or null if unparseable. */
-    private fun majorVersion(version: String): Int? = version.substringBefore(".").toIntOrNull()
 
     companion object {
         private const val URL_PREFIX = "https://duckduckgo.com/sync/pairing/"

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -48,7 +48,6 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
 import logcat.logcat
-import org.json.JSONObject
 import java.util.UUID
 import javax.inject.Inject
 
@@ -223,7 +222,7 @@ class RealExchangeV2Runner @Inject constructor(
                 _linkingCode = qrCode.buildLinkingCode(
                     channelId = ownChannelId!!,
                     publicKeyBase64Url = keyPair.publicKeyBase64,
-                    version = if (syncFeature.canUseExchangeV2Point1().isEnabled()) ExchangeProtocolVersion.V2_1 else ExchangeProtocolVersion.V2_0,
+                    version = ourProtocolVersion(),
                 )
                 // Presenter waits to receive hello before transitioning out of Bootstrapped.
                 session = smFactory.create(
@@ -666,14 +665,16 @@ class RealExchangeV2Runner @Inject constructor(
             emitSessionError("Cannot send hello — pairing session state is incomplete", SessionErrorKind.PairingSessionNotReady)
             return false
         }
-        val json = JSONObject().apply {
-            put("type", "hello")
-            put("channel_id", own)
-            put("public_key", ourKey.publicKeyBase64)
-            put("version", OUR_VERSION_STRING)
-        }.toString()
-        return sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.Hello(json, own, ourKey.publicKeyBase64, OUR_VERSION_STRING))
+        val hello = ExchangeV2Message.Hello.create(
+            channelId = own,
+            publicKey = ourKey.publicKeyBase64,
+            version = ourProtocolVersion(),
+        )
+        return sendOnWireAndRecord(hello, peer, peerKey)
     }
+
+    private fun ourProtocolVersion(): ExchangeProtocolVersion.V2 =
+        if (syncFeature.canUseExchangeV2Point1().isEnabled()) ExchangeProtocolVersion.V2_1 else ExchangeProtocolVersion.V2_0
 
     private fun sendOwnAvailability() {
         if (sentOwnAvailability) return
@@ -683,20 +684,18 @@ class RealExchangeV2Runner @Inject constructor(
         val userId = syncStore.userId
         val deviceName = syncDeviceIds.deviceName()
         if (userId != null) {
-            val json = JSONObject().apply {
-                put("type", "recovery_code_available")
-                put("name", deviceName)
-                put("kind", OWN_DEVICE_KIND)
-                put("user_id", userId)
-            }.toString()
-            sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeAvailable(json, userId, deviceName, OWN_DEVICE_KIND))
+            val available = ExchangeV2Message.RecoveryCodeAvailable.create(
+                userId = userId,
+                name = deviceName,
+                kind = OWN_DEVICE_KIND,
+            )
+            sendOnWireAndRecord(available, peer, peerKey)
         } else {
-            val json = JSONObject().apply {
-                put("type", "recovery_code_request")
-                put("name", deviceName)
-                put("kind", OWN_DEVICE_KIND)
-            }.toString()
-            sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeRequest(json, deviceName, OWN_DEVICE_KIND))
+            val request = ExchangeV2Message.RecoveryCodeRequest.create(
+                name = deviceName,
+                kind = OWN_DEVICE_KIND,
+            )
+            sendOnWireAndRecord(request, peer, peerKey)
         }
         sentOwnAvailability = true
         // Re-elect in case the peer's availability arrived before we sent ours.
@@ -731,17 +730,12 @@ class RealExchangeV2Runner @Inject constructor(
         return when (codeResult) {
             is Result.Success -> {
                 val recoveryCode = codeResult.data
-                val json = JSONObject().apply {
-                    put("type", "recovery_code_response")
-                    put("recovery_code", recoveryCode)
-                }.toString()
                 // Propagate the send result
-                sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeResponse(json, recoveryCode))
+                sendOnWireAndRecord(ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode), peer, peerKey)
             }
             is Result.Error -> {
                 logcat(ERROR) { "Sync-ExchangeV2: recovery code unavailable for peerKind=$_peerKind: ${codeResult.reason}" }
-                val json = """{"type":"recovery_code_unavailable"}"""
-                sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeUnavailable(json))
+                sendOnWireAndRecord(ExchangeV2Message.RecoveryCodeUnavailable.create(), peer, peerKey)
                 emitSessionError(
                     "Couldn't generate a recovery code: ${codeResult.reason}",
                     SessionErrorKind.RecoveryCodePreparationFailed,
@@ -785,19 +779,17 @@ class RealExchangeV2Runner @Inject constructor(
     private fun sendMessageJson(json: String) {
         val peer = peerChannelId ?: return
         val peerKey = peerPublicKey ?: return
-        val parsed = messageParser.parse(json)
-        sendOnWireAndRecord(json, peer, peerKey, parsed)
+        sendOnWireAndRecord(messageParser.parse(json), peer, peerKey)
     }
 
     /** Returns true on successful POST, false on transport error (caller decides if fatal). */
     private fun sendOnWireAndRecord(
-        messageJson: String,
+        outboundMessage: ExchangeV2Message,
         peerChannel: String,
         peerKey: String,
-        outboundMessage: ExchangeV2Message,
     ): Boolean {
         val own = ownChannelId ?: return false
-        return when (val r = channel.sendMessage(messageJson, peerChannel, peerKey, own)) {
+        return when (val r = channel.sendMessage(outboundMessage.rawJson, peerChannel, peerKey, own)) {
             is Result.Success -> {
                 recordSentMessage(outboundMessage)
                 true

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -789,7 +789,7 @@ class RealExchangeV2Runner @Inject constructor(
         peerKey: String,
     ): Boolean {
         val own = ownChannelId ?: return false
-        return when (val r = channel.sendMessage(outboundMessage.rawJson, peerChannel, peerKey, own)) {
+        return when (val r = channel.sendMessage(outboundMessage, peerChannel, peerKey, own)) {
             is Result.Success -> {
                 recordSentMessage(outboundMessage)
                 true

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -462,15 +462,15 @@ class RealExchangeV2Runner @Inject constructor(
         when (effect) {
             SideEffect.SendAwaitingConfirmation -> {
                 logcat { "Sync-ExchangeV2: side effect → SendAwaitingConfirmation" }
-                sendMessageJson("""{"type":"recovery_code_awaiting_confirmation"}""")
+                sendMessage(ExchangeV2Message.RecoveryCodeAwaitingConfirmation.create())
             }
             SideEffect.SendConfirmed -> {
                 logcat { "Sync-ExchangeV2: side effect → SendConfirmed" }
-                sendMessageJson("""{"type":"recovery_code_confirmed"}""")
+                sendMessage(ExchangeV2Message.RecoveryCodeConfirmed.create())
             }
             SideEffect.SendDenied -> {
                 logcat { "Sync-ExchangeV2: side effect → SendDenied" }
-                sendMessageJson("""{"type":"recovery_code_denied"}""")
+                sendMessage(ExchangeV2Message.RecoveryCodeDenied.create())
             }
             SideEffect.RequestRecoveryCodeShare -> {
                 logcat { "Sync-ExchangeV2: side effect → RequestRecoveryCodeShare" }
@@ -776,10 +776,10 @@ class RealExchangeV2Runner @Inject constructor(
         return recoveryCodeProvider.getThirdPartyRecoveryCode()
     }
 
-    private fun sendMessageJson(json: String) {
+    private fun sendMessage(message: ExchangeV2Message) {
         val peer = peerChannelId ?: return
         val peerKey = peerPublicKey ?: return
-        sendOnWireAndRecord(messageParser.parse(json), peer, peerKey)
+        sendOnWireAndRecord(message, peer, peerKey)
     }
 
     /** Returns true on successful POST, false on transport error (caller decides if fatal). */

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -21,8 +21,10 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncDeviceIds
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.crypto.RsaKeyPair
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Host
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.SameAccountAbort
@@ -116,6 +118,7 @@ class RealExchangeV2Runner @Inject constructor(
     private val qrCode: ExchangeV2QrCode,
     private val recoveryCodeProvider: RecoveryCodeProvider,
     private val syncDeviceIds: SyncDeviceIds,
+    private val syncFeature: SyncFeature,
     @AppCoroutineScope private val appScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
 ) : ExchangeV2Runner {
@@ -220,6 +223,7 @@ class RealExchangeV2Runner @Inject constructor(
                 _linkingCode = qrCode.buildLinkingCode(
                     channelId = ownChannelId!!,
                     publicKeyBase64Url = keyPair.publicKeyBase64,
+                    version = if (syncFeature.canUseExchangeV2Point1().isEnabled()) ExchangeProtocolVersion.V2_1 else ExchangeProtocolVersion.V2_0,
                 )
                 // Presenter waits to receive hello before transitioning out of Bootstrapped.
                 session = smFactory.create(

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -483,10 +483,7 @@ class RealSyncCodeDispatcherTest {
             timestampMs = 1L,
             from = ExchangeV2State.Joiner.Waiting,
             to = ExchangeV2State.Joiner.Done,
-            trigger = ExchangeV2Message.RecoveryCodeResponse(
-                rawJson = "{}",
-                recoveryCode = "stale-code-from-prior-session",
-            ),
+            trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = "stale-code-from-prior-session"),
             localTrigger = null,
         )
         val staleFlow = MutableSharedFlow<ExchangeV2Event>(replay = 10)
@@ -548,10 +545,7 @@ class RealSyncCodeDispatcherTest {
                     timestampMs = System.currentTimeMillis(),
                     from = ExchangeV2State.Joiner.Waiting,
                     to = ExchangeV2State.Joiner.Done,
-                    trigger = ExchangeV2Message.RecoveryCodeResponse(
-                        rawJson = payloadJson,
-                        recoveryCode = recoveryCodeB64,
-                    ),
+                    trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = recoveryCodeB64),
                     localTrigger = null,
                 ),
             )
@@ -850,10 +844,7 @@ class RealSyncCodeDispatcherTest {
             recoveryJson.toByteArray(Charsets.UTF_8),
             android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
         )
-        val responseMessage = ExchangeV2Message.RecoveryCodeResponse(
-            rawJson = "{}",
-            recoveryCode = b64,
-        )
+        val responseMessage = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = b64)
         whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
         whenever(runner.peerKind).thenReturn("ddg")
 
@@ -890,10 +881,7 @@ class RealSyncCodeDispatcherTest {
             recoveryJson.toByteArray(Charsets.UTF_8),
             android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
         )
-        val responseMessage = ExchangeV2Message.RecoveryCodeResponse(
-            rawJson = "{}",
-            recoveryCode = b64,
-        )
+        val responseMessage = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = b64)
         whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(Result.Success(true))
 
         dispatcher.presentV2().test {
@@ -941,7 +929,7 @@ class RealSyncCodeDispatcherTest {
                 transition(
                     from = ExchangeV2State.Joiner.Waiting,
                     to = ExchangeV2State.Joiner.AbortedLocal,
-                    trigger = ExchangeV2Message.Hello(rawJson = "{}"),
+                    trigger = ExchangeV2Message.Hello.fromJson("{}"),
                 ),
             )
             assertEquals(UNEXPECTED_EVENT.code, (awaitItem() as DispatchOutcome.Failed).code)
@@ -955,7 +943,7 @@ class RealSyncCodeDispatcherTest {
                 transition(
                     from = ExchangeV2State.Host.Confirming,
                     to = ExchangeV2State.Host.Aborted,
-                    trigger = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}"),
+                    trigger = ExchangeV2Message.RecoveryCodeResponse.fromJson("{}"),
                 ),
             )
             assertEquals(UNEXPECTED_EVENT.code, (awaitItem() as DispatchOutcome.Failed).code)
@@ -1113,7 +1101,7 @@ class RealSyncCodeDispatcherTest {
                 transition(
                     from = ExchangeV2State.Joiner.Confirming,
                     to = ExchangeV2State.Joiner.AbortedByHost,
-                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    trigger = ExchangeV2Message.RecoveryCodeDenied.fromJson("{}"),
                 ),
             )
             val outcome = awaitItem()
@@ -1129,7 +1117,7 @@ class RealSyncCodeDispatcherTest {
                 transition(
                     from = ExchangeV2State.Joiner.Confirming,
                     to = ExchangeV2State.Joiner.AbortedByHost,
-                    trigger = ExchangeV2Message.RecoveryCodeUnavailable(rawJson = "{}"),
+                    trigger = ExchangeV2Message.RecoveryCodeUnavailable.fromJson("{}"),
                 ),
             )
             assertEquals(PEER_RECOVERY_CODE_UNAVAILABLE.code, (awaitItem() as DispatchOutcome.Failed).code)
@@ -1157,7 +1145,7 @@ class RealSyncCodeDispatcherTest {
                 transition(
                     from = ExchangeV2State.Joiner.Waiting,
                     to = ExchangeV2State.Joiner.AbortedLocal,
-                    trigger = ExchangeV2Message.Hello(rawJson = "{}"),
+                    trigger = ExchangeV2Message.Hello.fromJson("{}"),
                 ),
             )
             assertEquals(UNEXPECTED_EVENT.code, (awaitItem() as DispatchOutcome.Failed).code)
@@ -1171,7 +1159,7 @@ class RealSyncCodeDispatcherTest {
                 transition(
                     from = ExchangeV2State.Host.Confirming,
                     to = ExchangeV2State.Host.Aborted,
-                    trigger = ExchangeV2Message.Hello(rawJson = "{}"),
+                    trigger = ExchangeV2Message.Hello.fromJson("{}"),
                 ),
             )
             assertEquals(UNEXPECTED_EVENT.code, (awaitItem() as DispatchOutcome.Failed).code)
@@ -1217,7 +1205,7 @@ class RealSyncCodeDispatcherTest {
                 transition(
                     from = ExchangeV2State.Joiner.Confirming,
                     to = ExchangeV2State.Joiner.AbortedByHost,
-                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    trigger = ExchangeV2Message.RecoveryCodeDenied.fromJson("{}"),
                 ),
             )
             assertEquals(PAIRING_REJECTED.code, (awaitItem() as DispatchOutcome.Failed).code)
@@ -1239,7 +1227,7 @@ class RealSyncCodeDispatcherTest {
                 transition(
                     from = ExchangeV2State.Joiner.Confirming,
                     to = ExchangeV2State.Joiner.AbortedByHost,
-                    trigger = ExchangeV2Message.Hello(rawJson = "{}"),
+                    trigger = ExchangeV2Message.Hello.fromJson("{}"),
                 ),
             )
             val outcome = awaitItem() as DispatchOutcome.Failed
@@ -1277,7 +1265,7 @@ class RealSyncCodeDispatcherTest {
             recoveryJson.toByteArray(Charsets.UTF_8),
             android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
         )
-        val responseMessage = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}", recoveryCode = b64)
+        val responseMessage = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = b64)
 
         dispatcher.presentV2().test {
             runnerEventsFlow.emit(

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.PEER_RECOVERY_CODE_UNAVAILABLE
 import com.duckduckgo.sync.impl.AccountErrorCodes.RECOVERY_CODE_PREPARATION_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.SESSION_TIMEOUT
 import com.duckduckgo.sync.impl.AccountErrorCodes.UNEXPECTED_EVENT
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -171,7 +172,7 @@ class RealSyncCodeDispatcherTest {
     @Test fun `v2 flag on, v2 LinkingV2 - returns V2InProgress and does NOT call parseSyncAuthCode`() {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
 
         val decision = dispatcher.route("v2-link-url")
@@ -476,7 +477,7 @@ class RealSyncCodeDispatcherTest {
     @Test fun `v2 flag on, LinkingV2 - ignores stale terminal events from prior sessions in the replay cache`() = runTest {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         val staleJoinerDone = ExchangeV2Event.Transition(
             timestampMs = 1L,
@@ -508,7 +509,7 @@ class RealSyncCodeDispatcherTest {
     @Test fun `v2 flag on, LinkingV2 - runner_startScan deferred until Flow is collected (cold)`() = runTest {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
 
         val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
@@ -523,7 +524,7 @@ class RealSyncCodeDispatcherTest {
         // Spec 1214802412121967: the v2 wire `secret` is base64url; v1 login decodes as standard base64.
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
         val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o"
@@ -671,7 +672,7 @@ class RealSyncCodeDispatcherTest {
     @Test fun `Scanner maps a version-too-new SessionError to UpgradeRequired`() = runTest {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
         flow.test {
@@ -689,7 +690,7 @@ class RealSyncCodeDispatcherTest {
     @Test fun `Scanner - Host_Aborted with UserDeniedHost maps to Failed PAIRING_CANCELLED`() = runTest {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
         flow.test {
@@ -711,7 +712,7 @@ class RealSyncCodeDispatcherTest {
     @Test fun `Scanner - Host_Aborted with HostUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
         flow.test {
@@ -989,7 +990,7 @@ class RealSyncCodeDispatcherTest {
             ExchangeV2CodeParseResult.LinkingV2(
                 channelId = "c",
                 publicKey = "k",
-                version = "2",
+                version = ExchangeProtocolVersion.V2_0,
             ),
         )
         val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
@@ -1026,7 +1027,7 @@ class RealSyncCodeDispatcherTest {
             ExchangeV2CodeParseResult.LinkingV2(
                 channelId = "peer-channel",
                 publicKey = "k",
-                version = "2",
+                version = ExchangeProtocolVersion.V2_0,
             ),
         )
         val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
@@ -1064,7 +1065,7 @@ class RealSyncCodeDispatcherTest {
     @Test fun `Scanner emits Failed when runner reaches Aborted (hello during negotiating)`() = runTest {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
         decision.outcomes.test {
@@ -1101,7 +1102,7 @@ class RealSyncCodeDispatcherTest {
     private fun startLinking(): kotlinx.coroutines.flow.Flow<DispatchOutcome> {
         configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         return (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/ExchangeProtocolVersionTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/ExchangeProtocolVersionTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange
+
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion.Unsupported
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion.V1
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion.V2
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(TestParameterInjector::class)
+class ExchangeProtocolVersionTest {
+
+    enum class ParseSuccessCase(
+        val rawVersion: String,
+        val expected: ExchangeProtocolVersion,
+    ) {
+        MajorOnlyV1("1", V1(minor = 0)),
+        MajorMinorV1("1.0", V1(minor = 0)),
+        HigherMinorV1("1.5", V1(minor = 5)),
+        MajorOnlyV2("2", V2(minor = 0)),
+        MajorMinorV2("2.1", V2(minor = 1)),
+        PatchComponentIgnored("2.1.7", V2(minor = 1)),
+        UnknownMajor("3", Unsupported("3")),
+        UnknownMajorWithMinor("3.2", Unsupported("3.2")),
+        ZeroMajor("0", Unsupported("0")),
+        DoubleDigitMajor("10.2", Unsupported("10.2")),
+    }
+
+    @Test
+    fun `parses valid version strings`(
+        @TestParameter case: ParseSuccessCase,
+    ) {
+        assertEquals(case.expected, ExchangeProtocolVersion.parse(case.rawVersion).getOrThrow())
+    }
+
+    @Test
+    fun `parsing malformed input returns failure`(
+        @TestParameter("", "abc", "1.x", "2..1", ".", "1.", " 1") rawVersion: String,
+    ) {
+        assertTrue(ExchangeProtocolVersion.parse(rawVersion).isFailure)
+    }
+
+    enum class OrderingCase(
+        val lower: ExchangeProtocolVersion,
+        val higher: ExchangeProtocolVersion,
+    ) {
+        MinorWithinV1(V1(minor = 0), V1(minor = 1)),
+        MinorWithinV2(V2(minor = 0), V2(minor = 1)),
+        MajorBeatsMinor(V1(minor = 9), V2(minor = 0)),
+        SupportedBelowUnsupported(V2(minor = 9), Unsupported("0")),
+        UnsupportedByRawVersion(Unsupported("3"), Unsupported("4")),
+    }
+
+    @Test
+    fun `orders versions`(
+        @TestParameter case: OrderingCase,
+    ) {
+        assertTrue(case.lower < case.higher)
+        assertTrue(case.higher > case.lower)
+    }
+
+    enum class EqualityCase(
+        val first: ExchangeProtocolVersion,
+        val second: ExchangeProtocolVersion,
+    ) {
+        SameV1(V1(minor = 3), V1(minor = 3)),
+        SameV2(V2(minor = 0), V2(minor = 0)),
+        SameUnsupported(Unsupported("3.2"), Unsupported("3.2")),
+    }
+
+    @Test
+    fun `equal versions compare as equal`(@TestParameter case: EqualityCase) {
+        assertEquals(0, case.first.compareTo(case.second))
+        assertEquals(case.first, case.second)
+    }
+
+    enum class ToStringCase(
+        val version: ExchangeProtocolVersion,
+        val expected: String,
+    ) {
+        ZeroMinorOmitted(V2(minor = 0), "2"),
+        NonZeroMinorIncluded(V2(minor = 1), "2.1"),
+        UnsupportedKeepsRawVersion(Unsupported("3.2.1"), "3.2.1"),
+    }
+
+    @Test
+    fun `renders version string`(
+        @TestParameter case: ToStringCase,
+    ) {
+        assertEquals(case.expected, case.version.toString())
+    }
+
+    @Test
+    fun `parsing the rendered form of a supported version round-trips`(
+        @TestParameter("1", "1.5", "2", "2.1") rawVersion: String,
+    ) {
+        val parsed = ExchangeProtocolVersion.parse(rawVersion).getOrThrow()
+        val reParsed = ExchangeProtocolVersion.parse(parsed.toString()).getOrThrow()
+
+        assertEquals(parsed, reParsed)
+    }
+
+    @Test
+    fun `parseOrUnsupported returns parsed version for valid input`(
+        @TestParameter case: ParseSuccessCase,
+    ) {
+        assertEquals(case.expected, ExchangeProtocolVersion.parseOrUnsupported(case.rawVersion))
+    }
+
+    @Test
+    fun `parseOrUnsupported falls back to Unsupported with raw version for malformed input`(
+        @TestParameter("", "abc", "1.x", "2..1", ".", "1.", " 1") rawVersion: String,
+    ) {
+        assertEquals(Unsupported(rawVersion), ExchangeProtocolVersion.parseOrUnsupported(rawVersion))
+    }
+
+    @Test
+    fun `predefined constants carry expected versions`() {
+        assertEquals(V1(minor = 0), ExchangeProtocolVersion.V1_0)
+        assertEquals(V2(minor = 0), ExchangeProtocolVersion.V2_0)
+        assertEquals(V2(minor = 1), ExchangeProtocolVersion.V2_1)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
@@ -41,14 +41,14 @@ class ExchangeV2StateMachineTest {
         RealExchangeV2StateMachine(localUserId = localUserId, clock = clock, initialState = ExchangeV2State.Negotiating)
 
     private fun availableFromPeer(userId: String = "other", name: String = "Peer", kind: String = "3party") =
-        RecoveryCodeAvailable(rawJson = "{}", userId = userId, name = name, kind = kind)
+        RecoveryCodeAvailable.create(userId = userId, name = name, kind = kind)
 
     private fun requestFromPeer(name: String = "Peer", kind: String = "3party") =
-        RecoveryCodeRequest(rawJson = "{}", name = name, kind = kind)
+        RecoveryCodeRequest.create(name = name, kind = kind)
 
     @Test fun `when hello received in Bootstrapped then transitions to Negotiating`() {
         val machine = sm()
-        val result = machine.receive(Hello("{}"))
+        val result = machine.receive(Hello.fromJson("{}"))
 
         assertSame(ExchangeV2State.Negotiating, result.newState)
         assertSame(ExchangeV2State.Negotiating, machine.currentState)
@@ -63,11 +63,11 @@ class ExchangeV2StateMachineTest {
         val known: List<ExchangeV2Message> = listOf(
             availableFromPeer(),
             requestFromPeer(),
-            RecoveryCodeAwaitingConfirmation("{}"),
-            RecoveryCodeConfirmed("{}"),
-            RecoveryCodeDenied("{}"),
-            RecoveryCodeUnavailable("{}"),
-            RecoveryCodeResponse("{}"),
+            RecoveryCodeAwaitingConfirmation.fromJson("{}"),
+            RecoveryCodeConfirmed.fromJson("{}"),
+            RecoveryCodeDenied.fromJson("{}"),
+            RecoveryCodeUnavailable.fromJson("{}"),
+            RecoveryCodeResponse.fromJson("{}"),
         )
         for (msg in known) {
             val machine = sm()
@@ -84,7 +84,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when unknown message received in Bootstrapped then dropped and state unchanged`() {
         val machine = sm()
-        val result = machine.receive(Unknown("{}", "future_message"))
+        val result = machine.receive(Unknown.fromJson("{}", "future_message"))
 
         assertSame(TransitionOutcome.Dropped, result.outcome)
         assertSame(ExchangeV2State.Bootstrapped, machine.currentState)
@@ -105,9 +105,9 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when presenter receives second hello in Negotiating then aborts to terminal Aborted`() {
         val machine = sm()
-        assertSame(ExchangeV2State.Negotiating, machine.receive(Hello("{}")).newState)
+        assertSame(ExchangeV2State.Negotiating, machine.receive(Hello.fromJson("{}")).newState)
 
-        val result = machine.receive(Hello("{}"))
+        val result = machine.receive(Hello.fromJson("{}"))
 
         assertSame(ExchangeV2State.Aborted, machine.currentState)
         assertTrue(result.outcome is TransitionOutcome.Aborted)
@@ -120,7 +120,7 @@ class ExchangeV2StateMachineTest {
     @Test fun `when scanner receives hello in Negotiating then aborts to terminal Aborted`() {
         val machine = scannerSm()
 
-        val result = machine.receive(Hello("{}"))
+        val result = machine.receive(Hello.fromJson("{}"))
 
         assertSame(ExchangeV2State.Aborted, machine.currentState)
         assertTrue(result.outcome is TransitionOutcome.Aborted)
@@ -132,7 +132,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when message received in Aborted then state unchanged and aborts`() {
         val machine = scannerSm()
-        machine.receive(Hello("{}"))
+        machine.receive(Hello.fromJson("{}"))
         assertSame(ExchangeV2State.Aborted, machine.currentState)
 
         val result = machine.receive(availableFromPeer())
@@ -143,7 +143,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when recovery_code_available with matching user_id received in Negotiating then transitions to SameAccountAbort`() {
         val machine = sm(localUserId = "shared-user")
-        machine.receive(Hello("{}"))
+        machine.receive(Hello.fromJson("{}"))
         val msg = availableFromPeer(userId = "shared-user")
         val result = machine.receive(msg)
 
@@ -162,7 +162,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when recovery_code_available with different user_id received in Negotiating then stays in Negotiating`() {
         val machine = sm(localUserId = "local-user")
-        machine.receive(Hello("{}"))
+        machine.receive(Hello.fromJson("{}"))
         val result = machine.receive(availableFromPeer(userId = "other-user"))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
@@ -173,7 +173,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when recovery_code_request received in Negotiating then stays in Negotiating`() {
         val machine = sm()
-        machine.receive(Hello("{}"))
+        machine.receive(Hello.fromJson("{}"))
         val result = machine.receive(requestFromPeer())
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
@@ -182,15 +182,15 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when finalise-phase message received in Negotiating then aborts to terminal Aborted`() {
         val finalise: List<ExchangeV2Message> = listOf(
-            RecoveryCodeAwaitingConfirmation("{}"),
-            RecoveryCodeConfirmed("{}"),
-            RecoveryCodeDenied("{}"),
-            RecoveryCodeUnavailable("{}"),
-            RecoveryCodeResponse("{}"),
+            RecoveryCodeAwaitingConfirmation.fromJson("{}"),
+            RecoveryCodeConfirmed.fromJson("{}"),
+            RecoveryCodeDenied.fromJson("{}"),
+            RecoveryCodeUnavailable.fromJson("{}"),
+            RecoveryCodeResponse.fromJson("{}"),
         )
         for (msg in finalise) {
             val machine = sm()
-            machine.receive(Hello("{}"))
+            machine.receive(Hello.fromJson("{}"))
             val result = machine.receive(msg)
             assertTrue("expected abort for $msg in Negotiating, got ${result.outcome}", result.outcome is TransitionOutcome.Aborted)
             assertSame("recv $msg in Negotiating should drive to Aborted", ExchangeV2State.Aborted, machine.currentState)
@@ -203,7 +203,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when RoleElected Host in Negotiating then transitions to Host Confirming`() {
         val machine = sm()
-        machine.receive(Hello("{}"))
+        machine.receive(Hello.fromJson("{}"))
         val result = machine.localTrigger(LocalTrigger.RoleElected(Role.Host))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
@@ -212,7 +212,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when RoleElected Joiner in Negotiating then transitions to Joiner Confirming`() {
         val machine = sm()
-        machine.receive(Hello("{}"))
+        machine.receive(Hello.fromJson("{}"))
         val result = machine.localTrigger(LocalTrigger.RoleElected(Role.Joiner))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
@@ -221,7 +221,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when RoleElected fires after peer availability then transitions to Joiner Confirming`() {
         val machine = sm()
-        machine.receive(Hello("{}"))
+        machine.receive(Hello.fromJson("{}"))
         machine.receive(availableFromPeer(userId = "other-user"))
         val result = machine.localTrigger(LocalTrigger.RoleElected(Role.Joiner))
 
@@ -262,10 +262,10 @@ class ExchangeV2StateMachineTest {
             },
         )
         val knownIncoming: List<ExchangeV2Message> = listOf(
-            Hello("{}"),
+            Hello.fromJson("{}"),
             availableFromPeer(),
             requestFromPeer(),
-            RecoveryCodeResponse("{}"),
+            RecoveryCodeResponse.fromJson("{}"),
         )
         for ((from, build) in hostStateBuilders) {
             for (msg in knownIncoming) {
@@ -283,7 +283,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when unknown message received in Host Confirming then dropped`() {
         val machine = inHostConfirming()
-        val result = machine.receive(Unknown("{}", "future"))
+        val result = machine.receive(Unknown.fromJson("{}", "future"))
 
         assertSame(TransitionOutcome.Dropped, result.outcome)
         assertSame(ExchangeV2State.Host.Confirming, machine.currentState)
@@ -307,7 +307,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when denied received in Joiner Confirming then transitions to Joiner AbortedByHost`() {
         val machine = inJoinerConfirming()
-        val result = machine.receive(RecoveryCodeDenied("{}"))
+        val result = machine.receive(RecoveryCodeDenied.fromJson("{}"))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
         assertSame(ExchangeV2State.Joiner.AbortedByHost, machine.currentState)
@@ -315,7 +315,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when unavailable received in Joiner Confirming then transitions to Joiner AbortedByHost`() {
         val machine = inJoinerConfirming()
-        val result = machine.receive(RecoveryCodeUnavailable("{}"))
+        val result = machine.receive(RecoveryCodeUnavailable.fromJson("{}"))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
         assertSame(ExchangeV2State.Joiner.AbortedByHost, machine.currentState)
@@ -323,9 +323,9 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when host success-phase message received in Joiner Confirming then aborts to terminal Joiner AbortedLocal`() {
         val hostSuccessPhase: List<ExchangeV2Message> = listOf(
-            RecoveryCodeAwaitingConfirmation("{}"),
-            RecoveryCodeConfirmed("{}"),
-            RecoveryCodeResponse("{}"),
+            RecoveryCodeAwaitingConfirmation.fromJson("{}"),
+            RecoveryCodeConfirmed.fromJson("{}"),
+            RecoveryCodeResponse.fromJson("{}"),
         )
         for (msg in hostSuccessPhase) {
             val machine = inJoinerConfirming()
@@ -342,7 +342,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when negotiation-phase message received in Joiner Confirming then aborts to terminal Joiner AbortedLocal`() {
         val negotiationPhase: List<ExchangeV2Message> = listOf(
-            Hello("{}"),
+            Hello.fromJson("{}"),
             availableFromPeer(),
             requestFromPeer(),
         )
@@ -356,7 +356,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when unknown message received in Joiner Confirming then dropped`() {
         val machine = inJoinerConfirming()
-        val result = machine.receive(Unknown("{}", "future"))
+        val result = machine.receive(Unknown.fromJson("{}", "future"))
 
         assertSame(TransitionOutcome.Dropped, result.outcome)
         assertSame(ExchangeV2State.Joiner.Confirming, machine.currentState)
@@ -364,7 +364,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when awaiting_confirmation received in Joiner Waiting then stays in Joiner Waiting`() {
         val machine = inJoinerWaiting()
-        val result = machine.receive(RecoveryCodeAwaitingConfirmation("{}"))
+        val result = machine.receive(RecoveryCodeAwaitingConfirmation.fromJson("{}"))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
         assertSame(ExchangeV2State.Joiner.Waiting, machine.currentState)
@@ -372,7 +372,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when confirmed received in Joiner Waiting then stays in Joiner Waiting`() {
         val machine = inJoinerWaiting()
-        val result = machine.receive(RecoveryCodeConfirmed("{}"))
+        val result = machine.receive(RecoveryCodeConfirmed.fromJson("{}"))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
         assertSame(ExchangeV2State.Joiner.Waiting, machine.currentState)
@@ -380,7 +380,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when denied received in Joiner Waiting then transitions to Joiner AbortedByHost`() {
         val machine = inJoinerWaiting()
-        val result = machine.receive(RecoveryCodeDenied("{}"))
+        val result = machine.receive(RecoveryCodeDenied.fromJson("{}"))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
         assertSame(ExchangeV2State.Joiner.AbortedByHost, machine.currentState)
@@ -388,7 +388,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when unavailable received in Joiner Waiting then transitions to Joiner AbortedByHost`() {
         val machine = inJoinerWaiting()
-        val result = machine.receive(RecoveryCodeUnavailable("{}"))
+        val result = machine.receive(RecoveryCodeUnavailable.fromJson("{}"))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
         assertSame(ExchangeV2State.Joiner.AbortedByHost, machine.currentState)
@@ -396,7 +396,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when response received in Joiner Waiting then transitions to Joiner Done`() {
         val machine = inJoinerWaiting()
-        val result = machine.receive(RecoveryCodeResponse("{}"))
+        val result = machine.receive(RecoveryCodeResponse.fromJson("{}"))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
         assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
@@ -404,7 +404,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when negotiation-phase message received in Joiner Waiting then aborts to terminal Joiner AbortedLocal`() {
         val negotiationPhase: List<ExchangeV2Message> = listOf(
-            Hello("{}"),
+            Hello.fromJson("{}"),
             availableFromPeer(),
             requestFromPeer(),
         )
@@ -422,7 +422,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when unknown message received in Joiner Waiting then dropped`() {
         val machine = inJoinerWaiting()
-        val result = machine.receive(Unknown("{}", "future"))
+        val result = machine.receive(Unknown.fromJson("{}", "future"))
 
         assertSame(TransitionOutcome.Dropped, result.outcome)
         assertSame(ExchangeV2State.Joiner.Waiting, machine.currentState)
@@ -430,10 +430,10 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when message received in SameAccountAbort then aborts and state unchanged`() {
         val machine = sm(localUserId = "shared-user")
-        machine.receive(Hello("{}"))
+        machine.receive(Hello.fromJson("{}"))
         machine.receive(availableFromPeer(userId = "shared-user"))
         val before = machine.currentState
-        val result = machine.receive(RecoveryCodeResponse("{}"))
+        val result = machine.receive(RecoveryCodeResponse.fromJson("{}"))
 
         assertTrue(result.outcome is TransitionOutcome.Aborted)
         assertSame(before, machine.currentState)
@@ -441,7 +441,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when recovery_code_available received and local user is null then stays in Negotiating`() {
         val machine = sm(localUserId = null)
-        machine.receive(Hello("{}"))
+        machine.receive(Hello.fromJson("{}"))
         val result = machine.receive(availableFromPeer(userId = "anything"))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
@@ -450,7 +450,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when RoleElected Host then emits SendAwaitingConfirmation side effect`() {
         val machine = sm()
-        machine.receive(Hello("{}"))
+        machine.receive(Hello.fromJson("{}"))
         machine.receive(requestFromPeer())
 
         val result = machine.localTrigger(LocalTrigger.RoleElected(Role.Host))
@@ -460,7 +460,7 @@ class ExchangeV2StateMachineTest {
 
     @Test fun `when RoleElected Joiner then emits no side effects`() {
         val machine = sm()
-        machine.receive(Hello("{}"))
+        machine.receive(Hello.fromJson("{}"))
         machine.receive(availableFromPeer(userId = "other"))
 
         val result = machine.localTrigger(LocalTrigger.RoleElected(Role.Joiner))
@@ -532,17 +532,17 @@ class ExchangeV2StateMachineTest {
         }
         assertSame(ExchangeV2State.Host.Done, machine.currentState)
 
-        val result = machine.receive(RecoveryCodeResponse("{}"))
+        val result = machine.receive(RecoveryCodeResponse.fromJson("{}"))
 
         assertTrue(result.outcome is TransitionOutcome.Aborted)
         assertSame(ExchangeV2State.Host.Done, machine.currentState)
     }
 
     @Test fun `when message received in Joiner Done then state unchanged and outcome is Aborted`() {
-        val machine = inJoinerWaiting().also { it.receive(RecoveryCodeResponse("{}")) }
+        val machine = inJoinerWaiting().also { it.receive(RecoveryCodeResponse.fromJson("{}")) }
         assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
 
-        val result = machine.receive(Hello("{}"))
+        val result = machine.receive(Hello.fromJson("{}"))
 
         assertTrue(result.outcome is TransitionOutcome.Aborted)
         assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
@@ -550,14 +550,14 @@ class ExchangeV2StateMachineTest {
 
     private fun inHostConfirming(): ExchangeV2StateMachine =
         sm().also {
-            it.receive(Hello("{}"))
+            it.receive(Hello.fromJson("{}"))
             it.receive(requestFromPeer())
             it.localTrigger(LocalTrigger.RoleElected(Role.Host))
         }
 
     private fun inJoinerConfirming(): ExchangeV2StateMachine =
         sm().also {
-            it.receive(Hello("{}"))
+            it.receive(Hello.fromJson("{}"))
             it.receive(availableFromPeer(userId = "other"))
             it.localTrigger(LocalTrigger.RoleElected(Role.Joiner))
         }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/JsonExchangeV2MessageParserTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/JsonExchangeV2MessageParserTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.sync.impl.exchange.v2
 
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -31,13 +32,13 @@ class JsonExchangeV2MessageParserTest {
 
         assertEquals("abc", parsed.channelId)
         assertEquals("key", parsed.publicKey)
-        assertEquals("2.1", parsed.version)
+        assertEquals(ExchangeProtocolVersion.V2(minor = 1), parsed.version)
         assertEquals(json, parsed.rawJson)
     }
 
     @Test fun `hello defaults version to 2 when omitted`() {
         val parsed = parser.parse("""{"type":"hello"}""") as ExchangeV2Message.Hello
-        assertEquals("2", parsed.version)
+        assertEquals(ExchangeProtocolVersion.V2(minor = 0), parsed.version)
     }
 
     @Test fun `parses recovery_code_available with user_id+name+kind`() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2EnvelopeTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2EnvelopeTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.sync.impl.exchange.v2
 
 import com.duckduckgo.sync.impl.ExchangeEnvelope
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
@@ -32,19 +33,20 @@ class RealExchangeV2EnvelopeTest {
     private val jweCrypto: SyncJweCrypto = mock()
     private val envelope = RealExchangeV2Envelope(jweCrypto)
 
-    @Test fun `seal produces envelope with our version and JWE payload`() {
+    @Test fun `seal produces envelope with message version and JWE payload`() {
+        val message = ExchangeV2Message.Hello.create("chanelId", "publicKey", ExchangeProtocolVersion.V2_1)
         whenever(jweCrypto.jweEncryptRsaOaep(any(), any(), any())).thenReturn("jwe-bytes")
 
         val result = envelope.seal(
-            messageJson = """{"type":"hello"}""",
+            message = message,
             peerPublicKeyBase64 = "peer-pub",
             senderChannelId = "our-channel",
         )
 
-        assertEquals(OUR_VERSION_STRING, result.version)
+        assertEquals(message.protocolVersion.toString(), result.version)
         assertEquals("jwe-bytes", result.payload)
         verify(jweCrypto).jweEncryptRsaOaep(
-            plaintext = """{"type":"hello"}""".toByteArray(Charsets.UTF_8),
+            plaintext = message.rawJson.toByteArray(Charsets.UTF_8),
             recipientPublicKeyBase64 = "peer-pub",
             kid = "our-channel",
         )
@@ -71,14 +73,14 @@ class RealExchangeV2EnvelopeTest {
         val ex = assertThrows(EnvelopeVersionTooNew::class.java) {
             envelope.open(ExchangeEnvelope(version = "3", payload = "anything"), "k")
         }
-        assertEquals("3", ex.version)
+        assertEquals(ExchangeProtocolVersion.Unsupported("3"), ex.version)
     }
 
     @Test fun `open throws EnvelopeVersionTooNew even when minor is set`() {
         val ex = assertThrows(EnvelopeVersionTooNew::class.java) {
             envelope.open(ExchangeEnvelope(version = "4.2", payload = "anything"), "k")
         }
-        assertEquals("4.2", ex.version)
+        assertEquals(ExchangeProtocolVersion.Unsupported("4.2"), ex.version)
     }
 
     @Test fun `open rejects obsolete (lower major) versions`() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.sync.impl.exchange.v2
 
 import android.util.Base64
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -33,7 +34,7 @@ class RealExchangeV2QrCodeTest {
     // ---- parse: LinkingV2 ----
 
     @Test fun `parse identifies a well-formed v2 linking URL`() {
-        val url = qrCode.buildLinkingCode(channelId = "abc", publicKeyBase64Url = "pubkey", version = "2")
+        val url = qrCode.buildLinkingCode(channelId = "abc", publicKeyBase64Url = "pubkey", version = ExchangeProtocolVersion.V2_0)
 
         val result = qrCode.parse(url)
 
@@ -41,11 +42,11 @@ class RealExchangeV2QrCodeTest {
         result as ExchangeV2CodeParseResult.LinkingV2
         assertEquals("abc", result.channelId)
         assertEquals("pubkey", result.publicKey)
-        assertEquals("2", result.version)
+        assertEquals(ExchangeProtocolVersion.V2_0, result.version)
     }
 
     @Test fun `parse tolerates leading whitespace and prefix text before the URL`() {
-        val url = qrCode.buildLinkingCode("c", "k")
+        val url = qrCode.buildLinkingCode("c", "k", version = ExchangeProtocolVersion.V2_0)
         val noisy = "   Linking code: $url"
 
         val result = qrCode.parse(noisy)
@@ -133,7 +134,7 @@ class RealExchangeV2QrCodeTest {
         parsed as ExchangeV2CodeParseResult.LinkingV2
         assertEquals("chan", parsed.channelId)
         assertEquals("pub", parsed.publicKey)
-        assertEquals("2.1", parsed.version)
+        assertEquals(ExchangeProtocolVersion.V2_1, parsed.version)
     }
 
     @Test fun `parse rejects a v2 code with an empty public_key`() {
@@ -149,7 +150,7 @@ class RealExchangeV2QrCodeTest {
     // ---- buildLinkingCode round-trip ----
 
     @Test fun `buildLinkingCode emits a URL parse can decode back to its inputs`() {
-        val built = qrCode.buildLinkingCode(channelId = "chan-123", publicKeyBase64Url = "pubkey-456")
+        val built = qrCode.buildLinkingCode(channelId = "chan-123", publicKeyBase64Url = "pubkey-456", version = ExchangeProtocolVersion.V2_0)
 
         val parsed = qrCode.parse(built) as ExchangeV2CodeParseResult.LinkingV2
 
@@ -158,20 +159,20 @@ class RealExchangeV2QrCodeTest {
     }
 
     @Test fun `buildLinkingCode produces the documented URL shape`() {
-        val built = qrCode.buildLinkingCode(channelId = "c", publicKeyBase64Url = "k")
+        val built = qrCode.buildLinkingCode(channelId = "c", publicKeyBase64Url = "k", version = ExchangeProtocolVersion.V2_0)
         assertTrue("expected URL prefix, got: $built", built.startsWith("https://duckduckgo.com/sync/pairing/#&code2="))
     }
 
     @Test fun `buildLinkingCode emits the expected compact JSON shape`() {
         // Field order is not contractual (codes are parse-only, never byte-compared); this pins the current serializer output.
-        val built = qrCode.buildLinkingCode(channelId = "c", publicKeyBase64Url = "k", version = "2")
+        val built = qrCode.buildLinkingCode(channelId = "c", publicKeyBase64Url = "k", version = ExchangeProtocolVersion.V2_0)
         val fragment = built.substringAfter("code2=")
         val decoded = String(Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP))
         assertEquals("""{"channel_id":"c","public_key":"k","version":"2"}""", decoded)
     }
 
     @Test fun `buildLinkingCode does not escape forward slashes (defense-in-depth)`() {
-        val built = qrCode.buildLinkingCode(channelId = "chan/123", publicKeyBase64Url = "pub/key+raw")
+        val built = qrCode.buildLinkingCode(channelId = "chan/123", publicKeyBase64Url = "pub/key+raw", version = ExchangeProtocolVersion.V2_0)
         val fragment = built.substringAfter("code2=")
         val decoded = String(Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP))
         assertFalse("linking JSON must not contain escaped slashes (\\/): $decoded", decoded.contains("\\/"))
@@ -180,7 +181,7 @@ class RealExchangeV2QrCodeTest {
     }
 
     @Test fun `buildLinkingCode honours custom version`() {
-        val built = qrCode.buildLinkingCode("c", "k", version = "2.1")
+        val built = qrCode.buildLinkingCode("c", "k", version = ExchangeProtocolVersion.V2_1)
         val fragment = built.substringAfter("code2=")
         val decoded = Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
         assertTrue(String(decoded).contains("\"version\":\"2.1\""))

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -27,6 +27,9 @@ import com.duckduckgo.sync.impl.crypto.RsaKeyPair
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAvailable
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAwaitingConfirmation
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeConfirmed
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
 import com.duckduckgo.sync.store.SyncStore
@@ -124,7 +127,7 @@ class RealExchangeV2RunnerTest {
         val runner = newRunner()
         runner.startScan("")
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeAvailable.create(userId = "peer", name = "Peer", kind = "3party"),
+            RecoveryCodeAvailable.create(userId = "peer", name = "Peer", kind = "3party"),
         )
 
         runner.startScan("")
@@ -209,7 +212,7 @@ class RealExchangeV2RunnerTest {
         whenever(syncStore.userId).thenReturn(null)
         val runner = newRunner()
         runner.startScan("")
-        runner.deliverIncomingMessage(ExchangeV2Message.RecoveryCodeAvailable.create(userId = "other", name = "Peer", kind = "3party"))
+        runner.deliverIncomingMessage(RecoveryCodeAvailable.create(userId = "other", name = "Peer", kind = "3party"))
         runner.localTrigger(LocalTrigger.RoleElected(Role.Joiner))
         runner.localTrigger(LocalTrigger.UserConfirmedJoiner)
         runner.deliverIncomingMessage(RecoveryCodeResponse.fromJson("{}"))
@@ -224,7 +227,7 @@ class RealExchangeV2RunnerTest {
 
         runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
             runner.deliverIncomingMessage(
-                ExchangeV2Message.RecoveryCodeAvailable.create(userId = "shared-user", name = "Peer", kind = "3party"),
+                RecoveryCodeAvailable.create(userId = "shared-user", name = "Peer", kind = "3party"),
             )
             val event = awaitItem()
             assertSame(ExchangeV2State.SameAccountAbort, event.to)
@@ -241,7 +244,7 @@ class RealExchangeV2RunnerTest {
         // The peer shows this name on its security-confirmation screen, so it must be the real
         // device name (e.g. "google Pixel 7"), never a generic "Android".
         verify(channel).sendMessage(
-            argThat { contains("recovery_code_request") && contains("\"name\":\"google Pixel 7\"") },
+            argThat { this is RecoveryCodeRequest && this.name == "google Pixel 7" },
             any(),
             any(),
             any(),
@@ -256,7 +259,7 @@ class RealExchangeV2RunnerTest {
         runner.startScan("")
 
         verify(channel).sendMessage(
-            argThat { contains("recovery_code_available") && contains("\"name\":\"google Pixel 7\"") },
+            argThat { this is RecoveryCodeAvailable && this.name == "google Pixel 7" },
             any(),
             any(),
             any(),
@@ -328,7 +331,7 @@ class RealExchangeV2RunnerTest {
         runner.startScan("")
 
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeAvailable.create(userId = "host-user", name = "Host", kind = "ddg"),
+            RecoveryCodeAvailable.create(userId = "host-user", name = "Host", kind = "ddg"),
         )
 
         assertSame(ExchangeV2State.Joiner.Confirming, runner.currentState)
@@ -341,7 +344,7 @@ class RealExchangeV2RunnerTest {
         runner.deliverIncomingMessage(Hello.fromJson("{}"))
 
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"),
+            RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"),
         )
 
         assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
@@ -354,19 +357,19 @@ class RealExchangeV2RunnerTest {
         runner.deliverIncomingMessage(Hello.fromJson("{}"))
 
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"),
+            RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"),
         )
 
         // Spec §"Exchange Confirmations → Host": awaiting_confirmation is sent on entry to
         // Confirming, before the user is prompted.
         verify(channel).sendMessage(
-            argThat { contains("recovery_code_awaiting_confirmation") },
+            argThat { this is RecoveryCodeAwaitingConfirmation },
             any(),
             any(),
             any(),
         )
         verify(channel, never()).sendMessage(
-            argThat { contains("recovery_code_confirmed") },
+            argThat { this is RecoveryCodeConfirmed },
             any(),
             any(),
             any(),
@@ -380,18 +383,18 @@ class RealExchangeV2RunnerTest {
         runner.startPresent()
         runner.deliverIncomingMessage(Hello.fromJson("{}"))
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"),
+            RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"),
         )
         runner.localTrigger(LocalTrigger.UserConfirmedHost)
 
         verify(channel).sendMessage(
-            argThat { contains("recovery_code_confirmed") && !contains("recovery_code_awaiting_confirmation") },
+            argThat { this is RecoveryCodeConfirmed },
             any(),
             any(),
             any(),
         )
         verify(channel, org.mockito.kotlin.times(1)).sendMessage(
-            argThat { contains("recovery_code_awaiting_confirmation") },
+            argThat { this is RecoveryCodeAwaitingConfirmation },
             any(),
             any(),
             any(),
@@ -403,7 +406,7 @@ class RealExchangeV2RunnerTest {
         whenever(recoveryCodeProvider.createDdgAccountIfNeeded()).thenReturn(Result.Success(Unit))
         whenever(recoveryCodeProvider.getDdgRecoveryCode()).thenReturn(Result.Success("the-code"))
         whenever(
-            channel.sendMessage(argThat { contains("recovery_code_response") }, any(), any(), any()),
+            channel.sendMessage(any<RecoveryCodeResponse>(), any(), any(), any()),
         ).thenReturn(Result.Error(reason = "relay unreachable"))
 
         val runner = newRunner()
@@ -422,7 +425,7 @@ class RealExchangeV2RunnerTest {
         runner.startScan("")
 
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeAvailable.create(userId = "peer-user", name = "Peer", kind = "3party"),
+            RecoveryCodeAvailable.create(userId = "peer-user", name = "Peer", kind = "3party"),
         )
 
         assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
@@ -448,7 +451,7 @@ class RealExchangeV2RunnerTest {
 
         runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
             runner.deliverIncomingMessage(
-                ExchangeV2Message.RecoveryCodeAvailable.create(userId = "shared-user", name = "Peer", kind = "ddg"),
+                RecoveryCodeAvailable.create(userId = "shared-user", name = "Peer", kind = "ddg"),
             )
             val event = awaitItem()
             assertSame(ExchangeV2State.SameAccountAbort, event.to)
@@ -463,7 +466,7 @@ class RealExchangeV2RunnerTest {
         runner.deliverIncomingMessage(Hello.fromJson("{}"))
 
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeAvailable.create(userId = "peer-user", name = "Peer", kind = "ddg"),
+            RecoveryCodeAvailable.create(userId = "peer-user", name = "Peer", kind = "ddg"),
         )
 
         assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
@@ -475,7 +478,7 @@ class RealExchangeV2RunnerTest {
         runner.startScan("")
 
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeAvailable.create(userId = "peer-user", name = "Peer", kind = "ddg"),
+            RecoveryCodeAvailable.create(userId = "peer-user", name = "Peer", kind = "ddg"),
         )
 
         assertSame(ExchangeV2State.Joiner.Confirming, runner.currentState)
@@ -507,7 +510,7 @@ class RealExchangeV2RunnerTest {
         val runner = newRunner()
         runner.startScan("")
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeAvailable.create(userId = "other", name = "Peer", kind = "3party"),
+            RecoveryCodeAvailable.create(userId = "other", name = "Peer", kind = "3party"),
         )
         runner.localTrigger(LocalTrigger.UserConfirmedJoiner)
         runner.deliverIncomingMessage(RecoveryCodeResponse.fromJson("{}"))
@@ -560,7 +563,7 @@ class RealExchangeV2RunnerTest {
         whenever(syncStore.userId).thenReturn("shared")
         whenever(channel.poll(any(), any())).thenReturn(
             flowOf(
-                ExchangeV2Message.RecoveryCodeAvailable.create(userId = "shared", name = "Peer", kind = "ddg"),
+                RecoveryCodeAvailable.create(userId = "shared", name = "Peer", kind = "ddg"),
             ),
         )
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -18,10 +18,14 @@ package com.duckduckgo.sync.impl.exchange.v2
 
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncDeviceIds
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.crypto.RsaKeyPair
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
@@ -44,6 +48,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -62,6 +67,7 @@ class RealExchangeV2RunnerTest {
     private val qrCode: ExchangeV2QrCode = mock()
     private val recoveryCodeProvider: RecoveryCodeProvider = mock()
     private val syncDeviceIds: SyncDeviceIds = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
 
     private fun newRunner(): RealExchangeV2Runner =
         RealExchangeV2Runner(
@@ -74,13 +80,14 @@ class RealExchangeV2RunnerTest {
             qrCode = qrCode,
             recoveryCodeProvider = recoveryCodeProvider,
             syncDeviceIds = syncDeviceIds,
+            syncFeature = syncFeature,
             appScope = coroutineTestRule.testScope,
             dispatchers = coroutineTestRule.testDispatcherProvider,
         )
 
     @Before fun stubWireDeps() {
         whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "peer-channel", publicKey = "peer-pubkey", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "peer-channel", publicKey = "peer-pubkey", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(qrCode.buildLinkingCode(any(), any(), any())).thenReturn("https://duckduckgo.com/sync/pairing/#&code2=fake")
         whenever(jweCrypto.generateRsaKeyPair(any())).thenReturn(RsaKeyPair(publicKeyBase64 = "own-pub", privateKeyBase64 = "own-priv"))
@@ -254,6 +261,22 @@ class RealExchangeV2RunnerTest {
             any(),
             any(),
         )
+    }
+
+    @Test fun `startPresent builds a v2_0 linking code when the v2_1 exchange flag is disabled`() {
+        syncFeature.canUseExchangeV2Point1().setRawStoredState(State(enable = false))
+        val runner = newRunner()
+        runner.startPresent()
+
+        verify(qrCode).buildLinkingCode(any(), any(), eq(ExchangeProtocolVersion.V2_0))
+    }
+
+    @Test fun `startPresent builds a v2_1 linking code when the v2_1 exchange flag is enabled`() {
+        syncFeature.canUseExchangeV2Point1().setRawStoredState(State(enable = true))
+        val runner = newRunner()
+        runner.startPresent()
+
+        verify(qrCode).buildLinkingCode(any(), any(), eq(ExchangeProtocolVersion.V2_1))
     }
 
     // ---- Auto role election ----

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -124,7 +124,7 @@ class RealExchangeV2RunnerTest {
         val runner = newRunner()
         runner.startScan("")
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "peer", name = "Peer", kind = "3party"),
+            ExchangeV2Message.RecoveryCodeAvailable.create(userId = "peer", name = "Peer", kind = "3party"),
         )
 
         runner.startScan("")
@@ -139,7 +139,7 @@ class RealExchangeV2RunnerTest {
         runner.startPresent()
 
         runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
-            runner.deliverIncomingMessage(Hello("""{"type":"hello"}"""))
+            runner.deliverIncomingMessage(Hello.fromJson("""{"type":"hello"}"""))
             val event = awaitItem()
             assertSame(ExchangeV2State.Bootstrapped, event.from)
             assertSame(ExchangeV2State.Negotiating, event.to)
@@ -149,7 +149,7 @@ class RealExchangeV2RunnerTest {
     @Test fun `deliverIncomingMessage without a session emits PairingSessionNotReady`() = runTest {
         val runner = newRunner()
         runner.events.filterIsInstance<ExchangeV2Event.SessionError>().test {
-            runner.deliverIncomingMessage(Hello("{}"))
+            runner.deliverIncomingMessage(Hello.fromJson("{}"))
             val event = awaitItem()
             assertEquals(SessionErrorKind.PairingSessionNotReady, event.kind)
         }
@@ -182,7 +182,7 @@ class RealExchangeV2RunnerTest {
 
     @Test fun `recordSentMessage emits MessageSent with given message`() = runTest {
         val runner = newRunner()
-        val sent = RecoveryCodeRequest(rawJson = "{}", name = "me", kind = "3party")
+        val sent = RecoveryCodeRequest.create(name = "me", kind = "3party")
 
         runner.events.test {
             runner.recordSentMessage(sent)
@@ -195,7 +195,7 @@ class RealExchangeV2RunnerTest {
         whenever(syncStore.userId).thenReturn("my-user")
         val runner = newRunner()
         runner.startPresent()
-        runner.deliverIncomingMessage(Hello("{}"))
+        runner.deliverIncomingMessage(Hello.fromJson("{}"))
 
         runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
             awaitItem()
@@ -209,10 +209,10 @@ class RealExchangeV2RunnerTest {
         whenever(syncStore.userId).thenReturn(null)
         val runner = newRunner()
         runner.startScan("")
-        runner.deliverIncomingMessage(ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "other", name = "Peer", kind = "3party"))
+        runner.deliverIncomingMessage(ExchangeV2Message.RecoveryCodeAvailable.create(userId = "other", name = "Peer", kind = "3party"))
         runner.localTrigger(LocalTrigger.RoleElected(Role.Joiner))
         runner.localTrigger(LocalTrigger.UserConfirmedJoiner)
-        runner.deliverIncomingMessage(RecoveryCodeResponse("{}"))
+        runner.deliverIncomingMessage(RecoveryCodeResponse.fromJson("{}"))
 
         assertNull(runner.currentState)
     }
@@ -224,7 +224,7 @@ class RealExchangeV2RunnerTest {
 
         runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
             runner.deliverIncomingMessage(
-                ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "shared-user", name = "Peer", kind = "3party"),
+                ExchangeV2Message.RecoveryCodeAvailable.create(userId = "shared-user", name = "Peer", kind = "3party"),
             )
             val event = awaitItem()
             assertSame(ExchangeV2State.SameAccountAbort, event.to)
@@ -328,7 +328,7 @@ class RealExchangeV2RunnerTest {
         runner.startScan("")
 
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "host-user", name = "Host", kind = "ddg"),
+            ExchangeV2Message.RecoveryCodeAvailable.create(userId = "host-user", name = "Host", kind = "ddg"),
         )
 
         assertSame(ExchangeV2State.Joiner.Confirming, runner.currentState)
@@ -338,10 +338,10 @@ class RealExchangeV2RunnerTest {
         whenever(syncStore.userId).thenReturn("my-user")
         val runner = newRunner()
         runner.startPresent()
-        runner.deliverIncomingMessage(Hello("{}"))
+        runner.deliverIncomingMessage(Hello.fromJson("{}"))
 
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"),
+            ExchangeV2Message.RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"),
         )
 
         assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
@@ -351,10 +351,10 @@ class RealExchangeV2RunnerTest {
         whenever(syncStore.userId).thenReturn("my-user")
         val runner = newRunner()
         runner.startPresent()
-        runner.deliverIncomingMessage(Hello("{}"))
+        runner.deliverIncomingMessage(Hello.fromJson("{}"))
 
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"),
+            ExchangeV2Message.RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"),
         )
 
         // Spec §"Exchange Confirmations → Host": awaiting_confirmation is sent on entry to
@@ -378,9 +378,9 @@ class RealExchangeV2RunnerTest {
         whenever(recoveryCodeProvider.getDdgRecoveryCode()).thenReturn(com.duckduckgo.sync.impl.Result.Success("the-code"))
         val runner = newRunner()
         runner.startPresent()
-        runner.deliverIncomingMessage(Hello("{}"))
+        runner.deliverIncomingMessage(Hello.fromJson("{}"))
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"),
+            ExchangeV2Message.RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"),
         )
         runner.localTrigger(LocalTrigger.UserConfirmedHost)
 
@@ -408,8 +408,8 @@ class RealExchangeV2RunnerTest {
 
         val runner = newRunner()
         runner.startPresent()
-        runner.deliverIncomingMessage(Hello("{}"))
-        runner.deliverIncomingMessage(RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"))
+        runner.deliverIncomingMessage(Hello.fromJson("{}"))
+        runner.deliverIncomingMessage(RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"))
         runner.localTrigger(LocalTrigger.UserConfirmedHost)
 
         val lastTransition = runner.events.replayCache.filterIsInstance<ExchangeV2Event.Transition>().last()
@@ -422,7 +422,7 @@ class RealExchangeV2RunnerTest {
         runner.startScan("")
 
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "peer-user", name = "Peer", kind = "3party"),
+            ExchangeV2Message.RecoveryCodeAvailable.create(userId = "peer-user", name = "Peer", kind = "3party"),
         )
 
         assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
@@ -434,7 +434,7 @@ class RealExchangeV2RunnerTest {
         runner.startScan("")
 
         runner.events.filterIsInstance<ExchangeV2Event.SessionError>().test {
-            runner.deliverIncomingMessage(Hello("{}"))
+            runner.deliverIncomingMessage(Hello.fromJson("{}"))
             val event = awaitItem()
             assertSame(SessionErrorKind.UnexpectedSecondHello, event.kind)
         }
@@ -448,7 +448,7 @@ class RealExchangeV2RunnerTest {
 
         runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
             runner.deliverIncomingMessage(
-                ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "shared-user", name = "Peer", kind = "ddg"),
+                ExchangeV2Message.RecoveryCodeAvailable.create(userId = "shared-user", name = "Peer", kind = "ddg"),
             )
             val event = awaitItem()
             assertSame(ExchangeV2State.SameAccountAbort, event.to)
@@ -460,10 +460,10 @@ class RealExchangeV2RunnerTest {
         whenever(syncStore.userId).thenReturn("my-user")
         val runner = newRunner()
         runner.startPresent()
-        runner.deliverIncomingMessage(Hello("{}"))
+        runner.deliverIncomingMessage(Hello.fromJson("{}"))
 
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "peer-user", name = "Peer", kind = "ddg"),
+            ExchangeV2Message.RecoveryCodeAvailable.create(userId = "peer-user", name = "Peer", kind = "ddg"),
         )
 
         assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
@@ -475,7 +475,7 @@ class RealExchangeV2RunnerTest {
         runner.startScan("")
 
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "peer-user", name = "Peer", kind = "ddg"),
+            ExchangeV2Message.RecoveryCodeAvailable.create(userId = "peer-user", name = "Peer", kind = "ddg"),
         )
 
         assertSame(ExchangeV2State.Joiner.Confirming, runner.currentState)
@@ -507,10 +507,10 @@ class RealExchangeV2RunnerTest {
         val runner = newRunner()
         runner.startScan("")
         runner.deliverIncomingMessage(
-            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "other", name = "Peer", kind = "3party"),
+            ExchangeV2Message.RecoveryCodeAvailable.create(userId = "other", name = "Peer", kind = "3party"),
         )
         runner.localTrigger(LocalTrigger.UserConfirmedJoiner)
-        runner.deliverIncomingMessage(RecoveryCodeResponse("{}"))
+        runner.deliverIncomingMessage(RecoveryCodeResponse.fromJson("{}"))
         assertNull(runner.currentState)
 
         advanceTimeBy(6 * 60 * 1000L)
@@ -545,8 +545,8 @@ class RealExchangeV2RunnerTest {
         whenever(syncStore.userId).thenReturn("my-user")
         whenever(channel.poll(any(), any())).thenReturn(
             flowOf(
-                Hello("""{"type":"hello"}"""),
-                RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"),
+                Hello.fromJson("""{"type":"hello"}"""),
+                RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"),
             ),
         )
 
@@ -560,7 +560,7 @@ class RealExchangeV2RunnerTest {
         whenever(syncStore.userId).thenReturn("shared")
         whenever(channel.poll(any(), any())).thenReturn(
             flowOf(
-                ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "shared", name = "Peer", kind = "ddg"),
+                ExchangeV2Message.RecoveryCodeAvailable.create(userId = "shared", name = "Peer", kind = "ddg"),
             ),
         )
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -444,7 +444,7 @@ internal class EnterCodeViewModelTest {
                     timestampMs = 0L,
                     from = ExchangeV2State.Joiner.Confirming,
                     to = ExchangeV2State.Joiner.AbortedByHost,
-                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    trigger = ExchangeV2Message.RecoveryCodeDenied.fromJson("{}"),
                     localTrigger = null,
                 ),
             ),

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -46,6 +46,7 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncAuthCode.Unknown
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -164,7 +165,7 @@ internal class EnterCodeViewModelTest {
         val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
         whenever(qrCode.parse(pastedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
@@ -404,7 +405,7 @@ internal class EnterCodeViewModelTest {
         val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
         whenever(qrCode.parse(pastedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(
@@ -435,7 +436,7 @@ internal class EnterCodeViewModelTest {
         val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
         whenever(qrCode.parse(pastedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -549,7 +549,7 @@ class SyncConnectViewModelTest {
                 transition(
                     from = ExchangeV2State.Joiner.Waiting,
                     to = ExchangeV2State.Joiner.Done,
-                    trigger = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}", recoveryCode = b64),
+                    trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = b64),
                 ),
             )
             cancelAndIgnoreRemainingEvents()
@@ -592,7 +592,7 @@ class SyncConnectViewModelTest {
                 transition(
                     from = ExchangeV2State.Joiner.Waiting,
                     to = ExchangeV2State.Joiner.Done,
-                    trigger = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}", recoveryCode = b64),
+                    trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = b64),
                 ),
             )
             cancelAndIgnoreRemainingEvents()
@@ -640,7 +640,7 @@ class SyncConnectViewModelTest {
                 transition(
                     from = ExchangeV2State.Joiner.Waiting,
                     to = ExchangeV2State.Joiner.Done,
-                    trigger = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}", recoveryCode = recoveryB64),
+                    trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = recoveryB64),
                 ),
             )
             val command = awaitItem()
@@ -840,7 +840,7 @@ class SyncConnectViewModelTest {
                     timestampMs = 0L,
                     from = ExchangeV2State.Joiner.Confirming,
                     to = ExchangeV2State.Joiner.AbortedByHost,
-                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    trigger = ExchangeV2Message.RecoveryCodeDenied.fromJson("{}"),
                     localTrigger = null,
                 ),
             ),

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.sync.impl.SyncAuthCode.Connect
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncCodeType
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -613,7 +614,7 @@ class SyncConnectViewModelTest {
             com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult.LinkingV2(
                 channelId = "chan",
                 publicKey = "pk",
-                version = "2",
+                version = ExchangeProtocolVersion.V2_0,
             ),
         )
         val recoveryJson = org.json.JSONObject().apply {
@@ -831,7 +832,7 @@ class SyncConnectViewModelTest {
         whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
         val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(qrCode.parse(scannedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(
@@ -883,7 +884,7 @@ class SyncConnectViewModelTest {
         whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
         val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(qrCode.parse(scannedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -139,7 +139,7 @@ class SyncLoginViewModelTest {
                     timestampMs = 0L,
                     from = ExchangeV2State.Joiner.Confirming,
                     to = ExchangeV2State.Joiner.AbortedByHost,
-                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    trigger = ExchangeV2Message.RecoveryCodeDenied.fromJson("{}"),
                     localTrigger = null,
                 ),
             ),

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -110,7 +111,7 @@ class SyncLoginViewModelTest {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
         val scanned = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(qrCode.parse(scanned)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
@@ -130,7 +131,7 @@ class SyncLoginViewModelTest {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
         val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(qrCode.parse(scannedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(
@@ -169,7 +170,7 @@ class SyncLoginViewModelTest {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
         val scanned = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(qrCode.parse(scanned)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -786,7 +786,7 @@ class SyncWithAnotherDeviceViewModelTest {
                     timestampMs = System.currentTimeMillis(),
                     from = ExchangeV2State.Joiner.Confirming,
                     to = ExchangeV2State.Joiner.AbortedByHost,
-                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    trigger = ExchangeV2Message.RecoveryCodeDenied.fromJson("{}"),
                     localTrigger = null,
                 ),
             )

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -54,6 +54,7 @@ import com.duckduckgo.sync.impl.SyncAuthCode.Exchange
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.encodeB64
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -775,7 +776,7 @@ class SyncWithAnotherDeviceViewModelTest {
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
         val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(qrCode.parse(scannedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
 
         testee.commands().test {
@@ -834,7 +835,7 @@ class SyncWithAnotherDeviceViewModelTest {
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
         val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(qrCode.parse(scannedCode)).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
         whenever(runner.eventsSince(any())).thenReturn(
             flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -158,6 +158,7 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.syncFaviconsPromptCta.setOnClickListener {
             viewModel.resetFaviconsPrompt()
         }
+        binding.checkLinkingCodeCta.setOnClickListener { viewModel.onCheckLinkingCodeClicked() }
         binding.testSyncWarningToggle.setOnCheckedChangeListener(testSyncWarningListener)
         binding.clearHistoryBookmarkAddedDialogPromo.setOnClickListener { viewModel.onClearHistoryBookmarkAddedDialogPromoClicked() }
         binding.clearHistoryBookmarkScreenPromo.setOnClickListener { viewModel.onClearHistoryBookmarkScreenPromoClicked() }
@@ -348,6 +349,7 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.recoveryCodeDecodedTextView.text = decodeStandardBase64(viewState.recoveryCode, emptyPlaceholder = "(not signed in)")
         binding.thirdPartyRecoveryCodeTextView.text = viewState.thirdPartyRecoveryCode.ifEmpty { "(no 3party credential yet)" }
         binding.thirdPartyRecoveryCodeDecodedTextView.text = decodeThirdPartyRecoveryCode(viewState.thirdPartyRecoveryCode)
+        binding.checkLinkingCodeResultTextView.text = viewState.checkLinkingCodeResult
         binding.connectedDevicesList.removeAllViews()
         binding.blockStoreFeatureFlag.text = viewState.blockStoreFeatureFlagText
         binding.blockStoreAvailability.text = viewState.blockStoreAvailabilityText
@@ -367,6 +369,9 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         }
         binding.canShowV2ConnectCodeToggle.quietlySetIsChecked(viewState.canShowV2ConnectCodeEnabled) { _, enabled ->
             viewModel.onCanShowV2ConnectCodeFlagChanged(enabled)
+        }
+        binding.canUseExchangeV2Point1.quietlySetIsChecked(viewState.canUseExchangeV2Point1) { _, enabled ->
+            viewModel.onCanUseExchangeV2Point1FlagChanged(enabled)
         }
         binding.accessCredentialsTextView.text = viewState.accessCredentialsText
         binding.scopedTokenResultTextView.text = viewState.scopedTokenResult

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -480,11 +480,19 @@ constructor(
         }
     }
 
-    private fun fetchV1LinkingCode(): String =
-        when (val result = syncAccountRepository.getConnectQR()) {
-            is Success -> describeQrCode(result.data.qrCode)
-            is Error -> "Failed to fetch v1 connect code: $result"
+    private fun fetchV1LinkingCode(): String {
+        val signedIn = syncAccountRepository.isSignedIn()
+        val result = if (signedIn) {
+            syncAccountRepository.generateExchangeInvitationCode()
+        } else {
+            syncAccountRepository.getConnectQR()
         }
+        val label = if (signedIn) "invitation" else "connect"
+        return when (result) {
+            is Success -> describeQrCode(result.data.qrCode)
+            is Error -> "Failed to fetch v1 $label code: $result"
+        }
+    }
 
     private suspend fun fetchV2LinkingCode(): String {
         val outcome = syncCodeDispatcher.presentV2().firstOrNull { it is DispatchOutcome.LinkingCodeReady || it is DispatchOutcome.Failed }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.internal.ui
 import android.annotation.SuppressLint
 import android.app.KeyguardManager
 import android.content.Context
+import android.util.Base64
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
@@ -37,16 +38,20 @@ import com.duckduckgo.sync.impl.DeviceInfoMigrator
 import com.duckduckgo.sync.impl.DeviceInfoSessionResult
 import com.duckduckgo.sync.impl.DeviceInfoUpdater
 import com.duckduckgo.sync.impl.DeviceV2
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncApi
 import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncDeviceIds
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
 import com.duckduckgo.sync.impl.autorestore.SyncRecoveryPersistentStorageKey
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
 import com.duckduckgo.sync.impl.getOrNull
 import com.duckduckgo.sync.impl.internal.SyncInternalEnvDataStore
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore
@@ -65,6 +70,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
@@ -95,6 +101,8 @@ constructor(
     private val deviceFieldDecryptor: DeviceFieldDecryptor,
     private val deviceInfoMigrator: DeviceInfoMigrator,
     private val syncDeviceIds: SyncDeviceIds,
+    private val exchangeV2QrCode: ExchangeV2QrCode,
+    private val syncCodeDispatcher: SyncCodeDispatcher,
     @field:SuppressLint("StaticFieldLeak") private val context: Context,
 ) : ViewModel() {
 
@@ -131,6 +139,8 @@ constructor(
         val blockStoreCurrentValueText: String = "Loading...",
         val canUseV2ConnectFlowEnabled: Boolean = false,
         val canShowV2ConnectCodeEnabled: Boolean = false,
+        val canUseExchangeV2Point1: Boolean = false,
+        val checkLinkingCodeResult: String = "",
         val accessCredentialsText: String = "",
         val scopedTokenResult: String = "",
         val v2StoreFieldsText: String = "",
@@ -258,6 +268,15 @@ constructor(
     }
 
     @SuppressLint("DenyListedApi")
+    fun onCanUseExchangeV2Point1FlagChanged(enabled: Boolean) {
+        viewModelScope.launch(dispatchers.io()) {
+            logcat { "Sync-ScopedToken: setting canUseExchangeV2Point1 flag = $enabled" }
+            setRawToggleState(syncFeature.canUseExchangeV2Point1(), enabled)
+            updateViewState()
+        }
+    }
+
+    @SuppressLint("DenyListedApi")
     private fun setRawToggleState(
         toggle: Toggle,
         enabled: Boolean,
@@ -329,6 +348,7 @@ constructor(
                 environment = syncEnvDataStore.syncEnvironmentUrl,
                 canUseV2ConnectFlowEnabled = syncFeature.canUseV2ConnectFlow().isEnabled(),
                 canShowV2ConnectCodeEnabled = syncFeature.canShowV2ConnectCode().isEnabled(),
+                canUseExchangeV2Point1 = syncFeature.canUseExchangeV2Point1().isEnabled(),
                 v2StoreFieldsText = buildV2StoreFieldsText(),
                 // Clear per-session dev-tool results once signed out so stale keys aren't shown.
                 keysText = if (accountInfo.isSignedIn) viewState.value.keysText else "",
@@ -362,6 +382,23 @@ constructor(
         viewModelScope.launch(dispatchers.io()) {
             val recoveryCode = syncAccountRepository.getRecoveryCode().getOrNull() ?: return@launch
             command.send(ShowQR(recoveryCode.qrCode))
+        }
+    }
+
+    private fun describeQrCode(rawCode: String): String {
+        val decodedPayload = runCatching {
+            String(Base64.decode(rawCode, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP), Charsets.UTF_8)
+        }.getOrDefault(rawCode)
+        return when (val parsed = exchangeV2QrCode.parse(rawCode)) {
+            is ExchangeV2CodeParseResult.LinkingV1 -> "v1 linking code\n$decodedPayload"
+
+            is ExchangeV2CodeParseResult.LinkingV2 -> {
+                "v2 linking code\nversion ${parsed.version}\nchannel_id: ${parsed.channelId}\npublic_key: ${parsed.publicKey}"
+            }
+
+            is ExchangeV2CodeParseResult.RecoveryCode -> "recovery code\n${parsed.rawJson}"
+
+            is ExchangeV2CodeParseResult.Unknown -> decodedPayload
         }
     }
 
@@ -431,6 +468,30 @@ constructor(
                     }
                 }
             }
+        }
+    }
+
+    fun onCheckLinkingCodeClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            val useV2 = syncFeature.canUseV2ConnectFlow().isEnabled() && syncFeature.canShowV2ConnectCode().isEnabled()
+            viewState.update { it.copy(checkLinkingCodeResult = "Fetching ${if (useV2) "v2" else "v1"} linking code…") }
+            val result = if (useV2) fetchV2LinkingCode() else fetchV1LinkingCode()
+            viewState.update { it.copy(checkLinkingCodeResult = result) }
+        }
+    }
+
+    private fun fetchV1LinkingCode(): String =
+        when (val result = syncAccountRepository.getConnectQR()) {
+            is Success -> describeQrCode(result.data.qrCode)
+            is Error -> "Failed to fetch v1 connect code: $result"
+        }
+
+    private suspend fun fetchV2LinkingCode(): String {
+        val outcome = syncCodeDispatcher.presentV2().firstOrNull { it is DispatchOutcome.LinkingCodeReady || it is DispatchOutcome.Failed }
+        return when (outcome) {
+            is DispatchOutcome.LinkingCodeReady -> describeQrCode(outcome.linkingCode)
+            is DispatchOutcome.Failed -> "Failed to fetch v2 linking code: ${outcome.reason}"
+            else -> "v2 session ended without a linking code"
         }
     }
 

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -112,6 +112,13 @@
             app:showSwitch="true"
             app:primaryText="canShowV2ConnectCode (display, requires canUseV2ConnectFlow)" />
 
+        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+            android:id="@+id/canUseExchangeV2Point1"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="canUseExchangeV2.1"
+            app:showSwitch="true" />
+
         <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
             android:id="@+id/openV2PairingDebugButton"
             android:layout_width="wrap_content"
@@ -694,6 +701,28 @@
                 android:layout_height="wrap_content"
                 android:ellipsize="end"
                 android:maxLines="5"
+                app:typography="body2" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Check linking code" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/checkLinkingCodeCta"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/sync_internal_check_linking_code_cta"
+                app:daxButtonSize="large" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/checkLinkingCodeResultTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginTop="@dimen/keyline_2"
+                android:layout_marginEnd="@dimen/keyline_4"
                 app:typography="body2" />
 
             <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem

--- a/sync/sync-internal/src/main/res/values/donottranslate.xml
+++ b/sync/sync-internal/src/main/res/values/donottranslate.xml
@@ -31,6 +31,7 @@
     <string name="sync_internal_recovery_code">Recovery code</string>
     <string name="sync_internal_recovery_code_cta">Copy Recovery code</string>
     <string name="sync_internal_favicons_prompt_cta">Reset Favicons Prompt</string>
+    <string name="sync_internal_check_linking_code_cta">Check linking code</string>
     <string name="userIdSectionHeader">User ID</string>
     <string name="deviceIdSectionHeader">Device Id</string>
     <string name="deviceNameSectionHeader">Device Name</string>

--- a/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
+++ b/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
@@ -86,7 +86,7 @@ class SyncV2PairingDebugViewModelTest {
                     timestampMs = 100L,
                     from = ExchangeV2State.Bootstrapped,
                     to = ExchangeV2State.Negotiating,
-                    trigger = Hello("""{"type":"hello"}"""),
+                    trigger = Hello.fromJson("""{"type":"hello"}"""),
                     localTrigger = null,
                 ),
             )
@@ -105,7 +105,7 @@ class SyncV2PairingDebugViewModelTest {
             eventFlow.emit(
                 ExchangeV2Event.MessageSent(
                     timestampMs = 0L,
-                    message = ExchangeV2Message.RecoveryCodeRequest(rawJson = "{}", name = "me", kind = "3party"),
+                    message = ExchangeV2Message.RecoveryCodeRequest.create(name = "me", kind = "3party"),
                 ),
             )
             val state = awaitItem()
@@ -121,8 +121,7 @@ class SyncV2PairingDebugViewModelTest {
             eventFlow.emit(
                 ExchangeV2Event.MessageRejected(
                     timestampMs = 0L,
-                    message = ExchangeV2Message.RecoveryCodeAvailable(
-                        rawJson = "{}",
+                    message = ExchangeV2Message.RecoveryCodeAvailable.create(
                         userId = "shared",
                         name = "Peer",
                         kind = "3party",
@@ -145,7 +144,7 @@ class SyncV2PairingDebugViewModelTest {
                     timestampMs = 0L,
                     from = ExchangeV2State.Bootstrapped,
                     to = ExchangeV2State.Negotiating,
-                    trigger = Hello("{}"),
+                    trigger = Hello.fromJson("{}"),
                     localTrigger = null,
                 ),
             )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1217777614176413
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1217626160385689
API Proposals URL(s) (if applicable): N/A

### Description

Prepares the Exchange v2 envelope for v2.1 by making the envelope carry the version required by the message it wraps, instead of a hard-coded "2". This is groundwork for sending messages that need a newer minor version, and there is no change to the pairing flow a user sees today.

- The v2 channel and envelope now take a typed `ExchangeV2Message` instead of a raw JSON string, so the message being sent is the same object all the way down to encryption.
- The version written into an outgoing envelope comes from the message's own `protocolVersion`, which is `2` for every message the app sends today, so codes and messages stay compatible with existing devices.
- Inbound envelopes are parsed with the shared `ExchangeProtocolVersion` type. A version with a higher major than we support is still rejected as too new, a v1 envelope is still rejected as obsolete, and a version that cannot be parsed at all is still rejected as malformed.
- The confirmation messages sent during a session (`recovery_code_awaiting_confirmation`, `recovery_code_confirmed`, `recovery_code_denied`) are built as typed messages rather than inline JSON literals, and go on the wire unchanged.
- The `OUR_MAJOR` and `OUR_VERSION_STRING` constants are gone, replaced by `ExchangeProtocolVersion.V2.MAJOR`.

### Steps to test this PR

_Pair with a production app, v2.1 disabled_
- [ ] Install this branch as an internal build on one device.
- [ ] Install the current Play Store release on a second device.
- [ ] On the internal build, leave `canUseExchangeV2Point1` disabled.
- [ ] On the internal build, start the flow that shows the sync QR code.
- [ ] Scan that code with the production app.
- [ ] Verify both devices end up signed in to the same sync account.
- [ ] Show the sync QR code on the production app.
- [ ] Scan that code with the internal build.
- [x] Verify pairing completes with no error.

_Pair with a production app, v2.1 enabled_
- [ ] On the internal build, enable `canUseExchangeV2Point1`.
- [ ] On the internal build, start the flow that shows the sync QR code.
- [ ] Scan that code with the production app.
- [ ] Verify both devices end up signed in to the same sync account.
- [ ] Show the sync QR code on the production app.
- [ ] Scan that code with the internal build.
- [x] Verify pairing completes with no error.

### UI changes
N/A

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync pairing encryption and envelope negotiation on the relay; behavior for current v2.0 traffic should stay compatible, but mistakes in version handling could break cross-device pairing.
> 
> **Overview**
> Prepares Exchange v2 for **v2.1** by tying relay envelope `version` to each outgoing message instead of a fixed `"2"`.
> 
> **Wire path:** `ExchangeV2Channel` and `ExchangeV2Envelope` now accept **`ExchangeV2Message`** (not raw JSON). Sealing encrypts `message.rawJson` and sets `ExchangeEnvelope.version` from **`message.protocolVersion`**, so future messages can advertise a newer minor while today’s traffic still uses the versions the app already sends.
> 
> **Inbound envelopes:** `open()` parses versions via **`ExchangeProtocolVersion`**—v2 majors (including minors like `2.5`) still decrypt; v1 is obsolete; unknown higher majors still raise **`EnvelopeVersionTooNew`** with a typed version. **`OUR_MAJOR` / `OUR_VERSION_STRING`** are removed.
> 
> **Runner/tests:** `sendOnWireAndRecord` passes typed messages through; Mockito checks use message types instead of JSON substring matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c39e7ec192445adeec4fba1c29afa75abe0cfc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->