### PR TITLE
Sync unified device list telemetry

### DIFF
--- a/PixelDefinitions/pixels/definitions/sync_unified_devices.json5
+++ b/PixelDefinitions/pixels/definitions/sync_unified_devices.json5
@@ -1,0 +1,216 @@
+{
+    "sync_unified_devices_own_row_resolved_device_info": {
+        "description": "Fired daily when this device's row resolves using device_info while unified device-list reading is enabled",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_unified_devices_own_row_resolved_legacy": {
+        "description": "Fired daily when this device's row falls back to its legacy encrypted name while unified reading and writing are enabled",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why this device's device_info could not be used",
+                "enum": ["not_published_yet", "blob_absent", "blob_decrypt_failed"]
+            }
+        ]
+    },
+    "sync_unified_devices_own_row_resolved_placeholder": {
+        "description": "Fired daily when this device's row cannot resolve through device_info or legacy fields",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why this device's device_info could not be used",
+                "enum": ["not_published_yet", "blob_absent", "blob_decrypt_failed"]
+            }
+        ]
+    },
+    "sync_unified_devices_account_info_key_unavailable": {
+        "description": "Fired daily when the account_info private key cannot be obtained for unified device-list reading",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the account_info private key could not be obtained",
+                "enum": ["no_key_on_server", "no_wrap_for_our_credential", "unwrap_failed", "keys_fetch_failed", "rate_limited"]
+            }
+        ]
+    },
+    "sync_unified_devices_other_row_device_info_failed_decryption": {
+        "description": "Fired daily when another device's present device_info cannot be decrypted",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "credential",
+                "type": "string",
+                "description": "Credential associated with the row whose device_info failed decryption",
+                "enum": ["ddg", "3party", "none"]
+            }
+        ]
+    },
+    "sync_unified_devices_other_row_resolved_placeholder": {
+        "description": "Fired daily when another device's row resolves as an unknown-device placeholder",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "credential",
+                "type": "string",
+                "description": "Credential associated with the placeholder row",
+                "enum": ["ddg", "3party", "none"]
+            }
+        ]
+    },
+    "sync_unified_devices_account_info_key_create_success": {
+        "description": "Fired when this device successfully registers a newly minted account_info key",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_unified_devices_account_info_key_create_failed": {
+        "description": "Fired daily when this device cannot mint or register a new account_info key",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why account_info key creation failed",
+                "enum": ["mint_failed", "request_failed", "rate_limited"]
+            }
+        ]
+    },
+    "sync_unified_devices_account_info_key_wrap_success": {
+        "description": "Fired when this device successfully adds its credential wrap to an existing account_info key",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_unified_devices_account_info_key_wrap_failed": {
+        "description": "Fired daily when this device cannot add its credential wrap to an existing account_info key",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why adding the account_info key wrap failed",
+                "enum": ["unwrap_failed", "request_failed", "rate_limited"]
+            }
+        ]
+    },
+    "sync_unified_devices_account_info_key_adopt_success": {
+        "description": "Fired when this device successfully adopts an account_info key registered by another client",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_unified_devices_account_info_key_adopt_failed": {
+        "description": "Fired daily when this device cannot adopt an account_info key registered by another client",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why adopting the account_info key failed",
+                "enum": ["keys_fetch_failed", "rate_limited"]
+            }
+        ]
+    },
+    "sync_unified_devices_own_row_device_info_first_write_success": {
+        "description": "Fired when this device successfully writes its device_info for the first time",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_unified_devices_own_row_device_info_first_write_failed": {
+        "description": "Fired daily when this device's first device_info write fails",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the first device_info write failed",
+                "enum": ["encrypt_failed", "request_failed", "rate_limited"]
+            }
+        ]
+    },
+    "sync_unified_devices_own_row_device_info_update_success": {
+        "description": "Fired when this device successfully writes device_info during a user rename",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_unified_devices_own_row_device_info_update_failed": {
+        "description": "Fired daily when writing device_info during a user rename fails",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the device_info update failed",
+                "enum": ["encrypt_failed", "request_failed", "rate_limited"]
+            }
+        ]
+    },
+    "sync_unified_devices_own_row_device_info_repair_success": {
+        "description": "Fired when this device successfully repairs its missing or undecryptable device_info",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_unified_devices_own_row_device_info_repair_failed": {
+        "description": "Fired daily when this device cannot repair its missing or undecryptable device_info",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the device_info repair failed",
+                "enum": ["encrypt_failed", "request_failed", "rate_limited"]
+            }
+        ]
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoKeyManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoKeyManager.kt
@@ -22,6 +22,10 @@ import com.duckduckgo.sync.crypto.SyncLib
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel
+import com.duckduckgo.sync.impl.pixels.toAccountInfoKeyAdoptFailureReason
+import com.duckduckgo.sync.impl.pixels.toAccountInfoKeyCreateFailureReason
 import com.duckduckgo.sync.store.AccountInfoPublicKey
 import com.duckduckgo.sync.store.ScopedPassword
 import com.duckduckgo.sync.store.SyncStore
@@ -75,6 +79,7 @@ class RealAccountInfoKeyManager @Inject constructor(
     private val thirdPartyKeyWrapper: ThirdPartyKeyWrapper,
     private val thirdPartyCredentialManager: ThirdPartyCredentialManager,
     private val dispatchers: DispatcherProvider,
+    private val syncPixels: SyncPixels,
 ) : AccountInfoKeyManager {
 
     override suspend fun ensureKeyRegistered(): Result<AccountInfoKeyResult> = withContext(dispatchers.io()) {
@@ -85,7 +90,14 @@ class RealAccountInfoKeyManager @Inject constructor(
 
         val minted = when (val result = mintUnregistered(accountSecretKey)) {
             is Success -> result.data
-            is Error -> return@withContext result
+            is Error -> {
+                syncPixels.fireUnifiedDeviceListPixel(
+                    UnifiedDeviceListPixel.AccountInfoKeyCreateFailed(
+                        UnifiedDeviceListPixel.AccountInfoKeyCreateFailureReason.MINT_FAILED,
+                    ),
+                )
+                return@withContext result
+            }
         }
 
         val entries = when (val result = wrapForCredentials(minted)) {
@@ -98,6 +110,9 @@ class RealAccountInfoKeyManager @Inject constructor(
             is Success -> onSetIfAbsentSuccess(token, minted, entries.size, result.data)
             is Error -> {
                 logcat(ERROR) { "Sync-UnifiedDevices: setKeysIfAbsent failed: ${result.reason}" }
+                syncPixels.fireUnifiedDeviceListPixel(
+                    UnifiedDeviceListPixel.AccountInfoKeyCreateFailed(result.toAccountInfoKeyCreateFailureReason()),
+                )
                 result
             }
         }
@@ -162,12 +177,14 @@ class RealAccountInfoKeyManager @Inject constructor(
         return when (outcome) {
             SetKeysIfAbsentResult.Created -> {
                 logcat { "Sync-UnifiedDevices: our key won (kid=${minted.entry.kid})" }
+                syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyCreateSuccess)
                 Success(
                     AccountInfoKeyResult(kid = minted.entry.kid, publicKey = minted.entry.publicKey, created = true, wrapsSent = wrapsSent),
                 )
             }
             is SetKeysIfAbsentResult.Existing -> {
                 logcat { "Sync-UnifiedDevices: another device's key won (kid=${outcome.kid}); adopting from response" }
+                syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyAdoptSuccess)
                 Success(
                     AccountInfoKeyResult(kid = outcome.kid, publicKey = outcome.publicKey, created = false, wrapsSent = wrapsSent),
                 )
@@ -182,17 +199,27 @@ class RealAccountInfoKeyManager @Inject constructor(
         return when (val result = syncApi.getProtectedKeys(token)) {
             is Success -> {
                 val existing = result.data.firstOrNull { it.purpose == SYNC_PURPOSE_ACCOUNT_INFO }
-                    ?: return Error(reason = "CreateAccountInfoKey: server reported an existing key but none was found on fetch")
+                    ?: return Error(reason = "CreateAccountInfoKey: server reported an existing key but none was found on fetch").also {
+                        fireAdoptFailed(it)
+                    }
                 logcat { "Sync-UnifiedDevices: adopted existing key (kid=${existing.kid})" }
+                syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyAdoptSuccess)
                 Success(
                     AccountInfoKeyResult(kid = existing.kid, publicKey = existing.publicKey, created = false, wrapsSent = wrapsSent),
                 )
             }
             is Error -> {
                 logcat(ERROR) { "Sync-UnifiedDevices: failed to fetch keys to adopt existing: ${result.reason}" }
+                fireAdoptFailed(result)
                 result
             }
         }
+    }
+
+    private fun fireAdoptFailed(error: Error) {
+        syncPixels.fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.AccountInfoKeyAdoptFailed(error.toAccountInfoKeyAdoptFailureReason()),
+        )
     }
 
     private fun RsaJwk.toStoredKey(kid: String) = AccountInfoPublicKey(keyId = kid, modulus = n, exponent = e)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoPrivateKeyProvider.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoPrivateKeyProvider.kt
@@ -37,7 +37,20 @@ import javax.inject.Inject
  */
 @WorkerThread
 interface AccountInfoPrivateKeyProvider {
-    fun privateKey(): Result<String>
+    fun privateKey(): AccountInfoPrivateKeyResult
+}
+
+sealed interface AccountInfoPrivateKeyResult {
+    data class Available(val privateKey: String) : AccountInfoPrivateKeyResult
+    data class Unavailable(val reason: AccountInfoKeyUnavailableReason) : AccountInfoPrivateKeyResult
+}
+
+enum class AccountInfoKeyUnavailableReason {
+    NO_KEY_ON_SERVER,
+    NO_WRAP_FOR_OUR_CREDENTIAL,
+    UNWRAP_FAILED,
+    KEYS_FETCH_FAILED,
+    RATE_LIMITED,
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -55,46 +68,73 @@ class RealAccountInfoPrivateKeyProvider @Inject constructor(
 
     private data class CachedEntry(val userId: String, val credentialId: String, val wrappedEntry: ProtectedKeyEntry)
 
-    override fun privateKey(): Result<String> {
+    override fun privateKey(): AccountInfoPrivateKeyResult {
         val token = syncStore.token.takeUnless { it.isNullOrEmpty() }
             ?: run {
                 cachedEntry = null
-                return Error(reason = "AccountInfoPrivateKey: not signed in")
+                return AccountInfoPrivateKeyResult.Unavailable(AccountInfoKeyUnavailableReason.KEYS_FETCH_FAILED)
             }
         val userId = syncStore.userId.takeUnless { it.isNullOrEmpty() }
             ?: run {
                 cachedEntry = null
-                return Error(reason = "AccountInfoPrivateKey: no user id")
+                return AccountInfoPrivateKeyResult.Unavailable(AccountInfoKeyUnavailableReason.KEYS_FETCH_FAILED)
             }
         val credentialId = syncStore.credentialId ?: CREDENTIAL_ID_DDG
 
         val entry = when (val result = wrappedEntry(token, userId, credentialId)) {
-            is Success -> result.data
-            is Error -> return result
+            is WrappedEntryOutcome.Available -> result.entry
+            is WrappedEntryOutcome.Unavailable -> return AccountInfoPrivateKeyResult.Unavailable(result.reason)
         }
 
         return when (val result = protectedKeyUnwrapper.unwrap(entry)) {
-            is Success -> Success(Base64.encodeToString(result.data, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP))
-            is Error -> result
+            is Success -> AccountInfoPrivateKeyResult.Available(
+                Base64.encodeToString(result.data, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP),
+            )
+            is Error -> AccountInfoPrivateKeyResult.Unavailable(AccountInfoKeyUnavailableReason.UNWRAP_FAILED)
         }
     }
 
     /** Returns the wrapped `account_info` entry from cache, or fetches it once (deduping a concurrent burst) and caches it. */
-    private fun wrappedEntry(token: String, userId: String, credentialId: String): Result<ProtectedKeyEntry> {
-        cachedEntry?.let { if (it.userId == userId && it.credentialId == credentialId) return Success(it.wrappedEntry) }
+    private fun wrappedEntry(token: String, userId: String, credentialId: String): WrappedEntryOutcome {
+        cachedEntry?.let { if (it.userId == userId && it.credentialId == credentialId) return WrappedEntryOutcome.Available(it.wrappedEntry) }
 
         return synchronized(fetchLock) {
             // another thread may have populated the cache while we waited on the lock
-            cachedEntry?.let { if (it.userId == userId && it.credentialId == credentialId) return@synchronized Success(it.wrappedEntry) }
+            cachedEntry?.let {
+                if (it.userId == userId && it.credentialId == credentialId) {
+                    return@synchronized WrappedEntryOutcome.Available(it.wrappedEntry)
+                }
+            }
 
             val entry = when (val result = syncApi.getProtectedKeys(token)) {
-                is Success -> result.data.firstOrNull { it.purpose == SYNC_PURPOSE_ACCOUNT_INFO && it.encryptedWith == credentialId }
-                    ?: return@synchronized Error(reason = "AccountInfoPrivateKey: no account_info key wrapped for credential=$credentialId")
-                is Error -> return@synchronized result
+                is Success -> {
+                    result.data.firstOrNull { it.purpose == SYNC_PURPOSE_ACCOUNT_INFO && it.encryptedWith == credentialId }
+                        ?: return@synchronized WrappedEntryOutcome.Unavailable(
+                            if (result.data.any { it.purpose == SYNC_PURPOSE_ACCOUNT_INFO }) {
+                                AccountInfoKeyUnavailableReason.NO_WRAP_FOR_OUR_CREDENTIAL
+                            } else {
+                                AccountInfoKeyUnavailableReason.NO_KEY_ON_SERVER
+                            },
+                        )
+                }
+                is Error -> {
+                    return@synchronized WrappedEntryOutcome.Unavailable(
+                        if (result.code == API_CODE.TOO_MANY_REQUESTS_1.code) {
+                            AccountInfoKeyUnavailableReason.RATE_LIMITED
+                        } else {
+                            AccountInfoKeyUnavailableReason.KEYS_FETCH_FAILED
+                        },
+                    )
+                }
             }
 
             cachedEntry = CachedEntry(userId = userId, credentialId = credentialId, wrappedEntry = entry)
-            Success(entry)
+            WrappedEntryOutcome.Available(entry)
         }
+    }
+
+    private sealed interface WrappedEntryOutcome {
+        data class Available(val entry: ProtectedKeyEntry) : WrappedEntryOutcome
+        data class Unavailable(val reason: AccountInfoKeyUnavailableReason) : WrappedEntryOutcome
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoDecryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoDecryptor.kt
@@ -32,7 +32,7 @@ import javax.inject.Inject
  */
 @WorkerThread
 interface DeviceInfoDecryptor {
-    fun openSession(): Result<Session>
+    fun openSession(): DeviceInfoSessionResult
 
     /** Decrypts `device_info` blobs with a private key held only for this session's lifetime. */
     @WorkerThread
@@ -41,16 +41,22 @@ interface DeviceInfoDecryptor {
     }
 }
 
+sealed interface DeviceInfoSessionResult {
+    data class Available(val session: DeviceInfoDecryptor.Session) : DeviceInfoSessionResult
+    data class Unavailable(val reason: AccountInfoKeyUnavailableReason) : DeviceInfoSessionResult
+}
+
 @ContributesBinding(AppScope::class)
 class RealDeviceInfoDecryptor @Inject constructor(
     private val accountInfoPrivateKeyProvider: AccountInfoPrivateKeyProvider,
     private val syncJweCrypto: SyncJweCrypto,
 ) : DeviceInfoDecryptor {
 
-    override fun openSession(): Result<DeviceInfoDecryptor.Session> =
+    override fun openSession(): DeviceInfoSessionResult =
         when (val result = accountInfoPrivateKeyProvider.privateKey()) {
-            is Success -> Success(RealSession(privateKeyBase64Url = result.data, syncJweCrypto = syncJweCrypto))
-            is Error -> result
+            is AccountInfoPrivateKeyResult.Available ->
+                DeviceInfoSessionResult.Available(RealSession(privateKeyBase64Url = result.privateKey, syncJweCrypto = syncJweCrypto))
+            is AccountInfoPrivateKeyResult.Unavailable -> DeviceInfoSessionResult.Unavailable(result.reason)
         }
 
     private class RealSession(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoMigrator.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoMigrator.kt
@@ -126,7 +126,12 @@ class RealDeviceInfoMigrator @Inject constructor(
     }
 
     private suspend fun writeDeviceInfo(userId: String): Result<Unit> {
-        return when (val updateResult = deviceInfoUpdater.setThisDeviceName(syncDeviceIds.deviceName())) {
+        return when (
+            val updateResult = deviceInfoUpdater.setThisDeviceName(
+                name = syncDeviceIds.deviceName(),
+                source = DeviceInfoUpdateSource.FIRST_WRITE,
+            )
+        ) {
             is Success -> {
                 markMigrated(userId)
                 logcat { "Sync-UnifiedDevices: migration complete for this device (${updateResult.data.size} devices_v2 returned)" }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoUpdater.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoUpdater.kt
@@ -20,6 +20,9 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel
+import com.duckduckgo.sync.impl.pixels.toDeviceInfoWriteFailureReason
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -40,7 +43,16 @@ interface DeviceInfoUpdater {
      *
      * @return the server's device list as it stands after the update
      */
-    suspend fun setThisDeviceName(name: String): Result<List<DeviceV2>>
+    suspend fun setThisDeviceName(
+        name: String,
+        source: DeviceInfoUpdateSource? = null,
+    ): Result<List<DeviceV2>>
+}
+
+enum class DeviceInfoUpdateSource {
+    FIRST_WRITE,
+    UPDATE,
+    REPAIR,
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -54,12 +66,13 @@ class RealDeviceInfoUpdater @Inject constructor(
     private val accountInfoKeyManager: AccountInfoKeyManager,
     private val syncFeature: SyncFeature,
     private val dispatchers: DispatcherProvider,
+    private val syncPixels: SyncPixels,
 ) : DeviceInfoUpdater {
 
     private val mutex = Mutex()
 
-    override suspend fun setThisDeviceName(name: String): Result<List<DeviceV2>> = withContext(dispatchers.io()) {
-        mutex.withLock { setName(name) }
+    override suspend fun setThisDeviceName(name: String, source: DeviceInfoUpdateSource?): Result<List<DeviceV2>> = withContext(dispatchers.io()) {
+        mutex.withLock { setName(name, source) }
     }
 
     /**
@@ -68,7 +81,7 @@ class RealDeviceInfoUpdater @Inject constructor(
      * @param name The new device name
      * @return the server's device list as it stands after the update
      */
-    private suspend fun setName(name: String): Result<List<DeviceV2>> {
+    private suspend fun setName(name: String, source: DeviceInfoUpdateSource?): Result<List<DeviceV2>> {
         val includeDeviceInfo = syncFeature.canWriteDeviceInfo()
 
         val token = syncStore.token.takeUnless { it.isNullOrEmpty() }
@@ -82,7 +95,12 @@ class RealDeviceInfoUpdater @Inject constructor(
             }
             when (val result = deviceInfoEncryptor.encrypt(name, type)) {
                 is Success -> result.data
-                is Error -> return result
+                is Error -> {
+                    source?.let {
+                        fireWriteFailure(it, UnifiedDeviceListPixel.DeviceInfoWriteFailureReason.ENCRYPT_FAILED)
+                    }
+                    return result
+                }
             }
         } else {
             null
@@ -103,10 +121,25 @@ class RealDeviceInfoUpdater @Inject constructor(
         ) {
             is Success -> {
                 syncStore.deviceName = name
+                if (includeDeviceInfo && source != null) {
+                    syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.writeSuccess(source))
+                }
                 Success(result.data.devicesV2)
             }
-            is Error -> result
+            is Error -> {
+                if (includeDeviceInfo && source != null) {
+                    fireWriteFailure(source, result.toDeviceInfoWriteFailureReason())
+                }
+                result
+            }
         }
+    }
+
+    private fun fireWriteFailure(
+        source: DeviceInfoUpdateSource,
+        reason: UnifiedDeviceListPixel.DeviceInfoWriteFailureReason,
+    ) {
+        syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.writeFailed(source, reason))
     }
 
     /**

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/LoginDeviceInfoWriter.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/LoginDeviceInfoWriter.kt
@@ -21,6 +21,9 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.crypto.SyncLib
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel
+import com.duckduckgo.sync.impl.pixels.toAccountInfoKeyWrapFailureReason
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.withContext
@@ -49,6 +52,7 @@ class RealLoginDeviceInfoWriter @Inject constructor(
     private val nativeLib: SyncLib,
     private val deviceInfoMigrator: DeviceInfoMigrator,
     private val dispatchers: DispatcherProvider,
+    private val syncPixels: SyncPixels,
 ) : LoginDeviceInfoWriter {
 
     /**
@@ -58,7 +62,7 @@ class RealLoginDeviceInfoWriter @Inject constructor(
      *  No-op when the write feature flag is off.
      */
     override suspend fun onLogin(loginResponseKeys: List<ProtectedKeyEntry>?): Result<Unit> = withContext(dispatchers.io()) {
-        if (!syncFeature.canWriteUnifiedDeviceList().isEnabled()) return@withContext Success(Unit)
+        if (!syncFeature.canWriteDeviceInfo()) return@withContext Success(Unit)
         addDdgWrapIfThirdPartyOnly(loginResponseKeys)
         deviceInfoMigrator.ensureMigrated()
     }
@@ -100,6 +104,11 @@ class RealLoginDeviceInfoWriter @Inject constructor(
             is Success -> result.data
             is Error -> {
                 logcat(ERROR) { "Sync-UnifiedDevices: failed to build ddg wrap for account_info: ${result.reason}" }
+                syncPixels.fireUnifiedDeviceListPixel(
+                    UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(
+                        UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.UNWRAP_FAILED,
+                    ),
+                )
                 return
             }
         }
@@ -107,8 +116,30 @@ class RealLoginDeviceInfoWriter @Inject constructor(
         // Add the missing ddg wrap via set-if-absent, reusing the existing key's kid.
         // Best-effort; any failure just leaves this device's reads degraded until the key converges; it never blocks the device_info write below.
         when (val result = syncApi.setKeysIfAbsent(token, SYNC_PURPOSE_ACCOUNT_INFO, listOf(ddgEntry))) {
-            is Success -> logcat { "Sync-UnifiedDevices: added ddg wrap for account_info (kid=${threeParty.kid}); set-if-absent → ${result.data}" }
-            is Error -> logcat(ERROR) { "Sync-UnifiedDevices: set-if-absent of ddg account_info wrap failed: ${result.reason}" }
+            is Success -> when (result.data) {
+                SetKeysIfAbsentResult.Created -> {
+                    logcat { "Sync-UnifiedDevices: added ddg wrap for account_info (kid=${threeParty.kid})" }
+                    syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyWrapSuccess)
+                }
+                // 200: this encrypted_with was already stored; this device did not add a wrap
+                is SetKeysIfAbsentResult.Existing -> {
+                    logcat { "Sync-UnifiedDevices: ddg account_info wrap already present (kid=${threeParty.kid})" }
+                }
+                SetKeysIfAbsentResult.ExistsFetchRequired -> {
+                    logcat(ERROR) { "Sync-UnifiedDevices: server rejected the ddg account_info wrap" }
+                    syncPixels.fireUnifiedDeviceListPixel(
+                        UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(
+                            UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.REQUEST_FAILED,
+                        ),
+                    )
+                }
+            }
+            is Error -> {
+                logcat(ERROR) { "Sync-UnifiedDevices: set-if-absent of ddg account_info wrap failed: ${result.reason}" }
+                syncPixels.fireUnifiedDeviceListPixel(
+                    UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(result.toAccountInfoKeyWrapFailureReason()),
+                )
+            }
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SignupAccountInfoBuilder.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SignupAccountInfoBuilder.kt
@@ -20,6 +20,11 @@ import androidx.annotation.WorkerThread
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel.AccountInfoKeyCreateFailed
+import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel.AccountInfoKeyCreateFailureReason
+import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel.DeviceInfoWriteFailureReason
+import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel.OwnRowDeviceInfoFirstWriteFailed
 import com.duckduckgo.sync.store.AccountInfoPublicKey
 import com.squareup.anvil.annotations.ContributesBinding
 import logcat.LogPriority.ERROR
@@ -53,6 +58,7 @@ class RealSignupAccountInfoBuilder @Inject constructor(
     private val syncFeature: SyncFeature,
     private val accountInfoKeyManager: AccountInfoKeyManager,
     private val deviceInfoEncryptor: DeviceInfoEncryptor,
+    private val syncPixels: SyncPixels,
 ) : SignupAccountInfoBuilder {
 
     override fun build(accountSecretKey: String, deviceName: String, deviceType: String): SignupAccountInfo? {
@@ -62,6 +68,9 @@ class RealSignupAccountInfoBuilder @Inject constructor(
             is Success -> result.data
             is Error -> {
                 logcat(ERROR) { "Sync-UnifiedDevices: signup account_info mint failed, signing up without it: ${result.reason}" }
+                syncPixels.fireUnifiedDeviceListPixel(
+                    AccountInfoKeyCreateFailed(AccountInfoKeyCreateFailureReason.MINT_FAILED),
+                )
                 return null
             }
         }
@@ -75,6 +84,9 @@ class RealSignupAccountInfoBuilder @Inject constructor(
             is Success -> result.data
             is Error -> {
                 logcat(ERROR) { "Sync-UnifiedDevices: signup device_info encryption failed, signing up without it: ${result.reason}" }
+                syncPixels.fireUnifiedDeviceListPixel(
+                    OwnRowDeviceInfoFirstWriteFailed(DeviceInfoWriteFailureReason.ENCRYPT_FAILED),
+                )
                 return null
             }
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -426,7 +426,12 @@ class AppSyncAccountRepository @Inject constructor(
         val canPatchDevice = withDeviceInfo || syncFeature.canUsePatchEndpointForLegacyDeviceRename().isEnabled()
         logcat { "Sync-UnifiedDevices: rename via ${if (canPatchDevice) "PATCH" else "login"}, withDeviceInfo=$withDeviceInfo" }
         if (canPatchDevice) {
-            return@withContext when (val result = deviceInfoUpdater.setThisDeviceName(device.deviceName)) {
+            return@withContext when (
+                val result = deviceInfoUpdater.setThisDeviceName(
+                    name = device.deviceName,
+                    source = DeviceInfoUpdateSource.UPDATE,
+                )
+            ) {
                 is Success -> Success(true)
                 is Error -> result.alsoFireUpdateDeviceErrorPixel()
             }
@@ -986,13 +991,48 @@ class AppSyncAccountRepository @Inject constructor(
             val devices = if (entriesV2 != null) {
                 val decryptResult = thirdPartyDeviceListDecryptor.decryptAll(entriesV2, syncStore.deviceId)
                 logoutFailedV2Devices(decryptResult.undecryptable)
-                if (decryptResult.thisDeviceInfoUnresolved) republishThisDeviceInfo()
+                fireUnifiedDeviceListReadPixels(decryptResult)
+                if (decryptResult.thisDeviceInfoNeedsRepair) republishThisDeviceInfo()
                 decryptResult.decrypted.map { it.toConnectedDevice() }
             } else {
                 // entries_v2 missing
                 decryptLegacyEntries(result.data.entries, primaryKey)
             }
             finishWith(devices)
+        }
+    }
+
+    private fun fireUnifiedDeviceListReadPixels(result: DecryptAllResult) {
+        if (!syncFeature.canReadUnifiedDeviceList().isEnabled()) return
+
+        result.keyUnavailableReason?.let {
+            syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyUnavailable(it))
+            return
+        }
+
+        when (val outcome = result.ownDeviceReadOutcome) {
+            OwnDeviceReadOutcome.ResolvedDeviceInfo ->
+                syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.OwnRowResolvedDeviceInfo)
+            is OwnDeviceReadOutcome.ResolvedLegacy -> fireOwnRowFallbackIfWritable(
+                UnifiedDeviceListPixel.OwnRowResolvedLegacy(outcome.reason),
+            )
+            is OwnDeviceReadOutcome.ResolvedPlaceholder -> fireOwnRowFallbackIfWritable(
+                UnifiedDeviceListPixel.OwnRowResolvedPlaceholder(outcome.reason),
+            )
+            null -> {}
+        }
+
+        result.otherRowFailedDecryptionCredentials.forEach {
+            syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.OtherRowDeviceInfoFailedDecryption(it))
+        }
+        result.otherRowPlaceholderCredentials.forEach {
+            syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.OtherRowResolvedPlaceholder(it))
+        }
+    }
+
+    private fun fireOwnRowFallbackIfWritable(event: UnifiedDeviceListPixel) {
+        if (syncFeature.canWriteUnifiedDeviceList().isEnabled()) {
+            syncPixels.fireUnifiedDeviceListPixel(event)
         }
     }
 
@@ -1012,7 +1052,12 @@ class AppSyncAccountRepository @Inject constructor(
 
         appCoroutineScope.launch(dispatcherProvider.io()) {
             logcat { "Sync-UnifiedDevices: this device's device_info did not resolve on read; re-publishing it" }
-            when (val result = deviceInfoUpdater.setThisDeviceName(syncDeviceIds.deviceName())) {
+            when (
+                val result = deviceInfoUpdater.setThisDeviceName(
+                    name = syncDeviceIds.deviceName(),
+                    source = DeviceInfoUpdateSource.REPAIR,
+                )
+            ) {
                 is Success -> logcat { "Sync-UnifiedDevices: device_info re-published" }
                 is Error -> {
                     logcat(WARN) { "Sync-UnifiedDevices: device_info re-publish failed: ${result.reason}" }
@@ -1195,6 +1240,11 @@ class AppSyncAccountRepository @Inject constructor(
 
         return when (result) {
             is Error -> {
+                if (unifiedDeviceInfo != null) {
+                    syncPixels.fireUnifiedDeviceListPixel(
+                        UnifiedDeviceListPixel.AccountInfoKeyCreateFailed(result.toAccountInfoKeyCreateFailureReason()),
+                    )
+                }
                 result
             }
 
@@ -1205,6 +1255,8 @@ class AppSyncAccountRepository @Inject constructor(
                     syncStore.credentialId = CREDENTIAL_ID_DDG
                 }
                 unifiedDeviceInfo?.let {
+                    syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyCreateSuccess)
+                    syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.OwnRowDeviceInfoFirstWriteSuccess)
                     // cache the pubkey and mark migration done
                     syncStore.accountInfoPublicKey = it.publicKey
                     syncStore.unifiedDeviceListMigratedForUserId = account.userId

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptor.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.sync.impl
 
 import androidx.annotation.WorkerThread
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
 import logcat.LogPriority
 import logcat.LogPriority.WARN
@@ -47,15 +48,33 @@ interface ThirdPartyDeviceListDecryptor {
     }
 }
 
-/**
- * @param thisDeviceInfoUnresolved this device's own row was in the batch but did not resolve via `device_info` — either the server holds no blob
- *   for us or the one it holds can't be decrypted. Only ever set when the read flag is on, since with it off no blob is read at all.
- */
 data class DecryptAllResult(
     val decrypted: List<DecryptedDevice>,
     val undecryptable: List<String>,
-    val thisDeviceInfoUnresolved: Boolean = false,
+    val thisDeviceInfoNeedsRepair: Boolean = false,
+    val keyUnavailableReason: AccountInfoKeyUnavailableReason? = null,
+    val ownDeviceReadOutcome: OwnDeviceReadOutcome? = null,
+    val otherRowFailedDecryptionCredentials: Set<DeviceCredential> = emptySet(),
+    val otherRowPlaceholderCredentials: Set<DeviceCredential> = emptySet(),
 )
+
+sealed interface OwnDeviceReadOutcome {
+    data object ResolvedDeviceInfo : OwnDeviceReadOutcome
+    data class ResolvedLegacy(val reason: DeviceInfoReadFailureReason) : OwnDeviceReadOutcome
+    data class ResolvedPlaceholder(val reason: DeviceInfoReadFailureReason) : OwnDeviceReadOutcome
+}
+
+enum class DeviceInfoReadFailureReason {
+    NOT_PUBLISHED_YET,
+    BLOB_ABSENT,
+    BLOB_DECRYPT_FAILED,
+}
+
+enum class DeviceCredential {
+    DDG,
+    THIRD_PARTY,
+    NONE,
+}
 
 @ContributesBinding(AppScope::class)
 class RealThirdPartyDeviceListDecryptor @Inject constructor(
@@ -63,45 +82,107 @@ class RealThirdPartyDeviceListDecryptor @Inject constructor(
     private val thirdPartyCredentialManager: ThirdPartyCredentialManager,
     private val deviceInfoDecryptor: DeviceInfoDecryptor,
     private val syncFeature: SyncFeature,
+    private val syncStore: SyncStore,
 ) : ThirdPartyDeviceListDecryptor {
 
     override fun decryptAll(entries: List<DeviceV2>, thisDeviceId: String?): DecryptAllResult {
         if (entries.isEmpty()) return DecryptAllResult(emptyList(), emptyList())
 
         val readEnabled = syncFeature.canReadUnifiedDeviceList().isEnabled()
+        // Opening the session even when all blobs are absent distinguishes a missing blob from a key that could not be obtained.
+        val sessionOutcome = if (readEnabled) deviceInfoDecryptor.openSession() else null
+        val session = (sessionOutcome as? DeviceInfoSessionResult.Available)?.session
 
-        val viaDeviceInfo = mutableListOf<DecryptedDevice>()
-        val legacyEntries = mutableListOf<DeviceV2>()
-
-        // a single session can decrypt every device's blob since device_info is encrypted using account-wide account_info key
-        // only open one if the read flag is on and some entry actually carries device_info to decrypt
-        val session = if (readEnabled && entries.any { !it.deviceInfo.isNullOrEmpty() }) openDeviceInfoSession() else null
-
-        entries.forEach { entry ->
-            val resolved = session?.let { decryptDeviceInfo(entry, it) }
-            if (resolved != null) {
-                viaDeviceInfo += resolved
-            } else {
-                // entries it can't resolve (e.g. feature flag off, or undecryptable device_info) fall through to the legacy path
-                legacyEntries += entry
-            }
-        }
-
-        // read flag on ⇒ never auto-logout; undecryptable entries become "Unknown device" placeholders instead
-        val legacy = decryptLegacy(legacyEntries, neverAutoLogout = readEnabled)
+        val viaDeviceInfo = resolveViaDeviceInfo(entries, session)
+        val legacy = decryptLegacy(viaDeviceInfo.unresolved, neverAutoLogout = readEnabled)
 
         logcat(LogPriority.VERBOSE) {
-            "Sync-UnifiedDevices: ${entries.size} devices → ${viaDeviceInfo.size} via device_info, " +
+            "Sync-UnifiedDevices: ${entries.size} devices → ${viaDeviceInfo.resolved.size} via device_info, " +
                 "${legacy.viaLegacy.size} via legacy, ${legacy.fallbacks.size} placeholder, ${legacy.undecryptable.size} undecryptable"
         }
+
+        val ownDeviceReadOutcome = session?.let {
+            ownDeviceReadOutcome(entries, thisDeviceId, viaDeviceInfo.resolved, legacy, viaDeviceInfo.failedDecryptIds)
+        }
+        val credentialsById = otherRowCredentialsById(entries, excludingDeviceId = thisDeviceId)
+
         return DecryptAllResult(
-            decrypted = viaDeviceInfo + legacy.viaLegacy + legacy.fallbacks,
+            decrypted = viaDeviceInfo.resolved + legacy.viaLegacy + legacy.fallbacks,
             undecryptable = legacy.undecryptable,
-            thisDeviceInfoUnresolved = readEnabled &&
-                thisDeviceId != null &&
-                entries.any { it.deviceId == thisDeviceId } &&
-                viaDeviceInfo.none { it.deviceId == thisDeviceId },
+            thisDeviceInfoNeedsRepair = ownDeviceReadOutcome.needsRepair(),
+            keyUnavailableReason = (sessionOutcome as? DeviceInfoSessionResult.Unavailable)?.reason,
+            ownDeviceReadOutcome = ownDeviceReadOutcome,
+            otherRowFailedDecryptionCredentials = viaDeviceInfo.failedDecryptIds.mapNotNull(credentialsById::get).toSet(),
+            otherRowPlaceholderCredentials = legacy.fallbacks.mapNotNull { credentialsById[it.deviceId] }.toSet(),
         )
+    }
+
+    /**
+     * Tries `device_info` for every entry. [unresolved] is everything that must fall through to the legacy path
+     * (no session, blob absent, or blob present but undecryptable). [failedDecryptIds] is only the last of those.
+     */
+    private fun resolveViaDeviceInfo(
+        entries: List<DeviceV2>,
+        session: DeviceInfoDecryptor.Session?,
+    ): DeviceInfoDecryptResult {
+        if (session == null) {
+            return DeviceInfoDecryptResult(resolved = emptyList(), unresolved = entries, failedDecryptIds = emptySet())
+        }
+
+        val resolved = mutableListOf<DecryptedDevice>()
+        val unresolved = mutableListOf<DeviceV2>()
+        val failedDecryptIds = mutableSetOf<String>()
+        entries.forEach { entry ->
+            val device = decryptDeviceInfo(entry, session)
+            if (device != null) {
+                resolved += device
+            } else {
+                if (!entry.deviceInfo.isNullOrEmpty()) {
+                    entry.deviceId?.let(failedDecryptIds::add)
+                }
+                unresolved += entry
+            }
+        }
+        return DeviceInfoDecryptResult(resolved, unresolved, failedDecryptIds)
+    }
+
+    private fun otherRowCredentialsById(
+        entries: List<DeviceV2>,
+        excludingDeviceId: String?,
+    ): Map<String, DeviceCredential> = entries.mapNotNull { entry ->
+        if (entry.deviceId == excludingDeviceId) return@mapNotNull null
+        val id = entry.deviceId ?: return@mapNotNull null
+        val credential = entry.credentialId.toDeviceCredentialOrNull() ?: return@mapNotNull null
+        id to credential
+    }.toMap()
+
+    private fun OwnDeviceReadOutcome?.needsRepair(): Boolean = when (this) {
+        is OwnDeviceReadOutcome.ResolvedLegacy -> reason != DeviceInfoReadFailureReason.NOT_PUBLISHED_YET
+        is OwnDeviceReadOutcome.ResolvedPlaceholder -> reason != DeviceInfoReadFailureReason.NOT_PUBLISHED_YET
+        OwnDeviceReadOutcome.ResolvedDeviceInfo, null -> false
+    }
+
+    private fun ownDeviceReadOutcome(
+        entries: List<DeviceV2>,
+        thisDeviceId: String?,
+        viaDeviceInfo: List<DecryptedDevice>,
+        legacy: LegacyDecryptResult,
+        failedDeviceInfoIds: Set<String>,
+    ): OwnDeviceReadOutcome? {
+        val ownDeviceId = thisDeviceId ?: return null
+        val ownEntry = entries.firstOrNull { it.deviceId == ownDeviceId } ?: return null
+        if (viaDeviceInfo.any { it.deviceId == ownDeviceId }) return OwnDeviceReadOutcome.ResolvedDeviceInfo
+
+        val reason = when {
+            ownEntry.deviceId in failedDeviceInfoIds -> DeviceInfoReadFailureReason.BLOB_DECRYPT_FAILED
+            syncStore.unifiedDeviceListMigratedForUserId == syncStore.userId -> DeviceInfoReadFailureReason.BLOB_ABSENT
+            else -> DeviceInfoReadFailureReason.NOT_PUBLISHED_YET
+        }
+        return if (legacy.viaLegacy.any { it.deviceId == ownDeviceId }) {
+            OwnDeviceReadOutcome.ResolvedLegacy(reason)
+        } else {
+            OwnDeviceReadOutcome.ResolvedPlaceholder(reason)
+        }
     }
 
     private fun decryptDeviceInfo(
@@ -174,15 +255,6 @@ class RealThirdPartyDeviceListDecryptor @Inject constructor(
     private fun List<Pair<DeviceV2, Result<DecryptedDevice>>>.anyThirdPartyFailure(): Boolean =
         any { (entry, result) -> result is Result.Error && entry.credentialId == CREDENTIAL_ID_3PARTY }
 
-    private fun openDeviceInfoSession(): DeviceInfoDecryptor.Session? =
-        when (val result = deviceInfoDecryptor.openSession()) {
-            is Result.Success -> result.data
-            is Result.Error -> {
-                logcat(WARN) { "Sync-UnifiedDevices: device_info session unavailable (code=${result.code}), using legacy: ${result.reason}" }
-                null
-            }
-        }
-
     /**
      * Decides what to do with a device we couldn't decrypt.
      *
@@ -221,6 +293,12 @@ class RealThirdPartyDeviceListDecryptor @Inject constructor(
             type = if (credentialId == CREDENTIAL_ID_3PARTY) ThirdPartyDeviceListDecryptor.FALLBACK_TYPE_3PARTY else null,
         )
 
+    private data class DeviceInfoDecryptResult(
+        val resolved: List<DecryptedDevice>,
+        val unresolved: List<DeviceV2>,
+        val failedDecryptIds: Set<String>,
+    )
+
     /**
      * Outcome of the legacy per-credential pass, split so the caller can report and merge each bucket.
      * [viaLegacy] decrypted successfully; [fallbacks] rendered as an "Unknown device" placeholder; [undecryptable] marked for logout.
@@ -230,6 +308,13 @@ class RealThirdPartyDeviceListDecryptor @Inject constructor(
         val fallbacks: List<DecryptedDevice>,
         val undecryptable: List<String>,
     )
+
+    private fun String?.toDeviceCredentialOrNull(): DeviceCredential? = when (this) {
+        CREDENTIAL_ID_DDG -> DeviceCredential.DDG
+        CREDENTIAL_ID_3PARTY -> DeviceCredential.THIRD_PARTY
+        null -> DeviceCredential.NONE
+        else -> null
+    }
 
     private sealed interface FailureOutcome {
         /** Render an "Unknown device" placeholder row. */

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -247,6 +247,8 @@ interface SyncPixels {
     fun fireAiChatActive()
     fun fireAiChatsRescopeTokenError(error: Error)
 
+    fun fireUnifiedDeviceListPixel(event: UnifiedDeviceListPixel)
+
     fun fireAutoRestoreSetupToggleShown()
     fun fireAutoRestoreSetupToggleOptedOut()
     fun fireAutoRestoreSettingsReadyShown(source: String)
@@ -922,6 +924,19 @@ class RealSyncPixels @Inject constructor(
         )
     }
 
+    override fun fireUnifiedDeviceListPixel(event: UnifiedDeviceListPixel) {
+        val parameter = event.parameter
+        pixel.fire(
+            event.pixelName,
+            parameters = parameter?.let { mapOf(it.first to it.second) }.orEmpty(),
+            type = if (event.isDaily) {
+                Pixel.PixelType.Daily(tag = event.tag)
+            } else {
+                Pixel.PixelType.Count
+            },
+        )
+    }
+
     companion object {
         private const val SYNC_PIXELS_PREF_FILE = "com.duckduckgo.sync.pixels.v1"
         private const val FLOW_VERSION_V1 = "v1"
@@ -1012,6 +1027,25 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_SETUP_ANOTHER_DEVICE_PROMPT_SHOWN("m_settings_sync_another_device_prompt_shown"),
     SYNC_SETUP_ANOTHER_DEVICE_PROMPT_OPTION_TAPPED("m_settings_sync_another_device_prompt_option_tapped"),
     SYNC_AI_CHAT_ACTIVE("sync_ai_chat_active"),
+
+    SYNC_UNIFIED_DEVICES_OWN_ROW_RESOLVED_DEVICE_INFO("sync_unified_devices_own_row_resolved_device_info"),
+    SYNC_UNIFIED_DEVICES_OWN_ROW_RESOLVED_LEGACY("sync_unified_devices_own_row_resolved_legacy"),
+    SYNC_UNIFIED_DEVICES_OWN_ROW_RESOLVED_PLACEHOLDER("sync_unified_devices_own_row_resolved_placeholder"),
+    SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_UNAVAILABLE("sync_unified_devices_account_info_key_unavailable"),
+    SYNC_UNIFIED_DEVICES_OTHER_ROW_DEVICE_INFO_FAILED_DECRYPTION("sync_unified_devices_other_row_device_info_failed_decryption"),
+    SYNC_UNIFIED_DEVICES_OTHER_ROW_RESOLVED_PLACEHOLDER("sync_unified_devices_other_row_resolved_placeholder"),
+    SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_CREATE_SUCCESS("sync_unified_devices_account_info_key_create_success"),
+    SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_CREATE_FAILED("sync_unified_devices_account_info_key_create_failed"),
+    SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_WRAP_SUCCESS("sync_unified_devices_account_info_key_wrap_success"),
+    SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_WRAP_FAILED("sync_unified_devices_account_info_key_wrap_failed"),
+    SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_ADOPT_SUCCESS("sync_unified_devices_account_info_key_adopt_success"),
+    SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_ADOPT_FAILED("sync_unified_devices_account_info_key_adopt_failed"),
+    SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_FIRST_WRITE_SUCCESS("sync_unified_devices_own_row_device_info_first_write_success"),
+    SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_FIRST_WRITE_FAILED("sync_unified_devices_own_row_device_info_first_write_failed"),
+    SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_UPDATE_SUCCESS("sync_unified_devices_own_row_device_info_update_success"),
+    SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_UPDATE_FAILED("sync_unified_devices_own_row_device_info_update_failed"),
+    SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_REPAIR_SUCCESS("sync_unified_devices_own_row_device_info_repair_success"),
+    SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_REPAIR_FAILED("sync_unified_devices_own_row_device_info_repair_failed"),
 
     SYNC_AUTO_RESTORE_TOGGLE_SHOWN("sync-auto-restore_toggle_shown"),
     SYNC_AUTO_RESTORE_TOGGLE_OPTED_OUT("sync-auto-restore_toggle_opted_out"),

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/UnifiedDeviceListPixel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/UnifiedDeviceListPixel.kt
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.pixels
+
+import com.duckduckgo.sync.impl.API_CODE
+import com.duckduckgo.sync.impl.AccountInfoKeyUnavailableReason
+import com.duckduckgo.sync.impl.DeviceCredential
+import com.duckduckgo.sync.impl.DeviceInfoReadFailureReason
+import com.duckduckgo.sync.impl.DeviceInfoUpdateSource
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_ADOPT_FAILED
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_ADOPT_SUCCESS
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_CREATE_FAILED
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_CREATE_SUCCESS
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_UNAVAILABLE
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_WRAP_FAILED
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_WRAP_SUCCESS
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_OTHER_ROW_DEVICE_INFO_FAILED_DECRYPTION
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_OTHER_ROW_RESOLVED_PLACEHOLDER
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_FIRST_WRITE_FAILED
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_FIRST_WRITE_SUCCESS
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_REPAIR_FAILED
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_REPAIR_SUCCESS
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_UPDATE_FAILED
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_UPDATE_SUCCESS
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_OWN_ROW_RESOLVED_DEVICE_INFO
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_OWN_ROW_RESOLVED_LEGACY
+import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_UNIFIED_DEVICES_OWN_ROW_RESOLVED_PLACEHOLDER
+
+sealed class UnifiedDeviceListPixel(
+    val pixelName: SyncPixelName,
+    val isDaily: Boolean = true,
+    val parameter: Pair<String, String>? = null,
+    val tag: String? = null,
+) {
+    data object OwnRowResolvedDeviceInfo : UnifiedDeviceListPixel(
+        SYNC_UNIFIED_DEVICES_OWN_ROW_RESOLVED_DEVICE_INFO,
+    )
+
+    data class OwnRowResolvedLegacy(val reason: DeviceInfoReadFailureReason) : UnifiedDeviceListPixel(
+        pixelName = SYNC_UNIFIED_DEVICES_OWN_ROW_RESOLVED_LEGACY,
+        parameter = REASON to reason.toPixelValue(),
+        tag = dailyTag(SYNC_UNIFIED_DEVICES_OWN_ROW_RESOLVED_LEGACY, REASON, reason.toPixelValue()),
+    )
+
+    data class OwnRowResolvedPlaceholder(val reason: DeviceInfoReadFailureReason) : UnifiedDeviceListPixel(
+        pixelName = SYNC_UNIFIED_DEVICES_OWN_ROW_RESOLVED_PLACEHOLDER,
+        parameter = REASON to reason.toPixelValue(),
+        tag = dailyTag(SYNC_UNIFIED_DEVICES_OWN_ROW_RESOLVED_PLACEHOLDER, REASON, reason.toPixelValue()),
+    )
+
+    data class AccountInfoKeyUnavailable(val reason: AccountInfoKeyUnavailableReason) : UnifiedDeviceListPixel(
+        pixelName = SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_UNAVAILABLE,
+        parameter = REASON to reason.toPixelValue(),
+        tag = dailyTag(SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_UNAVAILABLE, REASON, reason.toPixelValue()),
+    )
+
+    data class OtherRowDeviceInfoFailedDecryption(val credential: DeviceCredential) : UnifiedDeviceListPixel(
+        pixelName = SYNC_UNIFIED_DEVICES_OTHER_ROW_DEVICE_INFO_FAILED_DECRYPTION,
+        parameter = CREDENTIAL to credential.toPixelValue(),
+        tag = dailyTag(SYNC_UNIFIED_DEVICES_OTHER_ROW_DEVICE_INFO_FAILED_DECRYPTION, CREDENTIAL, credential.toPixelValue()),
+    )
+
+    data class OtherRowResolvedPlaceholder(val credential: DeviceCredential) : UnifiedDeviceListPixel(
+        pixelName = SYNC_UNIFIED_DEVICES_OTHER_ROW_RESOLVED_PLACEHOLDER,
+        parameter = CREDENTIAL to credential.toPixelValue(),
+        tag = dailyTag(SYNC_UNIFIED_DEVICES_OTHER_ROW_RESOLVED_PLACEHOLDER, CREDENTIAL, credential.toPixelValue()),
+    )
+
+    data object AccountInfoKeyCreateSuccess : UnifiedDeviceListPixel(
+        SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_CREATE_SUCCESS,
+        isDaily = false,
+    )
+
+    data class AccountInfoKeyCreateFailed(val reason: AccountInfoKeyCreateFailureReason) : UnifiedDeviceListPixel(
+        pixelName = SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_CREATE_FAILED,
+        parameter = REASON to reason.toPixelValue(),
+        tag = dailyTag(SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_CREATE_FAILED, REASON, reason.toPixelValue()),
+    )
+
+    data object AccountInfoKeyWrapSuccess : UnifiedDeviceListPixel(
+        SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_WRAP_SUCCESS,
+        isDaily = false,
+    )
+
+    data class AccountInfoKeyWrapFailed(val reason: AccountInfoKeyWrapFailureReason) : UnifiedDeviceListPixel(
+        pixelName = SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_WRAP_FAILED,
+        parameter = REASON to reason.toPixelValue(),
+        tag = dailyTag(SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_WRAP_FAILED, REASON, reason.toPixelValue()),
+    )
+
+    data object AccountInfoKeyAdoptSuccess : UnifiedDeviceListPixel(
+        SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_ADOPT_SUCCESS,
+        isDaily = false,
+    )
+
+    data class AccountInfoKeyAdoptFailed(val reason: AccountInfoKeyAdoptFailureReason) : UnifiedDeviceListPixel(
+        pixelName = SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_ADOPT_FAILED,
+        parameter = REASON to reason.toPixelValue(),
+        tag = dailyTag(SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_ADOPT_FAILED, REASON, reason.toPixelValue()),
+    )
+
+    data object OwnRowDeviceInfoFirstWriteSuccess : UnifiedDeviceListPixel(
+        SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_FIRST_WRITE_SUCCESS,
+        isDaily = false,
+    )
+
+    data class OwnRowDeviceInfoFirstWriteFailed(val reason: DeviceInfoWriteFailureReason) : UnifiedDeviceListPixel(
+        pixelName = SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_FIRST_WRITE_FAILED,
+        parameter = REASON to reason.toPixelValue(),
+        tag = dailyTag(SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_FIRST_WRITE_FAILED, REASON, reason.toPixelValue()),
+    )
+
+    data object OwnRowDeviceInfoUpdateSuccess : UnifiedDeviceListPixel(
+        SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_UPDATE_SUCCESS,
+        isDaily = false,
+    )
+
+    data class OwnRowDeviceInfoUpdateFailed(val reason: DeviceInfoWriteFailureReason) : UnifiedDeviceListPixel(
+        pixelName = SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_UPDATE_FAILED,
+        parameter = REASON to reason.toPixelValue(),
+        tag = dailyTag(SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_UPDATE_FAILED, REASON, reason.toPixelValue()),
+    )
+
+    data object OwnRowDeviceInfoRepairSuccess : UnifiedDeviceListPixel(
+        SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_REPAIR_SUCCESS,
+        isDaily = false,
+    )
+
+    data class OwnRowDeviceInfoRepairFailed(val reason: DeviceInfoWriteFailureReason) : UnifiedDeviceListPixel(
+        pixelName = SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_REPAIR_FAILED,
+        parameter = REASON to reason.toPixelValue(),
+        tag = dailyTag(SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_REPAIR_FAILED, REASON, reason.toPixelValue()),
+    )
+
+    enum class AccountInfoKeyCreateFailureReason {
+        MINT_FAILED,
+        REQUEST_FAILED,
+        RATE_LIMITED,
+    }
+
+    enum class AccountInfoKeyWrapFailureReason {
+        UNWRAP_FAILED,
+        REQUEST_FAILED,
+        RATE_LIMITED,
+    }
+
+    enum class AccountInfoKeyAdoptFailureReason {
+        KEYS_FETCH_FAILED,
+        RATE_LIMITED,
+    }
+
+    enum class DeviceInfoWriteFailureReason {
+        ENCRYPT_FAILED,
+        REQUEST_FAILED,
+        RATE_LIMITED,
+    }
+
+    companion object {
+        fun writeSuccess(source: DeviceInfoUpdateSource): UnifiedDeviceListPixel = when (source) {
+            DeviceInfoUpdateSource.FIRST_WRITE -> OwnRowDeviceInfoFirstWriteSuccess
+            DeviceInfoUpdateSource.UPDATE -> OwnRowDeviceInfoUpdateSuccess
+            DeviceInfoUpdateSource.REPAIR -> OwnRowDeviceInfoRepairSuccess
+        }
+
+        fun writeFailed(
+            source: DeviceInfoUpdateSource,
+            reason: DeviceInfoWriteFailureReason,
+        ): UnifiedDeviceListPixel = when (source) {
+            DeviceInfoUpdateSource.FIRST_WRITE -> OwnRowDeviceInfoFirstWriteFailed(reason)
+            DeviceInfoUpdateSource.UPDATE -> OwnRowDeviceInfoUpdateFailed(reason)
+            DeviceInfoUpdateSource.REPAIR -> OwnRowDeviceInfoRepairFailed(reason)
+        }
+
+        private const val REASON = "reason"
+        private const val CREDENTIAL = "credential"
+
+        private fun dailyTag(
+            pixelName: SyncPixelName,
+            key: String,
+            value: String,
+        ): String = "${pixelName.pixelName}:$key:$value"
+    }
+}
+
+internal fun Error.toAccountInfoKeyCreateFailureReason(): UnifiedDeviceListPixel.AccountInfoKeyCreateFailureReason =
+    if (isHttpTooManyRequests()) {
+        UnifiedDeviceListPixel.AccountInfoKeyCreateFailureReason.RATE_LIMITED
+    } else {
+        UnifiedDeviceListPixel.AccountInfoKeyCreateFailureReason.REQUEST_FAILED
+    }
+
+internal fun Error.toAccountInfoKeyWrapFailureReason(): UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason =
+    if (isHttpTooManyRequests()) {
+        UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.RATE_LIMITED
+    } else {
+        UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.REQUEST_FAILED
+    }
+
+internal fun Error.toAccountInfoKeyAdoptFailureReason(): UnifiedDeviceListPixel.AccountInfoKeyAdoptFailureReason =
+    if (isHttpTooManyRequests()) {
+        UnifiedDeviceListPixel.AccountInfoKeyAdoptFailureReason.RATE_LIMITED
+    } else {
+        UnifiedDeviceListPixel.AccountInfoKeyAdoptFailureReason.KEYS_FETCH_FAILED
+    }
+
+internal fun Error.toDeviceInfoWriteFailureReason(): UnifiedDeviceListPixel.DeviceInfoWriteFailureReason =
+    if (isHttpTooManyRequests()) {
+        UnifiedDeviceListPixel.DeviceInfoWriteFailureReason.RATE_LIMITED
+    } else {
+        UnifiedDeviceListPixel.DeviceInfoWriteFailureReason.REQUEST_FAILED
+    }
+
+private fun Error.isHttpTooManyRequests(): Boolean = code == API_CODE.TOO_MANY_REQUESTS_1.code
+
+private fun DeviceInfoReadFailureReason.toPixelValue(): String = when (this) {
+    DeviceInfoReadFailureReason.NOT_PUBLISHED_YET -> "not_published_yet"
+    DeviceInfoReadFailureReason.BLOB_ABSENT -> "blob_absent"
+    DeviceInfoReadFailureReason.BLOB_DECRYPT_FAILED -> "blob_decrypt_failed"
+}
+
+private fun DeviceCredential.toPixelValue(): String = when (this) {
+    DeviceCredential.DDG -> "ddg"
+    DeviceCredential.THIRD_PARTY -> "3party"
+    DeviceCredential.NONE -> "none"
+}
+
+private fun AccountInfoKeyUnavailableReason.toPixelValue(): String = when (this) {
+    AccountInfoKeyUnavailableReason.NO_KEY_ON_SERVER -> "no_key_on_server"
+    AccountInfoKeyUnavailableReason.NO_WRAP_FOR_OUR_CREDENTIAL -> "no_wrap_for_our_credential"
+    AccountInfoKeyUnavailableReason.UNWRAP_FAILED -> "unwrap_failed"
+    AccountInfoKeyUnavailableReason.KEYS_FETCH_FAILED -> "keys_fetch_failed"
+    AccountInfoKeyUnavailableReason.RATE_LIMITED -> "rate_limited"
+}
+
+private fun UnifiedDeviceListPixel.AccountInfoKeyCreateFailureReason.toPixelValue(): String = when (this) {
+    UnifiedDeviceListPixel.AccountInfoKeyCreateFailureReason.MINT_FAILED -> "mint_failed"
+    UnifiedDeviceListPixel.AccountInfoKeyCreateFailureReason.REQUEST_FAILED -> "request_failed"
+    UnifiedDeviceListPixel.AccountInfoKeyCreateFailureReason.RATE_LIMITED -> "rate_limited"
+}
+
+private fun UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.toPixelValue(): String = when (this) {
+    UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.UNWRAP_FAILED -> "unwrap_failed"
+    UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.REQUEST_FAILED -> "request_failed"
+    UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.RATE_LIMITED -> "rate_limited"
+}
+
+private fun UnifiedDeviceListPixel.AccountInfoKeyAdoptFailureReason.toPixelValue(): String = when (this) {
+    UnifiedDeviceListPixel.AccountInfoKeyAdoptFailureReason.KEYS_FETCH_FAILED -> "keys_fetch_failed"
+    UnifiedDeviceListPixel.AccountInfoKeyAdoptFailureReason.RATE_LIMITED -> "rate_limited"
+}
+
+private fun UnifiedDeviceListPixel.DeviceInfoWriteFailureReason.toPixelValue(): String = when (this) {
+    UnifiedDeviceListPixel.DeviceInfoWriteFailureReason.ENCRYPT_FAILED -> "encrypt_failed"
+    UnifiedDeviceListPixel.DeviceInfoWriteFailureReason.REQUEST_FAILED -> "request_failed"
+    UnifiedDeviceListPixel.DeviceInfoWriteFailureReason.RATE_LIMITED -> "rate_limited"
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoKeyManagerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoKeyManagerTest.kt
@@ -27,6 +27,8 @@ import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.crypto.RsaKeyPair
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel
 import com.duckduckgo.sync.store.AccountInfoPublicKey
 import com.duckduckgo.sync.store.ScopedPassword
 import com.duckduckgo.sync.store.SyncStore
@@ -55,6 +57,7 @@ class AccountInfoKeyManagerTest {
     private val syncJweCrypto: SyncJweCrypto = mock()
     private val nativeLib: SyncLib = mock()
     private val thirdPartyCredentialManager: ThirdPartyCredentialManager = mock()
+    private val syncPixels: SyncPixels = mock()
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
@@ -71,6 +74,7 @@ class AccountInfoKeyManagerTest {
             thirdPartyKeyWrapper = RealThirdPartyKeyWrapper(syncJweCrypto),
             thirdPartyCredentialManager = thirdPartyCredentialManager,
             dispatchers = coroutineTestRule.testDispatcherProvider,
+            syncPixels = syncPixels,
         )
         configureForSuccessfulKeypairMint()
     }
@@ -127,6 +131,7 @@ class AccountInfoKeyManagerTest {
         val result = manager.ensureKeyRegistered() as Success
 
         assertEquals(RsaJwk(n = "modulus", e = "AQAB"), result.data.publicKey)
+        verify(syncPixels).fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyCreateSuccess)
         assertTrue(result.data.created)
         assertEquals(1, result.data.wrapsSent)
         verify(syncJweCrypto).generateRsaKeyPair(3072)
@@ -233,6 +238,7 @@ class AccountInfoKeyManagerTest {
         assertEquals("other-kid", result.data.kid)
         assertEquals(RsaJwk(n = "other-mod", e = "AQAB"), result.data.publicKey)
         assertTrue(!result.data.created)
+        verify(syncPixels).fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyAdoptSuccess)
         verify(syncStore).accountInfoPublicKey = AccountInfoPublicKey(keyId = "other-kid", modulus = "other-mod", exponent = "AQAB")
     }
 
@@ -259,6 +265,7 @@ class AccountInfoKeyManagerTest {
         assertEquals("server-kid", result.data.kid)
         assertEquals(RsaJwk(n = "server-mod", e = "AQAB"), result.data.publicKey)
         assertTrue(!result.data.created)
+        verify(syncPixels).fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyAdoptSuccess)
         verify(syncStore).accountInfoPublicKey = AccountInfoPublicKey(keyId = "server-kid", modulus = "server-mod", exponent = "AQAB")
     }
 
@@ -272,6 +279,9 @@ class AccountInfoKeyManagerTest {
         val result = manager.ensureKeyRegistered()
 
         assertTrue(result is Error)
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.AccountInfoKeyAdoptFailed(UnifiedDeviceListPixel.AccountInfoKeyAdoptFailureReason.KEYS_FETCH_FAILED),
+        )
     }
 
     @Test
@@ -281,6 +291,9 @@ class AccountInfoKeyManagerTest {
         val result = manager.ensureKeyRegistered()
 
         assertTrue(result is Error)
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.AccountInfoKeyCreateFailed(UnifiedDeviceListPixel.AccountInfoKeyCreateFailureReason.REQUEST_FAILED),
+        )
         verify(syncStore, org.mockito.kotlin.times(0)).accountInfoPublicKey = anyOrNull()
     }
 
@@ -291,6 +304,9 @@ class AccountInfoKeyManagerTest {
         val result = manager.ensureKeyRegistered()
 
         assertTrue(result is Error)
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.AccountInfoKeyCreateFailed(UnifiedDeviceListPixel.AccountInfoKeyCreateFailureReason.MINT_FAILED),
+        )
         verify(syncApi, never()).setKeysIfAbsent(anyString(), anyString(), any())
     }
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoPrivateKeyProviderTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoPrivateKeyProviderTest.kt
@@ -56,32 +56,66 @@ class AccountInfoPrivateKeyProviderTest {
         val result = provider.privateKey()
 
         // base64url of {0xFB, 0xF0, 0x00}, unpadded — "+" and "/" would appear in standard base64.
-        assertEquals(Result.Success("-_AA"), result)
+        assertEquals(AccountInfoPrivateKeyResult.Available("-_AA"), result)
     }
 
     @Test
     fun whenNotSignedInThenErrorWithoutFetching() {
         whenever(syncStore.token).thenReturn(null)
 
-        assertTrue(provider.privateKey() is Result.Error)
+        assertTrue(provider.privateKey() is AccountInfoPrivateKeyResult.Unavailable)
         verify(syncApi, never()).getProtectedKeys(any())
     }
 
     @Test
-    fun whenNoKeyWrappedForCurrentCredentialThenError() {
+    fun whenAccountInfoKeyExistsForAnotherCredentialThenTypedOutcomeIsNoWrapForOurCredential() {
         stubSignedIn()
         whenever(syncApi.getProtectedKeys(token)).thenReturn(Result.Success(listOf(ddgKey.copy(encryptedWith = "3party"))))
 
-        assertTrue(provider.privateKey() is Result.Error)
+        val result = provider.privateKey()
+
+        assertEquals(
+            AccountInfoPrivateKeyResult.Unavailable(AccountInfoKeyUnavailableReason.NO_WRAP_FOR_OUR_CREDENTIAL),
+            result,
+        )
     }
 
     @Test
-    fun whenUnwrapFailsThenError() {
+    fun whenNoAccountInfoKeyExistsThenTypedOutcomeIsNoKeyOnServer() {
+        stubSignedIn()
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Result.Success(emptyList()))
+
+        val result = provider.privateKey()
+
+        assertEquals(
+            AccountInfoPrivateKeyResult.Unavailable(AccountInfoKeyUnavailableReason.NO_KEY_ON_SERVER),
+            result,
+        )
+    }
+
+    @Test
+    fun whenKeysFetchIsRateLimitedThenTypedOutcomeIsRateLimited() {
+        stubSignedIn()
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Result.Error(code = 429))
+
+        val result = provider.privateKey()
+
+        assertEquals(
+            AccountInfoPrivateKeyResult.Unavailable(AccountInfoKeyUnavailableReason.RATE_LIMITED),
+            result,
+        )
+    }
+
+    @Test
+    fun whenUnwrapFailsThenTypedOutcomeIsUnwrapFailed() {
         stubSignedIn()
         whenever(syncApi.getProtectedKeys(token)).thenReturn(Result.Success(listOf(ddgKey)))
         whenever(protectedKeyUnwrapper.unwrap(ddgKey)).thenReturn(Result.Error(reason = "no account secret key"))
 
-        assertTrue(provider.privateKey() is Result.Error)
+        assertEquals(
+            AccountInfoPrivateKeyResult.Unavailable(AccountInfoKeyUnavailableReason.UNWRAP_FAILED),
+            provider.privateKey(),
+        )
     }
 
     @Test
@@ -93,8 +127,8 @@ class AccountInfoPrivateKeyProviderTest {
         val first = provider.privateKey()
         val second = provider.privateKey()
 
-        assertEquals(Result.Success("-_AA"), first)
-        assertEquals(Result.Success("-_AA"), second)
+        assertEquals(AccountInfoPrivateKeyResult.Available("-_AA"), first)
+        assertEquals(AccountInfoPrivateKeyResult.Available("-_AA"), second)
         // the wrapped entry is cached (one network fetch), but we unwrap per call so the plaintext key is never cached
         verify(syncApi, times(1)).getProtectedKeys(token)
         verify(protectedKeyUnwrapper, times(2)).unwrap(ddgKey)
@@ -111,8 +145,8 @@ class AccountInfoPrivateKeyProviderTest {
         val first = provider.privateKey()
         val second = provider.privateKey()
 
-        assertTrue(first is Result.Error)
-        assertEquals(Result.Success("-_AA"), second)
+        assertTrue(first is AccountInfoPrivateKeyResult.Unavailable)
+        assertEquals(AccountInfoPrivateKeyResult.Available("-_AA"), second)
         verify(syncApi, times(2)).getProtectedKeys(token)
     }
 
@@ -125,7 +159,7 @@ class AccountInfoPrivateKeyProviderTest {
 
         whenever(syncStore.token).thenReturn(null)
 
-        assertTrue(provider.privateKey() is Result.Error)
+        assertTrue(provider.privateKey() is AccountInfoPrivateKeyResult.Unavailable)
     }
 
     private fun stubSignedIn() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -78,6 +78,7 @@ import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.impl.metrics.ConnectedDevicesObserver
 import com.duckduckgo.sync.impl.pixels.SyncAccountOperation
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel
 import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl
 import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrlWrapper
 import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
@@ -683,6 +684,7 @@ class AppSyncAccountRepositoryTest {
     @Test
     fun whenV2FlagOnAndEntriesV2PresentThenUsesV2Decryptor() {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(true))
         whenever(syncStore.token).thenReturn(token)
         whenever(syncStore.primaryKey).thenReturn(primaryKey)
         whenever(syncStore.deviceId).thenReturn(deviceId)
@@ -694,6 +696,7 @@ class AppSyncAccountRepositoryTest {
             DecryptAllResult(
                 decrypted = listOf(DecryptedDevice(deviceId = "d1", name = "Chrome/148", type = "Browser")),
                 undecryptable = emptyList(),
+                ownDeviceReadOutcome = OwnDeviceReadOutcome.ResolvedDeviceInfo,
             ),
         )
 
@@ -702,7 +705,111 @@ class AppSyncAccountRepositoryTest {
         assertEquals(1, result.data.size)
         assertEquals("Chrome/148", result.data[0].deviceName)
         verify(thirdPartyDeviceListDecryptor).decryptAll(listOf(v2Entry), deviceId)
+        verify(syncPixels).fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.OwnRowResolvedDeviceInfo)
         verify(syncApi, never()).logout(anyString(), anyString())
+    }
+
+    @Test
+    fun whenOwnRowFallsBackWithReadAndWriteEnabledThenLegacyPixelFires() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(true))
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.deviceId).thenReturn(deviceId)
+        val own = DeviceV2(deviceId = deviceId, credentialId = "ddg")
+        whenever(syncApi.getDevices(anyString())).thenReturn(Success(DeviceEntries(emptyList(), listOf(own))))
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(own), deviceId)).thenReturn(
+            DecryptAllResult(
+                decrypted = listOf(DecryptedDevice(deviceId, deviceName, "phone")),
+                undecryptable = emptyList(),
+                ownDeviceReadOutcome = OwnDeviceReadOutcome.ResolvedLegacy(DeviceInfoReadFailureReason.BLOB_ABSENT),
+            ),
+        )
+
+        syncRepo.getConnectedDevices()
+
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.OwnRowResolvedLegacy(DeviceInfoReadFailureReason.BLOB_ABSENT),
+        )
+    }
+
+    @Test
+    fun whenOwnRowFallsBackWithWriteDisabledThenLegacyPixelDoesNotFire() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(true))
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(false))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.deviceId).thenReturn(deviceId)
+        val own = DeviceV2(deviceId = deviceId, credentialId = "ddg")
+        whenever(syncApi.getDevices(anyString())).thenReturn(Success(DeviceEntries(emptyList(), listOf(own))))
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(own), deviceId)).thenReturn(
+            DecryptAllResult(
+                decrypted = listOf(DecryptedDevice(deviceId, deviceName, "phone")),
+                undecryptable = emptyList(),
+                ownDeviceReadOutcome = OwnDeviceReadOutcome.ResolvedLegacy(DeviceInfoReadFailureReason.BLOB_ABSENT),
+            ),
+        )
+
+        syncRepo.getConnectedDevices()
+
+        verify(syncPixels, never()).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.OwnRowResolvedLegacy(DeviceInfoReadFailureReason.BLOB_ABSENT),
+        )
+    }
+
+    @Test
+    fun whenKeyIsUnavailableThenOnlyKeyUnavailablePixelFires() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(true))
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.deviceId).thenReturn(deviceId)
+        val own = DeviceV2(deviceId = deviceId, credentialId = "ddg")
+        whenever(syncApi.getDevices(anyString())).thenReturn(Success(DeviceEntries(emptyList(), listOf(own))))
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(own), deviceId)).thenReturn(
+            DecryptAllResult(
+                decrypted = listOf(DecryptedDevice(deviceId, deviceName, "phone")),
+                undecryptable = emptyList(),
+                keyUnavailableReason = AccountInfoKeyUnavailableReason.RATE_LIMITED,
+            ),
+        )
+
+        syncRepo.getConnectedDevices()
+
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.AccountInfoKeyUnavailable(AccountInfoKeyUnavailableReason.RATE_LIMITED),
+        )
+    }
+
+    @Test
+    fun whenOtherRowDecryptFailsToPlaceholderThenBothPixelsFire() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.deviceId).thenReturn(deviceId)
+        val other = DeviceV2(deviceId = "other", credentialId = "3party")
+        whenever(syncApi.getDevices(anyString())).thenReturn(Success(DeviceEntries(emptyList(), listOf(other))))
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(other), deviceId)).thenReturn(
+            DecryptAllResult(
+                decrypted = listOf(DecryptedDevice("other", "Unknown device", "Browser")),
+                undecryptable = emptyList(),
+                otherRowFailedDecryptionCredentials = setOf(DeviceCredential.THIRD_PARTY),
+                otherRowPlaceholderCredentials = setOf(DeviceCredential.THIRD_PARTY),
+            ),
+        )
+
+        syncRepo.getConnectedDevices()
+
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.OtherRowDeviceInfoFailedDecryption(DeviceCredential.THIRD_PARTY),
+        )
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.OtherRowResolvedPlaceholder(DeviceCredential.THIRD_PARTY),
+        )
     }
 
     @Test
@@ -793,48 +900,50 @@ class AppSyncAccountRepositoryTest {
     fun whenThisDeviceInfoUnresolvedThenRepublishesItWithTheCurrentName() = runTest {
         givenThisDeviceInfoUnresolvedOnRead()
         syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
-        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Success(emptyList()))
+        whenever(deviceInfoUpdater.setThisDeviceName(name = any(), source = eq(DeviceInfoUpdateSource.REPAIR))).thenReturn(Success(emptyList()))
 
         syncRepo.getConnectedDevices()
 
-        verify(deviceInfoUpdater).setThisDeviceName(deviceName)
+        verify(deviceInfoUpdater).setThisDeviceName(name = deviceName, source = DeviceInfoUpdateSource.REPAIR)
     }
 
     @Test
     fun whenThisDeviceInfoUnresolvedOnEveryRenderThenRepublishesOnlyOncePerProcess() = runTest {
         givenThisDeviceInfoUnresolvedOnRead()
         syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
-        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Success(emptyList()))
+        whenever(deviceInfoUpdater.setThisDeviceName(name = any(), source = eq(DeviceInfoUpdateSource.REPAIR))).thenReturn(Success(emptyList()))
 
         syncRepo.getConnectedDevices()
         syncRepo.getConnectedDevices()
 
-        verify(deviceInfoUpdater, times(1)).setThisDeviceName(anyString())
+        verify(deviceInfoUpdater, times(1)).setThisDeviceName(name = anyString(), source = eq(DeviceInfoUpdateSource.REPAIR))
     }
 
     @Test
     fun whenRepublishFailsThenRetriesOnTheNextRender() = runTest {
         givenThisDeviceInfoUnresolvedOnRead()
         syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
-        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Error(reason = "no network"))
+        whenever(
+            deviceInfoUpdater.setThisDeviceName(name = any(), source = eq(DeviceInfoUpdateSource.REPAIR)),
+        ).thenReturn(Error(reason = "no network"))
 
         syncRepo.getConnectedDevices()
         syncRepo.getConnectedDevices()
 
-        verify(deviceInfoUpdater, times(2)).setThisDeviceName(anyString())
+        verify(deviceInfoUpdater, times(2)).setThisDeviceName(name = anyString(), source = eq(DeviceInfoUpdateSource.REPAIR))
     }
 
     @Test
     fun whenSignedIntoAnotherAccountInTheSameProcessThenRepublishesAgain() = runTest {
         givenThisDeviceInfoUnresolvedOnRead()
         syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
-        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Success(emptyList()))
+        whenever(deviceInfoUpdater.setThisDeviceName(name = any(), source = eq(DeviceInfoUpdateSource.REPAIR))).thenReturn(Success(emptyList()))
 
         syncRepo.getConnectedDevices()
         whenever(syncStore.userId).thenReturn("anotherUserId")
         syncRepo.getConnectedDevices()
 
-        verify(deviceInfoUpdater, times(2)).setThisDeviceName(anyString())
+        verify(deviceInfoUpdater, times(2)).setThisDeviceName(name = anyString(), source = eq(DeviceInfoUpdateSource.REPAIR))
     }
 
     @Test
@@ -884,7 +993,7 @@ class AppSyncAccountRepositoryTest {
             DecryptAllResult(
                 decrypted = listOf(DecryptedDevice(deviceId = deviceId, name = deviceName, type = "phone")),
                 undecryptable = emptyList(),
-                thisDeviceInfoUnresolved = unresolved,
+                thisDeviceInfoNeedsRepair = unresolved,
             ),
         )
     }
@@ -1075,12 +1184,12 @@ class AppSyncAccountRepositoryTest {
         givenAuthenticatedDevice()
         prepareForLoginSuccess()
         syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
-        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Success(emptyList()))
+        whenever(deviceInfoUpdater.setThisDeviceName(name = any(), source = eq(DeviceInfoUpdateSource.UPDATE))).thenReturn(Success(emptyList()))
 
         val result = syncRepo.renameDevice(connectedDevice.copy(deviceName = "New Name"))
 
         assertTrue(result is Success)
-        verify(deviceInfoUpdater).setThisDeviceName("New Name")
+        verify(deviceInfoUpdater).setThisDeviceName(name = "New Name", source = DeviceInfoUpdateSource.UPDATE)
         verify(syncApi, never()).login(anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull())
     }
 
@@ -1089,7 +1198,9 @@ class AppSyncAccountRepositoryTest {
         givenAuthenticatedDevice()
         prepareForLoginSuccess()
         syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
-        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Error(reason = "patch failed"))
+        whenever(
+            deviceInfoUpdater.setThisDeviceName(name = any(), source = eq(DeviceInfoUpdateSource.UPDATE)),
+        ).thenReturn(Error(reason = "patch failed"))
 
         val result = syncRepo.renameDevice(connectedDevice)
 
@@ -1117,12 +1228,12 @@ class AppSyncAccountRepositoryTest {
         givenAuthenticatedDevice()
         prepareForLoginSuccess()
         syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = false))
-        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Success(emptyList()))
+        whenever(deviceInfoUpdater.setThisDeviceName(name = any(), source = eq(DeviceInfoUpdateSource.UPDATE))).thenReturn(Success(emptyList()))
 
         val result = syncRepo.renameDevice(connectedDevice.copy(deviceName = "New Name"))
 
         assertTrue(result is Success)
-        verify(deviceInfoUpdater).setThisDeviceName("New Name")
+        verify(deviceInfoUpdater).setThisDeviceName(name = "New Name", source = DeviceInfoUpdateSource.UPDATE)
         verify(syncApi, never()).login(anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull())
     }
 
@@ -1131,7 +1242,9 @@ class AppSyncAccountRepositoryTest {
         givenAuthenticatedDevice()
         prepareForLoginSuccess()
         syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = false))
-        whenever(deviceInfoUpdater.setThisDeviceName(any())).thenReturn(Error(reason = "patch failed"))
+        whenever(
+            deviceInfoUpdater.setThisDeviceName(name = any(), source = eq(DeviceInfoUpdateSource.UPDATE)),
+        ).thenReturn(Error(reason = "patch failed"))
 
         val result = syncRepo.renameDevice(connectedDevice)
 
@@ -1492,6 +1605,32 @@ class AppSyncAccountRepositoryTest {
         )
         verify(syncStore).accountInfoPublicKey = publicKey
         verify(syncStore).unifiedDeviceListMigratedForUserId = userId
+        verify(syncPixels).fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyCreateSuccess)
+        verify(syncPixels).fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.OwnRowDeviceInfoFirstWriteSuccess)
+    }
+
+    @Test
+    fun whenSignupPostWithUnifiedDataFailsThenOnlyCreateFailedPixelFires() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        prepareToProvideDeviceIds()
+        prepareForCreateAccountSuccess()
+        whenever(signupAccountInfoBuilder.build(any(), any(), any())).thenReturn(
+            SignupAccountInfo(
+                deviceInfo = "deviceInfoJwe",
+                keys = listOf(unifiedAccountInfoEntry()),
+                publicKey = AccountInfoPublicKey(keyId = "kid-1", modulus = "n", exponent = "AQAB"),
+            ),
+        )
+        whenever(anyCreateAccountCall()).thenReturn(Error(code = 500))
+
+        syncRepo.createAccount()
+
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.AccountInfoKeyCreateFailed(UnifiedDeviceListPixel.AccountInfoKeyCreateFailureReason.REQUEST_FAILED),
+        )
+        verify(syncPixels, never()).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.OwnRowDeviceInfoFirstWriteFailed(UnifiedDeviceListPixel.DeviceInfoWriteFailureReason.REQUEST_FAILED),
+        )
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoDecryptorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoDecryptorTest.kt
@@ -39,7 +39,7 @@ class DeviceInfoDecryptorTest {
 
     @Test
     fun whenBlobDecryptsThenReturnNameAndType() {
-        whenever(accountInfoPrivateKeyProvider.privateKey()).thenReturn(Result.Success("private-key"))
+        givenPrivateKeyAvailable()
         whenever(syncJweCrypto.jweDecryptRsaOaep("device.info.jwe", "private-key"))
             .thenReturn("""{"name":"My Phone","type":"phone"}""".toByteArray(Charsets.UTF_8))
 
@@ -50,7 +50,7 @@ class DeviceInfoDecryptorTest {
 
     @Test
     fun whenTypeIsEmptyThenReturnNullType() {
-        whenever(accountInfoPrivateKeyProvider.privateKey()).thenReturn(Result.Success("private-key"))
+        givenPrivateKeyAvailable()
         whenever(syncJweCrypto.jweDecryptRsaOaep(any(), any()))
             .thenReturn("""{"name":"My Phone","type":""}""".toByteArray(Charsets.UTF_8))
 
@@ -60,16 +60,23 @@ class DeviceInfoDecryptorTest {
     }
 
     @Test
-    fun whenPrivateKeyUnavailableThenOpenSessionErrorsWithoutDecrypting() {
-        whenever(accountInfoPrivateKeyProvider.privateKey()).thenReturn(Result.Error(reason = "not signed in"))
+    fun whenPrivateKeyOutcomeIsUnavailableThenSessionPreservesTypedReasonWithoutDecrypting() {
+        whenever(accountInfoPrivateKeyProvider.privateKey()).thenReturn(
+            AccountInfoPrivateKeyResult.Unavailable(AccountInfoKeyUnavailableReason.NO_WRAP_FOR_OUR_CREDENTIAL),
+        )
 
-        assertTrue(decryptor.openSession() is Result.Error)
+        val result = decryptor.openSession()
+
+        assertEquals(
+            DeviceInfoSessionResult.Unavailable(AccountInfoKeyUnavailableReason.NO_WRAP_FOR_OUR_CREDENTIAL),
+            result,
+        )
         verify(syncJweCrypto, never()).jweDecryptRsaOaep(any(), any())
     }
 
     @Test
     fun whenBlobCannotBeDecryptedThenReturnError() {
-        whenever(accountInfoPrivateKeyProvider.privateKey()).thenReturn(Result.Success("private-key"))
+        givenPrivateKeyAvailable()
         whenever(syncJweCrypto.jweDecryptRsaOaep(eq("device.info.jwe"), any())).thenThrow(RuntimeException("bad tag"))
 
         assertTrue(openSessionAndDecrypt("device.info.jwe") is Result.Error)
@@ -77,7 +84,7 @@ class DeviceInfoDecryptorTest {
 
     @Test
     fun whenPayloadIsNotValidJsonThenReturnError() {
-        whenever(accountInfoPrivateKeyProvider.privateKey()).thenReturn(Result.Success("private-key"))
+        givenPrivateKeyAvailable()
         whenever(syncJweCrypto.jweDecryptRsaOaep(any(), any())).thenReturn("{ malformed".toByteArray(Charsets.UTF_8))
 
         assertTrue(openSessionAndDecrypt("device.info.jwe") is Result.Error)
@@ -85,11 +92,11 @@ class DeviceInfoDecryptorTest {
 
     @Test
     fun whenSessionDecryptsManyBlobsThenPrivateKeyFetchedOnce() {
-        whenever(accountInfoPrivateKeyProvider.privateKey()).thenReturn(Result.Success("private-key"))
+        givenPrivateKeyAvailable()
         whenever(syncJweCrypto.jweDecryptRsaOaep(any(), any()))
             .thenReturn("""{"name":"n","type":"phone"}""".toByteArray(Charsets.UTF_8))
 
-        val session = (decryptor.openSession() as Result.Success).data
+        val session = (decryptor.openSession() as DeviceInfoSessionResult.Available).session
         session.decrypt("a")
         session.decrypt("b")
         session.decrypt("c")
@@ -97,9 +104,14 @@ class DeviceInfoDecryptorTest {
         verify(accountInfoPrivateKeyProvider, times(1)).privateKey()
     }
 
+    private fun givenPrivateKeyAvailable() {
+        whenever(accountInfoPrivateKeyProvider.privateKey())
+            .thenReturn(AccountInfoPrivateKeyResult.Available("private-key"))
+    }
+
     private fun openSessionAndDecrypt(deviceInfoJwe: String): Result<DeviceInfoPayload> =
-        when (val session = decryptor.openSession()) {
-            is Result.Success -> session.data.decrypt(deviceInfoJwe)
-            is Result.Error -> session
+        when (val outcome = decryptor.openSession()) {
+            is DeviceInfoSessionResult.Available -> outcome.session.decrypt(deviceInfoJwe)
+            is DeviceInfoSessionResult.Unavailable -> Result.Error(reason = outcome.reason.name)
         }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoMigratorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoMigratorTest.kt
@@ -116,18 +116,19 @@ class DeviceInfoMigratorTest {
 
         assertTrue(result is Result.Success)
         verify(syncStore).unifiedDeviceListMigratedForUserId = userId
-        verify(deviceInfoUpdater, never()).setThisDeviceName(any())
+        verify(deviceInfoUpdater, never()).setThisDeviceName(name = any(), source = any())
     }
 
     @Test
     fun whenDeviceInfoWrittenThenMarkDone() = runTest {
         whenever(syncApi.getDevices(token)).thenReturn(Result.Success(deviceEntries(deviceInfo = null)))
-        whenever(deviceInfoUpdater.setThisDeviceName("deviceName")).thenReturn(Result.Success(emptyList()))
+        whenever(deviceInfoUpdater.setThisDeviceName(name = "deviceName", source = DeviceInfoUpdateSource.FIRST_WRITE))
+            .thenReturn(Result.Success(emptyList()))
 
         val result = migrator.ensureMigrated()
 
         assertTrue(result is Result.Success)
-        verify(deviceInfoUpdater).setThisDeviceName("deviceName")
+        verify(deviceInfoUpdater).setThisDeviceName(name = "deviceName", source = DeviceInfoUpdateSource.FIRST_WRITE)
         verify(syncStore).unifiedDeviceListMigratedForUserId = userId
     }
 
@@ -136,14 +137,15 @@ class DeviceInfoMigratorTest {
         whenever(syncApi.getDevices(token)).thenReturn(Result.Error(reason = "network"))
 
         assertTrue(migrator.ensureMigrated() is Result.Error)
-        verify(deviceInfoUpdater, never()).setThisDeviceName(any())
+        verify(deviceInfoUpdater, never()).setThisDeviceName(name = any(), source = any())
         verify(syncStore, never()).unifiedDeviceListMigratedForUserId = any()
     }
 
     @Test
     fun whenWriteFailsThenErrorAndNotMarked() = runTest {
         whenever(syncApi.getDevices(token)).thenReturn(Result.Success(deviceEntries(deviceInfo = null)))
-        whenever(deviceInfoUpdater.setThisDeviceName("deviceName")).thenReturn(Result.Error(reason = "patch failed"))
+        whenever(deviceInfoUpdater.setThisDeviceName(name = "deviceName", source = DeviceInfoUpdateSource.FIRST_WRITE))
+            .thenReturn(Result.Error(reason = "patch failed"))
 
         assertTrue(migrator.ensureMigrated() is Result.Error)
         verify(syncStore, never()).unifiedDeviceListMigratedForUserId = any()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoUpdaterTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoUpdaterTest.kt
@@ -22,6 +22,8 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.TestSyncFixtures.token
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel
 import com.duckduckgo.sync.store.AccountInfoPublicKey
 import com.duckduckgo.sync.store.SyncStore
 import kotlinx.coroutines.test.runTest
@@ -37,6 +39,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 @SuppressLint("DenyListedApi")
@@ -50,6 +53,7 @@ class DeviceInfoUpdaterTest {
     private val deviceFieldEncryptor: DeviceFieldEncryptor = mock()
     private val accountInfoKeyManager: AccountInfoKeyManager = mock()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val syncPixels: SyncPixels = mock()
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
@@ -71,6 +75,7 @@ class DeviceInfoUpdaterTest {
             accountInfoKeyManager = accountInfoKeyManager,
             syncFeature = syncFeature,
             dispatchers = coroutineTestRule.testDispatcherProvider,
+            syncPixels = syncPixels,
         )
         syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
         whenever(syncStore.token).thenReturn(token)
@@ -86,16 +91,26 @@ class DeviceInfoUpdaterTest {
         whenever(syncApi.patchThisDevice(token, "encName", "encType", "device.info.jwe"))
             .thenReturn(Result.Success(PatchDevicesResponse(devicesV2 = updatedDevices)))
 
-        val result = updater.setThisDeviceName("My Phone")
+        val result = updater.setThisDeviceName(name = "My Phone", source = DeviceInfoUpdateSource.UPDATE)
 
         assertEquals(Result.Success(updatedDevices), result)
+        verify(syncPixels).fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.OwnRowDeviceInfoUpdateSuccess)
+    }
+
+    @Test
+    fun whenNoProductionSourceIsProvidedThenNoUnifiedDevicePixelFires() = runTest {
+        givenEncryptionAndPatchSucceed()
+
+        updater.setThisDeviceName(name = "My Phone")
+
+        verifyNoInteractions(syncPixels)
     }
 
     @Test
     fun whenUpdateSucceedsThenStoreTheNewNameLocally() = runTest {
         givenEncryptionAndPatchSucceed()
 
-        updater.setThisDeviceName("My Phone")
+        updater.setThisDeviceName(name = "My Phone")
 
         verify(syncStore).deviceName = "My Phone"
     }
@@ -104,7 +119,7 @@ class DeviceInfoUpdaterTest {
     fun whenNotSignedInThenErrorWithoutEncrypting() = runTest {
         whenever(syncStore.token).thenReturn(null)
 
-        assertTrue(updater.setThisDeviceName("My Phone") is Result.Error)
+        assertTrue(updater.setThisDeviceName(name = "My Phone") is Result.Error)
         verify(deviceInfoEncryptor, never()).encrypt(any(), any())
     }
 
@@ -112,7 +127,7 @@ class DeviceInfoUpdaterTest {
     fun whenAccountInfoPublicKeyIsCachedThenNoKeyRegistration() = runTest {
         givenEncryptionAndPatchSucceed()
 
-        updater.setThisDeviceName("My Phone")
+        updater.setThisDeviceName(name = "My Phone")
 
         verify(accountInfoKeyManager, never()).ensureKeyRegistered()
     }
@@ -123,7 +138,7 @@ class DeviceInfoUpdaterTest {
         whenever(accountInfoKeyManager.ensureKeyRegistered()).thenReturn(Result.Success(keyRegistered))
         givenEncryptionAndPatchSucceed()
 
-        val result = updater.setThisDeviceName("My Phone")
+        val result = updater.setThisDeviceName(name = "My Phone")
 
         assertTrue(result is Result.Success)
         verify(accountInfoKeyManager).ensureKeyRegistered()
@@ -135,7 +150,7 @@ class DeviceInfoUpdaterTest {
         whenever(syncStore.accountInfoPublicKey).thenReturn(null)
         whenever(accountInfoKeyManager.ensureKeyRegistered()).thenReturn(Result.Error(reason = "no account secret key"))
 
-        assertTrue(updater.setThisDeviceName("My Phone") is Result.Error)
+        assertTrue(updater.setThisDeviceName(name = "My Phone") is Result.Error)
         verify(deviceInfoEncryptor, never()).encrypt(any(), any())
         verify(syncApi, never()).patchThisDevice(any(), any(), any(), any())
     }
@@ -144,8 +159,11 @@ class DeviceInfoUpdaterTest {
     fun whenDeviceInfoEncryptionFailsThenErrorWithoutPatching() = runTest {
         whenever(deviceInfoEncryptor.encrypt(any(), any())).thenReturn(Result.Error(reason = "no cached account_info key"))
 
-        assertTrue(updater.setThisDeviceName("My Phone") is Result.Error)
+        assertTrue(updater.setThisDeviceName(name = "My Phone", source = DeviceInfoUpdateSource.REPAIR) is Result.Error)
         verify(syncApi, never()).patchThisDevice(any(), any(), any(), any())
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.OwnRowDeviceInfoRepairFailed(UnifiedDeviceListPixel.DeviceInfoWriteFailureReason.ENCRYPT_FAILED),
+        )
     }
 
     @Test
@@ -153,7 +171,7 @@ class DeviceInfoUpdaterTest {
         whenever(deviceInfoEncryptor.encrypt(any(), any())).thenReturn(Result.Success("device.info.jwe"))
         whenever(deviceFieldEncryptor.encrypt(any(), any())).thenReturn(Result.Error(reason = "primaryKey missing"))
 
-        assertTrue(updater.setThisDeviceName("My Phone") is Result.Error)
+        assertTrue(updater.setThisDeviceName(name = "My Phone") is Result.Error)
         verify(syncApi, never()).patchThisDevice(any(), any(), any(), any())
     }
 
@@ -165,8 +183,22 @@ class DeviceInfoUpdaterTest {
         whenever(syncApi.patchThisDevice(any(), any(), any(), any()))
             .thenReturn(Result.Error(code = 500, reason = "unexpected status code"))
 
-        assertEquals(Result.Error(code = 500, reason = "unexpected status code"), updater.setThisDeviceName("My Phone"))
+        assertEquals(Result.Error(code = 500, reason = "unexpected status code"), updater.setThisDeviceName(name = "My Phone"))
         verify(syncStore, never()).deviceName = any()
+    }
+
+    @Test
+    fun whenFirstWritePatchIsRateLimitedThenFirstWriteRateLimitedPixelFires() = runTest {
+        whenever(deviceInfoEncryptor.encrypt(any(), any())).thenReturn(Result.Success("device.info.jwe"))
+        whenever(deviceFieldEncryptor.encrypt(any(), any()))
+            .thenReturn(Result.Success(EncryptedDeviceFields(name = "encName", type = "encType")))
+        whenever(syncApi.patchThisDevice(any(), any(), any(), any())).thenReturn(Result.Error(code = 429))
+
+        updater.setThisDeviceName(name = "My Phone", source = DeviceInfoUpdateSource.FIRST_WRITE)
+
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.OwnRowDeviceInfoFirstWriteFailed(UnifiedDeviceListPixel.DeviceInfoWriteFailureReason.RATE_LIMITED),
+        )
     }
 
     @Test
@@ -174,7 +206,7 @@ class DeviceInfoUpdaterTest {
         syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = false))
         givenEncryptionAndPatchSucceed()
 
-        val result = updater.setThisDeviceName("My Phone")
+        val result = updater.setThisDeviceName(name = "My Phone")
 
         assertTrue(result is Result.Success)
         verify(syncApi).patchThisDevice(token, "encName", "encType", null)
@@ -187,7 +219,7 @@ class DeviceInfoUpdaterTest {
         whenever(syncStore.accountInfoPublicKey).thenReturn(null)
         givenEncryptionAndPatchSucceed()
 
-        updater.setThisDeviceName("My Phone")
+        updater.setThisDeviceName(name = "My Phone")
 
         verify(accountInfoKeyManager, never()).ensureKeyRegistered()
         verify(deviceInfoEncryptor, never()).encrypt(any(), any())
@@ -201,7 +233,7 @@ class DeviceInfoUpdaterTest {
         whenever(syncApi.patchThisDevice(any(), any(), any(), anyOrNull()))
             .thenReturn(Result.Error(code = 500, reason = "unexpected status code"))
 
-        assertTrue(updater.setThisDeviceName("My Phone") is Result.Error)
+        assertTrue(updater.setThisDeviceName(name = "My Phone") is Result.Error)
         verify(syncStore, never()).deviceName = any()
     }
 
@@ -211,7 +243,7 @@ class DeviceInfoUpdaterTest {
         whenever(syncStore.accountInfoPublicKey).thenReturn(null)
         givenEncryptionAndPatchSucceed()
 
-        val result = updater.setThisDeviceName("My Phone")
+        val result = updater.setThisDeviceName(name = "My Phone")
 
         assertTrue(result is Result.Success)
         verify(syncApi).patchThisDevice(token, "encName", "encType", null)
@@ -222,7 +254,7 @@ class DeviceInfoUpdaterTest {
     fun whenWriteFeatureEnabledThenSendDeviceInfoAlongsideTheLegacyFields() = runTest {
         givenEncryptionAndPatchSucceed()
 
-        updater.setThisDeviceName("My Phone")
+        updater.setThisDeviceName(name = "My Phone")
 
         verify(syncApi).patchThisDevice(token, "encName", "encType", "device.info.jwe")
     }
@@ -232,7 +264,7 @@ class DeviceInfoUpdaterTest {
         whenever(syncDeviceIds.deviceType()).thenReturn(DeviceType("desktop"))
         givenEncryptionAndPatchSucceed()
 
-        updater.setThisDeviceName("My Laptop")
+        updater.setThisDeviceName(name = "My Laptop")
 
         verify(deviceInfoEncryptor).encrypt(eq("My Laptop"), eq("desktop"))
         verify(deviceFieldEncryptor).encrypt(eq("My Laptop"), eq("desktop"))

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/LoginDeviceInfoWriterTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/LoginDeviceInfoWriterTest.kt
@@ -24,6 +24,8 @@ import com.duckduckgo.sync.TestSyncFixtures.token
 import com.duckduckgo.sync.TestSyncFixtures.userId
 import com.duckduckgo.sync.crypto.EncryptBytesResult
 import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel
 import com.duckduckgo.sync.store.ScopedPassword
 import com.duckduckgo.sync.store.SyncStore
 import kotlinx.coroutines.runBlocking
@@ -39,6 +41,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
@@ -50,6 +53,7 @@ class LoginDeviceInfoWriterTest {
     private val nativeLib: SyncLib = mock()
     private val deviceInfoMigrator: DeviceInfoMigrator = mock()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val syncPixels: SyncPixels = mock()
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
@@ -68,7 +72,9 @@ class LoginDeviceInfoWriterTest {
             nativeLib = nativeLib,
             deviceInfoMigrator = deviceInfoMigrator,
             dispatchers = coroutineTestRule.testDispatcherProvider,
+            syncPixels = syncPixels,
         )
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(enable = true))
         syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
         whenever(syncStore.token).thenReturn(token)
         whenever(syncStore.secretKey).thenReturn(secretKey)
@@ -115,6 +121,7 @@ class LoginDeviceInfoWriterTest {
             },
         )
         verify(deviceInfoMigrator).ensureMigrated()
+        verify(syncPixels).fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyWrapSuccess)
     }
 
     @Test
@@ -136,6 +143,9 @@ class LoginDeviceInfoWriterTest {
 
         verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
         verify(deviceInfoMigrator).ensureMigrated()
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.UNWRAP_FAILED),
+        )
     }
 
     @Test
@@ -149,6 +159,41 @@ class LoginDeviceInfoWriterTest {
 
         assertTrue(result is Result.Success)
         verify(deviceInfoMigrator).ensureMigrated()
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.REQUEST_FAILED),
+        )
+    }
+
+    @Test
+    fun whenSetKeysIfAbsentReportsExistingThenNoWrapPixelFires() = runTest {
+        whenever(protectedKeyUnwrapper.unwrap(any())).thenReturn(Result.Success("rawKey".toByteArray()))
+        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey)))
+            .thenReturn(EncryptBytesResult(0, "ddgWrapped".toByteArray()))
+        whenever(syncApi.setKeysIfAbsent(any(), any(), any())).thenReturn(
+            Result.Success(SetKeysIfAbsentResult.Existing("kid-1", RsaJwk(n = "n", e = "AQAB"))),
+        )
+
+        writer.onLogin(loginResponseKeys = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
+
+        verifyNoInteractions(syncPixels)
+        verify(deviceInfoMigrator).ensureMigrated()
+    }
+
+    @Test
+    fun whenSetKeysIfAbsentReportsConflictThenWrapFailedPixelFires() = runTest {
+        whenever(protectedKeyUnwrapper.unwrap(any())).thenReturn(Result.Success("rawKey".toByteArray()))
+        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey)))
+            .thenReturn(EncryptBytesResult(0, "ddgWrapped".toByteArray()))
+        whenever(syncApi.setKeysIfAbsent(any(), any(), any())).thenReturn(
+            Result.Success(SetKeysIfAbsentResult.ExistsFetchRequired),
+        )
+
+        writer.onLogin(loginResponseKeys = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
+
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.REQUEST_FAILED),
+        )
+        verify(deviceInfoMigrator).ensureMigrated()
     }
 
     @Test
@@ -160,6 +205,17 @@ class LoginDeviceInfoWriterTest {
         assertTrue(result is Result.Success)
         verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
         verify(deviceInfoMigrator, never()).ensureMigrated()
+    }
+
+    @Test
+    fun whenV2ConnectFlowDisabledThenNothingRuns() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(enable = false))
+
+        writer.onLogin(listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
+
+        verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
+        verify(deviceInfoMigrator, never()).ensureMigrated()
+        verifyNoInteractions(syncPixels)
     }
 
     private fun accountInfoEntry(encryptedWith: String) = ProtectedKeyEntry(

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SignupAccountInfoBuilderTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SignupAccountInfoBuilderTest.kt
@@ -21,6 +21,8 @@ import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel
 import com.duckduckgo.sync.store.AccountInfoPublicKey
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -40,6 +42,7 @@ class SignupAccountInfoBuilderTest {
     private val accountInfoKeyManager: AccountInfoKeyManager = mock()
     private val deviceInfoEncryptor: DeviceInfoEncryptor = mock()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val syncPixels: SyncPixels = mock()
 
     private lateinit var builder: SignupAccountInfoBuilder
 
@@ -47,7 +50,7 @@ class SignupAccountInfoBuilderTest {
 
     @Before
     fun before() {
-        builder = RealSignupAccountInfoBuilder(syncFeature, accountInfoKeyManager, deviceInfoEncryptor)
+        builder = RealSignupAccountInfoBuilder(syncFeature, accountInfoKeyManager, deviceInfoEncryptor, syncPixels)
         syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
     }
 
@@ -65,6 +68,9 @@ class SignupAccountInfoBuilderTest {
 
         assertNull(builder.build(secretKey, "My Phone", "phone"))
         verify(deviceInfoEncryptor, never()).encrypt(any(), any(), any())
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.AccountInfoKeyCreateFailed(UnifiedDeviceListPixel.AccountInfoKeyCreateFailureReason.MINT_FAILED),
+        )
     }
 
     @Test
@@ -73,6 +79,9 @@ class SignupAccountInfoBuilderTest {
         whenever(deviceInfoEncryptor.encrypt(any(), any(), any())).thenReturn(Error(reason = "encrypt boom"))
 
         assertNull(builder.build(secretKey, "My Phone", "phone"))
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.OwnRowDeviceInfoFirstWriteFailed(UnifiedDeviceListPixel.DeviceInfoWriteFailureReason.ENCRYPT_FAILED),
+        )
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptorTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.ThirdPartyDeviceListDecryptor.Companion.FALLBACK_NAME
 import com.duckduckgo.sync.impl.ThirdPartyDeviceListDecryptor.Companion.FALLBACK_TYPE_3PARTY
+import com.duckduckgo.sync.store.SyncStore
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -45,18 +46,19 @@ class ThirdPartyDeviceListDecryptorTest {
     private val thirdPartyCredentialManager: ThirdPartyCredentialManager = mock()
     private val deviceInfoDecryptor: DeviceInfoDecryptor = mock()
     private val session: Session = mock()
+    private val syncStore: SyncStore = mock()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
 
     private lateinit var decryptor: ThirdPartyDeviceListDecryptor
 
     @Before
     fun before() {
-        decryptor = RealThirdPartyDeviceListDecryptor(fieldDecryptor, thirdPartyCredentialManager, deviceInfoDecryptor, syncFeature)
+        decryptor = RealThirdPartyDeviceListDecryptor(fieldDecryptor, thirdPartyCredentialManager, deviceInfoDecryptor, syncFeature, syncStore)
     }
 
     private fun enableReadFlag() {
         syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(enable = true))
-        whenever(deviceInfoDecryptor.openSession()).thenReturn(Success(session))
+        whenever(deviceInfoDecryptor.openSession()).thenReturn(DeviceInfoSessionResult.Available(session))
     }
 
     @Test
@@ -235,8 +237,8 @@ class ThirdPartyDeviceListDecryptorTest {
     }
 
     @Test
-    fun whenReadFlagOnButNoEntryHasDeviceInfoThenSessionNeverOpenedAndLegacyUsed() {
-        syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(enable = true))
+    fun whenReadFlagOnButNoEntryHasDeviceInfoThenSessionIsOpenedAndLegacyUsed() {
+        enableReadFlag()
         val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
         val tp = DeviceV2(deviceId = "d2", credentialId = "3party", deviceName = "ENC", deviceInfo = "")
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Pixel", "phone")))
@@ -245,7 +247,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val result = decryptor.decryptAll(listOf(ddg, tp), thisDeviceId = null)
 
         assertEquals(2, result.decrypted.size)
-        verify(deviceInfoDecryptor, never()).openSession()
+        verify(deviceInfoDecryptor).openSession()
     }
 
     @Test
@@ -309,7 +311,9 @@ class ThirdPartyDeviceListDecryptorTest {
     @Test
     fun whenReadFlagOnButSessionFailsToOpenThenWholeListDegradesToLegacy() {
         syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(enable = true))
-        whenever(deviceInfoDecryptor.openSession()).thenReturn(Error(reason = "no account_info key"))
+        whenever(deviceInfoDecryptor.openSession()).thenReturn(
+            DeviceInfoSessionResult.Unavailable(AccountInfoKeyUnavailableReason.NO_KEY_ON_SERVER),
+        )
         val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
 
@@ -370,12 +374,15 @@ class ThirdPartyDeviceListDecryptorTest {
 
         val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1")
 
-        assertFalse(result.thisDeviceInfoUnresolved)
+        assertFalse(result.thisDeviceInfoNeedsRepair)
+        assertEquals(OwnDeviceReadOutcome.ResolvedDeviceInfo, result.ownDeviceReadOutcome)
     }
 
     @Test
     fun whenOwnDeviceInfoIsAbsentThenReportedAsUnresolved() {
         enableReadFlag()
+        whenever(syncStore.userId).thenReturn("user")
+        whenever(syncStore.unifiedDeviceListMigratedForUserId).thenReturn(null)
         val own = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
         val other = DeviceV2(deviceId = "d2", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
         whenever(session.decrypt("info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Chrome", type = "Browser")))
@@ -383,7 +390,28 @@ class ThirdPartyDeviceListDecryptorTest {
 
         val result = decryptor.decryptAll(listOf(own, other), thisDeviceId = "d1")
 
-        assertTrue(result.thisDeviceInfoUnresolved)
+        assertFalse(result.thisDeviceInfoNeedsRepair)
+        assertEquals(
+            OwnDeviceReadOutcome.ResolvedLegacy(DeviceInfoReadFailureReason.NOT_PUBLISHED_YET),
+            result.ownDeviceReadOutcome,
+        )
+    }
+
+    @Test
+    fun whenOwnDeviceInfoIsAbsentAfterMigrationThenReportedAsBlobAbsent() {
+        enableReadFlag()
+        whenever(syncStore.userId).thenReturn("user")
+        whenever(syncStore.unifiedDeviceListMigratedForUserId).thenReturn("user")
+        val own = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
+        whenever(fieldDecryptor.decrypt(own)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
+
+        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1")
+
+        assertEquals(
+            OwnDeviceReadOutcome.ResolvedLegacy(DeviceInfoReadFailureReason.BLOB_ABSENT),
+            result.ownDeviceReadOutcome,
+        )
+        assertTrue(result.thisDeviceInfoNeedsRepair)
     }
 
     @Test
@@ -395,7 +423,52 @@ class ThirdPartyDeviceListDecryptorTest {
 
         val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1")
 
-        assertTrue(result.thisDeviceInfoUnresolved)
+        assertTrue(result.thisDeviceInfoNeedsRepair)
+        assertEquals(
+            OwnDeviceReadOutcome.ResolvedLegacy(DeviceInfoReadFailureReason.BLOB_DECRYPT_FAILED),
+            result.ownDeviceReadOutcome,
+        )
+    }
+
+    @Test
+    fun whenSessionCannotOpenThenTypedReasonIsReported() {
+        syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(enable = true))
+        whenever(deviceInfoDecryptor.openSession()).thenReturn(
+            DeviceInfoSessionResult.Unavailable(AccountInfoKeyUnavailableReason.NO_WRAP_FOR_OUR_CREDENTIAL),
+        )
+        val own = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
+        whenever(fieldDecryptor.decrypt(own)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
+
+        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1")
+
+        assertEquals(AccountInfoKeyUnavailableReason.NO_WRAP_FOR_OUR_CREDENTIAL, result.keyUnavailableReason)
+        assertEquals(null, result.ownDeviceReadOutcome)
+    }
+
+    @Test
+    fun whenOtherDeviceInfoAndLegacyFailThenBothDecryptionAndPlaceholderCredentialsAreReported() {
+        enableReadFlag()
+        val other = DeviceV2(deviceId = "d2", credentialId = "3party", deviceName = "ENC", deviceInfo = "corrupt.jwe")
+        whenever(session.decrypt("corrupt.jwe")).thenReturn(Error(reason = "bad device_info"))
+        whenever(fieldDecryptor.decrypt(other)).thenReturn(Error(reason = "bad legacy"))
+
+        val result = decryptor.decryptAll(listOf(other), thisDeviceId = "d1")
+
+        assertEquals(setOf(DeviceCredential.THIRD_PARTY), result.otherRowFailedDecryptionCredentials)
+        assertEquals(setOf(DeviceCredential.THIRD_PARTY), result.otherRowPlaceholderCredentials)
+    }
+
+    @Test
+    fun whenOtherRowOmitsCredentialThenNoneIsReportedForBothFailurePixels() {
+        enableReadFlag()
+        val other = DeviceV2(deviceId = "d2", credentialId = null, deviceName = "ENC", deviceInfo = "corrupt.jwe")
+        whenever(session.decrypt("corrupt.jwe")).thenReturn(Error(reason = "bad device_info"))
+        whenever(fieldDecryptor.decrypt(other)).thenReturn(Error(reason = "bad legacy"))
+
+        val result = decryptor.decryptAll(listOf(other), thisDeviceId = "d1")
+
+        assertEquals(setOf(DeviceCredential.NONE), result.otherRowFailedDecryptionCredentials)
+        assertEquals(setOf(DeviceCredential.NONE), result.otherRowPlaceholderCredentials)
     }
 
     @Test
@@ -408,7 +481,7 @@ class ThirdPartyDeviceListDecryptorTest {
 
         val result = decryptor.decryptAll(listOf(own, other), thisDeviceId = "d1")
 
-        assertFalse(result.thisDeviceInfoUnresolved)
+        assertFalse(result.thisDeviceInfoNeedsRepair)
     }
 
     @Test
@@ -419,7 +492,18 @@ class ThirdPartyDeviceListDecryptorTest {
 
         val result = decryptor.decryptAll(listOf(other), thisDeviceId = "d1")
 
-        assertFalse(result.thisDeviceInfoUnresolved)
+        assertFalse(result.thisDeviceInfoNeedsRepair)
+    }
+
+    @Test
+    fun whenThisDeviceIdIsUnknownThenOrphanRowIsNotTreatedAsOwn() {
+        enableReadFlag()
+        val orphan = DeviceV2(deviceId = null, credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
+        whenever(fieldDecryptor.decrypt(orphan)).thenReturn(Error(reason = "missing device id"))
+
+        val result = decryptor.decryptAll(listOf(orphan), thisDeviceId = null)
+
+        assertEquals(null, result.ownDeviceReadOutcome)
     }
 
     @Test
@@ -430,7 +514,7 @@ class ThirdPartyDeviceListDecryptorTest {
 
         val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1")
 
-        assertFalse(result.thisDeviceInfoUnresolved)
+        assertFalse(result.thisDeviceInfoNeedsRepair)
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
@@ -25,6 +25,9 @@ import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.api.engine.SyncableType
 import com.duckduckgo.sync.impl.API_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes
+import com.duckduckgo.sync.impl.AccountInfoKeyUnavailableReason
+import com.duckduckgo.sync.impl.DeviceCredential
+import com.duckduckgo.sync.impl.DeviceInfoReadFailureReason
 import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.SyncCodeType
@@ -1129,6 +1132,106 @@ class RealSyncPixelsTest {
                 SyncPixelParameters.SYNC_SETUP_UI_VERSION to ui.value,
                 SyncPixelParameters.OPTION to option.value,
             ),
+        )
+    }
+
+    @Test
+    fun `when unified device read succeeds then daily pixel is fired`() {
+        testee.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.OwnRowResolvedDeviceInfo)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_UNIFIED_DEVICES_OWN_ROW_RESOLVED_DEVICE_INFO,
+            emptyMap(),
+            emptyMap(),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun `when unified device read falls back then each reason keeps its wire value and own daily latch`(
+        @TestParameter reason: DeviceInfoReadFailureReason,
+    ) {
+        val wireValue = when (reason) {
+            DeviceInfoReadFailureReason.NOT_PUBLISHED_YET -> "not_published_yet"
+            DeviceInfoReadFailureReason.BLOB_ABSENT -> "blob_absent"
+            DeviceInfoReadFailureReason.BLOB_DECRYPT_FAILED -> "blob_decrypt_failed"
+        }
+
+        testee.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.OwnRowResolvedLegacy(reason))
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_UNIFIED_DEVICES_OWN_ROW_RESOLVED_LEGACY,
+            mapOf("reason" to wireValue),
+            emptyMap(),
+            type = Pixel.PixelType.Daily("sync_unified_devices_own_row_resolved_legacy:reason:$wireValue"),
+        )
+    }
+
+    @Test
+    fun `when unified device other row fails then each credential keeps its wire value and own daily latch`(
+        @TestParameter credential: DeviceCredential,
+    ) {
+        val wireValue = when (credential) {
+            DeviceCredential.DDG -> "ddg"
+            DeviceCredential.THIRD_PARTY -> "3party"
+            DeviceCredential.NONE -> "none"
+        }
+
+        testee.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.OtherRowDeviceInfoFailedDecryption(credential))
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_UNIFIED_DEVICES_OTHER_ROW_DEVICE_INFO_FAILED_DECRYPTION,
+            mapOf("credential" to wireValue),
+            emptyMap(),
+            type = Pixel.PixelType.Daily("sync_unified_devices_other_row_device_info_failed_decryption:credential:$wireValue"),
+        )
+    }
+
+    @Test
+    fun `when account info key is unavailable then each reason keeps its wire value and own daily latch`(
+        @TestParameter reason: AccountInfoKeyUnavailableReason,
+    ) {
+        val wireValue = when (reason) {
+            AccountInfoKeyUnavailableReason.NO_KEY_ON_SERVER -> "no_key_on_server"
+            AccountInfoKeyUnavailableReason.NO_WRAP_FOR_OUR_CREDENTIAL -> "no_wrap_for_our_credential"
+            AccountInfoKeyUnavailableReason.UNWRAP_FAILED -> "unwrap_failed"
+            AccountInfoKeyUnavailableReason.KEYS_FETCH_FAILED -> "keys_fetch_failed"
+            AccountInfoKeyUnavailableReason.RATE_LIMITED -> "rate_limited"
+        }
+
+        testee.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyUnavailable(reason))
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_UNIFIED_DEVICES_ACCOUNT_INFO_KEY_UNAVAILABLE,
+            mapOf("reason" to wireValue),
+            emptyMap(),
+            type = Pixel.PixelType.Daily("sync_unified_devices_account_info_key_unavailable:reason:$wireValue"),
+        )
+    }
+
+    @Test
+    fun `when unified device write succeeds then count pixel is fired`() {
+        testee.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.OwnRowDeviceInfoUpdateSuccess)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_UPDATE_SUCCESS,
+            emptyMap(),
+            emptyMap(),
+            type = Pixel.PixelType.Count,
+        )
+    }
+
+    @Test
+    fun `when unified device write fails then reason gets its own daily latch`() {
+        testee.fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.OwnRowDeviceInfoRepairFailed(UnifiedDeviceListPixel.DeviceInfoWriteFailureReason.RATE_LIMITED),
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_UNIFIED_DEVICES_OWN_ROW_DEVICE_INFO_REPAIR_FAILED,
+            mapOf("reason" to "rate_limited"),
+            emptyMap(),
+            type = Pixel.PixelType.Daily("sync_unified_devices_own_row_device_info_repair_failed:reason:rate_limited"),
         )
     }
 

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.sync.impl.ConnectedDevice
 import com.duckduckgo.sync.impl.DeviceFieldDecryptor
 import com.duckduckgo.sync.impl.DeviceInfoDecryptor
 import com.duckduckgo.sync.impl.DeviceInfoMigrator
+import com.duckduckgo.sync.impl.DeviceInfoSessionResult
 import com.duckduckgo.sync.impl.DeviceInfoUpdater
 import com.duckduckgo.sync.impl.DeviceV2
 import com.duckduckgo.sync.impl.Result
@@ -708,7 +709,7 @@ constructor(
 
     fun onRenameDeviceConfirmed(newName: String) {
         viewModelScope.launch(dispatchers.io()) {
-            when (val result = deviceInfoUpdater.setThisDeviceName(newName)) {
+            when (val result = deviceInfoUpdater.setThisDeviceName(name = newName)) {
                 is Success -> {
                     val text = "PATCH ok — ${result.data.size} devices_v2 returned; name set to \"$newName\""
                     logcat { "Sync-UnifiedDevices: $text" }
@@ -755,7 +756,7 @@ constructor(
         }
     }
 
-    private fun describeDeviceInfo(entry: DeviceV2, session: Result<DeviceInfoDecryptor.Session>): String {
+    private fun describeDeviceInfo(entry: DeviceV2, session: DeviceInfoSessionResult): String {
         val id = entry.deviceId ?: "(no id)"
         val marker = if (entry.deviceId != null && entry.deviceId == syncStore.deviceId) " (this device)" else ""
 
@@ -767,8 +768,8 @@ constructor(
         val info = entry.deviceInfo
         val deviceInfo = when {
             info.isNullOrEmpty() -> "(no device_info)"
-            session is Error -> "(cannot decrypt: ${session.reason})"
-            session is Success -> when (val result = session.data.decrypt(info)) {
+            session is DeviceInfoSessionResult.Unavailable -> "(cannot decrypt: ${session.reason})"
+            session is DeviceInfoSessionResult.Available -> when (val result = session.session.decrypt(info)) {
                 is Success -> "name=${result.data.name}, type=${result.data.type ?: "(none)"}"
                 is Error -> "(cannot decrypt: ${result.reason})"
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1216795439124280?focus=true
Tech Design URL (if applicable): [Pixel definitions / spec for unified sync list](https://app.asana.com/1/137249556945/task/1217680430827537?focus=true)
API Proposals URL(s) (if applicable):

### Description

Sync unified device list telemetry. Covers how we resolve our own row, wrap/adopt the account_info key, and write/repair `device_info`. Daily on the noisy read path; count for the one-shot write events.

### Steps to test this PR

> [!TIP]
> Filter logcat for `message~:"Pixel.*sync_unified_devices"  `.

**Flags off**
- [ ] Fresh install and open sync dev settings
- [ ] Ensure `canWriteUnifiedDeviceList` and `canReadUnifiedDeviceList` are both disabled
- [ ] Tap on `Launch Sync Settings V2` and `Sync This Device`
- [ ] Return to Sync & Backup screen (showing connected devices)
- [ ] Rename this device
- [ ] Verify no `sync_unified_devices` pixels fired at all, and device names show correctly

**Flags on**
- [ ] Fresh install and open sync dev settings
- [ ] Enable `canWriteUnifiedDeviceList` and `canReadUnifiedDeviceList`
- [ ] Tap on `Launch Sync Settings V2` and `Sync This Device`
- Verify in logs:
  - [ ] `account_info_key_create_success` 
  - [ ] and `own_row_device_info_first_write_success`
- [ ] Return to Sync & Backup screen (showing connected devices). Verify `own_row_resolved_device_info` (once a day)
- [ ] Rename this device. Verify `own_row_device_info_update_success`

### UI changes
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics and observability only; sync behavior changes are limited to richer failure typing and session open timing for reads, with feature flags still gating pixels and writes.
> 
> **Overview**
> Adds **sync_unified_devices** pixel definitions and wires telemetry through the unified device-list path: daily pixels for read outcomes (own-row resolution, `account_info` key availability, other-row decrypt/placeholder failures) and count pixels for one-shot writes (key create/wrap/adopt, first write, rename update, repair).
> 
> **Typed outcomes** replace generic `Result` errors in `AccountInfoPrivateKeyProvider` and `DeviceInfoDecryptor` so failures map to stable `reason`/`credential` parameters. `ThirdPartyDeviceListDecryptor` now opens a decrypt session whenever read is enabled (even without blobs), classifies own-row outcomes (`not_published_yet` vs `blob_absent` vs decrypt failure), and reports `thisDeviceInfoNeedsRepair` only when repair is warranted. `DeviceInfoUpdater.setThisDeviceName` accepts an optional `DeviceInfoUpdateSource` so migration, rename, and repair fire the correct write pixels; dev/internal rename calls omit `source` and do not emit write telemetry.
> 
> `LoginDeviceInfoWriter` gates on `canWriteDeviceInfo()` and emits wrap success/failure pixels. Signup and account creation fire create/first-write pixels on success; failed signup posts only the create-failed pixel when unified signup data was included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74f445780703e08951eb86d4f4aebb098594da9d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->