### PR TITLE
Contextual/DuckAi: Fix crash on Take Photo

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
@@ -64,6 +64,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Named
 import com.google.android.material.R as MaterialR
@@ -218,24 +219,28 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
     }
 
     private fun registerFileChooserResult() {
-        externalCameraLauncher.registerForResult(this) {
-            when (it) {
-                is UploadFromExternalMediaAppLauncher.MediaCaptureResult.MediaCaptured ->
-                    pendingUploadTask?.onReceiveValue(arrayOf(Uri.fromFile(it.file)))
+        externalCameraLauncher.registerForResult(this) { result ->
+            // The launcher may deliver the result from a background thread (media capture moves the file
+            // off the main thread), so hop back to the main thread before touching views / WebView callbacks.
+            lifecycleScope.launch {
+                when (result) {
+                    is UploadFromExternalMediaAppLauncher.MediaCaptureResult.MediaCaptured ->
+                        pendingUploadTask?.onReceiveValue(arrayOf(Uri.fromFile(result.file)))
 
-                is UploadFromExternalMediaAppLauncher.MediaCaptureResult.CouldNotCapturePermissionDenied -> {
-                    pendingUploadTask?.onReceiveValue(null)
-                    externalCameraLauncher.showPermissionRationaleDialog(requireActivity(), it.inputAction)
-                }
+                    is UploadFromExternalMediaAppLauncher.MediaCaptureResult.CouldNotCapturePermissionDenied -> {
+                        pendingUploadTask?.onReceiveValue(null)
+                        externalCameraLauncher.showPermissionRationaleDialog(requireActivity(), result.inputAction)
+                    }
 
-                is UploadFromExternalMediaAppLauncher.MediaCaptureResult.NoMediaCaptured -> pendingUploadTask?.onReceiveValue(null)
-                is UploadFromExternalMediaAppLauncher.MediaCaptureResult.ErrorAccessingMediaApp -> {
-                    pendingUploadTask?.onReceiveValue(null)
-                    Snackbar.make(binding.entryDialogRoot, it.messageId, Snackbar.LENGTH_SHORT).show()
+                    is UploadFromExternalMediaAppLauncher.MediaCaptureResult.NoMediaCaptured -> pendingUploadTask?.onReceiveValue(null)
+                    is UploadFromExternalMediaAppLauncher.MediaCaptureResult.ErrorAccessingMediaApp -> {
+                        pendingUploadTask?.onReceiveValue(null)
+                        Snackbar.make(binding.entryDialogRoot, result.messageId, Snackbar.LENGTH_SHORT).show()
+                    }
                 }
+                pendingUploadTask = null
+                restoreInputFocusAfterPicker()
             }
-            pendingUploadTask = null
-            restoreInputFocusAfterPicker()
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1006,10 +1006,14 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val bottomRow = findViewById<View?>(R.id.inputModeWidgetBottomRow) ?: return
         val suppress = nativeInputState?.shouldSuppressBottomRow() == true
         val visible = isChatTabSelected() &&
-            (inputField.hasFocus() || previewEnterFocus || isContextualWidget || isEditWidget) &&
+            (inputField.hasFocus() || previewEnterFocus || showForUnfocusedContextual() || isEditWidget) &&
             !isStreaming &&
             !suppress
         bottomRow.visibility = if (visible) VISIBLE else GONE
+    }
+
+    private fun showForUnfocusedContextual(): Boolean {
+        return isContextualWidget && !duckChatInternal.isContextualSheetRedesignEnabled()
     }
 
     /**


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462763415876/task/1217854028451102?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Fixed a crash (`CalledFromWrongThreadException`) when taking a photo from the contextual Duck.ai entry dialog — the media-capture launcher delivers its result on a background thread, so the result handler (input focus restore and the WebView ValueCallback) now runs on the main thread.

### Steps to test this PR

- [x] Open contextual sheet and select the attachment button (lower left)
- [x] Attach photo via Take Photo
- [x] Verify photo is attached and keyboard and input is still shown
- [x] Remove attached photo
- [x] Attach photo via Add Image
- [x] Verify photo is attached and keyboard and input is still shown
- [x] Remove attached photo
- [x] Attach file
- [x] Verify file is attached and keyboard and input is still shown


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thread-safety fix for media capture callbacks plus a feature-flag-scoped UI visibility tweak; no auth or data-path changes.
> 
> **Overview**
> Fixes a **crash when taking a photo** from the contextual Duck.ai entry dialog: the external camera launcher can deliver its result off the main thread, so the handler now runs inside `lifecycleScope.launch` before invoking the WebView `ValueCallback`, showing snackbars, clearing `pendingUploadTask`, and restoring input focus.
> 
> Separately, the native input **bottom row** (attachments, etc.) stays visible on the **legacy** contextual sheet when the field is unfocused—gated by `showForUnfocusedContextual()` so the behavior does not apply when the contextual sheet redesign flag is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38b659edd3114ba468b44a7f36f7251e8b1a6399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->