### PR TITLE
Fix a crash caused by releasing EmbellishmentController with 2 or more animations running

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/EmbellishmentController.kt
@@ -153,8 +153,10 @@ class EmbellishmentControllerImpl(
     }
 
     override fun release() {
-        trackedAnimators.forEach { it.cancel() }
+        val animators = trackedAnimators.toList()
         trackedAnimators.clear()
+        animators.forEach { it.cancel() }
+
         pendingExit?.let {
             it.view.removeAnimatorListener(it.listener)
             it.view.cancelAnimation()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1217897031882113?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Fixed a crash caused by releasing `EmbellishmentController` with 2 or more animations running.

To get into the faulty state a fragment needed to be destroyed while 2 or more animations were running (app exited most likely, screen rotation, or theme change). The window for that is rather narrow. Looking through code, the max possible window is ~500ms.

The fix creates a copy of the list before canceling the animations to avoid competing with their natural removal from the list.

### Steps to test this PR

- [x] Go to developer settings and increase animation scale to 10x.
- [x] Clean install the app. While the Dax walking animation start being visible on screen, rotate the device or change the theme:
```
adb shell cmd uimode night yes
```
or
```
adb shell cmd uimode night no
```
- [x] Verify there's no crash

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle fix in onboarding animation cleanup with no auth, data, or API changes.
> 
> **Overview**
> Fixes a crash when **`EmbellishmentController.release()`** runs while two or more tracked entrance/exit animators are still running (e.g. fragment destroy during onboarding Dax walking animation on rotation or theme change).
> 
> **`release()`** now snapshots **`trackedAnimators`** with **`toList()`**, clears the live list, then **`cancel()`**s each animator—matching **`drainInFlight()`**—so **`onAnimationEnd`** listeners that remove from **`trackedAnimators`** do not mutate the list during iteration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a20c8e3efe0120a0053fc97c0e139fb2e3788e30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->