### PR TITLE
fix/cbarreiro/asana release board task move

### DIFF
--- a/.github/workflows/action-pr-merged.yaml
+++ b/.github/workflows/action-pr-merged.yaml
@@ -33,12 +33,23 @@ jobs:
           case "$status" in identical|behind) on_default=true ;; *) on_default=false ;; esac
           echo "compare status: ${status:-<error>} -> on_default: $on_default"
           echo "on_default=$on_default" >> "$GITHUB_OUTPUT"
-      - name: If merged to the default branch, add to Waiting for release
+      # Resolve the task id here rather than letting add-task-asana-project parse the body: given
+      # asana-project it also uses it to filter, so it drops any task not already on the board it
+      # is meant to add the task to.
+      - name: Find Asana task ID
+        id: find-asana-task
         if: steps.landed.outputs.on_default == 'true'
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          trigger-phrase: "Task/Issue URL:"
+          action: 'find-asana-task-id'
+      - name: If merged to the default branch, add to Waiting for release
+        if: steps.find-asana-task.outputs.asanaTaskId != ''
         uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_RELEASE_BOARD_PROJECT_ID }}
           asana-section: ${{ vars.GH_ANDROID_RELEASE_BOARD_WAITING_FOR_RELEASE_SECTION_ID }}
-          trigger-phrase: "Task/Issue URL:"
+          asana-task-id: ${{ steps.find-asana-task.outputs.asanaTaskId }}
           action: 'add-task-asana-project'

--- a/.github/workflows/action-pr-opened.yaml
+++ b/.github/workflows/action-pr-opened.yaml
@@ -14,8 +14,11 @@ jobs:
     permissions:
       issues: write
     steps:
+      # A stacked PR is retargeted to the default branch when its parent merges, which fires an
+      # `edited` event and lands it on the board then. That retarget can arrive after the PR has
+      # merged, so ignore closed PRs or this moves the task back out of Waiting for release.
       - name: Find Asana Task ID
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == github.event.repository.default_branch }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.base.ref == github.event.repository.default_branch }}
         id: find-asana-task
         uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1217938726519256?focus=true 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Two fixes for stacked PRs whose tasks don't reach Waiting for release.
* The merge automation couldn't add a task that wasn't already on the board.
* action-pr-opened moved the task back out of Waiting for release. A stacked PR is retargeted to develop when its parent merges, which fires an edited event — sometimes after the PR itself has merged. Since the action is given a section, Asana moves an already-present task into it, so that late run pulled the task into the PR section. It now ignores PRs that are no longer open.

### Steps to test this PR
n/a

### UI changes
n/a

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI workflow conditions and Asana action inputs; no app runtime or security-sensitive code.
> 
> **Overview**
> Fixes **GitHub Actions** Asana sync so release-board sections stay correct for **stacked PRs** and merges to the default branch.
> 
> In **`action-pr-merged.yaml`**, the workflow now **finds the Asana task ID** before moving a task to **Waiting for release**, then passes **`asana-task-id`** into `add-task-asana-project` instead of relying on body parsing with a project filter (which skipped tasks not already on the release board).
> 
> In **`action-pr-opened.yaml`**, **Find Asana Task ID** runs only when the PR is **`open`**, so a late **`edited`** retarget to the default branch on a **closed** stacked PR no longer re-adds the task to the PR section and pulls it out of **Waiting for release**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bcdedb4f61f8232f1e84d3dce36db3f90b5013c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->