### PR TITLE
Contextual/UnifiedInput: Add unfocused state in chat in progress

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1006,10 +1006,14 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val bottomRow = findViewById<View?>(R.id.inputModeWidgetBottomRow) ?: return
         val suppress = nativeInputState?.shouldSuppressBottomRow() == true
         val visible = isChatTabSelected() &&
-            (inputField.hasFocus() || previewEnterFocus || isContextualWidget || isEditWidget) &&
+            (inputField.hasFocus() || previewEnterFocus || showForUnfocusedContextual() || isEditWidget) &&
             !isStreaming &&
             !suppress
         bottomRow.visibility = if (visible) VISIBLE else GONE
+    }
+
+    private fun showForUnfocusedContextual(): Boolean {
+        return isContextualWidget && !duckChatInternal.isContextualSheetRedesignEnabled()
     }
 
     /**


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462763415876/task/1217712426296197?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Unfocused state for the contextual sheet under the redesign: the input widget's bottom row is now hidden for an unfocused contextual widget when the redesign is enabled (still shown in the legacy flow), via the new showForUnfocusedContextual() gate.

### Steps to test this PR

_contextualSheetRedesign ON (default Internal)_
- [x] Open contextual sheet > Ask About Page
- [x] Verify that affordances are visible (all bottom row buttons)
- [x] Submit a prompt
- [x] Verify that while streaming and after it completes, it shows the unfocused state
- [x] Click on the input
- [x] Verify Verify that affordances are visible (all bottom row buttons)

_contextualSheetRedesign OFF (default Internal)_
- [x] Disable FF via FF inventory
- [x] Open contextual sheet on a new tab
- [x] Verify that affordances are visible (all bottom row buttons)
- [x] Submit a prompt
- [x] Verify that while streaming and after it completes, it shows the full state and affordances are visible.
- [x] Click on the input
- [x] Verify that affordances are still visible (all bottom row buttons)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI visibility change in the native input widget, scoped to contextual sheet and gated by an existing internal feature flag.
> 
> **Overview**
> **Contextual sheet bottom row** visibility when the input is unfocused now depends on the **contextual sheet redesign** flag instead of always treating contextual widgets like focused ones.
> 
> `updateBottomRowVisibility()` no longer uses bare `isContextualWidget` to keep affordances visible without focus. It calls **`showForUnfocusedContextual()`**, which returns true only for the **legacy** flow (`isContextualWidget` and redesign **disabled**). With redesign **on** (default internal), an unfocused contextual composer hides the bottom row during and after streaming until the user focuses the field again—matching the new unfocused “chat in progress” state. Edit mode and focus/preview paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bba89d96440b17c571ac2c405554b3fd68d6089f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->