### PR TITLE
Add pixel for the Partner Benefits settings tap

### DIFF
--- a/PixelDefinitions/pixels/definitions/subscription_pixels.json5
+++ b/PixelDefinitions/pixels/definitions/subscription_pixels.json5
@@ -185,6 +185,13 @@
             }
         ]
     },
+    "m_privacy-pro_app-settings_partner-benefits_click": {
+        "description": "The user tapped 'Partner Benefits' (DuckDuckGo Subscription) in the app-wide Settings.",
+        "owners": ["Kyriakos-Georgiopoulos"],
+        "triggers": ["other"],
+        "suffixes": ["count_short", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "m_privacy-pro_app-settings_get_click": {
         "description": "The user tapped 'Get Subscription' (DuckDuckGo Subscription) in the app-wide Settings.",
         "owners": ["YoussefKeyrouz"],

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
@@ -180,7 +180,7 @@ enum class SubscriptionPixel(
     APP_SETTINGS_PARTNER_BENEFITS_CLICK(
         baseName = "m_privacy-pro_app-settings_partner-benefits_click",
         type = Count,
-        includedParameters = setOf(ATB, APP_VERSION),
+        includedParameters = setOf(APP_VERSION),
     ),
     SUBSCRIPTION_SETTINGS_CHANGE_PLAN_OR_BILLING_CLICK(
         baseName = "m_privacy-pro_settings_change-plan-or-billing_click",

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
@@ -177,6 +177,11 @@ enum class SubscriptionPixel(
         type = Count,
         includedParameters = setOf(ATB, APP_VERSION),
     ),
+    APP_SETTINGS_PARTNER_BENEFITS_CLICK(
+        baseName = "m_privacy-pro_app-settings_partner-benefits_click",
+        type = Count,
+        includedParameters = setOf(ATB, APP_VERSION),
+    ),
     SUBSCRIPTION_SETTINGS_CHANGE_PLAN_OR_BILLING_CLICK(
         baseName = "m_privacy-pro_settings_change-plan-or-billing_click",
         type = Count,

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.ACTIVATE_SUBSC
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.ACTIVATE_SUBSCRIPTION_RESTORE_PURCHASE_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_GET_SUBSCRIPTION_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_IDTR_CLICK
+import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_PARTNER_BENEFITS_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_PIR_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_RESTORE_PURCHASE_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.AUTH_V2_INVALID_REFRESH_TOKEN_DETECTED
@@ -121,6 +122,7 @@ interface SubscriptionPixelSender {
     fun reportAppSettingsIdtrClick()
     fun reportAppSettingsGetSubscriptionClick()
     fun reportAppSettingsRestorePurchaseClick()
+    fun reportAppSettingsPartnerBenefitsClick()
     fun reportSubscriptionSettingsChangePlanOrBillingClick()
     fun reportSubscriptionSettingsRemoveFromDeviceClick()
     fun reportMonthlyPriceClick()
@@ -283,6 +285,9 @@ class SubscriptionPixelSenderImpl @Inject constructor(
 
     override fun reportAppSettingsRestorePurchaseClick() =
         fire(APP_SETTINGS_RESTORE_PURCHASE_CLICK)
+
+    override fun reportAppSettingsPartnerBenefitsClick() =
+        fire(APP_SETTINGS_PARTNER_BENEFITS_CLICK)
 
     override fun reportSubscriptionSettingsChangePlanOrBillingClick() =
         fire(SUBSCRIPTION_SETTINGS_CHANGE_PLAN_OR_BILLING_CLICK)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/PartnershipsSettingViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/PartnershipsSettingViewModel.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
 import com.duckduckgo.subscriptions.impl.internal.PartnershipsHubUrlProvider
+import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.repository.isActive
 import com.duckduckgo.subscriptions.impl.settings.views.PartnershipsSettingViewModel.Command.OpenPartnershipsHub
 import kotlinx.coroutines.channels.BufferOverflow
@@ -49,6 +50,7 @@ class PartnershipsSettingViewModel @Inject constructor(
     private val subscriptions: Subscriptions,
     private val subscriptionsFeature: SubscriptionsFeature,
     private val partnershipsHubUrlProvider: PartnershipsHubUrlProvider,
+    private val pixelSender: SubscriptionPixelSender,
     private val dispatcherProvider: DispatcherProvider,
 ) : ViewModel(), DefaultLifecycleObserver {
 
@@ -77,6 +79,8 @@ class PartnershipsSettingViewModel @Inject constructor(
     }
 
     fun onPartnershipsHubClicked() {
+        pixelSender.reportAppSettingsPartnerBenefitsClick()
+
         viewModelScope.launch {
             val url = withContext(dispatcherProvider.io()) { partnershipsHubUrlProvider.partnershipsHubUrl }
             command.send(OpenPartnershipsHub(url))

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/PartnershipsSettingViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/PartnershipsSettingViewModelTest.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus.WAITING
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
 import com.duckduckgo.subscriptions.impl.internal.PartnershipsHubUrlProvider
+import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.settings.views.PartnershipsSettingViewModel.Command.OpenPartnershipsHub
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -40,6 +41,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class PartnershipsSettingViewModelTest {
@@ -50,11 +52,13 @@ class PartnershipsSettingViewModelTest {
     private val subscriptions: Subscriptions = mock()
     private val urlProvider: PartnershipsHubUrlProvider = mock()
     private val subscriptionsFeature: SubscriptionsFeature = FakeFeatureToggleFactory.create(SubscriptionsFeature::class.java)
+    private val pixelSender: SubscriptionPixelSender = mock()
 
     private fun viewModel() = PartnershipsSettingViewModel(
         subscriptions = subscriptions,
         subscriptionsFeature = subscriptionsFeature,
         partnershipsHubUrlProvider = urlProvider,
+        pixelSender = pixelSender,
         dispatcherProvider = coroutineTestRule.testDispatcherProvider,
     )
 
@@ -126,6 +130,15 @@ class PartnershipsSettingViewModelTest {
             testee.onPartnershipsHubClicked()
             assertEquals(OpenPartnershipsHub("https://duckduckgo.com/partner-benefits"), awaitItem())
         }
+    }
+
+    @Test
+    fun whenOnPartnershipsHubClickedThenPixelFired() = runTest {
+        whenever(urlProvider.partnershipsHubUrl).thenReturn("https://duckduckgo.com/partner-benefits")
+
+        viewModel().onPartnershipsHubClicked()
+
+        verify(pixelSender).reportAppSettingsPartnerBenefitsClick()
     }
 
     private fun activeStatuses(): List<SubscriptionStatus> = listOf(AUTO_RENEWABLE, NOT_AUTO_RENEWABLE, GRACE_PERIOD)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1217858592616612?focus=true
Tech Design URL (if applicable): None
API Proposals URL(s) (if applicable): None

### Description

Adds a pixel for when the Partner Benefits row is tapped. `m_privacy-pro_app-settings_partner-benefits_click` is a `Count` pixel with ATB and app version, matching the other row taps in the DuckDuckGo Subscription section.

### Steps to test this PR

_Pre steps_
- [ ] Install the internal debug build.
- [ ] Open Settings > Internal Features > Feature Flag Inventory, search for `partnershipsHub` and enable it.
- [ ] Leave Settings and open it again.

_Pixel fires_
- [ ] Filter logcat by `Pixel sent`.
- [ ] Tap Partner Benefits in the DuckDuckGo Subscription section.
- [ ] Verify `Pixel sent: m_privacy-pro_app-settings_partner-benefits_click_c with params: {} {}` appears once per tap.

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change with no user-facing behavior beyond firing a count pixel on an existing settings tap.
> 
> **Overview**
> Adds analytics when users tap **Partner Benefits** in app Settings (DuckDuckGo Subscription section).
> 
> The new count pixel `m_privacy-pro_app-settings_partner-benefits_click` is registered in pixel definitions and wired through `SubscriptionPixel` / `SubscriptionPixelSender`, aligned with other app-settings row taps (count suffix, `appVersion`).
> 
> `PartnershipsSettingViewModel.onPartnershipsHubClicked()` now fires the pixel before opening the partnerships hub URL. A unit test verifies `reportAppSettingsPartnerBenefitsClick()` is called on tap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70ce4ab398930d804a5d5c95495c61d40f8e51a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->