### PR TITLE
Add dev settings to reset modal coordinator cooldown

### DIFF
--- a/app/src/internal/AndroidManifest.xml
+++ b/app/src/internal/AndroidManifest.xml
@@ -34,6 +34,10 @@
             android:name="com.duckduckgo.app.dev.settings.onboarding.OnboardingDevSettingsActivity"
             android:label="@string/onboardingDevSettingsTitle"
             android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />
+        <activity
+            android:name="com.duckduckgo.app.dev.settings.modals.ModalCoordinatorDevSettingsActivity"
+            android:label="@string/modalCoordinatorDevSettingsTitle"
+            android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />
     </application>
 
 </manifest>

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/modals/ModalCoordinatorDevSettingsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/modals/ModalCoordinatorDevSettingsActivity.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.dev.settings.modals
+
+import android.os.Bundle
+import android.widget.Toast
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.ActivityModalCoordinatorDevSettingsBinding
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.promptscoordinator.impl.RealPromptsCoordinator
+import com.duckduckgo.promptscoordinator.impl.store.ModalEvaluatorCompletionStore
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@InjectWith(ActivityScope::class)
+@ContributeToActivityStarter(ModalCoordinatorDevSettingsScreen::class)
+class ModalCoordinatorDevSettingsActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
+    @Inject
+    lateinit var completionStore: ModalEvaluatorCompletionStore
+
+    @Inject
+    lateinit var promptsCoordinator: RealPromptsCoordinator
+
+    private val binding: ActivityModalCoordinatorDevSettingsBinding by viewBinding()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
+        setContentView(binding.root)
+        configureEdgeToEdgeInsets()
+        setupToolbar(binding.includeToolbar.toolbar)
+
+        binding.resetCooldownButton.setOnClickListener {
+            lifecycleScope.launch {
+                completionStore.resetCooldown()
+                promptsCoordinator.resetGap()
+                Toast.makeText(
+                    this@ModalCoordinatorDevSettingsActivity,
+                    R.string.modalCoordinatorDevSettingsResetCooldownDone,
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
+        }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
+    }
+}
+
+data object ModalCoordinatorDevSettingsScreen : GlobalActivityStarter.ActivityParams {
+    private fun readResolve(): Any = ModalCoordinatorDevSettingsScreen
+}

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/modals/ModalCoordinatorDevSettingsFeature.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/modals/ModalCoordinatorDevSettingsFeature.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.dev.settings.modals
+
+import android.content.Context
+import com.duckduckgo.anvil.annotations.PriorityKey
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.internal.features.api.InternalFeaturePlugin
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+@PriorityKey(InternalFeaturePlugin.MODAL_COORDINATOR_DEV_SETTINGS_PRIO_KEY)
+class ModalCoordinatorDevSettingsFeature @Inject constructor(
+    private val globalActivityStarter: GlobalActivityStarter,
+) : InternalFeaturePlugin {
+
+    override fun internalFeatureTitle(): String = "Modal Coordinator Dev Settings"
+
+    override fun internalFeatureSubtitle(): String = "Reset the 24-hour modal cooldown"
+
+    override fun onInternalFeatureClicked(activityContext: Context) {
+        globalActivityStarter.start(activityContext, ModalCoordinatorDevSettingsScreen)
+    }
+}

--- a/app/src/internal/res/layout/activity_modal_coordinator_dev_settings.xml
+++ b/app/src/internal/res/layout/activity_modal_coordinator_dev_settings.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context="com.duckduckgo.app.dev.settings.modals.ModalCoordinatorDevSettingsActivity">
+
+    <include
+        android:id="@+id/includeToolbar"
+        layout="@layout/include_default_toolbar" />
+
+    <ScrollView
+        android:id="@+id/contentScrollView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/keyline_4"
+                android:text="@string/modalCoordinatorDevSettingsResetCooldownDescription"
+                app:typography="body2" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/resetCooldownButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:text="@string/modalCoordinatorDevSettingsResetCooldown" />
+
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -134,4 +134,10 @@
     <string name="onboardingDevSettingsCompletedTitle">Onboarding completed</string>
     <string name="onboardingDevSettingsSkippedTitle">Onboarding skipped</string>
     <string name="onboardingDevSettingsDialogsSection">Dialogs shown</string>
+
+    <!-- Modal Coordinator Dev Settings -->
+    <string name="modalCoordinatorDevSettingsTitle">Modal Coordinator Dev Settings</string>
+    <string name="modalCoordinatorDevSettingsResetCooldownDescription">Once a prompt is shown, further modals are blocked: by the prompts coordinator quiet gap, or by the internal 24-hour window when the coordinator is off. This clears both, so modals are evaluated again on the next app resume.</string>
+    <string name="modalCoordinatorDevSettingsResetCooldown">Reset modal cooldown</string>
+    <string name="modalCoordinatorDevSettingsResetCooldownDone">Modal cooldown reset</string>
 </resources>

--- a/internal-features/internal-features-api/src/main/java/com/duckduckgo/internal/features/api/InternalFeaturePlugin.kt
+++ b/internal-features/internal-features-api/src/main/java/com/duckduckgo/internal/features/api/InternalFeaturePlugin.kt
@@ -51,5 +51,6 @@ interface InternalFeaturePlugin {
         const val SAVED_SITES_SETTINGS_PRIO_KEY = 1_100
         const val ATTRIBUTED_METRICS_SETTINGS_PRIO_KEY = 1_200
         const val ONBOARDING_DEV_SETTINGS_PRIO_KEY = 1_300
+        const val MODAL_COORDINATOR_DEV_SETTINGS_PRIO_KEY = 1_400
     }
 }

--- a/prompts-coordinator/prompts-coordinator-impl/src/main/java/com/duckduckgo/promptscoordinator/impl/RealPromptsCoordinator.kt
+++ b/prompts-coordinator/prompts-coordinator-impl/src/main/java/com/duckduckgo/promptscoordinator/impl/RealPromptsCoordinator.kt
@@ -159,6 +159,15 @@ class RealPromptsCoordinator @Inject constructor(
         }
     }
 
+    /** Clears the persisted quiet gap so the next claim cannot be refused by it. Internal builds only. */
+    suspend fun resetGap() = withContext(dispatchers.io()) {
+        claimMutex.withLock {
+            lastPromptAt.set(NO_PROMPT)
+            store.edit { it.remove(LAST_PROMPT_AT_KEY) }
+            logcat { "PromptsCoordinator: gap timestamp reset" }
+        }
+    }
+
     private val PromptType.cooldownMillis: Long
         get() = (cooldownMinutes * TimeUnit.MINUTES.toMillis(1)).toLong()
 

--- a/prompts-coordinator/prompts-coordinator-impl/src/main/java/com/duckduckgo/promptscoordinator/impl/store/ModalEvaluatorCompletionStore.kt
+++ b/prompts-coordinator/prompts-coordinator-impl/src/main/java/com/duckduckgo/promptscoordinator/impl/store/ModalEvaluatorCompletionStore.kt
@@ -52,6 +52,11 @@ interface ModalEvaluatorCompletionStore {
      * @return true if blocked (within 24 hours of last completion)
      */
     suspend fun isBlockedBy24HourWindow(): Boolean
+
+    /**
+     * Clears the last completion timestamp, so the next evaluation pass is not blocked by the 24-hour window.
+     */
+    suspend fun resetCooldown()
 }
 
 @ContributesBinding(AppScope::class)
@@ -94,6 +99,14 @@ class ModalEvaluatorCompletionStoreImpl @Inject constructor(
         }
         if (timestamp == NO_COMPLETION) return false
         return System.currentTimeMillis() - timestamp < TWENTY_FOUR_HOURS_MILLIS
+    }
+
+    override suspend fun resetCooldown() {
+        lastCompletionTimestamp.set(NO_COMPLETION)
+        withContext(dispatchers.io()) {
+            val key = getKeyCompletionTimestamp()
+            store.edit { it.remove(key) }
+        }
     }
 
     private suspend fun getLastCompletionTimestamp(): Long? {


### PR DESCRIPTION
Task/Issue URL: 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are scoped to internal dev settings and test helpers; release users do not get the reset entry point, though impl-layer reset methods exist if misused elsewhere later.
> 
> **Overview**
> Adds an **internal** “Modal Coordinator Dev Settings” entry (via `InternalFeaturePlugin`) that opens a new dev screen with a **Reset modal cooldown** action.
> 
> That action clears **both** modal throttling paths: the prompts coordinator **quiet gap** (`RealPromptsCoordinator.resetGap`) and the **24-hour modal evaluator window** (`ModalEvaluatorCompletionStore.resetCooldown`), so modal evaluation can run again on the next app resume. UI strings explain the two mechanisms.
> 
> Production modal/prompt behavior is unchanged unless someone uses internal builds and triggers the reset; the new reset APIs are only wired from this internal activity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cba0c6084da96729425863da2eb55eb85b3d43d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->