### PR TITLE
Add first_prompt_new_install param to Duck.ai prompt-submission pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1736,5 +1736,31 @@
         "triggers": ["exception"],
         "suffixes": ["first_daily_count", "form_factor"],
         "parameters": ["appVersion"]
+    },
+    "aichat_sent_prompt_ongoing_chat": {
+        "description": "User submitted a follow-up prompt in an existing Duck.ai chat, reported by the Duck.ai frontend via the reportMetric JS bridge.",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "parameters": [
+            {
+                "key": "delta-timestamp-minutes",
+                "type": "integer",
+                "description": "Minutes since the previous Duck.ai session interaction"
+            },
+            "firstPromptNewInstall"
+        ]
+    },
+    "aichat_start_new_conversation": {
+        "description": "User submitted the first prompt of a new Duck.ai chat, reported by the Duck.ai frontend via the reportMetric JS bridge.",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "parameters": [
+            {
+                "key": "delta-timestamp-minutes",
+                "type": "integer",
+                "description": "Minutes since the previous Duck.ai session interaction"
+            },
+            "firstPromptNewInstall"
+        ]
     }
 }

--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1262,7 +1262,8 @@
             { "key": "has_file_attachment", "type": "boolean", "description": "Whether the prompt included a file attachment" },
             { "key": "has_text", "type": "boolean", "description": "Whether the prompt included text" },
             "duckAiPromptPageType",
-            "duckAiEntrySource"
+            "duckAiEntrySource",
+            "firstPromptNewInstall"
         ]
     },
     "m_aichat_unified_input_prompt_submitted_daily": {
@@ -1296,7 +1297,8 @@
             { "key": "has_file_attachment", "type": "boolean", "description": "Whether the prompt included a file attachment" },
             { "key": "has_text", "type": "boolean", "description": "Whether the prompt included text" },
             "duckAiPromptPageType",
-            "duckAiEntrySource"
+            "duckAiEntrySource",
+            "firstPromptNewInstall"
         ]
     },
     "m_aichat_unified_input_sent_prompt_in_chat_count": {

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -38,6 +38,11 @@
             "none"
         ]
     },
+    "firstPromptNewInstall": {
+        "key": "first_prompt_new_install",
+        "type": "boolean",
+        "description": "Whether this is the first Duck.ai prompt ever submitted by a new install, across all surfaces. Omitted for existing installs and when false."
+    },
     "duckAiPromptPageType": {
         "key": "page_type",
         "type": "string",

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.DuckAiTabSessionRepository
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
@@ -286,7 +287,12 @@ class RealDuckChatPixels @Inject constructor(
     private val duckAiMetricCollector: DuckAiMetricCollector,
     private val termsOfServiceHandler: DuckChatTermsOfServiceHandler,
     private val duckAiTabSessionRepository: DuckAiTabSessionRepository,
+    private val appBuildConfig: AppBuildConfig,
 ) : DuckChatPixels {
+
+    /** `first_prompt_new_install` must be attributable to a fresh install, never to an existing user who just updated. */
+    private suspend fun isFirstPromptForNewInstall(): Boolean =
+        appBuildConfig.isNewInstall() && duckChatFeatureRepository.checkAndMarkFirstPromptSubmission()
 
     private fun fireCountAndDaily(
         count: DuckChatPixelName,
@@ -404,12 +410,20 @@ class RealDuckChatPixels @Inject constructor(
             val (pixelName, params) = when (reportMetric) {
                 USER_DID_SUBMIT_PROMPT -> {
                     refreshAtb = true
-                    DUCK_CHAT_SEND_PROMPT_ONGOING_CHAT to sessionParams
+                    val isFirstPrompt = isFirstPromptForNewInstall()
+                    DUCK_CHAT_SEND_PROMPT_ONGOING_CHAT to buildMap {
+                        putAll(sessionParams)
+                        if (isFirstPrompt) put(DuckChatPixelParameters.FIRST_PROMPT_NEW_INSTALL, "true")
+                    }
                 }
 
                 USER_DID_SUBMIT_FIRST_PROMPT -> {
                     refreshAtb = true
-                    DUCK_CHAT_START_NEW_CONVERSATION to sessionParams
+                    val isFirstPrompt = isFirstPromptForNewInstall()
+                    DUCK_CHAT_START_NEW_CONVERSATION to buildMap {
+                        putAll(sessionParams)
+                        if (isFirstPrompt) put(DuckChatPixelParameters.FIRST_PROMPT_NEW_INSTALL, "true")
+                    }
                 }
 
                 USER_DID_OPEN_HISTORY -> DUCK_CHAT_OPEN_HISTORY to sessionParams
@@ -816,6 +830,7 @@ class RealDuckChatPixels @Inject constructor(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_DAILY,
         ) {
             val source = resolveEntrySource(surface, tabId, addressBarEntryPoint)
+            val isFirstPrompt = isFirstPromptForNewInstall()
             buildMap {
                 put(DuckChatPixelParameters.SELECTED_TOOL, selectedTool)
                 modelId?.let { put(DuckChatPixelParameters.MODEL_ID, it) }
@@ -829,6 +844,7 @@ class RealDuckChatPixels @Inject constructor(
                     ?.let { put(DuckChatPixelParameters.DEFAULT_MODE, it.pixelValue()) }
                 put(DuckChatPixelParameters.PROMPT_PAGE_TYPE, pageType.value)
                 source?.let { put(DuckChatPixelParameters.ENTRY_SOURCE, it) }
+                if (isFirstPrompt) put(DuckChatPixelParameters.FIRST_PROMPT_NEW_INSTALL, "true")
             }
         }
     }
@@ -1440,6 +1456,7 @@ object DuckChatPixelParameters {
 
     /** What the user was looking at when a prompt was submitted. Distinct from [PAGE_TYPE], which classifies contextual suggestions. */
     const val PROMPT_PAGE_TYPE = "page_type"
+    const val FIRST_PROMPT_NEW_INSTALL = "first_prompt_new_install"
     const val IS_SMART = "isSmart"
     const val DELTA_TIMESTAMP_PARAMETERS = "delta-timestamp-minutes"
     const val INPUT_SCREEN_MODE = "mode"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepository.kt
@@ -105,6 +105,8 @@ interface DuckChatFeatureRepository {
     suspend fun setLastUsedTogglePosition(position: String)
 
     fun observeLastUsedTogglePosition(): StateFlow<String?>
+
+    suspend fun checkAndMarkFirstPromptSubmission(): Boolean
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -223,6 +225,14 @@ class RealDuckChatFeatureRepository @Inject constructor(
     }
 
     override fun observeLastUsedTogglePosition(): StateFlow<String?> = duckChatDataStore.observeLastUsedTogglePosition()
+
+    override suspend fun checkAndMarkFirstPromptSubmission(): Boolean {
+        val isFirst = !duckChatDataStore.hasSubmittedPromptBefore()
+        if (isFirst) {
+            duckChatDataStore.setPromptSubmitted()
+        }
+        return isFirst
+    }
 
     private fun updateWidgets() {
         val intent = Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatDataStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatDataStore.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.duckchat.impl.di.DuckChat
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_AUTOMATIC_CONTEXT_ATTACHMENT
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_CHAT_SUGGESTIONS_USER_SETTING
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_DEFAULT_TOGGLE_POSITION
+import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_HAS_SUBMITTED_PROMPT
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_INPUT_SCREEN_COSMETIC_SETTING
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_INPUT_SCREEN_EVER_ENABLED
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_INPUT_SCREEN_USER_SETTING
@@ -140,6 +141,10 @@ interface DuckChatDataStore {
 
     suspend fun setUserAcceptedTerms()
 
+    suspend fun hasSubmittedPromptBefore(): Boolean
+
+    suspend fun setPromptSubmitted()
+
     suspend fun setDefaultTogglePosition(position: String)
 
     suspend fun getDefaultTogglePosition(): String?
@@ -200,6 +205,7 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
         val DUCK_AI_AUTOMATIC_CONTEXT_ATTACHMENT = booleanPreferencesKey(name = "DUCK_AI_AUTOMATIC_CONTEXT_ATTACHMENT")
         val DUCK_AI_CHAT_SUGGESTIONS_USER_SETTING = booleanPreferencesKey(name = "DUCK_AI_CHAT_SUGGESTIONS_USER_SETTING")
         val DUCK_AI_TERMS_ACCEPTED = booleanPreferencesKey(name = "DUCK_AI_TERMS_ACCEPTED")
+        val DUCK_AI_HAS_SUBMITTED_PROMPT = booleanPreferencesKey(name = "DUCK_AI_HAS_SUBMITTED_PROMPT")
         val DUCK_AI_DEFAULT_TOGGLE_POSITION = stringPreferencesKey(name = "DUCK_AI_DEFAULT_TOGGLE_POSITION")
         val DUCK_AI_LAST_USED_TOGGLE_POSITION = stringPreferencesKey(name = "DUCK_AI_LAST_USED_TOGGLE_POSITION")
         val DUCK_AI_SELECTED_MODEL_ID = stringPreferencesKey(name = "DUCK_AI_SELECTED_MODEL_ID")
@@ -444,6 +450,12 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
 
     override suspend fun setUserAcceptedTerms() {
         store.edit { prefs -> prefs[DUCK_AI_TERMS_ACCEPTED] = true }
+    }
+
+    override suspend fun hasSubmittedPromptBefore(): Boolean = store.data.firstOrNull()?.let { it[DUCK_AI_HAS_SUBMITTED_PROMPT] } ?: false
+
+    override suspend fun setPromptSubmitted() {
+        store.edit { prefs -> prefs[DUCK_AI_HAS_SUBMITTED_PROMPT] = true }
     }
 
     override suspend fun setDefaultTogglePosition(position: String) {

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
@@ -48,6 +48,7 @@ class RealDuckChatPixelsAttachmentsTest {
         duckAiMetricCollector = duckAiMetricCollector,
         termsOfServiceHandler = termsOfServiceHandler,
         duckAiTabSessionRepository = mock(),
+        appBuildConfig = mock(),
     )
 
     @Test

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
@@ -48,6 +48,7 @@ class RealDuckChatPixelsPickerTest {
         duckAiMetricCollector = duckAiMetricCollector,
         termsOfServiceHandler = termsOfServiceHandler,
         duckAiTabSessionRepository = mock(),
+        appBuildConfig = mock(),
     )
 
     @Test

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
@@ -20,12 +20,14 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.DuckAiTabSessionRepository
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
 import com.duckduckgo.duckchat.impl.helper.DuckChatTermsOfServiceHandler
 import com.duckduckgo.duckchat.impl.metric.DuckAiMetricCollector
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -46,6 +48,7 @@ class RealDuckChatPixelsToolsTest {
     private val duckAiMetricCollector: DuckAiMetricCollector = mock()
     private val termsOfServiceHandler: DuckChatTermsOfServiceHandler = mock()
     private val duckAiTabSessionRepository: DuckAiTabSessionRepository = mock()
+    private val appBuildConfig: AppBuildConfig = mock()
 
     private val testee = RealDuckChatPixels(
         pixel = pixel,
@@ -56,9 +59,15 @@ class RealDuckChatPixelsToolsTest {
         duckAiMetricCollector = duckAiMetricCollector,
         termsOfServiceHandler = termsOfServiceHandler,
         duckAiTabSessionRepository = duckAiTabSessionRepository,
+        appBuildConfig = appBuildConfig,
     )
 
     private val surfaceParams = mapOf(DuckChatPixelParameters.SURFACE to "contextual_chat")
+
+    init {
+        runBlocking { whenever(duckChatFeatureRepository.checkAndMarkFirstPromptSubmission()).thenReturn(false) }
+        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
+    }
 
     @Test
     fun whenImageGenerationSelectedThenFiresCountAndDaily() = runTest {
@@ -165,6 +174,79 @@ class RealDuckChatPixelsToolsTest {
             DuckChatPixelParameters.MODEL_ID to "gpt-5",
             DuckChatPixelParameters.REASONING_EFFORT to "fast",
             DuckChatPixelParameters.HAS_IMAGE_ATTACHMENT to "true",
+            DuckChatPixelParameters.HAS_FILE_ATTACHMENT to "false",
+            DuckChatPixelParameters.HAS_TEXT to "true",
+            DuckChatPixelParameters.SURFACE to "contextual_chat",
+            DuckChatPixelParameters.PROMPT_PAGE_TYPE to "contextual",
+            DuckChatPixelParameters.ENTRY_SOURCE to "contextual_chat",
+        )
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_COUNT, parameters = params)
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_DAILY,
+            parameters = params,
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenPromptSubmittedAsFirstPromptOnNewInstallThenParamsIncludeFirstPromptNewInstall() = runTest {
+        whenever(appBuildConfig.isNewInstall()).thenReturn(true)
+        whenever(duckChatFeatureRepository.checkAndMarkFirstPromptSubmission()).thenReturn(true)
+
+        testee.firePromptSubmitted(
+            selectedTool = "none",
+            modelId = null,
+            reasoningEffort = null,
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
+            defaultMode = null,
+            tabId = null,
+            pageType = DuckChatPixelPageType.CONTEXTUAL,
+            addressBarEntryPoint = null,
+        )
+
+        val params = mapOf(
+            DuckChatPixelParameters.SELECTED_TOOL to "none",
+            DuckChatPixelParameters.HAS_IMAGE_ATTACHMENT to "false",
+            DuckChatPixelParameters.HAS_FILE_ATTACHMENT to "false",
+            DuckChatPixelParameters.HAS_TEXT to "true",
+            DuckChatPixelParameters.SURFACE to "contextual_chat",
+            DuckChatPixelParameters.PROMPT_PAGE_TYPE to "contextual",
+            DuckChatPixelParameters.ENTRY_SOURCE to "contextual_chat",
+            DuckChatPixelParameters.FIRST_PROMPT_NEW_INSTALL to "true",
+        )
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_COUNT, parameters = params)
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_DAILY,
+            parameters = params,
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenPromptSubmittedAsFirstPromptOnExistingInstallThenParamsOmitFirstPromptNewInstall() = runTest {
+        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
+        whenever(duckChatFeatureRepository.checkAndMarkFirstPromptSubmission()).thenReturn(true)
+
+        testee.firePromptSubmitted(
+            selectedTool = "none",
+            modelId = null,
+            reasoningEffort = null,
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
+            defaultMode = null,
+            tabId = null,
+            pageType = DuckChatPixelPageType.CONTEXTUAL,
+            addressBarEntryPoint = null,
+        )
+
+        val params = mapOf(
+            DuckChatPixelParameters.SELECTED_TOOL to "none",
+            DuckChatPixelParameters.HAS_IMAGE_ATTACHMENT to "false",
             DuckChatPixelParameters.HAS_FILE_ATTACHMENT to "false",
             DuckChatPixelParameters.HAS_TEXT to "true",
             DuckChatPixelParameters.SURFACE to "contextual_chat",

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.pixel
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.DuckAiTabSessionRepository
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
@@ -96,12 +97,15 @@ class RealDuckChatPixelsTest {
     private val duckAiMetricCollector: DuckAiMetricCollector = mock()
     private val mockTermsOfServiceHandler: DuckChatTermsOfServiceHandler = mock()
     private val mockDuckAiTabSessionRepository: DuckAiTabSessionRepository = mock()
+    private val mockAppBuildConfig: AppBuildConfig = mock()
 
     private lateinit var testee: RealDuckChatPixels
 
     @Before
     fun setup() = runTest {
         whenever(mockDuckChatFeatureRepository.sessionDeltaInMinutes()).thenReturn(1)
+        whenever(mockDuckChatFeatureRepository.checkAndMarkFirstPromptSubmission()).thenReturn(false)
+        whenever(mockAppBuildConfig.isNewInstall()).thenReturn(false)
 
         testee = RealDuckChatPixels(
             pixel = mockPixel,
@@ -112,6 +116,7 @@ class RealDuckChatPixelsTest {
             duckAiMetricCollector = duckAiMetricCollector,
             termsOfServiceHandler = mockTermsOfServiceHandler,
             duckAiTabSessionRepository = mockDuckAiTabSessionRepository,
+            appBuildConfig = mockAppBuildConfig,
         )
     }
 
@@ -132,6 +137,25 @@ class RealDuckChatPixelsTest {
     }
 
     @Test
+    fun `when sendReportMetricPixel with USER_DID_SUBMIT_PROMPT as first prompt on new install then params include it`() = runTest {
+        whenever(mockAppBuildConfig.isNewInstall()).thenReturn(true)
+        whenever(mockDuckChatFeatureRepository.checkAndMarkFirstPromptSubmission()).thenReturn(true)
+        whenever(mockDuckChatFeatureRepository.sessionDeltaInMinutes()).thenReturn(5)
+
+        testee.sendReportMetricPixel(USER_DID_SUBMIT_PROMPT)
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(
+            DUCK_CHAT_SEND_PROMPT_ONGOING_CHAT,
+            parameters = mapOf(
+                DuckChatPixelParameters.DELTA_TIMESTAMP_PARAMETERS to "5",
+                DuckChatPixelParameters.FIRST_PROMPT_NEW_INSTALL to "true",
+            ),
+        )
+    }
+
+    @Test
     fun `when sendReportMetricPixel with USER_DID_SUBMIT_FIRST_PROMPT then fires correct pixel with session params`() = runTest {
         whenever(mockDuckChatFeatureRepository.sessionDeltaInMinutes()).thenReturn(10)
 
@@ -145,6 +169,25 @@ class RealDuckChatPixelsTest {
         )
         verify(statisticsUpdater).refreshDuckAiRetentionAtb(mapOf("modelTier" to null))
         verify(duckAiMetricCollector).onMessageSent()
+    }
+
+    @Test
+    fun `when sendReportMetricPixel with USER_DID_SUBMIT_FIRST_PROMPT as first prompt on new install then params include it`() = runTest {
+        whenever(mockAppBuildConfig.isNewInstall()).thenReturn(true)
+        whenever(mockDuckChatFeatureRepository.checkAndMarkFirstPromptSubmission()).thenReturn(true)
+        whenever(mockDuckChatFeatureRepository.sessionDeltaInMinutes()).thenReturn(10)
+
+        testee.sendReportMetricPixel(USER_DID_SUBMIT_FIRST_PROMPT)
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(
+            DUCK_CHAT_START_NEW_CONVERSATION,
+            parameters = mapOf(
+                DuckChatPixelParameters.DELTA_TIMESTAMP_PARAMETERS to "10",
+                DuckChatPixelParameters.FIRST_PROMPT_NEW_INSTALL to "true",
+            ),
+        )
     }
 
     @Test
@@ -299,6 +342,38 @@ class RealDuckChatPixelsTest {
             parameters = expectedParams,
             type = Pixel.PixelType.Daily(),
         )
+    }
+
+    @Test
+    fun `when reportContextualPromptSubmittedWithContextNative then never includes first_prompt_new_install`() = runTest {
+        testee.reportContextualPromptSubmittedWithContextNative()
+
+        advanceUntilIdle()
+
+        val expectedParams = mapOf("page_type" to "contextual", "source" to "contextual_chat")
+        verify(mockPixel).fire(DUCK_CHAT_CONTEXTUAL_PROMPT_SUBMITTED_WITH_CONTEXT_NATIVE_COUNT, parameters = expectedParams)
+        verify(mockPixel).fire(
+            DUCK_CHAT_CONTEXTUAL_PROMPT_SUBMITTED_WITH_CONTEXT_NATIVE_DAILY,
+            parameters = expectedParams,
+            type = Pixel.PixelType.Daily(),
+        )
+        verifyNoInteractions(mockAppBuildConfig)
+    }
+
+    @Test
+    fun `when reportContextualPromptSubmittedWithoutContextNative then never includes first_prompt_new_install`() = runTest {
+        testee.reportContextualPromptSubmittedWithoutContextNative()
+
+        advanceUntilIdle()
+
+        val expectedParams = mapOf("page_type" to "contextual", "source" to "contextual_chat")
+        verify(mockPixel).fire(DUCK_CHAT_CONTEXTUAL_PROMPT_SUBMITTED_WITHOUT_CONTEXT_NATIVE_COUNT, parameters = expectedParams)
+        verify(mockPixel).fire(
+            DUCK_CHAT_CONTEXTUAL_PROMPT_SUBMITTED_WITHOUT_CONTEXT_NATIVE_DAILY,
+            parameters = expectedParams,
+            type = Pixel.PixelType.Daily(),
+        )
+        verifyNoInteractions(mockAppBuildConfig)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepositoryTest.kt
@@ -256,6 +256,26 @@ class DuckChatFeatureRepositoryTest {
     }
 
     @Test
+    fun whenIsFirstPromptSubmissionCalledForTheFirstTimeThenReturnTrueAndMarkSubmitted() = runTest {
+        whenever(mockDataStore.hasSubmittedPromptBefore()).thenReturn(false)
+
+        val result = testee.checkAndMarkFirstPromptSubmission()
+
+        assertTrue(result)
+        verify(mockDataStore).setPromptSubmitted()
+    }
+
+    @Test
+    fun whenIsFirstPromptSubmissionCalledAfterAPriorSubmissionThenReturnFalseAndDoNotMarkAgain() = runTest {
+        whenever(mockDataStore.hasSubmittedPromptBefore()).thenReturn(true)
+
+        val result = testee.checkAndMarkFirstPromptSubmission()
+
+        assertFalse(result)
+        verify(mockDataStore, never()).setPromptSubmitted()
+    }
+
+    @Test
     fun whenLastSessionTimestampCheckedThenReturnDataFromTheStore() = runTest {
         whenever(mockDataStore.lastSessionTimestamp()).thenReturn(12345L)
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/store/SharedPreferencesDuckChatDataStoreTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/store/SharedPreferencesDuckChatDataStoreTest.kt
@@ -394,6 +394,17 @@ class SharedPreferencesDuckChatDataStoreTest {
     }
 
     @Test
+    fun `when hasSubmittedPromptBefore default then return false`() = runTest {
+        assertFalse(testee.hasSubmittedPromptBefore())
+    }
+
+    @Test
+    fun `when setPromptSubmitted then hasSubmittedPromptBefore returns true`() = runTest {
+        testee.setPromptSubmitted()
+        assertTrue(testee.hasSubmittedPromptBefore())
+    }
+
+    @Test
     fun `when observeDefaultTogglePosition then receive updates`() = runTest {
         val results = mutableListOf<String?>()
         val job = launch {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1217798276718607?focus=true 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
- Adds `first_prompt_new_install` param to `m_aichat_unified_input_prompt_submitted`
- Answers "where does a new install's first Duck.ai prompt come from?"
- true only once, on a new install's first-ever prompt submission across all surfaces; omitted otherwise
- Gated on AppBuildConfig.isNewInstall() so an existing user updating the app never gets a false positive on their first post-update prompt

Known gap: tapping a suggestion pill in the contextual sheet bypasses the native input widget entirely so the pixel is not sent. See https://app.asana.com/1/137249556945/project/1212810093780571/task/1217793387787365?focus=true for follow up

Steps to test
- [ ] Fresh install → Search + Duck.ai mode in the settings → NTP → submit a prompt via native unified input → confirm `first_prompt_new_install=true` on `m_aichat_unified_input_prompt_submitted`
- [ ] Same install → open a webpage → use contextual Duck.ai to write a prompt and submit → confirm `first_prompt_new_install` is not present (already consumed by the first prompt above)
- [ ] Fresh install → go directly into Duck.ai from the hamburger menu → and send a prompt from there → confirm the `first_prompt_new_install` present
- [ ] Kill the app but do not uninstall it → NTP → submit a prompt via native unified input → confirm the `m_aichat_unified_input_prompt_submitted ` pixel does NOT have `first_prompt_new_install`
- [ ] Fresh install  → Open a website  →  use contextual Duck.ai → submit a prompt from the native input with attached context → `m_aichat_contextual_prompt_submitted_with_context_native` contains `first_prompt_new_install`
- [ ] Any subsequent prompts from anywhere should not carry the param.

> [!NOTE]
> **Low Risk**
> Analytics-only change with local install/prompt flags; misclassification risk is mitigated by requiring isNewInstall() alongside first-submission marking.
> 
> **Overview**
> Adds analytics parameter **`first_prompt_new_install`** so the **first Duck.ai prompt on a fresh install** can be distinguished across surfaces (contextual sheet and Unified Input), without tagging users who only **updated** the app.
> 
> Pixel definitions and `params_dictionary` now include **`firstPromptNewInstall`** on contextual prompt-submission count/daily pixels and unified-input prompt-submitted pixels. **`RealDuckChatPixels`** sets `first_prompt_new_install=true` only when **`AppBuildConfig.isNewInstall()`** and **`checkAndMarkFirstPromptSubmission()`** both succeed; otherwise the param is omitted.
> 
> Persistence uses a new DataStore flag **`DUCK_AI_HAS_SUBMITTED_PROMPT`**, exposed through **`DuckChatFeatureRepository`** / **`DuckChatDataStore`**. Tests cover repository, datastore, and pixel firing for new vs existing installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 824186a8b8659c9cdd638b5f490ed0ac1a3aa1d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->