### PR TITLE
Add Exchange channel authentication

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -102,6 +102,14 @@ interface SyncFeature {
     fun canUseExchangeV2Point1(): Toggle
 
     /**
+     * Kill switch for sending the exchange channel secret as the `Authorization` header on the v2.0
+     * exchange relay endpoints. Independent of [canUseExchangeV2Point1] so the header can be turned
+     * on (or off) without moving the protocol version. See [authenticateExchangeEndpoints].
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun canSendExchangeChannelSecret(): Toggle
+
+    /**
      * When enabled, the sync barcode scanner only attempts to decode QR codes. Sync codes are
      * always encoded as QR, so other formats only add noise (and false-positive decodes) to
      * the scanner.
@@ -148,3 +156,10 @@ interface SyncFeature {
  */
 internal fun SyncFeature.canWriteDeviceInfo(): Boolean =
     canUseV2ConnectFlow().isEnabled() && canWriteUnifiedDeviceList().isEnabled()
+
+/**
+ * The v2.1 protocol requires the channel secret on every exchange relay call, so speaking v2.1 implies authenticating.
+ * [SyncFeature.canSendExchangeChannelSecret] lets the header be enabled ahead of (or independently of) that version bump.
+ */
+internal fun SyncFeature.authenticateExchangeEndpoints(): Boolean =
+    canSendExchangeChannelSecret().isEnabled() || canUseExchangeV2Point1().isEnabled()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
@@ -166,24 +166,28 @@ interface SyncService {
 
     @PUT("$SYNC_PROD_ENVIRONMENT_URL/sync/v2/exchange/{channelId}")
     fun createExchangeChannel(
+        @Header("Authorization") authorization: String?,
         @Path("channelId") channelId: String,
         @Body body: ExchangeChannelCreateRequest,
     ): Call<Void>
 
     @POST("$SYNC_PROD_ENVIRONMENT_URL/sync/v2/exchange/{channelId}/messages")
     fun postExchangeMessages(
+        @Header("Authorization") authorization: String?,
         @Path("channelId") channelId: String,
         @Body body: ExchangeMessagesRequest,
     ): Call<Void>
 
     @GET("$SYNC_PROD_ENVIRONMENT_URL/sync/v2/exchange/{channelId}/messages")
     fun pollExchangeMessages(
+        @Header("Authorization") authorization: String?,
         @Path("channelId") channelId: String,
         @Query("after") after: Int,
     ): Call<ExchangeMessagesResponse>
 
     @DELETE("$SYNC_PROD_ENVIRONMENT_URL/sync/v2/exchange/{channelId}")
     fun deleteExchangeChannel(
+        @Header("Authorization") authorization: String?,
         @Path("channelId") channelId: String,
     ): Call<Void>
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -28,7 +28,7 @@ import logcat.logcat
 import org.json.JSONObject
 import retrofit2.HttpException
 import retrofit2.Response
-import javax.inject.*
+import javax.inject.Inject
 
 interface SyncApi {
     fun createAccount(
@@ -154,17 +154,43 @@ interface SyncApi {
         request: CreateAccessCredentialRequest,
     ): Result<Boolean>
 
-    /** Open a relay channel for the v2 pairing flow. Returns Error(code=409) on UUID collision. */
-    fun createExchangeChannel(channelId: String): Result<Unit>
+    /**
+     * Open a relay channel for the v2 pairing flow. [channelSecret] claims the channel and authorizes every later
+     * call on it, or null to claim it unauthenticated. Returns Error(code=409) on UUID collision.
+     */
+    fun createExchangeChannel(
+        channelId: String,
+        channelSecret: String?,
+    ): Result<Unit>
 
-    /** Send a batch of encrypted envelopes to [channelId]. */
-    fun sendExchangeMessages(channelId: String, envelopes: List<ExchangeEnvelope>): Result<Unit>
+    /**
+     * Send a batch of encrypted envelopes to [channelId]. [channelSecret] authorizes the call, or null when the
+     * channel is unauthenticated. Writing to a peer's channel carries our own secret, never the peer's.
+     */
+    fun sendExchangeMessages(
+        channelId: String,
+        channelSecret: String?,
+        envelopes: List<ExchangeEnvelope>,
+    ): Result<Unit>
 
-    /** Poll [channelId] for messages with seq > [after]. Returns Error(code=404) if channel is gone. */
-    fun pollExchangeMessages(channelId: String, after: Int): Result<List<ExchangeMessageEntry>>
+    /**
+     * Poll [channelId] for messages with seq > [after]. [channelSecret] authorizes the call, or null when the
+     * channel is unauthenticated. Returns Error(code=404) if channel is gone.
+     */
+    fun pollExchangeMessages(
+        channelId: String,
+        channelSecret: String?,
+        after: Int,
+    ): Result<List<ExchangeMessageEntry>>
 
-    /** Best-effort DELETE of our own channel — discards relay state. */
-    fun deleteExchangeChannel(channelId: String): Result<Unit>
+    /**
+     * Best-effort DELETE of our own channel, discarding relay state. [channelSecret] authorizes the call, or null
+     * when the channel is unauthenticated.
+     */
+    fun deleteExchangeChannel(
+        channelId: String,
+        channelSecret: String?,
+    ): Result<Unit>
 }
 
 /**
@@ -666,23 +692,46 @@ class SyncServiceRemote @Inject constructor(
         }
     }
 
-    override fun createExchangeChannel(channelId: String): Result<Unit> {
+    override fun createExchangeChannel(
+        channelId: String,
+        channelSecret: String?,
+    ): Result<Unit> {
         val response = runCatching {
-            syncService.createExchangeChannel(channelId, ExchangeChannelCreateRequest()).execute()
+            syncService.createExchangeChannel(
+                authorization = channelSecret?.asBearerToken(),
+                channelId = channelId,
+                body = ExchangeChannelCreateRequest(),
+            ).execute()
         }.getOrElse { throwable -> return Result.Error(reason = throwable.message.toString()) }
         return onSuccess(response) { Result.Success(Unit) }
     }
 
-    override fun sendExchangeMessages(channelId: String, envelopes: List<ExchangeEnvelope>): Result<Unit> {
+    override fun sendExchangeMessages(
+        channelId: String,
+        channelSecret: String?,
+        envelopes: List<ExchangeEnvelope>,
+    ): Result<Unit> {
         val response = runCatching {
-            syncService.postExchangeMessages(channelId, ExchangeMessagesRequest(envelopes)).execute()
+            syncService.postExchangeMessages(
+                authorization = channelSecret?.asBearerToken(),
+                channelId = channelId,
+                body = ExchangeMessagesRequest(envelopes),
+            ).execute()
         }.getOrElse { throwable -> return Result.Error(reason = throwable.message.toString()) }
         return onSuccess(response) { Result.Success(Unit) }
     }
 
-    override fun pollExchangeMessages(channelId: String, after: Int): Result<List<ExchangeMessageEntry>> {
+    override fun pollExchangeMessages(
+        channelId: String,
+        channelSecret: String?,
+        after: Int,
+    ): Result<List<ExchangeMessageEntry>> {
         val response = runCatching {
-            syncService.pollExchangeMessages(channelId, after).execute()
+            syncService.pollExchangeMessages(
+                authorization = channelSecret?.asBearerToken(),
+                channelId = channelId,
+                after = after,
+            ).execute()
         }.getOrElse { throwable -> return Result.Error(reason = throwable.message.toString()) }
         return onSuccess(response) {
             val messages = response.body()?.messages ?: emptyList()
@@ -690,9 +739,15 @@ class SyncServiceRemote @Inject constructor(
         }
     }
 
-    override fun deleteExchangeChannel(channelId: String): Result<Unit> {
+    override fun deleteExchangeChannel(
+        channelId: String,
+        channelSecret: String?,
+    ): Result<Unit> {
         val response = runCatching {
-            syncService.deleteExchangeChannel(channelId).execute()
+            syncService.deleteExchangeChannel(
+                authorization = channelSecret?.asBearerToken(),
+                channelId = channelId,
+            ).execute()
         }.getOrElse { throwable -> return Result.Error(reason = throwable.message.toString()) }
         return onSuccess(response) { Result.Success(Unit) }
     }
@@ -712,6 +767,10 @@ class SyncServiceRemote @Inject constructor(
 
     private fun Response<*>.requestAuthToken(): String? {
         return raw().request.header("Authorization")?.removePrefix("Bearer ")
+    }
+
+    private fun String.asBearerToken(): String {
+        return "Bearer $this"
     }
 
     private class Adapters {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/crypto/SyncJweCrypto.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/crypto/SyncJweCrypto.kt
@@ -51,6 +51,11 @@ interface SyncJweCrypto {
     fun generateRsaKeyPair(keySizeBits: Int): RsaKeyPair
 
     /**
+     * Generate [byteCount] cryptographically random bytes.
+     */
+    fun generateSecureBytes(byteCount: Int): ByteArray
+
+    /**
      * JWE-encrypt content with a symmetric AES-256 key using direct encryption (alg=dir, enc=A256GCM).
      * Optional `kid` is written to the JWE header to identify which key was used to wrap the payload.
      */
@@ -116,6 +121,10 @@ class RealSyncJweCrypto @Inject constructor() : SyncJweCrypto {
             publicKeyBase64 = b64UrlEncode(keyPair.public.encoded),
             privateKeyBase64 = b64UrlEncode(keyPair.private.encoded),
         )
+    }
+
+    override fun generateSecureBytes(byteCount: Int): ByteArray {
+        return ByteArray(byteCount).also { secureRandom.nextBytes(it) }
     }
 
     override fun jweEncryptSymmetric(plaintext: ByteArray, symmetricKey: ByteArray, kid: String?): String {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
@@ -45,31 +45,49 @@ class PollAuthDenied(val status: Int) : RuntimeException("Poll denied with $stat
 interface ExchangeV2Channel {
 
     /**
-     * Create [channelId] on the relay. Returns Success on 2xx. Returns Error with code=409 on
-     * UUID collision (caller should retry with a fresh UUID).
+     * Create [channelId] on the relay. [channelSecret] claims the channel and authorizes every later call on it, or
+     * null to claim it unauthenticated. Returns Success on 2xx. Returns Error with code=409 on UUID collision
+     * (caller should retry with a fresh UUID).
      */
-    fun createChannel(channelId: String): Result<Unit>
+    fun createChannel(
+        channelId: String,
+        channelSecret: String?,
+    ): Result<Unit>
 
     /**
-     * Encrypt [message] and send it to [peerChannelId]. Sender's kid is [ownChannelId].
+     * Encrypt [message] and send it to [peerChannelId]. Sender's kid is [ownChannelId]. [ownChannelSecret] authorizes
+     * the call, or null when the channel is unauthenticated. Writing to a peer's channel carries our own secret,
+     * never the peer's.
      */
     fun sendMessage(
         message: ExchangeV2Message,
         peerChannelId: String,
         peerPublicKeyBase64: String,
         ownChannelId: String,
+        ownChannelSecret: String?,
     ): Result<Unit>
 
     /**
-     * Poll loop on [ownChannelId], emitting decrypted + parsed messages.
+     * Poll loop on [ownChannelId], emitting decrypted + parsed messages. [ownChannelSecret] authorizes the calls, or
+     * null when the channel is unauthenticated, and [ownPrivateKeyBase64] decrypts the envelopes.
      *  - Transient statuses (5xx / 429 / network / timeouts) keep polling; the 5-min session timer catches persistent transient failures.
      *  - Throws [ChannelGone] on 404/410 (channel deleted or TTL'd), [PollBadRequest] on 400, [PollAuthDenied] on 401/403
      *  - Throws [EnvelopeVersionTooNew] on a too-new envelope and [EnvelopeDecryptFailure] on decrypt failure
      */
-    fun poll(ownChannelId: String, ownPrivateKeyBase64: String): Flow<ExchangeV2Message>
+    fun poll(
+        ownChannelId: String,
+        ownPrivateKeyBase64: String,
+        ownChannelSecret: String?,
+    ): Flow<ExchangeV2Message>
 
-    /** Best-effort DELETE of our own channel. Used on user-cancel + terminal SM states. */
-    fun deleteChannel(channelId: String): Result<Unit>
+    /**
+     * Best-effort DELETE of our own channel, used on user-cancel + terminal SM states. [channelSecret] authorizes the
+     * call, or null when the channel is unauthenticated.
+     */
+    fun deleteChannel(
+        channelId: String,
+        channelSecret: String?,
+    ): Result<Unit>
 }
 
 @ContributesBinding(AppScope::class)
@@ -79,9 +97,15 @@ class RealExchangeV2Channel @Inject constructor(
     private val messageParser: ExchangeV2MessageParser,
 ) : ExchangeV2Channel {
 
-    override fun createChannel(channelId: String): Result<Unit> {
+    override fun createChannel(
+        channelId: String,
+        channelSecret: String?,
+    ): Result<Unit> {
         logcat { "Sync-ExchangeV2: PUT /sync/v2/exchange/$channelId" }
-        return syncApi.createExchangeChannel(channelId)
+        return syncApi.createExchangeChannel(
+            channelId = channelId,
+            channelSecret = channelSecret,
+        )
     }
 
     override fun sendMessage(
@@ -89,6 +113,7 @@ class RealExchangeV2Channel @Inject constructor(
         peerChannelId: String,
         peerPublicKeyBase64: String,
         ownChannelId: String,
+        ownChannelSecret: String?,
     ): Result<Unit> {
         val sealed = runCatching {
             envelope.seal(message, peerPublicKeyBase64, ownChannelId)
@@ -97,13 +122,26 @@ class RealExchangeV2Channel @Inject constructor(
             return Result.Error(reason = "Failed to seal envelope: ${it.message}")
         }
         logcat { "Sync-ExchangeV2: POST /sync/v2/exchange/$peerChannelId/messages" }
-        return syncApi.sendExchangeMessages(peerChannelId, listOf(sealed))
+        return syncApi.sendExchangeMessages(
+            channelId = peerChannelId,
+            channelSecret = ownChannelSecret,
+            envelopes = listOf(sealed),
+        )
     }
 
-    override fun poll(ownChannelId: String, ownPrivateKeyBase64: String): Flow<ExchangeV2Message> = flow {
+    override fun poll(
+        ownChannelId: String,
+        ownPrivateKeyBase64: String,
+        ownChannelSecret: String?,
+    ): Flow<ExchangeV2Message> = flow {
         var cursor = 0
         while (true) {
-            when (val outcome = syncApi.pollExchangeMessages(ownChannelId, cursor)) {
+            val outcome = syncApi.pollExchangeMessages(
+                channelId = ownChannelId,
+                channelSecret = ownChannelSecret,
+                after = cursor,
+            )
+            when (outcome) {
                 is Result.Success -> {
                     for (entry in outcome.data) {
                         val decoded = decode(entry, ownPrivateKeyBase64)
@@ -111,6 +149,7 @@ class RealExchangeV2Channel @Inject constructor(
                         emit(decoded)
                     }
                 }
+
                 is Result.Error -> {
                     when (outcome.code) {
                         404, 410 -> throw ChannelGone(outcome.code)
@@ -124,12 +163,21 @@ class RealExchangeV2Channel @Inject constructor(
         }
     }
 
-    override fun deleteChannel(channelId: String): Result<Unit> {
+    override fun deleteChannel(
+        channelId: String,
+        channelSecret: String?,
+    ): Result<Unit> {
         logcat { "Sync-ExchangeV2: DELETE /sync/v2/exchange/$channelId (best effort)" }
-        return syncApi.deleteExchangeChannel(channelId)
+        return syncApi.deleteExchangeChannel(
+            channelId = channelId,
+            channelSecret = channelSecret,
+        )
     }
 
-    private fun decode(entry: com.duckduckgo.sync.impl.ExchangeMessageEntry, ownPrivateKeyBase64: String): ExchangeV2Message {
+    private fun decode(
+        entry: com.duckduckgo.sync.impl.ExchangeMessageEntry,
+        ownPrivateKeyBase64: String,
+    ): ExchangeV2Message {
         val inner = runCatching {
             envelope.open(ExchangeEnvelope(entry.version, entry.payload), ownPrivateKeyBase64)
         }.getOrElse {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncDeviceIds
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.authenticateExchangeEndpoints
 import com.duckduckgo.sync.impl.crypto.RsaKeyPair
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
@@ -48,6 +49,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
 import logcat.logcat
+import java.util.Base64
 import java.util.UUID
 import javax.inject.Inject
 
@@ -126,6 +128,8 @@ class RealExchangeV2Runner @Inject constructor(
     @Volatile private var _pairingRole: PairingRole? = null
 
     @Volatile private var ownChannelId: String? = null
+
+    @Volatile private var ownChannelSecret: String? = null
 
     @Volatile private var ownKeyPair: RsaKeyPair? = null
 
@@ -246,9 +250,11 @@ class RealExchangeV2Runner @Inject constructor(
         ownKeyPair = keyPair
         repeat(MAX_CHANNEL_CREATE_RETRIES) { attempt ->
             val candidate = UUID.randomUUID().toString()
-            when (val r = channel.createChannel(candidate)) {
+            val candidateSecret = generateChannelSecret()
+            when (val r = channel.createChannel(candidate, candidateSecret)) {
                 is Result.Success -> {
                     ownChannelId = candidate
+                    ownChannelSecret = candidateSecret
                     logcat { "Sync-ExchangeV2: bootstrap as $role channel_id=$candidate" }
                     return keyPair
                 }
@@ -314,16 +320,18 @@ class RealExchangeV2Runner @Inject constructor(
         pollJob = null
         timeoutJob?.cancel()
         timeoutJob = null
-        val toDelete = ownChannelId
-        if (toDelete != null) {
+        val channelId = ownChannelId
+        val channelSecret = ownChannelSecret
+        if (channelId != null) {
             // Best-effort DELETE.
             appScope.launch(dispatchers.io()) {
-                runCatching { channel.deleteChannel(toDelete) }
+                runCatching { channel.deleteChannel(channelId, channelSecret) }
             }
         }
         session = null
         _pairingRole = null
         ownChannelId = null
+        ownChannelSecret = null
         ownKeyPair = null
         peerChannelId = null
         peerPublicKey = null
@@ -344,12 +352,13 @@ class RealExchangeV2Runner @Inject constructor(
     private fun startPolling() {
         val ch = ownChannelId ?: return
         val key = ownKeyPair ?: return
+        val sec = ownChannelSecret
         pollJob = appScope.launch(dispatchers.io()) {
             try {
                 // collect suspends per message so envelopes are handled in poll() seq order. A
                 // message driving the SM terminal cancels this very poll job; that
                 // self-cancellation surfaces as the CancellationException caught below.
-                channel.poll(ch, key.privateKeyBase64).collect { incoming ->
+                channel.poll(ch, key.privateKeyBase64, sec).collect { incoming ->
                     deliverIncomingMessage(incoming)
                 }
             } catch (versionTooNew: EnvelopeVersionTooNew) {
@@ -785,7 +794,8 @@ class RealExchangeV2Runner @Inject constructor(
         peerKey: String,
     ): Boolean {
         val own = ownChannelId ?: return false
-        return when (val r = channel.sendMessage(outboundMessage, peerChannel, peerKey, own)) {
+        val sec = ownChannelSecret
+        return when (val r = channel.sendMessage(outboundMessage, peerChannel, peerKey, own, sec)) {
             is Result.Success -> {
                 recordSentMessage(outboundMessage)
                 true
@@ -871,9 +881,24 @@ class RealExchangeV2Runner @Inject constructor(
         return negotiatedVersion
     }
 
+    /**
+     * Null when this device does not authenticate exchange endpoints. The decision is made once per session, at
+     * bootstrap: a channel created without a secret can never start presenting one, since the relay would reject
+     * a header the channel was not claimed with.
+     */
+    private fun generateChannelSecret(): String? {
+        if (!syncFeature.authenticateExchangeEndpoints()) return null
+        return Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(jweCrypto.generateSecureBytes(CHANNEL_SECRET_SIZE))
+    }
+
     companion object {
         // RSA modulus size (bits) for the v2 exchange pairing keypair.
         private const val EXCHANGE_RSA_KEY_SIZE = 2048
+
+        // Channel authorization secret size for the v2 exchange transport layer.
+        private const val CHANNEL_SECRET_SIZE = 32
 
         private const val REPLAY = 100
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
@@ -533,4 +533,60 @@ class SyncServiceRemoteTest {
 
         verify(syncStore).clearAll()
     }
+
+    @Test
+    fun whenCreateExchangeChannelThenChannelSecretSentAsBearerAuthorization() {
+        val call: Call<Void> = mock()
+        whenever(syncService.createExchangeChannel(anyOrNull(), anyString(), any())).thenReturn(call)
+        whenever(call.execute()).thenReturn(Response.success(null))
+
+        val result = syncRemote.createExchangeChannel(CHANNEL_ID, CHANNEL_SECRET)
+
+        assertEquals(Result.Success(Unit), result)
+        verify(syncService).createExchangeChannel(eq("Bearer $CHANNEL_SECRET"), eq(CHANNEL_ID), any())
+    }
+
+    @Test
+    fun whenSendExchangeMessagesThenChannelSecretSentAsBearerAuthorization() {
+        val call: Call<Void> = mock()
+        val envelopes = listOf(ExchangeEnvelope(version = "2.0", payload = "jwe"))
+        whenever(syncService.postExchangeMessages(anyOrNull(), anyString(), any())).thenReturn(call)
+        whenever(call.execute()).thenReturn(Response.success(null))
+
+        val result = syncRemote.sendExchangeMessages(PEER_CHANNEL_ID, CHANNEL_SECRET, envelopes)
+
+        assertEquals(Result.Success(Unit), result)
+        verify(syncService).postExchangeMessages(eq("Bearer $CHANNEL_SECRET"), eq(PEER_CHANNEL_ID), eq(ExchangeMessagesRequest(envelopes)))
+    }
+
+    @Test
+    fun whenPollExchangeMessagesThenChannelSecretSentAsBearerAuthorization() {
+        val entry = ExchangeMessageEntry(seq = 3, version = "2.0", payload = "jwe")
+        val call: Call<ExchangeMessagesResponse> = mock()
+        whenever(syncService.pollExchangeMessages(anyOrNull(), anyString(), any())).thenReturn(call)
+        whenever(call.execute()).thenReturn(Response.success(ExchangeMessagesResponse(listOf(entry))))
+
+        val result = syncRemote.pollExchangeMessages(CHANNEL_ID, CHANNEL_SECRET, after = 2)
+
+        assertEquals(Result.Success(listOf(entry)), result)
+        verify(syncService).pollExchangeMessages(eq("Bearer $CHANNEL_SECRET"), eq(CHANNEL_ID), eq(2))
+    }
+
+    @Test
+    fun whenDeleteExchangeChannelThenChannelSecretSentAsBearerAuthorization() {
+        val call: Call<Void> = mock()
+        whenever(syncService.deleteExchangeChannel(anyOrNull(), anyString())).thenReturn(call)
+        whenever(call.execute()).thenReturn(Response.success(null))
+
+        val result = syncRemote.deleteExchangeChannel(CHANNEL_ID, CHANNEL_SECRET)
+
+        assertEquals(Result.Success(Unit), result)
+        verify(syncService).deleteExchangeChannel(eq("Bearer $CHANNEL_SECRET"), eq(CHANNEL_ID))
+    }
+
+    private companion object {
+        const val CHANNEL_ID = "channel-id"
+        const val PEER_CHANNEL_ID = "peer-channel-id"
+        const val CHANNEL_SECRET = "channel-secret"
+    }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2ChannelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2ChannelTest.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.sync.impl.exchange.v2
 
+import com.duckduckgo.sync.impl.ExchangeEnvelope
+import com.duckduckgo.sync.impl.ExchangeMessageEntry
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncApi
 import kotlinx.coroutines.flow.toList
@@ -24,6 +26,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -42,54 +45,118 @@ class RealExchangeV2ChannelTest {
     )
 
     @Test fun `poll throws PollAuthDenied on 403 without retrying`() = runTest {
-        whenever(syncApi.pollExchangeMessages(any(), any())).thenReturn(
+        whenever(syncApi.pollExchangeMessages(any(), any(), any())).thenReturn(
             Result.Error(code = 403, reason = "Forbidden"),
             Result.Error(code = 404, reason = "should not be reached"),
         )
 
         var thrown: PollAuthDenied? = null
-        try { channel.poll("own-channel", "own-priv").toList() } catch (e: PollAuthDenied) { thrown = e }
+        try { channel.poll("own-channel", "own-priv", "own-secret").toList() } catch (e: PollAuthDenied) { thrown = e }
 
         assertNotNull(thrown)
         assertEquals(403, thrown!!.status)
-        verify(syncApi, times(1)).pollExchangeMessages(any(), any())
+        verify(syncApi, times(1)).pollExchangeMessages(any(), any(), any())
     }
 
     @Test fun `poll throws PollBadRequest on 400 without retrying`() = runTest {
-        whenever(syncApi.pollExchangeMessages(any(), any())).thenReturn(
+        whenever(syncApi.pollExchangeMessages(any(), any(), any())).thenReturn(
             Result.Error(code = 400, reason = "Bad Request"),
         )
 
         var thrown: PollBadRequest? = null
-        try { channel.poll("own-channel", "own-priv").toList() } catch (e: PollBadRequest) { thrown = e }
+        try { channel.poll("own-channel", "own-priv", "own-secret").toList() } catch (e: PollBadRequest) { thrown = e }
 
         assertNotNull(thrown)
         assertEquals(400, thrown!!.status)
     }
 
     @Test fun `poll keeps polling after a transient status and throws ChannelGone on 404`() = runTest {
-        whenever(syncApi.pollExchangeMessages(any(), any())).thenReturn(
+        whenever(syncApi.pollExchangeMessages(any(), any(), any())).thenReturn(
             Result.Error(code = 500, reason = "Server error"),
             Result.Error(code = 404, reason = "channel gone"),
         )
 
         var thrown: ChannelGone? = null
-        try { channel.poll("own-channel", "own-priv").toList() } catch (e: ChannelGone) { thrown = e }
+        try { channel.poll("own-channel", "own-priv", "own-secret").toList() } catch (e: ChannelGone) { thrown = e }
 
         assertNotNull(thrown)
         assertEquals(404, thrown!!.status)
-        verify(syncApi, times(2)).pollExchangeMessages(any(), any())
+        verify(syncApi, times(2)).pollExchangeMessages(any(), any(), any())
     }
 
     @Test fun `poll throws ChannelGone on 410`() = runTest {
-        whenever(syncApi.pollExchangeMessages(any(), any())).thenReturn(
+        whenever(syncApi.pollExchangeMessages(any(), any(), any())).thenReturn(
             Result.Error(code = 410, reason = "Gone"),
         )
 
         var thrown: ChannelGone? = null
-        try { channel.poll("own-channel", "own-priv").toList() } catch (e: ChannelGone) { thrown = e }
+        try { channel.poll("own-channel", "own-priv", "own-secret").toList() } catch (e: ChannelGone) { thrown = e }
 
         assertNotNull(thrown)
         assertEquals(410, thrown!!.status)
+    }
+
+    @Test fun `createChannel claims the channel with the given secret`() = runTest {
+        whenever(syncApi.createExchangeChannel(any(), any())).thenReturn(Result.Success(Unit))
+
+        channel.createChannel("own-channel", "own-secret")
+
+        verify(syncApi).createExchangeChannel(channelId = "own-channel", channelSecret = "own-secret")
+    }
+
+    @Test fun `sendMessage authorizes the write to the peer channel with our own secret`() = runTest {
+        val sealed = ExchangeEnvelope(version = "2.0", payload = "jwe")
+        whenever(envelope.seal(any(), any(), any())).thenReturn(sealed)
+        whenever(syncApi.sendExchangeMessages(any(), any(), any())).thenReturn(Result.Success(Unit))
+
+        channel.sendMessage(
+            message = ExchangeV2Message.Hello.fromJson("{}"),
+            peerChannelId = "peer-channel",
+            peerPublicKeyBase64 = "peer-pub",
+            ownChannelId = "own-channel",
+            ownChannelSecret = "own-secret",
+        )
+
+        verify(syncApi).sendExchangeMessages(
+            channelId = "peer-channel",
+            channelSecret = "own-secret",
+            envelopes = listOf(sealed),
+        )
+    }
+
+    @Test fun `poll authorizes each request with the own channel secret`() = runTest {
+        whenever(syncApi.pollExchangeMessages(any(), any(), any())).thenReturn(
+            Result.Success(listOf(ExchangeMessageEntry(seq = 1, version = "2.0", payload = "jwe"))),
+            Result.Error(code = 410, reason = "Gone"),
+        )
+        whenever(envelope.open(any(), any())).thenReturn("{}")
+        whenever(messageParser.parse(any())).thenReturn(ExchangeV2Message.Hello.fromJson("{}"))
+
+        runCatching { channel.poll("own-channel", "own-priv", "own-secret").toList() }
+
+        verify(syncApi).pollExchangeMessages(channelId = "own-channel", channelSecret = "own-secret", after = 0)
+        verify(syncApi).pollExchangeMessages(channelId = "own-channel", channelSecret = "own-secret", after = 1)
+    }
+
+    @Test fun `deleteChannel authorizes the delete with the channel secret`() = runTest {
+        whenever(syncApi.deleteExchangeChannel(any(), any())).thenReturn(Result.Success(Unit))
+
+        channel.deleteChannel("own-channel", "own-secret")
+
+        verify(syncApi).deleteExchangeChannel(channelId = "own-channel", channelSecret = "own-secret")
+    }
+
+    @Test fun `a channel without a secret is created, polled and deleted unauthenticated`() = runTest {
+        whenever(syncApi.createExchangeChannel(any(), anyOrNull())).thenReturn(Result.Success(Unit))
+        whenever(syncApi.pollExchangeMessages(any(), anyOrNull(), any())).thenReturn(Result.Error(code = 410, reason = "Gone"))
+        whenever(syncApi.deleteExchangeChannel(any(), anyOrNull())).thenReturn(Result.Success(Unit))
+
+        channel.createChannel("own-channel", null)
+        runCatching { channel.poll("own-channel", "own-priv", null).toList() }
+        channel.deleteChannel("own-channel", null)
+
+        verify(syncApi).createExchangeChannel(channelId = "own-channel", channelSecret = null)
+        verify(syncApi).pollExchangeMessages(channelId = "own-channel", channelSecret = null, after = 0)
+        verify(syncApi).deleteExchangeChannel(channelId = "own-channel", channelSecret = null)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -54,12 +54,16 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.Base64
 
 @RunWith(TestParameterInjector::class)
 class RealExchangeV2RunnerTest {
@@ -95,10 +99,11 @@ class RealExchangeV2RunnerTest {
         givenLinkingCodeVersion(ExchangeProtocolVersion.V2_0)
         whenever(qrCode.buildLinkingCode(any(), any(), any())).thenReturn("https://duckduckgo.com/sync/pairing/#&code2=fake")
         whenever(jweCrypto.generateRsaKeyPair(any())).thenReturn(RsaKeyPair(publicKeyBase64 = "own-pub", privateKeyBase64 = "own-priv"))
-        whenever(channel.createChannel(any())).thenReturn(Result.Success(Unit))
-        whenever(channel.poll(any(), any())).thenReturn(emptyFlow())
-        whenever(channel.sendMessage(any(), any(), any(), any())).thenReturn(Result.Success(Unit))
-        whenever(channel.deleteChannel(any())).thenReturn(Result.Success(Unit))
+        whenever(jweCrypto.generateSecureBytes(any())).thenReturn("channel-secret".toByteArray())
+        whenever(channel.createChannel(any(), anyOrNull())).thenReturn(Result.Success(Unit))
+        whenever(channel.poll(any(), any(), anyOrNull())).thenReturn(emptyFlow())
+        whenever(channel.sendMessage(any(), any(), any(), any(), anyOrNull())).thenReturn(Result.Success(Unit))
+        whenever(channel.deleteChannel(any(), anyOrNull())).thenReturn(Result.Success(Unit))
         whenever(syncDeviceIds.deviceName()).thenReturn("This Device")
     }
 
@@ -249,6 +254,7 @@ class RealExchangeV2RunnerTest {
             any(),
             any(),
             any(),
+            anyOrNull(),
         )
     }
 
@@ -264,6 +270,7 @@ class RealExchangeV2RunnerTest {
             any(),
             any(),
             any(),
+            anyOrNull(),
         )
     }
 
@@ -295,6 +302,7 @@ class RealExchangeV2RunnerTest {
             any(),
             any(),
             any(),
+            anyOrNull(),
         )
     }
 
@@ -456,12 +464,14 @@ class RealExchangeV2RunnerTest {
             any(),
             any(),
             any(),
+            anyOrNull(),
         )
         verify(channel, never()).sendMessage(
             argThat { this is RecoveryCodeConfirmed },
             any(),
             any(),
             any(),
+            anyOrNull(),
         )
     }
 
@@ -481,12 +491,14 @@ class RealExchangeV2RunnerTest {
             any(),
             any(),
             any(),
+            anyOrNull(),
         )
         verify(channel, org.mockito.kotlin.times(1)).sendMessage(
             argThat { this is RecoveryCodeAwaitingConfirmation },
             any(),
             any(),
             any(),
+            anyOrNull(),
         )
     }
 
@@ -495,7 +507,7 @@ class RealExchangeV2RunnerTest {
         whenever(recoveryCodeProvider.createDdgAccountIfNeeded()).thenReturn(Result.Success(Unit))
         whenever(recoveryCodeProvider.getDdgRecoveryCode()).thenReturn(Result.Success("the-code"))
         whenever(
-            channel.sendMessage(any<RecoveryCodeResponse>(), any(), any(), any()),
+            channel.sendMessage(any<RecoveryCodeResponse>(), any(), any(), any(), anyOrNull()),
         ).thenReturn(Result.Error(reason = "relay unreachable"))
 
         val runner = newRunner()
@@ -617,7 +629,7 @@ class RealExchangeV2RunnerTest {
 
     @Test fun `an unexpected poll error tears down the session with a SessionError`() = runTest {
         whenever(syncStore.userId).thenReturn("my-user")
-        whenever(channel.poll(any(), any())).thenReturn(flow<ExchangeV2Message> { throw RuntimeException("boom") })
+        whenever(channel.poll(any(), any(), anyOrNull())).thenReturn(flow<ExchangeV2Message> { throw RuntimeException("boom") })
         val runner = newRunner()
         runner.startPresent()
 
@@ -635,7 +647,7 @@ class RealExchangeV2RunnerTest {
 
     @Test fun `polled messages are processed in wire order (hello before request reaches Host_Confirming)`() = runTest {
         whenever(syncStore.userId).thenReturn("my-user")
-        whenever(channel.poll(any(), any())).thenReturn(
+        whenever(channel.poll(any(), any(), anyOrNull())).thenReturn(
             flowOf(
                 Hello.fromJson("""{"type":"hello"}"""),
                 RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"),
@@ -650,7 +662,7 @@ class RealExchangeV2RunnerTest {
 
     @Test fun `a polled message that reaches a terminal state tears down without a spurious error`() = runTest {
         whenever(syncStore.userId).thenReturn("shared")
-        whenever(channel.poll(any(), any())).thenReturn(
+        whenever(channel.poll(any(), any(), anyOrNull())).thenReturn(
             flowOf(
                 RecoveryCodeAvailable.create(userId = "shared", name = "Peer", kind = "ddg"),
             ),
@@ -668,7 +680,7 @@ class RealExchangeV2RunnerTest {
 
     @Test fun `cancel during an open poll does not surface a spurious error`() = runTest {
         whenever(syncStore.userId).thenReturn("my-user")
-        whenever(channel.poll(any(), any())).thenReturn(flow<ExchangeV2Message> { awaitCancellation() })
+        whenever(channel.poll(any(), any(), anyOrNull())).thenReturn(flow<ExchangeV2Message> { awaitCancellation() })
         val runner = newRunner()
         runner.startPresent()
 
@@ -681,7 +693,7 @@ class RealExchangeV2RunnerTest {
     }
 
     @Test fun `startScan with a failed channel bootstrap aborts cleanly without the misleading reach-Presenter error`() = runTest {
-        whenever(channel.createChannel(any())).thenReturn(Result.Error(reason = "relay 500"))
+        whenever(channel.createChannel(any(), anyOrNull())).thenReturn(Result.Error(reason = "relay 500"))
         val runner = newRunner()
         runner.startScan("")
 
@@ -691,12 +703,93 @@ class RealExchangeV2RunnerTest {
     }
 
     @Test fun `a failed bootstrap clears the pairing role so no half-started session lingers`() = runTest {
-        whenever(channel.createChannel(any())).thenReturn(Result.Error(reason = "relay 500"))
+        whenever(channel.createChannel(any(), anyOrNull())).thenReturn(Result.Error(reason = "relay 500"))
         val runner = newRunner()
 
         runner.startScan("")
 
         assertNull("pairingRole must be cleared after a failed bootstrap", runner.pairingRole)
+    }
+
+    // ---- Channel authentication ----
+
+    @Test fun `the channel is claimed, polled and written to with a secret only when a flag calls for it`(
+        @TestParameter case: ExchangeAuthCase,
+    ) = runTest {
+        case.configure(syncFeature)
+        val utf8Secret = "channel-secret"
+        val expectedSecret = utf8Secret.toBase64Url().takeIf { case.isAuthenticated }
+        whenever(jweCrypto.generateSecureBytes(any())).thenReturn(utf8Secret.toByteArray())
+
+        val runner = newRunner()
+        runner.startScan("")
+
+        verify(jweCrypto, times(if (case.isAuthenticated) 1 else 0)).generateSecureBytes(any())
+        verify(channel).createChannel(any(), eq(expectedSecret))
+        verify(channel).poll(any(), any(), eq(expectedSecret))
+        verify(channel, atLeastOnce()).sendMessage(any(), any(), any(), any(), eq(expectedSecret))
+    }
+
+    @Test fun `cancel deletes the channel with whatever secret it was created with`(
+        @TestParameter case: ExchangeAuthCase,
+    ) = runTest {
+        case.configure(syncFeature)
+        val utf8Secret = "channel-secret"
+        val expectedSecret = utf8Secret.toBase64Url().takeIf { case.isAuthenticated }
+        whenever(jweCrypto.generateSecureBytes(any())).thenReturn(utf8Secret.toByteArray())
+
+        val runner = newRunner()
+        runner.startScan("")
+        runner.cancel()
+
+        verify(channel).deleteChannel(any(), eq(expectedSecret))
+    }
+
+    @Test fun `a channel_id collision retries with a fresh secret and keeps the one that was accepted`() = runTest {
+        val utf8Secrets = listOf("first-secret", "second-secret")
+        val base64UrlSecrets = utf8Secrets.map { it.toBase64Url() }
+        whenever(jweCrypto.generateSecureBytes(any())).thenReturn(
+            utf8Secrets[0].toByteArray(),
+            utf8Secrets[1].toByteArray(),
+        )
+        whenever(channel.createChannel(any(), anyOrNull())).thenReturn(
+            Result.Error(code = 409, reason = "channel_id taken"),
+            Result.Success(Unit),
+        )
+        val runner = newRunner()
+
+        runner.startScan("")
+
+        verify(channel).createChannel(any(), eq(base64UrlSecrets[0]))
+        verify(channel).createChannel(any(), eq(base64UrlSecrets[1]))
+        verify(channel).poll(any(), any(), eq(base64UrlSecrets[1]))
+    }
+
+    @Test fun `a new session claims its channel with a fresh secret`() = runTest {
+        val utf8Secrets = listOf("first-secret", "second-secret")
+        val base64UrlSecrets = utf8Secrets.map { it.toBase64Url() }
+        whenever(jweCrypto.generateSecureBytes(any())).thenReturn(
+            utf8Secrets[0].toByteArray(),
+            utf8Secrets[1].toByteArray(),
+        )
+        val runner = newRunner()
+
+        runner.startScan("")
+        runner.cancel()
+        runner.startScan("")
+
+        verify(channel).createChannel(any(), eq(base64UrlSecrets[0]))
+        verify(channel).createChannel(any(), eq(base64UrlSecrets[1]))
+    }
+
+    @Test fun `the channel secret is url-safe and unpadded so it survives an Authorization header`() = runTest {
+        // Standard base64 of these bytes is "fn4/Pz4+c2VjcmV0IQ==" — the '+', '/' and padding must all be gone.
+        whenever(jweCrypto.generateSecureBytes(any())).thenReturn("~~??>>secret!".toByteArray())
+        val runner = newRunner()
+
+        runner.startScan("")
+
+        verify(channel).createChannel(any(), eq("fn4_Pz4-c2VjcmV0IQ"))
     }
 
     // ---- Helpers ----
@@ -719,4 +812,39 @@ class RealExchangeV2RunnerTest {
     private fun String.toProtocolVersion() = ExchangeProtocolVersion.parse(this).getOrThrow()
 
     private fun String.toV2ProtocolVersion() = toProtocolVersion() as ExchangeProtocolVersion.V2
+
+    private fun String.toBase64Url(): String = Base64.getUrlEncoder().withoutPadding().encodeToString(toByteArray())
+
+    enum class ExchangeAuthCase(
+        val canSendExchangeChannelSecret: Boolean,
+        val canUseExchangeV2Point1: Boolean,
+        val isAuthenticated: Boolean,
+    ) {
+        BothFlagsOff(
+            canSendExchangeChannelSecret = false,
+            canUseExchangeV2Point1 = false,
+            isAuthenticated = false,
+        ),
+        SecretFlagOn(
+            canSendExchangeChannelSecret = true,
+            canUseExchangeV2Point1 = false,
+            isAuthenticated = true,
+        ),
+        V2Point1FlagOn(
+            canSendExchangeChannelSecret = false,
+            canUseExchangeV2Point1 = true,
+            isAuthenticated = true,
+        ),
+        BothFlagsOn(
+            canSendExchangeChannelSecret = true,
+            canUseExchangeV2Point1 = true,
+            isAuthenticated = true,
+        ),
+        ;
+
+        fun configure(syncFeature: SyncFeature) {
+            syncFeature.canSendExchangeChannelSecret().setRawStoredState(State(canSendExchangeChannelSecret))
+            syncFeature.canUseExchangeV2Point1().setRawStoredState(State(canUseExchangeV2Point1))
+        }
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217270894558254?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/72649045549333/task/1217579192660466?focus=true
API Proposals URL(s) (if applicable): N/A

### Description

Authenticates the v2 exchange relay endpoints. Each device now generates a random secret when it claims its own exchange channel and presents that secret as an `Authorization: Bearer` header on every later call for the channel, so only the device that claimed a channel can poll or delete it, and writes to a peer's channel are attributable.

Channel secret:
- The secret is 32 cryptographically random bytes, encoded as url-safe base64 without padding so it is safe to carry in a header.
- It is generated once per pairing session, at the moment the channel is claimed, and held in memory only.
- If the relay rejects the channel id as taken, the retry uses both a fresh channel id and a fresh secret, and the accepted pair is the one kept for the rest of the session.
- Cancelling or finishing a session clears the secret, so a later session claims its channel with a new one.

Authenticated calls:
- Creating, polling and deleting our own channel all carry our own secret.
- Sending a message to the peer's channel also carries our own secret.

Feature flags:
- The new `canSendExchangeChannelSecret` flag is a kill switch for the header on the v2.0 protocol and is on by default.
- `canUseExchangeV2Point1` also implies authentication, because the v2.1 protocol requires the secret on every relay call.
- With both flags off, channels are claimed and used without a secret exactly as before, and no secret is generated at all.
- The decision is taken once, at channel creation. A channel claimed without a secret never starts sending one, since the relay would reject a header the channel was not claimed with.

### Steps to test this PR

_Pair two devices with channel authentication on_
- [ ] Install an internal build on two devices.
- [ ] Verify `canSendExchangeChannelSecret` is enabled on both devices.
- [ ] Open Sync settings on the presenting device.
- [ ] Start the flow that shows the sync QR code.
- [ ] Scan that code from the second device.
- [ ] Verify pairing completes and both devices end up synced.

_Pair two devices with the v2.1 protocol_
- [ ] Enable `canUseExchangeV2Point1` on both devices.
- [ ] Repeat the pairing steps above.
- [ ] Verify pairing completes and both devices end up synced.

_Pair with the header disabled_
- [ ] Disable `canSendExchangeChannelSecret` and `canUseExchangeV2Point1` on both devices.
- [ ] Repeat the pairing steps above.
- [ ] Verify pairing still completes and both devices end up synced.

_Pair with the header disabled on one device_
- [ ] Disable `canSendExchangeChannelSecret` and `canUseExchangeV2Point1` on one of the devices and enabled on the other.
- [ ] Repeat the pairing steps above.
- [ ] Verify pairing still completes and both devices end up synced.

### UI changes
N/A

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync pairing transport auth and relay authorization semantics; mitigated by remote flags and backward-compatible unauthenticated mode when both flags are off.
> 
> **Overview**
> Adds **channel-secret authentication** for sync v2 exchange relay calls: when enabled, each device generates 32 random bytes at channel claim time and sends them as `Authorization: Bearer` on create, poll, post-to-peer, and delete.
> 
> **Feature flags:** `canSendExchangeChannelSecret` (default on) is an independent kill switch for v2.0; `canUseExchangeV2Point1` also forces auth. `authenticateExchangeEndpoints()` gates secret generation once per session—unclaimed channels never later send a header.
> 
> **Stack:** Retrofit `SyncService` optional auth headers → `SyncApi`/`SyncServiceRemote` with `asBearerToken()` → `ExchangeV2Channel` passes **our** secret when writing to the peer’s channel → `ExchangeV2Runner` holds `ownChannelSecret`, retries 409 with fresh id+secret, clears on teardown. `SyncJweCrypto.generateSecureBytes` supplies the entropy.
> 
> Tests cover Bearer wiring, secret vs null paths, flag matrix, collision retry, and URL-safe base64 encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ecbbd84b974b252a2d67a868c6a16cb6025e21a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->