### PR TITLE
Add pixel definitions for CPM popup

### DIFF
--- a/PixelDefinitions/pixels/definitions/autoconsent.json5
+++ b/PixelDefinitions/pixels/definitions/autoconsent.json5
@@ -112,6 +112,42 @@
         "suffixes": ["form_factor"],
         "parameters": ["appVersion", "consentHeuristicEnabled"]
     },
+    "cookie_popup_opt_in_shown_first": {
+        "description": "Fires the first time the Cookie Pop-up Protection opt-in dialog is shown on app launch (once per install).",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "autoconsentEnabled"]
+    },
+    "cookie_popup_opt_in_shown_repeat": {
+        "description": "Fires when the Cookie Pop-up Protection opt-in dialog is shown again on app launch (any presentation after the first).",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "autoconsentEnabled"]
+    },
+    "cookie_popup_opt_in_option_confirmed": {
+        "description": "Fires when the user confirms the Cookie Pop-up Protection opt-in dialog. cookie_popup_preference is the resulting preference; autoconsent_enabled is the feature state when the dialog was shown; time_since_shown is the bucketed time from when the dialog was first shown to confirmation.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            "autoconsentEnabled",
+            {
+                "key": "cookie_popup_preference",
+                "type": "string",
+                "description": "The resulting Cookie Pop-up Protection preference after the user confirms the opt-in dialog.",
+                "enum": ["max", "default", "off"]
+            },
+            {
+                "key": "time_since_shown",
+                "type": "string",
+                "description": "Bucketed time elapsed from when the opt-in dialog was first shown to when it was confirmed.",
+                "enum": ["0-1min", "1-5min", "5-60min", "1h-1d", "1d+"]
+            }
+        ]
+    },
     "m_autoconsent_summary": {
         "description": "Fires periodically with counts of autoconsent metrics accumulated over 2 minutes.",
         "owners": ["muodov"],

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -220,6 +220,11 @@
         "description": "Heuristic action mode derived from user preference and feature flags.",
         "enum": ["off", "tier1", "tier2", "reject"]
     },
+    "autoconsentEnabled": {
+        "key": "autoconsent_enabled",
+        "type": "boolean",
+        "description": "Whether Cookie Pop-up Protection (autoconsent) was enabled at the moment the pixel fired."
+    },
     "pirCancellationReason": {
         "key": "feature.data.ext.cancellation_reason",
         "type": "string",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212227266948491/task/1217785389349034?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only pixel and param dictionary changes with no client or server runtime logic in this PR.
> 
> **Overview**
> Adds **telemetry definitions** for the Cookie Pop-up Protection (CPM) opt-in dialog under the existing autoconsent pixel bundle.
> 
> Three new pixels track **first vs repeat** dialog impressions on app launch (`cookie_popup_opt_in_shown_first`, `cookie_popup_opt_in_shown_repeat`) and **confirmation** (`cookie_popup_opt_in_option_confirmed`), including the chosen preference (`max`, `default`, `off`) and bucketed delay from first show to confirm.
> 
> A shared **`autoconsentEnabled`** param is added to `params_dictionary.json` (wire key `autoconsent_enabled`) and attached to these pixels so events can record whether autoconsent was on when the dialog fired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc506387e6c8f8e091b3661add307a2f4416d039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->