### PR TITLE
Improve Exhchange V2 testing capabilities

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -104,7 +104,7 @@ interface SyncFeature {
     /**
      * Kill switch for sending the exchange channel secret as the `Authorization` header on the v2.0
      * exchange relay endpoints. Independent of [canUseExchangeV2Point1] so the header can be turned
-     * on (or off) without moving the protocol version. See [authenticateExchangeEndpoints].
+     * on (or off) without moving the protocol version.
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun canSendExchangeChannelSecret(): Toggle
@@ -156,10 +156,3 @@ interface SyncFeature {
  */
 internal fun SyncFeature.canWriteDeviceInfo(): Boolean =
     canUseV2ConnectFlow().isEnabled() && canWriteUnifiedDeviceList().isEnabled()
-
-/**
- * The v2.1 protocol requires the channel secret on every exchange relay call, so speaking v2.1 implies authenticating.
- * [SyncFeature.canSendExchangeChannelSecret] lets the header be enabled ahead of (or independently of) that version bump.
- */
-internal fun SyncFeature.authenticateExchangeEndpoints(): Boolean =
-    canSendExchangeChannelSecret().isEnabled() || canUseExchangeV2Point1().isEnabled()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/ExchangeProtocolVersion.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/ExchangeProtocolVersion.kt
@@ -17,12 +17,15 @@
 package com.duckduckgo.sync.impl.exchange
 
 sealed class ExchangeProtocolVersion : Comparable<ExchangeProtocolVersion> {
+    abstract fun prettyPrint(): String
 
     sealed class Supported : ExchangeProtocolVersion() {
         abstract val major: Int
         abstract val minor: Int
 
         final override fun toString() = if (minor == 0) "$major" else "$major.$minor"
+
+        final override fun prettyPrint() = "v$major.$minor"
     }
 
     data class V1(
@@ -49,6 +52,8 @@ sealed class ExchangeProtocolVersion : Comparable<ExchangeProtocolVersion> {
         val rawVersion: String,
     ) : ExchangeProtocolVersion() {
         override fun toString() = rawVersion
+
+        override fun prettyPrint() = "v$rawVersion"
     }
 
     override fun compareTo(other: ExchangeProtocolVersion): Int = when {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/AdvertisedExchangeV2Version.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/AdvertisedExchangeV2Version.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+/**
+ * The exchange protocol version this device offers a pairing session. Everything version-dependent
+ * (e.g. whether relay calls carry the channel-secret `Authorization` header) derives from it inside
+ * [ExchangeV2Runner], which reads it once per session, at bootstrap, so answers only take effect on
+ * the next session.
+ */
+interface AdvertisedExchangeV2Version {
+    /** The highest exchange protocol version this device advertises to peers. */
+    fun resolve(): ExchangeProtocolVersion.V2
+}
+
+@ContributesBinding(AppScope::class)
+class RealAdvertisedExchangeV2Version @Inject constructor(
+    private val syncFeature: SyncFeature,
+) : AdvertisedExchangeV2Version {
+
+    override fun resolve(): ExchangeProtocolVersion.V2 = if (syncFeature.canUseExchangeV2Point1().isEnabled()) {
+        ExchangeProtocolVersion.V2_1
+    } else {
+        ExchangeProtocolVersion.V2_0
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.sync.impl.exchange.v2
 
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.ExchangeEnvelope
+import com.duckduckgo.sync.impl.ExchangeMessageEntry
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncApi
 import com.squareup.anvil.annotations.ContributesBinding
@@ -175,7 +176,7 @@ class RealExchangeV2Channel @Inject constructor(
     }
 
     private fun decode(
-        entry: com.duckduckgo.sync.impl.ExchangeMessageEntry,
+        entry: ExchangeMessageEntry,
         ownPrivateKeyBase64: String,
     ): ExchangeV2Message {
         val inner = runCatching {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Envelope.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Envelope.kt
@@ -24,9 +24,12 @@ import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
 /**
- * Wire-level envelope wrapping for relay messages. The outer object is `{version, payload}`
- * with [version] unencrypted (used for protocol version negotiation) and [payload] a JWE
- * compact string carrying the encrypted message JSON.
+ * Wire-level envelope wrapping for relay messages, converting between an [ExchangeV2Message] and the
+ * `{version, payload}` object the relay carries.
+ *
+ * [ExchangeEnvelope.version] travels unencrypted, so a peer can tell whether it can read an envelope
+ * before trying to; [ExchangeEnvelope.payload] is a JWE compact string carrying the encrypted
+ * message JSON. The relay sees only the version, never the message.
  *
  * Spec: Transport TD (Asana 1214486492252757) §Message Envelope + §Encryption.
  *  - alg = RSA-OAEP-256 (wraps an ephemeral A256GCM key)
@@ -43,8 +46,11 @@ interface ExchangeV2Envelope {
 
     /**
      * Decrypt an inbound envelope with our ephemeral private key, returning the inner message JSON.
+     * Parsing that JSON into a message is [ExchangeV2MessageParser]'s job, not this one's.
      *
      * @throws EnvelopeVersionTooNew if the envelope's major version is higher than ours.
+     * @throws IllegalArgumentException if the version is malformed, or is a v1 envelope on a v2
+     *  channel, neither of which a peer following the spec can produce.
      */
     fun open(envelope: ExchangeEnvelope, ownPrivateKeyBase64: String): String
 }
@@ -55,8 +61,9 @@ class EnvelopeVersionTooNew(val version: ExchangeProtocolVersion) : RuntimeExcep
 )
 
 /**
- * Thrown when an envelope's payload can't be decrypted or parsed. Permanent (the same bytes
- * fail identically on retry), so the runner treats it as terminal rather than retrying.
+ * Thrown when an envelope's payload can't be decrypted or parsed. Raised by the channel, which knows
+ * the [seq] of the entry that failed. Permanent (the same bytes fail identically on retry), so the
+ * runner treats it as terminal rather than retrying.
  */
 class EnvelopeDecryptFailure(val seq: Int, cause: Throwable) : RuntimeException(
     "Failed to decrypt envelope seq=$seq: ${cause.message}",

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Event.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Event.kt
@@ -16,15 +16,25 @@
 
 package com.duckduckgo.sync.impl.exchange.v2
 
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.pixels.SyncPixels.TimeoutStage
 
 /**
  * Observable events emitted by the v2 exchange runner. Downstream consumers
  * subscribe to the runner's event flow and react.
+ *
+ * Purely observational: the exchange runs to completion regardless of whether anyone is listening,
+ * so consumers (pixels, the pairing debug screen, UI) may drop events without affecting the protocol.
  */
 sealed interface ExchangeV2Event {
+    /** When the runner created the event, from its own clock, not when a consumer received it. */
     val timestampMs: Long
 
+    /**
+     * The state machine accepted a trigger and moved from [from] to [to]. Exactly one of [trigger] (an
+     * inbound peer message) and [localTrigger] (a user or runner decision) is set; an abort driven by a
+     * peer message arrives here rather than as [MessageRejected] whenever [from] was still active.
+     */
     data class Transition(
         override val timestampMs: Long,
         val from: ExchangeV2State,
@@ -33,11 +43,20 @@ sealed interface ExchangeV2Event {
         val localTrigger: LocalTrigger?,
     ) : ExchangeV2Event
 
+    /**
+     * [message] was accepted by the relay for delivery to the peer. Says nothing about the peer having
+     * polled it: the relay accepts messages for a channel the peer has already abandoned.
+     */
     data class MessageSent(
         override val timestampMs: Long,
         val message: ExchangeV2Message,
     ) : ExchangeV2Event
 
+    /**
+     * [message] was received but not acted on in [state]: either an unknown message type dropped to keep
+     * the session alive, or a protocol violation aborting a session already in a terminal state (an abort
+     * from an active state surfaces as a [Transition] instead). See [RejectReason].
+     */
     data class MessageRejected(
         override val timestampMs: Long,
         val message: ExchangeV2Message,
@@ -57,7 +76,9 @@ sealed interface ExchangeV2Event {
     ) : ExchangeV2Event
 
     /**
-     * A transport or protocol-level failure during bootstrap / poll / send.
+     * A transport or protocol-level failure while bootstrapping, polling, or sending. Terminal: the runner tears the
+     * session down after emitting, and emits at most one per session. [message] is developer-facing text;
+     * [kind] is the value to branch on. [timeoutStage] is set only for [SessionErrorKind.SessionTimeout].
      */
     data class SessionError(
         override val timestampMs: Long,
@@ -65,17 +86,69 @@ sealed interface ExchangeV2Event {
         val kind: SessionErrorKind = SessionErrorKind.Unknown,
         val timeoutStage: TimeoutStage? = null,
     ) : ExchangeV2Event
+
+    /**
+     * The peer's advertised protocol version became known and both sides settled on [negotiatedVersion],
+     * the lower of [ourVersion] and [peerVersion], falling back to the baseline when the peer advertises
+     * something we can't parse. Emitted once per side, at the point named by [peerSource]: the Scanner
+     * learns the version from the linking code, the Presenter from the peer's hello.
+     */
+    data class VersionNegotiated(
+        override val timestampMs: Long,
+        val peerSource: PeerVersionSource,
+        val peerVersion: ExchangeProtocolVersion,
+        val ourVersion: ExchangeProtocolVersion,
+        val negotiatedVersion: ExchangeProtocolVersion,
+    ) : ExchangeV2Event
 }
 
-enum class RejectReason { ImplicitAbort, SameAccount, UnknownMessageDropped }
+/** Why a received message was not acted on. See [ExchangeV2Event.MessageRejected]. */
+enum class RejectReason {
+    /** A known message type that the current state does not allow: a protocol violation, aborts the session. */
+    ImplicitAbort,
 
+    /** The peer turned out to be the same sync account as us, so there is nothing to pair. */
+    SameAccount,
+
+    /** An unrecognized message type, ignored so a newer peer's extra messages can't kill the session. */
+    UnknownMessageDropped,
+}
+
+/**
+ * What went wrong in a [ExchangeV2Event.SessionError], as a bounded value consumers can branch on.
+ * Mapped to sync pixel error codes, so treat the entries as part of the telemetry contract.
+ */
 enum class SessionErrorKind {
+    /** No progress within the deadline for the current stage; the stage is carried in `timeoutStage`. */
     SessionTimeout,
+
+    /** A second hello arrived after negotiation had already started. */
     UnexpectedSecondHello,
+
+    /** A protocol violation that isn't covered by a more specific kind. Not currently emitted by the runner. */
     UnexpectedEvent,
+
+    /** An outbound message was attempted before the local session had the keys and channel ids it needs. */
     PairingSessionNotReady,
+
+    /** The relay could not create the channel, or reported ours or the peer's channel as gone. */
     RelayChannelUnavailable,
+
+    /** We failed to produce the recovery code to hand over, e.g. account creation failed. */
     RecoveryCodePreparationFailed,
+
+    /** The relay rejected our request as malformed. */
     MalformedRelayRequest,
+
+    /** Anything else, including generic transport failures. */
     Unknown,
+}
+
+/** Where the peer's advertised version was read from. See [ExchangeV2Event.VersionNegotiated]. */
+enum class PeerVersionSource {
+    /** Scanner side: parsed out of the linking code before any message is exchanged. */
+    LinkingCode,
+
+    /** Presenter side: taken from the peer's hello. */
+    HelloMessage,
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2MessageParser.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2MessageParser.kt
@@ -17,9 +17,18 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAvailable
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAwaitingConfirmation
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeConfirmed
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDenied
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeUnavailable
 import com.squareup.anvil.annotations.ContributesBinding
 import org.json.JSONObject
 import javax.inject.Inject
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Unknown as UnknownMessage
 
 interface ExchangeV2MessageParser {
     fun parse(rawJson: String): ExchangeV2Message
@@ -30,19 +39,19 @@ class JsonExchangeV2MessageParser @Inject constructor() : ExchangeV2MessageParse
 
     override fun parse(rawJson: String): ExchangeV2Message {
         val type = runCatching { JSONObject(rawJson).optString(ExchangeV2Message.FIELD_TYPE, "") }
-            .getOrElse { return ExchangeV2Message.Unknown.fromJson(rawJson, messageType = "") }
+            .getOrElse { return UnknownMessage.fromJson(rawJson, messageType = "") }
         return runCatching {
             when (type) {
-                ExchangeV2Message.Hello.TYPE -> ExchangeV2Message.Hello.fromJson(rawJson)
-                ExchangeV2Message.RecoveryCodeAvailable.TYPE -> ExchangeV2Message.RecoveryCodeAvailable.fromJson(rawJson)
-                ExchangeV2Message.RecoveryCodeRequest.TYPE -> ExchangeV2Message.RecoveryCodeRequest.fromJson(rawJson)
-                ExchangeV2Message.RecoveryCodeAwaitingConfirmation.TYPE -> ExchangeV2Message.RecoveryCodeAwaitingConfirmation.fromJson(rawJson)
-                ExchangeV2Message.RecoveryCodeConfirmed.TYPE -> ExchangeV2Message.RecoveryCodeConfirmed.fromJson(rawJson)
-                ExchangeV2Message.RecoveryCodeDenied.TYPE -> ExchangeV2Message.RecoveryCodeDenied.fromJson(rawJson)
-                ExchangeV2Message.RecoveryCodeUnavailable.TYPE -> ExchangeV2Message.RecoveryCodeUnavailable.fromJson(rawJson)
-                ExchangeV2Message.RecoveryCodeResponse.TYPE -> ExchangeV2Message.RecoveryCodeResponse.fromJson(rawJson)
-                else -> ExchangeV2Message.Unknown.fromJson(rawJson, messageType = type)
+                Hello.TYPE -> Hello.fromJson(rawJson)
+                RecoveryCodeAvailable.TYPE -> RecoveryCodeAvailable.fromJson(rawJson)
+                RecoveryCodeRequest.TYPE -> RecoveryCodeRequest.fromJson(rawJson)
+                RecoveryCodeAwaitingConfirmation.TYPE -> RecoveryCodeAwaitingConfirmation.fromJson(rawJson)
+                RecoveryCodeConfirmed.TYPE -> RecoveryCodeConfirmed.fromJson(rawJson)
+                RecoveryCodeDenied.TYPE -> RecoveryCodeDenied.fromJson(rawJson)
+                RecoveryCodeUnavailable.TYPE -> RecoveryCodeUnavailable.fromJson(rawJson)
+                RecoveryCodeResponse.TYPE -> RecoveryCodeResponse.fromJson(rawJson)
+                else -> UnknownMessage.fromJson(rawJson, messageType = type)
             }
-        }.getOrElse { ExchangeV2Message.Unknown.fromJson(rawJson, messageType = type) }
+        }.getOrElse { UnknownMessage.fromJson(rawJson, messageType = type) }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -54,13 +54,32 @@ import java.util.UUID
 import javax.inject.Inject
 
 /**
- * Drives a single Exchange V2 protocol session.
+ * Drives a single Exchange V2 pairing session, from the linking code to a terminal state.
  *
- * Two entry points: [startPresent] generates a v2 linking code (surfaced via [SessionStarted]);
- * [startScan] parses a peer's code and joins their session. From there the runner manages the
- * wire I/O, drives the SM, and auto-elects role per the Unified Algorithm.
+ * Two entry points open a session: [startPresent] publishes a linking code for a peer to scan,
+ * [startScan] joins the session behind a code this device scanned. Either way the runner owns
+ * everything the [ExchangeV2StateMachine] deliberately does not: the relay channel, the poll loop,
+ * the session keys, role election, the session deadline, and executing the [SideEffect]s each
+ * transition declares. The state machine decides what is allowed; the runner makes it happen.
+ *
+ * Only a single session is allowed. Opening a session abandons any session already running, and
+ * reaching a terminal state tears the current one down, so nothing outlives it.
+ *
+ * Callers observe through [events] rather than polling the getters: the session advances on the
+ * poll loop's own coroutine, so [currentState] and friends are snapshots that can change between
+ * two reads.
+ *
+ * Spec:
+ *  - Asana 1214739740392701, Unified Algorithm: role election, and the abort rules applied around
+ *    the state machine.
+ *  - Asana 1214486492252757, Transport TD: channel lifecycle, polling, and the session deadline.
  */
 interface ExchangeV2Runner {
+
+    /**
+     * Everything that happened in this runner, including sessions that have already ended: the
+     * buffer is not cleared at teardown. Scope to one session with [eventsSince].
+     */
     val events: SharedFlow<ExchangeV2Event>
 
     /**
@@ -69,11 +88,13 @@ interface ExchangeV2Runner {
      */
     fun eventsSince(sinceMs: Long): Flow<ExchangeV2Event> = events.filter { it.timestampMs >= sinceMs }
 
+    /** Where the session currently is, or null when no session is running. */
     val currentState: ExchangeV2State?
 
+    /** How this device entered the session (scanned or presented), which is not its elected [Role]. */
     val pairingRole: PairingRole?
 
-    /** Linking code URL for the Presenter side — populated after [startPresent] completes bootstrap. */
+    /** Linking code URL for the Presenter side, populated once [startPresent] has bootstrapped. */
     val linkingCode: String?
 
     /**
@@ -88,8 +109,23 @@ interface ExchangeV2Runner {
     /** Peer device's credential kind ("ddg" / "3party"), learned during role election. Null before then. */
     val peerKind: String?
 
+    /**
+     * Join the session behind a linking code this device scanned or pasted. Returns immediately;
+     * the session is only usable once [ExchangeV2Event.SessionStarted] has been emitted, and a code
+     * that doesn't parse surfaces as a [ExchangeV2Event.SessionError] rather than a thrown exception.
+     *
+     * Starts in [ExchangeV2State.Negotiating]: the code already identifies the peer, so unlike the
+     * Presenter this side has no hello to wait for.
+     */
     fun startScan(pastedUrl: String)
 
+    /**
+     * Open a session for a peer to scan and publish a linking code for it. Returns immediately; the
+     * code is on [linkingCode], and in the emitted [ExchangeV2Eve nt.SessionStarted], once bootstrap
+     * completes.
+     *
+     * Starts in [ExchangeV2State.Bootstrapped], waiting for the peer's hello.
+     */
     fun startPresent()
 
     /**
@@ -98,6 +134,11 @@ interface ExchangeV2Runner {
      */
     suspend fun cancel()
 
+    /**
+     * Drive the state machine with something that didn't come off the wire, such as the user
+     * answering a confirmation prompt. Returns immediately, and a trigger the current state does not
+     * allow aborts the session rather than being ignored.
+     */
     fun localTrigger(trigger: LocalTrigger)
 }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -22,7 +22,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncDeviceIds
 import com.duckduckgo.sync.impl.SyncFeature
-import com.duckduckgo.sync.impl.authenticateExchangeEndpoints
 import com.duckduckgo.sync.impl.crypto.RsaKeyPair
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
@@ -150,6 +149,7 @@ class RealExchangeV2Runner @Inject constructor(
     private val qrCode: ExchangeV2QrCode,
     private val recoveryCodeProvider: RecoveryCodeProvider,
     private val syncDeviceIds: SyncDeviceIds,
+    private val advertisedExchangeV2Version: AdvertisedExchangeV2Version,
     private val syncFeature: SyncFeature,
     @AppCoroutineScope private val appScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
@@ -285,7 +285,7 @@ class RealExchangeV2Runner @Inject constructor(
      * (in which case an error event was already emitted).
      */
     private fun bootstrapLocked(role: PairingRole): RsaKeyPair? {
-        advertisedVersion = if (syncFeature.canUseExchangeV2Point1().isEnabled()) ExchangeProtocolVersion.V2_1 else BASELINE_PROTOCOL_VERSION
+        advertisedVersion = advertisedExchangeV2Version.resolve()
         val keyPair = jweCrypto.generateRsaKeyPair(EXCHANGE_RSA_KEY_SIZE)
         ownKeyPair = keyPair
         repeat(MAX_CHANNEL_CREATE_RETRIES) { attempt ->
@@ -941,7 +941,8 @@ class RealExchangeV2Runner @Inject constructor(
      * a header the channel was not claimed with.
      */
     private fun generateChannelSecret(): String? {
-        if (!syncFeature.authenticateExchangeEndpoints()) return null
+        val authenticate = advertisedVersion >= ExchangeProtocolVersion.V2_1 || syncFeature.canSendExchangeChannelSecret().isEnabled()
+        if (!authenticate) return null
         return Base64.getUrlEncoder()
             .withoutPadding()
             .encodeToString(jweCrypto.generateSecureBytes(CHANNEL_SECRET_SIZE))

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -26,9 +26,6 @@ import com.duckduckgo.sync.impl.authenticateExchangeEndpoints
 import com.duckduckgo.sync.impl.crypto.RsaKeyPair
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
-import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Host
-import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner
-import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.SameAccountAbort
 import com.duckduckgo.sync.impl.pixels.SyncPixels.TimeoutStage
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
@@ -198,7 +195,6 @@ class RealExchangeV2Runner @Inject constructor(
     @Volatile private var advertisedVersion: ExchangeProtocolVersion.V2 = BASELINE_PROTOCOL_VERSION
 
     @Volatile private var negotiatedVersion: ExchangeProtocolVersion.V2 = BASELINE_PROTOCOL_VERSION
-        private set
 
     /**
      * Host-side messages arriving while the Joiner is still at the user-confirm prompt, buffered
@@ -288,7 +284,7 @@ class RealExchangeV2Runner @Inject constructor(
      * the relay channel (with 409 retry). Returns the new keypair on success, null on error
      * (in which case an error event was already emitted).
      */
-    private suspend fun bootstrapLocked(role: PairingRole): RsaKeyPair? {
+    private fun bootstrapLocked(role: PairingRole): RsaKeyPair? {
         advertisedVersion = if (syncFeature.canUseExchangeV2Point1().isEnabled()) ExchangeProtocolVersion.V2_1 else BASELINE_PROTOCOL_VERSION
         val keyPair = jweCrypto.generateRsaKeyPair(EXCHANGE_RSA_KEY_SIZE)
         ownKeyPair = keyPair
@@ -451,8 +447,8 @@ class RealExchangeV2Runner @Inject constructor(
     private fun ExchangeV2State.toTimeoutStage(): TimeoutStage? = when (this) {
         ExchangeV2State.Bootstrapped -> TimeoutStage.WAITING_FOR_PEER_HELLO
         ExchangeV2State.Negotiating -> TimeoutStage.WAITING_FOR_PEER_STATUS
-        Host.Confirming, Joiner.Confirming -> TimeoutStage.WAITING_FOR_CONFIRMATION
-        Host.Sending, Joiner.Waiting -> TimeoutStage.WAITING_FOR_RECOVERY_CODE
+        ExchangeV2State.Host.Confirming, ExchangeV2State.Joiner.Confirming -> TimeoutStage.WAITING_FOR_CONFIRMATION
+        ExchangeV2State.Host.Sending, ExchangeV2State.Joiner.Waiting -> TimeoutStage.WAITING_FOR_RECOVERY_CODE
         else -> null
     }
 
@@ -466,7 +462,7 @@ class RealExchangeV2Runner @Inject constructor(
         mutex.withLock { processIncomingLocked(message) }
     }
 
-    private suspend fun processIncomingLocked(message: ExchangeV2Message) {
+    private fun processIncomingLocked(message: ExchangeV2Message) {
         val sm = session ?: run {
             logcat { "Sync-ExchangeV2: deliverIncomingMessage ${message.messageType} rejected — no active session" }
             emitSessionError(
@@ -590,7 +586,8 @@ class RealExchangeV2Runner @Inject constructor(
 
     /**
      * Can we auto-elect a role now? Requires an accepted transition, SM in Negotiating, and a
-     * peer availability message ([RecoveryCodeAvailable]/[RecoveryCodeRequest]) carrying peer kind/userId.
+     * peer availability message ([ExchangeV2Message.RecoveryCodeAvailable]/[ExchangeV2Message.RecoveryCodeRequest])
+     * carrying peer kind/userId.
      */
     private fun canAutoElectRole(
         sm: ExchangeV2StateMachine,
@@ -661,7 +658,7 @@ class RealExchangeV2Runner @Inject constructor(
         }
     }
 
-    private suspend fun processLocalTriggerLocked(trigger: LocalTrigger) {
+    private fun processLocalTriggerLocked(trigger: LocalTrigger) {
         val sm = session ?: run {
             logcat { "Sync-ExchangeV2: localTrigger $trigger ignored — no active session" }
             return
@@ -687,7 +684,7 @@ class RealExchangeV2Runner @Inject constructor(
      * Caller must have come from [ExchangeV2State.Joiner.Confirming]. On confirm (→ Joiner.Waiting)
      * replay buffered host-side messages; on any other exit discard them.
      */
-    private suspend fun replayBufferedJoinerMessagesLocked(newState: ExchangeV2State) {
+    private fun replayBufferedJoinerMessagesLocked(newState: ExchangeV2State) {
         if (pendingJoinerWaitingMessages.isEmpty()) return
         if (newState == ExchangeV2State.Joiner.Waiting) {
             val buffered = pendingJoinerWaitingMessages.toList()
@@ -914,13 +911,13 @@ class RealExchangeV2Runner @Inject constructor(
     }
 
     private fun ExchangeV2State.isTerminal(): Boolean = when (this) {
-        SameAccountAbort,
+        ExchangeV2State.SameAccountAbort,
         ExchangeV2State.Aborted,
-        Host.Aborted,
-        Host.Done,
-        Joiner.AbortedLocal,
-        Joiner.AbortedByHost,
-        Joiner.Done,
+        ExchangeV2State.Host.Aborted,
+        ExchangeV2State.Host.Done,
+        ExchangeV2State.Joiner.AbortedLocal,
+        ExchangeV2State.Joiner.AbortedByHost,
+        ExchangeV2State.Joiner.Done,
         -> true
         else -> false
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -117,7 +117,10 @@ class RealExchangeV2Runner @Inject constructor(
     private val dispatchers: DispatcherProvider,
 ) : ExchangeV2Runner {
 
-    private val _events = MutableSharedFlow<ExchangeV2Event>(replay = REPLAY, extraBufferCapacity = REPLAY)
+    private val _events = MutableSharedFlow<ExchangeV2Event>(
+        replay = EVENT_BUFFER_SIZE,
+        extraBufferCapacity = EVENT_BUFFER_SIZE,
+    )
     override val events: SharedFlow<ExchangeV2Event> = _events.asSharedFlow()
 
     // Mutex serialises SM mutations + peer-state writes across the poll loop + user clicks.
@@ -153,7 +156,7 @@ class RealExchangeV2Runner @Inject constructor(
 
     @Volatile private var advertisedVersion: ExchangeProtocolVersion.V2 = BASELINE_PROTOCOL_VERSION
 
-    @Volatile internal var negotiatedVersion: ExchangeProtocolVersion.V2 = BASELINE_PROTOCOL_VERSION
+    @Volatile private var negotiatedVersion: ExchangeProtocolVersion.V2 = BASELINE_PROTOCOL_VERSION
         private set
 
     /**
@@ -191,7 +194,7 @@ class RealExchangeV2Runner @Inject constructor(
                     cancelLocked() // bootstrap already emitted the error; just clear the half-set state
                     return@launch
                 }
-                negotiatedVersion = negotiateProtocolVersion(parsed.version)
+                negotiatedVersion = negotiateProtocolVersion(parsed.version, PeerVersionSource.LinkingCode)
                 // Scanner already knows the peer; SM starts directly in Negotiating.
                 session = smFactory.create(
                     localUserId = syncStore.userId,
@@ -528,7 +531,7 @@ class RealExchangeV2Runner @Inject constructor(
             is ExchangeV2Message.Hello -> {
                 peerChannelId = message.channelId
                 peerPublicKey = message.publicKey
-                negotiatedVersion = negotiateProtocolVersion(message.version)
+                negotiatedVersion = negotiateProtocolVersion(message.version, PeerVersionSource.HelloMessage)
             }
             is ExchangeV2Message.RecoveryCodeAvailable -> {
                 _peerKind = message.kind
@@ -841,6 +844,16 @@ class RealExchangeV2Runner @Inject constructor(
                 "Sync-ExchangeV2: session started role=${event.pairingRole} channel_id=${event.ownChannelId}$codeLine"
             }
             is ExchangeV2Event.SessionError -> logcat(ERROR) { "Sync-ExchangeV2: session error: ${event.message}" }
+            is ExchangeV2Event.VersionNegotiated -> logcat {
+                buildString {
+                    append("Sync-ExchangeV2: negotiated protocol version: ")
+                    append(event.negotiatedVersion.prettyPrint())
+                    append(", our version: ")
+                    append(event.ourVersion.prettyPrint())
+                    append(", peer version: ")
+                    append(event.peerVersion.prettyPrint())
+                }
+            }
         }
         _events.tryEmit(event)
     }
@@ -871,13 +884,16 @@ class RealExchangeV2Runner @Inject constructor(
         else -> false
     }
 
-    private fun negotiateProtocolVersion(peerVersion: ExchangeProtocolVersion): ExchangeProtocolVersion.V2 {
+    private fun negotiateProtocolVersion(
+        peerVersion: ExchangeProtocolVersion,
+        peerSource: PeerVersionSource,
+    ): ExchangeProtocolVersion.V2 {
         val ourVersion = advertisedVersion
         val negotiatedVersion = when (peerVersion) {
             is ExchangeProtocolVersion.V2 -> minOf(ourVersion, peerVersion)
             else -> BASELINE_PROTOCOL_VERSION
         }
-        logcat { "Sync-ExchangeV2: negotiated protocol version: v$negotiatedVersion, our version: v$ourVersion, peer version: v$peerVersion" }
+        emit(ExchangeV2Event.VersionNegotiated(clock.nowMs(), peerSource, peerVersion, advertisedVersion, negotiatedVersion))
         return negotiatedVersion
     }
 
@@ -900,7 +916,8 @@ class RealExchangeV2Runner @Inject constructor(
         // Channel authorization secret size for the v2 exchange transport layer.
         private const val CHANNEL_SECRET_SIZE = 32
 
-        private const val REPLAY = 100
+        // Max count ExchangeV2Event held in buffer that will be replayed to consumers.
+        private const val EVENT_BUFFER_SIZE = 100
 
         // Transport TD 1214486492252757 §Session Lifecycle: 5-minute client session deadline.
         private const val SESSION_TIMEOUT_MS = 5 * 60 * 1000L

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2State.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2State.kt
@@ -17,47 +17,157 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 /**
- * State machine nodes for the v2 exchange protocol.
+ * Every node the Exchange V2 protocol session can be in.
  *
- * Spec: Asana 1215056232572322. The machine starts in [Bootstrapped], shares a
- * negotiation phase with the peer, then forks into [Host] or [Joiner] after role election.
+ * The state machine exists to validate the order of messages, not their content: for a given
+ * state it decides whether an inbound message is accepted, dropped, or a protocol error. States
+ * therefore mirror "what are we waiting for", never "what is the UI showing".
+ *
+ * The session starts in a shared phase where roles aren't known yet ([Bootstrapped] to
+ * [Negotiating]), then forks into the [Host] or [Joiner] substate once the runner elects a role.
+ * Each fork ends in one of its own terminal states, at which point the runner tears the session
+ * down: deletes its relay channel and discards the session keys. Nothing can happen after a
+ * terminal, so any work that must outlive it belongs in a non-terminal state.
+ *
+ * Each state below is tagged with the protocol version that introduced it.
+ *
+ * Spec:
+ *  - Asana 1215056232572322, Exchange V2 Message Sequence State Machine: the 2.0 machine, plus the
+ *    implicit-abort and unknown-message-drop rules the transitions rely on.
+ *  - Asana 1214739740392701, Unified Algorithm: role election and the abort rules the runner applies
+ *    around this machine.
  */
 sealed interface ExchangeV2State {
+
+    /**
+     * Presenter's start state: the linking code is published, and we're waiting for a peer to scan it
+     * and send `hello`. A Scanner never sees this state: it learned the peer from the QR code, so it
+     * starts in [Negotiating] (messages you send never come back to your own inbox, so a Scanner
+     * could not receive its own `hello`).
+     *
+     * Since 2.0.
+     */
     data object Bootstrapped : ExchangeV2State
+
+    /**
+     * Peer identity is established and both sides declare whether they have an account
+     * (`recovery_code_available` / `recovery_code_request`). Stays here, absorbing those, until the
+     * runner has enough to elect a role and fires `RoleElected`.
+     *
+     * Since 2.0.
+     */
     data object Negotiating : ExchangeV2State
 
     /**
-     * Detected during Negotiating that the peer reports the same `user_id` as us — both
-     * devices are already on the same account. Per spec §"Same-account case" this is **not
+     * Terminal. Detected during [Negotiating] that the peer reports the same `user_id` as us, so
+     * both devices are already on the same account. Per spec §"Same-account case" this is **not
      * an abort**: callers should surface a friendly "Connected" finish, not an error. The
      * dispatcher maps this state to [com.duckduckgo.sync.impl.DispatchOutcome.AlreadyConnected].
      * Name retained for historical continuity; treat semantically as a success terminal.
+     *
+     * Since 2.0.
      */
     data object SameAccountAbort : ExchangeV2State
 
     /**
-     * Negotiation aborted before role election — e.g. an unexpected or duplicate `hello`
-     * received while in [Negotiating] (a second hello, or the double-scan race). Terminal.
-     * Per Unified Algorithm 1214739740392701 §Handshake Note: "abort and close the channel".
+     * Terminal. Negotiation aborted before role election, e.g. an unexpected or duplicate `hello`
+     * received while in [Negotiating] (a second hello, or the double-scan race). Per Unified
+     * Algorithm 1214739740392701 §Handshake Note: "abort and close the channel". The role-specific
+     * forks have their own abort terminals ([Host.Aborted], [Joiner.AbortedLocal]); this one only
+     * covers failures from before a role existed.
+     *
+     * Since 2.0.
      */
     data object Aborted : ExchangeV2State
 
+    /**
+     * The device that owns (or will create) the account and hands over the recovery code. Elected,
+     * not chosen by the user: a Presenter can end up Joiner and vice versa.
+     */
     sealed interface Host : ExchangeV2State {
+
+        /**
+         * Prompting our own user to approve sharing. `recovery_code_awaiting_confirmation` has
+         * already gone out, so the peer can show "check the other device" while we wait.
+         *
+         * Since 2.0.
+         */
         data object Confirming : Host
+
+        /**
+         * User approved. Provisioning whatever the peer's kind needs (create the account, add a
+         * 3party credential) and sending `recovery_code_response`, or `recovery_code_unavailable`
+         * if none of that can be produced.
+         *
+         * Since 2.0.
+         */
         data object Sending : Host
+
+        /**
+         * Terminal. The Host side gave up: our user denied the prompt, no recovery code could be
+         * produced, or the peer broke the message sequence.
+         *
+         * Since 2.0.
+         */
         data object Aborted : Host
+
+        /**
+         * Terminal. Finished as Host, which means only that the recovery code was sent: the Joiner
+         * never reports what it did with it.
+         *
+         * Since 2.0.
+         */
         data object Done : Host
     }
 
+    /**
+     * The device that receives the recovery code and joins the Host's account.
+     */
     sealed interface Joiner : ExchangeV2State {
+
+        /**
+         * Prompting our own user to approve joining. Nothing is sent to the peer from here, since by
+         * spec the Joiner's denial is silent, so the only inbound messages that matter are the
+         * Host's own aborts.
+         *
+         * Since 2.0.
+         */
         data object Confirming : Joiner
+
+        /**
+         * User approved; waiting on the Host. Absorbs its progress messages
+         * (`recovery_code_awaiting_confirmation`, `recovery_code_confirmed`) without changing state.
+         *
+         * Since 2.0.
+         */
         data object Waiting : Joiner
+
+        /**
+         * Terminal. We ended it ourselves: our user denied the prompt, or the Host broke the message
+         * sequence. Nothing is sent to the peer.
+         *
+         * Since 2.0.
+         */
         data object AbortedLocal : Joiner
+
+        /**
+         * Terminal. The Host ended it: `recovery_code_denied` (its user declined) or
+         * `recovery_code_unavailable` (it couldn't produce a code).
+         *
+         * Since 2.0.
+         */
         data object AbortedByHost : Joiner
+
+        /**
+         * Terminal. Reached on receiving the recovery code, before it has been applied.
+         *
+         * Since 2.0.
+         */
         data object Done : Joiner
     }
 }
 
+/** Which side of the exchange this device plays, decided by role election in the runner. */
 enum class Role {
     Host,
     Joiner,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
@@ -24,8 +24,8 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDenied
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeUnavailable
-import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Unknown
 import javax.inject.Inject
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Unknown as UnknownMessage
 
 /**
  * Pure validator for the Exchange V2 wire protocol. Stateful (it tracks [currentState] and the
@@ -103,7 +103,7 @@ internal class RealExchangeV2StateMachine(
         // Forward-compat rule, applied once for every state: a type this client doesn't model is
         // dropped, never treated as a protocol error. Handlers below therefore only decide between
         // "expected here" and the implicit abort.
-        if (msg is Unknown) return drop(msg)
+        if (msg is UnknownMessage) return drop(msg)
         return when (val state = currentState) {
             ExchangeV2State.Bootstrapped -> receiveInBootstrapped(state, msg)
             ExchangeV2State.Negotiating -> receiveInNegotiating(state, msg)
@@ -157,7 +157,7 @@ internal class RealExchangeV2StateMachine(
             is RecoveryCodeUnavailable,
             is RecoveryCodeResponse,
             -> abort(state, msg, RejectReason.ImplicitAbort)
-            is Unknown -> drop(msg)
+            is UnknownMessage -> drop(msg)
         }
     }
 
@@ -182,7 +182,7 @@ internal class RealExchangeV2StateMachine(
             is RecoveryCodeAvailable,
             is RecoveryCodeRequest,
             -> abort(state, msg, RejectReason.ImplicitAbort)
-            is Unknown -> drop(msg)
+            is UnknownMessage -> drop(msg)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
@@ -33,11 +33,35 @@ import javax.inject.Inject
  * input returns a [TransitionResult] that the runner forwards to the event sink and whose declared
  * [SideEffect]s the runner executes.
  *
- * Spec: Asana 1215056232572322 — Exchange V2 Message Sequence State Machine.
+ * Validates order, never content: it decides whether an input is allowed where the session
+ * currently is, and leaves what the input means to the runner. Which is why role election,
+ * provisioning and all network work live there instead.
+ *
+ * Every input is answered with a transition, so there is no way to ask "may I" without also moving.
+ * An input the current state doesn't allow is a protocol violation and aborts the session, with the
+ * single exception of an unrecognized message type, which is dropped so a newer peer can't kill the
+ * session by talking about things we don't model.
+ *
+ * Not thread-safe: one instance belongs to one session, and the runner serializes access to it.
+ *
+ * Spec: Asana 1215056232572322, Exchange V2 Message Sequence State Machine.
  */
 interface ExchangeV2StateMachine {
+
+    /** Where the session is now. Moves on every [receive] and [localTrigger], including aborts. */
     val currentState: ExchangeV2State
+
+    /**
+     * Feed in a message received from the peer. Accepts it, drops it, or aborts the session, per
+     * [TransitionResult.outcome].
+     */
     fun receive(msg: ExchangeV2Message): TransitionResult
+
+    /**
+     * Feed in something that didn't come off the wire: a user decision, role election, or the
+     * completion of work the runner was doing. Aborts the session if the current state does not
+     * allow the trigger.
+     */
     fun localTrigger(trigger: LocalTrigger): TransitionResult
 }
 
@@ -76,6 +100,9 @@ internal class RealExchangeV2StateMachine(
         private set
 
     override fun receive(msg: ExchangeV2Message): TransitionResult {
+        // Forward-compat rule, applied once for every state: a type this client doesn't model is
+        // dropped, never treated as a protocol error. Handlers below therefore only decide between
+        // "expected here" and the implicit abort.
         if (msg is Unknown) return drop(msg)
         return when (val state = currentState) {
             ExchangeV2State.Bootstrapped -> receiveInBootstrapped(state, msg)
@@ -134,7 +161,7 @@ internal class RealExchangeV2StateMachine(
         }
     }
 
-    // If the peer aborts while we're still showing the confirm prompt, act on it now instead of
+    // If the peer aborts while we're still showing the confirmation prompt, act on it now instead of
     // making the user confirm a doomed pairing.
     private fun receiveInJoinerConfirming(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
         return when (msg) {
@@ -245,9 +272,9 @@ internal class RealExchangeV2StateMachine(
     }
 
     /**
-     * Reject [msg] and abort. By default we drive to [from]'s terminal state (see [abortTerminal]):
-     *  - If [from] is still active, that's a real transition into the terminal → emit [Transition].
-     *  - If [from] is already terminal, [abortTerminal] returns itself, so we stay put → emit [MessageRejected].
+     * Reject [msg] and abort. By default, we drive to [from]'s terminal state (see [abortTerminal]):
+     *  - If [from] is still active, that's a real transition into the terminal → emit [ExchangeV2Event.Transition].
+     *  - If [from] is already terminal, [abortTerminal] returns itself, so we stay put → emit [ExchangeV2Event.MessageRejected].
      *
      * Callers can override [newState] to abort somewhere other than the default terminal.
      */

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/LocalTrigger.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/LocalTrigger.kt
@@ -17,14 +17,50 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 /**
- * Side-effect-free transitions driven by something other than an inbound wire message
- * (user input, role election by the runner, completion of an outbound send).
+ * An input to the state machine that didn't come off the wire: a user decision, role election, or
+ * the completion of work the runner was doing.
+ *
+ * Triggers carry no side effects themselves, but the transitions they drive declare most of them:
+ * every spec-mandated message this device originates follows a local decision rather than an
+ * inbound message (see [SideEffect]).
+ *
+ * A trigger the current state does not allow aborts the session, so the runner fires these only
+ * from the state each one belongs to.
  */
 sealed interface LocalTrigger {
+
+    /**
+     * Our user approved sharing the recovery code, at [ExchangeV2State.Host.Confirming]. Moves to
+     * [ExchangeV2State.Host.Sending], telling the peer and starting the handover.
+     */
     data object UserConfirmedHost : LocalTrigger
+
+    /**
+     * Our user refused to share, at [ExchangeV2State.Host.Confirming]. Moves to
+     * [ExchangeV2State.Host.Aborted], telling the peer why the session ended.
+     */
     data object UserDeniedHost : LocalTrigger
+
+    /**
+     * Our user approved joining, at [ExchangeV2State.Joiner.Confirming]. Moves to
+     * [ExchangeV2State.Joiner.Waiting], which is also when the runner replays any Host messages that
+     * arrived while the prompt was still up.
+     */
     data object UserConfirmedJoiner : LocalTrigger
+
+    /**
+     * Our user refused to join, at [ExchangeV2State.Joiner.Confirming]. Moves to
+     * [ExchangeV2State.Joiner.AbortedLocal]. Nothing is sent to the peer, since by spec the Joiner's
+     * denial is silent.
+     */
     data object UserDeniedJoiner : LocalTrigger
+
+    /**
+     * The runner picked which side this device plays, which is what forks the machine into the
+     * [ExchangeV2State.Host] or [ExchangeV2State.Joiner] branch. Election itself lives in the runner
+     * (Asana Unified Algorithm 1214739740392701), because it needs peer and account context the
+     * state machine deliberately doesn't track.
+     */
     data class RoleElected(val role: Role) : LocalTrigger
 
     /**

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/RecoveryCodeProvider.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/RecoveryCodeProvider.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.ThirdPartyRecoveryCode
 import com.duckduckgo.sync.impl.ThirdPartyRecoveryCodeWrapper
+import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.Moshi
 import org.json.JSONObject
@@ -62,7 +63,7 @@ interface RecoveryCodeProvider {
 @ContributesBinding(AppScope::class)
 class RealRecoveryCodeProvider @Inject constructor(
     private val syncAccountRepository: SyncAccountRepository,
-    private val syncStore: com.duckduckgo.sync.store.SyncStore,
+    private val syncStore: SyncStore,
 ) : RecoveryCodeProvider {
 
     override fun createDdgAccountIfNeeded(): Result<Unit> {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/SideEffect.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/SideEffect.kt
@@ -17,18 +17,65 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 /**
- * Spec-defined protocol actions that accompany a state transition. The state machine attaches
- * these to its [TransitionResult]; the runner executes them. Keeping side effects declared at
- * the transition (rather than scattered across the runner's post-trigger hooks) means each
- * spec rule lives in exactly one place and is easy to audit against the Unified Algorithm.
+ * A protocol action the runner must perform because a transition happened.
  *
- * Spec source: Asana Unified Algorithm 1214739740392701, §"Exchange Confirmations" and
- * §"Exchange Share Recovery Code".
+ * The state machine is a pure validator: it decides the next state and declares what the spec
+ * requires alongside it, but never touches the network itself. The runner executes these in list
+ * order, after the transition has already been applied and its event emitted. Two consequences
+ * follow from that:
+ *  - Order within one [TransitionResult] is significant. [SendConfirmed] ahead of
+ *    [RequestRecoveryCodeShare] is what puts `recovery_code_confirmed` on the wire before the
+ *    recovery code itself.
+ *  - No state may depend on an effect succeeding. The state has already moved by the time one runs,
+ *    so a failed send surfaces as a session error and is never rolled back or retried.
+ *
+ * Declaring effects at the transition, rather than scattering them across the runner's post-trigger
+ * hooks, keeps each spec rule in exactly one place and auditable against the spec.
+ *
+ * Spec: Asana 1214739740392701, Unified Algorithm: §"Exchange Confirmations" and §"Exchange Share
+ * Recovery Code" define the effects and the point at which each fires.
  */
 sealed interface SideEffect {
 
+    /**
+     * Send `recovery_code_awaiting_confirmation`.
+     *
+     * Fires on entry to [ExchangeV2State.Host.Confirming], deliberately before our own user prompt,
+     * so the Joiner can show "check the other device" while the Host's user is still deciding.
+     *
+     * Since 2.0.
+     */
     data object SendAwaitingConfirmation : SideEffect
+
+    /**
+     * Send `recovery_code_confirmed`: our user approved sharing. Paired with
+     * [RequestRecoveryCodeShare] on the same transition and ordered first, so the peer learns the
+     * decision before the code arrives.
+     *
+     * Since 2.0.
+     */
     data object SendConfirmed : SideEffect
+
+    /**
+     * Send `recovery_code_denied`: our user refused, on the deny branch out of
+     * [ExchangeV2State.Host.Confirming]. The Joiner has no equivalent, because by spec its denial is
+     * silent.
+     *
+     * Since 2.0.
+     */
     data object SendDenied : SideEffect
+
+    /**
+     * Produce and deliver the recovery code. The one effect that is not a single message send, and
+     * the one that feeds back into the machine.
+     *
+     * The runner provisions whatever the peer's kind needs (create the account, add a 3party
+     * credential), then sends `recovery_code_response`, or `recovery_code_unavailable` if none of
+     * that could be produced. Because that involves network calls it runs asynchronously, and
+     * finishes by firing [LocalTrigger.HostSendComplete] or [LocalTrigger.HostUnavailable]. Those
+     * triggers, not this effect, are what move the Host off [ExchangeV2State.Host.Sending].
+     *
+     * Since 2.0.
+     */
     data object RequestRecoveryCodeShare : SideEffect
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealAdvertisedExchangeV2VersionTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealAdvertisedExchangeV2VersionTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RealAdvertisedExchangeV2VersionTest {
+
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val advertisedVersion = RealAdvertisedExchangeV2Version(syncFeature)
+
+    @Test fun `advertises v2_1 when the version flag is enabled`() {
+        syncFeature.canUseExchangeV2Point1().setRawStoredState(State(remoteEnableState = true))
+
+        assertEquals(ExchangeProtocolVersion.V2_1, advertisedVersion.resolve())
+    }
+
+    @Test fun `advertises v2_0 when the version flag is disabled`() {
+        syncFeature.canUseExchangeV2Point1().setRawStoredState(State(remoteEnableState = false))
+
+        assertEquals(ExchangeProtocolVersion.V2_0, advertisedVersion.resolve())
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -79,6 +79,7 @@ class RealExchangeV2RunnerTest {
     private val recoveryCodeProvider: RecoveryCodeProvider = mock()
     private val syncDeviceIds: SyncDeviceIds = mock()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val advertisedVersion: AdvertisedExchangeV2Version = mock()
 
     private fun newRunner(): RealExchangeV2Runner =
         RealExchangeV2Runner(
@@ -90,12 +91,14 @@ class RealExchangeV2RunnerTest {
             qrCode = qrCode,
             recoveryCodeProvider = recoveryCodeProvider,
             syncDeviceIds = syncDeviceIds,
+            advertisedExchangeV2Version = advertisedVersion,
             syncFeature = syncFeature,
             appScope = coroutineTestRule.testScope,
             dispatchers = coroutineTestRule.testDispatcherProvider,
         )
 
     @Before fun stubWireDeps() {
+        givenOurVersion(ExchangeProtocolVersion.V2_0)
         givenLinkingCodeVersion(ExchangeProtocolVersion.V2_0)
         whenever(qrCode.buildLinkingCode(any(), any(), any())).thenReturn("https://duckduckgo.com/sync/pairing/#&code2=fake")
         whenever(jweCrypto.generateRsaKeyPair(any())).thenReturn(RsaKeyPair(publicKeyBase64 = "own-pub", privateKeyBase64 = "own-priv"))
@@ -306,7 +309,7 @@ class RealExchangeV2RunnerTest {
         )
     }
 
-    @Test fun `each session re-reads the flag rather than reusing the previous session's advertised version`() = runTest {
+    @Test fun `each session re-resolves the advertised version rather than reusing the previous session's`() = runTest {
         val runner = newRunner()
 
         givenOurVersion(ExchangeProtocolVersion.V2_1)
@@ -333,7 +336,7 @@ class RealExchangeV2RunnerTest {
         peerVersion: String,
         negotiated: String,
     ) = runTest {
-        givenOurVersion(ourVersion.toProtocolVersion())
+        givenOurVersion(ourVersion.toV2ProtocolVersion())
         givenLinkingCodeVersion(peerVersion.toV2ProtocolVersion())
 
         val runner = newRunner()
@@ -358,7 +361,7 @@ class RealExchangeV2RunnerTest {
         peerVersion: String,
         negotiated: String,
     ) = runTest {
-        givenOurVersion(ourVersion.toProtocolVersion())
+        givenOurVersion(ourVersion.toV2ProtocolVersion())
         whenever(syncStore.userId).thenReturn("my-user")
 
         val runner = newRunner()
@@ -757,7 +760,7 @@ class RealExchangeV2RunnerTest {
     @Test fun `the channel is claimed, polled and written to with a secret only when a flag calls for it`(
         @TestParameter case: ExchangeAuthCase,
     ) = runTest {
-        case.configure(syncFeature)
+        configure(case)
         val utf8Secret = "channel-secret"
         val expectedSecret = utf8Secret.toBase64Url().takeIf { case.isAuthenticated }
         whenever(jweCrypto.generateSecureBytes(any())).thenReturn(utf8Secret.toByteArray())
@@ -774,7 +777,7 @@ class RealExchangeV2RunnerTest {
     @Test fun `cancel deletes the channel with whatever secret it was created with`(
         @TestParameter case: ExchangeAuthCase,
     ) = runTest {
-        case.configure(syncFeature)
+        configure(case)
         val utf8Secret = "channel-secret"
         val expectedSecret = utf8Secret.toBase64Url().takeIf { case.isAuthenticated }
         whenever(jweCrypto.generateSecureBytes(any())).thenReturn(utf8Secret.toByteArray())
@@ -835,9 +838,8 @@ class RealExchangeV2RunnerTest {
 
     // ---- Helpers ----
 
-    private fun givenOurVersion(version: ExchangeProtocolVersion) {
-        val state = State(remoteEnableState = version == ExchangeProtocolVersion.V2_1)
-        syncFeature.canUseExchangeV2Point1().setRawStoredState(state)
+    private fun givenOurVersion(version: ExchangeProtocolVersion.V2) {
+        whenever(advertisedVersion.resolve()).thenReturn(version)
     }
 
     private fun givenLinkingCodeVersion(version: ExchangeProtocolVersion.V2) {
@@ -857,35 +859,34 @@ class RealExchangeV2RunnerTest {
     private fun String.toBase64Url(): String = Base64.getUrlEncoder().withoutPadding().encodeToString(toByteArray())
 
     enum class ExchangeAuthCase(
+        val advertisedVersion: ExchangeProtocolVersion.V2,
         val canSendExchangeChannelSecret: Boolean,
-        val canUseExchangeV2Point1: Boolean,
         val isAuthenticated: Boolean,
     ) {
-        BothFlagsOff(
+        V20WithoutSecretFlag(
+            advertisedVersion = ExchangeProtocolVersion.V2_0,
             canSendExchangeChannelSecret = false,
-            canUseExchangeV2Point1 = false,
             isAuthenticated = false,
         ),
-        SecretFlagOn(
+        V20WithSecretFlag(
+            advertisedVersion = ExchangeProtocolVersion.V2_0,
             canSendExchangeChannelSecret = true,
-            canUseExchangeV2Point1 = false,
             isAuthenticated = true,
         ),
-        V2Point1FlagOn(
+        V21WithoutSecretFlag(
+            advertisedVersion = ExchangeProtocolVersion.V2_1,
             canSendExchangeChannelSecret = false,
-            canUseExchangeV2Point1 = true,
             isAuthenticated = true,
         ),
-        BothFlagsOn(
+        V21WithSecretFlag(
+            advertisedVersion = ExchangeProtocolVersion.V2_1,
             canSendExchangeChannelSecret = true,
-            canUseExchangeV2Point1 = true,
             isAuthenticated = true,
         ),
-        ;
+    }
 
-        fun configure(syncFeature: SyncFeature) {
-            syncFeature.canSendExchangeChannelSecret().setRawStoredState(State(canSendExchangeChannelSecret))
-            syncFeature.canUseExchangeV2Point1().setRawStoredState(State(canUseExchangeV2Point1))
-        }
+    private fun configure(case: ExchangeAuthCase) {
+        givenOurVersion(case.advertisedVersion)
+        syncFeature.canSendExchangeChannelSecret().setRawStoredState(State(case.canSendExchangeChannelSecret))
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -339,7 +339,8 @@ class RealExchangeV2RunnerTest {
         val runner = newRunner()
         runner.startScan("")
 
-        assertEquals(negotiated.toProtocolVersion(), runner.negotiatedVersion)
+        val negotiation = runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().single()
+        assertEquals(negotiated.toProtocolVersion(), negotiation.negotiatedVersion)
     }
 
     @Test
@@ -364,19 +365,59 @@ class RealExchangeV2RunnerTest {
         runner.startPresent()
         runner.deliverHello(peerVersion.toProtocolVersion())
 
-        assertEquals(negotiated.toProtocolVersion(), runner.negotiatedVersion)
+        val negotiation = runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().single()
+        assertEquals(negotiated.toProtocolVersion(), negotiation.negotiatedVersion)
     }
 
-    @Test fun `cancel clears negotiated version`() = runTest {
+    @Test fun `Scanner reports the scanned code as the source of the peer version`() = runTest {
         givenOurVersion(ExchangeProtocolVersion.V2_1)
-        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_1)
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_0)
 
         val runner = newRunner()
         runner.startScan("")
-        assertEquals(ExchangeProtocolVersion.V2_1, runner.negotiatedVersion)
 
-        runner.cancel()
-        assertEquals(ExchangeProtocolVersion.V2_0, runner.negotiatedVersion)
+        val negotiation = runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().single()
+        assertEquals(PeerVersionSource.LinkingCode, negotiation.peerSource)
+        assertEquals(ExchangeProtocolVersion.V2_1, negotiation.ourVersion)
+        assertEquals(ExchangeProtocolVersion.V2_0, negotiation.peerVersion)
+        assertEquals(ExchangeProtocolVersion.V2_0, negotiation.negotiatedVersion)
+    }
+
+    @Test fun `Presenter reports the peer hello as the source of the peer version`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_0)
+        whenever(syncStore.userId).thenReturn("my-user")
+
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverHello(ExchangeProtocolVersion.V2_1)
+
+        val negotiation = runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().single()
+        assertEquals(PeerVersionSource.HelloMessage, negotiation.peerSource)
+        assertEquals(ExchangeProtocolVersion.V2_0, negotiation.ourVersion)
+        assertEquals(ExchangeProtocolVersion.V2_1, negotiation.peerVersion)
+        assertEquals(ExchangeProtocolVersion.V2_0, negotiation.negotiatedVersion)
+    }
+
+    @Test fun `a peer version we cannot speak falls back to the baseline but is reported as advertised`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        whenever(syncStore.userId).thenReturn("my-user")
+
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverHello("3.4".toProtocolVersion())
+
+        val negotiation = runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().single()
+        assertEquals("3.4".toProtocolVersion(), negotiation.peerVersion)
+        assertEquals(ExchangeProtocolVersion.V2_0, negotiation.negotiatedVersion)
+    }
+
+    @Test fun `a peer that never advertises a version produces no negotiation event`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+
+        val runner = newRunner()
+        runner.startPresent()
+
+        assertTrue(runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().isEmpty())
     }
 
     // ---- Auto role election ----

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/exchange/SyncInternalAdvertisedExchangeV2Version.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/exchange/SyncInternalAdvertisedExchangeV2Version.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.internal.exchange
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.duckduckgo.sync.impl.exchange.v2.AdvertisedExchangeV2Version
+import com.duckduckgo.sync.impl.exchange.v2.RealAdvertisedExchangeV2Version
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(scope = AppScope::class, replaces = [RealAdvertisedExchangeV2Version::class])
+class SyncInternalAdvertisedExchangeV2Version @Inject constructor(
+    private val real: RealAdvertisedExchangeV2Version,
+) : AdvertisedExchangeV2Version {
+
+    val overrideFlow = MutableStateFlow<ExchangeProtocolVersion.V2?>(null)
+
+    override fun resolve() = overrideFlow.value ?: defaultVersion()
+
+    fun defaultVersion() = real.resolve()
+}

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -370,9 +370,6 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.canShowV2ConnectCodeToggle.quietlySetIsChecked(viewState.canShowV2ConnectCodeEnabled) { _, enabled ->
             viewModel.onCanShowV2ConnectCodeFlagChanged(enabled)
         }
-        binding.canUseExchangeV2Point1.quietlySetIsChecked(viewState.canUseExchangeV2Point1) { _, enabled ->
-            viewModel.onCanUseExchangeV2Point1FlagChanged(enabled)
-        }
         binding.accessCredentialsTextView.text = viewState.accessCredentialsText
         binding.scopedTokenResultTextView.text = viewState.scopedTokenResult
         binding.v2StoreFieldsTextView.text = viewState.v2StoreFieldsText

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -139,7 +139,6 @@ constructor(
         val blockStoreCurrentValueText: String = "Loading...",
         val canUseV2ConnectFlowEnabled: Boolean = false,
         val canShowV2ConnectCodeEnabled: Boolean = false,
-        val canUseExchangeV2Point1: Boolean = false,
         val checkLinkingCodeResult: String = "",
         val accessCredentialsText: String = "",
         val scopedTokenResult: String = "",
@@ -268,15 +267,6 @@ constructor(
     }
 
     @SuppressLint("DenyListedApi")
-    fun onCanUseExchangeV2Point1FlagChanged(enabled: Boolean) {
-        viewModelScope.launch(dispatchers.io()) {
-            logcat { "Sync-ScopedToken: setting canUseExchangeV2Point1 flag = $enabled" }
-            setRawToggleState(syncFeature.canUseExchangeV2Point1(), enabled)
-            updateViewState()
-        }
-    }
-
-    @SuppressLint("DenyListedApi")
     private fun setRawToggleState(
         toggle: Toggle,
         enabled: Boolean,
@@ -348,7 +338,6 @@ constructor(
                 environment = syncEnvDataStore.syncEnvironmentUrl,
                 canUseV2ConnectFlowEnabled = syncFeature.canUseV2ConnectFlow().isEnabled(),
                 canShowV2ConnectCodeEnabled = syncFeature.canShowV2ConnectCode().isEnabled(),
-                canUseExchangeV2Point1 = syncFeature.canUseExchangeV2Point1().isEnabled(),
                 v2StoreFieldsText = buildV2StoreFieldsText(),
                 // Clear per-session dev-tool results once signed out so stale keys aren't shown.
                 keysText = if (accountInfo.isSignedIn) viewState.value.keysText else "",

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.sync.impl.exchange.v2.Role
 import com.duckduckgo.sync.internal.databinding.ActivitySyncV2PairingDebugBinding
 import com.duckduckgo.sync.internal.databinding.ItemSyncV2PairingLogRowBinding
 import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.ConfirmationRequest
+import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.LogDetails
 import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.LogRow
 import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.TerminalReached
 import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.ViewState
@@ -253,15 +254,19 @@ class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
             val rowBinding = ItemSyncV2PairingLogRowBinding.inflate(layoutInflater, binding.logContainer, true)
             val timestamp = timestampFormat.format(Date(row.timestampMs))
             rowBinding.summaryTextView.text = "[$timestamp] ${row.summary}"
-            rowBinding.rawJsonTextView.text = row.rawJson
+            rowBinding.rawJsonTextView.text = row.details.value
             applyExpansion(rowBinding, row.id in expandedRowIds)
             rowBinding.summaryRow.setOnClickListener {
                 val newlyExpanded = row.id !in expandedRowIds
                 if (newlyExpanded) expandedRowIds.add(row.id) else expandedRowIds.remove(row.id)
                 applyExpansion(rowBinding, newlyExpanded)
             }
-            rowBinding.copyRawButton.setOnClickListener {
-                copyToClipboard("Raw JSON", row.rawJson)
+            when (val details = row.details) {
+                is LogDetails.Json -> {
+                    rowBinding.copyRawButton.visibility = View.VISIBLE
+                    rowBinding.copyRawButton.setOnClickListener { copyToClipboard("Raw JSON", details.value) }
+                }
+                is LogDetails.PlainText -> rowBinding.copyRawButton.visibility = View.GONE
             }
         }
     }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
@@ -29,12 +29,14 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.dialog.DaxAlertDialog
+import com.duckduckgo.common.ui.view.dialog.RadioListAlertDialogBuilder
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.Role
 import com.duckduckgo.sync.internal.databinding.ActivitySyncV2PairingDebugBinding
 import com.duckduckgo.sync.internal.databinding.ItemSyncV2PairingLogRowBinding
@@ -69,6 +71,7 @@ class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
     private val expandedRowIds = mutableSetOf<Long>()
     private var renderedRows: List<LogRow> = emptyList()
     private var activeConfirmationDialog: DaxAlertDialog? = null
+    private var selectedProtocolVersion: ExchangeProtocolVersion.V2? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -112,8 +115,32 @@ class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
         binding.autoApproveSetting.quietlySetIsChecked(newCheckedState = true) { _, enabled ->
             viewModel.onAutoApproveToggled(enabled)
         }
+        binding.protocolVersionSetting.setOnClickListener { showProtocolVersionDialog() }
+        binding.changeProtocolVersionButton.setOnClickListener { showProtocolVersionDialog() }
 
         binding.signInOutButton.setOnClickListener { viewModel.onSignInOutClicked() }
+    }
+
+    @Suppress("DEPRECATION") // Options don't need to be localized in the debug screen
+    private fun showProtocolVersionDialog() {
+        RadioListAlertDialogBuilder(this)
+            .setTitle("Protocol version")
+            .setMessage("Force the advertised exchange protocol version. Applies to the next session.")
+            .setOptions(
+                PROTOCOL_VERSION_OPTIONS.map(viewModel::labelFor),
+                PROTOCOL_VERSION_OPTIONS.indexOf(selectedProtocolVersion) + 1,
+            )
+            .setPositiveButton(com.duckduckgo.mobile.android.R.string.dialogSave)
+            .setNegativeButton(android.R.string.cancel)
+            .addEventListener(
+                object : RadioListAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked(selectedItem: Int) {
+                        viewModel.onProtocolOverrideSelected(PROTOCOL_VERSION_OPTIONS[selectedItem - 1])
+                    }
+                },
+            )
+            .setCancelable(true)
+            .show()
     }
 
     private fun observeViewState() {
@@ -193,6 +220,7 @@ class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
 
     private fun render(state: ViewState) {
         renderAccountStatus(state.accountStatus)
+        renderProtocolVersion(state)
         binding.currentStateTextView.text = state.currentStateLabel
         val code = state.linkingCode
         if (code != null) {
@@ -324,6 +352,11 @@ class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
         startScanFromInput()
     }
 
+    private fun renderProtocolVersion(state: ViewState) {
+        selectedProtocolVersion = state.protocolOverride
+        binding.protocolVersionSetting.setSecondaryText(viewModel.labelFor(state.protocolOverride))
+    }
+
     private fun renderAccountStatus(status: SyncV2PairingDebugViewModel.AccountStatus) {
         binding.statusSignedIn.setSecondaryText(
             if (status.signedIn) "Yes · user_id ${status.userId ?: "(unknown)"}" else "No",
@@ -340,5 +373,11 @@ class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
 
     private companion object {
         const val QR_SIZE_PX = 600
+
+        private val PROTOCOL_VERSION_OPTIONS = listOf(
+            null, // Default
+            ExchangeProtocolVersion.V2_0,
+            ExchangeProtocolVersion.V2_1,
+        )
     }
 }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
@@ -32,10 +32,12 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event.VersionNegotiated
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.PeerVersionSource
 import com.duckduckgo.sync.impl.exchange.v2.RejectReason
 import com.duckduckgo.sync.impl.exchange.v2.Role
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
@@ -67,8 +69,16 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         val id: Long,
         val timestampMs: Long,
         val summary: String,
-        val rawJson: String,
+        val details: LogDetails,
     )
+
+    sealed interface LogDetails {
+        val value: String
+
+        data class Json(override val value: String) : LogDetails
+
+        data class PlainText(override val value: String) : LogDetails
+    }
 
     /**
      * Snapshot of the device's sync setup that's relevant to v2 pairing. Read from
@@ -299,7 +309,7 @@ class SyncV2PairingDebugViewModel @Inject constructor(
 
     /**
      * Push a synthetic row into the event log so v1-fallback progress is visible alongside
-     * native v2 [ExchangeV2Event]s. Reuses [LogRow] with the message in both summary and rawJson.
+     * native v2 [ExchangeV2Event]s. Reuses [LogRow] with the message in both summary and details.
      * Also tees to logcat with a `Sync-V2Debug:` prefix so the fallback path is traceable
      * end-to-end (the in-screen log alone misses the eyes of anyone watching logcat).
      */
@@ -311,7 +321,7 @@ class SyncV2PairingDebugViewModel @Inject constructor(
                     id = nextRowId++,
                     timestampMs = System.currentTimeMillis(),
                     summary = message,
-                    rawJson = message,
+                    details = LogDetails.PlainText(message),
                 ),
             )
         }
@@ -387,7 +397,7 @@ class SyncV2PairingDebugViewModel @Inject constructor(
             id = nextRowId++,
             timestampMs = event.timestampMs,
             summary = summarise(event),
-            rawJson = rawJsonFor(event),
+            details = detailsFor(event),
         )
         viewState.update { current ->
             current.copy(
@@ -552,40 +562,60 @@ class SyncV2PairingDebugViewModel @Inject constructor(
     }
 
     private fun summarise(event: ExchangeV2Event): String = when (event) {
-        is ExchangeV2Event.Transition -> {
-            val trigger = event.trigger?.let { "msg=${it.messageType}${peerSuffix(it)}" }
-                ?: event.localTrigger?.let { "local=${labelFor(it)}" }
-                ?: "(no trigger)"
-            "Transition ${labelFor(event.from)} → ${labelFor(event.to)} [$trigger]"
-        }
-        is ExchangeV2Event.MessageSent -> "Sent ${event.message.messageType}${peerSuffix(event.message)}"
-        is ExchangeV2Event.MessageRejected -> {
-            val verb = when (event.reason) {
-                RejectReason.ImplicitAbort -> "Aborted"
-                RejectReason.SameAccount -> "SameAccountAbort"
-                RejectReason.UnknownMessageDropped -> "Dropped (unknown)"
+        is ExchangeV2Event.Transition -> buildString {
+            append("Transition ${labelFor(event.from)} → ${labelFor(event.to)} [")
+            val trigger = event.trigger
+            val localTrigger = event.localTrigger
+            when {
+                trigger != null -> {
+                    append("msg=${trigger.messageType}")
+                    appendPeerDetails(trigger)
+                }
+                localTrigger != null -> append("local=${labelFor(localTrigger)}")
+                else -> append("no trigger")
             }
-            "$verb on ${event.message.messageType}${peerSuffix(event.message)} in ${labelFor(event.state)}"
+            append(']')
         }
-        is ExchangeV2Event.SessionStarted -> {
-            val codeLine = event.linkingCode?.let { " linkingCode=$it" } ?: ""
-            "Session started as ${event.pairingRole} ownChannelId=${event.ownChannelId}$codeLine"
+        is ExchangeV2Event.MessageSent -> buildString {
+            append("Sent ${event.message.messageType}")
+            appendPeerDetails(event.message)
+        }
+        is ExchangeV2Event.MessageRejected -> buildString {
+            append("${labelFor(event.reason)} on ${event.message.messageType}")
+            appendPeerDetails(event.message)
+            append(" in ${labelFor(event.state)}")
+        }
+        is ExchangeV2Event.SessionStarted -> buildString {
+            append("Session started as ${event.pairingRole} ownChannelId=${event.ownChannelId}")
+            event.linkingCode?.let { append(" linkingCode=$it") }
         }
         is ExchangeV2Event.SessionError -> "Session error: ${event.message}"
+        is VersionNegotiated -> "Negotiated Exchange protocol ${event.negotiatedVersion.prettyPrint()}"
     }
 
-    private fun peerSuffix(message: ExchangeV2Message): String = when (message) {
-        is ExchangeV2Message.RecoveryCodeAvailable -> " name=${message.name} kind=${message.kind} user_id=${message.userId}"
-        is ExchangeV2Message.RecoveryCodeRequest -> " name=${message.name} kind=${message.kind}"
-        else -> ""
+    private fun StringBuilder.appendPeerDetails(message: ExchangeV2Message) {
+        when (message) {
+            is ExchangeV2Message.RecoveryCodeAvailable -> append(" name=${message.name} kind=${message.kind} user_id=${message.userId}")
+            is ExchangeV2Message.RecoveryCodeRequest -> append(" name=${message.name} kind=${message.kind}")
+            else -> Unit
+        }
     }
 
-    private fun rawJsonFor(event: ExchangeV2Event): String = when (event) {
-        is ExchangeV2Event.Transition -> event.trigger?.rawJson ?: "(local trigger: ${event.localTrigger?.let(::labelFor)})"
-        is ExchangeV2Event.MessageSent -> event.message.rawJson
-        is ExchangeV2Event.MessageRejected -> event.message.rawJson
-        is ExchangeV2Event.SessionStarted -> event.linkingCode ?: "(no linking code — Scanner side)"
-        is ExchangeV2Event.SessionError -> event.message
+    private fun detailsFor(event: ExchangeV2Event): LogDetails = when (event) {
+        is ExchangeV2Event.Transition -> when (val trigger = event.trigger) {
+            null -> LogDetails.PlainText("local trigger: ${event.localTrigger?.let(::labelFor) ?: "none"}")
+            else -> LogDetails.Json(trigger.rawJson)
+        }
+        is ExchangeV2Event.MessageSent -> LogDetails.Json(event.message.rawJson)
+        is ExchangeV2Event.MessageRejected -> LogDetails.Json(event.message.rawJson)
+        is ExchangeV2Event.SessionStarted -> when (val linkingCode = event.linkingCode) {
+            null -> LogDetails.PlainText("no linking code — Scanner side")
+            else -> LogDetails.PlainText(linkingCode)
+        }
+        is ExchangeV2Event.SessionError -> LogDetails.PlainText(event.message)
+        is VersionNegotiated -> LogDetails.PlainText(
+            "ours=${event.ourVersion.prettyPrint()}, peer=${event.peerVersion.prettyPrint()} [${labelFor(event.peerSource)}]",
+        )
     }
 
     private fun labelFor(state: ExchangeV2State?): String = when (state) {
@@ -613,5 +643,16 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         LocalTrigger.HostSendComplete -> "HostSendComplete"
         LocalTrigger.HostUnavailable -> "HostUnavailable"
         is LocalTrigger.RoleElected -> "RoleElected(${trigger.role})"
+    }
+
+    private fun labelFor(reason: RejectReason): String = when (reason) {
+        RejectReason.ImplicitAbort -> "Aborted"
+        RejectReason.SameAccount -> "SameAccountAbort"
+        RejectReason.UnknownMessageDropped -> "Dropped (unknown)"
+    }
+
+    private fun labelFor(peerSource: PeerVersionSource): String = when (peerSource) {
+        PeerVersionSource.LinkingCode -> "linking_code"
+        PeerVersionSource.HelloMessage -> "hello_message"
     }
 }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event.VersionNegotiated
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -41,6 +42,7 @@ import com.duckduckgo.sync.impl.exchange.v2.PeerVersionSource
 import com.duckduckgo.sync.impl.exchange.v2.RejectReason
 import com.duckduckgo.sync.impl.exchange.v2.Role
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
+import com.duckduckgo.sync.internal.exchange.SyncInternalAdvertisedExchangeV2Version
 import com.duckduckgo.sync.store.SyncStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
@@ -48,7 +50,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -61,6 +62,7 @@ class SyncV2PairingDebugViewModel @Inject constructor(
     private val syncStore: SyncStore,
     private val syncAccountRepository: SyncAccountRepository,
     private val dispatcher: SyncCodeDispatcher,
+    private val internalAdvertisedVersion: SyncInternalAdvertisedExchangeV2Version,
     private val dispatchers: DispatcherProvider,
     @AppCoroutineScope private val appScope: CoroutineScope,
 ) : ViewModel() {
@@ -97,6 +99,7 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         val rows: List<LogRow> = emptyList(),
         val autoApproveConfirmation: Boolean = true,
         val accountStatus: AccountStatus = AccountStatus(false, null, false),
+        val protocolOverride: ExchangeProtocolVersion.V2? = null,
     )
 
     /**
@@ -131,7 +134,10 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         super.onCleared()
         // cancel() suspends until teardown completes; onCleared can't await and viewModelScope is
         // already cancelling, so fire-and-forget the teardown on the app scope (it outlives the VM).
-        appScope.launch { runner.cancel() }
+        appScope.launch {
+            runner.cancel()
+            internalAdvertisedVersion.overrideFlow.value = null
+        }
     }
 
     private val confirmationRequests = Channel<ConfirmationRequest>(Channel.BUFFERED)
@@ -157,6 +163,11 @@ class SyncV2PairingDebugViewModel @Inject constructor(
             runner.events.collect { event ->
                 appendEvent(event, isReplay = processed < replayCount)
                 processed++
+            }
+        }
+        viewModelScope.launch {
+            internalAdvertisedVersion.overrideFlow.collect { version ->
+                viewState.update { it.copy(protocolOverride = version) }
             }
         }
     }
@@ -375,6 +386,16 @@ class SyncV2PairingDebugViewModel @Inject constructor(
 
     fun onAutoApproveToggled(checked: Boolean) {
         viewState.update { it.copy(autoApproveConfirmation = checked) }
+    }
+
+    fun onProtocolOverrideSelected(version: ExchangeProtocolVersion.V2?) {
+        internalAdvertisedVersion.overrideFlow.value = version
+        appendDevToolLog("Protocol version override → ${labelFor(version)} (applies to the next session)")
+    }
+
+    fun labelFor(version: ExchangeProtocolVersion.V2?): String = when (version) {
+        null -> "Default (${internalAdvertisedVersion.defaultVersion().prettyPrint()})"
+        else -> version.prettyPrint()
     }
 
     fun onConfirmationApproved(role: Role) {

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -112,13 +112,6 @@
             app:showSwitch="true"
             app:primaryText="canShowV2ConnectCode (display, requires canUseV2ConnectFlow)" />
 
-        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
-            android:id="@+id/canUseExchangeV2Point1"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:primaryText="canUseExchangeV2.1"
-            app:showSwitch="true" />
-
         <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
             android:id="@+id/openV2PairingDebugButton"
             android:layout_width="wrap_content"

--- a/sync/sync-internal/src/main/res/layout/activity_sync_v2_pairing_debug.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_sync_v2_pairing_debug.xml
@@ -46,8 +46,8 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center_vertical">
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
 
                 <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
                     android:id="@+id/statusSignedIn"
@@ -89,6 +89,28 @@
                 app:secondaryText="When on, this device automatically confirms its own Host/Joiner prompt. Turn off to see the real alert dialog."
                 app:showSwitch="true" />
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                    android:id="@+id/protocolVersionSetting"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    app:primaryText="Protocol version"
+                    tools:secondaryText="Default" />
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                    android:id="@+id/changeProtocolVersionButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/keyline_4"
+                    android:text="Change" />
+            </LinearLayout>
+
             <com.duckduckgo.common.ui.view.divider.HorizontalDivider
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
@@ -112,8 +134,8 @@
                 android:id="@+id/runPresentButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/keyline_4"
                 android:layout_margin="10dp"
+                android:layout_marginStart="@dimen/keyline_4"
                 android:text="Start as Presenter" />
 
             <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem

--- a/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/exchange/SyncInternalAdvertisedExchangeV2VersionTest.kt
+++ b/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/exchange/SyncInternalAdvertisedExchangeV2VersionTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.internal.exchange
+
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.duckduckgo.sync.impl.exchange.v2.RealAdvertisedExchangeV2Version
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+class SyncInternalAdvertisedExchangeV2VersionTest {
+
+    private val real: RealAdvertisedExchangeV2Version = mock()
+    private val advertisedVersion = SyncInternalAdvertisedExchangeV2Version(real)
+
+    @Test fun `no override delegates to the real resolver`() {
+        whenever(real.resolve()).thenReturn(ExchangeProtocolVersion.V2_1)
+        advertisedVersion.overrideFlow.value = null
+
+        assertEquals(ExchangeProtocolVersion.V2_1, advertisedVersion.resolve())
+    }
+
+    @Test fun `override forces the selected version regardless of flags`() {
+        advertisedVersion.overrideFlow.value = ExchangeProtocolVersion.V2_1
+
+        assertEquals(ExchangeProtocolVersion.V2_1, advertisedVersion.resolve())
+        verifyNoInteractions(real)
+    }
+}

--- a/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
+++ b/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
@@ -26,13 +26,16 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.RealAdvertisedExchangeV2Version
 import com.duckduckgo.sync.impl.exchange.v2.RejectReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.internal.exchange.SyncInternalAdvertisedExchangeV2Version
 import com.duckduckgo.sync.store.SyncStore
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
@@ -63,12 +66,17 @@ class SyncV2PairingDebugViewModelTest {
     private val syncStore: SyncStore = mock()
     private val syncAccountRepository: SyncAccountRepository = mock()
     private val dispatcher: SyncCodeDispatcher = mock()
+    private val realAdvertisedVersion: RealAdvertisedExchangeV2Version = mock<RealAdvertisedExchangeV2Version>().also {
+        whenever(it.resolve()).thenReturn(ExchangeProtocolVersion.V2_0)
+    }
+    private val internalAdvertisedVersion = SyncInternalAdvertisedExchangeV2Version(realAdvertisedVersion)
 
     private fun newViewModel() = SyncV2PairingDebugViewModel(
         runner = runner,
         syncStore = syncStore,
         syncAccountRepository = syncAccountRepository,
         dispatcher = dispatcher,
+        internalAdvertisedVersion = internalAdvertisedVersion,
         dispatchers = coroutineTestRule.testDispatcherProvider,
         appScope = coroutineTestRule.testScope,
     )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1217367677188795
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Makes Exchange protocol version negotiation visible and controllable while testing v2.1. The negotiated version was only written to logcat, and the advertised version could only be changed through the `canUseExchangeV2Point1` flag, which applied to the whole app and could not be varied per device quickly.

Main changes:
- The runner reports version negotiation as an event when the peer's advertised version becomes known. 
- The "V2 Pairing Debug" screen has a new "Protocol version" setting with "Default", "v2.0" and "v2.1" options. 
- The "canUseExchangeV2.1" toggle has been removed from Sync Dev Settings, replaced by the per-session override from the "V2 Pairing Debug" screen.
- Row details are now either JSON or plain text, and "Copy JSON" is only shown on rows that hold real JSON. 
- Rows holding plain text no longer show a "Copy JSON"
- Documentation update across the Exchange v2 classes and an import clean up in the `exchange/v2` package.

### Steps to test this PR

_Pair two devices and read the negotiated version_
- [ ] Install an internal build on two devices.
- [ ] Sign device A into a sync account.
- [ ] Open Sync Dev Settings on device A.
- [ ] Tap "V2 Pairing Debug".
- [ ] Tap "Start as Presenter".
- [ ] Tap "Copy linking code".
- [ ] Send the linking code to device B.
- [ ] Copy the linking code to the clipboard on device B.
- [ ] Open Sync Dev Settings on device B.
- [ ] Tap "V2 Pairing Debug".
- [ ] Tap "Paste & Go".
- [ ] Verify both devices show a "Negotiated Exchange protocol" row in the log.
- [ ] Tap that row on device A.
- [ ] Verify the details show both versions and end with "[hello message]".
- [ ] Tap that row on device B.
- [ ] Verify the details show both versions and end with "[linking code]".

_Force v2.1 on both devices_
- [ ] Select "v2.1" under "Protocol version" on device A.
- [ ] Verify a "Protocol version override" row is added to the log.
- [ ] Select "v2.1" under "Protocol version" on device B.
- [ ] Pair the two devices again.
- [ ] Verify both devices report "Negotiated Exchange protocol v2.1".

_Negotiate down to the older version_
- [ ] Select "v2.0" under "Protocol version" on device B.
- [ ] Pair the two devices again.
- [ ] Verify both devices report "Negotiated Exchange protocol v2.0".
- [ ] Tap the "Negotiated Exchange protocol" row on device A.
- [ ] Verify the details show "ours=v2.1, peer=v2.0".

### UI changes
| Debug screen  | Protocol selection dialog |
| ------ | ----- |
| <img width="540" height="1212" alt="image" src="https://github.com/user-attachments/assets/6d379ec4-2d3d-4e85-9379-32dc6b776278" /> | <img width="540" height="1212" alt="image" src="https://github.com/user-attachments/assets/a63c3861-47e1-4ee9-a3db-25a110e8feab" /> |

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Exchange v2 pairing bootstrap, version negotiation, and relay channel authentication—important for interoperability with v2.0/v2.1 peers, though changes are mostly observability and internal debug overrides with production logic routed through the new advertised-version abstraction.
> 
> **Overview**
> Improves **Exchange V2 protocol version** visibility and per-session control for internal testing, without changing production pairing behavior beyond how advertised version and channel auth are derived.
> 
> The runner now emits **`VersionNegotiated`** when the peer’s version is known (from the linking code on Scanner or hello on Presenter), including ours, theirs, the negotiated minimum, and **`PeerVersionSource`**. **`AdvertisedExchangeV2Version`** centralizes which v2.x this device advertises at session bootstrap; channel-secret generation uses advertised **v2.1+** or **`canSendExchangeChannelSecret`** instead of the removed **`authenticateExchangeEndpoints`** helper.
> 
> On **V2 Pairing Debug**, a **Protocol version** picker (Default / v2.0 / v2.1) overrides the advertised version for the next session via **`SyncInternalAdvertisedExchangeV2Version`**; the global **`canUseExchangeV2Point1`** toggle is removed from Sync Dev Settings. The event log shows negotiation rows and uses **JSON vs plain-text** details so **Copy JSON** only appears when appropriate.
> 
> Also adds **`prettyPrint()`** on protocol versions, expanded Exchange v2 documentation, and test updates for advertised version and negotiation events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c228be21aa0febbf990298a8acf459185a520ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->