### PR TITLE
Fix e2e maestro tests omnibar IDs

### DIFF
--- a/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
 

--- a/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled_for_an_update.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled_for_an_update.yaml
@@ -20,7 +20,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
       - runFlow: ../steps/decline_autofill_prompt.yaml

--- a/.maestro/autofill/backfillingUsername/multi_step_login_username_not_backfilled_if_provided_explicitly.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_login_username_not_backfilled_if_provided_explicitly.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
 

--- a/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_autogenerated.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_autogenerated.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://autofill.me/form/registration-username"
       - pressKey: Enter
 

--- a/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_manually_entered.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_manually_entered.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://autofill.me/form/registration-username"
       - pressKey: Enter
 

--- a/.maestro/autofill/backfillingUsername/password_reset_flow_autogenerated_password.yaml
+++ b/.maestro/autofill/backfillingUsername/password_reset_flow_autogenerated_password.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill login form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
 
@@ -35,7 +35,7 @@ tags:
 
       # get to password reset form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - eraseText
       - inputText: "https://autofill.me/form/change-password"
       - pressKey: Enter

--- a/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_generated_password.yaml
+++ b/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_generated_password.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill login form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
 
@@ -35,7 +35,7 @@ tags:
 
       # get to password reset form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - eraseText
       - inputText: "https://autofill.me/form/change-password"
       - pressKey: Enter

--- a/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_manual_password.yaml
+++ b/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_manual_password.yaml
@@ -20,7 +20,7 @@ tags:
 
       # get to autofill login form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
       - runFlow: ../steps/decline_autofill_prompt.yaml
@@ -36,7 +36,7 @@ tags:
 
       # get to password reset form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - eraseText
       - inputText: "https://autofill.me/form/change-password"
       - pressKey: Enter

--- a/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_with_username.yaml
+++ b/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_with_username.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://autofill.me/form/registration-username"
       - pressKey: Enter
 

--- a/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_without_username.yaml
+++ b/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_without_username.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://autofill.me/form/registration-username"
       - pressKey: Enter
 

--- a/.maestro/autofill/steps/search_logins.yaml
+++ b/.maestro/autofill/steps/search_logins.yaml
@@ -32,7 +32,7 @@ name: "Autofill: Search credentials"
 - assertVisible: user
 
 - tapOn:
-    id: omnibarTextInput
+    id: "omnibarTextInput|inputField"
 - inputText: "no match"
 
 - assertVisible: "No results for.*"
@@ -40,7 +40,7 @@ name: "Autofill: Search credentials"
 - eraseText
 
 - tapOn:
-      id: omnibarTextInput
+      id: "omnibarTextInput|inputField"
 - inputText: "192"
 
 - assertVisible: 192.168.0.100

--- a/.maestro/deeplink/deeplink_to_serp_with_query.yaml
+++ b/.maestro/deeplink/deeplink_to_serp_with_query.yaml
@@ -14,6 +14,6 @@ tags:
           link: duck://https://duckduckgo.com?q=why%20use%20duckduckgo
 
       - copyTextFrom:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
 
       - assertTrue: ${maestro.copiedText == "why use duckduckgo" }

--- a/.maestro/duckplayer/common/assert_youtube_visible.yaml
+++ b/.maestro/duckplayer/common/assert_youtube_visible.yaml
@@ -3,7 +3,7 @@ appId: com.duckduckgo.mobile.android
 # Assert YouTube video overlay is not shown
 - scrollUntilVisible:
       element:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       direction: UP
 
 # Wait for video to load

--- a/.maestro/duckplayer/common/input_search.yaml
+++ b/.maestro/duckplayer/common/input_search.yaml
@@ -3,6 +3,6 @@ appId: com.duckduckgo.mobile.android
 # Select a YouTube video from SERP
 - runFlow: ../../shared/dismiss_native_input.yaml
 - tapOn:
-    id: "omnibarTextInput"
+    id: "omnibarTextInput|inputField"
 - inputText: "https://duckduckgo.com/?q=DuckDuckGo%20vs%20Google%3A%205%20Reasons%20You%20Should%20Switch%20video%20site%3Ayoutube.com&ko=-1&ia=web"
 - pressKey: Enter

--- a/.maestro/duckplayer/common/load_youtube_video.yaml
+++ b/.maestro/duckplayer/common/load_youtube_video.yaml
@@ -5,7 +5,7 @@ androidWebViewHierarchy: devtools
 # Navigate to a YouTube video
 - runFlow: ../../shared/dismiss_native_input.yaml
 - tapOn:
-    id: "omnibarTextInput"
+    id: "omnibarTextInput|inputField"
 - inputText: "https://m.youtube.com/@duckduckgo/search?query=DuckDuckGo%20vs%20Google%3A%205%20Reasons%20You%20Should%20Switch"
 - pressKey: Enter
 - runFlow: handle_youtube_cookies.yaml

--- a/.maestro/duckplayer/direct_duckplayer.yaml
+++ b/.maestro/duckplayer/direct_duckplayer.yaml
@@ -14,7 +14,7 @@ tags:
 
       - runFlow: ../shared/dismiss_native_input.yaml
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "duck://player/3ml7yeKBUhc"
       - pressKey: Enter
 

--- a/.maestro/duckplayer/direct_duckplayer_playback.yaml
+++ b/.maestro/duckplayer/direct_duckplayer_playback.yaml
@@ -13,7 +13,7 @@ tags:
 
       - runFlow: ../shared/dismiss_native_input.yaml
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "duck://player/3ml7yeKBUhc"
       - pressKey: Enter
 

--- a/.maestro/duckplayer/direct_duckplayer_youtube.yaml
+++ b/.maestro/duckplayer/direct_duckplayer_youtube.yaml
@@ -15,7 +15,7 @@ tags:
 
       - runFlow: ../shared/dismiss_native_input.yaml
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "duck://player/3ml7yeKBUhc"
       - pressKey: Enter
 

--- a/.maestro/duckplayer/never_youtube.yaml
+++ b/.maestro/duckplayer/never_youtube.yaml
@@ -18,11 +18,11 @@ tags:
       - runFlow:
           when:
             notVisible:
-              id: "omnibarTextInput"
+              id: "omnibarTextInput|inputField"
           commands:
             - scrollUntilVisible:
                 element:
-                  id: "omnibarTextInput"
+                  id: "omnibarTextInput|inputField"
                 direction: UP
 
       # Core assertion: Verify we're still on regular YouTube (not Duck Player)

--- a/.maestro/fire_button/dimiss_fire_during_onboarding.yaml
+++ b/.maestro/fire_button/dimiss_fire_during_onboarding.yaml
@@ -16,7 +16,7 @@ tags:
       # pre_onboarding ends on a search result page; type the test URL into the omnibar
       # (the native input field only exists on the new-tab page).
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - assertVisible:

--- a/.maestro/fire_button/fire_during_onboarding.yaml
+++ b/.maestro/fire_button/fire_during_onboarding.yaml
@@ -14,7 +14,7 @@ tags:
       - runFlow: ../shared/pre_onboarding.yaml
 
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - assertVisible:

--- a/.maestro/omnibar/split_omnibar_search.yaml
+++ b/.maestro/omnibar/split_omnibar_search.yaml
@@ -15,7 +15,7 @@ tags:
 
 # verify that autocomplete suggestions are shown when typing
 - tapOn:
-    id: "omnibarTextInput"
+    id: "omnibarTextInput|inputField"
     optional: true
 - inputText: "reddit"
 - assertVisible:
@@ -50,7 +50,7 @@ tags:
 
 # verify that clearing the text and submitting a URL opens the web page
 - tapOn:
-    id: "omnibarTextInput"
+    id: "omnibarTextInput|inputField"
 - tapOn:
     id: "inputFieldClearText"
 - inputText: "eff.org"
@@ -59,13 +59,13 @@ tags:
     id: "browserLayout"
 - extendedWaitUntil:
     visible:
-      id: "omnibarTextInput"
+      id: "omnibarTextInput|inputField"
       text: ".*eff.org.*"
     timeout: 10000
 
 # verify that tapping on a favorite opens the web page (SERP in this case)
 - tapOn:
-    id: "omnibarTextInput"
+    id: "omnibarTextInput|inputField"
 - tapOn:
     id: "inputFieldClearText"
 - tapOn:
@@ -75,7 +75,7 @@ tags:
 - assertVisible:
     id: "browserLayout"
 - assertVisible:
-    id: "omnibarTextInput"
+    id: "omnibarTextInput|inputField"
     text: "reddit"
 - assertVisible:
     text: "reddit"
@@ -94,7 +94,7 @@ tags:
 - tapOn:
     id: "cardContentsContainer"
 - assertVisible:
-    id: "omnibarTextInput"
+    id: "omnibarTextInput|inputField"
     text: "reddit"
 
 # verify that tapping on a new tab button opens a new tab
@@ -112,7 +112,7 @@ tags:
 - tapOn:
     id: "quickAccessFaviconCard"
 - assertVisible:
-    id: "omnibarTextInput"
+    id: "omnibarTextInput|inputField"
     text: "reddit"
 - assertVisible:
     id: "newTabButton"

--- a/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
+++ b/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
@@ -15,7 +15,7 @@ tags:
       - tapOn:
           id: "daxDialogDismissButton|contextualBrandDesignDismissButton"
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://www.search-company.site/#ad-id-14"
       - pressKey: Enter
       - assertVisible:

--- a/.maestro/onboarding/onboarding_dismiss_try_a_search_dialog.yaml
+++ b/.maestro/onboarding/onboarding_dismiss_try_a_search_dialog.yaml
@@ -16,4 +16,4 @@ tags:
       - assertNotVisible:
           text: ".*That's DuckDuckGo Search!.*"
       - assertVisible:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"

--- a/.maestro/performance/steps/cold_load.yaml
+++ b/.maestro/performance/steps/cold_load.yaml
@@ -14,7 +14,7 @@ appId: com.duckduckgo.mobile.android
     timeout: 5000
 
 - tapOn:
-    id: "omnibarTextInput"
+    id: "omnibarTextInput|inputField"
 
 - inputText: "${output.websites.urls[output.websites.counter]}"
 - pressKey: Enter

--- a/.maestro/ppro/launch_privacy_pro_from_special_url.yaml
+++ b/.maestro/ppro/launch_privacy_pro_from_special_url.yaml
@@ -13,7 +13,7 @@ tags:
       - runFlow: ../shared/skip_all_onboarding.yaml
 
       - tapOn:
-          id: "omnibarTextInput"
+          id: "omnibarTextInput|inputField"
       - inputText: "https://duckduckgo.com/pro"
       - pressKey: Enter
       - assertVisible:

--- a/.maestro/sync_flows/steps/action_add_bookmarks_and_folders.yaml
+++ b/.maestro/sync_flows/steps/action_add_bookmarks_and_folders.yaml
@@ -6,7 +6,7 @@ appId: com.duckduckgo.mobile.android
 # Now, we add a couple bookmarks
 - runFlow: ../../shared/dismiss_native_input.yaml
 - tapOn:
-    id: "omnibarTextInput"
+    id: "omnibarTextInput|inputField"
 - inputText: "${output.bookmarks.domains[0]}"
 # We need this because Dax Dialogs sometimes appears before pressing Enter
 - runFlow:
@@ -27,7 +27,7 @@ appId: com.duckduckgo.mobile.android
 - runFlow: ../../shared/browser_screen/click_on_menu_button.yaml
 - tapOn: "Add Bookmark"
 - tapOn:
-    id: "omnibarTextInput"
+    id: "omnibarTextInput|inputField"
 # Now, we add a favourite
 - inputText: "${output.bookmarks.domains[1]}"
 - pressKey: Enter

--- a/.maestro/unified_input_screen/shared/flow_search_suggestions.yaml
+++ b/.maestro/unified_input_screen/shared/flow_search_suggestions.yaml
@@ -41,4 +41,4 @@ appId: com.duckduckgo.mobile.android
 - assertVisible:
     text: ".*privacy-test-pages.site.*"
     childOf:
-      id: "omnibarTextInput"
+      id: "omnibarTextInput|inputField"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1217813496564228?focus=true 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

With the completion of the native search-only input rollout, several Maestro flows (autofill password
generation/backfilling…) stillused the old ID: `omnibarTextInput`. Updates them to `omnibarTextInput|inputField` so they would be toggle agnostic and pass whether we have the flag on or off.

### Steps to test this PR

Run Maestro tests for those failing tests. They should succeed.

```
maestro test .maestro/autofill/passwordGeneration .maestro/autofill/backfillingUsername
```

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro YAML selector updates with no production code changes.
> 
> **Overview**
> Updates Maestro E2E flows across autofill, Duck Player, onboarding, omnibar, sync, deeplinks, performance, and related shared steps so omnibar interactions use **`omnibarTextInput|inputField`** instead of **`omnibarTextInput`**.
> 
> **tapOn**, **copyTextFrom**, **scrollUntilVisible**, **extendedWaitUntil**, and **childOf** assertions that previously targeted the omnibar container now target the actual input field, matching the current omnibar UI/test tagging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d9a511d7d276e697fdc534eca0ab99a40633d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->