### PR TITLE
Handle Exchange v2.1 401 responses

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
@@ -164,28 +164,28 @@ interface SyncService {
         @Body request: CreateAccessCredentialRequest,
     ): Call<Void>
 
-    @PUT("$SYNC_PROD_ENVIRONMENT_URL/sync/v2/exchange/{channelId}")
+    @PUT("$SYNC_PROD_ENVIRONMENT_URL$EXCHANGE_CHANNEL_PATH_PREFIX{channelId}")
     fun createExchangeChannel(
         @Header("Authorization") authorization: String?,
         @Path("channelId") channelId: String,
         @Body body: ExchangeChannelCreateRequest,
     ): Call<Void>
 
-    @POST("$SYNC_PROD_ENVIRONMENT_URL/sync/v2/exchange/{channelId}/messages")
+    @POST("$SYNC_PROD_ENVIRONMENT_URL$EXCHANGE_CHANNEL_PATH_PREFIX{channelId}/messages")
     fun postExchangeMessages(
         @Header("Authorization") authorization: String?,
         @Path("channelId") channelId: String,
         @Body body: ExchangeMessagesRequest,
     ): Call<Void>
 
-    @GET("$SYNC_PROD_ENVIRONMENT_URL/sync/v2/exchange/{channelId}/messages")
+    @GET("$SYNC_PROD_ENVIRONMENT_URL$EXCHANGE_CHANNEL_PATH_PREFIX{channelId}/messages")
     fun pollExchangeMessages(
         @Header("Authorization") authorization: String?,
         @Path("channelId") channelId: String,
         @Query("after") after: Int,
     ): Call<ExchangeMessagesResponse>
 
-    @DELETE("$SYNC_PROD_ENVIRONMENT_URL/sync/v2/exchange/{channelId}")
+    @DELETE("$SYNC_PROD_ENVIRONMENT_URL$EXCHANGE_CHANNEL_PATH_PREFIX{channelId}")
     fun deleteExchangeChannel(
         @Header("Authorization") authorization: String?,
         @Path("channelId") channelId: String,
@@ -194,6 +194,8 @@ interface SyncService {
     companion object {
         const val SYNC_PROD_ENVIRONMENT_URL = "https://sync.duckduckgo.com"
         const val SYNC_DEV_ENVIRONMENT_URL = "https://sync-staging.duckduckgo.com"
+
+        const val EXCHANGE_CHANNEL_PATH_PREFIX = "/sync/v2/exchange/"
     }
 }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -607,7 +607,7 @@ class SyncServiceRemote @Inject constructor(
 
     private fun mapRescopeTokenError(response: Response<TokenRescopeResponse?>): Result<String> {
         val error = response.toUnparsedError()
-        error.removeKeysIfInvalid(response.requestAuthToken())
+        error.removeKeysIfInvalidForExchangeChannel(response)
         return error
     }
 
@@ -625,12 +625,12 @@ class SyncServiceRemote @Inject constructor(
                     val code = if (error.code == -1) response.code() else error.code
                     Result.Error(code, error.error)
                 } ?: Result.Error(code = response.code(), reason = response.message().toString())
-                error.removeKeysIfInvalid(response.requestAuthToken())
+                error.removeKeysIfInvalidForExchangeChannel(response)
                 return error
             }
         }.getOrElse {
             val result = Result.Error(response.code(), reason = response.message())
-            result.removeKeysIfInvalid(response.requestAuthToken())
+            result.removeKeysIfInvalidForExchangeChannel(response)
             return result
         }
     }
@@ -752,6 +752,13 @@ class SyncServiceRemote @Inject constructor(
         return onSuccess(response) { Result.Success(Unit) }
     }
 
+    private fun Result.Error.removeKeysIfInvalidForExchangeChannel(response: Response<*>) {
+        // These endpoints never authenticate the sync account, so a 401 from one carries no
+        // information about account validity. Regardless of whether we presented a channel secret.
+        if (response.isExchangeChannelRequest()) return
+        removeKeysIfInvalid(response.requestAuthToken())
+    }
+
     private fun Result.Error.removeKeysIfInvalid(requestToken: String?) {
         if (code != API_CODE.INVALID_LOGIN_CREDENTIALS.code) return
 
@@ -760,14 +767,17 @@ class SyncServiceRemote @Inject constructor(
         // token swap can 401 on the old token while the account is still valid. Only wipe local state
         // when the token that failed is still the current one (or unknown, preserving prior behavior).
         val tokenStillCurrent = requestToken == null || requestToken == syncStore.token
-        if (!syncFeature.preventStaleTokenLogout().isEnabled() || tokenStillCurrent) {
-            syncStore.clearAll()
-        }
+        if (!tokenStillCurrent && syncFeature.preventStaleTokenLogout().isEnabled()) return
+
+        syncStore.clearAll()
     }
 
     private fun Response<*>.requestAuthToken(): String? {
         return raw().request.header("Authorization")?.removePrefix("Bearer ")
     }
+
+    private fun Response<*>.isExchangeChannelRequest(): Boolean =
+        raw().request.url.encodedPath.startsWith(SyncService.EXCHANGE_CHANNEL_PATH_PREFIX)
 
     private fun String.asBearerToken(): String {
         return "Bearer $this"

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncInvalidTokenInterceptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncInvalidTokenInterceptor.kt
@@ -51,7 +51,12 @@ class SyncInvalidTokenInterceptor @Inject constructor(
         val response = chain.proceed(chain.request())
 
         val method = chain.request().method
-        if (response.code == API_CODE.INVALID_LOGIN_CREDENTIALS.code && method in METHODS_TRIGGERING_LOGGED_OUT_NOTIFICATION) {
+        val path = chain.request().url.encodedPath
+        if (
+            response.code == API_CODE.INVALID_LOGIN_CREDENTIALS.code &&
+            method in METHODS_TRIGGERING_LOGGED_OUT_NOTIFICATION &&
+            !path.startsWith(SyncService.EXCHANGE_CHANNEL_PATH_PREFIX)
+        ) {
             logcat { "Sync-Engine: User logged out, invalid token detected." }
             notificationManager.checkPermissionAndNotify(
                 context,

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
@@ -73,8 +73,12 @@ import com.duckduckgo.sync.TestSyncFixtures.signupSuccess
 import com.duckduckgo.sync.TestSyncFixtures.token
 import com.duckduckgo.sync.TestSyncFixtures.untilTimestamp
 import com.duckduckgo.sync.TestSyncFixtures.userId
+import com.duckduckgo.sync.impl.SyncService.Companion.EXCHANGE_CHANNEL_PATH_PREFIX
+import com.duckduckgo.sync.impl.SyncService.Companion.SYNC_PROD_ENVIRONMENT_URL
 import com.duckduckgo.sync.store.*
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.Protocol
+import okhttp3.Request
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -582,6 +586,77 @@ class SyncServiceRemoteTest {
 
         assertEquals(Result.Success(Unit), result)
         verify(syncService).deleteExchangeChannel(eq("Bearer $CHANNEL_SECRET"), eq(CHANNEL_ID))
+    }
+
+    @Test
+    fun whenPollExchangeMessagesReturnsInvalidCredentialsThenDoNotClearStore() {
+        val call: Call<ExchangeMessagesResponse> = mock()
+        whenever(syncService.pollExchangeMessages(anyOrNull(), anyString(), any())).thenReturn(call)
+        whenever(call.execute()).thenReturn(
+            invalidCredentialsResponse("$SYNC_PROD_ENVIRONMENT_URL$EXCHANGE_CHANNEL_PATH_PREFIX$CHANNEL_ID/messages", CHANNEL_SECRET),
+        )
+
+        val result = syncRemote.pollExchangeMessages(CHANNEL_ID, CHANNEL_SECRET, after = 0)
+
+        assertTrue(result is Result.Error)
+        verify(syncStore, never()).clearAll()
+    }
+
+    @Test
+    fun whenDeleteExchangeChannelReturnsInvalidCredentialsThenDoNotClearStore() {
+        val call: Call<Void> = mock()
+        whenever(syncService.deleteExchangeChannel(anyOrNull(), anyString())).thenReturn(call)
+        whenever(call.execute()).thenReturn(
+            invalidCredentialsResponse("$SYNC_PROD_ENVIRONMENT_URL$EXCHANGE_CHANNEL_PATH_PREFIX$CHANNEL_ID", CHANNEL_SECRET),
+        )
+
+        val result = syncRemote.deleteExchangeChannel(CHANNEL_ID, CHANNEL_SECRET)
+
+        assertTrue(result is Result.Error)
+        verify(syncStore, never()).clearAll()
+    }
+
+    @Test
+    fun whenAccountEndpointReturnsInvalidCredentialsForCurrentTokenThenClearStore() {
+        whenever(syncStore.token).thenReturn(token)
+        val call: Call<AccessCredentialsResponse> = mock()
+        whenever(syncService.getAccessCredentials(anyString())).thenReturn(call)
+        whenever(call.execute()).thenReturn(invalidCredentialsResponse("$SYNC_PROD_ENVIRONMENT_URL/sync/credentials", token))
+
+        syncRemote.getAccessCredentials(token)
+
+        verify(syncStore).clearAll()
+    }
+
+    @Test
+    fun whenAccountEndpointReturnsInvalidCredentialsForRotatedTokenThenDoNotClearStore() {
+        whenever(syncStore.token).thenReturn("newRotatedToken")
+        val call: Call<AccessCredentialsResponse> = mock()
+        whenever(syncService.getAccessCredentials(anyString())).thenReturn(call)
+        whenever(call.execute()).thenReturn(invalidCredentialsResponse("$SYNC_PROD_ENVIRONMENT_URL/sync/credentials", token))
+
+        syncRemote.getAccessCredentials(token)
+
+        verify(syncStore, never()).clearAll()
+    }
+
+    private fun <T> invalidCredentialsResponse(
+        url: String,
+        bearerToken: String,
+    ): Response<T> {
+        val request = Request.Builder()
+            .url(url)
+            .header("Authorization", "Bearer $bearerToken")
+            .build()
+        val raw = okhttp3.Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(API_CODE.INVALID_LOGIN_CREDENTIALS.code)
+            .message("Unauthorized")
+            .build()
+        val errorBody = """{"code":${API_CODE.INVALID_LOGIN_CREDENTIALS.code},"error":"invalid_login_credentials"}"""
+            .toResponseBody("application/json".toMediaTypeOrNull())
+        return Response.error(errorBody, raw)
     }
 
     private companion object {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncInvalidTokenInterceptorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncInvalidTokenInterceptorTest.kt
@@ -132,6 +132,15 @@ class SyncInvalidTokenInterceptorTest {
         assertNull(notificationManager.activeNotifications.find { it.id == SYNC_USER_LOGGED_OUT_NOTIFICATION_ID })
     }
 
+    @Test
+    fun whenInterceptingExchangeChannelRequestWithInvalidTokenThenDoNotNotifyUser() {
+        val chain = givenGetRequest(EXCHANGE_CHANNEL_URL, INVALID_LOGIN_CREDENTIALS.code)
+
+        invalidTokenInterceptor.intercept(chain)
+
+        assertNull(notificationManager.activeNotifications.find { it.id == SYNC_USER_LOGGED_OUT_NOTIFICATION_ID })
+    }
+
     private fun givenGetRequest(
         url: String,
         expectedResponseCode: Int? = null,
@@ -166,5 +175,9 @@ class SyncInvalidTokenInterceptorTest {
         return object : FakeChain(url, expectedResponseCode) {
             override fun request() = Request.Builder().url(url).method("POST", "".toRequestBody()).build()
         }
+    }
+
+    private companion object {
+        const val EXCHANGE_CHANNEL_URL = "$SYNC_PROD_ENVIRONMENT_URL/sync/v2/exchange/channel-id"
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1217367677188803
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1217579192660466
API Proposals URL(s) (if applicable): N/A

### Description

Stops a 401 from the exchange relay endpoints from signing the user out of Sync. Now that exchange calls send the channel secret as their `Authorization` header, a 401 from `/sync/v2/exchange/...` only means the channel is unknown, expired or presented the wrong secret.

- A 401 from any exchange relay endpoint (create channel, post messages, poll messages, delete channel) no longer clears the local sync account state, so the device stays signed in and keeps syncing.
- A 401 from an exchange relay endpoint no longer shows the "logged out" system notification.
- The affected call still fails normally, so the connect or pairing flow surfaces its usual error.
- A 401 from any other sync endpoint keeps the existing behavior. If the token that failed is still the current one, local state is cleared and the notification is shown. If the token was already rotated, the account is left alone, as gated by `preventStaleTokenLogout`.
- The exchange endpoint paths now share a single `EXCHANGE_CHANNEL_PATH_PREFIX` constant, which is what both the response handling and the interceptor match on.

> [!note]
> As suggested [here](https://app.asana.com/1/137249556945/task/1217579192660466/comment/1217776712569527?focus=true) I'll merge this PR directly to the `feature/mehow/exchange-2.1/authentication` branch (or push these changes there before merging). I created it as a separate PR for an easier code review.

### Steps to test this PR

_Regular sync 401 still logs out_
- [ ] Pair two devices A and B.
- [ ] Make sure that on device A you have sync notifications enabled.
- [ ] On device A go to any website.
- [ ] On device B delete the account to invalidate the token.
- [ ] On device A add a website bookmark.
- [ ] Verify the logged out notification is shown.

_Sync survives an unauthorized exchange channel_
- [ ] Install an internal build of this branch on device A.
- [ ] Apply [this patch](https://github.com/user-attachments/files/31421273/exchange-401-test.patch).
```sh
curl -fL https://github.com/user-attachments/files/31421273/exchange-401-test.patch | git apply
```
```diff
diff --git a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
index 67d2d8f0ff..93a91e869e 100644
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -28,7 +28,9 @@ import logcat.logcat
 import org.json.JSONObject
 import retrofit2.HttpException
 import retrofit2.Response
+import java.util.Base64
 import javax.inject.Inject
+import kotlin.random.Random
 
 interface SyncApi {
     fun createAccount(
@@ -698,7 +700,7 @@ class SyncServiceRemote @Inject constructor(
     ): Result<Unit> {
         val response = runCatching {
             syncService.createExchangeChannel(
-                authorization = channelSecret?.asBearerToken(),
+                authorization = randomBytes().asBearerToken(),
                 channelId = channelId,
                 body = ExchangeChannelCreateRequest(),
             ).execute()
@@ -713,7 +715,7 @@ class SyncServiceRemote @Inject constructor(
     ): Result<Unit> {
         val response = runCatching {
             syncService.postExchangeMessages(
-                authorization = channelSecret?.asBearerToken(),
+                authorization = randomBytes().asBearerToken(),
                 channelId = channelId,
                 body = ExchangeMessagesRequest(envelopes),
             ).execute()
@@ -728,7 +730,7 @@ class SyncServiceRemote @Inject constructor(
     ): Result<List<ExchangeMessageEntry>> {
         val response = runCatching {
             syncService.pollExchangeMessages(
-                authorization = channelSecret?.asBearerToken(),
+                authorization = randomBytes().asBearerToken(),
                 channelId = channelId,
                 after = after,
             ).execute()
@@ -745,7 +747,7 @@ class SyncServiceRemote @Inject constructor(
     ): Result<Unit> {
         val response = runCatching {
             syncService.deleteExchangeChannel(
-                authorization = channelSecret?.asBearerToken(),
+                authorization = randomBytes().asBearerToken(),
                 channelId = channelId,
             ).execute()
         }.getOrElse { throwable -> return Result.Error(reason = throwable.message.toString()) }
@@ -779,6 +781,10 @@ class SyncServiceRemote @Inject constructor(
     private fun Response<*>.isExchangeChannelRequest(): Boolean =
         raw().request.url.encodedPath.startsWith(SyncService.EXCHANGE_CHANNEL_PATH_PREFIX)
 
+    private fun randomBytes(): String = Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(Random.nextBytes(32))
+
     private fun String.asBearerToken(): String {
         return "Bearer $this"
     }

```
- [ ] Install the patched internal build on device B.
- [ ] Set up Sync on device B so it has an active account and is backed up.
- [ ] Start the "Sync with Another Device" flow on device A.
- [ ] Scan the code with device B.
- [ ] Verify the pairing fails with the usual error on device B.
- [ ] Go back to Sync Settings on device B.
- [ ] Verify device B is still signed in to Sync and its device list is intact.
- [ ] Verify no "You have been logged out" notification appears on device B.

### UI changes
N/A

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how 401 responses clear sync session state and show logout notifications; incorrect path matching could wrongly sign users out or leave invalid sessions active.
> 
> **Overview**
> Exchange v2 relay calls now use a shared **`EXCHANGE_CHANNEL_PATH_PREFIX`** for Retrofit routes and for matching responses in the client.
> 
> **401 handling** is split by endpoint type. A **401 from `/sync/v2/exchange/...`** (channel secret in `Authorization`) no longer clears local sync state or triggers the signed-out notification, because it reflects channel/auth failure rather than an invalid sync account token. **`SyncServiceRemote`** routes error cleanup through **`removeKeysIfInvalidForExchangeChannel`**, and **`SyncInvalidTokenInterceptor`** skips notification when the path is an exchange channel.
> 
> **Account sync endpoints** keep the existing behavior: **`syncStore.clearAll()`** on invalid credentials when the failing token is still current (or when **`preventStaleTokenLogout`** is off), with a small refactor to the stale-token early-return logic. Tests cover exchange vs account 401 paths and the interceptor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa24ab5f529a1a06883518f548e29b2124d18794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->