### PR TITLE
Fix reset button issue in Duck.ai dev settings

### DIFF
--- a/duckchat/duckchat-internal/src/main/java/com/duckduckgo/duckchat/internal/DuckAiUrlSettingsActivity.kt
+++ b/duckchat/duckchat-internal/src/main/java/com/duckduckgo/duckchat/internal/DuckAiUrlSettingsActivity.kt
@@ -72,7 +72,7 @@ class DuckAiUrlSettingsActivity : DuckDuckGoActivity() {
     private fun configureEdgeToEdgeInsets() {
         edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
         edgeToEdgeHandler.applyStatusBarInsets(binding.appBar)
-        edgeToEdgeHandler.applyNavigationBarInsets(binding.reset, drawBehindGestureNav = false)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentLayout, drawBehindGestureNav = false)
     }
 
     private fun configureViews() {

--- a/duckchat/duckchat-internal/src/main/res/layout/activity_duck_ai_url_settings.xml
+++ b/duckchat/duckchat-internal/src/main/res/layout/activity_duck_ai_url_settings.xml
@@ -36,6 +36,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <LinearLayout
+        android:id="@+id/contentLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1217820243120516?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

- Fixes an issue where the reset button expands to fill the space in Duck.ai dev settings

### Steps to test this PR

- [x] Go to Duck.ai dev settings and focus the input
- [x] Verify that the button is the correct size

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1080" height="2400" alt="Screenshot_20260825_115222" src="https://github.com/user-attachments/assets/18495778-16f0-44d4-a9c4-5ce994016c36" />|<img width="1080" height="2400" alt="Screenshot_20260825_120259" src="https://github.com/user-attachments/assets/0bfe4e95-a808-4d80-9745-4fa3a9f4ff92" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only UI inset/layout change with no auth, data, or production feature logic touched.
> 
> **Overview**
> Fixes a layout issue on the Duck.ai URL override dev settings screen where navigation bar inset handling was applied only to the **Reset** button.
> 
> The content `LinearLayout` (URL field, Save, and Reset) now has `contentLayout` id, and `configureEdgeToEdgeInsets` applies `applyNavigationBarInsets` to that container instead of `binding.reset`. This matches how other Duck Chat settings activities pad their main content and should keep both buttons and the input clear of the gesture navigation area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40e1e90c4808df650214a0fab77ad1b10260c5f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->