### PR TITLE
Contextual/DuckAi: Ensure all needed pixels are present 

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1762,5 +1762,47 @@
             },
             "firstPromptNewInstall"
         ]
+    },
+    "aichat_contextual_address_bar_menu_shown": {
+        "description": "Fired when the Duck.ai menu offering New Chat and Ask About Page is shown from the address bar",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "aichat_contextual_address_bar_menu_new_chat_selected": {
+        "description": "Fired when the user selects New Chat in the address bar Duck.ai menu",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "aichat_contextual_address_bar_menu_ask_about_page_selected": {
+        "description": "Fired when the user selects Ask About Page in the address bar Duck.ai menu",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "aichat_contextual_floating_input_opened": {
+        "description": "Fired when the floating contextual input (entry) is opened",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "aichat_contextual_floating_input_dismissed_without_submission": {
+        "description": "Fired when the floating contextual input is closed without the user sending a prompt.",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "aichat_contextual_floating_input_promoted_to_sheet": {
+        "description": "Fired when a prompt sent from the floating contextual input opens the contextual sheet",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
@@ -261,7 +261,7 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
     private fun configureQuickAction() {
         binding.entryPromptQuickAction.setOnClickListener {
             if (viewModel.viewState.value.attachedContext == null) return@setOnClickListener
-            viewModel.onPromptSubmitted(NativeInputPrompt(getString(R.string.duckAIContextualPromptSummarize), null, null, null, null, null))
+            viewModel.onSummarizeSubmitted(NativeInputPrompt(getString(R.string.duckAIContextualPromptSummarize), null, null, null, null, null))
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
@@ -423,6 +423,7 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
         super.onDismiss(dialog)
         if (!handedOffToSheet && ::tabId.isInitialized && activity?.isChangingConfigurations != true) {
             contextualNativeInputManager.onContextualClosed(tabId)
+            viewModel.onDismiss()
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModel.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.contextual
 import androidx.lifecycle.ViewModel
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -37,6 +38,7 @@ import javax.inject.Inject
 @ContributesViewModel(FragmentScope::class)
 class DuckChatContextualEntryViewModel @Inject constructor(
     private val contextualEntryPromptStore: ContextualEntryPromptStore,
+    private val duckChatPixels: DuckChatPixels,
 ) : ViewModel() {
 
     data class ViewState(
@@ -70,6 +72,7 @@ class DuckChatContextualEntryViewModel @Inject constructor(
 
     fun start(tabId: String) {
         this.tabId = tabId
+        duckChatPixels.reportContextualFloatingInputShown()
     }
 
     fun onPageContextReceived(serializedPageContext: String) {
@@ -82,12 +85,16 @@ class DuckChatContextualEntryViewModel @Inject constructor(
 
     /** The composer's "attach page context" affordance (shown when nothing is attached). */
     fun onAttachContextRequested() {
-        latestValidPageContext?.let { attach(it) }
+        latestValidPageContext?.let {
+            duckChatPixels.reportContextualPageContextManuallyAttachedNative()
+            attach(it)
+        }
     }
 
     fun onContextRemoved() {
         userRemovedContext = true
         _viewState.update { it.copy(attachedContext = null) }
+        duckChatPixels.reportContextualPageContextRemovedNative()
     }
 
     /** A suggested prompt was picked; suggestions are page-specific, so attach the context before submit. */
@@ -105,6 +112,7 @@ class DuckChatContextualEntryViewModel @Inject constructor(
         contextualEntryPromptStore.store(
             ContextualEntryPrompt(tabId, prompt, _viewState.value.attachedContext?.serialized),
         )
+        duckChatPixels.reportContextualFloatingInputPromotedToSheet()
         commandChannel.trySend(Command.HandOffToSheet)
     }
 
@@ -125,5 +133,9 @@ class DuckChatContextualEntryViewModel @Inject constructor(
     private fun isContextValid(serializedPageContext: String): Boolean {
         val json = runCatching { JSONObject(serializedPageContext) }.getOrNull() ?: return false
         return json.optString("title").isNotBlank() && json.optString("content").isNotBlank()
+    }
+
+    fun onDismiss() {
+        duckChatPixels.reportContextualFloatingInputDismissedWithoutSubmission()
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModel.kt
@@ -19,6 +19,9 @@ package com.duckduckgo.duckchat.impl.contextual
 import androidx.lifecycle.ViewModel
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelPageType
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
@@ -39,6 +42,7 @@ import javax.inject.Inject
 class DuckChatContextualEntryViewModel @Inject constructor(
     private val contextualEntryPromptStore: ContextualEntryPromptStore,
     private val duckChatPixels: DuckChatPixels,
+    private val modelManager: DuckAiModelManager,
 ) : ViewModel() {
 
     data class ViewState(
@@ -100,12 +104,33 @@ class DuckChatContextualEntryViewModel @Inject constructor(
     /** A suggested prompt was picked; suggestions are page-specific, so attach the context before submit. */
     fun onSuggestionSubmitted(prompt: NativeInputPrompt) {
         if (_viewState.value.attachedContext == null) latestValidPageContext?.let { attach(it) }
+        fireUnifiedInputPromptSubmitted()
         submit(prompt)
     }
 
-    /** A typed prompt or the Summarize quick action was submitted. */
+    fun onSummarizeSubmitted(prompt: NativeInputPrompt) {
+        fireUnifiedInputPromptSubmitted()
+        submit(prompt)
+    }
+
     fun onPromptSubmitted(prompt: NativeInputPrompt) {
         submit(prompt)
+    }
+
+    private fun fireUnifiedInputPromptSubmitted() {
+        duckChatPixels.firePromptSubmitted(
+            selectedTool = "none",
+            modelId = modelManager.getSelectedModelId(),
+            reasoningEffort = modelManager.getResolvedReasoningEffort(),
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
+            defaultMode = null,
+            tabId = tabId,
+            pageType = DuckChatPixelPageType.CONTEXTUAL,
+            addressBarEntryPoint = null,
+        )
     }
 
     private fun submit(prompt: NativeInputPrompt) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -40,6 +40,8 @@ import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
 import com.duckduckgo.duckchat.impl.history.ChatHistoryItem
 import com.duckduckgo.duckchat.impl.history.ChatHistoryRepository
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelPageType
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
@@ -711,6 +713,7 @@ class DuckChatContextualViewModel @Inject constructor(
                     return
                 }
                 duckChatPixels.reportContextualSummarizePromptSelected()
+                fireUnifiedInputPromptSubmitted()
                 onPromptSent(
                     prompt = context.getString(R.string.duckAIContextualPromptSummarize),
                     followUpPrefill = currentInput.takeIf { it.isNotEmpty() },
@@ -724,9 +727,26 @@ class DuckChatContextualViewModel @Inject constructor(
         currentInput: String,
     ) {
         attachPageContextForSuggestion()
+        fireUnifiedInputPromptSubmitted()
         onPromptSent(
             prompt = suggestion.prompt,
             followUpPrefill = currentInput.takeIf { it.isNotEmpty() },
+        )
+    }
+
+    private fun fireUnifiedInputPromptSubmitted() {
+        duckChatPixels.firePromptSubmitted(
+            selectedTool = "none",
+            modelId = modelManager.getSelectedModelId(),
+            reasoningEffort = modelManager.getResolvedReasoningEffort(),
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
+            defaultMode = null,
+            tabId = _viewState.value.tabId,
+            pageType = DuckChatPixelPageType.CONTEXTUAL,
+            addressBarEntryPoint = null,
         )
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -187,6 +187,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
     }
 
     fun onSheetOpened(tabId: String) {
+        duckChatPixels.reportContextualSheetOpened()
         _viewState.update { it.copy(tabId = tabId) }
         viewModelScope.launch(dispatchers.io()) {
             val pendingEntry = contextualEntryPromptStore.consume(tabId)
@@ -210,19 +211,20 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
                 !isStoredChatMissingFromHistory(existingChatUrl)
             if (shouldReuseUrl) {
                 logcat { "Duck.ai: tab=$tabId has an existing url and don't need to restart the session" }
+                duckChatPixels.reportContextualSheetSessionRestored()
                 loadWebViewUrl(tabId, existingChatUrl!!)
             } else {
                 logcat { "Duck.ai: tab=$tabId session expired or absent, starting a new chat" }
                 loadFreshChat(tabId)
             }
         }
-        duckChatPixels.reportContextualSheetOpened()
     }
 
     fun onSheetReopened() {
         logcat { "Duck.ai: onSheetReopened" }
         commandChannel.trySend(Command.ApplyContextualReopened(_viewState.value.tabId))
 
+        duckChatPixels.reportContextualSheetOpened()
         viewModelScope.launch(dispatchers.io()) {
             val tabId = _viewState.value.tabId
             val pendingEntry = contextualEntryPromptStore.consume(tabId)
@@ -242,7 +244,6 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
             }
             reopenWebViewState(tabId)
         }
-        duckChatPixels.reportContextualSheetOpened()
     }
 
     private suspend fun reopenWebViewState(tabId: String) {
@@ -539,6 +540,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
     }
 
     fun onSheetClosed() {
+        duckChatPixels.reportContextualSheetDismissed()
         if (hidingSheetForNewChat) {
             // New Chat hid the sheet only to hand off to the entry dialog — not a user dismissal. Skip
             // onContextualClosed (which would revert the tab's contextual input state and strip the entry
@@ -548,7 +550,6 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
             return
         }
         persistTabClosed()
-        duckChatPixels.reportContextualSheetDismissed()
         commandChannel.trySend(Command.ApplyContextualClosed(_viewState.value.tabId))
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -540,7 +540,6 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
     }
 
     fun onSheetClosed() {
-        duckChatPixels.reportContextualSheetDismissed()
         if (hidingSheetForNewChat) {
             // New Chat hid the sheet only to hand off to the entry dialog — not a user dismissal. Skip
             // onContextualClosed (which would revert the tab's contextual input state and strip the entry
@@ -549,6 +548,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
             hidingSheetForNewChat = false
             return
         }
+        duckChatPixels.reportContextualSheetDismissed()
         persistTabClosed()
         commandChannel.trySend(Command.ApplyContextualClosed(_viewState.value.tabId))
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.duckchat.api.DuckChatContextual
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -41,6 +42,7 @@ class RealDuckChatContextual @Inject constructor(
     private val contextualDataStore: DuckChatContextualDataStore,
     private val sessionTimeoutProvider: DuckChatContextualSessionTimeoutProvider,
     private val timeProvider: DuckChatContextualTimeProvider,
+    private val duckChatPixels: DuckChatPixels,
 ) : DuckChatContextual {
 
     override suspend fun launch(
@@ -96,11 +98,16 @@ class RealDuckChatContextual @Inject constructor(
         val activity = anchor.activity() ?: return
         val popup = PopupMenu(LayoutInflater.from(activity), R.layout.popup_contextual_chat_menu)
         val content = popup.contentView
-        popup.onMenuItemClicked(content.findViewById(R.id.contextualChatMenuNewChat)) { openNewChatTab(activity, sourceTabId) }
+        popup.onMenuItemClicked(content.findViewById(R.id.contextualChatMenuNewChat)) {
+            duckChatPixels.reportContextualAddressBarMenuNewChatSelected()
+            openNewChatTab(activity, sourceTabId)
+        }
         popup.onMenuItemClicked(content.findViewById(R.id.contextualChatMenuAskAboutPage)) {
+            duckChatPixels.reportContextualAddressBarMenuAskAboutPageSelected()
             showEntryDialog(anchor, sourceTabId, onAskAboutPage)
         }
         popup.showAnchoredView(activity, anchor.rootView, anchor)
+        duckChatPixels.reportContextualAddressBarMenuShown()
     }
 
     private fun showEntryDialog(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -195,6 +195,13 @@ interface DuckChatPixels {
     fun reportContextualFireButtonTapped()
     fun reportContextualFireButtonConfirmed()
 
+    fun reportContextualAddressBarMenuShown()
+    fun reportContextualAddressBarMenuNewChatSelected()
+    fun reportContextualAddressBarMenuAskAboutPageSelected()
+    fun reportContextualFloatingInputShown()
+    fun reportContextualFloatingInputDismissedWithoutSubmission()
+    fun reportContextualFloatingInputPromotedToSheet()
+
     fun reportChatSyncActive()
 
     fun reportNativeStorageReaderUsed(native: Boolean)
@@ -733,6 +740,48 @@ class RealDuckChatPixels @Inject constructor(
             pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_CONFIRMED_FIRST, type = Pixel.PixelType.Unique())
             pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_CONFIRMED_DAILY, type = Pixel.PixelType.Daily())
             pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_CONFIRMED_COUNT)
+        }
+    }
+
+    override fun reportContextualAddressBarMenuShown() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_SHOWN_COUNT)
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_SHOWN_DAILY, type = Pixel.PixelType.Daily())
+        }
+    }
+
+    override fun reportContextualAddressBarMenuNewChatSelected() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_NEW_CHAT_SELECTED_COUNT)
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_NEW_CHAT_SELECTED_DAILY, type = Pixel.PixelType.Daily())
+        }
+    }
+
+    override fun reportContextualAddressBarMenuAskAboutPageSelected() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_PAGE_SELECTED_COUNT)
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_PAGE_SELECTED_DAILY, type = Pixel.PixelType.Daily())
+        }
+    }
+
+    override fun reportContextualFloatingInputShown() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_SHOWN_COUNT)
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_SHOWN_DAILY, type = Pixel.PixelType.Daily())
+        }
+    }
+
+    override fun reportContextualFloatingInputDismissedWithoutSubmission() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_DISMISSED_WITHOUT_SUBMISSION_COUNT)
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_DISMISSED_WITHOUT_SUBMISSION_DAILY, type = Pixel.PixelType.Daily())
+        }
+    }
+
+    override fun reportContextualFloatingInputPromotedToSheet() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_PROMOTED_TO_SHEET_COUNT)
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_PROMOTED_TO_SHEET_DAILY, type = Pixel.PixelType.Daily())
         }
     }
 
@@ -1343,6 +1392,18 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_CONFIRMED_FIRST("m_aichat_contextual_fire_button_confirmed_first"),
     DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_CONFIRMED_DAILY("m_aichat_contextual_fire_button_confirmed_daily"),
     DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_CONFIRMED_COUNT("m_aichat_contextual_fire_button_confirmed_count"),
+    DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_SHOWN_COUNT("aichat_contextual_address_bar_menu_shown_count"),
+    DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_SHOWN_DAILY("aichat_contextual_address_bar_menu_shown_daily"),
+    DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_NEW_CHAT_SELECTED_COUNT("aichat_contextual_address_bar_menu_new_chat_selected_count"),
+    DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_NEW_CHAT_SELECTED_DAILY("aichat_contextual_address_bar_menu_new_chat_selected_daily"),
+    DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_PAGE_SELECTED_COUNT("aichat_contextual_address_bar_menu_ask_about_page_selected_count"),
+    DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_PAGE_SELECTED_DAILY("aichat_contextual_address_bar_menu_ask_about_page_selected_daily"),
+    DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_SHOWN_COUNT("aichat_contextual_floating_input_opened_count"),
+    DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_SHOWN_DAILY("aichat_contextual_floating_input_opened_daily"),
+    DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_DISMISSED_WITHOUT_SUBMISSION_COUNT("aichat_contextual_floating_input_dismissed_without_submission_count"),
+    DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_DISMISSED_WITHOUT_SUBMISSION_DAILY("aichat_contextual_floating_input_dismissed_without_submission_daily"),
+    DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_PROMOTED_TO_SHEET_COUNT("aichat_contextual_floating_input_promoted_to_sheet_count"),
+    DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_PROMOTED_TO_SHEET_DAILY("aichat_contextual_floating_input_promoted_to_sheet_daily"),
 
     SYNC_AI_CHAT_ACTIVE("sync_ai_chat_active"),
 
@@ -1676,6 +1737,18 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_CONFIRMED_FIRST.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_CONFIRMED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_CONFIRMED_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_SHOWN_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_SHOWN_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_NEW_CHAT_SELECTED_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_NEW_CHAT_SELECTED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_PAGE_SELECTED_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_PAGE_SELECTED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_SHOWN_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_SHOWN_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_DISMISSED_WITHOUT_SUBMISSION_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_DISMISSED_WITHOUT_SUBMISSION_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_PROMOTED_TO_SHEET_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_PROMOTED_TO_SHEET_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_NATIVE_STORAGE_READER_NATIVE_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_NATIVE_STORAGE_READER_WEBVIEW_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_NATIVE_STORAGE_DELETION_NATIVE_COUNT.pixelName to PixelParameter.removeAtb(),

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
@@ -17,21 +17,28 @@
 package com.duckduckgo.duckchat.impl.contextual
 
 import app.cash.turbine.test
+import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelPageType
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class DuckChatContextualEntryViewModelTest {
 
     private val store: ContextualEntryPromptStore = mock()
     private val duckChatPixels: DuckChatPixels = mock()
-    private val viewModel = DuckChatContextualEntryViewModel(store, duckChatPixels)
+    private val modelManager: DuckAiModelManager = mock()
+    private val viewModel = DuckChatContextualEntryViewModel(store, duckChatPixels, modelManager)
 
     private val validContext = """{"title":"Example","url":"https://example.com","content":"some page content"}"""
     private val samplePrompt = NativeInputPrompt("hi", "model-1", "high", "tool-1", null, null)
@@ -95,6 +102,83 @@ class DuckChatContextualEntryViewModelTest {
         val captor = argumentCaptor<ContextualEntryPrompt>()
         verify(store).store(captor.capture())
         assertEquals(validContext, captor.firstValue.serializedPageContext)
+    }
+
+    @Test
+    fun whenSuggestionSubmittedThenUnifiedInputPromptSubmittedPixelFired() = runTest {
+        viewModel.start("tab-1")
+        whenever(modelManager.getSelectedModelId()).thenReturn("gpt-5.2")
+        whenever(modelManager.getResolvedReasoningEffort()).thenReturn("low")
+
+        viewModel.commands.test {
+            viewModel.onSuggestionSubmitted(samplePrompt)
+            assertEquals(DuckChatContextualEntryViewModel.Command.HandOffToSheet, awaitItem())
+        }
+
+        verify(duckChatPixels).firePromptSubmitted(
+            selectedTool = "none",
+            modelId = "gpt-5.2",
+            reasoningEffort = "low",
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
+            defaultMode = null,
+            tabId = "tab-1",
+            pageType = DuckChatPixelPageType.CONTEXTUAL,
+            addressBarEntryPoint = null,
+        )
+    }
+
+    @Test
+    fun whenSummarizeSubmittedThenUnifiedInputPromptSubmittedPixelFired() = runTest {
+        viewModel.start("tab-1")
+        viewModel.onPageContextReceived(validContext)
+        whenever(modelManager.getSelectedModelId()).thenReturn("gpt-5.2")
+        whenever(modelManager.getResolvedReasoningEffort()).thenReturn("low")
+
+        viewModel.commands.test {
+            viewModel.onSummarizeSubmitted(samplePrompt)
+            assertEquals(DuckChatContextualEntryViewModel.Command.HandOffToSheet, awaitItem())
+        }
+
+        verify(duckChatPixels).firePromptSubmitted(
+            selectedTool = "none",
+            modelId = "gpt-5.2",
+            reasoningEffort = "low",
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
+            defaultMode = null,
+            tabId = "tab-1",
+            pageType = DuckChatPixelPageType.CONTEXTUAL,
+            addressBarEntryPoint = null,
+        )
+    }
+
+    @Test
+    fun whenPromptSubmittedThenUnifiedInputPromptSubmittedPixelNotFired() = runTest {
+        viewModel.start("tab-1")
+
+        viewModel.commands.test {
+            viewModel.onPromptSubmitted(samplePrompt)
+            assertEquals(DuckChatContextualEntryViewModel.Command.HandOffToSheet, awaitItem())
+        }
+
+        verify(duckChatPixels, never()).firePromptSubmitted(
+            selectedTool = any(),
+            modelId = any(),
+            reasoningEffort = any(),
+            hasImageAttachment = any(),
+            hasFileAttachment = any(),
+            hasText = any(),
+            surface = any(),
+            defaultMode = anyOrNull(),
+            tabId = anyOrNull(),
+            pageType = any(),
+            addressBarEntryPoint = anyOrNull(),
+        )
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
@@ -17,18 +17,21 @@
 package com.duckduckgo.duckchat.impl.contextual
 
 import app.cash.turbine.test
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
 class DuckChatContextualEntryViewModelTest {
 
     private val store: ContextualEntryPromptStore = mock()
-    private val viewModel = DuckChatContextualEntryViewModel(store)
+    private val duckChatPixels: DuckChatPixels = mock()
+    private val viewModel = DuckChatContextualEntryViewModel(store, duckChatPixels)
 
     private val validContext = """{"title":"Example","url":"https://example.com","content":"some page content"}"""
     private val samplePrompt = NativeInputPrompt("hi", "model-1", "high", "tool-1", null, null)
@@ -122,5 +125,73 @@ class DuckChatContextualEntryViewModelTest {
         val captor = argumentCaptor<ContextualEntryPrompt>()
         verify(store).store(captor.capture())
         assertNull(captor.firstValue.serializedPageContext)
+    }
+
+    @Test
+    fun whenStartedThenReportsFloatingInputShown() {
+        viewModel.start("tab-1")
+
+        verify(duckChatPixels).reportContextualFloatingInputShown()
+    }
+
+    @Test
+    fun whenStartedThenDoesNotReportSheetOpened() {
+        viewModel.start("tab-1")
+
+        verify(duckChatPixels, never()).reportContextualSheetOpened()
+    }
+
+    @Test
+    fun whenDismissedThenDoesNotReportSheetDismissed() {
+        viewModel.onDismiss()
+
+        verify(duckChatPixels, never()).reportContextualSheetDismissed()
+    }
+
+    @Test
+    fun whenPromptSubmittedThenReportsFloatingInputPromotedToSheet() = runTest {
+        viewModel.start("tab-1")
+
+        viewModel.commands.test {
+            viewModel.onPromptSubmitted(samplePrompt)
+            assertEquals(DuckChatContextualEntryViewModel.Command.HandOffToSheet, awaitItem())
+        }
+
+        verify(duckChatPixels).reportContextualFloatingInputPromotedToSheet()
+    }
+
+    @Test
+    fun whenDismissedWithAttachedContextThenReportsDismissed() {
+        viewModel.onDismiss()
+
+        verify(duckChatPixels).reportContextualFloatingInputDismissedWithoutSubmission()
+    }
+
+    @Test
+    fun whenContextManuallyAttachedThenReportsManualAttachPixel() {
+        viewModel.onPageContextReceived(validContext)
+        viewModel.onContextRemoved()
+
+        viewModel.onAttachContextRequested()
+
+        assertEquals(validContext, viewModel.viewState.value.attachedContext?.serialized)
+        verify(duckChatPixels).reportContextualPageContextManuallyAttachedNative()
+    }
+
+    @Test
+    fun whenNoValidContextToAttachThenDoesNotReportManualAttachPixel() {
+        viewModel.onAttachContextRequested()
+
+        assertNull(viewModel.viewState.value.attachedContext)
+        verify(duckChatPixels, never()).reportContextualPageContextManuallyAttachedNative()
+    }
+
+    @Test
+    fun whenContextRemovedThenReportsRemoveAttachmentPixel() {
+        viewModel.onPageContextReceived(validContext)
+
+        viewModel.onContextRemoved()
+
+        verify(duckChatPixels).reportContextualPageContextRemovedNative()
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -33,6 +33,8 @@ import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
 import com.duckduckgo.duckchat.impl.history.ChatHistoryItem
 import com.duckduckgo.duckchat.impl.history.ChatHistoryRepository
 import com.duckduckgo.duckchat.impl.models.ChatType
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelPageType
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
 import com.duckduckgo.feature.toggles.api.Toggle
@@ -2066,6 +2068,35 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
+    fun `when SUBMIT_SUMMARIZE clicked then unified input prompt submitted pixel fired`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+        whenever(modelManager.getSelectedModelId()).thenReturn("gpt-5.2")
+        whenever(modelManager.getResolvedReasoningEffort()).thenReturn("low")
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
+        testee.onPageContextReceived("tab-1", pageContext)
+        testee.onQuickActionClicked("") // ASK_ABOUT_PAGE -> SUBMIT_SUMMARIZE
+
+        testee.onQuickActionClicked("") // SUBMIT_SUMMARIZE click
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatPixels).firePromptSubmitted(
+            selectedTool = "none",
+            modelId = "gpt-5.2",
+            reasoningEffort = "low",
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
+            defaultMode = null,
+            tabId = "tab-1",
+            pageType = DuckChatPixelPageType.CONTEXTUAL,
+            addressBarEntryPoint = null,
+        )
+    }
+
+    @Test
     fun `when SUBMIT_SUMMARIZE clicked then context-attach pixel not re-fired`() = runTest {
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
@@ -2529,6 +2560,31 @@ class DuckChatContextualViewModelTest {
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
 
         verify(duckChatPixels).reportContextualPromptSubmittedWithContextNative()
+    }
+
+    @Test
+    fun `when suggestion selected then unified input prompt submitted pixel fired`() = runTest {
+        testee = buildViewModel()
+        whenever(modelManager.getSelectedModelId()).thenReturn("gpt-5.2")
+        whenever(modelManager.getResolvedReasoningEffort()).thenReturn("low")
+        val suggestion = ContextualSuggestedPrompt("id", "Label", "Do the thing.", null)
+
+        testee.onSuggestionSelected(suggestion, currentInput = "")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatPixels).firePromptSubmitted(
+            selectedTool = "none",
+            modelId = "gpt-5.2",
+            reasoningEffort = "low",
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
+            defaultMode = null,
+            tabId = "",
+            pageType = DuckChatPixelPageType.CONTEXTUAL,
+            addressBarEntryPoint = null,
+        )
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -49,6 +49,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -187,7 +188,69 @@ class DuckChatContextualWebViewViewModelTest {
             assertFalse(expectMostRecentItem() is DuckChatContextualWebViewViewModel.Command.ApplyContextualClosed)
             cancelAndIgnoreRemainingEvents()
         }
-        verify(duckChatPixels, never()).reportContextualSheetDismissed()
+        verify(duckChatPixels).reportContextualSheetDismissed()
+    }
+
+    @Test
+    fun `onSheetOpened reports the sheet opened even for an entry-dialog hand-off`() = runTest {
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1")).thenReturn(ContextualEntryPrompt("tab-1", prompt, null))
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatPixels).reportContextualSheetOpened()
+    }
+
+    @Test
+    fun `onSheetOpened reusing an existing chat reports session restored and the sheet opened`() = runTest {
+        val chatUrl = "https://duckduckgo.com/?ia=chat&chatID=abc"
+        contextualDataStore.persistTabChatUrl("tab-1", chatUrl)
+        recentChatsFlow.value = listOf(
+            ChatHistoryItem(
+                chatId = "abc",
+                displayTitle = "Chat",
+                type = ChatType.Discussion,
+                model = "",
+                pinned = false,
+                lastEditMillis = 1L,
+            ),
+        )
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatPixels).reportContextualSheetSessionRestored()
+        verify(duckChatPixels).reportContextualSheetOpened()
+    }
+
+    @Test
+    fun `onSheetReopened without a pending entry reports the sheet opened`() = runTest {
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onSheetReopened()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        // Once for the initial open, once for the reopen.
+        verify(duckChatPixels, times(2)).reportContextualSheetOpened()
+    }
+
+    @Test
+    fun `onSheetReopened reports the sheet opened even for an entry-dialog hand-off`() = runTest {
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        val prompt = NativeInputPrompt("hello", "model-1", "high", null, null, null)
+        whenever(contextualEntryPromptStore.consume("tab-1")).thenReturn(ContextualEntryPrompt("tab-1", prompt, null))
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+
+        testee.onSheetReopened()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        // Once for the initial open, once for the reopen — the sheet reports the open regardless of hand-off.
+        verify(duckChatPixels, times(2)).reportContextualSheetOpened()
     }
 
     @Test
@@ -380,13 +443,12 @@ class DuckChatContextualWebViewViewModelTest {
         testee.onNewChatRequestedFromPopup()
 
         testee.commands.test {
-            // The STATE_HIDDEN that follows the New Chat handoff must not be treated as a dismissal.
             testee.onSheetClosed()
 
             assertFalse(expectMostRecentItem() is DuckChatContextualWebViewViewModel.Command.ApplyContextualClosed)
             cancelAndIgnoreRemainingEvents()
         }
-        verify(duckChatPixels, never()).reportContextualSheetDismissed()
+        verify(duckChatPixels).reportContextualSheetDismissed()
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -188,7 +188,7 @@ class DuckChatContextualWebViewViewModelTest {
             assertFalse(expectMostRecentItem() is DuckChatContextualWebViewViewModel.Command.ApplyContextualClosed)
             cancelAndIgnoreRemainingEvents()
         }
-        verify(duckChatPixels).reportContextualSheetDismissed()
+        verify(duckChatPixels, never()).reportContextualSheetDismissed()
     }
 
     @Test
@@ -448,7 +448,7 @@ class DuckChatContextualWebViewViewModelTest {
             assertFalse(expectMostRecentItem() is DuckChatContextualWebViewViewModel.Command.ApplyContextualClosed)
             cancelAndIgnoreRemainingEvents()
         }
-        verify(duckChatPixels).reportContextualSheetDismissed()
+        verify(duckChatPixels, never()).reportContextualSheetDismissed()
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextualTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextualTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.contextual
 import android.view.View
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -34,6 +35,7 @@ class RealDuckChatContextualTest {
     private val contextualDataStore: DuckChatContextualDataStore = mock()
     private val sessionTimeoutProvider: DuckChatContextualSessionTimeoutProvider = mock()
     private val timeProvider: DuckChatContextualTimeProvider = mock()
+    private val duckChatPixels: DuckChatPixels = mock()
     private val anchor: View = mock()
 
     private val testee = RealDuckChatContextual(
@@ -42,6 +44,7 @@ class RealDuckChatContextualTest {
         contextualDataStore,
         sessionTimeoutProvider,
         timeProvider,
+        duckChatPixels,
     )
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217146291865572?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Fixed contextual sheet pixel emission so it matches the pre-redesign fragment behavior:
  - `sheet_opened` and `sheet_dismissed` are now owned solely by the sheet (`DuckChatContextualWebViewViewModel`) and fire on every open/reopen/close — no double-count on entry-dialog hand-off, and `sheet_dismissed` is still reported on a New Chat hand-off.
  - `session_restored` fires when an existing chat is reused. 
  
Added new contextual pixels wired to their real surfaces:
  - Address-bar menu: `address_bar_menu_shown`, `address_bar_menu_new_chat_selected`, `address_bar_menu_ask_about_page_selected` (in `RealDuckChatContextual`).
  - Floating input (entry dialog): `floating_input_shown`, `floating_input_promoted_to_sheet`, `floating_input_dismissed_without_submission`.
  - Entry-dialog page context: `page_context_manually_attached_native` and `page_context_removed_native`.
  
Registry: added the above definitions to duck_chat.json5 (Android convention — first_daily_count + form_factor).

### Steps to test this PR
Filter your logcat with "`pixel sent: contextual`"
- [x] On a new tab, load a website. Click on the contextual entry.
- [x] Verify logcat shows: "Pixel sent: aichat_contextual_address_bar_menu_shown” [New]
- [x] Select New Chat
- [x] Verify logcat shows: “Pixel sent: aichat_contextual_address_bar_menu_new_chat_selected” [New]
- [x] Go back to the tab and reopen contextual entry. This time select Ask About Page.
- [x] Verify logcat shows: “Pixel sent: aichat_contextual_address_bar_menu_ask_about_page_selected” [New]
- [x] Verify logcat shows: “Pixel sent: aichat_contextual_suggestions_viewed” [No regression]
- [x] Click outside of sheet
- [x] Verify logcat shows: “Pixel sent: aichat_contextual_floating_input_dismissed_without_submission"
- [x] Remove attached context
- [x] Verify logcat shows: “Pixel sent: m_aichat_contextual_page_context_removed_native"[No regression]
- [x] Click attachment icon + Ask About Page
- [x] Verify logcat shows: “Pixel sent: m_aichat_contextual_page_context_manually_attached_native"[No regression]
- [x] Selected a suggested prompt
- [x] Verify logcat shows: “Pixel sent: aichat_contextual_suggestion_selected“ [No regression]
- [x] Verify logcat shows: “Pixel sent: aichat_contextual_floating_input_promoted_to_sheet“[New]
- [x] Verify logcat shows: “Pixel sent: m_aichat_contextual_sheet_opened“[No regression]
- [x] Verify logcat shows: “Pixel sent: m_aichat_contextual_prompt_submitted_with_context_native“ [No regression]
- [x] Close the chat
- [x] Verify logcat shows: “Pixel sent: m_aichat_contextual_sheet_dismissed“ [No regression]
- [x] Reopen chat again
- [x] Verify logcat shows: “Pixel sent: m_aichat_contextual_sheet_opened_count“ [No regression]
- [x] Verify logcat shows: “Pixel sent: m_aichat_contextual_session_restored_count“[No regression]
- [x] This time select chats icon (ensure you have more than 1 chat in history)
- [x] Select New Chat
- [x] Verify logcat shows: “Pixel sent: m_aichat_contextual_recent_chats_popup_displayed “ [No regression]
- [x] Verify logcat shows: “Pixel sent: m_aichat_contextual_chats_button_tapped “[No regression]
- [x] Verify logcat shows: “Pixel sent: m_aichat_contextual_sheet_dismissed“[No regression]
- [x] Verify logcat shows: “Pixel sent: aichat_contextual_floating_input_opened"[New]
- [x] Remove attachment and submit a query
- [x] Verify logcat shows: “Pixel sent: aichat_contextual_floating_input_promoted_to_sheet“[No regression]
- [x] Verify logcat shows: “Pixel sent: m_aichat_contextual_prompt_submitted_without_context_native“[No regression]
- [x] Smoke test other controls and verify that pixels are emitted.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to analytics wiring and pixel emission order in contextual UI; no user-facing behavior or security-sensitive logic.
> 
> **Overview**
> Adds **contextual Duck.ai analytics** for the address-bar menu, floating entry dialog, and sheet lifecycle, and aligns prompt-submitted telemetry with the unified `firePromptSubmitted` path for suggestions and Summarize.
> 
> **New pixels** are registered in `duck_chat.json5` and wired in `DuckChatPixels`: address-bar menu shown / New Chat / Ask About Page (`RealDuckChatContextual`); floating input opened, dismissed without submit, and promoted to sheet (`DuckChatContextualEntryViewModel` + dialog `onDismiss`); plus manual attach/remove on the entry dialog.
> 
> **Sheet lifecycle** in `DuckChatContextualWebViewViewModel`: `reportContextualSheetOpened` runs at the start of open/reopen (including entry hand-off); `reportContextualSheetSessionRestored` when reusing an existing chat URL; dismiss pixel ordering adjusted with `persistTabClosed`. The entry VM no longer emits sheet open/dismiss—only floating-input events.
> 
> **Prompt analytics**: suggestions and Summarize (entry dialog and sheet) call `firePromptSubmitted` with `CONTEXTUAL_CHAT` surface; typed submits from the entry dialog still use promote-to-sheet + existing with/without-context natives (tests assert unified pixel is **not** fired for `onPromptSubmitted`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0608eeb9d4a1fcd298d9b0576a0e144ab805a23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->