### PR TITLE
Add petal randomize param to m_app_return pixel

### DIFF
--- a/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -454,7 +454,8 @@
                 "type": "string",
                 "description": "What triggered this foreground transition",
                 "enum": ["standard", "url", "shortcut", "widget", "other"]
-            }
+            },
+            "petal_randomize"
         ]
     }
 }

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -165,8 +165,14 @@
     "petal": {
         "key": "petal",
         "type": "string",
-        "description": "Signals the pixel processing pipeline",
+        "description": "Signals the pixel processing pipeline (deprecated)",
         "enum": ["true"]
+    },
+    "petal_randomize": {
+        "key": "petal",
+        "type": "string",
+        "description": "Routes the pixel through the PETAL timestamp-randomization pipeline",
+        "enum": ["randomize", "kanon"]
     },
     "tabs": {
         "key": "tabs",

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppReturnPixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppReturnPixelSender.kt
@@ -119,6 +119,7 @@ class RealAppReturnPixelSender @Inject constructor(
                 put(AppReturnPixelParameters.UNIFIED_INPUT_AVAILABLE, duckAiFeatureState.nativeInputFieldEnabled.value.toString())
                 put(AppReturnPixelParameters.TOGGLE_VISIBLE, toggleVisible.toString())
                 put(AppReturnPixelParameters.LAUNCH_SOURCE, launchSource)
+                put(AppReturnPixelParameters.PETAL, PetalValues.RANDOMIZE)
             }
 
             pixel.get().fire(pixel = AppPixelName.APP_RETURN_COUNT, parameters = params)
@@ -155,6 +156,12 @@ object AppReturnPixelParameters {
     const val UNIFIED_INPUT_AVAILABLE = "unified_input_available"
     const val TOGGLE_VISIBLE = "toggle_visible"
     const val LAUNCH_SOURCE = "launch_source"
+    const val PETAL = "petal"
+}
+
+object PetalValues {
+    const val RANDOMIZE = "randomize"
+    const val KANON = "kanon"
 }
 
 object LaunchSourceValues {

--- a/app/src/test/java/com/duckduckgo/app/pixels/AppReturnPixelSenderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/pixels/AppReturnPixelSenderTest.kt
@@ -101,6 +101,7 @@ class AppReturnPixelSenderTest {
             AppReturnPixelParameters.UNIFIED_INPUT_AVAILABLE to "false",
             AppReturnPixelParameters.TOGGLE_VISIBLE to "false",
             AppReturnPixelParameters.LAUNCH_SOURCE to "standard",
+            AppReturnPixelParameters.PETAL to "randomize",
         )
         verify(pixel).fire(pixel = AppPixelName.APP_RETURN_COUNT, parameters = params)
         verify(pixel).fire(pixel = AppPixelName.APP_RETURN_DAILY, parameters = params, type = Pixel.PixelType.Daily())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1217791108661908?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

Adds a `petal` param to the `m_app_return pixel`, routing it through the PETAL pipeline (randomize). The legacy petal dictionary entry (`true`, used by the subscription-active pixel) is kept but marked deprecated. `kanon` is reserved as a future enum value, not yet fired.

### Steps to test this PR

- [ ] Background the app then launch it again
- [ ] `m_app_return` pixel should be fired and contain `petal=randomize` param


### UI changes
No UI Chages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only pixel parameter and definition changes; no auth, data handling, or user-facing app behavior changes beyond how this event is processed server-side.
> 
> **Overview**
> Routes **`m_app_return`** (count and daily) through the PETAL timestamp-randomization pipeline by always attaching **`petal=randomize`** when `AppReturnPixelSender` fires on foreground return.
> 
> Pixel metadata is aligned: **`m_app_return`** in `ntp_after_idle.json5` now lists the shared **`petal_randomize`** parameter, and **`params_dictionary.json`** adds **`petal_randomize`** (`randomize` / `kanon` on key `petal`) while marking the legacy **`petal=true`** entry as deprecated. Unit tests expect the new parameter on the cold-start path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83fad14d6da443895c3f3a6d240fa20561592c0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->