### PR TITLE
Stacked alert dialog fill buttons rebrand

### DIFF
--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/StackedAlertDialogBuilder.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/StackedAlertDialogBuilder.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.common.ui.view.dialog
 
+import android.app.Activity
 import android.content.ComponentCallbacks
 import android.content.Context
 import android.content.res.Configuration
@@ -193,9 +194,6 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
             build()
         }
         showDialog()
-        if (isRebrandUpdate) {
-            registerConfigurationCallback()
-        }
         listener.onDialogShown()
     }
 
@@ -216,9 +214,20 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
 
     private fun showDialog() {
         dialog?.show()
-        if (isRebrandUpdate) {
-            dialog?.window?.setLayout(cardWidth(), WindowManager.LayoutParams.WRAP_CONTENT)
-        }
+        if (!isRebrandUpdate) return
+
+        val shown = dialog ?: return
+        shown.window?.setLayout(cardWidth(), WindowManager.LayoutParams.WRAP_CONTENT)
+        shown.window?.decorView?.addOnAttachStateChangeListener(
+            object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(view: View) = Unit
+
+                override fun onViewDetachedFromWindow(view: View) {
+                    if (dialog === shown) unregisterConfigurationCallback()
+                }
+            },
+        )
+        registerConfigurationCallback()
     }
 
     private fun cardWidth(): Int {
@@ -249,6 +258,12 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     }
 
     private fun recreate() {
+        val activity = context as? Activity
+        if (activity != null && (activity.isFinishing || activity.isDestroyed)) {
+            unregisterConfigurationCallback()
+            return
+        }
+
         val current = dialog ?: return
         if (!current.isShowing) return
 

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/StackedAlertDialogBuilder.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/StackedAlertDialogBuilder.kt
@@ -23,11 +23,23 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
+import com.duckduckgo.common.ui.view.button.ButtonType
 import com.duckduckgo.common.ui.view.button.DaxButtonGhost
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.mobile.android.R
 import com.duckduckgo.mobile.android.databinding.DialogStackedAlertBinding
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+/**
+ * A single stacked button, paired with the [ButtonType] it should be rendered as.
+ *
+ * Use with [StackedAlertDialogBuilder.setStackedButtons] when a dialog needs a filled
+ * primary/secondary action instead of the default ghost styling.
+ */
+data class StackedButton(
+    @StringRes val textId: Int,
+    val type: ButtonType = ButtonType.GHOST,
+)
 
 class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
 
@@ -40,13 +52,22 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
 
     internal class DefaultEventListener : EventListener()
 
+    /**
+     * A button ready to be rendered. A null [type] means "use the builder's default styling",
+     * which keeps the ghost/destructive behaviour of [setStackedButtons] and [setDestructiveButtons].
+     */
+    private data class StackedButtonSpec(
+        val text: CharSequence,
+        val type: ButtonType?,
+    )
+
     private var dialog: AlertDialog? = null
 
     private var listener: EventListener = DefaultEventListener()
     private var titleText: CharSequence = ""
     private var messageText: CharSequence = ""
     private var headerImageDrawableId = 0
-    private var stackedButtonList: MutableList<CharSequence> = mutableListOf()
+    private var stackedButtonList: MutableList<StackedButtonSpec> = mutableListOf()
     private var isDestructiveVersion: Boolean = false
 
     fun setHeaderImageResource(@DrawableRes drawableId: Int): StackedAlertDialogBuilder {
@@ -74,9 +95,28 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         return this
     }
 
+    /**
+     * Adds the given buttons, all rendered as ghost buttons, or tinted ghost buttons when
+     * [setDestructiveButtons] is enabled.
+     */
     fun setStackedButtons(@StringRes stackedButtonTextId: List<Int>): StackedAlertDialogBuilder {
         stackedButtonTextId.forEach {
-            stackedButtonList.add(context.getText(it))
+            stackedButtonList.add(StackedButtonSpec(context.getText(it), type = null))
+        }
+        return this
+    }
+
+    /**
+     * Adds the given buttons, each rendered as its own [StackedButton.type], so a dialog can mix a
+     * filled primary or secondary action with ghost ones.
+     *
+     * [StackedButton.type] defaults to [ButtonType.GHOST], matching the styling of the
+     * [List]-of-string-resources overload. Types set here always win over [setDestructiveButtons].
+     */
+    @JvmName("setStackedButtonsWithType")
+    fun setStackedButtons(stackedButtons: List<StackedButton>): StackedAlertDialogBuilder {
+        stackedButtons.forEach {
+            stackedButtonList.add(StackedButtonSpec(context.getText(it.textId), it.type))
         }
         return this
     }
@@ -145,15 +185,16 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
 
     private fun addButtons(
         root: LinearLayout,
-        stackedButtonList: MutableList<CharSequence>,
+        stackedButtonList: MutableList<StackedButtonSpec>,
         dialog: AlertDialog,
     ) {
-        val buttonParams = LinearLayout.LayoutParams(
-            LinearLayout.LayoutParams.WRAP_CONTENT,
-            LinearLayout.LayoutParams.WRAP_CONTENT,
-        )
-        stackedButtonList.forEachIndexed { index, text ->
+        val buttonSpacing = context.resources.getDimensionPixelSize(R.dimen.keyline_2)
+        stackedButtonList.forEachIndexed { index, stackedButton ->
             val button = when {
+                stackedButton.type != null -> {
+                    stackedButton.type.getView(context)
+                }
+
                 isDestructiveVersion && index == stackedButtonList.lastIndex -> {
                     val ghostButton = DaxButtonGhost(context, null)
                     ghostButton.setTextColor(
@@ -181,8 +222,15 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
                 }
             }
 
-            button.text = text
-            button.layoutParams = buttonParams
+            button.text = stackedButton.text
+            button.layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ).apply {
+                if (index > 0) {
+                    topMargin = buttonSpacing
+                }
+            }
 
             button.setOnClickListener {
                 listener.onButtonClicked(index)

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/StackedAlertDialogBuilder.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/StackedAlertDialogBuilder.kt
@@ -16,18 +16,25 @@
 
 package com.duckduckgo.common.ui.view.dialog
 
+import android.content.ComponentCallbacks
 import android.content.Context
+import android.content.res.Configuration
 import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import android.widget.LinearLayout
+import android.widget.ScrollView
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
+import androidx.core.view.updateLayoutParams
 import com.duckduckgo.common.ui.view.button.ButtonType
 import com.duckduckgo.common.ui.view.button.DaxButtonGhost
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.mobile.android.R
 import com.duckduckgo.mobile.android.databinding.DialogStackedAlertBinding
+import com.google.android.material.button.MaterialButton
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 /**
@@ -39,6 +46,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 data class StackedButton(
     @StringRes val textId: Int,
     val type: ButtonType = ButtonType.GHOST,
+    @DrawableRes val iconId: Int? = null,
 )
 
 class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
@@ -59,6 +67,7 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     private data class StackedButtonSpec(
         val text: CharSequence,
         val type: ButtonType?,
+        val iconId: Int? = null,
     )
 
     private var dialog: AlertDialog? = null
@@ -69,6 +78,9 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     private var headerImageDrawableId = 0
     private var stackedButtonList: MutableList<StackedButtonSpec> = mutableListOf()
     private var isDestructiveVersion: Boolean = false
+    private var isRebrandUpdate: Boolean = false
+    private var componentCallbacks: ComponentCallbacks? = null
+    private var isRecreating: Boolean = false
 
     fun setHeaderImageResource(@DrawableRes drawableId: Int): StackedAlertDialogBuilder {
         headerImageDrawableId = drawableId
@@ -116,8 +128,22 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     @JvmName("setStackedButtonsWithType")
     fun setStackedButtons(stackedButtons: List<StackedButton>): StackedAlertDialogBuilder {
         stackedButtons.forEach {
-            stackedButtonList.add(StackedButtonSpec(context.getText(it.textId), it.type))
+            stackedButtonList.add(StackedButtonSpec(context.getText(it.textId), it.type, it.iconId))
         }
+        return this
+    }
+
+    /**
+     * Opts into the brand design update styling: a fixed-width card with wider corners, the header
+     * image inside a circular container, and full-width buttons with centred labels.
+     *
+     * Opt-in per dialog rather than driven by the ThemeOverlay.Rebrand overlay, so dialogs that have not been
+     * redesigned keep their current appearance.
+     *
+     * Figma: https://www.figma.com/design/aMaDTBcE9Fsfu40NbjzcrH/Permission--iOS-Android-?node-id=1229-26621
+     */
+    fun setRebrandUpdate(isRebrandUpdate: Boolean): StackedAlertDialogBuilder {
+        this.isRebrandUpdate = isRebrandUpdate
         return this
     }
 
@@ -135,12 +161,23 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         checkRequiredFieldsSet()
         val binding: DialogStackedAlertBinding = DialogStackedAlertBinding.inflate(LayoutInflater.from(context))
 
-        val dialogBuilder = MaterialAlertDialogBuilder(context, com.duckduckgo.mobile.android.R.style.Widget_DuckDuckGo_Dialog)
-            .setView(binding.root)
+        val dialogTheme = if (isRebrandUpdate) {
+            R.style.Widget_DuckDuckGo_Dialog_Rebrand
+        } else {
+            R.style.Widget_DuckDuckGo_Dialog
+        }
+
+        val dialogBuilder = MaterialAlertDialogBuilder(context, dialogTheme)
+            .setView(dialogContent(binding))
             .apply {
                 setCancelable(false)
-                setOnDismissListener { listener.onDialogDismissed() }
-                setOnCancelListener { listener.onDialogCancelled() }
+                setOnDismissListener {
+                    if (!isRecreating) {
+                        unregisterConfigurationCallback()
+                        listener.onDialogDismissed()
+                    }
+                }
+                setOnCancelListener { if (!isRecreating) listener.onDialogCancelled() }
             }
 
         dialog = dialogBuilder.create()
@@ -149,12 +186,65 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         return this
     }
 
+    /**
+     * The layout has no scroll container of its own, so tall content is clipped rather than
+     * scrolled where the card cannot grow - short landscape screens, or large font scales.
+     */
+    private fun dialogContent(binding: DialogStackedAlertBinding): View {
+        if (!isRebrandUpdate) return binding.root
+
+        return ScrollView(context).apply {
+            isFillViewport = true
+            addView(
+                binding.root,
+                ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                ),
+            )
+        }
+    }
+
     override fun show() {
         if (dialog == null) {
             build()
         }
         dialog?.show()
+        if (isRebrandUpdate) {
+            registerConfigurationCallback()
+        }
         listener.onDialogShown()
+    }
+
+    /**
+     * Rebuilds the dialog against the new configuration. The dialog is not cancellable, so dropping
+     * it on rotation would strand the caller's flow with no way back to it.
+     */
+    private fun registerConfigurationCallback() {
+        if (componentCallbacks != null) return
+
+        val callbacks = object : ComponentCallbacks {
+            override fun onConfigurationChanged(newConfig: Configuration) = recreate()
+
+            override fun onLowMemory() = Unit
+        }
+        context.registerComponentCallbacks(callbacks)
+        componentCallbacks = callbacks
+    }
+
+    private fun unregisterConfigurationCallback() {
+        componentCallbacks?.let { context.unregisterComponentCallbacks(it) }
+        componentCallbacks = null
+    }
+
+    private fun recreate() {
+        if (dialog?.isShowing != true) return
+
+        isRecreating = true
+        dialog?.dismiss()
+        build()
+        dialog?.show()
+        isRecreating = false
     }
 
     override fun dismiss() {
@@ -168,6 +258,14 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     ) {
         if (headerImageDrawableId > 0) {
             binding.stackedAlertDialogImage.setImageResource(headerImageDrawableId)
+            if (isRebrandUpdate) {
+                val inset = context.resources.getDimensionPixelSize(R.dimen.rebrandDialogIconInset)
+                binding.stackedAlertDialogImage.setBackgroundResource(R.drawable.background_dialog_icon_circular)
+                binding.stackedAlertDialogImage.setPadding(inset, inset, inset, inset)
+                binding.stackedAlertDialogTitle.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                    topMargin = context.resources.getDimensionPixelSize(R.dimen.keyline_4)
+                }
+            }
         } else {
             binding.stackedAlertDialogImage.gone()
         }
@@ -178,6 +276,11 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
             binding.stackedlertDialogMessage.gone()
         } else {
             binding.stackedlertDialogMessage.text = messageText
+        }
+
+        if (isRebrandUpdate) {
+            val sidePadding = context.resources.getDimensionPixelSize(R.dimen.rebrandDialogButtonSidePadding)
+            binding.stackedAlertDialogButtonLayout.setPadding(sidePadding, 0, sidePadding, 0)
         }
 
         addButtons(binding.stackedAlertDialogButtonLayout, stackedButtonList, dialog)
@@ -223,12 +326,16 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
             }
 
             button.text = stackedButton.text
+            stackedButton.iconId?.let {
+                button.setIconResource(it)
+                button.iconGravity = MaterialButton.ICON_GRAVITY_TEXT_START
+            }
             button.layoutParams = LinearLayout.LayoutParams(
-                LinearLayout.LayoutParams.WRAP_CONTENT,
+                if (isRebrandUpdate) LinearLayout.LayoutParams.MATCH_PARENT else LinearLayout.LayoutParams.WRAP_CONTENT,
                 LinearLayout.LayoutParams.WRAP_CONTENT,
             ).apply {
-                if (index > 0) {
-                    topMargin = buttonSpacing
+                if (index > 0 && isRebrandUpdate) {
+                    topMargin = (buttonSpacing - button.insetTop - button.insetBottom).coerceAtLeast(0)
                 }
             }
 

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/StackedAlertDialogBuilder.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/StackedAlertDialogBuilder.kt
@@ -22,6 +22,7 @@ import android.content.res.Configuration
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import androidx.annotation.DrawableRes
@@ -80,7 +81,6 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     private var isDestructiveVersion: Boolean = false
     private var isRebrandUpdate: Boolean = false
     private var componentCallbacks: ComponentCallbacks? = null
-    private var isRecreating: Boolean = false
 
     fun setHeaderImageResource(@DrawableRes drawableId: Int): StackedAlertDialogBuilder {
         headerImageDrawableId = drawableId
@@ -172,12 +172,14 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
             .apply {
                 setCancelable(false)
                 setOnDismissListener {
-                    if (!isRecreating) {
-                        unregisterConfigurationCallback()
-                        listener.onDialogDismissed()
-                    }
+                    unregisterConfigurationCallback()
+                    listener.onDialogDismissed()
                 }
-                setOnCancelListener { if (!isRecreating) listener.onDialogCancelled() }
+                setOnCancelListener { listener.onDialogCancelled() }
+                if (isRebrandUpdate) {
+                    setBackgroundInsetStart(0)
+                    setBackgroundInsetEnd(0)
+                }
             }
 
         dialog = dialogBuilder.create()
@@ -186,10 +188,17 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         return this
     }
 
-    /**
-     * The layout has no scroll container of its own, so tall content is clipped rather than
-     * scrolled where the card cannot grow - short landscape screens, or large font scales.
-     */
+    override fun show() {
+        if (dialog == null) {
+            build()
+        }
+        showDialog()
+        if (isRebrandUpdate) {
+            registerConfigurationCallback()
+        }
+        listener.onDialogShown()
+    }
+
     private fun dialogContent(binding: DialogStackedAlertBinding): View {
         if (!isRebrandUpdate) return binding.root
 
@@ -205,15 +214,17 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         }
     }
 
-    override fun show() {
-        if (dialog == null) {
-            build()
-        }
+    private fun showDialog() {
         dialog?.show()
         if (isRebrandUpdate) {
-            registerConfigurationCallback()
+            dialog?.window?.setLayout(cardWidth(), WindowManager.LayoutParams.WRAP_CONTENT)
         }
-        listener.onDialogShown()
+    }
+
+    private fun cardWidth(): Int {
+        val maxWidth = context.resources.getDimensionPixelSize(R.dimen.rebrandDialogMaxWidth)
+        val margin = context.resources.getDimensionPixelSize(R.dimen.keyline_5)
+        return minOf(maxWidth, context.resources.displayMetrics.widthPixels - margin * 2)
     }
 
     /**
@@ -238,13 +249,15 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     }
 
     private fun recreate() {
-        if (dialog?.isShowing != true) return
+        val current = dialog ?: return
+        if (!current.isShowing) return
 
-        isRecreating = true
-        dialog?.dismiss()
+        current.setOnDismissListener(null)
+        current.setOnCancelListener(null)
+        current.dismiss()
+
         build()
-        dialog?.show()
-        isRecreating = false
+        showDialog()
     }
 
     override fun dismiss() {

--- a/android-design-system/design-system/src/main/res/drawable/background_dialog_icon_circular.xml
+++ b/android-design-system/design-system/src/main/res/drawable/background_dialog_icon_circular.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+   ~ Copyright (c) 2026 DuckDuckGo
+   ~
+   ~ Licensed under the Apache License, Version 2.0 (the "License");
+   ~ you may not use this file except in compliance with the License.
+   ~ You may obtain a copy of the License at
+   ~
+   ~     http://www.apache.org/licenses/LICENSE-2.0
+   ~
+   ~ Unless required by applicable law or agreed to in writing, software
+   ~ distributed under the License is distributed on an "AS IS" BASIS,
+   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   ~ See the License for the specific language governing permissions and
+   ~ limitations under the License.
+   -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="?attr/daxColorContainer" />
+</shape>

--- a/android-design-system/design-system/src/main/res/values-land/design-system-dimensions.xml
+++ b/android-design-system/design-system/src/main/res/values-land/design-system-dimensions.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <!-- Material caps dialog containers at 560dp; landscape has the room, portrait does not. -->
+    <dimen name="rebrandDialogMaxWidth">560dp</dimen>
+
+    <!-- The wider card would otherwise stretch the buttons across its full width. -->
+    <dimen name="rebrandDialogButtonSidePadding">@dimen/keyline_7</dimen>
+</resources>

--- a/android-design-system/design-system/src/main/res/values/design-system-dimensions.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-dimensions.xml
@@ -121,8 +121,9 @@
     <dimen name="dialogContentPaddingBottom">18dp</dimen>
     <dimen name="dialogContentPaddingStart">@dimen/keyline_5</dimen>
     <dimen name="dialogContentPaddingEnd">@dimen/keyline_5</dimen>
+    <dimen name="rebrandDialogMaxWidth">300dp</dimen>
     <dimen name="rebrandDialogBorderRadius">28dp</dimen>
-    <dimen name="rebrandDialogButtonSidePadding">@dimen/keyline_6</dimen>
+    <dimen name="rebrandDialogButtonSidePadding">0dp</dimen>
     <dimen name="rebrandDialogIconInset">@dimen/keyline_2</dimen>
 
     <!-- Dax Dialog -->

--- a/android-design-system/design-system/src/main/res/values/design-system-dimensions.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-dimensions.xml
@@ -121,6 +121,9 @@
     <dimen name="dialogContentPaddingBottom">18dp</dimen>
     <dimen name="dialogContentPaddingStart">@dimen/keyline_5</dimen>
     <dimen name="dialogContentPaddingEnd">@dimen/keyline_5</dimen>
+    <dimen name="rebrandDialogBorderRadius">28dp</dimen>
+    <dimen name="rebrandDialogButtonSidePadding">@dimen/keyline_6</dimen>
+    <dimen name="rebrandDialogIconInset">@dimen/keyline_2</dimen>
 
     <!-- Dax Dialog -->
     <dimen name="daxDialogContentPaddingTop">20dp</dimen>

--- a/android-design-system/design-system/src/main/res/values/widgets.xml
+++ b/android-design-system/design-system/src/main/res/values/widgets.xml
@@ -364,6 +364,14 @@
         <item name="cornerSize">@dimen/dialogBorderRadius</item>
     </style>
 
+    <style name="Widget.DuckDuckGo.DialogCorners.Rebrand">
+        <item name="cornerSize">@dimen/rebrandDialogBorderRadius</item>
+    </style>
+
+    <style name="Widget.DuckDuckGo.Dialog.Rebrand">
+        <item name="shapeAppearanceOverlay">@style/Widget.DuckDuckGo.DialogCorners.Rebrand</item>
+    </style>
+
     <style name="Widget.DuckDuckGo.Dialog.Content">
         <item name="android:paddingTop">@dimen/keyline_5</item>
         <item name="android:paddingBottom">@dimen/dialogContentPaddingBottom</item>

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -30,7 +30,10 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.ui.view.button.ButtonType.GHOST
+import com.duckduckgo.common.ui.view.button.ButtonType.PRIMARY
+import com.duckduckgo.common.ui.view.button.ButtonType.SECONDARY
 import com.duckduckgo.common.ui.view.dialog.StackedAlertDialogBuilder
+import com.duckduckgo.common.ui.view.dialog.StackedButton
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -634,13 +637,14 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
 
         if (isDuckAiAudioCapture) {
             StackedAlertDialogBuilder(activity)
+                .setRebrandUpdate(true)
                 .setHeaderImageResource(CommonR.drawable.ic_microphone_24)
                 .setTitle(R.string.duckAiMicPermissionDeniedDialogTitle)
                 .setMessage(R.string.duckAiMicPermissionDeniedDialogContent)
                 .setStackedButtons(
                     listOf(
-                        R.string.duckAiMicPermissionDeniedDialogPositiveButton,
-                        R.string.systemPermissionsDeniedDialogNegativeButton,
+                        StackedButton(R.string.duckAiMicPermissionDeniedDialogPositiveButton, PRIMARY, CommonR.drawable.ic_open_in_16),
+                        StackedButton(R.string.systemPermissionsDeniedDialogNegativeButton, SECONDARY),
                     ),
                 )
                 .addEventListener(

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/VoiceSearchPermissionDialogsLauncher.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/VoiceSearchPermissionDialogsLauncher.kt
@@ -81,7 +81,7 @@ class RealVoiceSearchPermissionDialogsLauncher @Inject constructor(
             R.string.voiceSearchMicAccessDeniedDialogMessage
         }
         val buttons = buildList {
-            add(StackedButton(R.string.voiceSearchMicAccessDeniedDialogChangePermissions, PRIMARY))
+            add(StackedButton(R.string.voiceSearchMicAccessDeniedDialogChangePermissions, PRIMARY, CommonR.drawable.ic_open_in_16))
             if (!isDuckAiMode) {
                 add(StackedButton(R.string.voiceSearchMicAccessDeniedDialogHideVoiceSearch, SECONDARY))
             }
@@ -94,6 +94,7 @@ class RealVoiceSearchPermissionDialogsLauncher @Inject constructor(
         )
 
         StackedAlertDialogBuilder(context)
+            .setRebrandUpdate(true)
             .setHeaderImageResource(CommonR.drawable.ic_microphone_24)
             .setTitle(R.string.voiceSearchMicAccessDeniedDialogTitle)
             .setMessage(message)

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/VoiceSearchPermissionDialogsLauncher.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/VoiceSearchPermissionDialogsLauncher.kt
@@ -21,7 +21,10 @@ import android.content.Context
 import android.content.res.Configuration
 import android.view.ViewGroup
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.ui.view.button.ButtonType.PRIMARY
+import com.duckduckgo.common.ui.view.button.ButtonType.SECONDARY
 import com.duckduckgo.common.ui.view.dialog.StackedAlertDialogBuilder
+import com.duckduckgo.common.ui.view.dialog.StackedButton
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.voice.api.VoiceSearchLauncher.VoiceSearchMode
@@ -78,11 +81,11 @@ class RealVoiceSearchPermissionDialogsLauncher @Inject constructor(
             R.string.voiceSearchMicAccessDeniedDialogMessage
         }
         val buttons = buildList {
-            add(R.string.voiceSearchMicAccessDeniedDialogChangePermissions)
+            add(StackedButton(R.string.voiceSearchMicAccessDeniedDialogChangePermissions, PRIMARY))
             if (!isDuckAiMode) {
-                add(R.string.voiceSearchMicAccessDeniedDialogHideVoiceSearch)
+                add(StackedButton(R.string.voiceSearchMicAccessDeniedDialogHideVoiceSearch, SECONDARY))
             }
-            add(R.string.voiceSearchNegativeAction)
+            add(StackedButton(R.string.voiceSearchNegativeAction, SECONDARY))
         }
 
         pixel.fire(


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1202857801505092/task/1217900046842843?focus=true


### Description
- Dialog width is 300.
- Buttons are centrally aligned and span across the width.
- Primary/Secondary fill with optional icons.
- Adjust the top icon size and margins.
- Make it optional so it doesn't affect other existing usages

### Steps to test this PR
- Click the mic icon in the address bar.
- Deny the permission.
- Repeat 3 times.
- See the new dialog.


### UI changes
| Before  | After |
| ------ | ----- |
|<img width="1440" height="3120" alt="Screenshot_20260824-133746" src="https://github.com/user-attachments/assets/52af1589-1c29-426c-bf43-d31c279dcf27" />|<img width="1440" height="3120" alt="Screenshot_20260827-161248" src="https://github.com/user-attachments/assets/c7a21161-a8a5-443b-bcf3-657833acef7a" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only design-system and two permission dialog call sites; opt-in preserves legacy stacked dialogs elsewhere. Rotation recreate logic is localized to rebrand dialogs.
> 
> **Overview**
> Adds an **opt-in rebrand** for `StackedAlertDialogBuilder` via `setRebrandUpdate(true)`: fixed-width card (300dp portrait / 560dp landscape), 28dp corners, header icon in a circular container, and **full-width** stacked actions with spacing tuned for rebrand layouts. Existing dialogs that do not opt in keep the previous theme and ghost-only buttons.
> 
> Introduces **`StackedButton`** and a `setStackedButtons(List<StackedButton>)` overload so each action can use **PRIMARY / SECONDARY fill** (and optional start icons) instead of ghost styling; the string-resource overload still maps to ghost/destructive behavior.
> 
> Rebrand dialogs **recreate on configuration changes** (rotation) because they are non-cancellable—dismiss listeners unregister `ComponentCallbacks` on dismiss/detach.
> 
> **Voice search** mic-permanently-denied and **Duck AI** system mic-denied flows are updated to use the rebrand dialog with primary “change permissions” (open-in icon) and secondary actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cff6f99c089d22915d36913a343348dce763d1ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->