### PR TITLE
Add Compose skeleton loading placeholders to ADS

### DIFF
--- a/android-design-system/design-system-internal/build.gradle
+++ b/android-design-system/design-system-internal/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation "androidx.datastore:datastore-preferences:_"
 
     implementation "com.airbnb.android:lottie-compose:_"
+    implementation "com.facebook.shimmer:shimmer:_"
 
     implementation AndroidX.activity.compose
     implementation AndroidX.appCompat

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/Component.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/Component.kt
@@ -47,4 +47,5 @@ enum class Component {
     SETTINGS_LIST_ITEM,
     SECTION_DIVIDER,
     PROGRESS_SPINNER,
+    SKELETON,
 }

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentOtherFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentOtherFragment.kt
@@ -18,6 +18,6 @@ package com.duckduckgo.common.ui.internal.ui.component
 
 class ComponentOtherFragment : ComponentFragment() {
     override fun getComponents(): List<Component> {
-        return listOf(Component.SECTION_DIVIDER, Component.PROGRESS_SPINNER)
+        return listOf(Component.SECTION_DIVIDER, Component.PROGRESS_SPINNER, Component.SKELETON)
     }
 }

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
@@ -89,6 +89,8 @@ import com.duckduckgo.common.ui.compose.panel.DaxAlertPanel
 import com.duckduckgo.common.ui.compose.panel.DaxInfoPanel
 import com.duckduckgo.common.ui.compose.progress.DaxProgressSpinner
 import com.duckduckgo.common.ui.compose.radiobutton.DaxRadioButton
+import com.duckduckgo.common.ui.compose.skeleton.DaxSkeletonListItem
+import com.duckduckgo.common.ui.compose.skeleton.DaxSkeletonSectionHeader
 import com.duckduckgo.common.ui.compose.snackbar.DaxSnackbar
 import com.duckduckgo.common.ui.compose.switch.DaxSwitch
 import com.duckduckgo.common.ui.compose.text.DaxText
@@ -938,6 +940,27 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
         }
     }
 
+    class SkeletonComponentViewHolder(
+        parent: ViewGroup,
+        private val isDarkTheme: Boolean,
+    ) : ComponentViewHolder(inflate(parent, R.layout.component_skeleton)) {
+        override fun bind(component: Component) {
+            view.setupThemedComposeView(id = R.id.compose_dax_skeleton_list_item, isDarkTheme = isDarkTheme) {
+                Column {
+                    DaxSkeletonListItem()
+                    DaxSkeletonListItem(hasTwoLines = true)
+                    DaxSkeletonListItem(hasLeadingIcon = false)
+                }
+            }
+            view.setupThemedComposeView(id = R.id.compose_dax_skeleton_section_header, isDarkTheme = isDarkTheme) {
+                Column {
+                    DaxSkeletonSectionHeader()
+                    DaxSkeletonSectionHeader(hasTrailingIcon = true)
+                }
+            }
+        }
+    }
+
     class ScaffoldComponentViewHolder(
         parent: ViewGroup,
         private val isDarkTheme: Boolean,
@@ -1026,6 +1049,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 Component.TWO_LINE_LIST_ITEM -> TwoLineItemComponentViewHolder(parent, isDarkTheme)
                 Component.SECTION_DIVIDER -> DividerComponentViewHolder(parent, isDarkTheme)
                 Component.PROGRESS_SPINNER -> ProgressSpinnerComponentViewHolder(parent, isDarkTheme)
+                Component.SKELETON -> SkeletonComponentViewHolder(parent, isDarkTheme)
                 Component.CARD -> CardComponentViewHolder(parent, isDarkTheme)
                 Component.SCAFFOLD -> ScaffoldComponentViewHolder(parent, isDarkTheme)
                 Component.SETTINGS_LIST_ITEM -> SettingsListItemComponentViewHolder(parent, isDarkTheme)

--- a/android-design-system/design-system-internal/src/main/res/layout/component_skeleton.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/component_skeleton.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingTop="@dimen/keyline_5"
+    android:paddingEnd="@dimen/keyline_4"
+    android:paddingBottom="@dimen/keyline_5">
+
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="View SkeletonView in a ShimmerFrameLayout" />
+
+    <com.facebook.shimmer.ShimmerFrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/keyline_4">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <com.duckduckgo.common.ui.view.SkeletonView
+                android:layout_width="40dp"
+                android:layout_height="40dp" />
+
+            <com.duckduckgo.common.ui.view.SkeletonView
+                android:layout_width="match_parent"
+                android:layout_height="16dp"
+                android:layout_marginStart="@dimen/keyline_4" />
+        </LinearLayout>
+    </com.facebook.shimmer.ShimmerFrameLayout>
+
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/keyline_5"
+        app:primaryText="Compose DaxSkeletonListItem, 1 line, 2 lines, no leading icon" />
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_dax_skeleton_list_item"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/keyline_5"
+        app:primaryText="Compose DaxSkeletonSectionHeader, with and without trailing icon" />
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_dax_skeleton_section_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/listitem/DaxListItem.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/listitem/DaxListItem.kt
@@ -21,14 +21,9 @@ package com.duckduckgo.common.ui.compose.listitem
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
@@ -119,55 +114,36 @@ internal fun DaxListItem(
     }
     val leadingScope = DaxListItemLeadingScope(enabled)
     val trailingScope = DaxListItemTrailingScope(enabled)
+    val contentAlpha = if (enabled) 1f else DaxListItemDefaults.DisabledAlpha
 
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .then(interaction)
-            .heightIn(min = rowMinHeight)
-            .padding(start = HorizontalPadding),
-        verticalAlignment = Alignment.CenterVertically,
+    DaxListItemLayout(
+        minHeight = rowMinHeight,
+        modifier = modifier.then(interaction),
+        leadingContent = leadingContent?.let { slot -> { leadingScope.slot() } },
+        trailingContent = trailingContent?.let { slot -> { trailingScope.slot() } },
     ) {
-        if (leadingContent != null) {
-            leadingScope.leadingContent()
-            Spacer(Modifier.width(DaxListItemDefaults.LeadingGap))
-        }
-
-        Column(
-            verticalArrangement = Arrangement.spacedBy(DaxListItemDefaults.TextSpacing),
-            modifier = Modifier
-                .weight(1f)
-                .alpha(if (enabled) 1f else DaxListItemDefaults.DisabledAlpha),
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                DaxText(
-                    text = primaryText,
-                    style = DuckDuckGoTheme.typography.body1,
-                    color = primaryTextColor,
-                    maxLines = primaryMaxLines,
-                    modifier = Modifier.weight(1f, fill = false),
-                )
-                if (inlineContent != null) {
-                    Spacer(Modifier.width(DaxListItemDefaults.PillGap))
-                    DaxListItemInlineScope.inlineContent()
-                }
-            }
-
-            if (secondaryText != null) {
-                DaxText(
-                    text = secondaryText,
-                    style = DuckDuckGoTheme.typography.body2,
-                    color = secondaryTextColor,
-                    maxLines = secondaryMaxLines,
-                )
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.alpha(contentAlpha)) {
+            DaxText(
+                text = primaryText,
+                style = DuckDuckGoTheme.typography.body1,
+                color = primaryTextColor,
+                maxLines = primaryMaxLines,
+                modifier = Modifier.weight(1f, fill = false),
+            )
+            if (inlineContent != null) {
+                Spacer(Modifier.width(DaxListItemDefaults.PillGap))
+                DaxListItemInlineScope.inlineContent()
             }
         }
 
-        if (trailingContent != null) {
-            Spacer(Modifier.width(DaxListItemDefaults.TrailingGap))
-            trailingScope.trailingContent()
-        } else {
-            Spacer(Modifier.width(HorizontalPadding))
+        if (secondaryText != null) {
+            DaxText(
+                text = secondaryText,
+                style = DuckDuckGoTheme.typography.body2,
+                color = secondaryTextColor,
+                maxLines = secondaryMaxLines,
+                modifier = Modifier.alpha(contentAlpha),
+            )
         }
     }
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/listitem/DaxListItemLayout.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/listitem/DaxListItemLayout.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.listitem
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+
+/**
+ * Content-agnostic row/column arrangement shared by [DaxListItem] and the design system's
+ * skeleton placeholders: paddings, gaps and the leading/content/trailing split, with no knowledge
+ * of text, colour, enabled state or click handling.
+ *
+ * @param minHeight Minimum row height. Callers derive this from their own content since a
+ * content-free shell has nothing to derive it from.
+ * @param modifier Modifier applied to the outer row.
+ * @param contentSpacing Vertical gap between children inside [content].
+ * @param leadingContent Optional leading slot, followed by [DaxListItemDefaults.LeadingGap] when present.
+ * @param trailingContent Optional trailing slot, preceded by [DaxListItemDefaults.TrailingGap] when present.
+ * @param trailingSpacerWidth Width of the spacer reserved at the row's end when [trailingContent] is `null`.
+ * @param content The middle, weighted column slot.
+ */
+@Composable
+internal fun DaxListItemLayout(
+    minHeight: Dp,
+    modifier: Modifier = Modifier,
+    contentSpacing: Dp = DaxListItemDefaults.TextSpacing,
+    leadingContent: (@Composable () -> Unit)? = null,
+    trailingContent: (@Composable () -> Unit)? = null,
+    trailingSpacerWidth: Dp = DaxListItemDefaults.HorizontalPadding,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(min = minHeight)
+            .padding(start = DaxListItemDefaults.HorizontalPadding),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (leadingContent != null) {
+            leadingContent()
+            Spacer(Modifier.width(DaxListItemDefaults.LeadingGap))
+        }
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(contentSpacing),
+            modifier = Modifier.weight(1f),
+            content = content,
+        )
+
+        if (trailingContent != null) {
+            Spacer(Modifier.width(DaxListItemDefaults.TrailingGap))
+            trailingContent()
+        } else {
+            Spacer(Modifier.width(trailingSpacerWidth))
+        }
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeleton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeleton.kt
@@ -111,9 +111,10 @@ private fun DaxSkeletonShape(
         modifier = modifier
             .clip(shape)
             .drawWithCache {
-                val tilt = size.height * tan(DaxSkeletonDefaults.SweepTiltRadians)
                 val sweepWidth = max(size.width, DaxSkeletonDefaults.MinSweepWidth.toPx())
-                val travel = size.width + sweepWidth + tilt
+                val clearance = size.height * tan(DaxSkeletonDefaults.SweepTiltRadians)
+                val bandTiltDy = sweepWidth * tan(DaxSkeletonDefaults.SweepTiltRadians)
+                val travel = size.width + sweepWidth + clearance
                 onDrawBehind {
                     val sweepStart = -sweepWidth + travel * progress
                     val brush = Brush.linearGradient(
@@ -123,7 +124,7 @@ private fun DaxSkeletonShape(
                             1f to restingColor,
                         ),
                         start = Offset(sweepStart, 0f),
-                        end = Offset(sweepStart + sweepWidth, tilt),
+                        end = Offset(sweepStart + sweepWidth, bandTiltDy),
                     )
                     drawRect(brush)
                 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeleton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeleton.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.skeleton
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.keyframes
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.tools.PreviewBox
+import kotlin.math.max
+import kotlin.math.tan
+
+@Composable
+internal fun DaxSkeletonLine(
+    modifier: Modifier = Modifier,
+    animated: Boolean = true,
+) {
+    DaxSkeletonShape(
+        modifier = Modifier
+            .height(DaxSkeletonDefaults.LineHeight)
+            .then(modifier),
+        shape = DuckDuckGoTheme.shapes.medium,
+        animated = animated,
+    )
+}
+
+@Composable
+internal fun DaxSkeletonCircle(
+    modifier: Modifier = Modifier,
+    size: Dp = DaxSkeletonDefaults.CircleSize,
+    animated: Boolean = true,
+) {
+    DaxSkeletonShape(
+        modifier = Modifier
+            .size(size)
+            .then(modifier),
+        shape = CircleShape,
+        animated = animated,
+    )
+}
+
+@Composable
+private fun DaxSkeletonShape(
+    shape: Shape,
+    animated: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val baseColor = DaxSkeletonDefaults.color
+    val restingColor = baseColor.copy(alpha = baseColor.alpha * DaxSkeletonDefaults.RestingAlpha)
+
+    val progress = if (animated) {
+        val transition = rememberInfiniteTransition(label = "DaxSkeletonShimmer")
+        val animatedProgress by transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = keyframes {
+                    durationMillis = DaxSkeletonDefaults.SweepDurationMillis + DaxSkeletonDefaults.SweepDelayMillis
+                    0f at 0 using LinearEasing
+                    1f at DaxSkeletonDefaults.SweepDurationMillis
+                },
+            ),
+            label = "DaxSkeletonShimmerProgress",
+        )
+        animatedProgress
+    } else {
+        DaxSkeletonDefaults.RestingProgress
+    }
+
+    Box(
+        modifier = modifier
+            .clip(shape)
+            .drawWithCache {
+                val tilt = size.height * tan(DaxSkeletonDefaults.SweepTiltRadians)
+                val sweepWidth = max(size.width, DaxSkeletonDefaults.MinSweepWidth.toPx())
+                val travel = size.width + sweepWidth + tilt
+                onDrawBehind {
+                    val sweepStart = -sweepWidth + travel * progress
+                    val brush = Brush.linearGradient(
+                        colorStops = arrayOf(
+                            0f to restingColor,
+                            0.5f to baseColor,
+                            1f to restingColor,
+                        ),
+                        start = Offset(sweepStart, 0f),
+                        end = Offset(sweepStart + sweepWidth, tilt),
+                    )
+                    drawRect(brush)
+                }
+            }
+            .clearAndSetSemantics { },
+    )
+}
+
+internal object DaxSkeletonDefaults {
+    val LineHeight: Dp = 16.dp
+    val CircleSize: Dp = 40.dp
+    const val SweepDurationMillis: Int = 500
+    const val SweepDelayMillis: Int = 500
+    const val RestingAlpha: Float = 0.3f
+    const val RestingProgress: Float = 0.5f
+    val SweepTiltRadians: Float = Math.toRadians(20.0).toFloat()
+    val MinSweepWidth: Dp = 160.dp
+
+    val color: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = DuckDuckGoTheme.colors.system.lines
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxSkeletonPreview() {
+    PreviewBox {
+        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                DaxSkeletonCircle()
+                DaxSkeletonLine(modifier = Modifier.fillMaxWidth())
+            }
+            DaxSkeletonCircle(size = 16.dp)
+            DaxSkeletonLine(modifier = Modifier.width(120.dp))
+        }
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeleton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeleton.kt
@@ -59,9 +59,7 @@ internal fun DaxSkeletonLine(
     modifier: Modifier = Modifier,
 ) {
     DaxSkeletonShape(
-        modifier = Modifier
-            .height(DaxSkeletonDefaults.LineHeight)
-            .then(modifier),
+        modifier = modifier.height(DaxSkeletonDefaults.LineHeight),
         shape = DuckDuckGoTheme.shapes.medium,
     )
 }
@@ -72,9 +70,7 @@ internal fun DaxSkeletonCircle(
     size: Dp = DaxSkeletonDefaults.CircleSize,
 ) {
     DaxSkeletonShape(
-        modifier = Modifier
-            .size(size)
-            .then(modifier),
+        modifier = modifier.size(size),
         shape = CircleShape,
     )
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeleton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeleton.kt
@@ -21,6 +21,7 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -35,32 +36,33 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
-import kotlin.math.max
+import kotlin.math.cos
+import kotlin.math.sin
 import kotlin.math.tan
 
 @Composable
 internal fun DaxSkeletonLine(
     modifier: Modifier = Modifier,
-    animated: Boolean = true,
 ) {
     DaxSkeletonShape(
         modifier = Modifier
             .height(DaxSkeletonDefaults.LineHeight)
             .then(modifier),
         shape = DuckDuckGoTheme.shapes.medium,
-        animated = animated,
     )
 }
 
@@ -68,26 +70,30 @@ internal fun DaxSkeletonLine(
 internal fun DaxSkeletonCircle(
     modifier: Modifier = Modifier,
     size: Dp = DaxSkeletonDefaults.CircleSize,
-    animated: Boolean = true,
 ) {
     DaxSkeletonShape(
         modifier = Modifier
             .size(size)
             .then(modifier),
         shape = CircleShape,
-        animated = animated,
     )
 }
 
 @Composable
 private fun DaxSkeletonShape(
     shape: Shape,
-    animated: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val baseColor = DaxSkeletonDefaults.color
-    val restingColor = baseColor.copy(alpha = baseColor.alpha * DaxSkeletonDefaults.RestingAlpha)
+    Box(
+        modifier = modifier
+            .background(color = DaxSkeletonDefaults.color, shape = shape)
+            .clearAndSetSemantics { },
+    )
+}
 
+/** Applies one shimmer phase and coordinate system to every skeleton shape in this subtree. */
+@Composable
+internal fun Modifier.daxSkeletonShimmer(animated: Boolean): Modifier {
     val progress = if (animated) {
         val transition = rememberInfiniteTransition(label = "DaxSkeletonShimmer")
         val animatedProgress by transition.animateFloat(
@@ -107,41 +113,53 @@ private fun DaxSkeletonShape(
         DaxSkeletonDefaults.RestingProgress
     }
 
-    Box(
-        modifier = modifier
-            .clip(shape)
-            .drawWithCache {
-                val sweepWidth = max(size.width, DaxSkeletonDefaults.MinSweepWidth.toPx())
-                val clearance = size.height * tan(DaxSkeletonDefaults.SweepTiltRadians)
-                val bandTiltDy = sweepWidth * tan(DaxSkeletonDefaults.SweepTiltRadians)
-                val travel = size.width + sweepWidth + clearance
-                onDrawBehind {
-                    val sweepStart = -sweepWidth + travel * progress
-                    val brush = Brush.linearGradient(
-                        colorStops = arrayOf(
-                            0f to restingColor,
-                            0.5f to baseColor,
-                            1f to restingColor,
-                        ),
-                        start = Offset(sweepStart, 0f),
-                        end = Offset(sweepStart + sweepWidth, bandTiltDy),
-                    )
-                    drawRect(brush)
-                }
-            }
-            .clearAndSetSemantics { },
-    )
+    return graphicsLayer {
+        compositingStrategy = CompositingStrategy.Offscreen
+    }.drawWithContent {
+        drawContent()
+
+        val tilt = DaxSkeletonDefaults.SweepTiltRadians
+        val tiltCos = cos(tilt)
+        val tiltSin = sin(tilt)
+        val centerX = size.width / 2f
+        val centerY = size.height / 2f
+        val travel = size.width + tan(tilt) * size.height
+        val translationX = -travel + 2f * travel * progress
+        val gradientStart = Offset(
+            x = centerX * (1f - tiltCos) + centerY * tiltSin + translationX,
+            y = centerY * (1f - tiltCos) - centerX * tiltSin,
+        )
+        val gradientEnd = Offset(
+            x = centerX * (1f + tiltCos) + centerY * tiltSin + translationX,
+            y = centerY * (1f - tiltCos) + centerX * tiltSin,
+        )
+        val restingMask = Color.White.copy(alpha = DaxSkeletonDefaults.RestingAlpha)
+        val brush = Brush.linearGradient(
+            colorStops = arrayOf(
+                DaxSkeletonDefaults.BaseMaskStart to restingMask,
+                DaxSkeletonDefaults.HighlightMaskStart to Color.White,
+                DaxSkeletonDefaults.HighlightMaskEnd to Color.White,
+                DaxSkeletonDefaults.BaseMaskEnd to restingMask,
+            ),
+            start = gradientStart,
+            end = gradientEnd,
+        )
+        drawRect(brush = brush, blendMode = BlendMode.DstIn)
+    }
 }
 
 internal object DaxSkeletonDefaults {
     val LineHeight: Dp = 16.dp
     val CircleSize: Dp = 40.dp
-    const val SweepDurationMillis: Int = 500
-    const val SweepDelayMillis: Int = 500
+    const val SweepDurationMillis: Int = 1000
+    const val SweepDelayMillis: Int = 0
     const val RestingAlpha: Float = 0.3f
     const val RestingProgress: Float = 0.5f
+    const val BaseMaskStart: Float = 0.25f
+    const val HighlightMaskStart: Float = 0.4995f
+    const val HighlightMaskEnd: Float = 0.5005f
+    const val BaseMaskEnd: Float = 0.75f
     val SweepTiltRadians: Float = Math.toRadians(20.0).toFloat()
-    val MinSweepWidth: Dp = 160.dp
 
     val color: Color
         @Composable
@@ -153,7 +171,10 @@ internal object DaxSkeletonDefaults {
 @Composable
 private fun DaxSkeletonPreview() {
     PreviewBox {
-        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Column(
+            modifier = Modifier.daxSkeletonShimmer(animated = true),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeletonListItem.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeletonListItem.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.skeleton
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.duckduckgo.common.ui.compose.tools.PreviewBox
+
+/**
+ * DuckDuckGo design system loading skeleton shaped like a [com.duckduckgo.common.ui.compose.listitem.DaxOneLineListItem]
+ * / [com.duckduckgo.common.ui.compose.listitem.DaxTwoLineListItem] row.
+ *
+ * @param modifier the [Modifier] to apply.
+ * @param hasLeadingIcon whether to show the leading circular placeholder. Defaults to `true`.
+ * @param hasTwoLines whether to show a shorter secondary line under the primary one. Defaults to `false`.
+ * @param animated whether the shimmer sweep animates. Set to `false` for static previews or to respect reduced motion.
+ *
+ * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1217882625977300?focus=true
+ * Figma reference: https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?node-id=6032-13775&m=dev
+ */
+@Composable
+fun DaxSkeletonListItem(
+    modifier: Modifier = Modifier,
+    hasLeadingIcon: Boolean = true,
+    hasTwoLines: Boolean = false,
+    animated: Boolean = true,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                start = DaxSkeletonListItemDefaults.PaddingStart,
+                end = DaxSkeletonListItemDefaults.PaddingEnd,
+                top = DaxSkeletonListItemDefaults.PaddingVertical,
+                bottom = DaxSkeletonListItemDefaults.PaddingVertical,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(DaxSkeletonListItemDefaults.LeadingToLineGap),
+    ) {
+        if (hasLeadingIcon) {
+            DaxSkeletonCircle(animated = animated)
+        }
+        if (hasTwoLines) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(DaxSkeletonListItemDefaults.LineGap),
+            ) {
+                DaxSkeletonLine(modifier = Modifier.fillMaxWidth(), animated = animated)
+                DaxSkeletonLine(
+                    modifier = Modifier.fillMaxWidth(DaxSkeletonListItemDefaults.SecondaryLineWidthFraction),
+                    animated = animated,
+                )
+            }
+        } else {
+            DaxSkeletonLine(modifier = Modifier.weight(1f), animated = animated)
+        }
+    }
+}
+
+internal object DaxSkeletonListItemDefaults {
+    val PaddingStart: Dp = 16.dp
+    val PaddingEnd: Dp = 64.dp
+    val PaddingVertical: Dp = 8.dp
+    val LeadingToLineGap: Dp = 16.dp
+    val LineGap: Dp = 4.dp
+    const val SecondaryLineWidthFraction: Float = 0.5f
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxSkeletonListItemPreview() {
+    PreviewBox {
+        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            DaxSkeletonListItem()
+            DaxSkeletonListItem(hasTwoLines = true)
+            DaxSkeletonListItem(hasLeadingIcon = false)
+        }
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeletonListItem.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeletonListItem.kt
@@ -18,15 +18,15 @@ package com.duckduckgo.common.ui.compose.skeleton
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.takeOrElse
+import com.duckduckgo.common.ui.compose.listitem.DaxListItemDefaults
+import com.duckduckgo.common.ui.compose.listitem.DaxListItemLayout
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 
 /**
@@ -48,43 +48,30 @@ fun DaxSkeletonListItem(
     hasTwoLines: Boolean = false,
     animated: Boolean = true,
 ) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(
-                start = DaxSkeletonListItemDefaults.PaddingStart,
-                end = DaxSkeletonListItemDefaults.PaddingEnd,
-                top = DaxSkeletonListItemDefaults.PaddingVertical,
-                bottom = DaxSkeletonListItemDefaults.PaddingVertical,
-            ),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(DaxSkeletonListItemDefaults.LeadingToLineGap),
+    val rowMinHeight = when {
+        hasTwoLines -> DaxListItemDefaults.TwoLineMinHeight
+        hasLeadingIcon -> DaxListItemDefaults.OneLineWithIconMinHeight
+        else -> DaxListItemDefaults.OneLineMinHeight
+    }
+    DaxListItemLayout(
+        minHeight = rowMinHeight,
+        modifier = modifier,
+        contentSpacing = DaxSkeletonListItemDefaults.LineGap,
+        leadingContent = if (hasLeadingIcon) { { DaxSkeletonCircle(animated = animated) } } else null,
+        trailingSpacerWidth = DaxSkeletonListItemDefaults.PaddingEnd,
     ) {
-        if (hasLeadingIcon) {
-            DaxSkeletonCircle(animated = animated)
-        }
+        DaxSkeletonLine(modifier = Modifier.fillMaxWidth(), animated = animated)
         if (hasTwoLines) {
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(DaxSkeletonListItemDefaults.LineGap),
-            ) {
-                DaxSkeletonLine(modifier = Modifier.fillMaxWidth(), animated = animated)
-                DaxSkeletonLine(
-                    modifier = Modifier.fillMaxWidth(DaxSkeletonListItemDefaults.SecondaryLineWidthFraction),
-                    animated = animated,
-                )
-            }
-        } else {
-            DaxSkeletonLine(modifier = Modifier.weight(1f), animated = animated)
+            DaxSkeletonLine(
+                modifier = Modifier.fillMaxWidth(DaxSkeletonListItemDefaults.SecondaryLineWidthFraction),
+                animated = animated,
+            )
         }
     }
 }
 
 internal object DaxSkeletonListItemDefaults {
-    val PaddingStart: Dp = 16.dp
     val PaddingEnd: Dp = 64.dp
-    val PaddingVertical: Dp = 8.dp
-    val LeadingToLineGap: Dp = 16.dp
     val LineGap: Dp = 4.dp
     const val SecondaryLineWidthFraction: Float = 0.5f
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeletonListItem.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeletonListItem.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.takeOrElse
 import com.duckduckgo.common.ui.compose.listitem.DaxListItemDefaults
 import com.duckduckgo.common.ui.compose.listitem.DaxListItemLayout
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
@@ -55,16 +54,15 @@ fun DaxSkeletonListItem(
     }
     DaxListItemLayout(
         minHeight = rowMinHeight,
-        modifier = modifier,
+        modifier = modifier.daxSkeletonShimmer(animated),
         contentSpacing = DaxSkeletonListItemDefaults.LineGap,
-        leadingContent = if (hasLeadingIcon) { { DaxSkeletonCircle(animated = animated) } } else null,
+        leadingContent = if (hasLeadingIcon) { { DaxSkeletonCircle() } } else null,
         trailingSpacerWidth = DaxSkeletonListItemDefaults.PaddingEnd,
     ) {
-        DaxSkeletonLine(modifier = Modifier.fillMaxWidth(), animated = animated)
+        DaxSkeletonLine(modifier = Modifier.fillMaxWidth())
         if (hasTwoLines) {
             DaxSkeletonLine(
                 modifier = Modifier.fillMaxWidth(DaxSkeletonListItemDefaults.SecondaryLineWidthFraction),
-                animated = animated,
             )
         }
     }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeletonSectionHeader.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeletonSectionHeader.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.skeleton
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.duckduckgo.common.ui.compose.tools.PreviewBox
+
+/**
+ * DuckDuckGo design system loading skeleton shaped like a section header row
+ * (see the xml [com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem]).
+ *
+ * @param modifier the [Modifier] to apply.
+ * @param hasTrailingIcon whether to show a trailing circular icon placeholder. Defaults to `false`.
+ * @param animated whether the shimmer sweep animates. Set to `false` for static previews or to respect reduced motion.
+ *
+ * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1217882625977300?focus=true
+ * Figma reference: https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?node-id=6032-13775&m=dev
+ */
+@Composable
+fun DaxSkeletonSectionHeader(
+    modifier: Modifier = Modifier,
+    hasTrailingIcon: Boolean = false,
+    animated: Boolean = true,
+) {
+    val verticalPadding = if (hasTrailingIcon) {
+        DaxSkeletonSectionHeaderDefaults.PaddingVerticalWithTrailingIcon
+    } else {
+        DaxSkeletonSectionHeaderDefaults.PaddingVerticalNoTrailingIcon
+    }
+    val lineWidthFraction = if (hasTrailingIcon) {
+        DaxSkeletonSectionHeaderDefaults.LineWidthFractionWithTrailingIcon
+    } else {
+        DaxSkeletonSectionHeaderDefaults.LineWidthFractionNoTrailingIcon
+    }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = DaxSkeletonSectionHeaderDefaults.PaddingHorizontal, vertical = verticalPadding),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        DaxSkeletonLine(modifier = Modifier.fillMaxWidth(lineWidthFraction), animated = animated)
+        if (hasTrailingIcon) {
+            DaxSkeletonCircle(size = DaxSkeletonSectionHeaderDefaults.TrailingIconSize, animated = animated)
+        }
+    }
+}
+
+internal object DaxSkeletonSectionHeaderDefaults {
+    val PaddingHorizontal: Dp = 16.dp
+    val PaddingVerticalWithTrailingIcon: Dp = 12.dp
+    val PaddingVerticalNoTrailingIcon: Dp = 14.dp
+    const val LineWidthFractionWithTrailingIcon: Float = 0.5f
+    const val LineWidthFractionNoTrailingIcon: Float = 1f / 3f
+    val TrailingIconSize: Dp = 16.dp
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxSkeletonSectionHeaderPreview() {
+    PreviewBox {
+        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            DaxSkeletonSectionHeader()
+            DaxSkeletonSectionHeader(hasTrailingIcon = true)
+        }
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeletonSectionHeader.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/skeleton/DaxSkeletonSectionHeader.kt
@@ -59,14 +59,15 @@ fun DaxSkeletonSectionHeader(
 
     Row(
         modifier = modifier
+            .daxSkeletonShimmer(animated)
             .fillMaxWidth()
             .padding(horizontal = DaxSkeletonSectionHeaderDefaults.PaddingHorizontal, vertical = verticalPadding),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        DaxSkeletonLine(modifier = Modifier.fillMaxWidth(lineWidthFraction), animated = animated)
+        DaxSkeletonLine(modifier = Modifier.fillMaxWidth(lineWidthFraction))
         if (hasTrailingIcon) {
-            DaxSkeletonCircle(size = DaxSkeletonSectionHeaderDefaults.TrailingIconSize, animated = animated)
+            DaxSkeletonCircle(size = DaxSkeletonSectionHeaderDefaults.TrailingIconSize)
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1215496415658080/task/1211660489618993?focus=true

### Description

Adds `DaxSkeletonListItem` and `DaxSkeletonSectionHeader` to ADS Compose, replacing the xml `SkeletonView` + `ShimmerFrameLayout` pair with skeletons that own their own shimmer sweep.

### Steps to test this PR

> [!NOTE]
> Prerequisites:
> - [ ] Install Internal Debug.
> - [ ] Open Android Design System Preview → **OTHERS** tab → scroll to the Skeleton section.

_Happy path_

- [ ] Compare the xml `SkeletonView` + `ShimmerFrameLayout` row against the Compose `DaxSkeletonListItem` rows directly below it → confirm the shimmer look the same.
- [ ] Toggle **Enable Dark Theme** at the top of the screen → confirm both the xml and Compose skeletons render correctly in dark theme.

### UI changes

https://github.com/user-attachments/assets/08dacd20-5fac-4198-b772-d3dd2dc7a9db


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Design-system UI additions and a structural refactor of DaxListItem layout with no auth, data, or production flow changes.
> 
> **Overview**
> Adds **Compose skeleton loading placeholders** (`DaxSkeletonListItem`, `DaxSkeletonSectionHeader`) with a shared **`daxSkeletonShimmer`** sweep so loading states can match list rows and section headers without XML `SkeletonView` + `ShimmerFrameLayout`.
> 
> **`DaxListItem`** is refactored to use a new internal **`DaxListItemLayout`** so skeleton rows share the same padding, gaps, and leading/content/trailing structure as real list items.
> 
> The internal design-system preview gains a **SKELETON** component (OTHERS tab) that side-by-sides the legacy XML shimmer row with the new Compose variants; **`design-system-internal`** pulls in Facebook Shimmer only for that comparison UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0fb8f7a3cc480c79ae6dfa14fd7f54a0c1f1a6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->