### PR TITLE
Send and receive recovery_code_done message

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.RELAY_CHANNEL_UNAVAILABLE
 import com.duckduckgo.sync.impl.AccountErrorCodes.SESSION_TIMEOUT
 import com.duckduckgo.sync.impl.AccountErrorCodes.UNEXPECTED_EVENT
 import com.duckduckgo.sync.impl.AccountErrorCodes.UNEXPECTED_SECOND_HELLO
+import com.duckduckgo.sync.impl.AccountErrorCodes.UNSUPPORTED_CREDENTIAL_TYPE
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -308,17 +309,19 @@ class RealSyncCodeDispatcher @Inject constructor(
             DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
         ExchangeV2State.Host.Confirming ->
             DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
-        ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, peerKind)
+        ExchangeV2State.Host.Done -> hostDoneToOutcome(transition.trigger, peerKind)
         ExchangeV2State.Host.Aborted -> hostAbortedToOutcome(transition.localTrigger, transition.trigger)
         // Per spec §"Same-account case": not an abort; both devices share an account already.
         ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
-        ExchangeV2State.Joiner.Done -> {
+        ExchangeV2State.Joiner.Joining -> {
             val received = (transition.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
-            if (received.isNullOrBlank()) {
-                DispatchOutcome.Failed("joiner_done_missing_recovery_code", NO_RECOVERY_CODE.code)
+            val outcome = if (received.isNullOrBlank()) {
+                DispatchOutcome.Failed("joiner_joining_missing_recovery_code", NO_RECOVERY_CODE.code)
             } else {
                 loginWithV2RecoveryCode(received, peerKind)
             }
+            runner.localTrigger(LocalTrigger.JoinerJoinComplete(outcome.toRecoveryCodeDoneReason())).join()
+            outcome
         }
         ExchangeV2State.Joiner.AbortedByHost -> when (transition.trigger) {
             is ExchangeV2Message.RecoveryCodeDenied ->
@@ -350,6 +353,29 @@ class RealSyncCodeDispatcher @Inject constructor(
             SessionErrorKind.Unknown -> PAIRING_FAILED.code
         }
         return DispatchOutcome.Failed(event.message, code, timeoutStage = event.timeoutStage)
+    }
+
+    private fun DispatchOutcome.toRecoveryCodeDoneReason(): ExchangeV2Message.RecoveryCodeDone.Reason = when {
+        this is DispatchOutcome.LoggedIn || this is DispatchOutcome.AlreadyConnected -> {
+            ExchangeV2Message.RecoveryCodeDone.Reason.Success
+        }
+
+        this is DispatchOutcome.Failed && code == UNSUPPORTED_CREDENTIAL_TYPE.code -> {
+            ExchangeV2Message.RecoveryCodeDone.Reason.ScopeRejected
+        }
+
+        else -> ExchangeV2Message.RecoveryCodeDone.Reason.LoginFailed
+    }
+
+    private fun hostDoneToOutcome(
+        wireTrigger: ExchangeV2Message?,
+        peerKind: PeerKind?,
+    ): DispatchOutcome {
+        val reason = (wireTrigger as? ExchangeV2Message.RecoveryCodeDone)?.reason
+        if (reason != null && reason != ExchangeV2Message.RecoveryCodeDone.Reason.Success) {
+            logcat { "$TAG: Host.Done with peer-reported outcome $reason; host sync succeeded regardless" }
+        }
+        return DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, peerKind)
     }
 
     private fun hostAbortedToOutcome(
@@ -404,7 +430,10 @@ class RealSyncCodeDispatcher @Inject constructor(
                         peerKind = peerKind,
                     )
             }
-            else -> DispatchOutcome.Failed("Received unknown credential type '${parsed.cid}' over v2 linking")
+            else -> DispatchOutcome.Failed(
+                "Received unknown credential type '${parsed.cid}' over v2 linking",
+                UNSUPPORTED_CREDENTIAL_TYPE.code,
+            )
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -1646,6 +1646,7 @@ enum class AccountErrorCodes(val code: Int) {
     UNEXPECTED_SECOND_HELLO(76),
     PAIRING_SESSION_NOT_READY(77),
     RELAY_CHANNEL_UNAVAILABLE(78),
+    UNSUPPORTED_CREDENTIAL_TYPE(79),
 }
 
 sealed interface SyncAuthCode {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -104,7 +104,7 @@ interface SyncFeature {
     /**
      * Kill switch for sending the exchange channel secret as the `Authorization` header on the v2.0
      * exchange relay endpoints. Independent of [canUseExchangeV2Point1] so the header can be turned
-     * on (or off) without moving the protocol version. See [authenticateExchangeEndpoints].
+     * on (or off) without moving the protocol version.
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun canSendExchangeChannelSecret(): Toggle
@@ -156,10 +156,3 @@ interface SyncFeature {
  */
 internal fun SyncFeature.canWriteDeviceInfo(): Boolean =
     canUseV2ConnectFlow().isEnabled() && canWriteUnifiedDeviceList().isEnabled()
-
-/**
- * The v2.1 protocol requires the channel secret on every exchange relay call, so speaking v2.1 implies authenticating.
- * [SyncFeature.canSendExchangeChannelSecret] lets the header be enabled ahead of (or independently of) that version bump.
- */
-internal fun SyncFeature.authenticateExchangeEndpoints(): Boolean =
-    canSendExchangeChannelSecret().isEnabled() || canUseExchangeV2Point1().isEnabled()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/ExchangeProtocolVersion.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/ExchangeProtocolVersion.kt
@@ -17,12 +17,15 @@
 package com.duckduckgo.sync.impl.exchange
 
 sealed class ExchangeProtocolVersion : Comparable<ExchangeProtocolVersion> {
+    abstract fun prettyPrint(): String
 
     sealed class Supported : ExchangeProtocolVersion() {
         abstract val major: Int
         abstract val minor: Int
 
         final override fun toString() = if (minor == 0) "$major" else "$major.$minor"
+
+        final override fun prettyPrint() = "v$major.$minor"
     }
 
     data class V1(
@@ -49,6 +52,8 @@ sealed class ExchangeProtocolVersion : Comparable<ExchangeProtocolVersion> {
         val rawVersion: String,
     ) : ExchangeProtocolVersion() {
         override fun toString() = rawVersion
+
+        override fun prettyPrint() = "v$rawVersion"
     }
 
     override fun compareTo(other: ExchangeProtocolVersion): Int = when {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/AdvertisedExchangeV2Version.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/AdvertisedExchangeV2Version.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+/**
+ * The exchange protocol version this device offers a pairing session. Everything version-dependent
+ * (e.g. whether relay calls carry the channel-secret `Authorization` header) derives from it inside
+ * [ExchangeV2Runner], which reads it once per session, at bootstrap, so answers only take effect on
+ * the next session.
+ */
+interface AdvertisedExchangeV2Version {
+    /** The highest exchange protocol version this device advertises to peers. */
+    fun resolve(): ExchangeProtocolVersion.V2
+}
+
+@ContributesBinding(AppScope::class)
+class RealAdvertisedExchangeV2Version @Inject constructor(
+    private val syncFeature: SyncFeature,
+) : AdvertisedExchangeV2Version {
+
+    override fun resolve(): ExchangeProtocolVersion.V2 = if (syncFeature.canUseExchangeV2Point1().isEnabled()) {
+        ExchangeProtocolVersion.V2_1
+    } else {
+        ExchangeProtocolVersion.V2_0
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.sync.impl.exchange.v2
 
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.ExchangeEnvelope
+import com.duckduckgo.sync.impl.ExchangeMessageEntry
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncApi
 import com.squareup.anvil.annotations.ContributesBinding
@@ -175,7 +176,7 @@ class RealExchangeV2Channel @Inject constructor(
     }
 
     private fun decode(
-        entry: com.duckduckgo.sync.impl.ExchangeMessageEntry,
+        entry: ExchangeMessageEntry,
         ownPrivateKeyBase64: String,
     ): ExchangeV2Message {
         val inner = runCatching {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Envelope.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Envelope.kt
@@ -24,9 +24,12 @@ import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
 /**
- * Wire-level envelope wrapping for relay messages. The outer object is `{version, payload}`
- * with [version] unencrypted (used for protocol version negotiation) and [payload] a JWE
- * compact string carrying the encrypted message JSON.
+ * Wire-level envelope wrapping for relay messages, converting between an [ExchangeV2Message] and the
+ * `{version, payload}` object the relay carries.
+ *
+ * [ExchangeEnvelope.version] travels unencrypted, so a peer can tell whether it can read an envelope
+ * before trying to; [ExchangeEnvelope.payload] is a JWE compact string carrying the encrypted
+ * message JSON. The relay sees only the version, never the message.
  *
  * Spec: Transport TD (Asana 1214486492252757) §Message Envelope + §Encryption.
  *  - alg = RSA-OAEP-256 (wraps an ephemeral A256GCM key)
@@ -43,8 +46,11 @@ interface ExchangeV2Envelope {
 
     /**
      * Decrypt an inbound envelope with our ephemeral private key, returning the inner message JSON.
+     * Parsing that JSON into a message is [ExchangeV2MessageParser]'s job, not this one's.
      *
      * @throws EnvelopeVersionTooNew if the envelope's major version is higher than ours.
+     * @throws IllegalArgumentException if the version is malformed, or is a v1 envelope on a v2
+     *  channel, neither of which a peer following the spec can produce.
      */
     fun open(envelope: ExchangeEnvelope, ownPrivateKeyBase64: String): String
 }
@@ -55,8 +61,9 @@ class EnvelopeVersionTooNew(val version: ExchangeProtocolVersion) : RuntimeExcep
 )
 
 /**
- * Thrown when an envelope's payload can't be decrypted or parsed. Permanent (the same bytes
- * fail identically on retry), so the runner treats it as terminal rather than retrying.
+ * Thrown when an envelope's payload can't be decrypted or parsed. Raised by the channel, which knows
+ * the [seq] of the entry that failed. Permanent (the same bytes fail identically on retry), so the
+ * runner treats it as terminal rather than retrying.
  */
 class EnvelopeDecryptFailure(val seq: Int, cause: Throwable) : RuntimeException(
     "Failed to decrypt envelope seq=$seq: ${cause.message}",

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Event.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Event.kt
@@ -16,15 +16,25 @@
 
 package com.duckduckgo.sync.impl.exchange.v2
 
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.pixels.SyncPixels.TimeoutStage
 
 /**
  * Observable events emitted by the v2 exchange runner. Downstream consumers
  * subscribe to the runner's event flow and react.
+ *
+ * Purely observational: the exchange runs to completion regardless of whether anyone is listening,
+ * so consumers (pixels, the pairing debug screen, UI) may drop events without affecting the protocol.
  */
 sealed interface ExchangeV2Event {
+    /** When the runner created the event, from its own clock, not when a consumer received it. */
     val timestampMs: Long
 
+    /**
+     * The state machine accepted a trigger and moved from [from] to [to]. Exactly one of [trigger] (an
+     * inbound peer message) and [localTrigger] (a user or runner decision) is set; an abort driven by a
+     * peer message arrives here rather than as [MessageRejected] whenever [from] was still active.
+     */
     data class Transition(
         override val timestampMs: Long,
         val from: ExchangeV2State,
@@ -33,11 +43,20 @@ sealed interface ExchangeV2Event {
         val localTrigger: LocalTrigger?,
     ) : ExchangeV2Event
 
+    /**
+     * [message] was accepted by the relay for delivery to the peer. Says nothing about the peer having
+     * polled it: the relay accepts messages for a channel the peer has already abandoned.
+     */
     data class MessageSent(
         override val timestampMs: Long,
         val message: ExchangeV2Message,
     ) : ExchangeV2Event
 
+    /**
+     * [message] was received but not acted on in [state]: either an unknown message type dropped to keep
+     * the session alive, or a protocol violation aborting a session already in a terminal state (an abort
+     * from an active state surfaces as a [Transition] instead). See [RejectReason].
+     */
     data class MessageRejected(
         override val timestampMs: Long,
         val message: ExchangeV2Message,
@@ -57,7 +76,9 @@ sealed interface ExchangeV2Event {
     ) : ExchangeV2Event
 
     /**
-     * A transport or protocol-level failure during bootstrap / poll / send.
+     * A transport or protocol-level failure while bootstrapping, polling, or sending. Terminal: the runner tears the
+     * session down after emitting, and emits at most one per session. [message] is developer-facing text;
+     * [kind] is the value to branch on. [timeoutStage] is set only for [SessionErrorKind.SessionTimeout].
      */
     data class SessionError(
         override val timestampMs: Long,
@@ -65,17 +86,69 @@ sealed interface ExchangeV2Event {
         val kind: SessionErrorKind = SessionErrorKind.Unknown,
         val timeoutStage: TimeoutStage? = null,
     ) : ExchangeV2Event
+
+    /**
+     * The peer's advertised protocol version became known and both sides settled on [negotiatedVersion],
+     * the lower of [ourVersion] and [peerVersion], falling back to the baseline when the peer advertises
+     * something we can't parse. Emitted once per side, at the point named by [peerSource]: the Scanner
+     * learns the version from the linking code, the Presenter from the peer's hello.
+     */
+    data class VersionNegotiated(
+        override val timestampMs: Long,
+        val peerSource: PeerVersionSource,
+        val peerVersion: ExchangeProtocolVersion,
+        val ourVersion: ExchangeProtocolVersion,
+        val negotiatedVersion: ExchangeProtocolVersion,
+    ) : ExchangeV2Event
 }
 
-enum class RejectReason { ImplicitAbort, SameAccount, UnknownMessageDropped }
+/** Why a received message was not acted on. See [ExchangeV2Event.MessageRejected]. */
+enum class RejectReason {
+    /** A known message type that the current state does not allow: a protocol violation, aborts the session. */
+    ImplicitAbort,
 
+    /** The peer turned out to be the same sync account as us, so there is nothing to pair. */
+    SameAccount,
+
+    /** An unrecognized message type, ignored so a newer peer's extra messages can't kill the session. */
+    UnknownMessageDropped,
+}
+
+/**
+ * What went wrong in a [ExchangeV2Event.SessionError], as a bounded value consumers can branch on.
+ * Mapped to sync pixel error codes, so treat the entries as part of the telemetry contract.
+ */
 enum class SessionErrorKind {
+    /** No progress within the deadline for the current stage; the stage is carried in `timeoutStage`. */
     SessionTimeout,
+
+    /** A second hello arrived after negotiation had already started. */
     UnexpectedSecondHello,
+
+    /** A protocol violation that isn't covered by a more specific kind. Not currently emitted by the runner. */
     UnexpectedEvent,
+
+    /** An outbound message was attempted before the local session had the keys and channel ids it needs. */
     PairingSessionNotReady,
+
+    /** The relay could not create the channel, or reported ours or the peer's channel as gone. */
     RelayChannelUnavailable,
+
+    /** We failed to produce the recovery code to hand over, e.g. account creation failed. */
     RecoveryCodePreparationFailed,
+
+    /** The relay rejected our request as malformed. */
     MalformedRelayRequest,
+
+    /** Anything else, including generic transport failures. */
     Unknown,
+}
+
+/** Where the peer's advertised version was read from. See [ExchangeV2Event.VersionNegotiated]. */
+enum class PeerVersionSource {
+    /** Scanner side: parsed out of the linking code before any message is exchanged. */
+    LinkingCode,
+
+    /** Presenter side: taken from the peer's hello. */
+    HelloMessage,
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Message.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Message.kt
@@ -27,8 +27,8 @@ import org.json.JSONObject
  * required to process it) and `payload` (the JWE compact serialization of the encrypted message
  * JSON, whose `kid` header is the sender's channel ID).
  *
- * Spec: Asana 1215056232572321 (Exchange V2 Messages), 1215056232572322 (Exchange V2 Message
- * Sequence State Machine).
+ * Spec: Asana 1215056232572321 (Exchange V2 Messages), 1216906886019334 (Exchange V2.1 Messages)
+ * 1215056232572322 (Exchange V2 Message Sequence State Machine).
  */
 sealed interface ExchangeV2Message {
     /**
@@ -65,7 +65,7 @@ sealed interface ExchangeV2Message {
         val publicKey: String,
         val version: ExchangeProtocolVersion,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -120,7 +120,7 @@ sealed interface ExchangeV2Message {
         val name: String,
         val kind: String,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -174,7 +174,7 @@ sealed interface ExchangeV2Message {
         val name: String,
         val kind: String,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -215,7 +215,7 @@ sealed interface ExchangeV2Message {
     data class RecoveryCodeAwaitingConfirmation(
         override val rawJson: String,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -236,7 +236,7 @@ sealed interface ExchangeV2Message {
     data class RecoveryCodeConfirmed(
         override val rawJson: String,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -255,7 +255,7 @@ sealed interface ExchangeV2Message {
     data class RecoveryCodeDenied(
         override val rawJson: String,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -274,7 +274,7 @@ sealed interface ExchangeV2Message {
     data class RecoveryCodeUnavailable(
         override val rawJson: String,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -296,7 +296,7 @@ sealed interface ExchangeV2Message {
         override val rawJson: String,
         val recoveryCode: String,
     ) : ExchangeV2Message {
-        override val messageType: String = TYPE
+        override val messageType get() = TYPE
         override val protocolVersion get() = ExchangeProtocolVersion.V2_0
 
         companion object {
@@ -313,6 +313,67 @@ sealed interface ExchangeV2Message {
                 return RecoveryCodeResponse(
                     rawJson = rawJson,
                     recoveryCode = json.optString(FIELD_RECOVERY_CODE, ""),
+                )
+            }
+        }
+    }
+
+    /**
+     * Sent by the Joiner once it has finished using the recovery code, carrying the real outcome so
+     * the Host can show it instead of assuming success. Only valid after `recovery_code_response`.
+     */
+    data class RecoveryCodeDone(
+        override val rawJson: String,
+        val reason: Reason,
+    ) : ExchangeV2Message {
+        override val messageType get() = TYPE
+        override val protocolVersion get() = ExchangeProtocolVersion.V2_1
+
+        sealed interface Reason {
+            val value: String
+
+            data object Success : Reason {
+                override val value = "success"
+            }
+
+            data object LoginFailed : Reason {
+                override val value = "login_failed"
+            }
+
+            data object ScopeRejected : Reason {
+                override val value = "scope_rejected"
+            }
+
+            data class Unknown(
+                val rawValue: String,
+            ) : Reason {
+                override val value get() = rawValue
+            }
+
+            companion object {
+                fun fromJsonValue(value: String): Reason = when (value) {
+                    Success.value -> Success
+                    LoginFailed.value -> LoginFailed
+                    ScopeRejected.value -> ScopeRejected
+                    else -> Unknown(value)
+                }
+            }
+        }
+
+        companion object {
+            const val TYPE = "recovery_code_done"
+            private const val FIELD_REASON = "reason"
+
+            fun create(reason: Reason) = RecoveryCodeDone(
+                rawJson = buildMessageJson(TYPE) { put(FIELD_REASON, reason.value) },
+                reason = reason,
+            )
+
+            fun fromJson(rawJson: String): RecoveryCodeDone {
+                val json = JSONObject(rawJson)
+                return RecoveryCodeDone(
+                    rawJson = rawJson,
+                    reason = Reason.fromJsonValue(json.optString(FIELD_REASON, "")),
                 )
             }
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2MessageParser.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2MessageParser.kt
@@ -17,9 +17,18 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAvailable
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAwaitingConfirmation
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeConfirmed
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDenied
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeUnavailable
 import com.squareup.anvil.annotations.ContributesBinding
 import org.json.JSONObject
 import javax.inject.Inject
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Unknown as UnknownMessage
 
 interface ExchangeV2MessageParser {
     fun parse(rawJson: String): ExchangeV2Message
@@ -30,19 +39,19 @@ class JsonExchangeV2MessageParser @Inject constructor() : ExchangeV2MessageParse
 
     override fun parse(rawJson: String): ExchangeV2Message {
         val type = runCatching { JSONObject(rawJson).optString(ExchangeV2Message.FIELD_TYPE, "") }
-            .getOrElse { return ExchangeV2Message.Unknown.fromJson(rawJson, messageType = "") }
+            .getOrElse { return UnknownMessage.fromJson(rawJson, messageType = "") }
         return runCatching {
             when (type) {
-                ExchangeV2Message.Hello.TYPE -> ExchangeV2Message.Hello.fromJson(rawJson)
-                ExchangeV2Message.RecoveryCodeAvailable.TYPE -> ExchangeV2Message.RecoveryCodeAvailable.fromJson(rawJson)
-                ExchangeV2Message.RecoveryCodeRequest.TYPE -> ExchangeV2Message.RecoveryCodeRequest.fromJson(rawJson)
-                ExchangeV2Message.RecoveryCodeAwaitingConfirmation.TYPE -> ExchangeV2Message.RecoveryCodeAwaitingConfirmation.fromJson(rawJson)
-                ExchangeV2Message.RecoveryCodeConfirmed.TYPE -> ExchangeV2Message.RecoveryCodeConfirmed.fromJson(rawJson)
-                ExchangeV2Message.RecoveryCodeDenied.TYPE -> ExchangeV2Message.RecoveryCodeDenied.fromJson(rawJson)
-                ExchangeV2Message.RecoveryCodeUnavailable.TYPE -> ExchangeV2Message.RecoveryCodeUnavailable.fromJson(rawJson)
-                ExchangeV2Message.RecoveryCodeResponse.TYPE -> ExchangeV2Message.RecoveryCodeResponse.fromJson(rawJson)
-                else -> ExchangeV2Message.Unknown.fromJson(rawJson, messageType = type)
+                Hello.TYPE -> Hello.fromJson(rawJson)
+                RecoveryCodeAvailable.TYPE -> RecoveryCodeAvailable.fromJson(rawJson)
+                RecoveryCodeRequest.TYPE -> RecoveryCodeRequest.fromJson(rawJson)
+                RecoveryCodeAwaitingConfirmation.TYPE -> RecoveryCodeAwaitingConfirmation.fromJson(rawJson)
+                RecoveryCodeConfirmed.TYPE -> RecoveryCodeConfirmed.fromJson(rawJson)
+                RecoveryCodeDenied.TYPE -> RecoveryCodeDenied.fromJson(rawJson)
+                RecoveryCodeUnavailable.TYPE -> RecoveryCodeUnavailable.fromJson(rawJson)
+                RecoveryCodeResponse.TYPE -> RecoveryCodeResponse.fromJson(rawJson)
+                else -> UnknownMessage.fromJson(rawJson, messageType = type)
             }
-        }.getOrElse { ExchangeV2Message.Unknown.fromJson(rawJson, messageType = type) }
+        }.getOrElse { UnknownMessage.fromJson(rawJson, messageType = type) }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2MessageParser.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2MessageParser.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAvaila
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAwaitingConfirmation
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeConfirmed
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDenied
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeUnavailable
@@ -50,6 +51,7 @@ class JsonExchangeV2MessageParser @Inject constructor() : ExchangeV2MessageParse
                 RecoveryCodeDenied.TYPE -> RecoveryCodeDenied.fromJson(rawJson)
                 RecoveryCodeUnavailable.TYPE -> RecoveryCodeUnavailable.fromJson(rawJson)
                 RecoveryCodeResponse.TYPE -> RecoveryCodeResponse.fromJson(rawJson)
+                RecoveryCodeDone.TYPE -> RecoveryCodeDone.fromJson(rawJson)
                 else -> UnknownMessage.fromJson(rawJson, messageType = type)
             }
         }.getOrElse { UnknownMessage.fromJson(rawJson, messageType = type) }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -134,8 +134,11 @@ interface ExchangeV2Runner {
      * Drive the state machine with something that didn't come off the wire, such as the user
      * answering a confirmation prompt. Returns immediately, and a trigger the current state does not
      * allow aborts the session rather than being ignored.
+     *
+     * The returned [Job] is that work. Most callers can ignore it, but one about to end the session
+     * must join it first, and never from code holding the runner's mutex.
      */
-    fun localTrigger(trigger: LocalTrigger)
+    fun localTrigger(trigger: LocalTrigger): Job
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -449,6 +452,7 @@ class RealExchangeV2Runner @Inject constructor(
         ExchangeV2State.Negotiating -> TimeoutStage.WAITING_FOR_PEER_STATUS
         ExchangeV2State.Host.Confirming, ExchangeV2State.Joiner.Confirming -> TimeoutStage.WAITING_FOR_CONFIRMATION
         ExchangeV2State.Host.Sending, ExchangeV2State.Joiner.Waiting -> TimeoutStage.WAITING_FOR_RECOVERY_CODE
+        ExchangeV2State.Host.AwaitingStatus, ExchangeV2State.Joiner.Joining -> TimeoutStage.LOGGING_IN
         else -> null
     }
 
@@ -527,6 +531,10 @@ class RealExchangeV2Runner @Inject constructor(
                 logcat { "Sync-ExchangeV2: side effect → RequestRecoveryCodeShare" }
                 shareRecoveryCodeAndAdvanceLocked()
             }
+            is SideEffect.SendRecoveryCodeDone -> {
+                logcat { "Sync-ExchangeV2: side effect → SendRecoveryCodeDone(${effect.reason.value})" }
+                sendMessage(ExchangeV2Message.RecoveryCodeDone.create(effect.reason))
+            }
         }
     }
 
@@ -541,7 +549,7 @@ class RealExchangeV2Runner @Inject constructor(
             mutex.withLock {
                 val s = session ?: return@withLock
                 if (s.currentState != ExchangeV2State.Host.Sending) return@withLock
-                val terminalTrigger = if (responseOk) LocalTrigger.HostSendComplete else LocalTrigger.HostUnavailable
+                val terminalTrigger = if (responseOk) LocalTrigger.HostSendComplete(negotiatedVersion) else LocalTrigger.HostUnavailable
                 val r = s.localTrigger(terminalTrigger)
                 emit(r.event)
                 r.sideEffects.forEach { applySideEffectLocked(it) }
@@ -652,11 +660,10 @@ class RealExchangeV2Runner @Inject constructor(
     // Local triggers — drive SM + send outbound messages on Host transitions
     // -----------------------------------------------------------------------
 
-    override fun localTrigger(trigger: LocalTrigger) {
+    override fun localTrigger(trigger: LocalTrigger): Job =
         appScope.launch(dispatchers.io()) {
             mutex.withLock { processLocalTriggerLocked(trigger) }
         }
-    }
 
     private fun processLocalTriggerLocked(trigger: LocalTrigger) {
         val sm = session ?: run {
@@ -825,7 +832,11 @@ class RealExchangeV2Runner @Inject constructor(
     private fun sendMessage(message: ExchangeV2Message) {
         val peer = peerChannelId ?: return
         val peerKey = peerPublicKey ?: return
-        sendOnWireAndRecord(message, peer, peerKey)
+        if (message.protocolVersion <= negotiatedVersion) {
+            sendOnWireAndRecord(message, peer, peerKey)
+        } else {
+            logcat { "Sync-ExchangeV2: skipping ${message.messageType} (needs v${message.protocolVersion}, negotiated v$negotiatedVersion)" }
+        }
     }
 
     /** Returns true on successful POST, false on transport error (caller decides if fatal). */
@@ -918,6 +929,7 @@ class RealExchangeV2Runner @Inject constructor(
         ExchangeV2State.Joiner.AbortedLocal,
         ExchangeV2State.Joiner.AbortedByHost,
         ExchangeV2State.Joiner.Done,
+        ExchangeV2State.Joiner.JoinFailed,
         -> true
         else -> false
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -54,13 +54,32 @@ import java.util.UUID
 import javax.inject.Inject
 
 /**
- * Drives a single Exchange V2 protocol session.
+ * Drives a single Exchange V2 pairing session, from the linking code to a terminal state.
  *
- * Two entry points: [startPresent] generates a v2 linking code (surfaced via [SessionStarted]);
- * [startScan] parses a peer's code and joins their session. From there the runner manages the
- * wire I/O, drives the SM, and auto-elects role per the Unified Algorithm.
+ * Two entry points open a session: [startPresent] publishes a linking code for a peer to scan,
+ * [startScan] joins the session behind a code this device scanned. Either way the runner owns
+ * everything the [ExchangeV2StateMachine] deliberately does not: the relay channel, the poll loop,
+ * the session keys, role election, the session deadline, and executing the [SideEffect]s each
+ * transition declares. The state machine decides what is allowed; the runner makes it happen.
+ *
+ * Only a single session is allowed. Opening a session abandons any session already running, and
+ * reaching a terminal state tears the current one down, so nothing outlives it.
+ *
+ * Callers observe through [events] rather than polling the getters: the session advances on the
+ * poll loop's own coroutine, so [currentState] and friends are snapshots that can change between
+ * two reads.
+ *
+ * Spec:
+ *  - Asana 1214739740392701, Unified Algorithm: role election, and the abort rules applied around
+ *    the state machine.
+ *  - Asana 1214486492252757, Transport TD: channel lifecycle, polling, and the session deadline.
  */
 interface ExchangeV2Runner {
+
+    /**
+     * Everything that happened in this runner, including sessions that have already ended: the
+     * buffer is not cleared at teardown. Scope to one session with [eventsSince].
+     */
     val events: SharedFlow<ExchangeV2Event>
 
     /**
@@ -69,11 +88,13 @@ interface ExchangeV2Runner {
      */
     fun eventsSince(sinceMs: Long): Flow<ExchangeV2Event> = events.filter { it.timestampMs >= sinceMs }
 
+    /** Where the session currently is, or null when no session is running. */
     val currentState: ExchangeV2State?
 
+    /** How this device entered the session (scanned or presented), which is not its elected [Role]. */
     val pairingRole: PairingRole?
 
-    /** Linking code URL for the Presenter side — populated after [startPresent] completes bootstrap. */
+    /** Linking code URL for the Presenter side, populated once [startPresent] has bootstrapped. */
     val linkingCode: String?
 
     /**
@@ -88,8 +109,23 @@ interface ExchangeV2Runner {
     /** Peer device's credential kind ("ddg" / "3party"), learned during role election. Null before then. */
     val peerKind: String?
 
+    /**
+     * Join the session behind a linking code this device scanned or pasted. Returns immediately;
+     * the session is only usable once [ExchangeV2Event.SessionStarted] has been emitted, and a code
+     * that doesn't parse surfaces as a [ExchangeV2Event.SessionError] rather than a thrown exception.
+     *
+     * Starts in [ExchangeV2State.Negotiating]: the code already identifies the peer, so unlike the
+     * Presenter this side has no hello to wait for.
+     */
     fun startScan(pastedUrl: String)
 
+    /**
+     * Open a session for a peer to scan and publish a linking code for it. Returns immediately; the
+     * code is on [linkingCode], and in the emitted [ExchangeV2Eve nt.SessionStarted], once bootstrap
+     * completes.
+     *
+     * Starts in [ExchangeV2State.Bootstrapped], waiting for the peer's hello.
+     */
     fun startPresent()
 
     /**
@@ -98,6 +134,11 @@ interface ExchangeV2Runner {
      */
     suspend fun cancel()
 
+    /**
+     * Drive the state machine with something that didn't come off the wire, such as the user
+     * answering a confirmation prompt. Returns immediately, and a trigger the current state does not
+     * allow aborts the session rather than being ignored.
+     */
     fun localTrigger(trigger: LocalTrigger)
 }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -22,7 +22,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncDeviceIds
 import com.duckduckgo.sync.impl.SyncFeature
-import com.duckduckgo.sync.impl.authenticateExchangeEndpoints
 import com.duckduckgo.sync.impl.crypto.RsaKeyPair
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
@@ -150,6 +149,7 @@ class RealExchangeV2Runner @Inject constructor(
     private val qrCode: ExchangeV2QrCode,
     private val recoveryCodeProvider: RecoveryCodeProvider,
     private val syncDeviceIds: SyncDeviceIds,
+    private val advertisedExchangeV2Version: AdvertisedExchangeV2Version,
     private val syncFeature: SyncFeature,
     @AppCoroutineScope private val appScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
@@ -285,7 +285,7 @@ class RealExchangeV2Runner @Inject constructor(
      * (in which case an error event was already emitted).
      */
     private fun bootstrapLocked(role: PairingRole): RsaKeyPair? {
-        advertisedVersion = if (syncFeature.canUseExchangeV2Point1().isEnabled()) ExchangeProtocolVersion.V2_1 else BASELINE_PROTOCOL_VERSION
+        advertisedVersion = advertisedExchangeV2Version.resolve()
         val keyPair = jweCrypto.generateRsaKeyPair(EXCHANGE_RSA_KEY_SIZE)
         ownKeyPair = keyPair
         repeat(MAX_CHANNEL_CREATE_RETRIES) { attempt ->
@@ -941,7 +941,8 @@ class RealExchangeV2Runner @Inject constructor(
      * a header the channel was not claimed with.
      */
     private fun generateChannelSecret(): String? {
-        if (!syncFeature.authenticateExchangeEndpoints()) return null
+        val authenticate = advertisedVersion >= ExchangeProtocolVersion.V2_1 || syncFeature.canSendExchangeChannelSecret().isEnabled()
+        if (!authenticate) return null
         return Base64.getUrlEncoder()
             .withoutPadding()
             .encodeToString(jweCrypto.generateSecureBytes(CHANNEL_SECRET_SIZE))

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -26,9 +26,6 @@ import com.duckduckgo.sync.impl.authenticateExchangeEndpoints
 import com.duckduckgo.sync.impl.crypto.RsaKeyPair
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
-import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Host
-import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner
-import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.SameAccountAbort
 import com.duckduckgo.sync.impl.pixels.SyncPixels.TimeoutStage
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
@@ -198,7 +195,6 @@ class RealExchangeV2Runner @Inject constructor(
     @Volatile private var advertisedVersion: ExchangeProtocolVersion.V2 = BASELINE_PROTOCOL_VERSION
 
     @Volatile private var negotiatedVersion: ExchangeProtocolVersion.V2 = BASELINE_PROTOCOL_VERSION
-        private set
 
     /**
      * Host-side messages arriving while the Joiner is still at the user-confirm prompt, buffered
@@ -288,7 +284,7 @@ class RealExchangeV2Runner @Inject constructor(
      * the relay channel (with 409 retry). Returns the new keypair on success, null on error
      * (in which case an error event was already emitted).
      */
-    private suspend fun bootstrapLocked(role: PairingRole): RsaKeyPair? {
+    private fun bootstrapLocked(role: PairingRole): RsaKeyPair? {
         advertisedVersion = if (syncFeature.canUseExchangeV2Point1().isEnabled()) ExchangeProtocolVersion.V2_1 else BASELINE_PROTOCOL_VERSION
         val keyPair = jweCrypto.generateRsaKeyPair(EXCHANGE_RSA_KEY_SIZE)
         ownKeyPair = keyPair
@@ -451,8 +447,8 @@ class RealExchangeV2Runner @Inject constructor(
     private fun ExchangeV2State.toTimeoutStage(): TimeoutStage? = when (this) {
         ExchangeV2State.Bootstrapped -> TimeoutStage.WAITING_FOR_PEER_HELLO
         ExchangeV2State.Negotiating -> TimeoutStage.WAITING_FOR_PEER_STATUS
-        Host.Confirming, Joiner.Confirming -> TimeoutStage.WAITING_FOR_CONFIRMATION
-        Host.Sending, Joiner.Waiting -> TimeoutStage.WAITING_FOR_RECOVERY_CODE
+        ExchangeV2State.Host.Confirming, ExchangeV2State.Joiner.Confirming -> TimeoutStage.WAITING_FOR_CONFIRMATION
+        ExchangeV2State.Host.Sending, ExchangeV2State.Joiner.Waiting -> TimeoutStage.WAITING_FOR_RECOVERY_CODE
         else -> null
     }
 
@@ -466,7 +462,7 @@ class RealExchangeV2Runner @Inject constructor(
         mutex.withLock { processIncomingLocked(message) }
     }
 
-    private suspend fun processIncomingLocked(message: ExchangeV2Message) {
+    private fun processIncomingLocked(message: ExchangeV2Message) {
         val sm = session ?: run {
             logcat { "Sync-ExchangeV2: deliverIncomingMessage ${message.messageType} rejected — no active session" }
             emitSessionError(
@@ -590,7 +586,8 @@ class RealExchangeV2Runner @Inject constructor(
 
     /**
      * Can we auto-elect a role now? Requires an accepted transition, SM in Negotiating, and a
-     * peer availability message ([RecoveryCodeAvailable]/[RecoveryCodeRequest]) carrying peer kind/userId.
+     * peer availability message ([ExchangeV2Message.RecoveryCodeAvailable]/[ExchangeV2Message.RecoveryCodeRequest])
+     * carrying peer kind/userId.
      */
     private fun canAutoElectRole(
         sm: ExchangeV2StateMachine,
@@ -661,7 +658,7 @@ class RealExchangeV2Runner @Inject constructor(
         }
     }
 
-    private suspend fun processLocalTriggerLocked(trigger: LocalTrigger) {
+    private fun processLocalTriggerLocked(trigger: LocalTrigger) {
         val sm = session ?: run {
             logcat { "Sync-ExchangeV2: localTrigger $trigger ignored — no active session" }
             return
@@ -687,7 +684,7 @@ class RealExchangeV2Runner @Inject constructor(
      * Caller must have come from [ExchangeV2State.Joiner.Confirming]. On confirm (→ Joiner.Waiting)
      * replay buffered host-side messages; on any other exit discard them.
      */
-    private suspend fun replayBufferedJoinerMessagesLocked(newState: ExchangeV2State) {
+    private fun replayBufferedJoinerMessagesLocked(newState: ExchangeV2State) {
         if (pendingJoinerWaitingMessages.isEmpty()) return
         if (newState == ExchangeV2State.Joiner.Waiting) {
             val buffered = pendingJoinerWaitingMessages.toList()
@@ -914,13 +911,13 @@ class RealExchangeV2Runner @Inject constructor(
     }
 
     private fun ExchangeV2State.isTerminal(): Boolean = when (this) {
-        SameAccountAbort,
+        ExchangeV2State.SameAccountAbort,
         ExchangeV2State.Aborted,
-        Host.Aborted,
-        Host.Done,
-        Joiner.AbortedLocal,
-        Joiner.AbortedByHost,
-        Joiner.Done,
+        ExchangeV2State.Host.Aborted,
+        ExchangeV2State.Host.Done,
+        ExchangeV2State.Joiner.AbortedLocal,
+        ExchangeV2State.Joiner.AbortedByHost,
+        ExchangeV2State.Joiner.Done,
         -> true
         else -> false
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -117,7 +117,10 @@ class RealExchangeV2Runner @Inject constructor(
     private val dispatchers: DispatcherProvider,
 ) : ExchangeV2Runner {
 
-    private val _events = MutableSharedFlow<ExchangeV2Event>(replay = REPLAY, extraBufferCapacity = REPLAY)
+    private val _events = MutableSharedFlow<ExchangeV2Event>(
+        replay = EVENT_BUFFER_SIZE,
+        extraBufferCapacity = EVENT_BUFFER_SIZE,
+    )
     override val events: SharedFlow<ExchangeV2Event> = _events.asSharedFlow()
 
     // Mutex serialises SM mutations + peer-state writes across the poll loop + user clicks.
@@ -153,7 +156,7 @@ class RealExchangeV2Runner @Inject constructor(
 
     @Volatile private var advertisedVersion: ExchangeProtocolVersion.V2 = BASELINE_PROTOCOL_VERSION
 
-    @Volatile internal var negotiatedVersion: ExchangeProtocolVersion.V2 = BASELINE_PROTOCOL_VERSION
+    @Volatile private var negotiatedVersion: ExchangeProtocolVersion.V2 = BASELINE_PROTOCOL_VERSION
         private set
 
     /**
@@ -191,7 +194,7 @@ class RealExchangeV2Runner @Inject constructor(
                     cancelLocked() // bootstrap already emitted the error; just clear the half-set state
                     return@launch
                 }
-                negotiatedVersion = negotiateProtocolVersion(parsed.version)
+                negotiatedVersion = negotiateProtocolVersion(parsed.version, PeerVersionSource.LinkingCode)
                 // Scanner already knows the peer; SM starts directly in Negotiating.
                 session = smFactory.create(
                     localUserId = syncStore.userId,
@@ -528,7 +531,7 @@ class RealExchangeV2Runner @Inject constructor(
             is ExchangeV2Message.Hello -> {
                 peerChannelId = message.channelId
                 peerPublicKey = message.publicKey
-                negotiatedVersion = negotiateProtocolVersion(message.version)
+                negotiatedVersion = negotiateProtocolVersion(message.version, PeerVersionSource.HelloMessage)
             }
             is ExchangeV2Message.RecoveryCodeAvailable -> {
                 _peerKind = message.kind
@@ -841,6 +844,16 @@ class RealExchangeV2Runner @Inject constructor(
                 "Sync-ExchangeV2: session started role=${event.pairingRole} channel_id=${event.ownChannelId}$codeLine"
             }
             is ExchangeV2Event.SessionError -> logcat(ERROR) { "Sync-ExchangeV2: session error: ${event.message}" }
+            is ExchangeV2Event.VersionNegotiated -> logcat {
+                buildString {
+                    append("Sync-ExchangeV2: negotiated protocol version: ")
+                    append(event.negotiatedVersion.prettyPrint())
+                    append(", our version: ")
+                    append(event.ourVersion.prettyPrint())
+                    append(", peer version: ")
+                    append(event.peerVersion.prettyPrint())
+                }
+            }
         }
         _events.tryEmit(event)
     }
@@ -871,13 +884,16 @@ class RealExchangeV2Runner @Inject constructor(
         else -> false
     }
 
-    private fun negotiateProtocolVersion(peerVersion: ExchangeProtocolVersion): ExchangeProtocolVersion.V2 {
+    private fun negotiateProtocolVersion(
+        peerVersion: ExchangeProtocolVersion,
+        peerSource: PeerVersionSource,
+    ): ExchangeProtocolVersion.V2 {
         val ourVersion = advertisedVersion
         val negotiatedVersion = when (peerVersion) {
             is ExchangeProtocolVersion.V2 -> minOf(ourVersion, peerVersion)
             else -> BASELINE_PROTOCOL_VERSION
         }
-        logcat { "Sync-ExchangeV2: negotiated protocol version: v$negotiatedVersion, our version: v$ourVersion, peer version: v$peerVersion" }
+        emit(ExchangeV2Event.VersionNegotiated(clock.nowMs(), peerSource, peerVersion, advertisedVersion, negotiatedVersion))
         return negotiatedVersion
     }
 
@@ -900,7 +916,8 @@ class RealExchangeV2Runner @Inject constructor(
         // Channel authorization secret size for the v2 exchange transport layer.
         private const val CHANNEL_SECRET_SIZE = 32
 
-        private const val REPLAY = 100
+        // Max count ExchangeV2Event held in buffer that will be replayed to consumers.
+        private const val EVENT_BUFFER_SIZE = 100
 
         // Transport TD 1214486492252757 §Session Lifecycle: 5-minute client session deadline.
         private const val SESSION_TIMEOUT_MS = 5 * 60 * 1000L

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2State.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2State.kt
@@ -17,47 +17,157 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 /**
- * State machine nodes for the v2 exchange protocol.
+ * Every node the Exchange V2 protocol session can be in.
  *
- * Spec: Asana 1215056232572322. The machine starts in [Bootstrapped], shares a
- * negotiation phase with the peer, then forks into [Host] or [Joiner] after role election.
+ * The state machine exists to validate the order of messages, not their content: for a given
+ * state it decides whether an inbound message is accepted, dropped, or a protocol error. States
+ * therefore mirror "what are we waiting for", never "what is the UI showing".
+ *
+ * The session starts in a shared phase where roles aren't known yet ([Bootstrapped] to
+ * [Negotiating]), then forks into the [Host] or [Joiner] substate once the runner elects a role.
+ * Each fork ends in one of its own terminal states, at which point the runner tears the session
+ * down: deletes its relay channel and discards the session keys. Nothing can happen after a
+ * terminal, so any work that must outlive it belongs in a non-terminal state.
+ *
+ * Each state below is tagged with the protocol version that introduced it.
+ *
+ * Spec:
+ *  - Asana 1215056232572322, Exchange V2 Message Sequence State Machine: the 2.0 machine, plus the
+ *    implicit-abort and unknown-message-drop rules the transitions rely on.
+ *  - Asana 1214739740392701, Unified Algorithm: role election and the abort rules the runner applies
+ *    around this machine.
  */
 sealed interface ExchangeV2State {
+
+    /**
+     * Presenter's start state: the linking code is published, and we're waiting for a peer to scan it
+     * and send `hello`. A Scanner never sees this state: it learned the peer from the QR code, so it
+     * starts in [Negotiating] (messages you send never come back to your own inbox, so a Scanner
+     * could not receive its own `hello`).
+     *
+     * Since 2.0.
+     */
     data object Bootstrapped : ExchangeV2State
+
+    /**
+     * Peer identity is established and both sides declare whether they have an account
+     * (`recovery_code_available` / `recovery_code_request`). Stays here, absorbing those, until the
+     * runner has enough to elect a role and fires `RoleElected`.
+     *
+     * Since 2.0.
+     */
     data object Negotiating : ExchangeV2State
 
     /**
-     * Detected during Negotiating that the peer reports the same `user_id` as us — both
-     * devices are already on the same account. Per spec §"Same-account case" this is **not
+     * Terminal. Detected during [Negotiating] that the peer reports the same `user_id` as us, so
+     * both devices are already on the same account. Per spec §"Same-account case" this is **not
      * an abort**: callers should surface a friendly "Connected" finish, not an error. The
      * dispatcher maps this state to [com.duckduckgo.sync.impl.DispatchOutcome.AlreadyConnected].
      * Name retained for historical continuity; treat semantically as a success terminal.
+     *
+     * Since 2.0.
      */
     data object SameAccountAbort : ExchangeV2State
 
     /**
-     * Negotiation aborted before role election — e.g. an unexpected or duplicate `hello`
-     * received while in [Negotiating] (a second hello, or the double-scan race). Terminal.
-     * Per Unified Algorithm 1214739740392701 §Handshake Note: "abort and close the channel".
+     * Terminal. Negotiation aborted before role election, e.g. an unexpected or duplicate `hello`
+     * received while in [Negotiating] (a second hello, or the double-scan race). Per Unified
+     * Algorithm 1214739740392701 §Handshake Note: "abort and close the channel". The role-specific
+     * forks have their own abort terminals ([Host.Aborted], [Joiner.AbortedLocal]); this one only
+     * covers failures from before a role existed.
+     *
+     * Since 2.0.
      */
     data object Aborted : ExchangeV2State
 
+    /**
+     * The device that owns (or will create) the account and hands over the recovery code. Elected,
+     * not chosen by the user: a Presenter can end up Joiner and vice versa.
+     */
     sealed interface Host : ExchangeV2State {
+
+        /**
+         * Prompting our own user to approve sharing. `recovery_code_awaiting_confirmation` has
+         * already gone out, so the peer can show "check the other device" while we wait.
+         *
+         * Since 2.0.
+         */
         data object Confirming : Host
+
+        /**
+         * User approved. Provisioning whatever the peer's kind needs (create the account, add a
+         * 3party credential) and sending `recovery_code_response`, or `recovery_code_unavailable`
+         * if none of that can be produced.
+         *
+         * Since 2.0.
+         */
         data object Sending : Host
+
+        /**
+         * Terminal. The Host side gave up: our user denied the prompt, no recovery code could be
+         * produced, or the peer broke the message sequence.
+         *
+         * Since 2.0.
+         */
         data object Aborted : Host
+
+        /**
+         * Terminal. Finished as Host, which means only that the recovery code was sent: the Joiner
+         * never reports what it did with it.
+         *
+         * Since 2.0.
+         */
         data object Done : Host
     }
 
+    /**
+     * The device that receives the recovery code and joins the Host's account.
+     */
     sealed interface Joiner : ExchangeV2State {
+
+        /**
+         * Prompting our own user to approve joining. Nothing is sent to the peer from here, since by
+         * spec the Joiner's denial is silent, so the only inbound messages that matter are the
+         * Host's own aborts.
+         *
+         * Since 2.0.
+         */
         data object Confirming : Joiner
+
+        /**
+         * User approved; waiting on the Host. Absorbs its progress messages
+         * (`recovery_code_awaiting_confirmation`, `recovery_code_confirmed`) without changing state.
+         *
+         * Since 2.0.
+         */
         data object Waiting : Joiner
+
+        /**
+         * Terminal. We ended it ourselves: our user denied the prompt, or the Host broke the message
+         * sequence. Nothing is sent to the peer.
+         *
+         * Since 2.0.
+         */
         data object AbortedLocal : Joiner
+
+        /**
+         * Terminal. The Host ended it: `recovery_code_denied` (its user declined) or
+         * `recovery_code_unavailable` (it couldn't produce a code).
+         *
+         * Since 2.0.
+         */
         data object AbortedByHost : Joiner
+
+        /**
+         * Terminal. Reached on receiving the recovery code, before it has been applied.
+         *
+         * Since 2.0.
+         */
         data object Done : Joiner
     }
 }
 
+/** Which side of the exchange this device plays, decided by role election in the runner. */
 enum class Role {
     Host,
     Joiner,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2State.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2State.kt
@@ -29,11 +29,14 @@ package com.duckduckgo.sync.impl.exchange.v2
  * down: deletes its relay channel and discards the session keys. Nothing can happen after a
  * terminal, so any work that must outlive it belongs in a non-terminal state.
  *
- * Each state below is tagged with the protocol version that introduced it.
+ * Each state below is tagged with the protocol version that introduced it. 2.1 states are only ever
+ * reached when *both* peers advertised 2.1; against a 2.0 peer the session follows the 2.0 path
+ * unchanged, which is what keeps the two versions interoperable.
  *
  * Spec:
  *  - Asana 1215056232572322, Exchange V2 Message Sequence State Machine: the 2.0 machine, plus the
  *    implicit-abort and unknown-message-drop rules the transitions rely on.
+ *  - Asana 1216906888491126, Exchange v2.1 State machine: the delta, which is the join-status states.
  *  - Asana 1214739740392701, Unified Algorithm: role election and the abort rules the runner applies
  *    around this machine.
  */
@@ -104,6 +107,18 @@ sealed interface ExchangeV2State {
         data object Sending : Host
 
         /**
+         * Recovery code delivered; waiting for the Joiner to report what it did with it. Reached
+         * only when the negotiated version is 2.1. A 2.0 Joiner never reports, so against one the
+         * Host goes straight to [Done] exactly as it did in 2.0.
+         *
+         * Not terminal: the session stays alive and keeps polling until the report arrives or the
+         * session deadline fires.
+         *
+         * Since 2.1.
+         */
+        data object AwaitingStatus : Host
+
+        /**
          * Terminal. The Host side gave up: our user denied the prompt, no recovery code could be
          * produced, or the peer broke the message sequence.
          *
@@ -112,8 +127,9 @@ sealed interface ExchangeV2State {
         data object Aborted : Host
 
         /**
-         * Terminal. Finished as Host, which means only that the recovery code was sent: the Joiner
-         * never reports what it did with it.
+         * Terminal. Finished as Host. Against a 2.0 peer that means only "the recovery code was
+         * sent"; against a 2.1 peer it means the Joiner reported back, and the reason it reported,
+         * carried on the `recovery_code_done` that got us here, says whether it actually worked.
          *
          * Since 2.0.
          */
@@ -143,6 +159,18 @@ sealed interface ExchangeV2State {
         data object Waiting : Joiner
 
         /**
+         * Recovery code received; applying it (login, 3party upgrade, initial sync) and not yet
+         * done.
+         *
+         * Not terminal, and that is the whole point: the session has to outlive the login so
+         * `recovery_code_done` can still be sent afterward. In 2.0 `recovery_code_response` landed
+         * straight on [Done] because there was nothing left to report.
+         *
+         * Since 2.1.
+         */
+        data object Joining : Joiner
+
+        /**
          * Terminal. We ended it ourselves: our user denied the prompt, or the Host broke the message
          * sequence. Nothing is sent to the peer.
          *
@@ -159,11 +187,20 @@ sealed interface ExchangeV2State {
         data object AbortedByHost : Joiner
 
         /**
-         * Terminal. Reached on receiving the recovery code, before it has been applied.
+         * Terminal. Joined successfully. Since 2.1 this is reached only after
+         * `recovery_code_done(success)` has been sent, not on receiving the recovery code.
          *
          * Since 2.0.
          */
         data object Done : Joiner
+
+        /**
+         * Terminal. Failed to apply the recovery code, and reported that. Both this and [Done] are
+         * reached only after `recovery_code_done` has been sent; the reason distinguishes them.
+         *
+         * Since 2.1.
+         */
+        data object JoinFailed : Joiner
     }
 }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
@@ -16,11 +16,13 @@
 
 package com.duckduckgo.sync.impl.exchange.v2
 
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAvailable
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAwaitingConfirmation
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeConfirmed
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDenied
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeUnavailable
@@ -107,6 +109,7 @@ internal class RealExchangeV2StateMachine(
         return when (val state = currentState) {
             ExchangeV2State.Bootstrapped -> receiveInBootstrapped(state, msg)
             ExchangeV2State.Negotiating -> receiveInNegotiating(state, msg)
+            ExchangeV2State.Host.AwaitingStatus -> receiveInHostAwaitingStatus(state, msg)
             ExchangeV2State.Joiner.Confirming -> receiveInJoinerConfirming(state, msg)
             ExchangeV2State.Joiner.Waiting -> receiveInJoinerWaiting(state, msg)
             else -> abort(state, msg, RejectReason.ImplicitAbort)
@@ -119,6 +122,7 @@ internal class RealExchangeV2StateMachine(
             ExchangeV2State.Host.Confirming -> localTriggerInHostConfirming(state, trigger)
             ExchangeV2State.Host.Sending -> localTriggerInHostSending(state, trigger)
             ExchangeV2State.Joiner.Confirming -> localTriggerInJoinerConfirming(state, trigger)
+            ExchangeV2State.Joiner.Joining -> localTriggerInJoinerJoining(state, trigger)
             else -> abortLocal(state, trigger)
         }
     }
@@ -156,8 +160,16 @@ internal class RealExchangeV2StateMachine(
             is RecoveryCodeDenied,
             is RecoveryCodeUnavailable,
             is RecoveryCodeResponse,
+            is RecoveryCodeDone,
             -> abort(state, msg, RejectReason.ImplicitAbort)
             is UnknownMessage -> drop(msg)
+        }
+    }
+
+    private fun receiveInHostAwaitingStatus(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
+        return when (msg) {
+            is RecoveryCodeDone -> accept(state, ExchangeV2State.Host.Done, msg)
+            else -> abort(state, msg, RejectReason.ImplicitAbort)
         }
     }
 
@@ -177,10 +189,11 @@ internal class RealExchangeV2StateMachine(
             is RecoveryCodeConfirmed -> accept(state, ExchangeV2State.Joiner.Waiting, msg)
             is RecoveryCodeDenied -> accept(state, ExchangeV2State.Joiner.AbortedByHost, msg)
             is RecoveryCodeUnavailable -> accept(state, ExchangeV2State.Joiner.AbortedByHost, msg)
-            is RecoveryCodeResponse -> accept(state, ExchangeV2State.Joiner.Done, msg)
+            is RecoveryCodeResponse -> accept(state, ExchangeV2State.Joiner.Joining, msg)
             is Hello,
             is RecoveryCodeAvailable,
             is RecoveryCodeRequest,
+            is RecoveryCodeDone,
             -> abort(state, msg, RejectReason.ImplicitAbort)
             is UnknownMessage -> drop(msg)
         }
@@ -227,7 +240,14 @@ internal class RealExchangeV2StateMachine(
 
     private fun localTriggerInHostSending(state: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
         return when (trigger) {
-            LocalTrigger.HostSendComplete -> acceptLocal(state, ExchangeV2State.Host.Done, trigger)
+            // Spec 1216906886019334 §"Capability negotiation": only wait when the peer will actually
+            // report. A pre-2.1 peer never sends recovery_code_done, so waiting on one would turn a
+            // successful pairing into a spinner that only ends at the session deadline.
+            is LocalTrigger.HostSendComplete -> if (trigger.negotiatedVersion >= ExchangeProtocolVersion.V2_1) {
+                acceptLocal(state, ExchangeV2State.Host.AwaitingStatus, trigger)
+            } else {
+                acceptLocal(state, ExchangeV2State.Host.Done, trigger)
+            }
             // Host couldn't produce a recovery code (no account, no 3party credential, etc.).
             // Runner has already sent recovery_code_unavailable to peer; this just tears down.
             LocalTrigger.HostUnavailable -> acceptLocal(state, ExchangeV2State.Host.Aborted, trigger)
@@ -239,6 +259,20 @@ internal class RealExchangeV2StateMachine(
         return when (trigger) {
             LocalTrigger.UserConfirmedJoiner -> acceptLocal(state, ExchangeV2State.Joiner.Waiting, trigger)
             LocalTrigger.UserDeniedJoiner -> acceptLocal(state, ExchangeV2State.Joiner.AbortedLocal, trigger)
+            else -> abortLocal(state, trigger)
+        }
+    }
+
+    private fun localTriggerInJoinerJoining(state: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
+        return when (trigger) {
+            is LocalTrigger.JoinerJoinComplete -> {
+                val terminal = if (trigger.reason == RecoveryCodeDone.Reason.Success) {
+                    ExchangeV2State.Joiner.Done
+                } else {
+                    ExchangeV2State.Joiner.JoinFailed
+                }
+                acceptLocal(state, terminal, trigger, sideEffects = listOf(SideEffect.SendRecoveryCodeDone(trigger.reason)))
+            }
             else -> abortLocal(state, trigger)
         }
     }
@@ -327,8 +361,8 @@ internal class RealExchangeV2StateMachine(
 
 /** Terminal state to drive into on an implicit abort from [this]. Terminals return themselves. */
 private fun ExchangeV2State.abortTerminal(): ExchangeV2State = when (this) {
-    ExchangeV2State.Host.Confirming, ExchangeV2State.Host.Sending -> ExchangeV2State.Host.Aborted
-    ExchangeV2State.Joiner.Confirming, ExchangeV2State.Joiner.Waiting -> ExchangeV2State.Joiner.AbortedLocal
+    ExchangeV2State.Host.Confirming, ExchangeV2State.Host.Sending, ExchangeV2State.Host.AwaitingStatus -> ExchangeV2State.Host.Aborted
+    ExchangeV2State.Joiner.Confirming, ExchangeV2State.Joiner.Waiting, ExchangeV2State.Joiner.Joining -> ExchangeV2State.Joiner.AbortedLocal
     ExchangeV2State.Bootstrapped, ExchangeV2State.Negotiating -> ExchangeV2State.Aborted
     ExchangeV2State.Aborted,
     ExchangeV2State.SameAccountAbort,
@@ -337,5 +371,6 @@ private fun ExchangeV2State.abortTerminal(): ExchangeV2State = when (this) {
     ExchangeV2State.Joiner.AbortedByHost,
     ExchangeV2State.Joiner.AbortedLocal,
     ExchangeV2State.Joiner.Done,
+    ExchangeV2State.Joiner.JoinFailed,
     -> this
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
@@ -24,8 +24,8 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDenied
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeUnavailable
-import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Unknown
 import javax.inject.Inject
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Unknown as UnknownMessage
 
 /**
  * Pure validator for the Exchange V2 wire protocol. Stateful (it tracks [currentState] and the
@@ -103,7 +103,7 @@ internal class RealExchangeV2StateMachine(
         // Forward-compat rule, applied once for every state: a type this client doesn't model is
         // dropped, never treated as a protocol error. Handlers below therefore only decide between
         // "expected here" and the implicit abort.
-        if (msg is Unknown) return drop(msg)
+        if (msg is UnknownMessage) return drop(msg)
         return when (val state = currentState) {
             ExchangeV2State.Bootstrapped -> receiveInBootstrapped(state, msg)
             ExchangeV2State.Negotiating -> receiveInNegotiating(state, msg)
@@ -157,7 +157,7 @@ internal class RealExchangeV2StateMachine(
             is RecoveryCodeUnavailable,
             is RecoveryCodeResponse,
             -> abort(state, msg, RejectReason.ImplicitAbort)
-            is Unknown -> drop(msg)
+            is UnknownMessage -> drop(msg)
         }
     }
 
@@ -182,7 +182,7 @@ internal class RealExchangeV2StateMachine(
             is RecoveryCodeAvailable,
             is RecoveryCodeRequest,
             -> abort(state, msg, RejectReason.ImplicitAbort)
-            is Unknown -> drop(msg)
+            is UnknownMessage -> drop(msg)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
@@ -33,11 +33,35 @@ import javax.inject.Inject
  * input returns a [TransitionResult] that the runner forwards to the event sink and whose declared
  * [SideEffect]s the runner executes.
  *
- * Spec: Asana 1215056232572322 — Exchange V2 Message Sequence State Machine.
+ * Validates order, never content: it decides whether an input is allowed where the session
+ * currently is, and leaves what the input means to the runner. Which is why role election,
+ * provisioning and all network work live there instead.
+ *
+ * Every input is answered with a transition, so there is no way to ask "may I" without also moving.
+ * An input the current state doesn't allow is a protocol violation and aborts the session, with the
+ * single exception of an unrecognized message type, which is dropped so a newer peer can't kill the
+ * session by talking about things we don't model.
+ *
+ * Not thread-safe: one instance belongs to one session, and the runner serializes access to it.
+ *
+ * Spec: Asana 1215056232572322, Exchange V2 Message Sequence State Machine.
  */
 interface ExchangeV2StateMachine {
+
+    /** Where the session is now. Moves on every [receive] and [localTrigger], including aborts. */
     val currentState: ExchangeV2State
+
+    /**
+     * Feed in a message received from the peer. Accepts it, drops it, or aborts the session, per
+     * [TransitionResult.outcome].
+     */
     fun receive(msg: ExchangeV2Message): TransitionResult
+
+    /**
+     * Feed in something that didn't come off the wire: a user decision, role election, or the
+     * completion of work the runner was doing. Aborts the session if the current state does not
+     * allow the trigger.
+     */
     fun localTrigger(trigger: LocalTrigger): TransitionResult
 }
 
@@ -76,6 +100,9 @@ internal class RealExchangeV2StateMachine(
         private set
 
     override fun receive(msg: ExchangeV2Message): TransitionResult {
+        // Forward-compat rule, applied once for every state: a type this client doesn't model is
+        // dropped, never treated as a protocol error. Handlers below therefore only decide between
+        // "expected here" and the implicit abort.
         if (msg is Unknown) return drop(msg)
         return when (val state = currentState) {
             ExchangeV2State.Bootstrapped -> receiveInBootstrapped(state, msg)
@@ -134,7 +161,7 @@ internal class RealExchangeV2StateMachine(
         }
     }
 
-    // If the peer aborts while we're still showing the confirm prompt, act on it now instead of
+    // If the peer aborts while we're still showing the confirmation prompt, act on it now instead of
     // making the user confirm a doomed pairing.
     private fun receiveInJoinerConfirming(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
         return when (msg) {
@@ -245,9 +272,9 @@ internal class RealExchangeV2StateMachine(
     }
 
     /**
-     * Reject [msg] and abort. By default we drive to [from]'s terminal state (see [abortTerminal]):
-     *  - If [from] is still active, that's a real transition into the terminal → emit [Transition].
-     *  - If [from] is already terminal, [abortTerminal] returns itself, so we stay put → emit [MessageRejected].
+     * Reject [msg] and abort. By default, we drive to [from]'s terminal state (see [abortTerminal]):
+     *  - If [from] is still active, that's a real transition into the terminal → emit [ExchangeV2Event.Transition].
+     *  - If [from] is already terminal, [abortTerminal] returns itself, so we stay put → emit [ExchangeV2Event.MessageRejected].
      *
      * Callers can override [newState] to abort somewhere other than the default terminal.
      */

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/LocalTrigger.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/LocalTrigger.kt
@@ -17,14 +17,50 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 /**
- * Side-effect-free transitions driven by something other than an inbound wire message
- * (user input, role election by the runner, completion of an outbound send).
+ * An input to the state machine that didn't come off the wire: a user decision, role election, or
+ * the completion of work the runner was doing.
+ *
+ * Triggers carry no side effects themselves, but the transitions they drive declare most of them:
+ * every spec-mandated message this device originates follows a local decision rather than an
+ * inbound message (see [SideEffect]).
+ *
+ * A trigger the current state does not allow aborts the session, so the runner fires these only
+ * from the state each one belongs to.
  */
 sealed interface LocalTrigger {
+
+    /**
+     * Our user approved sharing the recovery code, at [ExchangeV2State.Host.Confirming]. Moves to
+     * [ExchangeV2State.Host.Sending], telling the peer and starting the handover.
+     */
     data object UserConfirmedHost : LocalTrigger
+
+    /**
+     * Our user refused to share, at [ExchangeV2State.Host.Confirming]. Moves to
+     * [ExchangeV2State.Host.Aborted], telling the peer why the session ended.
+     */
     data object UserDeniedHost : LocalTrigger
+
+    /**
+     * Our user approved joining, at [ExchangeV2State.Joiner.Confirming]. Moves to
+     * [ExchangeV2State.Joiner.Waiting], which is also when the runner replays any Host messages that
+     * arrived while the prompt was still up.
+     */
     data object UserConfirmedJoiner : LocalTrigger
+
+    /**
+     * Our user refused to join, at [ExchangeV2State.Joiner.Confirming]. Moves to
+     * [ExchangeV2State.Joiner.AbortedLocal]. Nothing is sent to the peer, since by spec the Joiner's
+     * denial is silent.
+     */
     data object UserDeniedJoiner : LocalTrigger
+
+    /**
+     * The runner picked which side this device plays, which is what forks the machine into the
+     * [ExchangeV2State.Host] or [ExchangeV2State.Joiner] branch. Election itself lives in the runner
+     * (Asana Unified Algorithm 1214739740392701), because it needs peer and account context the
+     * state machine deliberately doesn't track.
+     */
     data class RoleElected(val role: Role) : LocalTrigger
 
     /**

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/LocalTrigger.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/LocalTrigger.kt
@@ -16,6 +16,9 @@
 
 package com.duckduckgo.sync.impl.exchange.v2
 
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
+
 /**
  * An input to the state machine that didn't come off the wire: a user decision, role election, or
  * the completion of work the runner was doing.
@@ -67,7 +70,13 @@ sealed interface LocalTrigger {
      * Host has finished delivering [ExchangeV2Message.RecoveryCodeResponse] (or one of its
      * negative siblings) and is leaving the [ExchangeV2State.Host.Sending] state.
      */
-    data object HostSendComplete : LocalTrigger
+    data class HostSendComplete(val negotiatedVersion: ExchangeProtocolVersion.V2) : LocalTrigger
+
+    /**
+     * The Joiner has finished applying the recovery code, for better or worse. Carries the outcome
+     * so the state machine can both pick a terminal and declare the `recovery_code_done` to send.
+     */
+    data class JoinerJoinComplete(val reason: RecoveryCodeDone.Reason) : LocalTrigger
 
     /**
      * Host couldn't produce a recovery code for the peer (e.g. not signed in, or no 3party

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/RecoveryCodeProvider.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/RecoveryCodeProvider.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.ThirdPartyRecoveryCode
 import com.duckduckgo.sync.impl.ThirdPartyRecoveryCodeWrapper
+import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.Moshi
 import org.json.JSONObject
@@ -62,7 +63,7 @@ interface RecoveryCodeProvider {
 @ContributesBinding(AppScope::class)
 class RealRecoveryCodeProvider @Inject constructor(
     private val syncAccountRepository: SyncAccountRepository,
-    private val syncStore: com.duckduckgo.sync.store.SyncStore,
+    private val syncStore: SyncStore,
 ) : RecoveryCodeProvider {
 
     override fun createDdgAccountIfNeeded(): Result<Unit> {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/SideEffect.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/SideEffect.kt
@@ -17,18 +17,65 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 /**
- * Spec-defined protocol actions that accompany a state transition. The state machine attaches
- * these to its [TransitionResult]; the runner executes them. Keeping side effects declared at
- * the transition (rather than scattered across the runner's post-trigger hooks) means each
- * spec rule lives in exactly one place and is easy to audit against the Unified Algorithm.
+ * A protocol action the runner must perform because a transition happened.
  *
- * Spec source: Asana Unified Algorithm 1214739740392701, §"Exchange Confirmations" and
- * §"Exchange Share Recovery Code".
+ * The state machine is a pure validator: it decides the next state and declares what the spec
+ * requires alongside it, but never touches the network itself. The runner executes these in list
+ * order, after the transition has already been applied and its event emitted. Two consequences
+ * follow from that:
+ *  - Order within one [TransitionResult] is significant. [SendConfirmed] ahead of
+ *    [RequestRecoveryCodeShare] is what puts `recovery_code_confirmed` on the wire before the
+ *    recovery code itself.
+ *  - No state may depend on an effect succeeding. The state has already moved by the time one runs,
+ *    so a failed send surfaces as a session error and is never rolled back or retried.
+ *
+ * Declaring effects at the transition, rather than scattering them across the runner's post-trigger
+ * hooks, keeps each spec rule in exactly one place and auditable against the spec.
+ *
+ * Spec: Asana 1214739740392701, Unified Algorithm: §"Exchange Confirmations" and §"Exchange Share
+ * Recovery Code" define the effects and the point at which each fires.
  */
 sealed interface SideEffect {
 
+    /**
+     * Send `recovery_code_awaiting_confirmation`.
+     *
+     * Fires on entry to [ExchangeV2State.Host.Confirming], deliberately before our own user prompt,
+     * so the Joiner can show "check the other device" while the Host's user is still deciding.
+     *
+     * Since 2.0.
+     */
     data object SendAwaitingConfirmation : SideEffect
+
+    /**
+     * Send `recovery_code_confirmed`: our user approved sharing. Paired with
+     * [RequestRecoveryCodeShare] on the same transition and ordered first, so the peer learns the
+     * decision before the code arrives.
+     *
+     * Since 2.0.
+     */
     data object SendConfirmed : SideEffect
+
+    /**
+     * Send `recovery_code_denied`: our user refused, on the deny branch out of
+     * [ExchangeV2State.Host.Confirming]. The Joiner has no equivalent, because by spec its denial is
+     * silent.
+     *
+     * Since 2.0.
+     */
     data object SendDenied : SideEffect
+
+    /**
+     * Produce and deliver the recovery code. The one effect that is not a single message send, and
+     * the one that feeds back into the machine.
+     *
+     * The runner provisions whatever the peer's kind needs (create the account, add a 3party
+     * credential), then sends `recovery_code_response`, or `recovery_code_unavailable` if none of
+     * that could be produced. Because that involves network calls it runs asynchronously, and
+     * finishes by firing [LocalTrigger.HostSendComplete] or [LocalTrigger.HostUnavailable]. Those
+     * triggers, not this effect, are what move the Host off [ExchangeV2State.Host.Sending].
+     *
+     * Since 2.0.
+     */
     data object RequestRecoveryCodeShare : SideEffect
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/SideEffect.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/SideEffect.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.sync.impl.exchange.v2
 
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
+
 /**
  * A protocol action the runner must perform because a transition happened.
  *
@@ -32,8 +34,13 @@ package com.duckduckgo.sync.impl.exchange.v2
  * Declaring effects at the transition, rather than scattering them across the runner's post-trigger
  * hooks, keeps each spec rule in exactly one place and auditable against the spec.
  *
- * Spec: Asana 1214739740392701, Unified Algorithm: §"Exchange Confirmations" and §"Exchange Share
- * Recovery Code" define the effects and the point at which each fires.
+ * Each effect is tagged with the protocol version that introduced it. 2.1 effects are only reached
+ * when both peers advertised 2.1.
+ *
+ * Spec:
+ *  - Asana 1214739740392701, Unified Algorithm: §"Exchange Confirmations" and §"Exchange Share
+ *    Recovery Code" define the 2.0 effects and the point at which each fires.
+ *  - Asana 1216906886019334, Exchange v2.1 Messages: `recovery_code_done` and its best-effort rule.
  */
 sealed interface SideEffect {
 
@@ -78,4 +85,16 @@ sealed interface SideEffect {
      * Since 2.0.
      */
     data object RequestRecoveryCodeShare : SideEffect
+
+    /**
+     * Send `recovery_code_done`, telling the Host what we actually did with its recovery code, so it
+     * can report the real result instead of assuming success.
+     *
+     * Best-effort by spec: send once, never retry, and never depend on delivery. Not sent at all
+     * when the negotiated version is below 2.1, since the peer could only drop it; and even against
+     * a 2.1 Host the channel may already be gone.
+     *
+     * Since 2.1.
+     */
+    data class SendRecoveryCodeDone(val reason: RecoveryCodeDone.Reason) : SideEffect
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.PEER_RECOVERY_CODE_UNAVAILABLE
 import com.duckduckgo.sync.impl.AccountErrorCodes.RECOVERY_CODE_PREPARATION_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.SESSION_TIMEOUT
 import com.duckduckgo.sync.impl.AccountErrorCodes.UNEXPECTED_EVENT
+import com.duckduckgo.sync.impl.AccountErrorCodes.UNSUPPORTED_CREDENTIAL_TYPE
 import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
@@ -46,6 +47,7 @@ import com.duckduckgo.sync.impl.exchange.v2.SessionErrorKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -83,6 +85,7 @@ class RealSyncCodeDispatcherTest {
             val sinceMs = invocation.getArgument<Long>(0)
             runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
         }
+        whenever(it.localTrigger(any())).thenAnswer { Job().apply { complete() } }
     }
 
     private val dispatcher = RealSyncCodeDispatcher(
@@ -479,15 +482,15 @@ class RealSyncCodeDispatcherTest {
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = ExchangeProtocolVersion.V2_0),
         )
-        val staleJoinerDone = ExchangeV2Event.Transition(
+        val staleJoinerJoining = ExchangeV2Event.Transition(
             timestampMs = 1L,
             from = ExchangeV2State.Joiner.Waiting,
-            to = ExchangeV2State.Joiner.Done,
+            to = ExchangeV2State.Joiner.Joining,
             trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = "stale-code-from-prior-session"),
             localTrigger = null,
         )
         val staleFlow = MutableSharedFlow<ExchangeV2Event>(replay = 10)
-        staleFlow.tryEmit(staleJoinerDone)
+        staleFlow.tryEmit(staleJoinerJoining)
         whenever(runner.events).thenReturn(staleFlow)
         whenever(runner.eventsSince(any())).thenAnswer { invocation ->
             val sinceMs = invocation.getArgument<Long>(0)
@@ -544,7 +547,7 @@ class RealSyncCodeDispatcherTest {
                 ExchangeV2Event.Transition(
                     timestampMs = System.currentTimeMillis(),
                     from = ExchangeV2State.Joiner.Waiting,
-                    to = ExchangeV2State.Joiner.Done,
+                    to = ExchangeV2State.Joiner.Joining,
                     trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = recoveryCodeB64),
                     localTrigger = null,
                 ),
@@ -577,6 +580,36 @@ class RealSyncCodeDispatcherTest {
         trigger = trigger,
         localTrigger = localTrigger,
     )
+
+    private fun hostDone(reason: ExchangeV2Message.RecoveryCodeDone.Reason) = transition(
+        from = ExchangeV2State.Host.AwaitingStatus,
+        to = ExchangeV2State.Host.Done,
+        trigger = ExchangeV2Message.RecoveryCodeDone.create(reason),
+    )
+
+    private fun joinerJoining(recoveryCode: String) = transition(
+        from = ExchangeV2State.Joiner.Waiting,
+        to = ExchangeV2State.Joiner.Joining,
+        trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = recoveryCode),
+    )
+
+    private fun recoveryCode(cid: String): String {
+        val recoveryJson = JSONObject().apply {
+            put(
+                "recovery",
+                JSONObject().apply {
+                    put("user_id", "u-1")
+                    put("secret", "s-1")
+                    put("cid", cid)
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        return android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+    }
 
     private fun sessionStarted(linkingCode: String?, timestampMs: Long = System.currentTimeMillis()) =
         ExchangeV2Event.SessionStarted(
@@ -646,6 +679,42 @@ class RealSyncCodeDispatcherTest {
         dispatcher.presentV2().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Sending, to = ExchangeV2State.Host.Done))
             assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, PeerKind.THIRD_PARTY), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `Presenter emits LoggedIn when Host_Done carries recovery_code_done success`() = runTest {
+        whenever(runner.peerKind).thenReturn("ddg")
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(hostDone(ExchangeV2Message.RecoveryCodeDone.Reason.Success))
+            assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, PeerKind.DDG), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `Presenter emits LoggedIn when Host_Done carries recovery_code_done login_failed`() = runTest {
+        whenever(runner.peerKind).thenReturn("ddg")
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(hostDone(ExchangeV2Message.RecoveryCodeDone.Reason.LoginFailed))
+            assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, PeerKind.DDG), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `Presenter emits LoggedIn when Host_Done carries recovery_code_done scope_rejected`() = runTest {
+        whenever(runner.peerKind).thenReturn("ddg")
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(hostDone(ExchangeV2Message.RecoveryCodeDone.Reason.ScopeRejected))
+            assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, PeerKind.DDG), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `Presenter emits LoggedIn when Host_Done carries an unrecognised recovery_code_done reason`() = runTest {
+        whenever(runner.peerKind).thenReturn("ddg")
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(hostDone(ExchangeV2Message.RecoveryCodeDone.Reason.Unknown("sync_deferred")))
+            assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, PeerKind.DDG), awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -812,12 +881,12 @@ class RealSyncCodeDispatcherTest {
         }
     }
 
-    @Test fun `Presenter emits Failed when Joiner_Done arrives without a recovery code`() = runTest {
+    @Test fun `Presenter emits Failed when Joiner_Joining arrives without a recovery code`() = runTest {
         dispatcher.presentV2().test {
-            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Joining))
             assertEquals(
                 DispatchOutcome.Failed(
-                    "joiner_done_missing_recovery_code",
+                    "joiner_joining_missing_recovery_code",
                     NO_RECOVERY_CODE.code,
                     path = SetupPath.PAIRING,
                     myRole = SetupRole.JOINER,
@@ -828,7 +897,7 @@ class RealSyncCodeDispatcherTest {
         }
     }
 
-    @Test fun `Presenter emits LoggedIn when Joiner_Done carries a cid=ddg recovery code`() = runTest {
+    @Test fun `Presenter emits LoggedIn when Joiner_Joining carries a cid=ddg recovery code`() = runTest {
         val recoveryJson = JSONObject().apply {
             put(
                 "recovery",
@@ -853,7 +922,7 @@ class RealSyncCodeDispatcherTest {
                 ExchangeV2Event.Transition(
                     timestampMs = System.currentTimeMillis(),
                     from = ExchangeV2State.Joiner.Waiting,
-                    to = ExchangeV2State.Joiner.Done,
+                    to = ExchangeV2State.Joiner.Joining,
                     trigger = responseMessage,
                     localTrigger = null,
                 ),
@@ -865,7 +934,7 @@ class RealSyncCodeDispatcherTest {
         verify(syncAccountRepository, never()).joinAccountFromThirdPartyRecoveryCode(any())
     }
 
-    @Test fun `Presenter emits LoggedIn via 3party upgrade when Joiner_Done carries a cid=3party recovery code`() = runTest {
+    @Test fun `Presenter emits LoggedIn via 3party upgrade when Joiner_Joining carries a cid=3party recovery code`() = runTest {
         val recoveryJson = JSONObject().apply {
             put(
                 "recovery",
@@ -889,7 +958,7 @@ class RealSyncCodeDispatcherTest {
                 ExchangeV2Event.Transition(
                     timestampMs = System.currentTimeMillis(),
                     from = ExchangeV2State.Joiner.Waiting,
-                    to = ExchangeV2State.Joiner.Done,
+                    to = ExchangeV2State.Joiner.Joining,
                     trigger = responseMessage,
                     localTrigger = null,
                 ),
@@ -898,6 +967,48 @@ class RealSyncCodeDispatcherTest {
             cancelAndIgnoreRemainingEvents()
         }
         verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(any())
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `Presenter reports JoinerJoinComplete success when the Joiner_Joining login succeeds`() = runTest {
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(joinerJoining(recoveryCode(cid = "ddg")))
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify(runner).localTrigger(
+            LocalTrigger.JoinerJoinComplete(ExchangeV2Message.RecoveryCodeDone.Reason.Success),
+        )
+    }
+
+    @Test fun `Presenter reports JoinerJoinComplete login_failed when the Joiner_Joining login fails`() = runTest {
+        whenever(syncAccountRepository.processCode(any(), anyOrNull()))
+            .thenReturn(Result.Error(code = LOGIN_FAILED.code, reason = "login rejected"))
+
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(joinerJoining(recoveryCode(cid = "ddg")))
+            assertEquals(LOGIN_FAILED.code, (awaitItem() as DispatchOutcome.Failed).code)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify(runner).localTrigger(
+            LocalTrigger.JoinerJoinComplete(ExchangeV2Message.RecoveryCodeDone.Reason.LoginFailed),
+        )
+    }
+
+    @Test fun `Presenter reports JoinerJoinComplete scope_rejected when Joiner_Joining carries an unknown cid`() = runTest {
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(joinerJoining(recoveryCode(cid = "future-credential")))
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify(runner).localTrigger(
+            LocalTrigger.JoinerJoinComplete(ExchangeV2Message.RecoveryCodeDone.Reason.ScopeRejected),
+        )
         verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
 
@@ -1175,9 +1286,9 @@ class RealSyncCodeDispatcherTest {
         }
     }
 
-    @Test fun `Scanner - Joiner_Done without recovery code maps to Failed NO_RECOVERY_CODE`() = runTest {
+    @Test fun `Scanner - Joiner_Joining without recovery code maps to Failed NO_RECOVERY_CODE`() = runTest {
         startLinking().test {
-            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Joining))
             assertEquals(NO_RECOVERY_CODE.code, (awaitItem() as DispatchOutcome.Failed).code)
             cancelAndIgnoreRemainingEvents()
         }
@@ -1249,7 +1360,7 @@ class RealSyncCodeDispatcherTest {
         }
     }
 
-    @Test fun `Presenter emits Failed when Joiner_Done carries a recovery code with unknown cid`() = runTest {
+    @Test fun `Presenter emits Failed when Joiner_Joining carries a recovery code with unknown cid`() = runTest {
         val recoveryJson = JSONObject().apply {
             put(
                 "recovery",
@@ -1272,13 +1383,14 @@ class RealSyncCodeDispatcherTest {
                 ExchangeV2Event.Transition(
                     timestampMs = System.currentTimeMillis(),
                     from = ExchangeV2State.Joiner.Waiting,
-                    to = ExchangeV2State.Joiner.Done,
+                    to = ExchangeV2State.Joiner.Joining,
                     trigger = responseMessage,
                     localTrigger = null,
                 ),
             )
             val outcome = awaitItem() as DispatchOutcome.Failed
             assertTrue("expected reason to mention the unknown cid, got '${outcome.reason}'", outcome.reason.contains("future-credential"))
+            assertEquals(UNSUPPORTED_CREDENTIAL_TYPE.code, outcome.code)
             cancelAndIgnoreRemainingEvents()
         }
         verify(syncAccountRepository, never()).processCode(any(), anyOrNull())

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
@@ -16,11 +16,13 @@
 
 package com.duckduckgo.sync.impl.exchange.v2
 
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAvailable
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAwaitingConfirmation
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeConfirmed
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDenied
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeUnavailable
@@ -245,10 +247,98 @@ class ExchangeV2StateMachineTest {
         assertSame(ExchangeV2State.Host.Aborted, machine.currentState)
     }
 
-    @Test fun `when HostSendComplete in Host Sending then advances to Host Done`() {
+    @Test fun `when HostSendComplete v2_1 in Host Sending then advances to Host AwaitingStatus`() {
+        val machine = inHostSending()
+        val result = machine.localTrigger(LocalTrigger.HostSendComplete(ExchangeProtocolVersion.V2_1))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Host.AwaitingStatus, machine.currentState)
+    }
+
+    @Test fun `when recovery_code_done received in Host AwaitingStatus then transitions to Host Done`() {
+        val machine = inHostAwaitingStatus()
+        val done = RecoveryCodeDone.create(RecoveryCodeDone.Reason.Success)
+        val result = machine.receive(done)
+        val transition = result.event as ExchangeV2Event.Transition
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Host.Done, machine.currentState)
+        assertSame(ExchangeV2State.Host.AwaitingStatus, transition.from)
+        assertSame(done, transition.trigger)
+    }
+
+    @Test fun `when recovery_code_done with login_failed received in Host AwaitingStatus then transitions to Host Done`() {
+        val machine = inHostAwaitingStatus()
+        val result = machine.receive(RecoveryCodeDone.create(RecoveryCodeDone.Reason.LoginFailed))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Host.Done, machine.currentState)
+    }
+
+    @Test fun `when wire message received in Host AwaitingStatus then aborts to terminal Host Aborted`() {
+        val machine = inHostAwaitingStatus()
+        val result = machine.receive(RecoveryCodeResponse.fromJson("{}"))
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertSame(ExchangeV2State.Host.Aborted, machine.currentState)
+    }
+
+    @Test fun `when unknown message received in Host AwaitingStatus then dropped`() {
+        val machine = inHostAwaitingStatus()
+        val result = machine.receive(Unknown.fromJson("{}", "future"))
+
+        assertSame(TransitionOutcome.Dropped, result.outcome)
+        assertSame(ExchangeV2State.Host.AwaitingStatus, machine.currentState)
+    }
+
+    @Test fun `when JoinerJoinComplete success in Joiner Joining then advances to Joiner Done`() {
+        val machine = inJoinerJoining()
+        val result = machine.localTrigger(LocalTrigger.JoinerJoinComplete(RecoveryCodeDone.Reason.Success))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
+        assertEquals(listOf(SideEffect.SendRecoveryCodeDone(RecoveryCodeDone.Reason.Success)), result.sideEffects)
+    }
+
+    @Test fun `when JoinerJoinComplete login_failed in Joiner Joining then advances to Joiner JoinFailed`() {
+        val machine = inJoinerJoining()
+        val reason = RecoveryCodeDone.Reason.LoginFailed
+        val result = machine.localTrigger(LocalTrigger.JoinerJoinComplete(reason))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Joiner.JoinFailed, machine.currentState)
+        assertEquals(listOf(SideEffect.SendRecoveryCodeDone(reason)), result.sideEffects)
+    }
+
+    @Test fun `when JoinerJoinComplete with unknown reason in Joiner Joining then advances to Joiner JoinFailed`() {
+        val machine = inJoinerJoining()
+        val reason = RecoveryCodeDone.Reason.Unknown("future_reason")
+        val result = machine.localTrigger(LocalTrigger.JoinerJoinComplete(reason))
+
+        assertSame(ExchangeV2State.Joiner.JoinFailed, machine.currentState)
+        assertEquals(listOf(SideEffect.SendRecoveryCodeDone(reason)), result.sideEffects)
+    }
+
+    @Test fun `when wire message received in Joiner Joining then aborts to terminal Joiner AbortedLocal`() {
+        val machine = inJoinerJoining()
+        val result = machine.receive(RecoveryCodeConfirmed.fromJson("{}"))
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertSame(ExchangeV2State.Joiner.AbortedLocal, machine.currentState)
+    }
+
+    @Test fun `when out-of-sequence local trigger in Joiner Joining then aborts to terminal Joiner AbortedLocal`() {
+        val machine = inJoinerJoining()
+        val result = machine.localTrigger(LocalTrigger.UserConfirmedJoiner)
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertSame(ExchangeV2State.Joiner.AbortedLocal, machine.currentState)
+    }
+
+    @Test fun `when HostSendComplete v2_0 in Host Sending then advances to Host Done`() {
         val machine = inHostConfirming()
         machine.localTrigger(LocalTrigger.UserConfirmedHost)
-        val result = machine.localTrigger(LocalTrigger.HostSendComplete)
+        val result = machine.localTrigger(LocalTrigger.HostSendComplete(ExchangeProtocolVersion.V2_0))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
         assertSame(ExchangeV2State.Host.Done, machine.currentState)
@@ -394,12 +484,12 @@ class ExchangeV2StateMachineTest {
         assertSame(ExchangeV2State.Joiner.AbortedByHost, machine.currentState)
     }
 
-    @Test fun `when response received in Joiner Waiting then transitions to Joiner Done`() {
+    @Test fun `when response received in Joiner Waiting then transitions to Joiner Joining`() {
         val machine = inJoinerWaiting()
         val result = machine.receive(RecoveryCodeResponse.fromJson("{}"))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
-        assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
+        assertSame(ExchangeV2State.Joiner.Joining, machine.currentState)
     }
 
     @Test fun `when negotiation-phase message received in Joiner Waiting then aborts to terminal Joiner AbortedLocal`() {
@@ -528,7 +618,7 @@ class ExchangeV2StateMachineTest {
     @Test fun `when message received in Host Done then state unchanged and outcome is Aborted`() {
         val machine = inHostConfirming().also {
             it.localTrigger(LocalTrigger.UserConfirmedHost)
-            it.localTrigger(LocalTrigger.HostSendComplete)
+            it.localTrigger(LocalTrigger.HostSendComplete(ExchangeProtocolVersion.V2_0))
         }
         assertSame(ExchangeV2State.Host.Done, machine.currentState)
 
@@ -539,7 +629,10 @@ class ExchangeV2StateMachineTest {
     }
 
     @Test fun `when message received in Joiner Done then state unchanged and outcome is Aborted`() {
-        val machine = inJoinerWaiting().also { it.receive(RecoveryCodeResponse.fromJson("{}")) }
+        val machine = inJoinerWaiting().also {
+            it.receive(RecoveryCodeResponse.fromJson("{}"))
+            it.localTrigger(LocalTrigger.JoinerJoinComplete(RecoveryCodeDone.Reason.Success))
+        }
         assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
 
         val result = machine.receive(Hello.fromJson("{}"))
@@ -565,5 +658,20 @@ class ExchangeV2StateMachineTest {
     private fun inJoinerWaiting(): ExchangeV2StateMachine =
         inJoinerConfirming().also {
             it.localTrigger(LocalTrigger.UserConfirmedJoiner)
+        }
+
+    private fun inHostSending(): ExchangeV2StateMachine =
+        inHostConfirming().also {
+            it.localTrigger(LocalTrigger.UserConfirmedHost)
+        }
+
+    private fun inHostAwaitingStatus(): ExchangeV2StateMachine =
+        inHostSending().also {
+            it.localTrigger(LocalTrigger.HostSendComplete(ExchangeProtocolVersion.V2_1))
+        }
+
+    private fun inJoinerJoining(): ExchangeV2StateMachine =
+        inJoinerWaiting().also {
+            it.receive(RecoveryCodeResponse.fromJson("{}"))
         }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/JsonExchangeV2MessageParserTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/JsonExchangeV2MessageParserTest.kt
@@ -17,10 +17,15 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(TestParameterInjector::class)
 class JsonExchangeV2MessageParserTest {
 
     private val parser = JsonExchangeV2MessageParser()
@@ -66,6 +71,39 @@ class JsonExchangeV2MessageParserTest {
         val parsed = parser.parse(json) as ExchangeV2Message.RecoveryCodeResponse
 
         assertEquals("the-code", parsed.recoveryCode)
+    }
+
+    enum class RecoverCodeCase(
+        val rawReason: String,
+        val expectedReason: RecoveryCodeDone.Reason,
+    ) {
+        Success(
+            rawReason = "success",
+            expectedReason = RecoveryCodeDone.Reason.Success,
+        ),
+        LoginFailed(
+            rawReason = "login_failed",
+            expectedReason = RecoveryCodeDone.Reason.LoginFailed,
+        ),
+        ScopeRejected(
+            rawReason = "scope_rejected",
+            expectedReason = RecoveryCodeDone.Reason.ScopeRejected,
+        ),
+        Unknown(
+            rawReason = "future_reason",
+            expectedReason = RecoveryCodeDone.Reason.Unknown("future_reason"),
+        ),
+    }
+
+    @Test
+    fun `parses recovery_code_done with reason`(
+        @TestParameter case: RecoverCodeCase,
+    ) {
+        val json = """{"type":"recovery_code_done","reason":"${case.rawReason}"}"""
+
+        val parsed = parser.parse(json) as RecoveryCodeDone
+
+        assertEquals(case.expectedReason, parsed.reason)
     }
 
     @Test fun `parses bodyless types awaiting_confirmation confirmed denied unavailable`() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealAdvertisedExchangeV2VersionTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealAdvertisedExchangeV2VersionTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RealAdvertisedExchangeV2VersionTest {
+
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val advertisedVersion = RealAdvertisedExchangeV2Version(syncFeature)
+
+    @Test fun `advertises v2_1 when the version flag is enabled`() {
+        syncFeature.canUseExchangeV2Point1().setRawStoredState(State(remoteEnableState = true))
+
+        assertEquals(ExchangeProtocolVersion.V2_1, advertisedVersion.resolve())
+    }
+
+    @Test fun `advertises v2_0 when the version flag is disabled`() {
+        syncFeature.canUseExchangeV2Point1().setRawStoredState(State(remoteEnableState = false))
+
+        assertEquals(ExchangeProtocolVersion.V2_0, advertisedVersion.resolve())
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -79,6 +79,7 @@ class RealExchangeV2RunnerTest {
     private val recoveryCodeProvider: RecoveryCodeProvider = mock()
     private val syncDeviceIds: SyncDeviceIds = mock()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val advertisedVersion: AdvertisedExchangeV2Version = mock()
 
     private fun newRunner(): RealExchangeV2Runner =
         RealExchangeV2Runner(
@@ -90,12 +91,14 @@ class RealExchangeV2RunnerTest {
             qrCode = qrCode,
             recoveryCodeProvider = recoveryCodeProvider,
             syncDeviceIds = syncDeviceIds,
+            advertisedExchangeV2Version = advertisedVersion,
             syncFeature = syncFeature,
             appScope = coroutineTestRule.testScope,
             dispatchers = coroutineTestRule.testDispatcherProvider,
         )
 
     @Before fun stubWireDeps() {
+        givenOurVersion(ExchangeProtocolVersion.V2_0)
         givenLinkingCodeVersion(ExchangeProtocolVersion.V2_0)
         whenever(qrCode.buildLinkingCode(any(), any(), any())).thenReturn("https://duckduckgo.com/sync/pairing/#&code2=fake")
         whenever(jweCrypto.generateRsaKeyPair(any())).thenReturn(RsaKeyPair(publicKeyBase64 = "own-pub", privateKeyBase64 = "own-priv"))
@@ -306,7 +309,7 @@ class RealExchangeV2RunnerTest {
         )
     }
 
-    @Test fun `each session re-reads the flag rather than reusing the previous session's advertised version`() = runTest {
+    @Test fun `each session re-resolves the advertised version rather than reusing the previous session's`() = runTest {
         val runner = newRunner()
 
         givenOurVersion(ExchangeProtocolVersion.V2_1)
@@ -333,7 +336,7 @@ class RealExchangeV2RunnerTest {
         peerVersion: String,
         negotiated: String,
     ) = runTest {
-        givenOurVersion(ourVersion.toProtocolVersion())
+        givenOurVersion(ourVersion.toV2ProtocolVersion())
         givenLinkingCodeVersion(peerVersion.toV2ProtocolVersion())
 
         val runner = newRunner()
@@ -358,7 +361,7 @@ class RealExchangeV2RunnerTest {
         peerVersion: String,
         negotiated: String,
     ) = runTest {
-        givenOurVersion(ourVersion.toProtocolVersion())
+        givenOurVersion(ourVersion.toV2ProtocolVersion())
         whenever(syncStore.userId).thenReturn("my-user")
 
         val runner = newRunner()
@@ -757,7 +760,7 @@ class RealExchangeV2RunnerTest {
     @Test fun `the channel is claimed, polled and written to with a secret only when a flag calls for it`(
         @TestParameter case: ExchangeAuthCase,
     ) = runTest {
-        case.configure(syncFeature)
+        configure(case)
         val utf8Secret = "channel-secret"
         val expectedSecret = utf8Secret.toBase64Url().takeIf { case.isAuthenticated }
         whenever(jweCrypto.generateSecureBytes(any())).thenReturn(utf8Secret.toByteArray())
@@ -774,7 +777,7 @@ class RealExchangeV2RunnerTest {
     @Test fun `cancel deletes the channel with whatever secret it was created with`(
         @TestParameter case: ExchangeAuthCase,
     ) = runTest {
-        case.configure(syncFeature)
+        configure(case)
         val utf8Secret = "channel-secret"
         val expectedSecret = utf8Secret.toBase64Url().takeIf { case.isAuthenticated }
         whenever(jweCrypto.generateSecureBytes(any())).thenReturn(utf8Secret.toByteArray())
@@ -835,9 +838,8 @@ class RealExchangeV2RunnerTest {
 
     // ---- Helpers ----
 
-    private fun givenOurVersion(version: ExchangeProtocolVersion) {
-        val state = State(remoteEnableState = version == ExchangeProtocolVersion.V2_1)
-        syncFeature.canUseExchangeV2Point1().setRawStoredState(state)
+    private fun givenOurVersion(version: ExchangeProtocolVersion.V2) {
+        whenever(advertisedVersion.resolve()).thenReturn(version)
     }
 
     private fun givenLinkingCodeVersion(version: ExchangeProtocolVersion.V2) {
@@ -857,35 +859,34 @@ class RealExchangeV2RunnerTest {
     private fun String.toBase64Url(): String = Base64.getUrlEncoder().withoutPadding().encodeToString(toByteArray())
 
     enum class ExchangeAuthCase(
+        val advertisedVersion: ExchangeProtocolVersion.V2,
         val canSendExchangeChannelSecret: Boolean,
-        val canUseExchangeV2Point1: Boolean,
         val isAuthenticated: Boolean,
     ) {
-        BothFlagsOff(
+        V20WithoutSecretFlag(
+            advertisedVersion = ExchangeProtocolVersion.V2_0,
             canSendExchangeChannelSecret = false,
-            canUseExchangeV2Point1 = false,
             isAuthenticated = false,
         ),
-        SecretFlagOn(
+        V20WithSecretFlag(
+            advertisedVersion = ExchangeProtocolVersion.V2_0,
             canSendExchangeChannelSecret = true,
-            canUseExchangeV2Point1 = false,
             isAuthenticated = true,
         ),
-        V2Point1FlagOn(
+        V21WithoutSecretFlag(
+            advertisedVersion = ExchangeProtocolVersion.V2_1,
             canSendExchangeChannelSecret = false,
-            canUseExchangeV2Point1 = true,
             isAuthenticated = true,
         ),
-        BothFlagsOn(
+        V21WithSecretFlag(
+            advertisedVersion = ExchangeProtocolVersion.V2_1,
             canSendExchangeChannelSecret = true,
-            canUseExchangeV2Point1 = true,
             isAuthenticated = true,
         ),
-        ;
+    }
 
-        fun configure(syncFeature: SyncFeature) {
-            syncFeature.canSendExchangeChannelSecret().setRawStoredState(State(canSendExchangeChannelSecret))
-            syncFeature.canUseExchangeV2Point1().setRawStoredState(State(canUseExchangeV2Point1))
-        }
+    private fun configure(case: ExchangeAuthCase) {
+        givenOurVersion(case.advertisedVersion)
+        syncFeature.canSendExchangeChannelSecret().setRawStoredState(State(case.canSendExchangeChannelSecret))
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -339,7 +339,8 @@ class RealExchangeV2RunnerTest {
         val runner = newRunner()
         runner.startScan("")
 
-        assertEquals(negotiated.toProtocolVersion(), runner.negotiatedVersion)
+        val negotiation = runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().single()
+        assertEquals(negotiated.toProtocolVersion(), negotiation.negotiatedVersion)
     }
 
     @Test
@@ -364,19 +365,59 @@ class RealExchangeV2RunnerTest {
         runner.startPresent()
         runner.deliverHello(peerVersion.toProtocolVersion())
 
-        assertEquals(negotiated.toProtocolVersion(), runner.negotiatedVersion)
+        val negotiation = runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().single()
+        assertEquals(negotiated.toProtocolVersion(), negotiation.negotiatedVersion)
     }
 
-    @Test fun `cancel clears negotiated version`() = runTest {
+    @Test fun `Scanner reports the scanned code as the source of the peer version`() = runTest {
         givenOurVersion(ExchangeProtocolVersion.V2_1)
-        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_1)
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_0)
 
         val runner = newRunner()
         runner.startScan("")
-        assertEquals(ExchangeProtocolVersion.V2_1, runner.negotiatedVersion)
 
-        runner.cancel()
-        assertEquals(ExchangeProtocolVersion.V2_0, runner.negotiatedVersion)
+        val negotiation = runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().single()
+        assertEquals(PeerVersionSource.LinkingCode, negotiation.peerSource)
+        assertEquals(ExchangeProtocolVersion.V2_1, negotiation.ourVersion)
+        assertEquals(ExchangeProtocolVersion.V2_0, negotiation.peerVersion)
+        assertEquals(ExchangeProtocolVersion.V2_0, negotiation.negotiatedVersion)
+    }
+
+    @Test fun `Presenter reports the peer hello as the source of the peer version`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_0)
+        whenever(syncStore.userId).thenReturn("my-user")
+
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverHello(ExchangeProtocolVersion.V2_1)
+
+        val negotiation = runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().single()
+        assertEquals(PeerVersionSource.HelloMessage, negotiation.peerSource)
+        assertEquals(ExchangeProtocolVersion.V2_0, negotiation.ourVersion)
+        assertEquals(ExchangeProtocolVersion.V2_1, negotiation.peerVersion)
+        assertEquals(ExchangeProtocolVersion.V2_0, negotiation.negotiatedVersion)
+    }
+
+    @Test fun `a peer version we cannot speak falls back to the baseline but is reported as advertised`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        whenever(syncStore.userId).thenReturn("my-user")
+
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverHello("3.4".toProtocolVersion())
+
+        val negotiation = runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().single()
+        assertEquals("3.4".toProtocolVersion(), negotiation.peerVersion)
+        assertEquals(ExchangeProtocolVersion.V2_0, negotiation.negotiatedVersion)
+    }
+
+    @Test fun `a peer that never advertises a version produces no negotiation event`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+
+        val runner = newRunner()
+        runner.startPresent()
+
+        assertTrue(runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().isEmpty())
     }
 
     // ---- Auto role election ----

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAvailable
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAwaitingConfirmation
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeConfirmed
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
 import com.duckduckgo.sync.store.SyncStore
@@ -519,6 +520,80 @@ class RealExchangeV2RunnerTest {
         )
     }
 
+    @Test fun `Host with a v2_1 peer stays in Host_AwaitingStatus after sending the recovery code`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenHostCanProduceRecoveryCode()
+
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverHello(ExchangeProtocolVersion.V2_1)
+        runner.deliverIncomingMessage(RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"))
+
+        runner.localTrigger(LocalTrigger.UserConfirmedHost)
+
+        assertSame(ExchangeV2State.Host.AwaitingStatus, runner.currentState)
+        verify(channel, never()).deleteChannel(any(), anyOrNull())
+    }
+
+    @Test fun `Host with a v2_0 peer abandons the session after sending the recovery code`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenHostCanProduceRecoveryCode()
+
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverHello(ExchangeProtocolVersion.V2_0)
+        runner.deliverIncomingMessage(RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"))
+
+        runner.localTrigger(LocalTrigger.UserConfirmedHost)
+
+        assertNull(runner.currentState)
+        verify(channel).deleteChannel(any(), anyOrNull())
+    }
+
+    @Test fun `Joiner with a v2_1 peer sends recovery_code_done when the join completes`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_1)
+        whenever(syncStore.userId).thenReturn(null)
+
+        val runner = newRunner()
+        runner.startScan("")
+        runner.deliverIncomingMessage(RecoveryCodeAvailable.create(userId = "host-user", name = "Host", kind = "ddg"))
+        runner.localTrigger(LocalTrigger.UserConfirmedJoiner)
+        runner.deliverIncomingMessage(RecoveryCodeResponse.create(recoveryCode = "the-code"))
+
+        runner.localTrigger(LocalTrigger.JoinerJoinComplete(RecoveryCodeDone.Reason.Success))
+
+        verify(channel).sendMessage(
+            argThat { this is RecoveryCodeDone && reason == RecoveryCodeDone.Reason.Success },
+            any(),
+            any(),
+            any(),
+            anyOrNull(),
+        )
+    }
+
+    @Test fun `Joiner with a v2_0 peer does not send recovery_code_done`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_0)
+        whenever(syncStore.userId).thenReturn(null)
+
+        val runner = newRunner()
+        runner.startScan("")
+        runner.deliverIncomingMessage(RecoveryCodeAvailable.create(userId = "host-user", name = "Host", kind = "ddg"))
+        runner.localTrigger(LocalTrigger.UserConfirmedJoiner)
+        runner.deliverIncomingMessage(RecoveryCodeResponse.create(recoveryCode = "the-code"))
+
+        runner.localTrigger(LocalTrigger.JoinerJoinComplete(RecoveryCodeDone.Reason.Success))
+
+        verify(channel, never()).sendMessage(
+            argThat { this is RecoveryCodeDone },
+            any(),
+            any(),
+            any(),
+            anyOrNull(),
+        )
+    }
+
     @Test fun `UserConfirmedHost sends recovery_code_confirmed but does NOT re-send awaiting_confirmation`() = runTest {
         whenever(syncStore.userId).thenReturn("my-user")
         whenever(recoveryCodeProvider.getDdgRecoveryCode()).thenReturn(com.duckduckgo.sync.impl.Result.Success("the-code"))
@@ -659,6 +734,7 @@ class RealExchangeV2RunnerTest {
         )
         runner.localTrigger(LocalTrigger.UserConfirmedJoiner)
         runner.deliverIncomingMessage(RecoveryCodeResponse.fromJson("{}"))
+        runner.localTrigger(LocalTrigger.JoinerJoinComplete(RecoveryCodeDone.Reason.Success))
         assertNull(runner.currentState)
 
         advanceTimeBy(6 * 60 * 1000L)
@@ -846,6 +922,12 @@ class RealExchangeV2RunnerTest {
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "peer-channel", publicKey = "peer-pubkey", version = version),
         )
+    }
+
+    private fun givenHostCanProduceRecoveryCode() {
+        whenever(recoveryCodeProvider.createDdgAccountIfNeeded()).thenReturn(Result.Success(Unit))
+        whenever(recoveryCodeProvider.getDdgRecoveryCode()).thenReturn(Result.Success("the-code"))
+        whenever(syncStore.userId).thenReturn("my-user")
     }
 
     private suspend fun RealExchangeV2Runner.deliverHello(version: ExchangeProtocolVersion) {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -64,6 +64,7 @@ import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskJoinerConfirm
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowV2Error
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -106,6 +107,7 @@ class SyncConnectViewModelTest {
             val sinceMs = invocation.getArgument<Long>(0)
             runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
         }
+        whenever(it.localTrigger(any())).thenAnswer { Job().apply { complete() } }
     }
     private val codeDispatcher = com.duckduckgo.sync.impl.RealSyncCodeDispatcher(
         syncFeature = syncFeature,
@@ -548,7 +550,7 @@ class SyncConnectViewModelTest {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Joiner.Waiting,
-                    to = ExchangeV2State.Joiner.Done,
+                    to = ExchangeV2State.Joiner.Joining,
                     trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = b64),
                 ),
             )
@@ -591,7 +593,7 @@ class SyncConnectViewModelTest {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Joiner.Waiting,
-                    to = ExchangeV2State.Joiner.Done,
+                    to = ExchangeV2State.Joiner.Joining,
                     trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = b64),
                 ),
             )
@@ -639,7 +641,7 @@ class SyncConnectViewModelTest {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Joiner.Waiting,
-                    to = ExchangeV2State.Joiner.Done,
+                    to = ExchangeV2State.Joiner.Joining,
                     trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = recoveryB64),
                 ),
             )

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/exchange/SyncInternalAdvertisedExchangeV2Version.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/exchange/SyncInternalAdvertisedExchangeV2Version.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.internal.exchange
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.duckduckgo.sync.impl.exchange.v2.AdvertisedExchangeV2Version
+import com.duckduckgo.sync.impl.exchange.v2.RealAdvertisedExchangeV2Version
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(scope = AppScope::class, replaces = [RealAdvertisedExchangeV2Version::class])
+class SyncInternalAdvertisedExchangeV2Version @Inject constructor(
+    private val real: RealAdvertisedExchangeV2Version,
+) : AdvertisedExchangeV2Version {
+
+    val overrideFlow = MutableStateFlow<ExchangeProtocolVersion.V2?>(null)
+
+    override fun resolve() = overrideFlow.value ?: defaultVersion()
+
+    fun defaultVersion() = real.resolve()
+}

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -370,9 +370,6 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.canShowV2ConnectCodeToggle.quietlySetIsChecked(viewState.canShowV2ConnectCodeEnabled) { _, enabled ->
             viewModel.onCanShowV2ConnectCodeFlagChanged(enabled)
         }
-        binding.canUseExchangeV2Point1.quietlySetIsChecked(viewState.canUseExchangeV2Point1) { _, enabled ->
-            viewModel.onCanUseExchangeV2Point1FlagChanged(enabled)
-        }
         binding.accessCredentialsTextView.text = viewState.accessCredentialsText
         binding.scopedTokenResultTextView.text = viewState.scopedTokenResult
         binding.v2StoreFieldsTextView.text = viewState.v2StoreFieldsText

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -139,7 +139,6 @@ constructor(
         val blockStoreCurrentValueText: String = "Loading...",
         val canUseV2ConnectFlowEnabled: Boolean = false,
         val canShowV2ConnectCodeEnabled: Boolean = false,
-        val canUseExchangeV2Point1: Boolean = false,
         val checkLinkingCodeResult: String = "",
         val accessCredentialsText: String = "",
         val scopedTokenResult: String = "",
@@ -268,15 +267,6 @@ constructor(
     }
 
     @SuppressLint("DenyListedApi")
-    fun onCanUseExchangeV2Point1FlagChanged(enabled: Boolean) {
-        viewModelScope.launch(dispatchers.io()) {
-            logcat { "Sync-ScopedToken: setting canUseExchangeV2Point1 flag = $enabled" }
-            setRawToggleState(syncFeature.canUseExchangeV2Point1(), enabled)
-            updateViewState()
-        }
-    }
-
-    @SuppressLint("DenyListedApi")
     private fun setRawToggleState(
         toggle: Toggle,
         enabled: Boolean,
@@ -348,7 +338,6 @@ constructor(
                 environment = syncEnvDataStore.syncEnvironmentUrl,
                 canUseV2ConnectFlowEnabled = syncFeature.canUseV2ConnectFlow().isEnabled(),
                 canShowV2ConnectCodeEnabled = syncFeature.canShowV2ConnectCode().isEnabled(),
-                canUseExchangeV2Point1 = syncFeature.canUseExchangeV2Point1().isEnabled(),
                 v2StoreFieldsText = buildV2StoreFieldsText(),
                 // Clear per-session dev-tool results once signed out so stale keys aren't shown.
                 keysText = if (accountInfo.isSignedIn) viewState.value.keysText else "",

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.sync.impl.exchange.v2.Role
 import com.duckduckgo.sync.internal.databinding.ActivitySyncV2PairingDebugBinding
 import com.duckduckgo.sync.internal.databinding.ItemSyncV2PairingLogRowBinding
 import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.ConfirmationRequest
+import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.LogDetails
 import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.LogRow
 import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.TerminalReached
 import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.ViewState
@@ -253,15 +254,19 @@ class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
             val rowBinding = ItemSyncV2PairingLogRowBinding.inflate(layoutInflater, binding.logContainer, true)
             val timestamp = timestampFormat.format(Date(row.timestampMs))
             rowBinding.summaryTextView.text = "[$timestamp] ${row.summary}"
-            rowBinding.rawJsonTextView.text = row.rawJson
+            rowBinding.rawJsonTextView.text = row.details.value
             applyExpansion(rowBinding, row.id in expandedRowIds)
             rowBinding.summaryRow.setOnClickListener {
                 val newlyExpanded = row.id !in expandedRowIds
                 if (newlyExpanded) expandedRowIds.add(row.id) else expandedRowIds.remove(row.id)
                 applyExpansion(rowBinding, newlyExpanded)
             }
-            rowBinding.copyRawButton.setOnClickListener {
-                copyToClipboard("Raw JSON", row.rawJson)
+            when (val details = row.details) {
+                is LogDetails.Json -> {
+                    rowBinding.copyRawButton.visibility = View.VISIBLE
+                    rowBinding.copyRawButton.setOnClickListener { copyToClipboard("Raw JSON", details.value) }
+                }
+                is LogDetails.PlainText -> rowBinding.copyRawButton.visibility = View.GONE
             }
         }
     }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
@@ -29,12 +29,14 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.dialog.DaxAlertDialog
+import com.duckduckgo.common.ui.view.dialog.RadioListAlertDialogBuilder
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.Role
 import com.duckduckgo.sync.internal.databinding.ActivitySyncV2PairingDebugBinding
 import com.duckduckgo.sync.internal.databinding.ItemSyncV2PairingLogRowBinding
@@ -69,6 +71,7 @@ class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
     private val expandedRowIds = mutableSetOf<Long>()
     private var renderedRows: List<LogRow> = emptyList()
     private var activeConfirmationDialog: DaxAlertDialog? = null
+    private var selectedProtocolVersion: ExchangeProtocolVersion.V2? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -112,8 +115,32 @@ class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
         binding.autoApproveSetting.quietlySetIsChecked(newCheckedState = true) { _, enabled ->
             viewModel.onAutoApproveToggled(enabled)
         }
+        binding.protocolVersionSetting.setOnClickListener { showProtocolVersionDialog() }
+        binding.changeProtocolVersionButton.setOnClickListener { showProtocolVersionDialog() }
 
         binding.signInOutButton.setOnClickListener { viewModel.onSignInOutClicked() }
+    }
+
+    @Suppress("DEPRECATION") // Options don't need to be localized in the debug screen
+    private fun showProtocolVersionDialog() {
+        RadioListAlertDialogBuilder(this)
+            .setTitle("Protocol version")
+            .setMessage("Force the advertised exchange protocol version. Applies to the next session.")
+            .setOptions(
+                PROTOCOL_VERSION_OPTIONS.map(viewModel::labelFor),
+                PROTOCOL_VERSION_OPTIONS.indexOf(selectedProtocolVersion) + 1,
+            )
+            .setPositiveButton(com.duckduckgo.mobile.android.R.string.dialogSave)
+            .setNegativeButton(android.R.string.cancel)
+            .addEventListener(
+                object : RadioListAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked(selectedItem: Int) {
+                        viewModel.onProtocolOverrideSelected(PROTOCOL_VERSION_OPTIONS[selectedItem - 1])
+                    }
+                },
+            )
+            .setCancelable(true)
+            .show()
     }
 
     private fun observeViewState() {
@@ -193,6 +220,7 @@ class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
 
     private fun render(state: ViewState) {
         renderAccountStatus(state.accountStatus)
+        renderProtocolVersion(state)
         binding.currentStateTextView.text = state.currentStateLabel
         val code = state.linkingCode
         if (code != null) {
@@ -324,6 +352,11 @@ class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
         startScanFromInput()
     }
 
+    private fun renderProtocolVersion(state: ViewState) {
+        selectedProtocolVersion = state.protocolOverride
+        binding.protocolVersionSetting.setSecondaryText(viewModel.labelFor(state.protocolOverride))
+    }
+
     private fun renderAccountStatus(status: SyncV2PairingDebugViewModel.AccountStatus) {
         binding.statusSignedIn.setSecondaryText(
             if (status.signedIn) "Yes · user_id ${status.userId ?: "(unknown)"}" else "No",
@@ -340,5 +373,11 @@ class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
 
     private companion object {
         const val QR_SIZE_PX = 600
+
+        private val PROTOCOL_VERSION_OPTIONS = listOf(
+            null, // Default
+            ExchangeProtocolVersion.V2_0,
+            ExchangeProtocolVersion.V2_1,
+        )
     }
 }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.PairingRole
 import com.duckduckgo.sync.impl.exchange.v2.PeerVersionSource
 import com.duckduckgo.sync.impl.exchange.v2.RejectReason
 import com.duckduckgo.sync.impl.exchange.v2.Role
@@ -435,39 +436,66 @@ class SyncV2PairingDebugViewModel @Inject constructor(
             maybeHandleConfirmingTransition(event)
             maybeEmitTerminalAlert(event)
             maybeToastSessionError(event)
-            maybeLoginAfterJoinerDone(event)
+            maybeLoginAfterJoinerJoining(event)
         }
     }
 
     /**
-     * When the runner reaches [ExchangeV2State.Joiner.Done] from a session that was started
+     * When the runner reaches [ExchangeV2State.Joiner.Joining] from a session that was started
      * via [onRunPresentClicked] (i.e. not routed through [SyncCodeDispatcher]), the dispatcher's
      * own login Flow never runs and nothing else drives a login from the received recovery code.
-     * This handler closes that gap. Idempotent for dispatcher-routed sessions because
-     * [SyncCodeDispatcher.route] is only invoked from [onRunScanClicked] — the Presenter path
-     * never goes through it.
+     * This handler closes that gap. Scoped to Presenter sessions so a Scanner session, which does
+     * go through the dispatcher, isn't logged in twice and doesn't report two conflicting outcomes.
+     *
+     * Reports the result back to the peer, which is what moves the session off Joining and on to a
+     * Joiner terminal. A missing or blank recovery code reports login_failed rather than leaving
+     * the session parked in Joining until the deadline, matching the production dispatcher.
      */
-    private fun maybeLoginAfterJoinerDone(event: ExchangeV2Event) {
+    private fun maybeLoginAfterJoinerJoining(event: ExchangeV2Event) {
         if (event !is ExchangeV2Event.Transition) return
-        if (event.to != ExchangeV2State.Joiner.Done) return
+        if (event.to != ExchangeV2State.Joiner.Joining) return
+        if (runner.pairingRole != PairingRole.Presenter) return
         val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
-        if (received.isNullOrBlank()) return
         viewModelScope.launch(dispatchers.io()) {
-            appendDevToolLog("Joiner.Done — driving login from received recovery code")
-            when (val decision = dispatcher.route(received)) {
-                is RouteDecision.V2InProgress -> decision.outcomes.collect { handleV2Outcome(it) }
-                is RouteDecision.Legacy -> when (decision.authCode) {
-                    is SyncAuthCode.Recovery -> emitProcessCodeResult(
-                        "Joiner.Done login",
-                        syncAccountRepository.processCode(decision.authCode),
-                    )
-                    else -> {
-                        appendDevToolLog("Joiner.Done: received code wasn't a Recovery shape, can't auto-login")
-                        toasts.send("Joiner.Done: unexpected code shape, manual login required")
-                    }
+            val loggedIn = if (received.isNullOrBlank()) {
+                appendDevToolLog("Joiner.Joining: no recovery code in the response, reporting login_failed")
+                false
+            } else {
+                loginWithReceivedRecoveryCode(received)
+            }
+            val reason = if (loggedIn) {
+                ExchangeV2Message.RecoveryCodeDone.Reason.Success
+            } else {
+                ExchangeV2Message.RecoveryCodeDone.Reason.LoginFailed
+            }
+            runner.localTrigger(LocalTrigger.JoinerJoinComplete(reason)).join()
+            refreshState()
+        }
+    }
+
+    private suspend fun loginWithReceivedRecoveryCode(received: String): Boolean {
+        appendDevToolLog("Joiner.Joining: driving login from received recovery code")
+        return when (val decision = dispatcher.route(received)) {
+            is RouteDecision.V2InProgress -> {
+                var success = false
+                decision.outcomes.collect { outcome ->
+                    handleV2Outcome(outcome)
+                    if (outcome is DispatchOutcome.LoggedIn || outcome is DispatchOutcome.AlreadyConnected) success = true
+                }
+                success
+            }
+            is RouteDecision.Legacy -> when (decision.authCode) {
+                is SyncAuthCode.Recovery -> {
+                    val result = syncAccountRepository.processCode(decision.authCode)
+                    emitProcessCodeResult("Joiner.Joining login", result)
+                    result is Result.Success
+                }
+                else -> {
+                    appendDevToolLog("Joiner.Joining: received code wasn't a Recovery shape, can't auto-login")
+                    toasts.send("Joiner.Joining: unexpected code shape, manual login required")
+                    false
                 }
             }
-            refreshState()
         }
     }
 
@@ -483,59 +511,33 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         viewModelScope.launch { terminalReached.send(terminal) }
     }
 
-    private fun describeTerminal(event: ExchangeV2Event.Transition): TerminalReached? = when (event.to) {
-        ExchangeV2State.Host.Done -> TerminalReached(
-            state = event.to,
-            title = "✓ Pairing complete (Host)",
-            message = "Sent recovery_code_response to peer. Session closed on this side.",
-            isSuccess = true,
-        )
-        ExchangeV2State.Joiner.Done -> {
-            val code = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
-            TerminalReached(
-                state = event.to,
-                title = "✓ Pairing complete (Joiner)",
-                message = "Received recovery code from peer:\n\n${code ?: "(missing)"}",
-                isSuccess = true,
-            )
-        }
-        ExchangeV2State.Host.Aborted -> {
-            val (title, message) = when (event.localTrigger) {
-                LocalTrigger.HostUnavailable -> "✗ Pairing aborted (Host)" to (
-                    "Couldn't produce a recovery code on this device — sent recovery_code_unavailable to peer." +
-                        "\n\nIs this device signed in to a sync account?"
-                    )
-                else ->
-                    "✗ Pairing aborted (Host)" to
-                        "You denied the prompt on this device. Sent recovery_code_denied to peer."
+    private fun describeTerminal(event: ExchangeV2Event.Transition): TerminalReached? {
+        val (title, isSuccess) = when (event.to) {
+            ExchangeV2State.Host.Done -> if (event.isPeerFailure()) {
+                "✗ Join failed on the peer" to false
+            } else {
+                "✓ Pairing complete (Host)" to true
             }
-            TerminalReached(state = event.to, title = title, message = message, isSuccess = false)
+            ExchangeV2State.Joiner.Done -> "✓ Pairing complete (Joiner)" to true
+            ExchangeV2State.Joiner.JoinFailed -> "✗ Join failed (Joiner)" to false
+            ExchangeV2State.Host.Aborted -> "✗ Pairing aborted (Host)" to false
+            ExchangeV2State.Joiner.AbortedLocal -> "✗ Pairing aborted (Joiner)" to false
+            ExchangeV2State.Joiner.AbortedByHost -> "✗ Pairing aborted by peer" to false
+            ExchangeV2State.SameAccountAbort -> "✗ Same-account abort" to false
+            ExchangeV2State.Aborted -> "✗ Negotiation aborted" to false
+            else -> return null
         }
-        ExchangeV2State.Joiner.AbortedLocal -> TerminalReached(
+        return TerminalReached(
             state = event.to,
-            title = "✗ Pairing aborted (Joiner)",
-            message = "You denied the prompt on this device. No message sent to peer (per spec).",
-            isSuccess = false,
+            title = title,
+            message = "Check the event log for details.",
+            isSuccess = isSuccess,
         )
-        ExchangeV2State.Joiner.AbortedByHost -> TerminalReached(
-            state = event.to,
-            title = "✗ Pairing aborted by peer",
-            message = "Peer sent ${event.trigger?.messageType ?: "an abort message"}.",
-            isSuccess = false,
-        )
-        ExchangeV2State.SameAccountAbort -> TerminalReached(
-            state = event.to,
-            title = "✗ Same-account abort",
-            message = "Peer reported the same user_id — devices are already paired. No action taken.",
-            isSuccess = false,
-        )
-        ExchangeV2State.Aborted -> TerminalReached(
-            state = event.to,
-            title = "✗ Negotiation aborted",
-            message = "Received an unexpected hello during negotiation (duplicate or double-scan). Channel closed.",
-            isSuccess = false,
-        )
-        else -> null
+    }
+
+    private fun ExchangeV2Event.Transition.isPeerFailure(): Boolean {
+        val reason = (trigger as? ExchangeV2Message.RecoveryCodeDone)?.reason ?: return false
+        return reason != ExchangeV2Message.RecoveryCodeDone.Reason.Success
     }
 
     private fun maybeHandleConfirmingTransition(event: ExchangeV2Event) {
@@ -618,6 +620,7 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         when (message) {
             is ExchangeV2Message.RecoveryCodeAvailable -> append(" name=${message.name} kind=${message.kind} user_id=${message.userId}")
             is ExchangeV2Message.RecoveryCodeRequest -> append(" name=${message.name} kind=${message.kind}")
+            is ExchangeV2Message.RecoveryCodeDone -> append(" reason=${message.reason.value}")
             else -> Unit
         }
     }
@@ -647,13 +650,16 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         ExchangeV2State.Aborted -> "Aborted"
         ExchangeV2State.Host.Confirming -> "Host.Confirming"
         ExchangeV2State.Host.Sending -> "Host.Sending"
+        ExchangeV2State.Host.AwaitingStatus -> "Host.AwaitingStatus"
         ExchangeV2State.Host.Aborted -> "Host.Aborted"
         ExchangeV2State.Host.Done -> "Host.Done"
         ExchangeV2State.Joiner.Confirming -> "Joiner.Confirming"
         ExchangeV2State.Joiner.Waiting -> "Joiner.Waiting"
+        ExchangeV2State.Joiner.Joining -> "Joiner.Joining"
         ExchangeV2State.Joiner.AbortedLocal -> "Joiner.AbortedLocal"
         ExchangeV2State.Joiner.AbortedByHost -> "Joiner.AbortedByHost"
         ExchangeV2State.Joiner.Done -> "Joiner.Done"
+        ExchangeV2State.Joiner.JoinFailed -> "Joiner.JoinFailed"
     }
 
     private fun labelFor(trigger: LocalTrigger): String = when (trigger) {
@@ -661,7 +667,8 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         LocalTrigger.UserDeniedHost -> "UserDeniedHost"
         LocalTrigger.UserConfirmedJoiner -> "UserConfirmedJoiner"
         LocalTrigger.UserDeniedJoiner -> "UserDeniedJoiner"
-        LocalTrigger.HostSendComplete -> "HostSendComplete"
+        is LocalTrigger.HostSendComplete -> "HostSendComplete(${trigger.negotiatedVersion.prettyPrint()})"
+        is LocalTrigger.JoinerJoinComplete -> "JoinerJoinComplete(${trigger.reason.value})"
         LocalTrigger.HostUnavailable -> "HostUnavailable"
         is LocalTrigger.RoleElected -> "RoleElected(${trigger.role})"
     }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
@@ -32,10 +32,12 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event.VersionNegotiated
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.PeerVersionSource
 import com.duckduckgo.sync.impl.exchange.v2.RejectReason
 import com.duckduckgo.sync.impl.exchange.v2.Role
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
@@ -67,8 +69,16 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         val id: Long,
         val timestampMs: Long,
         val summary: String,
-        val rawJson: String,
+        val details: LogDetails,
     )
+
+    sealed interface LogDetails {
+        val value: String
+
+        data class Json(override val value: String) : LogDetails
+
+        data class PlainText(override val value: String) : LogDetails
+    }
 
     /**
      * Snapshot of the device's sync setup that's relevant to v2 pairing. Read from
@@ -299,7 +309,7 @@ class SyncV2PairingDebugViewModel @Inject constructor(
 
     /**
      * Push a synthetic row into the event log so v1-fallback progress is visible alongside
-     * native v2 [ExchangeV2Event]s. Reuses [LogRow] with the message in both summary and rawJson.
+     * native v2 [ExchangeV2Event]s. Reuses [LogRow] with the message in both summary and details.
      * Also tees to logcat with a `Sync-V2Debug:` prefix so the fallback path is traceable
      * end-to-end (the in-screen log alone misses the eyes of anyone watching logcat).
      */
@@ -311,7 +321,7 @@ class SyncV2PairingDebugViewModel @Inject constructor(
                     id = nextRowId++,
                     timestampMs = System.currentTimeMillis(),
                     summary = message,
-                    rawJson = message,
+                    details = LogDetails.PlainText(message),
                 ),
             )
         }
@@ -387,7 +397,7 @@ class SyncV2PairingDebugViewModel @Inject constructor(
             id = nextRowId++,
             timestampMs = event.timestampMs,
             summary = summarise(event),
-            rawJson = rawJsonFor(event),
+            details = detailsFor(event),
         )
         viewState.update { current ->
             current.copy(
@@ -552,40 +562,60 @@ class SyncV2PairingDebugViewModel @Inject constructor(
     }
 
     private fun summarise(event: ExchangeV2Event): String = when (event) {
-        is ExchangeV2Event.Transition -> {
-            val trigger = event.trigger?.let { "msg=${it.messageType}${peerSuffix(it)}" }
-                ?: event.localTrigger?.let { "local=${labelFor(it)}" }
-                ?: "(no trigger)"
-            "Transition ${labelFor(event.from)} → ${labelFor(event.to)} [$trigger]"
-        }
-        is ExchangeV2Event.MessageSent -> "Sent ${event.message.messageType}${peerSuffix(event.message)}"
-        is ExchangeV2Event.MessageRejected -> {
-            val verb = when (event.reason) {
-                RejectReason.ImplicitAbort -> "Aborted"
-                RejectReason.SameAccount -> "SameAccountAbort"
-                RejectReason.UnknownMessageDropped -> "Dropped (unknown)"
+        is ExchangeV2Event.Transition -> buildString {
+            append("Transition ${labelFor(event.from)} → ${labelFor(event.to)} [")
+            val trigger = event.trigger
+            val localTrigger = event.localTrigger
+            when {
+                trigger != null -> {
+                    append("msg=${trigger.messageType}")
+                    appendPeerDetails(trigger)
+                }
+                localTrigger != null -> append("local=${labelFor(localTrigger)}")
+                else -> append("no trigger")
             }
-            "$verb on ${event.message.messageType}${peerSuffix(event.message)} in ${labelFor(event.state)}"
+            append(']')
         }
-        is ExchangeV2Event.SessionStarted -> {
-            val codeLine = event.linkingCode?.let { " linkingCode=$it" } ?: ""
-            "Session started as ${event.pairingRole} ownChannelId=${event.ownChannelId}$codeLine"
+        is ExchangeV2Event.MessageSent -> buildString {
+            append("Sent ${event.message.messageType}")
+            appendPeerDetails(event.message)
+        }
+        is ExchangeV2Event.MessageRejected -> buildString {
+            append("${labelFor(event.reason)} on ${event.message.messageType}")
+            appendPeerDetails(event.message)
+            append(" in ${labelFor(event.state)}")
+        }
+        is ExchangeV2Event.SessionStarted -> buildString {
+            append("Session started as ${event.pairingRole} ownChannelId=${event.ownChannelId}")
+            event.linkingCode?.let { append(" linkingCode=$it") }
         }
         is ExchangeV2Event.SessionError -> "Session error: ${event.message}"
+        is VersionNegotiated -> "Negotiated Exchange protocol ${event.negotiatedVersion.prettyPrint()}"
     }
 
-    private fun peerSuffix(message: ExchangeV2Message): String = when (message) {
-        is ExchangeV2Message.RecoveryCodeAvailable -> " name=${message.name} kind=${message.kind} user_id=${message.userId}"
-        is ExchangeV2Message.RecoveryCodeRequest -> " name=${message.name} kind=${message.kind}"
-        else -> ""
+    private fun StringBuilder.appendPeerDetails(message: ExchangeV2Message) {
+        when (message) {
+            is ExchangeV2Message.RecoveryCodeAvailable -> append(" name=${message.name} kind=${message.kind} user_id=${message.userId}")
+            is ExchangeV2Message.RecoveryCodeRequest -> append(" name=${message.name} kind=${message.kind}")
+            else -> Unit
+        }
     }
 
-    private fun rawJsonFor(event: ExchangeV2Event): String = when (event) {
-        is ExchangeV2Event.Transition -> event.trigger?.rawJson ?: "(local trigger: ${event.localTrigger?.let(::labelFor)})"
-        is ExchangeV2Event.MessageSent -> event.message.rawJson
-        is ExchangeV2Event.MessageRejected -> event.message.rawJson
-        is ExchangeV2Event.SessionStarted -> event.linkingCode ?: "(no linking code — Scanner side)"
-        is ExchangeV2Event.SessionError -> event.message
+    private fun detailsFor(event: ExchangeV2Event): LogDetails = when (event) {
+        is ExchangeV2Event.Transition -> when (val trigger = event.trigger) {
+            null -> LogDetails.PlainText("local trigger: ${event.localTrigger?.let(::labelFor) ?: "none"}")
+            else -> LogDetails.Json(trigger.rawJson)
+        }
+        is ExchangeV2Event.MessageSent -> LogDetails.Json(event.message.rawJson)
+        is ExchangeV2Event.MessageRejected -> LogDetails.Json(event.message.rawJson)
+        is ExchangeV2Event.SessionStarted -> when (val linkingCode = event.linkingCode) {
+            null -> LogDetails.PlainText("no linking code — Scanner side")
+            else -> LogDetails.PlainText(linkingCode)
+        }
+        is ExchangeV2Event.SessionError -> LogDetails.PlainText(event.message)
+        is VersionNegotiated -> LogDetails.PlainText(
+            "ours=${event.ourVersion.prettyPrint()}, peer=${event.peerVersion.prettyPrint()} [${labelFor(event.peerSource)}]",
+        )
     }
 
     private fun labelFor(state: ExchangeV2State?): String = when (state) {
@@ -613,5 +643,16 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         LocalTrigger.HostSendComplete -> "HostSendComplete"
         LocalTrigger.HostUnavailable -> "HostUnavailable"
         is LocalTrigger.RoleElected -> "RoleElected(${trigger.role})"
+    }
+
+    private fun labelFor(reason: RejectReason): String = when (reason) {
+        RejectReason.ImplicitAbort -> "Aborted"
+        RejectReason.SameAccount -> "SameAccountAbort"
+        RejectReason.UnknownMessageDropped -> "Dropped (unknown)"
+    }
+
+    private fun labelFor(peerSource: PeerVersionSource): String = when (peerSource) {
+        PeerVersionSource.LinkingCode -> "linking_code"
+        PeerVersionSource.HelloMessage -> "hello_message"
     }
 }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event.VersionNegotiated
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -41,6 +42,7 @@ import com.duckduckgo.sync.impl.exchange.v2.PeerVersionSource
 import com.duckduckgo.sync.impl.exchange.v2.RejectReason
 import com.duckduckgo.sync.impl.exchange.v2.Role
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
+import com.duckduckgo.sync.internal.exchange.SyncInternalAdvertisedExchangeV2Version
 import com.duckduckgo.sync.store.SyncStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
@@ -48,7 +50,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -61,6 +62,7 @@ class SyncV2PairingDebugViewModel @Inject constructor(
     private val syncStore: SyncStore,
     private val syncAccountRepository: SyncAccountRepository,
     private val dispatcher: SyncCodeDispatcher,
+    private val internalAdvertisedVersion: SyncInternalAdvertisedExchangeV2Version,
     private val dispatchers: DispatcherProvider,
     @AppCoroutineScope private val appScope: CoroutineScope,
 ) : ViewModel() {
@@ -97,6 +99,7 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         val rows: List<LogRow> = emptyList(),
         val autoApproveConfirmation: Boolean = true,
         val accountStatus: AccountStatus = AccountStatus(false, null, false),
+        val protocolOverride: ExchangeProtocolVersion.V2? = null,
     )
 
     /**
@@ -131,7 +134,10 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         super.onCleared()
         // cancel() suspends until teardown completes; onCleared can't await and viewModelScope is
         // already cancelling, so fire-and-forget the teardown on the app scope (it outlives the VM).
-        appScope.launch { runner.cancel() }
+        appScope.launch {
+            runner.cancel()
+            internalAdvertisedVersion.overrideFlow.value = null
+        }
     }
 
     private val confirmationRequests = Channel<ConfirmationRequest>(Channel.BUFFERED)
@@ -157,6 +163,11 @@ class SyncV2PairingDebugViewModel @Inject constructor(
             runner.events.collect { event ->
                 appendEvent(event, isReplay = processed < replayCount)
                 processed++
+            }
+        }
+        viewModelScope.launch {
+            internalAdvertisedVersion.overrideFlow.collect { version ->
+                viewState.update { it.copy(protocolOverride = version) }
             }
         }
     }
@@ -375,6 +386,16 @@ class SyncV2PairingDebugViewModel @Inject constructor(
 
     fun onAutoApproveToggled(checked: Boolean) {
         viewState.update { it.copy(autoApproveConfirmation = checked) }
+    }
+
+    fun onProtocolOverrideSelected(version: ExchangeProtocolVersion.V2?) {
+        internalAdvertisedVersion.overrideFlow.value = version
+        appendDevToolLog("Protocol version override → ${labelFor(version)} (applies to the next session)")
+    }
+
+    fun labelFor(version: ExchangeProtocolVersion.V2?): String = when (version) {
+        null -> "Default (${internalAdvertisedVersion.defaultVersion().prettyPrint()})"
+        else -> version.prettyPrint()
     }
 
     fun onConfirmationApproved(role: Role) {

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -112,13 +112,6 @@
             app:showSwitch="true"
             app:primaryText="canShowV2ConnectCode (display, requires canUseV2ConnectFlow)" />
 
-        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
-            android:id="@+id/canUseExchangeV2Point1"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:primaryText="canUseExchangeV2.1"
-            app:showSwitch="true" />
-
         <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
             android:id="@+id/openV2PairingDebugButton"
             android:layout_width="wrap_content"

--- a/sync/sync-internal/src/main/res/layout/activity_sync_v2_pairing_debug.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_sync_v2_pairing_debug.xml
@@ -46,8 +46,8 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center_vertical">
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
 
                 <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
                     android:id="@+id/statusSignedIn"
@@ -89,6 +89,28 @@
                 app:secondaryText="When on, this device automatically confirms its own Host/Joiner prompt. Turn off to see the real alert dialog."
                 app:showSwitch="true" />
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                    android:id="@+id/protocolVersionSetting"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    app:primaryText="Protocol version"
+                    tools:secondaryText="Default" />
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                    android:id="@+id/changeProtocolVersionButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/keyline_4"
+                    android:text="Change" />
+            </LinearLayout>
+
             <com.duckduckgo.common.ui.view.divider.HorizontalDivider
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
@@ -112,8 +134,8 @@
                 android:id="@+id/runPresentButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/keyline_4"
                 android:layout_margin="10dp"
+                android:layout_marginStart="@dimen/keyline_4"
                 android:text="Start as Presenter" />
 
             <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem

--- a/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/exchange/SyncInternalAdvertisedExchangeV2VersionTest.kt
+++ b/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/exchange/SyncInternalAdvertisedExchangeV2VersionTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.internal.exchange
+
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.duckduckgo.sync.impl.exchange.v2.RealAdvertisedExchangeV2Version
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+class SyncInternalAdvertisedExchangeV2VersionTest {
+
+    private val real: RealAdvertisedExchangeV2Version = mock()
+    private val advertisedVersion = SyncInternalAdvertisedExchangeV2Version(real)
+
+    @Test fun `no override delegates to the real resolver`() {
+        whenever(real.resolve()).thenReturn(ExchangeProtocolVersion.V2_1)
+        advertisedVersion.overrideFlow.value = null
+
+        assertEquals(ExchangeProtocolVersion.V2_1, advertisedVersion.resolve())
+    }
+
+    @Test fun `override forces the selected version regardless of flags`() {
+        advertisedVersion.overrideFlow.value = ExchangeProtocolVersion.V2_1
+
+        assertEquals(ExchangeProtocolVersion.V2_1, advertisedVersion.resolve())
+        verifyNoInteractions(real)
+    }
+}

--- a/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
+++ b/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
@@ -32,15 +32,19 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.PairingRole
 import com.duckduckgo.sync.impl.exchange.v2.RealAdvertisedExchangeV2Version
 import com.duckduckgo.sync.impl.exchange.v2.RejectReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.internal.exchange.SyncInternalAdvertisedExchangeV2Version
 import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -79,6 +83,25 @@ class SyncV2PairingDebugViewModelTest {
         internalAdvertisedVersion = internalAdvertisedVersion,
         dispatchers = coroutineTestRule.testDispatcherProvider,
         appScope = coroutineTestRule.testScope,
+    )
+
+    private fun hostDone(reason: ExchangeV2Message.RecoveryCodeDone.Reason) = ExchangeV2Event.Transition(
+        timestampMs = 0L,
+        from = ExchangeV2State.Host.AwaitingStatus,
+        to = ExchangeV2State.Host.Done,
+        trigger = ExchangeV2Message.RecoveryCodeDone.create(reason),
+        localTrigger = null,
+    )
+
+    private fun joinerTerminal(
+        to: ExchangeV2State,
+        localTrigger: LocalTrigger = LocalTrigger.JoinerJoinComplete(ExchangeV2Message.RecoveryCodeDone.Reason.Success),
+    ) = ExchangeV2Event.Transition(
+        timestampMs = 0L,
+        from = ExchangeV2State.Joiner.Joining,
+        to = to,
+        trigger = null,
+        localTrigger = localTrigger,
     )
 
     // ---- Event log ----
@@ -140,6 +163,85 @@ class SyncV2PairingDebugViewModelTest {
             )
             val state = awaitItem()
             assertTrue(state.rows.single().summary.startsWith("SameAccountAbort"))
+        }
+    }
+
+    @Test fun `Joiner_JoinFailed alert is a failure that points at the event log`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.terminals().test {
+            eventFlow.emit(
+                joinerTerminal(
+                    ExchangeV2State.Joiner.JoinFailed,
+                    LocalTrigger.JoinerJoinComplete(ExchangeV2Message.RecoveryCodeDone.Reason.LoginFailed),
+                ),
+            )
+
+            val terminal = awaitItem()
+            assertEquals("✗ Join failed (Joiner)", terminal.title)
+            assertFalse(terminal.isSuccess)
+            assertEquals("Check the event log for details.", terminal.message)
+        }
+    }
+
+    @Test fun `Presenter at Joiner_Joining with no recovery code reports LoginFailed to the peer`() = runTest {
+        whenever(runner.pairingRole).thenReturn(PairingRole.Presenter)
+        val joinComplete = Job()
+        joinComplete.complete()
+        whenever(runner.localTrigger(any())).thenReturn(joinComplete)
+        newViewModel()
+
+        eventFlow.emit(
+            ExchangeV2Event.Transition(
+                timestampMs = 0L,
+                from = ExchangeV2State.Joiner.Waiting,
+                to = ExchangeV2State.Joiner.Joining,
+                trigger = ExchangeV2Message.RecoveryCodeResponse.create(recoveryCode = ""),
+                localTrigger = null,
+            ),
+        )
+
+        verify(runner).localTrigger(LocalTrigger.JoinerJoinComplete(ExchangeV2Message.RecoveryCodeDone.Reason.LoginFailed))
+        verify(dispatcher, never()).route(any())
+    }
+
+    @Test fun `Host_Done alert is a failure when the peer reported one`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.terminals().test {
+            eventFlow.emit(hostDone(ExchangeV2Message.RecoveryCodeDone.Reason.LoginFailed))
+
+            val terminal = awaitItem()
+            assertEquals("✗ Join failed on the peer", terminal.title)
+            assertFalse(terminal.isSuccess)
+        }
+    }
+
+    @Test fun `Host_Done alert is a success when the peer reported success`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.terminals().test {
+            eventFlow.emit(hostDone(ExchangeV2Message.RecoveryCodeDone.Reason.Success))
+
+            val terminal = awaitItem()
+            assertEquals("✓ Pairing complete (Host)", terminal.title)
+            assertTrue(terminal.isSuccess)
+        }
+    }
+
+    @Test fun `Host_Done alert is a success when a pre-2_1 peer sent no report`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.terminals().test {
+            eventFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Host.Sending,
+                    to = ExchangeV2State.Host.Done,
+                    trigger = null,
+                    localTrigger = LocalTrigger.HostSendComplete(ExchangeProtocolVersion.V2_0),
+                ),
+            )
+
+            val terminal = awaitItem()
+            assertEquals("✓ Pairing complete (Host)", terminal.title)
+            assertTrue(terminal.isSuccess)
         }
     }
 

--- a/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
+++ b/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
@@ -26,13 +26,16 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.RealAdvertisedExchangeV2Version
 import com.duckduckgo.sync.impl.exchange.v2.RejectReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.internal.exchange.SyncInternalAdvertisedExchangeV2Version
 import com.duckduckgo.sync.store.SyncStore
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
@@ -63,12 +66,17 @@ class SyncV2PairingDebugViewModelTest {
     private val syncStore: SyncStore = mock()
     private val syncAccountRepository: SyncAccountRepository = mock()
     private val dispatcher: SyncCodeDispatcher = mock()
+    private val realAdvertisedVersion: RealAdvertisedExchangeV2Version = mock<RealAdvertisedExchangeV2Version>().also {
+        whenever(it.resolve()).thenReturn(ExchangeProtocolVersion.V2_0)
+    }
+    private val internalAdvertisedVersion = SyncInternalAdvertisedExchangeV2Version(realAdvertisedVersion)
 
     private fun newViewModel() = SyncV2PairingDebugViewModel(
         runner = runner,
         syncStore = syncStore,
         syncAccountRepository = syncAccountRepository,
         dispatcher = dispatcher,
+        internalAdvertisedVersion = internalAdvertisedVersion,
         dispatchers = coroutineTestRule.testDispatcherProvider,
         appScope = coroutineTestRule.testScope,
     )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1217367677188795?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1217626160385689?focus=true
API Proposals URL(s) (if applicable): N/A

### Description

Adds the v2.1 `recovery_code_done` message to the Exchange pairing protocol. The joining device reports what it did with the recovery code it received, and the presenting device keeps the session open until that report arrives.

- The joining device now signs in while the session is still open, at the new `Joiner.Joining` state, and finishes only after reporting the outcome.
- Any report completes the pairing on the presenting device. A failed sign-in only affects the joining device and is surfaced there, as it is today.
- The message is only sent on a negotiated 2.1 session. Pre-2.1 peers never report, so the presenting device finishes as soon as the recovery code is sent, exactly as before.

### Steps to test this PR

_Pairing with a Play Store build, v2.1 off_
- [ ] Install the Play Store build on the first device.
- [ ] Install this build on the second device.
- [ ] Open "Feature Flag Inventory" on the second device.
- [ ] Confirm `canUseExchangeV2Point1` is off.
- [ ] Set up Sync & Backup on the first device.
- [ ] On the first device, open Settings.
- [ ] Tap "Sync & Backup".
- [ ] Tap "Sync With Another Device".
- [ ] On the second device, open Settings.
- [ ] Tap "Sync & Backup".
- [ ] Tap "Sync With Another Device".
- [ ] Tap "Scan QR Code".
- [ ] Scan the QR code shown on the first device.
- [ ] Verify the second device shows "Your data is synced!".
- [ ] Verify the first device shows "Your data is synced!".
- [ ] Verify each device lists the other under "Synced Devices".
- [ ] Filter logcat on the second device by `Sync-ExchangeV2`.
- [ ] Verify the negotiated protocol version is v2.0.
- [ ] Verify `recovery_code_done` is skipped.

_Pairing with a Play Store build, v2.1 on_
- [ ] Enable `canUseExchangeV2Point1` on the second device in "Feature Flag Inventory".
- [ ] Turn off Sync & Backup on the second device.
- [ ] Repeat the steps above.
- [ ] Verify the negotiated protocol version is still v2.0, because the Play Store build does not speak v2.1.
- [ ] Verify `recovery_code_done` is still skipped.
- [ ] Verify pairing still completes on both devices.

---

_Successful v2.1 pairing_
- [ ] Install this build on two devices.
- [ ] Open Sync Dev Settings on both devices.
- [ ] Tap "V2 Pairing Debug" on both devices.
- [ ] Tap "Change" next to "Protocol version" on both devices.
- [ ] Select v2.1 on both devices.
- [ ] On the first device, tap "Start as Presenter".
- [ ] On the first device, tap "Copy linking code".
- [ ] Transfer the linking code to the second device's clipboard.
- [ ] On the second device, tap "Paste & Go".
- [ ] Verify the second device shows "✓ Pairing complete (Joiner)".
- [ ] Verify the first device shows "✓ Pairing complete (Host)".
- [ ] Verify the first device's event log has a `recovery_code_done` row with `reason=success`.

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core sync pairing state machines and login timing, but v2.0 interoperability is preserved via version negotiation and gated wire messages.
> 
> **Overview**
> Implements **Exchange v2.1** so the **joiner** reports the real outcome after using a recovery code, instead of the host assuming success when the code is sent.
> 
> The joiner moves through a new **`Joiner.Joining`** state: it logs in (or fails) while the session stays open, then sends **`recovery_code_done`** with `success`, `login_failed`, or `scope_rejected`. Unknown credential types during linking now use **`UNSUPPORTED_CREDENTIAL_TYPE`** and map to `scope_rejected` on the wire. **`RealSyncCodeDispatcher`** drives `JoinerJoinComplete` after login and maps host **`Host.Done`** from `recovery_code_done` while still emitting **`LoggedIn`** on the host when the peer reports failure.
> 
> On a negotiated **2.1** session, the host enters **`Host.AwaitingStatus`** after sending the recovery code and only finishes on **`recovery_code_done**; against **2.0** peers the flow is unchanged (host completes immediately, joiner does not send the new message). Outbound messages are skipped when they require a higher protocol version than negotiated. **`localTrigger`** now returns a **`Job`** so callers can wait before tearing down the session.
> 
> Internal **V2 Pairing Debug** tooling follows the same join/report path and surfaces peer-reported failures on the host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b489c6fe7104653028b88eb0ae3edc8e49ae4fcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->