### PR TITLE
Add "petal=randomize" to the "m_site_permissions_auto_granted" pixel

### DIFF
--- a/PixelDefinitions/pixels/definitions/site_permissions.json5
+++ b/PixelDefinitions/pixels/definitions/site_permissions.json5
@@ -18,7 +18,8 @@
                 "type": "string",
                 "description": "Policy rule that produced the automatic grant",
                 "enum": ["allow_list", "protections_off"]
-            }
+            },
+            "petal_randomize"
         ]
     }
 }

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerImpl.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerImpl.kt
@@ -197,6 +197,7 @@ class SitePermissionsManagerImpl @Inject constructor(
             mapOf(
                 SitePermissionsPixelParameters.PERMISSION_TYPE to SitePermissionsPixelValues.DRM,
                 SitePermissionsPixelParameters.REASON to reason,
+                SitePermissionsPixelParameters.PETAL to SitePermissionsPetalValues.RANDOMIZE,
             ),
         )
     }

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsPixelName.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsPixelName.kt
@@ -28,6 +28,7 @@ object SitePermissionsPixelParameters {
     const val PERMISSION_TYPE = "type"
     const val PERMISSION_SELECTION = "selection"
     const val REASON = "reason"
+    const val PETAL = "petal"
 }
 
 object SitePermissionsPixelValues {
@@ -42,4 +43,8 @@ object SitePermissionsPixelValues {
     const val DENY_ONCE = "deny_once"
     const val ALLOW_LIST = "allow_list"
     const val PROTECTIONS_OFF = "protections_off"
+}
+
+object SitePermissionsPetalValues {
+    const val RANDOMIZE = "randomize"
 }

--- a/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerTest.kt
+++ b/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerTest.kt
@@ -161,6 +161,7 @@ class SitePermissionsManagerTest {
             mapOf(
                 SitePermissionsPixelParameters.PERMISSION_TYPE to SitePermissionsPixelValues.DRM,
                 SitePermissionsPixelParameters.REASON to SitePermissionsPixelValues.ALLOW_LIST,
+                SitePermissionsPixelParameters.PETAL to SitePermissionsPetalValues.RANDOMIZE,
             ),
         )
     }
@@ -183,6 +184,7 @@ class SitePermissionsManagerTest {
             mapOf(
                 SitePermissionsPixelParameters.PERMISSION_TYPE to SitePermissionsPixelValues.DRM,
                 SitePermissionsPixelParameters.REASON to SitePermissionsPixelValues.PROTECTIONS_OFF,
+                SitePermissionsPixelParameters.PETAL to SitePermissionsPetalValues.RANDOMIZE,
             ),
         )
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217820090315328?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Adds a `petal` param to the `m_site_permissions_auto_granted` pixel, routing it through the PETAL pipeline (randomize).
 
### Steps to test this PR
- [ ] Open an article with a video from https://www.foxnews.com
- [ ] Verify a pixel is sent: `Pixel sent: m_site_permissions_auto_granted with params: {type=drm, reason=allow_list, petal=randomize} {}`

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change to pixel parameters; site permission and DRM policy logic are untouched.
> 
> **Overview**
> Adds **`petal=randomize`** to the **`m_site_permissions_auto_granted`** pixel so DRM auto-grant events go through the PETAL timestamp-randomization pipeline, matching other site-permissions analytics.
> 
> The pixel definition now includes **`petal_randomize`**, and **`fireDrmAutoGrantedPixel`** always attaches **`petal`** with value **`randomize`** alongside existing **`type`** and **`reason`** params. New constants **`SitePermissionsPixelParameters.PETAL`** and **`SitePermissionsPetalValues.RANDOMIZE`** back the fire call; unit tests for allow-list and protections-off auto-grants were updated accordingly.
> 
> **DRM grant/deny behavior is unchanged**—only telemetry payload and schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1693e65210c1b140c4063512d18dc69346d246cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->