### PR TITLE
Negotiate Exchange v2 version

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -154,6 +154,11 @@ class RealExchangeV2Runner @Inject constructor(
 
     @Volatile private var sentOwnAvailability: Boolean = false
 
+    @Volatile private var advertisedVersion: ExchangeProtocolVersion.V2 = BASELINE_PROTOCOL_VERSION
+
+    // TODO: Change to private once the negotiated version is used for anything and can be tested
+    @Volatile internal var negotiatedVersion: ExchangeProtocolVersion.V2 = BASELINE_PROTOCOL_VERSION
+
     /**
      * Host-side messages arriving while the Joiner is still at the user-confirm prompt, buffered
      * and replayed on confirm (Joiner.Confirming → Joiner.Waiting) so the SM doesn't reject them
@@ -189,6 +194,7 @@ class RealExchangeV2Runner @Inject constructor(
                     cancelLocked() // bootstrap already emitted the error; just clear the half-set state
                     return@launch
                 }
+                negotiatedVersion = negotiateProtocolVersion(parsed.version)
                 // Scanner already knows the peer; SM starts directly in Negotiating.
                 session = smFactory.create(
                     localUserId = syncStore.userId,
@@ -222,7 +228,7 @@ class RealExchangeV2Runner @Inject constructor(
                 _linkingCode = qrCode.buildLinkingCode(
                     channelId = ownChannelId!!,
                     publicKeyBase64Url = keyPair.publicKeyBase64,
-                    version = ourProtocolVersion(),
+                    version = advertisedVersion,
                 )
                 // Presenter waits to receive hello before transitioning out of Bootstrapped.
                 session = smFactory.create(
@@ -242,6 +248,7 @@ class RealExchangeV2Runner @Inject constructor(
      * (in which case an error event was already emitted).
      */
     private suspend fun bootstrapLocked(role: PairingRole): RsaKeyPair? {
+        advertisedVersion = if (syncFeature.canUseExchangeV2Point1().isEnabled()) ExchangeProtocolVersion.V2_1 else BASELINE_PROTOCOL_VERSION
         val keyPair = jweCrypto.generateRsaKeyPair(EXCHANGE_RSA_KEY_SIZE)
         ownKeyPair = keyPair
         repeat(MAX_CHANNEL_CREATE_RETRIES) { attempt ->
@@ -331,6 +338,8 @@ class RealExchangeV2Runner @Inject constructor(
         peerUserId = null
         _peerName = null
         _linkingCode = null
+        advertisedVersion = BASELINE_PROTOCOL_VERSION
+        negotiatedVersion = BASELINE_PROTOCOL_VERSION
         sentOwnAvailability = false
         pendingJoinerWaitingMessages.clear()
     }
@@ -517,6 +526,7 @@ class RealExchangeV2Runner @Inject constructor(
             is ExchangeV2Message.Hello -> {
                 peerChannelId = message.channelId
                 peerPublicKey = message.publicKey
+                negotiatedVersion = negotiateProtocolVersion(message.version)
             }
             is ExchangeV2Message.RecoveryCodeAvailable -> {
                 _peerKind = message.kind
@@ -668,13 +678,10 @@ class RealExchangeV2Runner @Inject constructor(
         val hello = ExchangeV2Message.Hello.create(
             channelId = own,
             publicKey = ourKey.publicKeyBase64,
-            version = ourProtocolVersion(),
+            version = advertisedVersion,
         )
         return sendOnWireAndRecord(hello, peer, peerKey)
     }
-
-    private fun ourProtocolVersion(): ExchangeProtocolVersion.V2 =
-        if (syncFeature.canUseExchangeV2Point1().isEnabled()) ExchangeProtocolVersion.V2_1 else ExchangeProtocolVersion.V2_0
 
     private fun sendOwnAvailability() {
         if (sentOwnAvailability) return
@@ -865,6 +872,16 @@ class RealExchangeV2Runner @Inject constructor(
         else -> false
     }
 
+    private fun negotiateProtocolVersion(peerVersion: ExchangeProtocolVersion): ExchangeProtocolVersion.V2 {
+        val ourVersion = advertisedVersion
+        val negotiatedVersion = when (peerVersion) {
+            is ExchangeProtocolVersion.V2 -> minOf(ourVersion, peerVersion)
+            else -> BASELINE_PROTOCOL_VERSION
+        }
+        logcat { "Sync-ExchangeV2: negotiated protocol version: v$negotiatedVersion, our version: v$ourVersion, peer version: v$peerVersion" }
+        return negotiatedVersion
+    }
+
     companion object {
         // RSA modulus size (bits) for the v2 exchange pairing keypair.
         private const val EXCHANGE_RSA_KEY_SIZE = 2048
@@ -878,5 +895,7 @@ class RealExchangeV2Runner @Inject constructor(
         private const val OWN_DEVICE_KIND = "ddg"
         private const val MAX_CHANNEL_CREATE_RETRIES = 3
         private const val HTTP_CONFLICT = 409
+
+        private val BASELINE_PROTOCOL_VERSION get() = ExchangeProtocolVersion.V2_0
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -149,8 +149,8 @@ class RealExchangeV2Runner @Inject constructor(
 
     @Volatile private var advertisedVersion: ExchangeProtocolVersion.V2 = BASELINE_PROTOCOL_VERSION
 
-    // TODO: Change to private once the negotiated version is used for anything and can be tested
     @Volatile internal var negotiatedVersion: ExchangeProtocolVersion.V2 = BASELINE_PROTOCOL_VERSION
+        private set
 
     /**
      * Host-side messages arriving while the Joiner is still at the user-confirm prompt, buffered

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -96,20 +96,13 @@ interface ExchangeV2Runner {
      */
     suspend fun cancel()
 
-    suspend fun deliverIncomingMessage(message: ExchangeV2Message)
-
-    suspend fun deliverIncomingMessageJson(rawJson: String)
-
     fun localTrigger(trigger: LocalTrigger)
-
-    fun recordSentMessage(message: ExchangeV2Message)
 }
 
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealExchangeV2Runner @Inject constructor(
     private val smFactory: ExchangeV2StateMachineFactory,
-    private val messageParser: ExchangeV2MessageParser,
     private val clock: ExchangeV2Clock,
     private val syncStore: SyncStore,
     private val jweCrypto: SyncJweCrypto,
@@ -414,7 +407,7 @@ class RealExchangeV2Runner @Inject constructor(
     // Inbound message handling + orchestration
     // -----------------------------------------------------------------------
 
-    override suspend fun deliverIncomingMessage(message: ExchangeV2Message) {
+    internal suspend fun deliverIncomingMessage(message: ExchangeV2Message) {
         // Suspends until processing completes so the poll loop processes messages in wire order;
         // a fire-and-forget launch here would let a poll batch race to the SM out of sequence.
         mutex.withLock { processIncomingLocked(message) }
@@ -603,10 +596,6 @@ class RealExchangeV2Runner @Inject constructor(
             ownRole == PairingRole.Presenter -> Role.Host
             else -> Role.Joiner
         }
-    }
-
-    override suspend fun deliverIncomingMessageJson(rawJson: String) {
-        deliverIncomingMessage(messageParser.parse(rawJson))
     }
 
     // -----------------------------------------------------------------------
@@ -818,7 +807,7 @@ class RealExchangeV2Runner @Inject constructor(
         else -> SessionErrorKind.Unknown
     }
 
-    override fun recordSentMessage(message: ExchangeV2Message) {
+    internal fun recordSentMessage(message: ExchangeV2Message) {
         logcat { "Sync-ExchangeV2: recordSentMessage ${message.messageType}" }
         emit(ExchangeV2Event.MessageSent(clock.nowMs(), message))
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -67,7 +67,6 @@ class RealExchangeV2RunnerTest {
     @get:Rule val coroutineTestRule = CoroutineTestRule()
 
     private val clock = ExchangeV2Clock { 42L }
-    private val parser = JsonExchangeV2MessageParser()
     private val factory = ExchangeV2StateMachineFactory(clock)
     private val syncStore: SyncStore = mock()
     private val jweCrypto: SyncJweCrypto = mock()
@@ -80,7 +79,6 @@ class RealExchangeV2RunnerTest {
     private fun newRunner(): RealExchangeV2Runner =
         RealExchangeV2Runner(
             smFactory = factory,
-            messageParser = parser,
             clock = clock,
             syncStore = syncStore,
             jweCrypto = jweCrypto,
@@ -167,7 +165,7 @@ class RealExchangeV2RunnerTest {
         runner.startPresent()
 
         runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
-            runner.deliverIncomingMessageJson("""{"type":"hello"}""")
+            runner.deliverHello(ExchangeProtocolVersion.V2_0)
             val event = awaitItem()
             assertSame(ExchangeV2State.Negotiating, event.to)
             assertTrue(event.trigger is Hello)
@@ -180,7 +178,7 @@ class RealExchangeV2RunnerTest {
         runner.startPresent()
 
         runner.events.filterIsInstance<ExchangeV2Event.MessageRejected>().test {
-            runner.deliverIncomingMessageJson("""{"type":"future_msg"}""")
+            runner.deliverIncomingMessage(ExchangeV2Message.Unknown.fromJson("{}", "future_msg"))
             val event = awaitItem()
             assertSame(RejectReason.UnknownMessageDropped, event.reason)
         }
@@ -714,7 +712,7 @@ class RealExchangeV2RunnerTest {
         )
     }
 
-    private suspend fun ExchangeV2Runner.deliverHello(version: ExchangeProtocolVersion) {
+    private suspend fun RealExchangeV2Runner.deliverHello(version: ExchangeProtocolVersion) {
         deliverIncomingMessage(Hello.create(channelId = "peer-channel", publicKey = "peer-pubkey", version = version))
     }
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -33,6 +33,9 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeConfir
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
 import com.duckduckgo.sync.store.SyncStore
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.google.testing.junit.testparameterinjector.TestParameters
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterIsInstance
@@ -49,6 +52,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
@@ -57,6 +61,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@RunWith(TestParameterInjector::class)
 class RealExchangeV2RunnerTest {
 
     @get:Rule val coroutineTestRule = CoroutineTestRule()
@@ -89,9 +94,7 @@ class RealExchangeV2RunnerTest {
         )
 
     @Before fun stubWireDeps() {
-        whenever(qrCode.parse(any())).thenReturn(
-            ExchangeV2CodeParseResult.LinkingV2(channelId = "peer-channel", publicKey = "peer-pubkey", version = ExchangeProtocolVersion.V2_0),
-        )
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_0)
         whenever(qrCode.buildLinkingCode(any(), any(), any())).thenReturn("https://duckduckgo.com/sync/pairing/#&code2=fake")
         whenever(jweCrypto.generateRsaKeyPair(any())).thenReturn(RsaKeyPair(publicKeyBase64 = "own-pub", privateKeyBase64 = "own-priv"))
         whenever(channel.createChannel(any())).thenReturn(Result.Success(Unit))
@@ -266,20 +269,108 @@ class RealExchangeV2RunnerTest {
         )
     }
 
-    @Test fun `startPresent builds a v2_0 linking code when the v2_1 exchange flag is disabled`() {
-        syncFeature.canUseExchangeV2Point1().setRawStoredState(State(enable = false))
+    // ---- Protocol version negotiation ----
+
+    @Test fun `linking code advertises the version this device speaks`(
+        @TestParameter("2.0", "2.1") ourVersion: String,
+    ) {
+        val version = ourVersion.toV2ProtocolVersion()
+        givenOurVersion(version)
+
         val runner = newRunner()
         runner.startPresent()
 
+        verify(qrCode).buildLinkingCode(any(), any(), eq(version))
+    }
+
+    @Test fun `hello advertises the version this device speaks`(
+        @TestParameter("2.0", "2.1") ourVersion: String,
+    ) = runTest {
+        val version = ourVersion.toV2ProtocolVersion()
+        givenOurVersion(version)
+
+        val runner = newRunner()
+        runner.startScan("")
+
+        verify(channel).sendMessage(
+            argThat { this is Hello && this.version == version },
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test fun `each session re-reads the flag rather than reusing the previous session's advertised version`() = runTest {
+        val runner = newRunner()
+
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        runner.startPresent()
+        verify(qrCode).buildLinkingCode(any(), any(), eq(ExchangeProtocolVersion.V2_1))
+
+        runner.cancel()
+
+        givenOurVersion(ExchangeProtocolVersion.V2_0)
+        runner.startPresent()
         verify(qrCode).buildLinkingCode(any(), any(), eq(ExchangeProtocolVersion.V2_0))
     }
 
-    @Test fun `startPresent builds a v2_1 linking code when the v2_1 exchange flag is enabled`() {
-        syncFeature.canUseExchangeV2Point1().setRawStoredState(State(enable = true))
+    @Test
+    @TestParameters(
+        "{ourVersion: '2.1', peerVersion: '2.1', negotiated: '2.1'}",
+        "{ourVersion: '2.1', peerVersion: '2.9', negotiated: '2.1'}",
+        "{ourVersion: '2.1', peerVersion: '2.0', negotiated: '2.0'}",
+        "{ourVersion: '2.0', peerVersion: '2.1', negotiated: '2.0'}",
+        "{ourVersion: '2.0', peerVersion: '2.0', negotiated: '2.0'}",
+    )
+    fun `Scanner negotiates the lower of our version and the scanned code's`(
+        ourVersion: String,
+        peerVersion: String,
+        negotiated: String,
+    ) = runTest {
+        givenOurVersion(ourVersion.toProtocolVersion())
+        givenLinkingCodeVersion(peerVersion.toV2ProtocolVersion())
+
+        val runner = newRunner()
+        runner.startScan("")
+
+        assertEquals(negotiated.toProtocolVersion(), runner.negotiatedVersion)
+    }
+
+    @Test
+    @TestParameters(
+        "{ourVersion: '2.1', peerVersion: '2.1', negotiated: '2.1'}",
+        "{ourVersion: '2.1', peerVersion: '2.9', negotiated: '2.1'}",
+        "{ourVersion: '2.1', peerVersion: '2.0', negotiated: '2.0'}",
+        "{ourVersion: '2.0', peerVersion: '2.1', negotiated: '2.0'}",
+        "{ourVersion: '2.0', peerVersion: '2.0', negotiated: '2.0'}",
+        "{ourVersion: '2.1', peerVersion: '1.0', negotiated: '2.0'}",
+        "{ourVersion: '2.1', peerVersion: '3.4', negotiated: '2.0'}",
+    )
+    fun `Presenter negotiates the lower of our version and the peer hello's`(
+        ourVersion: String,
+        peerVersion: String,
+        negotiated: String,
+    ) = runTest {
+        givenOurVersion(ourVersion.toProtocolVersion())
+        whenever(syncStore.userId).thenReturn("my-user")
+
         val runner = newRunner()
         runner.startPresent()
+        runner.deliverHello(peerVersion.toProtocolVersion())
 
-        verify(qrCode).buildLinkingCode(any(), any(), eq(ExchangeProtocolVersion.V2_1))
+        assertEquals(negotiated.toProtocolVersion(), runner.negotiatedVersion)
+    }
+
+    @Test fun `cancel clears negotiated version`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_1)
+
+        val runner = newRunner()
+        runner.startScan("")
+        assertEquals(ExchangeProtocolVersion.V2_1, runner.negotiatedVersion)
+
+        runner.cancel()
+        assertEquals(ExchangeProtocolVersion.V2_0, runner.negotiatedVersion)
     }
 
     // ---- Auto role election ----
@@ -609,4 +700,25 @@ class RealExchangeV2RunnerTest {
 
         assertNull("pairingRole must be cleared after a failed bootstrap", runner.pairingRole)
     }
+
+    // ---- Helpers ----
+
+    private fun givenOurVersion(version: ExchangeProtocolVersion) {
+        val state = State(remoteEnableState = version == ExchangeProtocolVersion.V2_1)
+        syncFeature.canUseExchangeV2Point1().setRawStoredState(state)
+    }
+
+    private fun givenLinkingCodeVersion(version: ExchangeProtocolVersion.V2) {
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "peer-channel", publicKey = "peer-pubkey", version = version),
+        )
+    }
+
+    private suspend fun ExchangeV2Runner.deliverHello(version: ExchangeProtocolVersion) {
+        deliverIncomingMessage(Hello.create(channelId = "peer-channel", publicKey = "peer-pubkey", version = version))
+    }
+
+    private fun String.toProtocolVersion() = ExchangeProtocolVersion.parse(this).getOrThrow()
+
+    private fun String.toV2ProtocolVersion() = toProtocolVersion() as ExchangeProtocolVersion.V2
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1217270894583760
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1217626160385687
API Proposals URL(s) (if applicable): N/A

### Description

Adds protocol version negotiation to the v2 exchange pairing flow, so two devices agree on the highest version they both speak before exchanging anything beyond the handshake. 

Version negotiation:
- Each device reads the `canUseExchangeV2.1` flag once when a pairing session starts, and advertises v2.1 if it is enabled and v2.0 otherwise. The advertised version is used both in the linking code the presenter builds and in the `hello` message the scanner sends.
- The scanner negotiates as soon as it parses the presenter's linking code. The presenter negotiates when it receives the peer's `hello`.
- The negotiated version is the lower of the two advertised versions, so a v2.1 device pairing with a v2.0 device settles on v2.0.
- A peer advertising a v2 minor version we do not know about, for example 2.9, is clamped down to our own version.
- A peer advertising a version outside v2, for example 1.0 or 3.4, or a version we cannot parse at all, falls back to v2.0.
- The advertised and negotiated versions are reset to v2.0 when a session is cancelled, so a new session always re-reads the flag rather than reusing the previous session's result.

Interface cleanup:
- `deliverIncomingMessage`, `deliverIncomingMessageJson` and `recordSentMessage` are no longer part of the `ExchangeV2Runner` interface. They had no callers outside the implementation, so they are now `internal` members of `RealExchangeV2Runner`, and the unused `ExchangeV2MessageParser` dependency is gone.

### Steps to test this PR

_Both devices speak v2.1_
- [ ] Install an internal build on two devices.
- [ ] Open Sync Dev Settings on both devices.
- [ ] Enable `canUseExchangeV2.1` on both devices.
- [ ] Start the pairing flow so one device presents a code and the other scans it.
- [ ] Complete pairing.
- [ ] Verify pairing succeeds.
- [ ] Verify the `Sync-ExchangeV2` logs on both devices report a negotiated protocol version of 2.1.

_One device only speaks v2.0_
- [ ] Enable `canUseExchangeV2.1` on one device only.
- [ ] Start the pairing flow between the two devices.
- [ ] Complete pairing.
- [ ] Verify pairing succeeds.
- [ ] Verify the `Sync-ExchangeV2` logs on both devices report a negotiated protocol version of 2.0.

_Both devices speak v2.0_
- [ ] Disable `canUseExchangeV2.1` on both devices.
- [ ] Start the pairing flow between the two devices.
- [ ] Complete pairing.
- [ ] Verify pairing succeeds.
- [ ] Verify the `Sync-ExchangeV2` logs on both devices report a negotiated protocol version of 2.0.

### UI changes
N/A

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync pairing handshake versioning and public runner API surface; incorrect negotiation could break mixed v2.0/v2.1 pairing, though behavior is covered by extensive unit tests.
> 
> **Overview**
> Adds **protocol version negotiation** to Exchange v2 pairing so each session advertises v2.0 or v2.1 (from `canUseExchangeV2Point1` at bootstrap) in the presenter’s linking code and the scanner’s `hello`, then settles on the **lower** of local and peer versions. The scanner negotiates when parsing the scanned code; the presenter negotiates on the peer’s `hello`. Unknown v2 minors are clamped via `minOf`; non-v2 peer versions fall back to v2.0. Advertised and negotiated versions reset on session teardown so a new pairing re-reads the flag.
> 
> **Interface cleanup:** `deliverIncomingMessage`, `deliverIncomingMessageJson`, and `recordSentMessage` are removed from `ExchangeV2Runner` and kept as `internal` on `RealExchangeV2Runner`; the unused `ExchangeV2MessageParser` dependency is dropped. Tests add parameterized coverage for advertisement, negotiation matrix, and cancel reset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5773e4dc96cc0f3185fa3a6921bf783bee127cdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->