### PR TITLE
RMF Survey Param: last duck ai usage

### DIFF
--- a/duckchat/duckchat-impl/build.gradle
+++ b/duckchat/duckchat-impl/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation project(':history-api')
     implementation project(':saved-sites-api')
     implementation project(':remote-messaging-api')
+    implementation project(':survey-api')
     implementation project(':attributed-metrics-api')
     implementation project(':navigation-api')
     implementation project(':sync-api')

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/rmf/DuckAiSurveyParameter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/rmf/DuckAiSurveyParameter.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.rmf
+
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
+import com.duckduckgo.survey.api.SurveyParameterPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class LastDuckAiUsageSurveyParameterPlugin @Inject constructor(
+    private val duckChatFeatureRepository: DuckChatFeatureRepository,
+    private val currentTimeProvider: CurrentTimeProvider,
+) : SurveyParameterPlugin {
+    override fun matches(paramKey: String): Boolean = paramKey == "last_duck_ai_usage"
+
+    override suspend fun evaluate(paramKey: String): String {
+        val lastUsage = duckChatFeatureRepository.lastSessionTimestamp()
+        if (lastUsage == 0L) return "none"
+
+        val daysSinceLastUsage = TimeUnit.MILLISECONDS.toDays(currentTimeProvider.currentTimeMillis() - lastUsage)
+
+        return when {
+            daysSinceLastUsage < 2 -> "day"
+            daysSinceLastUsage <= 7 -> "week"
+            else -> "none"
+        }
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/rmf/LastDuckAiUsageSurveyParameterPluginTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/rmf/LastDuckAiUsageSurveyParameterPluginTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.rmf
+
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.concurrent.TimeUnit
+
+class LastDuckAiUsageSurveyParameterPluginTest {
+
+    private val mockRepository: DuckChatFeatureRepository = mock()
+    private val mockCurrentTimeProvider: CurrentTimeProvider = mock()
+
+    private lateinit var plugin: LastDuckAiUsageSurveyParameterPlugin
+
+    private val now = 1_750_000_000_000L
+
+    @Before
+    fun setup() {
+        plugin = LastDuckAiUsageSurveyParameterPlugin(mockRepository, mockCurrentTimeProvider)
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(now)
+    }
+
+    @Test
+    fun whenDuckAiWasNeverUsedThenReturnsNone() = runTest {
+        whenever(mockRepository.lastSessionTimestamp()).thenReturn(0L)
+
+        assertEquals("none", plugin.evaluate("last_duck_ai_usage"))
+    }
+
+    @Test
+    fun whenLastUsageWasLessThanADayAgoThenReturnsDay() = runTest {
+        whenever(mockRepository.lastSessionTimestamp()).thenReturn(now - TimeUnit.HOURS.toMillis(6))
+
+        assertEquals("day", plugin.evaluate("last_duck_ai_usage"))
+    }
+
+    @Test
+    fun whenLastUsageWasOneDayAgoThenReturnsDay() = runTest {
+        whenever(mockRepository.lastSessionTimestamp()).thenReturn(now - TimeUnit.DAYS.toMillis(1))
+
+        assertEquals("day", plugin.evaluate("last_duck_ai_usage"))
+    }
+
+    @Test
+    fun whenLastUsageWasTwoDaysAgoThenReturnsWeek() = runTest {
+        whenever(mockRepository.lastSessionTimestamp()).thenReturn(now - TimeUnit.DAYS.toMillis(2))
+
+        assertEquals("week", plugin.evaluate("last_duck_ai_usage"))
+    }
+
+    @Test
+    fun whenLastUsageWasSevenDaysAgoThenReturnsWeek() = runTest {
+        whenever(mockRepository.lastSessionTimestamp()).thenReturn(now - TimeUnit.DAYS.toMillis(7))
+
+        assertEquals("week", plugin.evaluate("last_duck_ai_usage"))
+    }
+
+    @Test
+    fun whenLastUsageWasEightDaysAgoThenReturnsNone() = runTest {
+        whenever(mockRepository.lastSessionTimestamp()).thenReturn(now - TimeUnit.DAYS.toMillis(8))
+
+        assertEquals("none", plugin.evaluate("last_duck_ai_usage"))
+    }
+
+    @Test
+    fun whenMatchesReturnsTrueForCorrectKey() {
+        assertTrue(plugin.matches("last_duck_ai_usage"))
+    }
+
+    @Test
+    fun whenMatchesReturnsFalseForOtherKeys() {
+        assertFalse(plugin.matches("last_search_state"))
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1217714717013229?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

Add new survey param for last duck.ai usage (`last_duck_ai_usage`).

The param is resolved from the stored timestamp of the last duck.ai session and mapped to `day` (used within the past 1–2 days), `week` (used 2–7 days ago) or `none` (no usage in the past 7 days, or never used).

### Steps to test this PR

- [x] Test setup instructions in https://app.asana.com/1/137249556945/project/1211724162604201/task/1217714717013229?focus=true

_No duck.ai usage_
- [x] Fresh install
- [x] Skip onboarding
- [x] Start survey and check last_duck_ai_usage param is `none`

_Duck.ai usage within 2 days_
- [x] Fresh install
- [x] Skip onboarding
- [x] Open duck.ai and send a prompt
- [x] Open a new tab
- [x] Start survey and check last_duck_ai_usage param is `day`

_Duck.ai usage in the past 2–7 days_
- [x] Fresh install
- [x] Skip onboarding
- [x] Open duck.ai and send a prompt
- [x] Change device date to 5 days later
- [x] Open a new tab
- [x] Start survey and check last_duck_ai_usage param is `week`

_Duck.ai usage > 7 days ago_
- [x] Fresh install
- [x] Skip onboarding
- [x] Open duck.ai and send a prompt
- [x] Change device date to > 7 days later
- [x] Open a new tab
- [x] Start survey and check last_duck_ai_usage param is `none`

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2030cd7794d4b6e8566460ad6b6b0af588f3ebb5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->