### PR TITLE
Add petal randomize to pixel definition to delay pixel reporting

### DIFF
--- a/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -410,6 +410,7 @@
         "owners": ["YoussefKeyrouz"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "form_factor"],
+        "petal": "randomize",
         "parameters": [
             "appVersion",
             {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1217791108661908?focus=true 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

Based on the discussion in [✓ Privacy Triage: Android - Add the m_app_return pixel, fired on every foreground return](https://app.asana.com/1/137249556945/project/69071770703008/task/1217524061930625?focus=true)

We need to add [petal=randomize](https://app.asana.com/1/137249556945/project/1209220182846570/task/1211062294407696?focus=true) to the definition of the pixel to add randomization to the app return pixel and resolve a privacy concern.

Only testing done was a smoke test to make sure the pixel is not impacted. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field pixel definition change that may alter telemetry timing for one high-volume event, with no auth, security, or core product logic changes.
> 
> **Overview**
> Adds **`petal": "randomize"`** to the **`m_app_return`** pixel definition in `ntp_after_idle.json5`, so the pixel processing pipeline can **delay or spread** when that event is reported (per the PR intent).
> 
> This only changes metadata for the app-return foreground pixel used as the denominator for “% of app opens” panels; no runtime app code changes appear in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0da5ed957708edea815483ebffe5dd8e55603af9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->