### PR TITLE
Add source param to wide_return_session for AI-prompt-submitted returns

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_return_session.json5
+++ b/PixelDefinitions/pixels/definitions/wide_return_session.json5
@@ -96,6 +96,35 @@
                 "key": "feature.data.ext.burn_tab_tapped",
                 "type": "boolean",
                 "description": "Whether the user tapped the burn-tab action on the escape hatch during the session"
+            },
+            {
+                "key": "feature.data.ext.source",
+                "type": "string",
+                "description": "The Duck.ai entry point that triggered the session's ai_prompt_submitted terminal. Omitted for every other status_reason or when unknown",
+                "enum": [
+                    "address_bar_prompt",
+                    "address_bar_icon",
+                    "address_bar_shortcut_chip",
+                    "address_bar_editing_state",
+                    "suggestion_ask_ai",
+                    "browsing_menu_ntp",
+                    "browsing_menu_webpage",
+                    "tab_switcher",
+                    "chat_history_new_chat",
+                    "chat_history_open_chat",
+                    "voice",
+                    "onboarding",
+                    "direct_url",
+                    "serp",
+                    "icon_shortcut",
+                    "contextual_chat",
+                    "widget_quick_actions",
+                    "widget_favorite",
+                    "system_search",
+                    "digital_assistant",
+                    "deep_link_other",
+                    "paid_settings"
+                ]
             }
         ]
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -309,6 +309,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.app.surrogates.SurrogateResponse
+import com.duckduckgo.app.tabs.model.DuckAiTabSessionRepository
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabPageContextRepository
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -582,6 +583,7 @@ class BrowserTabViewModel @Inject constructor(
     private val ntpAfterIdleManager: NtpAfterIdleManager,
     private val returnSessionLandingListener: ReturnSessionLandingListener,
     private val browserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin>,
+    private val duckAiTabSessionRepository: DuckAiTabSessionRepository,
     private val browserRefreshTriggerPlugins: PluginPoint<BrowserRefreshTriggerPlugin>,
     private val brokenSiteReportTriggerPlugins: PluginPoint<BrokenSiteReportTriggerPlugin>,
     private val inlinePdfHandler: InlinePdfHandler,
@@ -5676,7 +5678,7 @@ class BrowserTabViewModel @Inject constructor(
         val hasPrompt = hasAutoSubmittedPrompt(duckAiUrl)
         browserInteractionsPlugins.getPlugins().forEach { it.onInputSubmitted() }
         if (hasPrompt) {
-            browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted() }
+            browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted(source = entryPoint.name.lowercase()) }
         }
         navigateToDuckAi(
             url = duckAiUrl,
@@ -5703,7 +5705,11 @@ class BrowserTabViewModel @Inject constructor(
         // onInputSubmitted() too: an in-chat follow-up is still "the bar was used" for the old
         // post-idle-session event, which only listens for that generic signal.
         browserInteractionsPlugins.getPlugins().forEach { it.onInputSubmitted() }
-        browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted() }
+        viewModelScope.launch(dispatchers.io()) {
+            // The chat was already open, so its entry point was recorded when it was first navigated to.
+            val source = duckAiTabSessionRepository.getEntryPointSource(tabId)
+            browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted(source = source) }
+        }
     }
 
     private fun navigateToDuckAi(
@@ -5824,7 +5830,9 @@ class BrowserTabViewModel @Inject constructor(
                 }
                 if (duckChat.isDuckChatUrl(url.toUri())) {
                     if (submittedAiPrompt) {
-                        browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted() }
+                        browserInteractionsPlugins.getPlugins().forEach {
+                            it.onAiPromptSubmitted(source = DuckChatEntryPoint.ADDRESS_BAR_ICON.name.lowercase())
+                        }
                     }
                     duckChat.reportDuckChatEntry(
                         DuckChatEntryPoint.ADDRESS_BAR_ICON,

--- a/app/src/main/java/com/duckduckgo/app/browser/returnsession/RealReturnSessionWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/returnsession/RealReturnSessionWideEvent.kt
@@ -120,7 +120,6 @@ class RealReturnSessionWideEvent @Inject constructor(
                         // OnProcessStart cleanup sends whatever metadata is already persisted.
                         put(KEY_STATUS_REASON, REASON_APP_TERMINATED)
                     },
-                    samplingProbability = SAMPLING_PROBABILITY,
                 )
 
                 startResult.onSuccess { flowId ->
@@ -199,8 +198,8 @@ class RealReturnSessionWideEvent @Inject constructor(
         finishSession(statusReason = REASON_URL_SUBMITTED, status = FlowStatus.Success)
     }
 
-    override fun onAiPromptSubmitted() {
-        finishSession(statusReason = REASON_AI_PROMPT_SUBMITTED, status = FlowStatus.Success)
+    override fun onAiPromptSubmitted(source: String?) {
+        finishSession(statusReason = REASON_AI_PROMPT_SUBMITTED, status = FlowStatus.Success, aiPromptSource = source)
     }
 
     override fun onChatSelected() {
@@ -277,11 +276,11 @@ class RealReturnSessionWideEvent @Inject constructor(
         }
     }
 
-    private fun finishSession(statusReason: String, status: FlowStatus) {
+    private fun finishSession(statusReason: String, status: FlowStatus, aiPromptSource: String? = null) {
         coroutineScope.launch {
             mutex.withLock {
                 if (abortIfDisabled()) return@launch
-                finishSessionLocked(statusReason, status)
+                finishSessionLocked(statusReason, status, aiPromptSource)
             }
         }
     }
@@ -289,6 +288,7 @@ class RealReturnSessionWideEvent @Inject constructor(
     private suspend fun finishSessionLocked(
         statusReason: String,
         status: FlowStatus,
+        aiPromptSource: String? = null,
     ) {
         val session = activeSession ?: return
         activeSession = null
@@ -300,17 +300,18 @@ class RealReturnSessionWideEvent @Inject constructor(
         wideEventClient.flowFinish(
             wideEventId = session.flowId,
             status = status,
-            metadata = mapOf(
-                KEY_AFTER_IDLE to session.afterIdle.toString(),
-                KEY_LANDED_ON to session.landedOn.value,
-                KEY_STATUS_REASON to statusReason,
-                KEY_FOCUSED to (session.focused ?: false).toString(),
-                KEY_PAGE_ENGAGED to session.pageEngaged.toString(),
-                KEY_BACK_PRESSED to session.backPressed.toString(),
-                KEY_OPENING_SCREEN_CHANGED to session.openingScreenChanged.toString(),
-                KEY_CLOSE_TAB_TAPPED to session.closeTabTapped.toString(),
-                KEY_BURN_TAB_TAPPED to session.burnTabTapped.toString(),
-            ),
+            metadata = buildMap {
+                put(KEY_AFTER_IDLE, session.afterIdle.toString())
+                put(KEY_LANDED_ON, session.landedOn.value)
+                put(KEY_STATUS_REASON, statusReason)
+                put(KEY_FOCUSED, (session.focused ?: false).toString())
+                put(KEY_PAGE_ENGAGED, session.pageEngaged.toString())
+                put(KEY_BACK_PRESSED, session.backPressed.toString())
+                put(KEY_OPENING_SCREEN_CHANGED, session.openingScreenChanged.toString())
+                put(KEY_CLOSE_TAB_TAPPED, session.closeTabTapped.toString())
+                put(KEY_BURN_TAB_TAPPED, session.burnTabTapped.toString())
+                aiPromptSource?.let { put(KEY_SOURCE, it) }
+            },
         )
         logcat(tag = TAG) { "Return session finished: status=$status, reason=$statusReason" }
     }
@@ -351,8 +352,6 @@ class RealReturnSessionWideEvent @Inject constructor(
     private companion object {
         const val TAG = "RealReturnSessionWideEvent"
         const val FEATURE_NAME = "return_session"
-        const val SAMPLING_PROBABILITY = 0.05f
-
         const val REASON_SEARCH_SUBMITTED = "search_submitted"
         const val REASON_URL_SUBMITTED = "url_submitted"
         const val REASON_AI_PROMPT_SUBMITTED = "ai_prompt_submitted"
@@ -373,6 +372,7 @@ class RealReturnSessionWideEvent @Inject constructor(
         const val KEY_OPENING_SCREEN_CHANGED = "opening_screen_changed"
         const val KEY_CLOSE_TAB_TAPPED = "close_tab_tapped"
         const val KEY_BURN_TAB_TAPPED = "burn_tab_tapped"
+        const val KEY_SOURCE = "source"
         const val KEY_SESSION_DURATION = "session_duration_ms_bucketed"
         const val KEY_TIME_TO_FIRST_INTERACTION = "time_to_first_interaction_ms_bucketed"
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -245,6 +245,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_SERP_CTA
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.systemsearch.DeviceAppLookup
 import com.duckduckgo.app.tabs.model.AggregateTabProvider
+import com.duckduckgo.app.tabs.model.DuckAiTabSessionRepository
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabPageContextRepository
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -647,6 +648,7 @@ class BrowserTabViewModelTest {
     private val mockNtpAfterIdleManager: NtpAfterIdleManager = mock()
     private val mockReturnSessionLandingListener: ReturnSessionLandingListener = mock()
     private val mockBrowserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin> = mock()
+    private val mockDuckAiTabSessionRepository: DuckAiTabSessionRepository = mock()
     private val browserRefreshTriggerFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     private val browserRefreshTriggerPlugin: BrowserRefreshTriggerPlugin = mock {
         on { observeRefreshRequests() } doReturn browserRefreshTriggerFlow
@@ -1058,6 +1060,7 @@ class BrowserTabViewModelTest {
                 ntpAfterIdleManager = mockNtpAfterIdleManager,
                 returnSessionLandingListener = mockReturnSessionLandingListener,
                 browserInteractionsPlugins = mockBrowserInteractionsPlugins,
+                duckAiTabSessionRepository = mockDuckAiTabSessionRepository,
                 browserRefreshTriggerPlugins = mockBrowserRefreshTriggerPlugins,
                 brokenSiteReportTriggerPlugins = mockBrokenSiteReportTriggerPlugins,
                 inlinePdfHandler = mockInlinePdfHandler,
@@ -8954,7 +8957,7 @@ class BrowserTabViewModelTest {
         // Preserve the pre-return-session behavior: one callback is explicit and one comes from
         // reusing the NTP tab. The new AI classifier must still fire exactly once without a URL.
         verify(plugin, times(2)).onInputSubmitted()
-        verify(plugin, times(1)).onAiPromptSubmitted()
+        verify(plugin, times(1)).onAiPromptSubmitted(source = "address_bar_prompt")
         verify(plugin, never()).onUrlSubmitted()
         verify(plugin, never()).onSearchSubmitted()
     }
@@ -8993,7 +8996,7 @@ class BrowserTabViewModelTest {
         testee.openDuckAiQuery(query = "hello", autoPrompt = true, entryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT)
 
         verify(plugin).onInputSubmitted()
-        verify(plugin).onAiPromptSubmitted()
+        verify(plugin).onAiPromptSubmitted(source = "address_bar_prompt")
     }
 
     @Test
@@ -9027,11 +9030,25 @@ class BrowserTabViewModelTest {
     fun whenDuckAiChatPromptSubmittedThenFiresOnInputSubmittedAndOnAiPromptSubmitted() = runTest {
         val plugin: BrowserInteractionsPlugin = mock()
         whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+        whenever(mockDuckAiTabSessionRepository.getEntryPointSource("abc")).thenReturn(null)
 
         testee.onDuckAiChatPromptSubmitted()
+        advanceUntilIdle()
 
         verify(plugin).onInputSubmitted()
-        verify(plugin).onAiPromptSubmitted()
+        verify(plugin).onAiPromptSubmitted(source = null)
+    }
+
+    @Test
+    fun whenDuckAiChatPromptSubmittedThenSourceIsTheTabsRecordedEntryPoint() = runTest {
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+        whenever(mockDuckAiTabSessionRepository.getEntryPointSource("abc")).thenReturn("address_bar_prompt")
+
+        testee.onDuckAiChatPromptSubmitted()
+        advanceUntilIdle()
+
+        verify(plugin).onAiPromptSubmitted(source = "address_bar_prompt")
     }
 
     @Test
@@ -9287,7 +9304,7 @@ class BrowserTabViewModelTest {
         testee.onDuckChatOmnibarButtonClicked(query = "example", hasFocus = true, isNtp = false)
 
         verify(plugin).onInputSubmitted()
-        verify(plugin).onAiPromptSubmitted()
+        verify(plugin).onAiPromptSubmitted(source = "address_bar_icon")
         verify(plugin, never()).onUrlSubmitted()
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/returnsession/RealReturnSessionWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/returnsession/RealReturnSessionWideEventTest.kt
@@ -124,7 +124,7 @@ class RealReturnSessionWideEventTest {
             flowEntryPoint = isNull(),
             metadata = eq(defaultMetadata),
             cleanupPolicy = eq(CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = false, flowStatus = FlowStatus.Unknown)),
-            samplingProbability = eq(0.05f),
+            samplingProbability = eq(1.0f),
             definition = any(),
         )
     }
@@ -150,7 +150,7 @@ class RealReturnSessionWideEventTest {
                     ),
             ),
             cleanupPolicy = any(),
-            samplingProbability = eq(0.05f),
+            samplingProbability = eq(1.0f),
             definition = any(),
         )
     }
@@ -231,7 +231,7 @@ class RealReturnSessionWideEventTest {
             flowEntryPoint = isNull(),
             metadata = eq(defaultMetadata + ("landed_on" to "duck_ai")),
             cleanupPolicy = any(),
-            samplingProbability = eq(0.05f),
+            samplingProbability = eq(1.0f),
             definition = any(),
         )
     }
@@ -246,7 +246,7 @@ class RealReturnSessionWideEventTest {
             flowEntryPoint = isNull(),
             metadata = eq(defaultMetadata + ("landed_on" to "serp")),
             cleanupPolicy = any(),
-            samplingProbability = eq(0.05f),
+            samplingProbability = eq(1.0f),
             definition = any(),
         )
     }
@@ -261,7 +261,7 @@ class RealReturnSessionWideEventTest {
             flowEntryPoint = isNull(),
             metadata = eq(defaultMetadata + ("landed_on" to "web")),
             cleanupPolicy = any(),
-            samplingProbability = eq(0.05f),
+            samplingProbability = eq(1.0f),
             definition = any(),
         )
     }
@@ -276,7 +276,7 @@ class RealReturnSessionWideEventTest {
             flowEntryPoint = isNull(),
             metadata = eq(defaultMetadata),
             cleanupPolicy = any(),
-            samplingProbability = eq(0.05f),
+            samplingProbability = eq(1.0f),
             definition = any(),
         )
     }
@@ -344,7 +344,7 @@ class RealReturnSessionWideEventTest {
             flowEntryPoint = isNull(),
             metadata = eq(defaultMetadata + ("time_away_ms_bucketed" to "3600000")),
             cleanupPolicy = any(),
-            samplingProbability = eq(0.05f),
+            samplingProbability = eq(1.0f),
             definition = any(),
         )
     }
@@ -440,7 +440,22 @@ class RealReturnSessionWideEventTest {
         verify(wideEventClient).flowFinish(
             wideEventId = eq(123L),
             status = eq<FlowStatus>(FlowStatus.Success),
-            metadata = argThat { this["status_reason"] == "ai_prompt_submitted" },
+            metadata = argThat { this["status_reason"] == "ai_prompt_submitted" && !this.containsKey("source") },
+        )
+    }
+
+    @Test
+    fun `when onAiPromptSubmitted given a source then flowFinish metadata includes it`() = runTest {
+        startSession()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onAiPromptSubmitted(source = "address_bar_prompt")
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = argThat { this["status_reason"] == "ai_prompt_submitted" && this["source"] == "address_bar_prompt" },
         )
     }
 

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/wideevents/BrowserInteractionsPlugin.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/wideevents/BrowserInteractionsPlugin.kt
@@ -33,8 +33,8 @@ interface BrowserInteractionsPlugin {
     /** User submitted a typed URL via the omnibar. */
     fun onUrlSubmitted() {}
 
-    /** User submitted a Duck.ai chat prompt. */
-    fun onAiPromptSubmitted() {}
+    /** User submitted a Duck.ai chat prompt. [source] is the entry point that triggered it, when known. */
+    fun onAiPromptSubmitted(source: String? = null) {}
 
     /** User selected a Duck.ai chat suggestion (without typing a prompt). */
     fun onChatSelected() {}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -21,7 +21,9 @@ import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.DuckAiTabSessionRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
 import com.duckduckgo.di.scopes.AppScope
@@ -288,6 +290,7 @@ class RealDuckChatPixels @Inject constructor(
     private val termsOfServiceHandler: DuckChatTermsOfServiceHandler,
     private val duckAiTabSessionRepository: DuckAiTabSessionRepository,
     private val appBuildConfig: AppBuildConfig,
+    private val browserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin>,
 ) : DuckChatPixels {
 
     /** `first_prompt_new_install` must be attributable to a fresh install, never to an existing user who just updated. */
@@ -593,6 +596,7 @@ class RealDuckChatPixels @Inject constructor(
     override fun reportContextualPromptSubmittedWithContextNative() {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             val params = contextualPromptSubmittedParams()
+            browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted(source = DuckChatEntryPoint.CONTEXTUAL_CHAT.toPixelValue()) }
             pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PROMPT_SUBMITTED_WITH_CONTEXT_NATIVE_COUNT, parameters = params)
             pixel.fire(
                 DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PROMPT_SUBMITTED_WITH_CONTEXT_NATIVE_DAILY,
@@ -618,6 +622,7 @@ class RealDuckChatPixels @Inject constructor(
     override fun reportContextualPromptSubmittedWithoutContextNative() {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             val params = contextualPromptSubmittedParams()
+            browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted(source = DuckChatEntryPoint.CONTEXTUAL_CHAT.toPixelValue()) }
             pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PROMPT_SUBMITTED_WITHOUT_CONTEXT_NATIVE_COUNT, parameters = params)
             pixel.fire(
                 DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PROMPT_SUBMITTED_WITHOUT_CONTEXT_NATIVE_DAILY,
@@ -830,6 +835,7 @@ class RealDuckChatPixels @Inject constructor(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_DAILY,
         ) {
             val source = resolveEntrySource(surface, tabId, addressBarEntryPoint)
+            browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted(source = source) }
             val isFirstPrompt = isFirstPromptForNewInstall()
             buildMap {
                 put(DuckChatPixelParameters.SELECTED_TOOL, selectedTool)

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
@@ -49,6 +49,7 @@ class RealDuckChatPixelsAttachmentsTest {
         termsOfServiceHandler = termsOfServiceHandler,
         duckAiTabSessionRepository = mock(),
         appBuildConfig = mock(),
+        browserInteractionsPlugins = mock(),
     )
 
     @Test

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
@@ -49,6 +49,7 @@ class RealDuckChatPixelsPickerTest {
         termsOfServiceHandler = termsOfServiceHandler,
         duckAiTabSessionRepository = mock(),
         appBuildConfig = mock(),
+        browserInteractionsPlugins = mock(),
     )
 
     @Test

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
@@ -21,7 +21,9 @@ import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.DuckAiTabSessionRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
 import com.duckduckgo.duckchat.impl.helper.DuckChatTermsOfServiceHandler
@@ -49,6 +51,8 @@ class RealDuckChatPixelsToolsTest {
     private val termsOfServiceHandler: DuckChatTermsOfServiceHandler = mock()
     private val duckAiTabSessionRepository: DuckAiTabSessionRepository = mock()
     private val appBuildConfig: AppBuildConfig = mock()
+    private val browserInteractionsPlugin: BrowserInteractionsPlugin = mock()
+    private val browserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin> = mock()
 
     private val testee = RealDuckChatPixels(
         pixel = pixel,
@@ -60,6 +64,7 @@ class RealDuckChatPixelsToolsTest {
         termsOfServiceHandler = termsOfServiceHandler,
         duckAiTabSessionRepository = duckAiTabSessionRepository,
         appBuildConfig = appBuildConfig,
+        browserInteractionsPlugins = browserInteractionsPlugins,
     )
 
     private val surfaceParams = mapOf(DuckChatPixelParameters.SURFACE to "contextual_chat")
@@ -67,6 +72,7 @@ class RealDuckChatPixelsToolsTest {
     init {
         runBlocking { whenever(duckChatFeatureRepository.checkAndMarkFirstPromptSubmission()).thenReturn(false) }
         whenever(appBuildConfig.isNewInstall()).thenReturn(false)
+        whenever(browserInteractionsPlugins.getPlugins()).thenReturn(listOf(browserInteractionsPlugin))
     }
 
     @Test
@@ -382,6 +388,25 @@ class RealDuckChatPixelsToolsTest {
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_COUNT,
             parameters = promptSubmittedAddressBarParams(pageType = "website"),
         )
+    }
+
+    @Test
+    fun whenPromptSubmittedThenNotifiesBrowserInteractionsPluginWithTheResolvedSource() = runTest {
+        testee.firePromptSubmitted(
+            selectedTool = "none",
+            modelId = null,
+            reasoningEffort = null,
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.ADDRESS_BAR,
+            defaultMode = null,
+            tabId = "tab1",
+            pageType = DuckChatPixelPageType.WEBSITE,
+            addressBarEntryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT,
+        )
+
+        verify(browserInteractionsPlugin).onAiPromptSubmitted(source = "address_bar_prompt")
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -116,9 +116,7 @@ class RealDuckChatJSHelperTest {
     }
     private val mockEditPromptSessionStore: EditPromptSessionStore = mock()
     private val mockBrowserInteractionsPlugin: BrowserInteractionsPlugin = mock()
-    private val mockBrowserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin> = mock {
-        on { getPlugins() } doReturn listOf(mockBrowserInteractionsPlugin)
-    }
+    private val mockBrowserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin> = mock()
     private val testee = RealDuckChatJSHelper(
         duckChat = mockDuckChat,
         duckChatPixels = mockDuckChatPixels,
@@ -139,6 +137,10 @@ class RealDuckChatJSHelperTest {
         editPromptSessionStore = mockEditPromptSessionStore,
         browserInteractionsPlugins = mockBrowserInteractionsPlugins,
     )
+
+    init {
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(mockBrowserInteractionsPlugin))
+    }
     private val viewModel =
         object {
             val updatedPageContext: String =

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -20,7 +20,9 @@ import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.DuckAiTabSessionRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
 import com.duckduckgo.duckchat.impl.ReportMetric
@@ -98,6 +100,8 @@ class RealDuckChatPixelsTest {
     private val mockTermsOfServiceHandler: DuckChatTermsOfServiceHandler = mock()
     private val mockDuckAiTabSessionRepository: DuckAiTabSessionRepository = mock()
     private val mockAppBuildConfig: AppBuildConfig = mock()
+    private val mockBrowserInteractionsPlugin: BrowserInteractionsPlugin = mock()
+    private val mockBrowserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin> = mock()
 
     private lateinit var testee: RealDuckChatPixels
 
@@ -106,6 +110,7 @@ class RealDuckChatPixelsTest {
         whenever(mockDuckChatFeatureRepository.sessionDeltaInMinutes()).thenReturn(1)
         whenever(mockDuckChatFeatureRepository.checkAndMarkFirstPromptSubmission()).thenReturn(false)
         whenever(mockAppBuildConfig.isNewInstall()).thenReturn(false)
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(mockBrowserInteractionsPlugin))
 
         testee = RealDuckChatPixels(
             pixel = mockPixel,
@@ -117,6 +122,7 @@ class RealDuckChatPixelsTest {
             termsOfServiceHandler = mockTermsOfServiceHandler,
             duckAiTabSessionRepository = mockDuckAiTabSessionRepository,
             appBuildConfig = mockAppBuildConfig,
+            browserInteractionsPlugins = mockBrowserInteractionsPlugins,
         )
     }
 
@@ -342,6 +348,24 @@ class RealDuckChatPixelsTest {
             parameters = expectedParams,
             type = Pixel.PixelType.Daily(),
         )
+    }
+
+    @Test
+    fun `when reportContextualPromptSubmittedWithContextNative then notifies BrowserInteractionsPlugin with contextual_chat source`() = runTest {
+        testee.reportContextualPromptSubmittedWithContextNative()
+
+        advanceUntilIdle()
+
+        verify(mockBrowserInteractionsPlugin).onAiPromptSubmitted(source = "contextual_chat")
+    }
+
+    @Test
+    fun `when reportContextualPromptSubmittedWithoutContextNative then notifies BrowserInteractionsPlugin with contextual_chat source`() = runTest {
+        testee.reportContextualPromptSubmittedWithoutContextNative()
+
+        advanceUntilIdle()
+
+        verify(mockBrowserInteractionsPlugin).onAiPromptSubmitted(source = "contextual_chat")
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1217798816774827?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1212087397361015/task/1217382844057496?focus=true
API Proposals URL(s) (if applicable): https://app.asana.com/1/137249556945/project/1212087397361015/task/1217851495587508?focus=true

### Description

Adds `source` to `wide_return_session`, populated only when the session's terminal action is an AI
prompt submission (`status_reason=ai_prompt_submitted`); omitted for every other terminal reason. Value
is the shared `duckAiEntrySource` enum, reused as-is from `params_dictionary.json`. No new enum values
were introduced.

`BrowserInteractionsPlugin.onAiPromptSubmitted()` gains an optional `source: String? = null` param
(backward compatible, default preserves existing no-arg callers). Every call site that already knows its
entry point now forwards it:

Known, accepted gap: the Duck.ai WebView/frontend bridge path (`DuckChatJSHelper`'s `REPORT_METRIC`
handler for `USER_DID_SUBMIT_PROMPT` / `USER_DID_SUBMIT_FIRST_PROMPT`) still finishes the session with no
`source`. This is coming from the frontend and only when the native input field is off which is not something normally reachable. Also we wouldn’t know the source if it’s from the frontend.

Also included: `wide_return_session` collection moves from 5% sampling to 100%


### UI changes
N/A

*Prerequisites**

- [ ] Install an internal build.
- [ ] In Internal Settings > Feature Flags, enable `wideEvents`,
  `enqueueWideEventPixels`, `sendWideEventsViaPixels`, and
  `returnSessionWideEvent.. Force-stop and relaunch after changing overrides.
- [ ] Filter logcat with: `Pixel sent: wide_return_session`

**Baseline session recipe:** press Home, reopen the app, perform
the row's action, then wait for `Pixel sent: ... wide_return_session_c` and inspect `source`.

| Case | Setup | Action | Expected `source` |
| --- | --- | --- | --- |
| New Duck.ai chat, native input | NTP | Open Duck.ai from the address-bar prompt and submit a non-empty prompt | `address_bar_prompt` |
| New Duck.ai chat, address-bar icon | NTP | Tap the address-bar Duck.ai icon | `address_bar_icon` |
| Contextual sheet, with page context | Open the contextual sheet on a page with valid page context | Submit a prompt with context attached | `contextual_chat` |
| Contextual sheet, without page context | Open the contextual sheet where context isn't attached | Submit a prompt | `contextual_chat` |
| Follow-up in an already-open chat | Open app on a tab that already had Duck.ai opened | Submit a follow up chat | matches the **original** entry point used to open the tab |
| Non-AI terminal (regression check) | Any fresh return | Submit a search | `source` key absent entirely must not appear for non-`ai_prompt_submitted` terminals |




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes to wide events and plugin callbacks; no auth, networking, or user-data handling changes beyond richer telemetry metadata.
> 
> **Overview**
> Adds **`feature.data.ext.source`** to the `wide_return_session` pixel definition, using the existing Duck.ai entry-point enum. The field is included only when the session ends with **`status_reason=ai_prompt_submitted`**; other terminal reasons omit it.
> 
> **`BrowserInteractionsPlugin.onAiPromptSubmitted`** now accepts an optional **`source`** string. Call sites pass the known entry point (e.g. address bar prompt/icon, contextual chat) or, for follow-ups in an open chat, the tab’s stored entry point via **`DuckAiTabSessionRepository`**. **`RealDuckChatPixels`** also notifies browser-interaction plugins when unified-input and contextual prompts are submitted so return-session analytics stay aligned with Duck.ai pixels.
> 
> **`RealReturnSessionWideEvent`** forwards **`source`** into **`flowFinish`** metadata and drops the explicit 5% **`samplingProbability`** on **`flowStart`** (tests expect full sampling). The WebView **`REPORT_METRIC`** prompt path still finishes without **`source`** when the frontend submits without native input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6abd79ff32c032e16300c8c30f2cb64d5c143c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->