### PR TITLE
Add an onboarding small-text typography style to DaxTextView

### DIFF
--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/text/DaxTextView.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/text/DaxTextView.kt
@@ -102,6 +102,7 @@ constructor(
         CaptionAllCaps,
         TitleOnboarding,
         BodyOnboarding,
+        SmallTextOnboarding,
         ;
 
         companion object {
@@ -124,6 +125,7 @@ constructor(
                     13 -> CaptionAllCaps
                     14 -> TitleOnboarding
                     15 -> BodyOnboarding
+                    16 -> SmallTextOnboarding
                     else -> Body1
                 }
             }
@@ -146,6 +148,7 @@ constructor(
                     CaptionAllCaps -> R.style.Typography_DuckDuckGo_Caption_AllCaps
                     TitleOnboarding -> R.style.Typography_DuckDuckGo_Onboarding_Title
                     BodyOnboarding -> R.style.Typography_DuckDuckGo_Onboarding_Body
+                    SmallTextOnboarding -> R.style.Typography_DuckDuckGo_Onboarding_SmallText
                 }
             }
         }

--- a/android-design-system/design-system/src/main/res/values/attrs-typography.xml
+++ b/android-design-system/design-system/src/main/res/values/attrs-typography.xml
@@ -35,6 +35,7 @@
             <enum name="caption_allCaps" value="13"/>
             <enum name="onboarding_title" value="14"/>
             <enum name="onboarding_body" value="15"/>
+            <enum name="onboarding_small_text" value="16"/>
         </attr>
         <attr name="textType" format="enum" >
             <enum name="primary" value="0"/>

--- a/android-design-system/design-system/src/main/res/values/design-system-rebrand-onboarding-theming.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-rebrand-onboarding-theming.xml
@@ -200,6 +200,13 @@
         <item name="android:fontFamily">@font/ducksansproduct_regular</item>
     </style>
 
+    <style name="Typography.DuckDuckGo.Onboarding.SmallText">
+        <item name="android:textSize">14sp</item>
+        <item name="android:lineHeight">16sp</item>
+        <item name="android:lineSpacingExtra">0sp</item>
+        <item name="android:fontFamily">@font/ducksansproduct_regular</item>
+    </style>
+
     <style name="Typography.DuckDuckGo.Onboarding.Body.InContext">
         <item name="android:textSize">16sp</item>
     </style>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202857801505092/task/1217829951697340?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
The onboarding dialogs need a 14sp secondary text size that none of the existing onboarding typography values cover.

Not used as of yet, will be utilized in follow up PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive design-system typography with no changes to existing enum mappings or runtime behavior until layouts opt in.
> 
> **Overview**
> Adds a new **onboarding small text** typography option so onboarding UI can use **14sp** secondary-style copy without reusing body or caption styles.
> 
> `DaxTextView` gains `SmallTextOnboarding` (XML `onboarding_small_text`, enum value **16**), wired through `Typography.from` and `getTextAppearanceStyle` to `Typography.DuckDuckGo.Onboarding.SmallText`. That style uses **14sp** size, **16sp** line height, and `ducksansproduct_regular`, aligned with other onboarding typography in the rebrand theming file.
> 
> Nothing in this PR applies the new typography in layouts yet; follow-up work is expected to adopt it in onboarding dialogs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aaab2c9cef13fa07a8a1b87b789a153fc5774ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->