### PR TITLE
Contextual/DuckAi: Reset screen when chat does not exist instead of not doing anything

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
@@ -64,6 +64,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Named
 import com.google.android.material.R as MaterialR
@@ -218,24 +219,28 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
     }
 
     private fun registerFileChooserResult() {
-        externalCameraLauncher.registerForResult(this) {
-            when (it) {
-                is UploadFromExternalMediaAppLauncher.MediaCaptureResult.MediaCaptured ->
-                    pendingUploadTask?.onReceiveValue(arrayOf(Uri.fromFile(it.file)))
+        externalCameraLauncher.registerForResult(this) { result ->
+            // The launcher may deliver the result from a background thread (media capture moves the file
+            // off the main thread), so hop back to the main thread before touching views / WebView callbacks.
+            lifecycleScope.launch {
+                when (result) {
+                    is UploadFromExternalMediaAppLauncher.MediaCaptureResult.MediaCaptured ->
+                        pendingUploadTask?.onReceiveValue(arrayOf(Uri.fromFile(result.file)))
 
-                is UploadFromExternalMediaAppLauncher.MediaCaptureResult.CouldNotCapturePermissionDenied -> {
-                    pendingUploadTask?.onReceiveValue(null)
-                    externalCameraLauncher.showPermissionRationaleDialog(requireActivity(), it.inputAction)
-                }
+                    is UploadFromExternalMediaAppLauncher.MediaCaptureResult.CouldNotCapturePermissionDenied -> {
+                        pendingUploadTask?.onReceiveValue(null)
+                        externalCameraLauncher.showPermissionRationaleDialog(requireActivity(), result.inputAction)
+                    }
 
-                is UploadFromExternalMediaAppLauncher.MediaCaptureResult.NoMediaCaptured -> pendingUploadTask?.onReceiveValue(null)
-                is UploadFromExternalMediaAppLauncher.MediaCaptureResult.ErrorAccessingMediaApp -> {
-                    pendingUploadTask?.onReceiveValue(null)
-                    Snackbar.make(binding.entryDialogRoot, it.messageId, Snackbar.LENGTH_SHORT).show()
+                    is UploadFromExternalMediaAppLauncher.MediaCaptureResult.NoMediaCaptured -> pendingUploadTask?.onReceiveValue(null)
+                    is UploadFromExternalMediaAppLauncher.MediaCaptureResult.ErrorAccessingMediaApp -> {
+                        pendingUploadTask?.onReceiveValue(null)
+                        Snackbar.make(binding.entryDialogRoot, result.messageId, Snackbar.LENGTH_SHORT).show()
+                    }
                 }
+                pendingUploadTask = null
+                restoreInputFocusAfterPicker()
             }
-            pendingUploadTask = null
-            restoreInputFocusAfterPicker()
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -250,6 +250,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         val existingChatUrl = contextualDataStore.getTabChatUrl(tabId)
         if (!shouldReuseSession || isStoredChatMissingFromHistory(existingChatUrl)) {
             resetToNewChat()
+            hidingSheetForNewChat = true
             withContext(dispatchers.main()) {
                 commandChannel.trySend(Command.ShowNewChatEntryDialog(tabId))
             }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -250,6 +250,9 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         val existingChatUrl = contextualDataStore.getTabChatUrl(tabId)
         if (!shouldReuseSession || isStoredChatMissingFromHistory(existingChatUrl)) {
             resetToNewChat()
+            withContext(dispatchers.main()) {
+                commandChannel.trySend(Command.ShowNewChatEntryDialog(tabId))
+            }
             return
         }
         withContext(dispatchers.main()) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -293,8 +293,8 @@ interface DuckChatFeature {
 
     /**
      * @return `true` when the redesigned Duck.ai contextual sheet UI and flow are enabled.
-     * If the remote feature is not present defaults to `false`.
+     * If the remote feature is not present defaults to `INTERNAL`.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun contextualSheetRedesign(): Toggle
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1006,10 +1006,14 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val bottomRow = findViewById<View?>(R.id.inputModeWidgetBottomRow) ?: return
         val suppress = nativeInputState?.shouldSuppressBottomRow() == true
         val visible = isChatTabSelected() &&
-            (inputField.hasFocus() || previewEnterFocus || isContextualWidget || isEditWidget) &&
+            (inputField.hasFocus() || previewEnterFocus || showForUnfocusedContextual() || isEditWidget) &&
             !isStreaming &&
             !suppress
         bottomRow.visibility = if (visible) VISIBLE else GONE
+    }
+
+    private fun showForUnfocusedContextual(): Boolean {
+        return isContextualWidget && !duckChatInternal.isContextualSheetRedesignEnabled()
     }
 
     /**

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -153,6 +153,23 @@ class DuckChatContextualWebViewViewModelTest {
     }
 
     @Test
+    fun `reopen with an unreusable session resets to a new chat and hands off to the entry dialog`() = runTest {
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        contextualDataStore.persistTabClosedTimestamp("tab-1", 1L)
+
+        testee.commands.test {
+            testee.onSheetReopened()
+            coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+            assertTrue(expectMostRecentItem() is DuckChatContextualWebViewViewModel.Command.ShowNewChatEntryDialog)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `onPromptSent with attached page context includes it in the event`() = runTest {
         testee.onSheetOpened("tab-1")
         testee.onPageContextReceived("tab-1", serializedPageData)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -170,6 +170,27 @@ class DuckChatContextualWebViewViewModelTest {
     }
 
     @Test
+    fun `sheet closed after reopen entry dialog handoff does not revert the contextual input state`() = runTest {
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        contextualDataStore.persistTabClosedTimestamp("tab-1", 1L)
+
+        testee.onSheetReopened()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.commands.test {
+            // The STATE_HIDDEN that follows the entry dialog handoff must not be treated as a dismissal.
+            testee.onSheetClosed()
+
+            assertFalse(expectMostRecentItem() is DuckChatContextualWebViewViewModel.Command.ApplyContextualClosed)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(duckChatPixels, never()).reportContextualSheetDismissed()
+    }
+
+    @Test
     fun `onPromptSent with attached page context includes it in the event`() = runTest {
         testee.onSheetOpened("tab-1")
         testee.onPageContextReceived("tab-1", serializedPageData)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217823711195261?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
- When the webview / chat in progress sheet has been re-opened (same session) and for some reason the chat does NOT exist, we fix the handling from just resetting the sheet to resetting it AND showing the entry state again.
- Enabled the feature to INTERNAL by default

### Steps to test this PR

- [x] Filter locat for "DuckAiNativeStorage: "
- [x] Follow the steps to reproduce here https://app.asana.com/1/137249556945/project/1213881875984009/task/1217823711195252?focus=true
- [ ] Once you manage to hit the issue (submit a prompt via contextual sheet without ANY logs for DuckAiNativeStorage, re-open the sheet and verify it resets to entry state.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes contextual reopen/session-restore and feature-flag defaults (INTERNAL), which affects which users see the redesigned flow and how failed chat restoration is recovered; main-thread fix reduces crash risk on media capture callbacks.
> 
> **Overview**
> When the contextual sheet is **reopened** but the stored chat is expired, missing from history, or otherwise unreusable, the flow no longer stops at resetting the WebView—it **hands off to the entry dialog** (`ShowNewChatEntryDialog`) so users see the INPUT/suggestions surface again instead of a broken in-progress sheet.
> 
> That handoff reuses the existing `hidingSheetForNewChat` guard so the sheet hide that follows does **not** emit `ApplyContextualClosed` or the dismissed pixel, keeping contextual native input state intact for the entry composer.
> 
> **Other changes:** `contextualSheetRedesign()` defaults to **INTERNAL** (was `false`). **Native input:** legacy contextual (redesign off) still shows the bottom attachment row when unfocused; redesign-on contextual does not. **Entry dialog:** external camera capture results are handled on the **main thread** via `lifecycleScope.launch` before WebView callbacks and UI. Tests cover reopen reset + handoff and post-handoff `onSheetClosed` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 185891cd01092aca0d6c72cf68e82db725286666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->