### PR TITLE
Fire prompt submitted when suggested prompts are clicked

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryDialog.kt
@@ -261,7 +261,7 @@ class DuckChatContextualEntryDialog : DuckDuckGoBottomSheetDialogFragment() {
     private fun configureQuickAction() {
         binding.entryPromptQuickAction.setOnClickListener {
             if (viewModel.viewState.value.attachedContext == null) return@setOnClickListener
-            viewModel.onPromptSubmitted(NativeInputPrompt(getString(R.string.duckAIContextualPromptSummarize), null, null, null, null, null))
+            viewModel.onSummarizeSubmitted(NativeInputPrompt(getString(R.string.duckAIContextualPromptSummarize), null, null, null, null, null))
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModel.kt
@@ -104,6 +104,20 @@ class DuckChatContextualEntryViewModel @Inject constructor(
     /** A suggested prompt was picked; suggestions are page-specific, so attach the context before submit. */
     fun onSuggestionSubmitted(prompt: NativeInputPrompt) {
         if (_viewState.value.attachedContext == null) latestValidPageContext?.let { attach(it) }
+        fireUnifiedInputPromptSubmitted()
+        submit(prompt)
+    }
+
+    fun onSummarizeSubmitted(prompt: NativeInputPrompt) {
+        fireUnifiedInputPromptSubmitted()
+        submit(prompt)
+    }
+
+    fun onPromptSubmitted(prompt: NativeInputPrompt) {
+        submit(prompt)
+    }
+
+    private fun fireUnifiedInputPromptSubmitted() {
         duckChatPixels.firePromptSubmitted(
             selectedTool = "none",
             modelId = modelManager.getSelectedModelId(),
@@ -117,12 +131,6 @@ class DuckChatContextualEntryViewModel @Inject constructor(
             pageType = DuckChatPixelPageType.CONTEXTUAL,
             addressBarEntryPoint = null,
         )
-        submit(prompt)
-    }
-
-    /** A typed prompt or the Summarize quick action was submitted. */
-    fun onPromptSubmitted(prompt: NativeInputPrompt) {
-        submit(prompt)
     }
 
     private fun submit(prompt: NativeInputPrompt) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModel.kt
@@ -19,6 +19,9 @@ package com.duckduckgo.duckchat.impl.contextual
 import androidx.lifecycle.ViewModel
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelPageType
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
@@ -39,6 +42,7 @@ import javax.inject.Inject
 class DuckChatContextualEntryViewModel @Inject constructor(
     private val contextualEntryPromptStore: ContextualEntryPromptStore,
     private val duckChatPixels: DuckChatPixels,
+    private val modelManager: DuckAiModelManager,
 ) : ViewModel() {
 
     data class ViewState(
@@ -100,6 +104,19 @@ class DuckChatContextualEntryViewModel @Inject constructor(
     /** A suggested prompt was picked; suggestions are page-specific, so attach the context before submit. */
     fun onSuggestionSubmitted(prompt: NativeInputPrompt) {
         if (_viewState.value.attachedContext == null) latestValidPageContext?.let { attach(it) }
+        duckChatPixels.firePromptSubmitted(
+            selectedTool = "none",
+            modelId = modelManager.getSelectedModelId(),
+            reasoningEffort = modelManager.getResolvedReasoningEffort(),
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
+            defaultMode = null,
+            tabId = tabId,
+            pageType = DuckChatPixelPageType.CONTEXTUAL,
+            addressBarEntryPoint = null,
+        )
         submit(prompt)
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -713,6 +713,7 @@ class DuckChatContextualViewModel @Inject constructor(
                     return
                 }
                 duckChatPixels.reportContextualSummarizePromptSelected()
+                fireUnifiedInputPromptSubmitted()
                 onPromptSent(
                     prompt = context.getString(R.string.duckAIContextualPromptSummarize),
                     followUpPrefill = currentInput.takeIf { it.isNotEmpty() },
@@ -726,6 +727,14 @@ class DuckChatContextualViewModel @Inject constructor(
         currentInput: String,
     ) {
         attachPageContextForSuggestion()
+        fireUnifiedInputPromptSubmitted()
+        onPromptSent(
+            prompt = suggestion.prompt,
+            followUpPrefill = currentInput.takeIf { it.isNotEmpty() },
+        )
+    }
+
+    private fun fireUnifiedInputPromptSubmitted() {
         duckChatPixels.firePromptSubmitted(
             selectedTool = "none",
             modelId = modelManager.getSelectedModelId(),
@@ -738,10 +747,6 @@ class DuckChatContextualViewModel @Inject constructor(
             tabId = _viewState.value.tabId,
             pageType = DuckChatPixelPageType.CONTEXTUAL,
             addressBarEntryPoint = null,
-        )
-        onPromptSent(
-            prompt = suggestion.prompt,
-            followUpPrefill = currentInput.takeIf { it.isNotEmpty() },
         )
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -40,6 +40,8 @@ import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
 import com.duckduckgo.duckchat.impl.history.ChatHistoryItem
 import com.duckduckgo.duckchat.impl.history.ChatHistoryRepository
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelPageType
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
@@ -724,6 +726,19 @@ class DuckChatContextualViewModel @Inject constructor(
         currentInput: String,
     ) {
         attachPageContextForSuggestion()
+        duckChatPixels.firePromptSubmitted(
+            selectedTool = "none",
+            modelId = modelManager.getSelectedModelId(),
+            reasoningEffort = modelManager.getResolvedReasoningEffort(),
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
+            defaultMode = null,
+            tabId = _viewState.value.tabId,
+            pageType = DuckChatPixelPageType.CONTEXTUAL,
+            addressBarEntryPoint = null,
+        )
         onPromptSent(
             prompt = suggestion.prompt,
             followUpPrefill = currentInput.takeIf { it.isNotEmpty() },

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
@@ -131,6 +131,33 @@ class DuckChatContextualEntryViewModelTest {
     }
 
     @Test
+    fun whenSummarizeSubmittedThenUnifiedInputPromptSubmittedPixelFired() = runTest {
+        viewModel.start("tab-1")
+        viewModel.onPageContextReceived(validContext)
+        whenever(modelManager.getSelectedModelId()).thenReturn("gpt-5.2")
+        whenever(modelManager.getResolvedReasoningEffort()).thenReturn("low")
+
+        viewModel.commands.test {
+            viewModel.onSummarizeSubmitted(samplePrompt)
+            assertEquals(DuckChatContextualEntryViewModel.Command.HandOffToSheet, awaitItem())
+        }
+
+        verify(duckChatPixels).firePromptSubmitted(
+            selectedTool = "none",
+            modelId = "gpt-5.2",
+            reasoningEffort = "low",
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
+            defaultMode = null,
+            tabId = "tab-1",
+            pageType = DuckChatPixelPageType.CONTEXTUAL,
+            addressBarEntryPoint = null,
+        )
+    }
+
+    @Test
     fun whenPromptSubmittedThenUnifiedInputPromptSubmittedPixelNotFired() = runTest {
         viewModel.start("tab-1")
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualEntryViewModelTest.kt
@@ -17,21 +17,28 @@
 package com.duckduckgo.duckchat.impl.contextual
 
 import app.cash.turbine.test
+import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelPageType
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class DuckChatContextualEntryViewModelTest {
 
     private val store: ContextualEntryPromptStore = mock()
     private val duckChatPixels: DuckChatPixels = mock()
-    private val viewModel = DuckChatContextualEntryViewModel(store, duckChatPixels)
+    private val modelManager: DuckAiModelManager = mock()
+    private val viewModel = DuckChatContextualEntryViewModel(store, duckChatPixels, modelManager)
 
     private val validContext = """{"title":"Example","url":"https://example.com","content":"some page content"}"""
     private val samplePrompt = NativeInputPrompt("hi", "model-1", "high", "tool-1", null, null)
@@ -95,6 +102,56 @@ class DuckChatContextualEntryViewModelTest {
         val captor = argumentCaptor<ContextualEntryPrompt>()
         verify(store).store(captor.capture())
         assertEquals(validContext, captor.firstValue.serializedPageContext)
+    }
+
+    @Test
+    fun whenSuggestionSubmittedThenUnifiedInputPromptSubmittedPixelFired() = runTest {
+        viewModel.start("tab-1")
+        whenever(modelManager.getSelectedModelId()).thenReturn("gpt-5.2")
+        whenever(modelManager.getResolvedReasoningEffort()).thenReturn("low")
+
+        viewModel.commands.test {
+            viewModel.onSuggestionSubmitted(samplePrompt)
+            assertEquals(DuckChatContextualEntryViewModel.Command.HandOffToSheet, awaitItem())
+        }
+
+        verify(duckChatPixels).firePromptSubmitted(
+            selectedTool = "none",
+            modelId = "gpt-5.2",
+            reasoningEffort = "low",
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
+            defaultMode = null,
+            tabId = "tab-1",
+            pageType = DuckChatPixelPageType.CONTEXTUAL,
+            addressBarEntryPoint = null,
+        )
+    }
+
+    @Test
+    fun whenPromptSubmittedThenUnifiedInputPromptSubmittedPixelNotFired() = runTest {
+        viewModel.start("tab-1")
+
+        viewModel.commands.test {
+            viewModel.onPromptSubmitted(samplePrompt)
+            assertEquals(DuckChatContextualEntryViewModel.Command.HandOffToSheet, awaitItem())
+        }
+
+        verify(duckChatPixels, never()).firePromptSubmitted(
+            selectedTool = any(),
+            modelId = any(),
+            reasoningEffort = any(),
+            hasImageAttachment = any(),
+            hasFileAttachment = any(),
+            hasText = any(),
+            surface = any(),
+            defaultMode = anyOrNull(),
+            tabId = anyOrNull(),
+            pageType = any(),
+            addressBarEntryPoint = anyOrNull(),
+        )
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -2068,6 +2068,35 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
+    fun `when SUBMIT_SUMMARIZE clicked then unified input prompt submitted pixel fired`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+        whenever(modelManager.getSelectedModelId()).thenReturn("gpt-5.2")
+        whenever(modelManager.getResolvedReasoningEffort()).thenReturn("low")
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
+        testee.onPageContextReceived("tab-1", pageContext)
+        testee.onQuickActionClicked("") // ASK_ABOUT_PAGE -> SUBMIT_SUMMARIZE
+
+        testee.onQuickActionClicked("") // SUBMIT_SUMMARIZE click
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatPixels).firePromptSubmitted(
+            selectedTool = "none",
+            modelId = "gpt-5.2",
+            reasoningEffort = "low",
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
+            defaultMode = null,
+            tabId = "tab-1",
+            pageType = DuckChatPixelPageType.CONTEXTUAL,
+            addressBarEntryPoint = null,
+        )
+    }
+
+    @Test
     fun `when SUBMIT_SUMMARIZE clicked then context-attach pixel not re-fired`() = runTest {
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -33,6 +33,8 @@ import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
 import com.duckduckgo.duckchat.impl.history.ChatHistoryItem
 import com.duckduckgo.duckchat.impl.history.ChatHistoryRepository
 import com.duckduckgo.duckchat.impl.models.ChatType
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelPageType
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
 import com.duckduckgo.feature.toggles.api.Toggle
@@ -2529,6 +2531,31 @@ class DuckChatContextualViewModelTest {
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
 
         verify(duckChatPixels).reportContextualPromptSubmittedWithContextNative()
+    }
+
+    @Test
+    fun `when suggestion selected then unified input prompt submitted pixel fired`() = runTest {
+        testee = buildViewModel()
+        whenever(modelManager.getSelectedModelId()).thenReturn("gpt-5.2")
+        whenever(modelManager.getResolvedReasoningEffort()).thenReturn("low")
+        val suggestion = ContextualSuggestedPrompt("id", "Label", "Do the thing.", null)
+
+        testee.onSuggestionSelected(suggestion, currentInput = "")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatPixels).firePromptSubmitted(
+            selectedTool = "none",
+            modelId = "gpt-5.2",
+            reasoningEffort = "low",
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
+            defaultMode = null,
+            tabId = "",
+            pageType = DuckChatPixelPageType.CONTEXTUAL,
+            addressBarEntryPoint = null,
+        )
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1217893146750044?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
 Fire the existing `m_aichat_unified_input_prompt_submitted` pixel when a suggestion pill or the Summarize quick action is used. Applied in both the contextual sheet (`DuckChatContextualViewModel`) and the entry dialog (`DuckChatContextualEntryViewModel`), with the typed-prompt path left untouched to avoid double-firing.

### Steps to test this PR
Filter `m_aichat_unified_input_prompt_submitted` on logcat.

_contextualSheetRedesign ON (default)_
- [x] Open tab with allrecipes.com
- [x] Click on contextual entry > Ask about page
- [x] Select Summarize page
- [x] Verify pixel is emitted once.
- [x] Select New Chat (from chats menu)
- [x] Navigate to a specific recipe
- [x] Reopen contextual sheet
- [x] Select a suggested prompt
- [x] Verify pixel is emitted once.

_contextualSheetRedesign OFF_
- [ ] Re-do steps above and confirm they work as expected.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes on contextual UI submit paths; no auth, data, or prompt-handling logic changes beyond which pixel fires.
> 
> **Overview**
> Adds **`m_aichat_unified_input_prompt_submitted`** when users pick a **suggestion pill** or the **Summarize** quick action in contextual Duck.ai, so those taps match typed unified-input analytics.
> 
> In **`DuckChatContextualViewModel`**, **`fireUnifiedInputPromptSubmitted()`** runs before **`onSuggestionSelected`** and the **SUBMIT_SUMMARIZE** quick-action path (model/reasoning from **`DuckAiModelManager`**, surface **`CONTEXTUAL_CHAT`**). **`DuckChatContextualEntryViewModel`** mirrors that for **`onSuggestionSubmitted`** and a new **`onSummarizeSubmitted`**; the entry dialog’s Summarize button calls **`onSummarizeSubmitted`** instead of **`onPromptSubmitted`**. **Typed** **`onPromptSubmitted`** still only hands off to the sheet—no unified pixel here, avoiding double events when the native composer already fires the pixel.
> 
> Tests assert the pixel fires once for suggestions/Summarize and **never** for plain typed submit on the entry VM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef92a4b5c5d4c467bbb9581ef2e64062e7ce8410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->