### PR TITLE
Add Partner Benefits feature flag and hub URL config

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -305,6 +305,13 @@ interface SubscriptionsFeature {
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.FALSE)
     fun notificationsPermissionMessaging(): Toggle
 
+    /**
+     * When enabled, the Partnerships Hub entry point is shown in Settings.
+     * The flag settings carry the hub URL to open.
+     */
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.FALSE)
+    fun partnershipsHub(): Toggle
+
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun handleExpiredStateWhenSubscriptionChangeSelected(): Toggle
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
@@ -87,6 +87,7 @@ object SubscriptionsConstants {
     // URLs
     const val ITR_URL = "https://duckduckgo.com/identity-theft-restoration"
     const val FAQS_URL = "https://duckduckgo.com/duckduckgo-help-pages/privacy-pro/"
+    const val PARTNER_BENEFITS_URL = "https://duckduckgo.com/partner-benefits"
     const val SUBSCRIPTIONS_ETLD = "duckduckgo.com"
     const val FEATURE_PAGE_QUERY_PARAM_KEY = "featurePage"
     const val SUBSCRIPTIONS_PATH = "pro"

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PartnershipsHubUrlProvider.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PartnershipsHubUrlProvider.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.internal
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+interface PartnershipsHubUrlProvider {
+    val partnershipsHubUrl: String
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealPartnershipsHubUrlProvider @Inject constructor(
+    private val subscriptionsFeature: SubscriptionsFeature,
+    moshi: Moshi,
+) : PartnershipsHubUrlProvider {
+
+    private val jsonAdapter: JsonAdapter<PartnershipsHubSettings> by lazy {
+        moshi.newBuilder().add(KotlinJsonAdapterFactory()).build().adapter(PartnershipsHubSettings::class.java)
+    }
+
+    override val partnershipsHubUrl: String
+        get() = parseHubUrl() ?: DEFAULT_URL
+
+    private fun parseHubUrl(): String? {
+        val settings = subscriptionsFeature.partnershipsHub().getSettings()?.let {
+            runCatching { jsonAdapter.fromJson(it) }.getOrNull()
+        }
+        return settings?.url?.takeIf { it.isNotBlank() }
+    }
+
+    private data class PartnershipsHubSettings(
+        val url: String?,
+    )
+
+    companion object {
+        const val DEFAULT_URL = "https://duckduckgo.com/partner-benefits"
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PartnershipsHubUrlProvider.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PartnershipsHubUrlProvider.kt
@@ -23,14 +23,12 @@ import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import dagger.SingleInstanceIn
 import javax.inject.Inject
 
 interface PartnershipsHubUrlProvider {
     val partnershipsHubUrl: String
 }
 
-@SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealPartnershipsHubUrlProvider @Inject constructor(
     private val subscriptionsFeature: SubscriptionsFeature,

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PartnershipsHubUrlProvider.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PartnershipsHubUrlProvider.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.subscriptions.impl.internal
 
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.PARTNER_BENEFITS_URL
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.JsonAdapter
@@ -41,7 +42,7 @@ class RealPartnershipsHubUrlProvider @Inject constructor(
     }
 
     override val partnershipsHubUrl: String
-        get() = parseHubUrl() ?: DEFAULT_URL
+        get() = parseHubUrl() ?: PARTNER_BENEFITS_URL
 
     private fun parseHubUrl(): String? {
         val settings = subscriptionsFeature.partnershipsHub().getSettings()?.let {
@@ -53,8 +54,4 @@ class RealPartnershipsHubUrlProvider @Inject constructor(
     private data class PartnershipsHubSettings(
         val url: String?,
     )
-
-    companion object {
-        const val DEFAULT_URL = "https://duckduckgo.com/partner-benefits"
-    }
 }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/internal/RealPartnershipsHubUrlProviderTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/internal/RealPartnershipsHubUrlProviderTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.internal
+
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
+import com.duckduckgo.subscriptions.impl.internal.RealPartnershipsHubUrlProvider.Companion.DEFAULT_URL
+import com.squareup.moshi.Moshi
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RealPartnershipsHubUrlProviderTest {
+
+    private val subscriptionsFeature: SubscriptionsFeature = FakeFeatureToggleFactory.create(SubscriptionsFeature::class.java)
+
+    private val moshi = Moshi.Builder().build()
+
+    private val testee = RealPartnershipsHubUrlProvider(
+        subscriptionsFeature = subscriptionsFeature,
+        moshi = moshi,
+    )
+
+    @Test
+    fun whenNoRemoteSettingsThenDefaultHubUrlUsed() {
+        subscriptionsFeature.partnershipsHub().setRawStoredState(State(true))
+
+        assertEquals(DEFAULT_URL, testee.partnershipsHubUrl)
+    }
+
+    @Test
+    fun whenRemoteSettingsCarryUrlThenThatUrlUsed() {
+        subscriptionsFeature.partnershipsHub().setRawStoredState(
+            State(remoteEnableState = true, settings = """{"url":"https://example.com/hub"}"""),
+        )
+
+        assertEquals("https://example.com/hub", testee.partnershipsHubUrl)
+    }
+
+    @Test
+    fun whenRemoteSettingsMalformedThenDefaultHubUrlUsed() {
+        subscriptionsFeature.partnershipsHub().setRawStoredState(
+            State(remoteEnableState = true, settings = "not json"),
+        )
+
+        assertEquals(DEFAULT_URL, testee.partnershipsHubUrl)
+    }
+
+    @Test
+    fun whenRemoteSettingsMissingUrlKeyThenDefaultHubUrlUsed() {
+        subscriptionsFeature.partnershipsHub().setRawStoredState(
+            State(remoteEnableState = true, settings = """{"someOtherKey":"value"}"""),
+        )
+
+        assertEquals(DEFAULT_URL, testee.partnershipsHubUrl)
+    }
+
+    @Test
+    fun whenRemoteUrlBlankThenDefaultHubUrlUsed() {
+        subscriptionsFeature.partnershipsHub().setRawStoredState(
+            State(remoteEnableState = true, settings = """{"url":"  "}"""),
+        )
+
+        assertEquals(DEFAULT_URL, testee.partnershipsHubUrl)
+    }
+}

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/internal/RealPartnershipsHubUrlProviderTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/internal/RealPartnershipsHubUrlProviderTest.kt
@@ -18,8 +18,8 @@ package com.duckduckgo.subscriptions.impl.internal
 
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.PARTNER_BENEFITS_URL
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
-import com.duckduckgo.subscriptions.impl.internal.RealPartnershipsHubUrlProvider.Companion.DEFAULT_URL
 import com.squareup.moshi.Moshi
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -39,7 +39,7 @@ class RealPartnershipsHubUrlProviderTest {
     fun whenNoRemoteSettingsThenDefaultHubUrlUsed() {
         subscriptionsFeature.partnershipsHub().setRawStoredState(State(true))
 
-        assertEquals(DEFAULT_URL, testee.partnershipsHubUrl)
+        assertEquals(PARTNER_BENEFITS_URL, testee.partnershipsHubUrl)
     }
 
     @Test
@@ -57,7 +57,7 @@ class RealPartnershipsHubUrlProviderTest {
             State(remoteEnableState = true, settings = "not json"),
         )
 
-        assertEquals(DEFAULT_URL, testee.partnershipsHubUrl)
+        assertEquals(PARTNER_BENEFITS_URL, testee.partnershipsHubUrl)
     }
 
     @Test
@@ -66,7 +66,7 @@ class RealPartnershipsHubUrlProviderTest {
             State(remoteEnableState = true, settings = """{"someOtherKey":"value"}"""),
         )
 
-        assertEquals(DEFAULT_URL, testee.partnershipsHubUrl)
+        assertEquals(PARTNER_BENEFITS_URL, testee.partnershipsHubUrl)
     }
 
     @Test
@@ -75,6 +75,6 @@ class RealPartnershipsHubUrlProviderTest {
             State(remoteEnableState = true, settings = """{"url":"  "}"""),
         )
 
-        assertEquals(DEFAULT_URL, testee.partnershipsHubUrl)
+        assertEquals(PARTNER_BENEFITS_URL, testee.partnershipsHubUrl)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1217731708595911?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1217859719720381?focus=true
API Proposals URL(s) (if applicable): None

### Description

Adds the `partnershipsHub` flag and the provider that reads the Partner Benefits hub URL from the flag's remote `settings`, falling back to a compiled-in default when the settings are missing, malformed or blank.

It is a sub-feature of the existing `privacyPro` feature so it can be rolled out progressively, and it is off by default. Nothing is wired to it yet, the Settings entry point comes in the next PR of the stack.

### Steps to test this PR

1. Tap on Settings > Internal Features > Feature Flag Inventory.
2. Search for "partnerships".
3. Verify the `partnershipsHub` toggle is present and off.

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag defaults off and only adds a URL resolver with tests; no user-facing behavior or subscription logic changes yet.
> 
> **Overview**
> Introduces the **`partnershipsHub`** subscription feature toggle (default **off**) intended to gate a future Partnerships Hub entry in Settings; remote **`settings`** JSON can supply a custom hub URL.
> 
> Adds **`PartnershipsHubUrlProvider`**, which resolves that URL from the flag settings and falls back to **`PARTNER_BENEFITS_URL`** when settings are missing, invalid, or blank. **No UI or navigation is hooked up in this PR**—that follows in the stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c37ae09d34d6b934ac00304327cf02ee18f119b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217730323487522