### PR TITLE
foo

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -312,13 +312,15 @@ class RealSyncCodeDispatcher @Inject constructor(
         ExchangeV2State.Host.Aborted -> hostAbortedToOutcome(transition.localTrigger, transition.trigger)
         // Per spec §"Same-account case": not an abort; both devices share an account already.
         ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
-        ExchangeV2State.Joiner.Done -> {
+        ExchangeV2State.Joiner.Joining -> {
             val received = (transition.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
-            if (received.isNullOrBlank()) {
-                DispatchOutcome.Failed("joiner_done_missing_recovery_code", NO_RECOVERY_CODE.code)
+            val outcome = if (received.isNullOrBlank()) {
+                DispatchOutcome.Failed("joiner_joining_missing_recovery_code", NO_RECOVERY_CODE.code)
             } else {
                 loginWithV2RecoveryCode(received, peerKind)
             }
+            runner.localTrigger(LocalTrigger.JoinerJoinComplete(outcome.toRecoveryCodeDoneReason())).join()
+            outcome
         }
         ExchangeV2State.Joiner.AbortedByHost -> when (transition.trigger) {
             is ExchangeV2Message.RecoveryCodeDenied ->
@@ -350,6 +352,19 @@ class RealSyncCodeDispatcher @Inject constructor(
             SessionErrorKind.Unknown -> PAIRING_FAILED.code
         }
         return DispatchOutcome.Failed(event.message, code, timeoutStage = event.timeoutStage)
+    }
+
+    // TODO: Check how to map to a correct recovery_code_done.reason
+    private fun DispatchOutcome.toRecoveryCodeDoneReason(): ExchangeV2Message.RecoveryCodeDone.Reason = when {
+        this is DispatchOutcome.LoggedIn || this is DispatchOutcome.AlreadyConnected -> {
+            ExchangeV2Message.RecoveryCodeDone.Reason.Success
+        }
+
+        this is DispatchOutcome.Failed && code in SCOPE_REJECTION_CODES -> {
+            ExchangeV2Message.RecoveryCodeDone.Reason.ScopeRejected
+        }
+
+        else -> ExchangeV2Message.RecoveryCodeDone.Reason.LoginFailed
     }
 
     private fun hostAbortedToOutcome(
@@ -524,5 +539,12 @@ class RealSyncCodeDispatcher @Inject constructor(
 
         // Extracts the major version from the EnvelopeVersionTooNew SessionError message.
         private val VERSION_TOO_NEW_REGEX = Regex("""protocol v(\d+)""")
+
+        private val SCOPE_REJECTION_CODES = setOf(
+            AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED.code,
+            AccountErrorCodes.MISSING_3PARTY_CREDENTIAL.code,
+            AccountErrorCodes.UNDECRYPTABLE_3PARTY_CREDENTIAL.code,
+            AccountErrorCodes.MISSING_3PARTY_KEY.code,
+        )
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Message.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Message.kt
@@ -27,8 +27,8 @@ import org.json.JSONObject
  * required to process it) and `payload` (the JWE compact serialization of the encrypted message
  * JSON, whose `kid` header is the sender's channel ID).
  *
- * Spec: Asana 1215056232572321 (Exchange V2 Messages), 1215056232572322 (Exchange V2 Message
- * Sequence State Machine).
+ * Spec: Asana 1215056232572321 (Exchange V2 Messages), 1216906886019334 (Exchange V2.1 Messages)
+ * 1215056232572322 (Exchange V2 Message Sequence State Machine).
  */
 sealed interface ExchangeV2Message {
     /**
@@ -65,7 +65,7 @@ sealed interface ExchangeV2Message {
         val publicKey: String,
         val version: ExchangeProtocolVersion,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -120,7 +120,7 @@ sealed interface ExchangeV2Message {
         val name: String,
         val kind: String,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -174,7 +174,7 @@ sealed interface ExchangeV2Message {
         val name: String,
         val kind: String,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -215,7 +215,7 @@ sealed interface ExchangeV2Message {
     data class RecoveryCodeAwaitingConfirmation(
         override val rawJson: String,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -236,7 +236,7 @@ sealed interface ExchangeV2Message {
     data class RecoveryCodeConfirmed(
         override val rawJson: String,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -255,7 +255,7 @@ sealed interface ExchangeV2Message {
     data class RecoveryCodeDenied(
         override val rawJson: String,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -274,7 +274,7 @@ sealed interface ExchangeV2Message {
     data class RecoveryCodeUnavailable(
         override val rawJson: String,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -296,7 +296,7 @@ sealed interface ExchangeV2Message {
         override val rawJson: String,
         val recoveryCode: String,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -313,6 +313,67 @@ sealed interface ExchangeV2Message {
                 return RecoveryCodeResponse(
                     rawJson = rawJson,
                     recoveryCode = json.optString(FIELD_RECOVERY_CODE, ""),
+                )
+            }
+        }
+    }
+
+    /**
+     * Sent by the Joiner once it has finished using the recovery code, carrying the real outcome so
+     * the Host can show it instead of assuming success. Only valid after `recovery_code_response`.
+     */
+    data class RecoveryCodeDone(
+        override val rawJson: String,
+        val reason: Reason,
+    ) : ExchangeV2Message {
+        override val messageType get() = TYPE
+        override val protocolVersion get() = ExchangeProtocolVersion.V2_1
+
+        sealed interface Reason {
+            val value: String
+
+            data object Success : Reason {
+                override val value = "success"
+            }
+
+            data object LoginFailed : Reason {
+                override val value = "login_failed"
+            }
+
+            data object ScopeRejected : Reason {
+                override val value = "scope_rejected"
+            }
+
+            data class Unknown(
+                val rawValue: String,
+            ) : Reason {
+                override val value get() = rawValue
+            }
+
+            companion object {
+                fun fromJsonValue(value: String): Reason = when (value) {
+                    Success.value -> Success
+                    LoginFailed.value -> LoginFailed
+                    ScopeRejected.value -> ScopeRejected
+                    else -> Unknown(value)
+                }
+            }
+        }
+
+        companion object {
+            const val TYPE = "recovery_code_done"
+            private const val FIELD_REASON = "reason"
+
+            fun create(reason: Reason) = RecoveryCodeDone(
+                rawJson = buildMessageJson(TYPE) { put(FIELD_REASON, reason.value) },
+                reason = reason,
+            )
+
+            fun fromJson(rawJson: String): RecoveryCodeDone {
+                val json = JSONObject(rawJson)
+                return RecoveryCodeDone(
+                    rawJson = rawJson,
+                    reason = Reason.fromJsonValue(json.optString(FIELD_REASON, "")),
                 )
             }
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2MessageParser.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2MessageParser.kt
@@ -41,6 +41,7 @@ class JsonExchangeV2MessageParser @Inject constructor() : ExchangeV2MessageParse
                 ExchangeV2Message.RecoveryCodeDenied.TYPE -> ExchangeV2Message.RecoveryCodeDenied.fromJson(rawJson)
                 ExchangeV2Message.RecoveryCodeUnavailable.TYPE -> ExchangeV2Message.RecoveryCodeUnavailable.fromJson(rawJson)
                 ExchangeV2Message.RecoveryCodeResponse.TYPE -> ExchangeV2Message.RecoveryCodeResponse.fromJson(rawJson)
+                ExchangeV2Message.RecoveryCodeDone.TYPE -> ExchangeV2Message.RecoveryCodeDone.fromJson(rawJson)
                 else -> ExchangeV2Message.Unknown.fromJson(rawJson, messageType = type)
             }
         }.getOrElse { ExchangeV2Message.Unknown.fromJson(rawJson, messageType = type) }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -98,7 +98,13 @@ interface ExchangeV2Runner {
      */
     suspend fun cancel()
 
-    fun localTrigger(trigger: LocalTrigger)
+    /**
+     * Drive the state machine with a local trigger.
+     *
+     * Returns the [Job] doing that work. Most callers can ignore it, but one about to end the session
+     * must join it first. Never join it from code holding the runner's mutex.
+     */
+    fun localTrigger(trigger: LocalTrigger): Job
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -409,6 +415,7 @@ class RealExchangeV2Runner @Inject constructor(
         ExchangeV2State.Negotiating -> TimeoutStage.WAITING_FOR_PEER_STATUS
         Host.Confirming, Joiner.Confirming -> TimeoutStage.WAITING_FOR_CONFIRMATION
         Host.Sending, Joiner.Waiting -> TimeoutStage.WAITING_FOR_RECOVERY_CODE
+        Host.AwaitingStatus, Joiner.Joining -> TimeoutStage.LOGGING_IN
         else -> null
     }
 
@@ -487,6 +494,10 @@ class RealExchangeV2Runner @Inject constructor(
                 logcat { "Sync-ExchangeV2: side effect → RequestRecoveryCodeShare" }
                 shareRecoveryCodeAndAdvanceLocked()
             }
+            is SideEffect.SendRecoveryCodeDone -> {
+                logcat { "Sync-ExchangeV2: side effect → SendRecoveryCodeDone(${effect.reason.value})" }
+                sendMessage(ExchangeV2Message.RecoveryCodeDone.create(effect.reason))
+            }
         }
     }
 
@@ -501,7 +512,7 @@ class RealExchangeV2Runner @Inject constructor(
             mutex.withLock {
                 val s = session ?: return@withLock
                 if (s.currentState != ExchangeV2State.Host.Sending) return@withLock
-                val terminalTrigger = if (responseOk) LocalTrigger.HostSendComplete else LocalTrigger.HostUnavailable
+                val terminalTrigger = if (responseOk) LocalTrigger.HostSendComplete(negotiatedVersion) else LocalTrigger.HostUnavailable
                 val r = s.localTrigger(terminalTrigger)
                 emit(r.event)
                 r.sideEffects.forEach { applySideEffectLocked(it) }
@@ -611,11 +622,10 @@ class RealExchangeV2Runner @Inject constructor(
     // Local triggers — drive SM + send outbound messages on Host transitions
     // -----------------------------------------------------------------------
 
-    override fun localTrigger(trigger: LocalTrigger) {
+    override fun localTrigger(trigger: LocalTrigger): Job =
         appScope.launch(dispatchers.io()) {
             mutex.withLock { processLocalTriggerLocked(trigger) }
         }
-    }
 
     private suspend fun processLocalTriggerLocked(trigger: LocalTrigger) {
         val sm = session ?: run {
@@ -781,10 +791,20 @@ class RealExchangeV2Runner @Inject constructor(
         return recoveryCodeProvider.getThirdPartyRecoveryCode()
     }
 
+    /**
+     * Send one state-machine-declared message, unless the peer couldn't process it.
+     * [ExchangeV2Message.protocolVersion] is the minimum a receiver needs, so anything above what we
+     * negotiated is a type this peer would only drop. Skipping keeps a disabled protocol version off
+     * the wire entirely, rather than relying on the peer to ignore it.
+     */
     private fun sendMessage(message: ExchangeV2Message) {
         val peer = peerChannelId ?: return
         val peerKey = peerPublicKey ?: return
-        sendOnWireAndRecord(message, peer, peerKey)
+        if (message.protocolVersion <= negotiatedVersion) {
+            sendOnWireAndRecord(message, peer, peerKey)
+        } else {
+            logcat { "Sync-ExchangeV2: skipping ${message.messageType} (needs v${message.protocolVersion}, negotiated v$negotiatedVersion)" }
+        }
     }
 
     /** Returns true on successful POST, false on transport error (caller decides if fatal). */
@@ -867,6 +887,7 @@ class RealExchangeV2Runner @Inject constructor(
         Joiner.AbortedLocal,
         Joiner.AbortedByHost,
         Joiner.Done,
+        Joiner.JoinFailed,
         -> true
         else -> false
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2State.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2State.kt
@@ -17,47 +17,194 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 /**
- * State machine nodes for the v2 exchange protocol.
+ * Every node the Exchange V2 protocol session can be in.
  *
- * Spec: Asana 1215056232572322. The machine starts in [Bootstrapped], shares a
- * negotiation phase with the peer, then forks into [Host] or [Joiner] after role election.
+ * The state machine exists to validate the order of messages, not their content: for a given
+ * state it decides whether an inbound message is accepted, dropped, or a protocol error. States
+ * therefore mirror "what are we waiting for", never "what is the UI showing".
+ *
+ * The session starts in a shared phase where roles aren't known yet ([Bootstrapped] →
+ * [Negotiating]), then forks into the [Host] or [Joiner] substate once the runner elects a role.
+ * Each fork ends in one of its own terminal states, at which point the runner tears the session
+ * down: deletes its relay channel and discards the session keys. Nothing can happen after a
+ * terminal, so any work that must outlive it  belongs in a non-terminal state.
+ *
+ * Each state below is tagged with the protocol version that introduced it. 2.1 states are only ever
+ * reached when *both* peers advertised 2.1; against a 2.0 peer the session follows the 2.0 path
+ * unchanged, which is what keeps the two versions interoperable.
+ *
+ * Spec:
+ *  - Asana 1215056232572322, Exchange V2 Message Sequence State Machine: the 2.0 machine, plus the
+ *    implicit-abort and unknown-message-drop rules the transitions rely on.
+ *  - Asana 1216906888491126, Exchange v2.1 State machine: the delta, which is the join-status states.
+ *  - Asana 1214739740392701, Unified Algorithm: role election and the abort rules the runner applies
+ *    around this machine.
  */
 sealed interface ExchangeV2State {
+
+    /**
+     * Presenter's start state: the linking code is published, and we're waiting for a peer to scan it
+     * and send `hello`. A Scanner never sees this state: it learned the peer from the QR code, so it
+     * starts in [Negotiating] (messages you send never come back to your own inbox, so a Scanner
+     * could not receive its own `hello`).
+     *
+     * Since 2.0.
+     */
     data object Bootstrapped : ExchangeV2State
+
+    /**
+     * Peer identity is established and both sides declare whether they have an account
+     * (`recovery_code_available` / `recovery_code_request`). Stays here, absorbing those, until the
+     * runner has enough to elect a role and fires `RoleElected`.
+     *
+     * Since 2.0.
+     */
     data object Negotiating : ExchangeV2State
 
     /**
-     * Detected during Negotiating that the peer reports the same `user_id` as us — both
-     * devices are already on the same account. Per spec §"Same-account case" this is **not
+     * Terminal. Detected during [Negotiating] that the peer reports the same `user_id` as us, so
+     * both devices are already on the same account. Per spec §"Same-account case" this is **not
      * an abort**: callers should surface a friendly "Connected" finish, not an error. The
      * dispatcher maps this state to [com.duckduckgo.sync.impl.DispatchOutcome.AlreadyConnected].
      * Name retained for historical continuity; treat semantically as a success terminal.
+     *
+     * Since 2.0.
      */
     data object SameAccountAbort : ExchangeV2State
 
     /**
-     * Negotiation aborted before role election — e.g. an unexpected or duplicate `hello`
-     * received while in [Negotiating] (a second hello, or the double-scan race). Terminal.
-     * Per Unified Algorithm 1214739740392701 §Handshake Note: "abort and close the channel".
+     * Terminal. Negotiation aborted before role election, e.g. an unexpected or duplicate `hello`
+     * received while in [Negotiating] (a second hello, or the double-scan race). Per Unified
+     * Algorithm 1214739740392701 §Handshake Note: "abort and close the channel". The role-specific
+     * forks have their own abort terminals ([Host.Aborted], [Joiner.AbortedLocal]); this one only
+     * covers failures from before a role existed.
+     *
+     * Since 2.0.
      */
     data object Aborted : ExchangeV2State
 
+    /**
+     * The device that owns (or will create) the account and hands over the recovery code. Elected,
+     * not chosen by the user: a Presenter can end up Joiner and vice versa.
+     */
     sealed interface Host : ExchangeV2State {
+
+        /**
+         * Prompting our own user to approve sharing. `recovery_code_awaiting_confirmation` has
+         * already gone out, so the peer can show "check the other device" while we wait.
+         *
+         * Since 2.0.
+         */
         data object Confirming : Host
+
+        /**
+         * User approved. Provisioning whatever the peer's kind needs (create the account, add a
+         * 3party credential) and sending `recovery_code_response`, or `recovery_code_unavailable`
+         * if none of that can be produced.
+         *
+         * Since 2.0.
+         */
         data object Sending : Host
+
+        /**
+         * Recovery code delivered; waiting for the Joiner to report what it did with it. Reached
+         * only when the negotiated version is 2.1. A 2.0 Joiner never reports, so against one the
+         * Host goes straight to [Done] exactly as it did in 2.0.
+         *
+         * Not terminal: the session stays alive and keeps polling until the report arrives or the
+         * session deadline fires.
+         *
+         * Since 2.1.
+         */
+        data object AwaitingStatus : Host
+
+        /**
+         * Terminal. The Host side gave up: our user denied the prompt, no recovery code could be
+         * produced, or the peer broke the message sequence.
+         *
+         * Since 2.0.
+         */
         data object Aborted : Host
+
+        /**
+         * Terminal. Finished as Host. Against a 2.0 peer that means only "the recovery code was
+         * sent"; against a 2.1 peer it means the Joiner reported back, and the reason it reported,
+         * carried on the `recovery_code_done` that got us here, says whether it actually worked.
+         *
+         * Since 2.0.
+         */
         data object Done : Host
     }
 
+    /**
+     * The device that receives the recovery code and joins the Host's account.
+     */
     sealed interface Joiner : ExchangeV2State {
+
+        /**
+         * Prompting our own user to approve joining. Nothing is sent to the peer from here, since by
+         * spec the Joiner's denial is silent, so the only inbound messages that matter are the
+         * Host's own aborts.
+         *
+         * Since 2.0.
+         */
         data object Confirming : Joiner
+
+        /**
+         * User approved; waiting on the Host. Absorbs its progress messages
+         * (`recovery_code_awaiting_confirmation`, `recovery_code_confirmed`) without changing state.
+         *
+         * Since 2.0.
+         */
         data object Waiting : Joiner
+
+        /**
+         * Recovery code received; applying it (login, 3party upgrade, initial sync) and not yet
+         * done.
+         *
+         * Not terminal, and that is the whole point: the session has to outlive the login so
+         * `recovery_code_done` can still be sent afterward. In 2.0 `recovery_code_response` landed
+         * straight on [Done] because there was nothing left to report.
+         *
+         * Since 2.1.
+         */
+        data object Joining : Joiner
+
+        /**
+         * Terminal. We ended it ourselves: our user denied the prompt, or the Host broke the message
+         * sequence. Nothing is sent to the peer.
+         *
+         * Since 2.0.
+         */
         data object AbortedLocal : Joiner
+
+        /**
+         * Terminal. The Host ended it: `recovery_code_denied` (its user declined) or
+         * `recovery_code_unavailable` (it couldn't produce a code).
+         *
+         * Since 2.0.
+         */
         data object AbortedByHost : Joiner
+
+        /**
+         * Terminal. Joined successfully. Since 2.1 this is reached only after
+         * `recovery_code_done(success)` has been sent, not on receiving the recovery code.
+         *
+         * Since 2.0.
+         */
         data object Done : Joiner
+
+        /**
+         * Terminal. Failed to apply the recovery code, and reported that. Both this and [Done] are
+         * reached only after `recovery_code_done` has been sent; the reason distinguishes them.
+         *
+         * Since 2.1.
+         */
+        data object JoinFailed : Joiner
     }
 }
 
+/** Which side of the exchange this device plays, decided by role election in the runner. */
 enum class Role {
     Host,
     Joiner,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
@@ -16,11 +16,13 @@
 
 package com.duckduckgo.sync.impl.exchange.v2
 
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAvailable
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAwaitingConfirmation
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeConfirmed
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDenied
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeUnavailable
@@ -58,7 +60,7 @@ class ExchangeV2StateMachineFactory @Inject constructor(
         localUserId: String?,
         initialState: ExchangeV2State = ExchangeV2State.Bootstrapped,
     ): ExchangeV2StateMachine =
-        RealExchangeV2StateMachine(localUserId = localUserId, clock = clock, initialState = initialState)
+        RealExchangeV2StateMachine(localUserId, clock, initialState)
 }
 
 /** Indirection so tests can supply a fixed timestamp. */
@@ -76,143 +78,166 @@ internal class RealExchangeV2StateMachine(
         private set
 
     override fun receive(msg: ExchangeV2Message): TransitionResult {
+        // Forward-compat rule, applied once for every state: a type this client doesn't model is
+        // dropped, never treated as a protocol error. Handlers below therefore only decide between
+        // "expected here" and the implicit abort.
         if (msg is Unknown) return drop(msg)
-        return when (val state = currentState) {
-            ExchangeV2State.Bootstrapped -> receiveInBootstrapped(state, msg)
-            ExchangeV2State.Negotiating -> receiveInNegotiating(state, msg)
-            ExchangeV2State.Joiner.Confirming -> receiveInJoinerConfirming(state, msg)
-            ExchangeV2State.Joiner.Waiting -> receiveInJoinerWaiting(state, msg)
-            else -> abort(state, msg, RejectReason.ImplicitAbort)
+        return when (val from = currentState) {
+            ExchangeV2State.Bootstrapped -> receiveInBootstrapped(from, msg)
+            ExchangeV2State.Negotiating -> receiveInNegotiating(from, msg)
+            ExchangeV2State.Host.AwaitingStatus -> receiveInHostAwaitingStatus(from, msg)
+            ExchangeV2State.Joiner.Confirming -> receiveInJoinerConfirming(from, msg)
+            ExchangeV2State.Joiner.Waiting -> receiveInJoinerWaiting(from, msg)
+            else -> abort(from, msg, RejectReason.ImplicitAbort)
         }
     }
 
     override fun localTrigger(trigger: LocalTrigger): TransitionResult {
-        return when (val state = currentState) {
-            ExchangeV2State.Negotiating -> localTriggerInNegotiating(state, trigger)
-            ExchangeV2State.Host.Confirming -> localTriggerInHostConfirming(state, trigger)
-            ExchangeV2State.Host.Sending -> localTriggerInHostSending(state, trigger)
-            ExchangeV2State.Joiner.Confirming -> localTriggerInJoinerConfirming(state, trigger)
-            else -> abortLocal(state, trigger)
+        return when (val from = currentState) {
+            ExchangeV2State.Negotiating -> localTriggerInNegotiating(from, trigger)
+            ExchangeV2State.Host.Confirming -> localTriggerInHostConfirming(from, trigger)
+            ExchangeV2State.Host.Sending -> localTriggerInHostSending(from, trigger)
+            ExchangeV2State.Joiner.Confirming -> localTriggerInJoinerConfirming(from, trigger)
+            ExchangeV2State.Joiner.Joining -> localTriggerInJoinerJoining(from, trigger)
+            else -> abortLocal(from, trigger)
         }
     }
 
-    private fun receiveInBootstrapped(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
+    private fun receiveInBootstrapped(from: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
         return if (msg is Hello) {
-            accept(state, ExchangeV2State.Negotiating, msg)
+            accept(from, ExchangeV2State.Negotiating, msg)
         } else {
-            abort(state, msg, RejectReason.ImplicitAbort)
+            abort(from, msg, RejectReason.ImplicitAbort)
         }
     }
 
-    private fun receiveInNegotiating(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
+    private fun receiveInNegotiating(from: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
         return when (msg) {
-            // By the time we are in Negotiating the peer hello is already established
-            // (Scanner: by scanning the QR; Presenter: consumed in receiveInBootstrapped).
-            // Any further hello is a duplicate or the double-scan race → abort and close the
-            // channel. Deliberate "record a pixel; abort (scope-cut)" (pixel deferred: Asana 1215473364991760).
-            is Hello -> abort(state, msg, RejectReason.ImplicitAbort)
             is RecoveryCodeAvailable -> {
                 if (localUserId != null && msg.userId == localUserId) {
-                    abort(state, msg, RejectReason.SameAccount, newState = ExchangeV2State.SameAccountAbort)
+                    abort(from, msg, RejectReason.SameAccount, ExchangeV2State.SameAccountAbort)
                 } else {
                     // Role election lives in the runner: this device records the peer's
                     // availability and stays in Negotiating until LocalTrigger.RoleElected fires.
-                    accept(state, ExchangeV2State.Negotiating, msg)
+                    accept(from, ExchangeV2State.Negotiating, msg)
                 }
             }
             // Both availability messages keep us in Negotiating; the runner combines them
             // with own account state, own/peer kind, scan order, and channel_id tiebreak
             // before electing a role (see Asana Unified Algorithm 1214739740392701).
-            is RecoveryCodeRequest -> accept(state, ExchangeV2State.Negotiating, msg)
-            is RecoveryCodeAwaitingConfirmation,
-            is RecoveryCodeConfirmed,
-            is RecoveryCodeDenied,
-            is RecoveryCodeUnavailable,
-            is RecoveryCodeResponse,
-            -> abort(state, msg, RejectReason.ImplicitAbort)
-            is Unknown -> drop(msg)
+            is RecoveryCodeRequest -> accept(from, ExchangeV2State.Negotiating, msg)
+            // By the time we are in Negotiating the peer hello is already established
+            // (Scanner: by scanning the QR; Presenter: consumed in receiveInBootstrapped).
+            // Any further hello is a duplicate or the double-scan race → abort and close the
+            // channel. Deliberate "record a pixel; abort (scope-cut)" (pixel deferred: Asana 1215473364991760).
+            is Hello -> abort(from, msg, RejectReason.ImplicitAbort)
+            else -> abort(from, msg, RejectReason.ImplicitAbort)
         }
     }
 
-    // If the peer aborts while we're still showing the confirm prompt, act on it now instead of
+    private fun receiveInHostAwaitingStatus(from: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
+        return when (msg) {
+            is RecoveryCodeDone -> accept(from, ExchangeV2State.Host.Done, msg)
+            else -> abort(from, msg, RejectReason.ImplicitAbort)
+        }
+    }
+
+    // If the peer aborts while we're still showing the confirmation prompt, act on it now instead of
     // making the user confirm a doomed pairing.
-    private fun receiveInJoinerConfirming(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
+    private fun receiveInJoinerConfirming(from: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
         return when (msg) {
-            is RecoveryCodeDenied -> accept(state, ExchangeV2State.Joiner.AbortedByHost, msg)
-            is RecoveryCodeUnavailable -> accept(state, ExchangeV2State.Joiner.AbortedByHost, msg)
-            else -> abort(state, msg, RejectReason.ImplicitAbort)
+            is RecoveryCodeDenied -> accept(from, ExchangeV2State.Joiner.AbortedByHost, msg)
+            is RecoveryCodeUnavailable -> accept(from, ExchangeV2State.Joiner.AbortedByHost, msg)
+            else -> abort(from, msg, RejectReason.ImplicitAbort)
         }
     }
 
-    private fun receiveInJoinerWaiting(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
+    private fun receiveInJoinerWaiting(from: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
         return when (msg) {
-            is RecoveryCodeAwaitingConfirmation -> accept(state, ExchangeV2State.Joiner.Waiting, msg)
-            is RecoveryCodeConfirmed -> accept(state, ExchangeV2State.Joiner.Waiting, msg)
-            is RecoveryCodeDenied -> accept(state, ExchangeV2State.Joiner.AbortedByHost, msg)
-            is RecoveryCodeUnavailable -> accept(state, ExchangeV2State.Joiner.AbortedByHost, msg)
-            is RecoveryCodeResponse -> accept(state, ExchangeV2State.Joiner.Done, msg)
-            is Hello,
-            is RecoveryCodeAvailable,
-            is RecoveryCodeRequest,
-            -> abort(state, msg, RejectReason.ImplicitAbort)
-            is Unknown -> drop(msg)
+            is RecoveryCodeAwaitingConfirmation -> accept(from, ExchangeV2State.Joiner.Waiting, msg)
+            is RecoveryCodeConfirmed -> accept(from, ExchangeV2State.Joiner.Waiting, msg)
+            is RecoveryCodeDenied -> accept(from, ExchangeV2State.Joiner.AbortedByHost, msg)
+            is RecoveryCodeUnavailable -> accept(from, ExchangeV2State.Joiner.AbortedByHost, msg)
+            is RecoveryCodeResponse -> accept(from, ExchangeV2State.Joiner.Joining, msg)
+            else -> abort(from, msg, RejectReason.ImplicitAbort)
         }
     }
 
-    private fun localTriggerInNegotiating(state: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
+    private fun localTriggerInNegotiating(from: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
         return when (trigger) {
             is LocalTrigger.RoleElected -> when (trigger.role) {
                 // Spec "Exchange Confirmations → Host" step 1: send awaiting_confirmation
                 // on entry to Confirming, BEFORE the user prompt fires, so the peer can show
                 // its "confirm on the other device" UX in parallel.
                 Role.Host -> acceptLocal(
-                    state,
+                    from,
                     ExchangeV2State.Host.Confirming,
                     trigger,
                     sideEffects = listOf(SideEffect.SendAwaitingConfirmation),
                 )
-                Role.Joiner -> acceptLocal(state, ExchangeV2State.Joiner.Confirming, trigger)
+                Role.Joiner -> acceptLocal(from, ExchangeV2State.Joiner.Confirming, trigger)
             }
-            else -> abortLocal(state, trigger)
+            else -> abortLocal(from, trigger)
         }
     }
 
-    private fun localTriggerInHostConfirming(state: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
+    private fun localTriggerInHostConfirming(from: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
         return when (trigger) {
             // Spec "Exchange Confirmations → Host" step 3 (confirm branch): send confirmed,
             // then proceed to share the recovery code.
             LocalTrigger.UserConfirmedHost -> acceptLocal(
-                state,
+                from,
                 ExchangeV2State.Host.Sending,
                 trigger,
                 sideEffects = listOf(SideEffect.SendConfirmed, SideEffect.RequestRecoveryCodeShare),
             )
             // Spec "Exchange Confirmations → Host" step 3 (deny branch): send denied, abort.
             LocalTrigger.UserDeniedHost -> acceptLocal(
-                state,
+                from,
                 ExchangeV2State.Host.Aborted,
                 trigger,
                 sideEffects = listOf(SideEffect.SendDenied),
             )
-            else -> abortLocal(state, trigger)
+            else -> abortLocal(from, trigger)
         }
     }
 
-    private fun localTriggerInHostSending(state: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
+    private fun localTriggerInHostSending(from: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
         return when (trigger) {
-            LocalTrigger.HostSendComplete -> acceptLocal(state, ExchangeV2State.Host.Done, trigger)
+            // Spec 1216906886019334 §"Capability negotiation": only wait when the peer will actually
+            // report. A pre-2.1 peer never sends recovery_code_done, so waiting on one would turn a
+            // successful pairing into a spinner that only ends at the session deadline.
+            is LocalTrigger.HostSendComplete -> if (trigger.negotiatedVersion >= ExchangeProtocolVersion.V2_1) {
+                acceptLocal(from, ExchangeV2State.Host.AwaitingStatus, trigger)
+            } else {
+                acceptLocal(from, ExchangeV2State.Host.Done, trigger)
+            }
             // Host couldn't produce a recovery code (no account, no 3party credential, etc.).
             // Runner has already sent recovery_code_unavailable to peer; this just tears down.
-            LocalTrigger.HostUnavailable -> acceptLocal(state, ExchangeV2State.Host.Aborted, trigger)
-            else -> abortLocal(state, trigger)
+            LocalTrigger.HostUnavailable -> acceptLocal(from, ExchangeV2State.Host.Aborted, trigger)
+            else -> abortLocal(from, trigger)
         }
     }
 
-    private fun localTriggerInJoinerConfirming(state: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
+    private fun localTriggerInJoinerConfirming(from: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
         return when (trigger) {
-            LocalTrigger.UserConfirmedJoiner -> acceptLocal(state, ExchangeV2State.Joiner.Waiting, trigger)
-            LocalTrigger.UserDeniedJoiner -> acceptLocal(state, ExchangeV2State.Joiner.AbortedLocal, trigger)
-            else -> abortLocal(state, trigger)
+            LocalTrigger.UserConfirmedJoiner -> acceptLocal(from, ExchangeV2State.Joiner.Waiting, trigger)
+            LocalTrigger.UserDeniedJoiner -> acceptLocal(from, ExchangeV2State.Joiner.AbortedLocal, trigger)
+            else -> abortLocal(from, trigger)
+        }
+    }
+
+    private fun localTriggerInJoinerJoining(from: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
+        return when (trigger) {
+            is LocalTrigger.JoinerJoinComplete -> {
+                val to = if (trigger.reason == RecoveryCodeDone.Reason.Success) {
+                    ExchangeV2State.Joiner.Done
+                } else {
+                    ExchangeV2State.Joiner.JoinFailed
+                }
+                acceptLocal(from, to, trigger, sideEffects = listOf(SideEffect.SendRecoveryCodeDone(trigger.reason)))
+            }
+            else -> abortLocal(from, trigger)
         }
     }
 
@@ -245,64 +270,65 @@ internal class RealExchangeV2StateMachine(
     }
 
     /**
-     * Reject [msg] and abort. By default we drive to [from]'s terminal state (see [abortTerminal]):
-     *  - If [from] is still active, that's a real transition into the terminal → emit [Transition].
-     *  - If [from] is already terminal, [abortTerminal] returns itself, so we stay put → emit [MessageRejected].
+     * Reject [msg] and abort. By default, we drive to [from]'s terminal state (see [abortTerminal]):
+     *  - If [from] is still active, that's a real transition into the terminal → emit [ExchangeV2Event.Transition].
+     *  - If [from] is already terminal, [abortTerminal] returns itself, so we stay put → emit [ExchangeV2Event.MessageRejected].
      *
-     * Callers can override [newState] to abort somewhere other than the default terminal.
+     * Callers can override [to] to abort somewhere other than the default terminal.
      */
     private fun abort(
         from: ExchangeV2State,
         msg: ExchangeV2Message,
         reason: RejectReason,
-        newState: ExchangeV2State = from.abortTerminal(),
+        to: ExchangeV2State = from.abortTerminal(),
     ): TransitionResult {
-        currentState = newState
-        val event = if (newState == from) {
+        currentState = to
+        val event = if (to == from) {
             ExchangeV2Event.MessageRejected(clock.nowMs(), msg, from, reason)
         } else {
-            ExchangeV2Event.Transition(
-                timestampMs = clock.nowMs(),
-                from = from,
-                to = newState,
-                trigger = msg,
-                localTrigger = null,
-            )
+            ExchangeV2Event.Transition(clock.nowMs(), from, to, msg, null)
         }
-        return TransitionResult(
-            newState = newState,
-            event = event,
-            outcome = TransitionOutcome.Aborted(reason),
-        )
+        return TransitionResult(to, event, TransitionOutcome.Aborted(reason))
     }
 
     private fun abortLocal(
         from: ExchangeV2State,
         trigger: LocalTrigger,
     ): TransitionResult {
-        val newState = from.abortTerminal()
-        currentState = newState
+        val to = from.abortTerminal()
+        currentState = to
         return TransitionResult(
-            newState = newState,
-            event = ExchangeV2Event.Transition(clock.nowMs(), from, newState, trigger = null, localTrigger = trigger),
-            outcome = TransitionOutcome.Aborted(RejectReason.ImplicitAbort),
+            to,
+            ExchangeV2Event.Transition(clock.nowMs(), from, to, null, trigger),
+            TransitionOutcome.Aborted(RejectReason.ImplicitAbort),
         )
     }
 
     private fun drop(msg: ExchangeV2Message): TransitionResult {
         return TransitionResult(
-            newState = currentState,
-            event = ExchangeV2Event.MessageRejected(clock.nowMs(), msg, currentState, RejectReason.UnknownMessageDropped),
-            outcome = TransitionOutcome.Dropped,
+            currentState,
+            ExchangeV2Event.MessageRejected(clock.nowMs(), msg, currentState, RejectReason.UnknownMessageDropped),
+            TransitionOutcome.Dropped,
         )
     }
 }
 
 /** Terminal state to drive into on an implicit abort from [this]. Terminals return themselves. */
 private fun ExchangeV2State.abortTerminal(): ExchangeV2State = when (this) {
-    ExchangeV2State.Host.Confirming, ExchangeV2State.Host.Sending -> ExchangeV2State.Host.Aborted
-    ExchangeV2State.Joiner.Confirming, ExchangeV2State.Joiner.Waiting -> ExchangeV2State.Joiner.AbortedLocal
-    ExchangeV2State.Bootstrapped, ExchangeV2State.Negotiating -> ExchangeV2State.Aborted
+    ExchangeV2State.Host.Confirming,
+    ExchangeV2State.Host.Sending,
+    ExchangeV2State.Host.AwaitingStatus,
+    -> ExchangeV2State.Host.Aborted
+
+    ExchangeV2State.Joiner.Confirming,
+    ExchangeV2State.Joiner.Waiting,
+    ExchangeV2State.Joiner.Joining,
+    -> ExchangeV2State.Joiner.AbortedLocal
+
+    ExchangeV2State.Bootstrapped,
+    ExchangeV2State.Negotiating,
+    -> ExchangeV2State.Aborted
+
     ExchangeV2State.Aborted,
     ExchangeV2State.SameAccountAbort,
     ExchangeV2State.Host.Aborted,
@@ -310,5 +336,6 @@ private fun ExchangeV2State.abortTerminal(): ExchangeV2State = when (this) {
     ExchangeV2State.Joiner.AbortedByHost,
     ExchangeV2State.Joiner.AbortedLocal,
     ExchangeV2State.Joiner.Done,
+    ExchangeV2State.Joiner.JoinFailed,
     -> this
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/LocalTrigger.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/LocalTrigger.kt
@@ -16,6 +16,9 @@
 
 package com.duckduckgo.sync.impl.exchange.v2
 
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
+
 /**
  * Side-effect-free transitions driven by something other than an inbound wire message
  * (user input, role election by the runner, completion of an outbound send).
@@ -31,7 +34,13 @@ sealed interface LocalTrigger {
      * Host has finished delivering [ExchangeV2Message.RecoveryCodeResponse] (or one of its
      * negative siblings) and is leaving the [ExchangeV2State.Host.Sending] state.
      */
-    data object HostSendComplete : LocalTrigger
+    data class HostSendComplete(val negotiatedVersion: ExchangeProtocolVersion.V2) : LocalTrigger
+
+    /**
+     * The Joiner has finished applying the recovery code, for better or worse. Carries the outcome
+     * so the state machine can both pick a terminal and declare the `recovery_code_done` to send.
+     */
+    data class JoinerJoinComplete(val reason: RecoveryCodeDone.Reason) : LocalTrigger
 
     /**
      * Host couldn't produce a recovery code for the peer (e.g. not signed in, or no 3party

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/SideEffect.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/SideEffect.kt
@@ -16,19 +16,85 @@
 
 package com.duckduckgo.sync.impl.exchange.v2
 
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
+
 /**
- * Spec-defined protocol actions that accompany a state transition. The state machine attaches
- * these to its [TransitionResult]; the runner executes them. Keeping side effects declared at
- * the transition (rather than scattered across the runner's post-trigger hooks) means each
- * spec rule lives in exactly one place and is easy to audit against the Unified Algorithm.
+ * A protocol action the runner must perform because a transition happened.
  *
- * Spec source: Asana Unified Algorithm 1214739740392701, §"Exchange Confirmations" and
- * §"Exchange Share Recovery Code".
+ * The state machine is a pure validator: it decides the next state and declares what the spec
+ * requires alongside it, but never touches the network itself. The runner executes these in list
+ * order, after the transition has already been applied and its event emitted. Two consequences
+ * follow from that:
+ *  - Order within one [TransitionResult] is significant. [SendConfirmed] ahead of
+ *    [RequestRecoveryCodeShare] is what puts `recovery_code_confirmed` on the wire before the
+ *    recovery code itself.
+ *  - No state may depend on an effect succeeding. The state has already moved by the time one runs,
+ *    so a failed send surfaces as a session error and is never rolled back or retried.
+ *
+ * Declaring effects at the transition, rather than scattering them across the runner's post-trigger
+ * hooks, keeps each spec rule in exactly one place and auditable against the spec.
+ *
+ * Each effect is tagged with the protocol version that introduced it. 2.1 effects are only reached
+ * when both peers advertised 2.1.
+ *
+ * Spec:
+ *  - Asana 1214739740392701, Unified Algorithm: §"Exchange Confirmations" and §"Exchange Share
+ *    Recovery Code" define the 2.0 effects and the point at which each fires.
+ *  - Asana 1216906886019334, Exchange v2.1 Messages: `recovery_code_done` and its best-effort rule.
  */
 sealed interface SideEffect {
 
+    /**
+     * Send `recovery_code_awaiting_confirmation`.
+     *
+     * Fires on entry to [ExchangeV2State.Host.Confirming], deliberately before our own user prompt,
+     * so the Joiner can show "check the other device" while the Host's user is still deciding.
+     *
+     * Since 2.0.
+     */
     data object SendAwaitingConfirmation : SideEffect
+
+    /**
+     * Send `recovery_code_confirmed`: our user approved sharing. Paired with
+     * [RequestRecoveryCodeShare] on the same transition and ordered first, so the peer learns the
+     * decision before the code arrives.
+     *
+     * Since 2.0.
+     */
     data object SendConfirmed : SideEffect
+
+    /**
+     * Send `recovery_code_denied`: our user refused, on the deny branch out of
+     * [ExchangeV2State.Host.Confirming]. The Joiner has no equivalent, because by spec its denial is
+     * silent.
+     *
+     * Since 2.0.
+     */
     data object SendDenied : SideEffect
+
+    /**
+     * Produce and deliver the recovery code. The one effect that is not a single message send, and
+     * the one that feeds back into the machine.
+     *
+     * The runner provisions whatever the peer's kind needs (create the account, add a 3party
+     * credential), then sends `recovery_code_response`, or `recovery_code_unavailable` if none of
+     * that could be produced. Because that involves network calls it runs asynchronously, and
+     * finishes by firing [LocalTrigger.HostSendComplete] or [LocalTrigger.HostUnavailable]. Those
+     * triggers, not this effect, are what move the Host off [ExchangeV2State.Host.Sending].
+     *
+     * Since 2.0.
+     */
     data object RequestRecoveryCodeShare : SideEffect
+
+    /**
+     * Send `recovery_code_done`, telling the Host what we actually did with its recovery code, so it
+     * can report the real result instead of assuming success.
+     *
+     * Best-effort by spec: send once, never retry, and never depend on delivery. Not sent at all
+     * when the negotiated version is below 2.1, since the peer could only drop it; and even against
+     * a 2.1 Host the channel may already be gone.
+     *
+     * Since 2.1.
+     */
+    data class SendRecoveryCodeDone(val reason: RecoveryCodeDone.Reason) : SideEffect
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -46,6 +46,7 @@ import com.duckduckgo.sync.impl.exchange.v2.SessionErrorKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -83,6 +84,7 @@ class RealSyncCodeDispatcherTest {
             val sinceMs = invocation.getArgument<Long>(0)
             runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
         }
+        whenever(it.localTrigger(any())).thenAnswer { Job().apply { complete() } }
     }
 
     private val dispatcher = RealSyncCodeDispatcher(
@@ -479,15 +481,15 @@ class RealSyncCodeDispatcherTest {
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
-        val staleJoinerDone = ExchangeV2Event.Transition(
+        val staleJoinerJoining = ExchangeV2Event.Transition(
             timestampMs = 1L,
             from = ExchangeV2State.Joiner.Waiting,
-            to = ExchangeV2State.Joiner.Done,
+            to = ExchangeV2State.Joiner.Joining,
             trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = "stale-code-from-prior-session"),
             localTrigger = null,
         )
         val staleFlow = MutableSharedFlow<ExchangeV2Event>(replay = 10)
-        staleFlow.tryEmit(staleJoinerDone)
+        staleFlow.tryEmit(staleJoinerJoining)
         whenever(runner.events).thenReturn(staleFlow)
         whenever(runner.eventsSince(any())).thenAnswer { invocation ->
             val sinceMs = invocation.getArgument<Long>(0)
@@ -544,7 +546,7 @@ class RealSyncCodeDispatcherTest {
                 ExchangeV2Event.Transition(
                     timestampMs = System.currentTimeMillis(),
                     from = ExchangeV2State.Joiner.Waiting,
-                    to = ExchangeV2State.Joiner.Done,
+                    to = ExchangeV2State.Joiner.Joining,
                     trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = recoveryCodeB64),
                     localTrigger = null,
                 ),
@@ -812,12 +814,12 @@ class RealSyncCodeDispatcherTest {
         }
     }
 
-    @Test fun `Presenter emits Failed when Joiner_Done arrives without a recovery code`() = runTest {
+    @Test fun `Presenter emits Failed when Joiner_Joining arrives without a recovery code`() = runTest {
         dispatcher.presentV2().test {
-            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Joining))
             assertEquals(
                 DispatchOutcome.Failed(
-                    "joiner_done_missing_recovery_code",
+                    "joiner_joining_missing_recovery_code",
                     NO_RECOVERY_CODE.code,
                     path = SetupPath.PAIRING,
                     myRole = SetupRole.JOINER,
@@ -828,7 +830,7 @@ class RealSyncCodeDispatcherTest {
         }
     }
 
-    @Test fun `Presenter emits LoggedIn when Joiner_Done carries a cid=ddg recovery code`() = runTest {
+    @Test fun `Presenter emits LoggedIn when Joiner_Joining carries a cid=ddg recovery code`() = runTest {
         val recoveryJson = JSONObject().apply {
             put(
                 "recovery",
@@ -853,7 +855,7 @@ class RealSyncCodeDispatcherTest {
                 ExchangeV2Event.Transition(
                     timestampMs = System.currentTimeMillis(),
                     from = ExchangeV2State.Joiner.Waiting,
-                    to = ExchangeV2State.Joiner.Done,
+                    to = ExchangeV2State.Joiner.Joining,
                     trigger = responseMessage,
                     localTrigger = null,
                 ),
@@ -865,7 +867,7 @@ class RealSyncCodeDispatcherTest {
         verify(syncAccountRepository, never()).joinAccountFromThirdPartyRecoveryCode(any())
     }
 
-    @Test fun `Presenter emits LoggedIn via 3party upgrade when Joiner_Done carries a cid=3party recovery code`() = runTest {
+    @Test fun `Presenter emits LoggedIn via 3party upgrade when Joiner_Joining carries a cid=3party recovery code`() = runTest {
         val recoveryJson = JSONObject().apply {
             put(
                 "recovery",
@@ -889,7 +891,7 @@ class RealSyncCodeDispatcherTest {
                 ExchangeV2Event.Transition(
                     timestampMs = System.currentTimeMillis(),
                     from = ExchangeV2State.Joiner.Waiting,
-                    to = ExchangeV2State.Joiner.Done,
+                    to = ExchangeV2State.Joiner.Joining,
                     trigger = responseMessage,
                     localTrigger = null,
                 ),
@@ -1175,9 +1177,9 @@ class RealSyncCodeDispatcherTest {
         }
     }
 
-    @Test fun `Scanner - Joiner_Done without recovery code maps to Failed NO_RECOVERY_CODE`() = runTest {
+    @Test fun `Scanner - Joiner_Joining without recovery code maps to Failed NO_RECOVERY_CODE`() = runTest {
         startLinking().test {
-            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Joining))
             assertEquals(NO_RECOVERY_CODE.code, (awaitItem() as DispatchOutcome.Failed).code)
             cancelAndIgnoreRemainingEvents()
         }
@@ -1249,7 +1251,7 @@ class RealSyncCodeDispatcherTest {
         }
     }
 
-    @Test fun `Presenter emits Failed when Joiner_Done carries a recovery code with unknown cid`() = runTest {
+    @Test fun `Presenter emits Failed when Joiner_Joining carries a recovery code with unknown cid`() = runTest {
         val recoveryJson = JSONObject().apply {
             put(
                 "recovery",
@@ -1272,7 +1274,7 @@ class RealSyncCodeDispatcherTest {
                 ExchangeV2Event.Transition(
                     timestampMs = System.currentTimeMillis(),
                     from = ExchangeV2State.Joiner.Waiting,
-                    to = ExchangeV2State.Joiner.Done,
+                    to = ExchangeV2State.Joiner.Joining,
                     trigger = responseMessage,
                     localTrigger = null,
                 ),

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
@@ -16,11 +16,13 @@
 
 package com.duckduckgo.sync.impl.exchange.v2
 
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAvailable
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAwaitingConfirmation
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeConfirmed
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDenied
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeUnavailable
@@ -245,10 +247,10 @@ class ExchangeV2StateMachineTest {
         assertSame(ExchangeV2State.Host.Aborted, machine.currentState)
     }
 
-    @Test fun `when HostSendComplete in Host Sending then advances to Host Done`() {
+    @Test fun `when HostSendComplete against a v2 peer in Host Sending then advances to Host Done`() {
         val machine = inHostConfirming()
         machine.localTrigger(LocalTrigger.UserConfirmedHost)
-        val result = machine.localTrigger(LocalTrigger.HostSendComplete)
+        val result = machine.localTrigger(LocalTrigger.HostSendComplete(ExchangeProtocolVersion.V2_0))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
         assertSame(ExchangeV2State.Host.Done, machine.currentState)
@@ -394,12 +396,12 @@ class ExchangeV2StateMachineTest {
         assertSame(ExchangeV2State.Joiner.AbortedByHost, machine.currentState)
     }
 
-    @Test fun `when response received in Joiner Waiting then transitions to Joiner Done`() {
+    @Test fun `when response received in Joiner Waiting then transitions to Joiner Joining`() {
         val machine = inJoinerWaiting()
         val result = machine.receive(RecoveryCodeResponse.fromJson("{}"))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
-        assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
+        assertSame(ExchangeV2State.Joiner.Joining, machine.currentState)
     }
 
     @Test fun `when negotiation-phase message received in Joiner Waiting then aborts to terminal Joiner AbortedLocal`() {
@@ -528,7 +530,7 @@ class ExchangeV2StateMachineTest {
     @Test fun `when message received in Host Done then state unchanged and outcome is Aborted`() {
         val machine = inHostConfirming().also {
             it.localTrigger(LocalTrigger.UserConfirmedHost)
-            it.localTrigger(LocalTrigger.HostSendComplete)
+            it.localTrigger(LocalTrigger.HostSendComplete(ExchangeProtocolVersion.V2_0))
         }
         assertSame(ExchangeV2State.Host.Done, machine.currentState)
 
@@ -539,7 +541,10 @@ class ExchangeV2StateMachineTest {
     }
 
     @Test fun `when message received in Joiner Done then state unchanged and outcome is Aborted`() {
-        val machine = inJoinerWaiting().also { it.receive(RecoveryCodeResponse.fromJson("{}")) }
+        val machine = inJoinerWaiting().also {
+            it.receive(RecoveryCodeResponse.fromJson("{}"))
+            it.localTrigger(LocalTrigger.JoinerJoinComplete(RecoveryCodeDone.Reason.Success))
+        }
         assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
 
         val result = machine.receive(Hello.fromJson("{}"))

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/JsonExchangeV2MessageParserTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/JsonExchangeV2MessageParserTest.kt
@@ -17,10 +17,15 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(TestParameterInjector::class)
 class JsonExchangeV2MessageParserTest {
 
     private val parser = JsonExchangeV2MessageParser()
@@ -66,6 +71,39 @@ class JsonExchangeV2MessageParserTest {
         val parsed = parser.parse(json) as ExchangeV2Message.RecoveryCodeResponse
 
         assertEquals("the-code", parsed.recoveryCode)
+    }
+
+    enum class RecoverCodeCase(
+        val rawReason: String,
+        val expectedReason: RecoveryCodeDone.Reason,
+    ) {
+        Success(
+            rawReason = "success",
+            expectedReason = RecoveryCodeDone.Reason.Success,
+        ),
+        LoginFailed(
+            rawReason = "login_failed",
+            expectedReason = RecoveryCodeDone.Reason.LoginFailed,
+        ),
+        ScopeRejected(
+            rawReason = "scope_rejected",
+            expectedReason = RecoveryCodeDone.Reason.ScopeRejected,
+        ),
+        Unknown(
+            rawReason = "future_reason",
+            expectedReason = RecoveryCodeDone.Reason.Unknown("future_reason"),
+        ),
+    }
+
+    @Test
+    fun `parses recovery_code_done with reason`(
+        @TestParameter case: RecoverCodeCase,
+    ) {
+        val json = """{"type":"recovery_code_done","reason":"${case.rawReason}"}"""
+
+        val parsed = parser.parse(json) as RecoveryCodeDone
+
+        assertEquals(case.expectedReason, parsed.reason)
     }
 
     @Test fun `parses bodyless types awaiting_confirmation confirmed denied unavailable`() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -106,6 +106,7 @@ class SyncConnectViewModelTest {
             val sinceMs = invocation.getArgument<Long>(0)
             runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
         }
+        whenever(it.localTrigger(any())).thenAnswer { kotlinx.coroutines.Job().apply { complete() } }
     }
     private val codeDispatcher = com.duckduckgo.sync.impl.RealSyncCodeDispatcher(
         syncFeature = syncFeature,
@@ -548,7 +549,7 @@ class SyncConnectViewModelTest {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Joiner.Waiting,
-                    to = ExchangeV2State.Joiner.Done,
+                    to = ExchangeV2State.Joiner.Joining,
                     trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = b64),
                 ),
             )
@@ -591,7 +592,7 @@ class SyncConnectViewModelTest {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Joiner.Waiting,
-                    to = ExchangeV2State.Joiner.Done,
+                    to = ExchangeV2State.Joiner.Joining,
                     trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = b64),
                 ),
             )
@@ -639,7 +640,7 @@ class SyncConnectViewModelTest {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Joiner.Waiting,
-                    to = ExchangeV2State.Joiner.Done,
+                    to = ExchangeV2State.Joiner.Joining,
                     trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = recoveryB64),
                 ),
             )

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.PairingRole
 import com.duckduckgo.sync.impl.exchange.v2.RejectReason
 import com.duckduckgo.sync.impl.exchange.v2.Role
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
@@ -404,38 +405,56 @@ class SyncV2PairingDebugViewModel @Inject constructor(
             maybeHandleConfirmingTransition(event)
             maybeEmitTerminalAlert(event)
             maybeToastSessionError(event)
-            maybeLoginAfterJoinerDone(event)
+            maybeLoginAfterJoinerJoining(event)
         }
     }
 
     /**
-     * When the runner reaches [ExchangeV2State.Joiner.Done] from a session that was started
+     * When the runner reaches [ExchangeV2State.Joiner.Joining] from a session that was started
      * via [onRunPresentClicked] (i.e. not routed through [SyncCodeDispatcher]), the dispatcher's
      * own login Flow never runs and nothing else drives a login from the received recovery code.
-     * This handler closes that gap. Idempotent for dispatcher-routed sessions because
-     * [SyncCodeDispatcher.route] is only invoked from [onRunScanClicked] — the Presenter path
-     * never goes through it.
+     * This handler closes that gap. Scoped to Presenter sessions so a Scanner session, which does
+     * go through the dispatcher, isn't logged in twice and doesn't report two conflicting outcomes.
+     *
+     * Reports the result back to the peer, which is what moves the session off Joining and on to a
+     * Joiner terminal.
      */
-    private fun maybeLoginAfterJoinerDone(event: ExchangeV2Event) {
+    private fun maybeLoginAfterJoinerJoining(event: ExchangeV2Event) {
         if (event !is ExchangeV2Event.Transition) return
-        if (event.to != ExchangeV2State.Joiner.Done) return
+        if (event.to != ExchangeV2State.Joiner.Joining) return
+        if (runner.pairingRole != PairingRole.Presenter) return
         val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
         if (received.isNullOrBlank()) return
         viewModelScope.launch(dispatchers.io()) {
-            appendDevToolLog("Joiner.Done — driving login from received recovery code")
-            when (val decision = dispatcher.route(received)) {
-                is RouteDecision.V2InProgress -> decision.outcomes.collect { handleV2Outcome(it) }
+            appendDevToolLog("Joiner.Joining: driving login from received recovery code")
+            val loggedIn = when (val decision = dispatcher.route(received)) {
+                is RouteDecision.V2InProgress -> {
+                    var success = false
+                    decision.outcomes.collect { outcome ->
+                        handleV2Outcome(outcome)
+                        if (outcome is DispatchOutcome.LoggedIn || outcome is DispatchOutcome.AlreadyConnected) success = true
+                    }
+                    success
+                }
                 is RouteDecision.Legacy -> when (decision.authCode) {
-                    is SyncAuthCode.Recovery -> emitProcessCodeResult(
-                        "Joiner.Done login",
-                        syncAccountRepository.processCode(decision.authCode),
-                    )
+                    is SyncAuthCode.Recovery -> {
+                        val result = syncAccountRepository.processCode(decision.authCode)
+                        emitProcessCodeResult("Joiner.Joining login", result)
+                        result is Result.Success
+                    }
                     else -> {
-                        appendDevToolLog("Joiner.Done: received code wasn't a Recovery shape, can't auto-login")
-                        toasts.send("Joiner.Done: unexpected code shape, manual login required")
+                        appendDevToolLog("Joiner.Joining: received code wasn't a Recovery shape, can't auto-login")
+                        toasts.send("Joiner.Joining: unexpected code shape, manual login required")
+                        false
                     }
                 }
             }
+            val reason = if (loggedIn) {
+                ExchangeV2Message.RecoveryCodeDone.Reason.Success
+            } else {
+                ExchangeV2Message.RecoveryCodeDone.Reason.LoginFailed
+            }
+            runner.localTrigger(LocalTrigger.JoinerJoinComplete(reason)).join()
             refreshState()
         }
     }
@@ -456,16 +475,25 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         ExchangeV2State.Host.Done -> TerminalReached(
             state = event.to,
             title = "✓ Pairing complete (Host)",
-            message = "Sent recovery_code_response to peer. Session closed on this side.",
+            message = when (val reported = (event.trigger as? ExchangeV2Message.RecoveryCodeDone)?.reason) {
+                null -> "Sent recovery_code_response to peer. Session closed on this side."
+                else -> "Peer reported recovery_code_done(${reported.value})."
+            },
             isSuccess = true,
         )
-        ExchangeV2State.Joiner.Done -> {
-            val code = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
+        ExchangeV2State.Joiner.Done -> TerminalReached(
+            state = event.to,
+            title = "✓ Pairing complete (Joiner)",
+            message = "Applied the peer's recovery code and sent recovery_code_done(success).",
+            isSuccess = true,
+        )
+        ExchangeV2State.Joiner.JoinFailed -> {
+            val reason = (event.localTrigger as? LocalTrigger.JoinerJoinComplete)?.reason
             TerminalReached(
                 state = event.to,
-                title = "✓ Pairing complete (Joiner)",
-                message = "Received recovery code from peer:\n\n${code ?: "(missing)"}",
-                isSuccess = true,
+                title = "✗ Join failed (Joiner)",
+                message = "Couldn't apply the peer's recovery code. Sent recovery_code_done(${reason?.value ?: "unknown"}).",
+                isSuccess = false,
             )
         }
         ExchangeV2State.Host.Aborted -> {
@@ -596,13 +624,16 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         ExchangeV2State.Aborted -> "Aborted"
         ExchangeV2State.Host.Confirming -> "Host.Confirming"
         ExchangeV2State.Host.Sending -> "Host.Sending"
+        ExchangeV2State.Host.AwaitingStatus -> "Host.AwaitingStatus"
         ExchangeV2State.Host.Aborted -> "Host.Aborted"
         ExchangeV2State.Host.Done -> "Host.Done"
         ExchangeV2State.Joiner.Confirming -> "Joiner.Confirming"
         ExchangeV2State.Joiner.Waiting -> "Joiner.Waiting"
+        ExchangeV2State.Joiner.Joining -> "Joiner.Joining"
         ExchangeV2State.Joiner.AbortedLocal -> "Joiner.AbortedLocal"
         ExchangeV2State.Joiner.AbortedByHost -> "Joiner.AbortedByHost"
         ExchangeV2State.Joiner.Done -> "Joiner.Done"
+        ExchangeV2State.Joiner.JoinFailed -> "Joiner.JoinFailed"
     }
 
     private fun labelFor(trigger: LocalTrigger): String = when (trigger) {
@@ -610,7 +641,8 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         LocalTrigger.UserDeniedHost -> "UserDeniedHost"
         LocalTrigger.UserConfirmedJoiner -> "UserConfirmedJoiner"
         LocalTrigger.UserDeniedJoiner -> "UserDeniedJoiner"
-        LocalTrigger.HostSendComplete -> "HostSendComplete"
+        is LocalTrigger.HostSendComplete -> "HostSendComplete(v${trigger.negotiatedVersion})"
+        is LocalTrigger.JoinerJoinComplete -> "JoinerJoinComplete(${trigger.reason.value})"
         LocalTrigger.HostUnavailable -> "HostUnavailable"
         is LocalTrigger.RoleElected -> "RoleElected(${trigger.role})"
     }


### PR DESCRIPTION
Task/Issue URL: 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync pairing state machine and wire protocol with backward-compatible 2.0 paths, but login and pairing outcomes now depend on new sequencing and best-effort reporting.
> 
> **Overview**
> Implements **Exchange V2.1** so the Joiner reports whether applying the Host’s recovery code actually worked, instead of the Host assuming success after `recovery_code_response`.
> 
> The Joiner now enters **`Joiner.Joining`** after receiving the code, runs login/upgrade, then sends **`recovery_code_done`** (`success`, `login_failed`, or `scope_rejected`) before reaching **`Joiner.Done`** or **`Joiner.JoinFailed`**. On **2.1–negotiated** sessions the Host waits in **`Host.AwaitingStatus`** for that message; against **2.0** peers the flow stays as before (Host goes straight to **Done** after sending the code).
> 
> **`RealSyncCodeDispatcher`** handles login on the **Joining** transition, maps outcomes to `recovery_code_done` reasons (including scope-rejection account codes), and **`join()`s** `localTrigger(JoinerJoinComplete)` so the report is sent before the UI outcome is emitted. The runner **skips outbound messages** whose minimum protocol version is above what was negotiated, and **`localTrigger`** now returns a **`Job`** for that sequencing.
> 
> Tests and the internal pairing debug UI are updated for the new states and Presenter-only auto-login on **Joining**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d872912066f09e7a1099f2c19b5b9a543308fd00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->