### PR TITLE
Move stacked PRs to Waiting for release when merged via the queue

### DIFF
--- a/.github/workflows/action-pr-merged.yaml
+++ b/.github/workflows/action-pr-merged.yaml
@@ -25,9 +25,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPARE: repos/${{ github.repository }}/compare/${{ github.event.repository.default_branch }}...${{ github.event.pull_request.merge_commit_sha }}
         run: |
-          status=$(gh api "$COMPARE" --jq .status)
+          on_default=false
+          status=""
+          for i in {1..5}; do
+            status=$(gh api "$COMPARE" --jq .status 2>/dev/null) && break
+            sleep 2
+          done
           case "$status" in identical|behind) on_default=true ;; *) on_default=false ;; esac
-          echo "compare status: $status -> on_default: $on_default"
+          echo "compare status: ${status:-<error>} -> on_default: $on_default"
           echo "on_default=$on_default" >> "$GITHUB_OUTPUT"
       - name: If merged to the default branch, add to Waiting for release
         if: steps.landed.outputs.on_default == 'true'

--- a/.github/workflows/action-pr-merged.yaml
+++ b/.github/workflows/action-pr-merged.yaml
@@ -25,10 +25,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPARE: repos/${{ github.repository }}/compare/${{ github.event.repository.default_branch }}...${{ github.event.pull_request.merge_commit_sha }}
         run: |
-          on_default=false
-          status=""
           for i in {1..5}; do
-            status=$(gh api "$COMPARE" --jq .status 2>/dev/null) && break
+            if status=$(gh api "$COMPARE" --jq .status); then break; fi
+            status=""
             sleep 2
           done
           case "$status" in identical|behind) on_default=true ;; *) on_default=false ;; esac

--- a/.github/workflows/action-pr-merged.yaml
+++ b/.github/workflows/action-pr-merged.yaml
@@ -25,7 +25,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPARE: repos/${{ github.repository }}/compare/${{ github.event.repository.default_branch }}...${{ github.event.pull_request.merge_commit_sha }}
         run: |
-          for i in {1..5}; do
+          for _ in {1..5}; do
             if status=$(gh api "$COMPARE" --jq .status); then break; fi
             status=""
             sleep 2

--- a/.github/workflows/action-pr-merged.yaml
+++ b/.github/workflows/action-pr-merged.yaml
@@ -16,8 +16,21 @@ jobs:
           trigger-phrase: "Task/Issue URL:"
           action: 'notify-pr-merged'
           is-complete: true
+      # A stacked PR keeps its parent's branch as base.ref even though the merge queue lands its
+      # commit on the default branch, so check where the commit actually ended up.
+      - name: Check whether the merge commit landed on the default branch
+        id: landed
+        if: github.event.pull_request.merged
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPARE: repos/${{ github.repository }}/compare/${{ github.event.repository.default_branch }}...${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          status=$(gh api "$COMPARE" --jq .status)
+          case "$status" in identical|behind) on_default=true ;; *) on_default=false ;; esac
+          echo "compare status: $status -> on_default: $on_default"
+          echo "on_default=$on_default" >> "$GITHUB_OUTPUT"
       - name: If merged to the default branch, add to Waiting for release
-        if: github.event.pull_request.merged && github.event.pull_request.base.ref == github.event.repository.default_branch
+        if: steps.landed.outputs.on_default == 'true'
         uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1217938832983570?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
* Stacked PRs merged through the merge queue land as individual merge commits on develop, but the `github.event.pull_request.merged && github.event.pull_request.base.ref == github.event.repository.default_branch` check fails. Check if the merge commit actually landed on the default branch instead 

### Steps to test this PR
n/a


### UI changes
n/a

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to merge-close automation; uses `GITHUB_TOKEN` for read-only compare API calls with no app or release logic changes.
> 
> **Overview**
> Fixes **Asana “Waiting for release”** automation for stacked PRs merged through the **merge queue**: those PRs still report a non-default `base.ref` (parent branch), so the old `base.ref == default_branch` gate never ran even when the merge commit was on `develop`.
> 
> Adds a step that compares **`default_branch...merge_commit_sha`** via the GitHub API (with retries), treats compare status **`identical`** or **`behind`** as landed on the default branch, and gates the existing Asana **add-task-asana-project** step on that output instead of `base.ref`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18f762af45509b26ef9881d8fe4ff53960efb8a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->