### PR TITLE
Add wide event definitions for all Android wide events

### DIFF
--- a/PixelDefinitions/wide_events/base_event.json
+++ b/PixelDefinitions/wide_events/base_event.json
@@ -1,0 +1,67 @@
+{
+    "meta": {
+        "version": {
+            "description": "Version of the base_event schema. During processing this is combined with the two-octet version of each event schema to form the full schema version in the form of <base_version>.<event_minor_version>.<event_patch_version>",
+            "value": 1
+        }
+    },
+    "app": {
+        "name": {
+            "type": "string",
+            "description": "The name of the application sending the event",
+            "enum": ["DuckDuckGo Android"]
+        },
+        "version": {
+            "type": "string",
+            "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+        },
+        "form_factor": {
+            "type": "string",
+            "description": "The form factor of the current device",
+            "enum": ["phone", "tablet"]
+        },
+        "dev_mode": {
+            "type": "boolean",
+            "description": "Whether the app is a debug build"
+        }
+    },
+    "global": {
+        "platform": {
+            "type": "string",
+            "description": "The platform the app is running on",
+            "enum": ["Android"]
+        },
+        "type": {
+            "type": "string",
+            "description": "The type of software sending the event",
+            "enum": ["app"]
+        },
+        "sample_rate": {
+            "type": "number",
+            "description": "Sample rate for this event, between 0 and 1",
+            "minimum": 0,
+            "maximum": 1
+        },
+        "is_first_daily_occurrence": {
+            "type": "boolean",
+            "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+        }
+    },
+    "feature": {
+        "name": {
+            "type": "string",
+            "description": "The feature name for this event"
+        },
+        "status": {
+            "type": "string",
+            "description": "The terminal status of the flow"
+        }
+    },
+    "context": {
+        "name": {
+            "type": "string",
+            "description": "Entry point the flow was started from"
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/auth-token-refresh.json5
+++ b/PixelDefinitions/wide_events/definitions/auth-token-refresh.json5
@@ -1,0 +1,115 @@
+{
+    "android-auth-token-refresh": {
+        "description": "App refreshes the auth v2 token pair, from reading the stored refresh token through fetching, validating and saving the new tokens. CANCELLED means the account no longer exists in the backend and the user was signed out.",
+        "owners": ["lmac012"],
+        "meta": {
+            "type": "android-auth-token-refresh",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "auth-token-refresh",
+            "status": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "subscription_status": {
+                        "type": "string",
+                        "description": "User's subscription status when the refresh started",
+                        "enum": ["Auto-Renewable", "Not Auto-Renewable", "Grace Period", "Inactive", "Expired", "Unknown", "Waiting"]
+                    },
+                    "process_name": {
+                        "type": "string",
+                        "description": "App process the refresh ran in. 'main' is the browser process, the others are the app's secondary processes. 'UNKNOWN'/'ERROR' mean the process name could not be resolved.",
+                        "enum": ["main", ":vpn", ":pir", ":autofill", ":fire", "UNKNOWN", "ERROR"]
+                    },
+                    "netp_is_enabled": {
+                        "type": "string",
+                        "description": "Whether the VPN was enabled when the refresh started. Empty string if the value could not be read.",
+                        "enum": ["true", "false", ""]
+                    },
+                    "netp_is_running": {
+                        "type": "string",
+                        "description": "Whether the VPN was running when the refresh started. Empty string if the value could not be read.",
+                        "enum": ["true", "false", ""]
+                    },
+                    "serialization_enabled": {
+                        "type": "string",
+                        "description": "Whether refreshes were being serialized across processes with a cross-process lock, i.e. the value of the serializeTokenRefresh flag when the refresh started.",
+                        "enum": ["true", "false"]
+                    },
+                    "lock_outcome": {
+                        "type": "string",
+                        "description": "Outcome of acquiring the cross-process refresh lock. 'timeout' means another process held it for longer than the wait limit; the refresh then proceeds unserialized.",
+                        "enum": ["acquired", "timeout", "error"]
+                    },
+                    "token_refresh_lock_wait_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time spent waiting for the cross-process refresh lock in milliseconds",
+                        "enum": ["-1", "0", "100", "500", "1000", "3000", "10000", "30000", "60000"]
+                    },
+                    "fetch_jwks_latency_ms_bucketed": {
+                        "type": "string",
+                        "description": "Duration of the JWKS fetch in milliseconds",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "refresh_access_token_latency_ms_bucketed": {
+                        "type": "string",
+                        "description": "Duration of the token request in milliseconds",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "total_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Duration of the whole refresh in milliseconds, including any lock wait",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "backend_error_response": {
+                        "type": "string",
+                        "description": "Backend-supplied error code from the `error` field of the token endpoint's error body. Free-form as far as the app is concerned - the app only special-cases 'unknown_account'.",
+                        "examples": ["unknown_account", "invalid_token_request"]
+                    },
+                    "play_login_error": {
+                        "type": "string",
+                        "description": "Why the Play store login fallback failed. PurchaseInfoNotAvailable carries the reason Play could not be queried.",
+                        "pattern": "^(NoActivePurchase|AccountExternalIdMismatch|AuthenticationError|TokenValidationFailed|UnknownError|PurchaseInfoNotAvailable - .+)$",
+                        "examples": ["NoActivePurchase", "AuthenticationError", "PurchaseInfoNotAvailable - billing_client_not_ready"]
+                    },
+                    "failure_reason": "failureReason",
+                    "signed_out": {
+                        "type": "string",
+                        "description": "Whether the user was signed out after an irrecoverable error was encountered, such as an invalid refresh token.",
+                        "enum": ["true", "false"]
+                    },
+                    "step.lock_acquire": {
+                        "type": "string",
+                        "description": "true if the cross-process refresh lock was acquired, false if it timed out or errored. A false value does not fail the refresh - see lock_outcome.",
+                        "enum": ["true", "false"]
+                    },
+                    "step.token_read": {
+                        "type": "string",
+                        "description": "Parameter present if the stored refresh token was read successfully",
+                        "enum": ["true"]
+                    },
+                    "step.jwks_fetch": {
+                        "type": "string",
+                        "description": "Parameter present if the JWKS needed to validate the new tokens was fetched successfully",
+                        "enum": ["true"]
+                    },
+                    "step.token_request": {
+                        "type": "string",
+                        "description": "true if the token endpoint returned a new token pair, false if it returned an error. A false value can still end in SUCCESS when the Play store login fallback recovers the session.",
+                        "enum": ["true", "false"]
+                    },
+                    "step.token_validation": {
+                        "type": "string",
+                        "description": "Parameter present if the newly fetched tokens passed validation",
+                        "enum": ["true"]
+                    },
+                    "step.play_login": {
+                        "type": "string",
+                        "description": "true if the Play store login fallback recovered the session, false if it failed",
+                        "enum": ["true", "false"]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/bad-url-error-page.json5
+++ b/PixelDefinitions/wide_events/definitions/bad-url-error-page.json5
@@ -1,0 +1,48 @@
+{
+    "android-bad-url-error-page": {
+        "description": "Monitors the lifecycle of a BAD_URL (unresolved host) error page: whether a redirect suggestion was offered, whether the user clicked it, and how the error page was exited. Error pages shown in custom tabs are excluded, so the measured population is regular and fire tabs only.",
+        "owners": ["juandiana"],
+        "meta": {
+            "type": "android-bad-url-error-page",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "bad-url-error-page",
+            "status": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "step.redirect_suggested": {
+                        "type": "string",
+                        "description": "Parameter present when a redirect suggestion (Did you mean www.example.com?) was displayed on the error page. Absent when no suggestion was shown.",
+                        "enum": ["true"]
+                    },
+                    "step.redirect_clicked": {
+                        "type": "string",
+                        "description": "Parameter present when the user tapped the redirect suggestion. Absent when the suggestion was not shown or not clicked.",
+                        "enum": ["true"]
+                    },
+                    "last_step": {
+                        "type": "string",
+                        "description": "Furthest step reached when the flow ended. Persisted as each step is recorded, so flows force-completed by the cleanup policy (UNKNOWN status) still carry it. Absent when the error page was exited before any step was recorded.",
+                        "enum": ["redirect_suggested", "redirect_clicked"]
+                    },
+                    "cancel_reason": {
+                        "type": "string",
+                        "description": "Present only when the flow finished with CANCELLED status. recovered_on_refresh: the user refreshed the failed page and it loaded. error_replaced_on_refresh: the user refreshed and this error page was replaced by a different error page. abandoned: the user navigated back/forward or home, closed the tab, or submitted a new query. device_offline: the device was offline when the tapped redirect suggestion was looked up, so whether the suggested hostname resolves is unknowable.",
+                        "enum": ["recovered_on_refresh", "abandoned", "error_replaced_on_refresh", "device_offline"]
+                    },
+                    "failure_reason": {
+                        "type": "string",
+                        "description": "Present only when the flow finished with FAILURE status, i.e. the tapped redirect suggestion hit another BAD_URL error because the suggested hostname did not resolve either.",
+                        "enum": ["new_hostname_resolution_failed"]
+                    },
+                    "error_page_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "How long the error page was displayed before it was exited, bucketed. Uses lower end of the bucket; -1 records a negative measured duration (device clock changed mid-flow). Absent when the flow was force-completed by the cleanup policy.",
+                        "enum": ["-1", "0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/data-clearing.json5
+++ b/PixelDefinitions/wide_events/definitions/data-clearing.json5
@@ -1,0 +1,111 @@
+{
+    "android-data-clearing": {
+        "description": "User clears browsing data through various entry points (Fire button, single tab burn, Duck.ai chat deletion, app shortcuts, automatic clearing)",
+        "owners": ["lmac012"],
+        "meta": {
+            "type": "android-data-clearing",
+            "version": "1.0"
+        },
+        "feature": {
+            "name": "data-clearing",
+            "status": ["SUCCESS", "FAILURE", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "clear_options": {
+                        "type": "string",
+                        "description": "Comma-separated list of data types being cleared. Values: tabs,data,duckai_chats"
+                    },
+                    "browser_mode": {
+                        "type": "string",
+                        "description": "Whether this clear applies to Fire Mode or Regular Mode. Absent for flows that clear both in one pass (automatic foreground/background clearing).",
+                        "enum": ["regular", "fire"]
+                    },
+                    "tab_type": {
+                        "type": "string",
+                        "description": "Type of the active tab when the burn was confirmed. Only present for dialog-driven flows.",
+                        "enum": ["web", "ai"]
+                    },
+                    "tab_count": {
+                        "type": "string",
+                        "description": "Number of open tabs when the burn was confirmed, bucketed like the tab_count pixel parameter. Only present for dialog-driven flows.",
+                        "enum": ["1", "2-5", "6-10", "11-20", "21-40", "41-60", "61-80", "81+"]
+                    },
+                    "total_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Duration of the data clearing operation, bucketed using the lower bucket boundary. Does not include process restart duration.",
+                        "enum": ["-1", "0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "failure_reason": {
+                        "type": "string",
+                        "description": "Reason for failure. Only present on FAILURE events. Exception class name, or feature_not_supported / tab_not_found when the clear ended without an exception."
+                    },
+                    "step.web_storage_clear_success": {
+                        "type": "string",
+                        "description": "true if the step completed successfully, false otherwise. The implementation swallows exceptions so it does not affect the overall outcome of the data clearing operation, represented by feature.status.",
+                        "enum": ["true", "false"]
+                    },
+                    "web_storage_clear_error": {
+                        "type": "string",
+                        "description": "Error message (exception class) - only present if success=false for this step"
+                    },
+                    "step.webview_app_webview_clear_success": {
+                        "type": "string",
+                        "description": "true if the step completed successfully, false otherwise. The implementation swallows exceptions so it does not affect the overall outcome of the data clearing operation, represented by feature.status.",
+                        "enum": ["true", "false"]
+                    },
+                    "webview_app_webview_clear_error": {
+                        "type": "string",
+                        "description": "Error message (exception class) - only present if success=false for this step"
+                    },
+                    "step.webview_default_clear_success": {
+                        "type": "string",
+                        "description": "true if the step completed successfully, false otherwise. The implementation swallows exceptions so it does not affect the overall outcome of the data clearing operation, represented by feature.status.",
+                        "enum": ["true", "false"]
+                    },
+                    "webview_default_clear_error": {
+                        "type": "string",
+                        "description": "Error message (exception class) - only present if success=false for this step"
+                    },
+                    "step.indexeddb_clear_selective_success": {
+                        "type": "string",
+                        "description": "true if the step completed successfully, false otherwise. The implementation swallows exceptions so it does not affect the overall outcome of the data clearing operation, represented by feature.status.",
+                        "enum": ["true", "false"]
+                    },
+                    "indexeddb_clear_selective_error": {
+                        "type": "string",
+                        "description": "Error message (exception class) - only present if success=false for this step"
+                    },
+                    "step.indexeddb_clear_duckai_only_success": {
+                        "type": "string",
+                        "description": "true if the step completed successfully, false otherwise. The implementation swallows exceptions so it does not affect the overall outcome of the data clearing operation, represented by feature.status.",
+                        "enum": ["true", "false"]
+                    },
+                    "indexeddb_clear_duckai_only_error": {
+                        "type": "string",
+                        "description": "Error message (exception class) - only present if success=false for this step"
+                    },
+                    "step.app_cache_clear_success": {
+                        "type": "string",
+                        "description": "true if the step completed successfully, false otherwise. The implementation swallows exceptions so it does not affect the overall outcome of the data clearing operation, represented by feature.status.",
+                        "enum": ["true", "false"]
+                    },
+                    "app_cache_clear_error": {
+                        "type": "string",
+                        "description": "Error message (exception class) - only present if success=false for this step"
+                    }
+                }
+            }
+        },
+        "context": {
+            "name": [
+                "single_tab_fire_dialog",
+                "single_tab_burn",
+                "duckai_chat_deletion",
+                "app_shortcut",
+                "fire_tabs_emptied",
+                "auto_foreground",
+                "auto_background"
+            ]
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/free-trial-conversion.json5
+++ b/PixelDefinitions/wide_events/definitions/free-trial-conversion.json5
@@ -1,0 +1,56 @@
+{
+    "android-free-trial-conversion": {
+        "description": "Monitors free trial user journey from activation to conversion or expiration",
+        "owners": ["nalcalag"],
+        "meta": {
+            "type": "android-free-trial-conversion",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "free-trial-conversion",
+            "status": ["SUCCESS", "FAILURE"],
+            "data": {
+                "ext": {
+                    "free_trial_plan": {
+                        "type": "string",
+                        "description": "The base plan ID of the free trial product activated",
+                        "enum": [
+                            "ddg-privacy-pro-monthly-renews-us",
+                            "ddg-privacy-pro-monthly-renews-row",
+                            "ddg-privacy-pro-yearly-renews-us",
+                            "ddg-privacy-pro-yearly-renews-row",
+                            "ddg-privacy-pro-sandbox-monthly-renews-us",
+                            "ddg-privacy-pro-sandbox-monthly-renews-row",
+                            "ddg-privacy-pro-sandbox-yearly-renews-us",
+                            "ddg-privacy-pro-sandbox-yearly-renews-row",
+                            "ddg-subscription-pro-yearly-renews-us",
+                            "ddg-subscription-pro-monthly-renews-us",
+                            "ddg-subscription-pro-yearly-renews-row",
+                            "ddg-subscription-pro-monthly-renews-row"
+                        ]
+                    },
+                    "failure_reason": {
+                        "type": "string",
+                        "description": "Reason for failure. Only present on FAILURE events.",
+                        "enum": ["expired", "timeout"]
+                    },
+                    "step.vpn_activated_d1": {
+                        "type": "string",
+                        "description": "true if VPN was successfully activated within first day of Free Trial",
+                        "enum": ["true", "false"]
+                    },
+                    "step.vpn_activated_d2_to_d7": {
+                        "type": "string",
+                        "description": "true if VPN was successfully activated between D2-D7 of Free Trial",
+                        "enum": ["true", "false"]
+                    },
+                    "step.duck_ai_paid_used": {
+                        "type": "string",
+                        "description": "true if paid duck.ai model has been used within a Free Trial",
+                        "enum": ["true", "false"]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/input-screen-onboarding.json5
+++ b/PixelDefinitions/wide_events/definitions/input-screen-onboarding.json5
@@ -1,0 +1,31 @@
+{
+    "android-input-screen-onboarding": {
+        "description": "User enables Input Screen during onboarding",
+        "owners": ["joshliebe"],
+        "meta": {
+            "type": "android-input-screen-onboarding",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "input-screen-onboarding",
+            "status": ["SUCCESS", "CANCELLED", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "reinstallUser": {
+                        "type": "string",
+                        "description": "true if the user tapped 'I've been here before', false otherwise",
+                        "enum": ["true", "false"]
+                    },
+                    "enabled": {
+                        "type": "string",
+                        "description": "true if the Input Screen is enabled, false otherwise. Only present on CANCELLED events.",
+                        "enum": ["true", "false"]
+                    }
+                }
+            }
+        },
+        "context": {
+            "name": ["onboarding"]
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/page-load.json5
+++ b/PixelDefinitions/wide_events/definitions/page-load.json5
@@ -1,0 +1,146 @@
+{
+    "android-page-load": {
+        "description": "Monitors page load performance across lifecycle phases to track stuck-at-progress issues and overall load times",
+        "owners": ["GerardPaligot"],
+        "meta": {
+            "type": "android-page-load",
+            "version": "0.1"
+        },
+        "feature": {
+            "name": "page-load",
+            "status": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "elapsed_time_to_finish_ms_bucketed": {
+                        "type": "string",
+                        "description": "Total duration from page_start to page_finish, bucketed. Uses lower end of the bucket. -1 marks a negative interval caused by a wall-clock adjustment during measurement.",
+                        "enum": ["-1", "0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
+                    },
+                    "elapsed_time_to_visible_ms_bucketed": {
+                        "type": "string",
+                        "description": "Duration from page_start to page_visible, bucketed. Uses lower end of the bucket. -1 marks a negative interval caused by a wall-clock adjustment during measurement.",
+                        "enum": ["-1", "0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
+                    },
+                    "elapsed_time_to_escaped_fixed_progress_ms_bucketed": {
+                        "type": "string",
+                        "description": "Duration from page_start to page_escaped_fixed_progress, bucketed. Uses lower end of the bucket. -1 marks a negative interval caused by a wall-clock adjustment during measurement.",
+                        "enum": ["-1", "0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
+                    },
+                    "elapsed_time_to_content_scope_experiments_ms_bucketed": {
+                        "type": "string",
+                        "description": "Duration from page_start until the active content scope experiments were resolved, bucketed. Uses lower end of the bucket. Recorded during the page_content_scope_experiments_resolved step, so it is absent when the navigation ended before the experiments resolved.",
+                        "enum": ["-1", "0", "5", "10", "25", "50", "100", "200", "400", "800", "1600", "3200", "6400"]
+                    },
+                    "elapsed_time_to_js_injection_complete_ms_bucketed": {
+                        "type": "string",
+                        "description": "Duration from page_start until every JS injector plugin has run for the navigation, content scope scripts among them, bucketed. Also covers resolving the active experiments and the browser tab's own page-started handling, so it is an upper bound on content scope injection rather than a measure of it alone. Uses lower end of the bucket. Recorded during the page_js_injection_complete step, so it is absent when the navigation ended before injection completed.",
+                        "enum": ["-1", "0", "5", "10", "25", "50", "100", "200", "400", "800", "1600", "3200", "6400"]
+                    },
+                    "content_scope_injection_optimized": {
+                        "type": "string",
+                        "description": "Whether the optimized content scope script assembly path is enabled. Temporary: recorded to compare the durations above across kill-switch states during rollout of the content scope performance work.",
+                        "enum": ["true", "false"]
+                    },
+                    "content_scope_messaging_optimized": {
+                        "type": "string",
+                        "description": "Whether inbound content scope JS messages are queued off the WebView JavaBridge thread. Temporary: recorded to compare overall page load time across kill-switch states during rollout of the content scope performance work.",
+                        "enum": ["true", "false"]
+                    },
+                    "content_scope_experiments_cached": {
+                        "type": "string",
+                        "description": "Whether resolved content scope experiments are held between privacy config updates. Temporary: recorded to compare the durations above across kill-switch states during rollout of the content scope performance work.",
+                        "enum": ["true", "false"]
+                    },
+                    "webview_version": {
+                        "type": "string",
+                        "description": "WebView major version"
+                    },
+                    "cpm_enabled": {
+                        "type": "string",
+                        "description": "Whether Cookie Pop-up Management (autoconsent) is enabled",
+                        "enum": ["true", "false"]
+                    },
+                    "tracker_optimization_enabled_v2": {
+                        "type": "string",
+                        "description": "Whether tracker evaluation optimization is enabled. Deprecated key sent by app versions released before the field was renamed to tracker_optimization_enabled_v3; kept so historical data still validates.",
+                        "enum": ["true", "false"]
+                    },
+                    "tracker_optimization_enabled_v3": {
+                        "type": "string",
+                        "description": "Whether tracker evaluation optimization is enabled. Deprecated key sent by app versions released before the field was removed; kept so historical data still validates",
+                        "enum": ["true", "false"]
+                    },
+                    "is_tab_in_foreground_on_finish": {
+                        "type": "string",
+                        "description": "Whether the tab was in foreground when page finished loading. Reported by the caller at finish, so it is absent on a cancelled load.",
+                        "enum": ["true", "false"]
+                    },
+                    "active_requests_on_load_start": {
+                        "type": "string",
+                        "description": "Number of active network requests when page load started. Reported by the caller at finish, so it is absent on a cancelled load.",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "concurrent_requests_on_finish": {
+                        "type": "string",
+                        "description": "Number of concurrent network requests when page finished loading. Reported by the caller at finish, so it is absent on a cancelled load.",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "progress": {
+                        "type": "string",
+                        "description": "True if page became visible at or after fixed progress threshold (50%), false if before. Recorded during the page_visible step.",
+                        "enum": ["true", "false"]
+                    },
+                    "outcome": {
+                        "type": "string",
+                        "description": "Final outcome of the page load. Recorded during the page_finish step.",
+                        "enum": ["success", "error"]
+                    },
+                    "error_code": {
+                        "type": "string",
+                        "description": "WebViewClient error constant name (e.g., ERROR_HOST_LOOKUP, ERROR_CONNECT). Only present on error outcomes.",
+                        "examples": ["ERROR_HOST_LOOKUP", "ERROR_CONNECT"]
+                    },
+                    "failure_reason": {
+                        "type": "string",
+                        "description": "Failure reason auto-attached by the wide event client when the flow finishes with FlowStatus.Failure. Mirrors error_code for page-load failures."
+                    },
+                    "cancellation_reason": {
+                        "type": "string",
+                        "description": "Why a load ended without finishing. Only present on CANCELLED loads, which are loads superseded by another main frame load in the same tab before they finished. superseded_same_url covers a reload or restart; superseded_different_url covers a redirect hop and the user navigating away - WebView does not distinguish them.",
+                        "enum": ["superseded_same_url", "superseded_different_url"]
+                    },
+                    "step.page_start": {
+                        "type": "string",
+                        "description": "Parameter present when page load begins",
+                        "enum": ["true"]
+                    },
+                    "step.page_content_scope_experiments_resolved": {
+                        "type": "string",
+                        "description": "Parameter present when the active content scope experiments have been resolved for the navigation",
+                        "enum": ["true"]
+                    },
+                    "step.page_js_injection_complete": {
+                        "type": "string",
+                        "description": "Parameter present when every JS injector plugin has run for the navigation",
+                        "enum": ["true"]
+                    },
+                    "step.page_visible": {
+                        "type": "string",
+                        "description": "Parameter present when page becomes visible",
+                        "enum": ["true"]
+                    },
+                    "step.page_escaped_fixed_progress": {
+                        "type": "string",
+                        "description": "Parameter present when progress escapes the fixed progress zone (typically 50%)",
+                        "enum": ["true"]
+                    },
+                    "step.page_finish": {
+                        "type": "string",
+                        "description": "Parameter present when page load completes or fails",
+                        "enum": ["true", "false"]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/pir-initial-scan.json5
+++ b/PixelDefinitions/wide_events/definitions/pir-initial-scan.json5
@@ -1,0 +1,301 @@
+{
+    "android-pir-initial-scan": {
+        "description": "Wide event tracking the lifecycle of a manually-triggered PIR run (initial scan or post-profile-edit), covering scan progress in 10% increments, scan completion, and the follow-on opt-out scheduling phase. Used to measure end-to-end success rate, drop-off, and per-phase latency.",
+        "owners": ["karlenDimla", "landomen"],
+        "meta": {
+            "type": "android-pir-initial-scan",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "pir-initial-scan",
+            "status": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "execution_type": {
+                        "type": "string",
+                        "description": "Distinguishes the user's first manual scan after onboarding (manual_initial), a dashboard-triggered resume of an interrupted initial scan (manual_initial_resume), and a re-scan triggered by editing a saved profile (manual_edit_profile)",
+                        "enum": ["manual_initial", "manual_edit_profile", "manual_initial_resume"]
+                    },
+                    "profile_queries_count": {
+                        "type": "string",
+                        "description": "Number of user profile queries used in the run",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "broker_count": {
+                        "type": "string",
+                        "description": "Number of active brokers at the start of the run",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "total_scan_jobs": {
+                        "type": "string",
+                        "description": "Total number of (broker x profile) scan jobs eligible for execution at the start of the run",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "web_view_count": {
+                        "type": "string",
+                        "description": "Number of parallel WebView runners used during the scan portion. Equals min(total_scan_jobs, MAX_DETACHED_WEBVIEW_COUNT=20). 0 when there are no eligible scan jobs.",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "scheduling": {
+                        "type": "string",
+                        "description": "How scan/opt-out steps were distributed across the WebView runners for this run, as resolved from the workQueueScheduling remote toggle at run start: a shared cost-ordered work queue (queue) or contiguous equal-count chunks per runner (static).",
+                        "enum": ["queue", "static"]
+                    },
+                    "total_opt_out_jobs": {
+                        "type": "string",
+                        "description": "Total number of opt-out jobs executed during the run. 0 when opt-out was skipped (no eligible form-opt-out brokers). Only populated on terminal events.",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "power_saving": {
+                        "type": "string",
+                        "description": "Whether the device was in power saving mode at the start of the run",
+                        "enum": ["true", "false"]
+                    },
+                    "battery_optimizations": {
+                        "type": "string",
+                        "description": "Whether battery optimizations were enabled for the app at the start of the run",
+                        "enum": ["true", "false"]
+                    },
+                    "vpn_connection_state": {
+                        "type": "string",
+                        "description": "Reported VPN connection state at the start of the run",
+                        "enum": ["connected", "disconnected"]
+                    },
+                    "notifications_permission_granted": {
+                        "type": "string",
+                        "description": "Whether the user had granted the POST_NOTIFICATIONS runtime permission at the start of the run",
+                        "enum": ["true", "false"]
+                    },
+                    "tracker_blocking_state": {
+                        "type": "string",
+                        "description": "Whether tracker blocking was enabled or disabled during the run",
+                        "enum": ["enabled", "disabled"]
+                    },
+                    "last_step": {
+                        "type": "string",
+                        "description": "The last recorded step name when the flow terminated. Useful for understanding where flows drop off when status is FAILURE, CANCELLED, or UNKNOWN.",
+                        "enum": [
+                            "started",
+                            "progress_10",
+                            "progress_20",
+                            "progress_30",
+                            "progress_40",
+                            "progress_50",
+                            "progress_60",
+                            "progress_70",
+                            "progress_80",
+                            "progress_90",
+                            "scan_completed",
+                            "opt_out_started",
+                            "opt_out_completed",
+                            "opt_out_skipped"
+                        ]
+                    },
+                    "last_step_elapsed_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from run start to when last_step was reached, bucketed using the lower bucket boundary. Recorded on every step after 'started'. On UNKNOWN/killed runs this is the only signal for how long the run had been going before termination, since the total_*_duration intervals are never recorded when a run is killed.",
+                        "enum": [
+                            "0",
+                            "10000",
+                            "30000",
+                            "60000",
+                            "120000",
+                            "300000",
+                            "600000",
+                            "900000",
+                            "1800000",
+                            "3600000",
+                            "7200000",
+                            "14400000",
+                            "28800000"
+                        ]
+                    },
+                    "failure_reason": {
+                        "type": "string",
+                        "description": "Reason a run failed. Only present on FAILURE events. Specific exception types are mapped to bounded values; anything not in the known set falls back to unknown_error. The phase the run was in when it failed is recoverable from last_step.",
+                        "enum": [
+                            "no_active_brokers",
+                            "illegal_state_exception",
+                            "illegal_argument_exception",
+                            "null_pointer_exception",
+                            "io_exception",
+                            "sqlite_exception",
+                            "timeout_cancellation_exception",
+                            "renderer_gone",
+                            "unknown_error"
+                        ]
+                    },
+                    "did_crash": {
+                        "type": "string",
+                        "description": "Only present on renderer_gone failures. true = the WebView renderer actually crashed; false = the system reclaimed it (e.g. low memory).",
+                        "enum": ["true", "false"]
+                    },
+                    "cancellation_reason": "pirCancellationReason",
+                    "step.started": {
+                        "type": "string",
+                        "description": "Parameter present when the run body actually begins (after the no-profiles early return)",
+                        "enum": ["true"]
+                    },
+                    "step.progress_10": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 10%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_20": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 20%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_30": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 30%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_40": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 40%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_50": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 50%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_60": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 60%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_70": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 70%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_80": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 80%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_90": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 90%",
+                        "enum": ["true"]
+                    },
+                    "step.scan_completed": {
+                        "type": "string",
+                        "description": "Parameter present when all scan jobs finish (signals the end of the scan portion; replaces a hypothetical progress_100)",
+                        "enum": ["true"]
+                    },
+                    "step.opt_out_started": {
+                        "type": "string",
+                        "description": "Parameter present when the opt-out scheduling phase begins (only when there is at least one eligible form-opt-out broker)",
+                        "enum": ["true"]
+                    },
+                    "step.opt_out_completed": {
+                        "type": "string",
+                        "description": "Parameter present when the opt-out scheduling phase finishes successfully",
+                        "enum": ["true"]
+                    },
+                    "step.opt_out_skipped": {
+                        "type": "string",
+                        "description": "Parameter present when the opt-out scheduling phase is skipped because there are no eligible form-opt-out brokers",
+                        "enum": ["true"]
+                    },
+                    "decile_0_10_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from run start to crossing 10% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_10_20_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 10% to crossing 20% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_20_30_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 20% to crossing 30% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_30_40_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 30% to crossing 40% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_40_50_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 40% to crossing 50% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_50_60_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 50% to crossing 60% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_60_70_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 60% to crossing 70% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_70_80_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 70% to crossing 80% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_80_90_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 80% to crossing 90% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "opt_out_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time spent in the opt-out scheduling phase from opt_out_started to opt_out_completed, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "total_scan_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from run start to scan_completed — the full scan phase, including the final 90-100% band that the per-decile intervals don't cover — bucketed using the lower bucket boundary. Absent on runs that never reach scan_completed (e.g. UNKNOWN/killed runs). A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured.",
+                        "enum": [
+                            "-1",
+                            "0",
+                            "10000",
+                            "30000",
+                            "60000",
+                            "120000",
+                            "300000",
+                            "600000",
+                            "900000",
+                            "1800000",
+                            "3600000",
+                            "7200000",
+                            "14400000",
+                            "28800000"
+                        ]
+                    },
+                    "total_flow_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from run start to flow finish — end-to-end, including the opt-out scheduling phase — bucketed using the lower bucket boundary. Absent on runs finalized by the cleanup timeout (e.g. UNKNOWN/killed runs). A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured.",
+                        "enum": [
+                            "-1",
+                            "0",
+                            "10000",
+                            "30000",
+                            "60000",
+                            "120000",
+                            "300000",
+                            "600000",
+                            "900000",
+                            "1800000",
+                            "3600000",
+                            "7200000",
+                            "14400000",
+                            "28800000"
+                        ]
+                    }
+                }
+            }
+        },
+        "context": {
+            "name": ["funnel_pir_initial_android", "funnel_pir_edit_profile_android", "funnel_pir_initial_resume_android"]
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/pir-scheduled-scan.json5
+++ b/PixelDefinitions/wide_events/definitions/pir-scheduled-scan.json5
@@ -1,0 +1,301 @@
+{
+    "android-pir-scheduled-scan": {
+        "description": "Wide event tracking the lifecycle of a scheduled (background, WorkManager-triggered) PIR run, covering scan progress in 10% increments, scan completion, and the follow-on opt-out scheduling phase. Sampled client-side at 20% (hardcoded in PirScanWideEventImpl.SCHEDULED_SCAN_SAMPLE_RATE) to keep pixel volume manageable.",
+        "owners": ["karlenDimla", "landomen"],
+        "meta": {
+            "type": "android-pir-scheduled-scan",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "pir-scheduled-scan",
+            "status": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "execution_type": {
+                        "type": "string",
+                        "description": "Always 'scheduled' for this event; included for parity with the manual wide event so dashboards can union the two streams.",
+                        "enum": ["scheduled"]
+                    },
+                    "profile_queries_count": {
+                        "type": "string",
+                        "description": "Number of user profile queries used in the run",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "broker_count": {
+                        "type": "string",
+                        "description": "Number of active brokers at the start of the run",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "total_scan_jobs": {
+                        "type": "string",
+                        "description": "Total number of (broker x profile) scan jobs eligible for execution at the start of the run",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "web_view_count": {
+                        "type": "string",
+                        "description": "Number of parallel WebView runners used during the scan portion. Equals min(total_scan_jobs, MAX_DETACHED_WEBVIEW_COUNT=20). 0 when there are no eligible scan jobs.",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "scheduling": {
+                        "type": "string",
+                        "description": "How scan/opt-out steps were distributed across the WebView runners for this run, as resolved from the workQueueScheduling remote toggle at run start: a shared cost-ordered work queue (queue) or contiguous equal-count chunks per runner (static).",
+                        "enum": ["queue", "static"]
+                    },
+                    "total_opt_out_jobs": {
+                        "type": "string",
+                        "description": "Total number of opt-out jobs executed during the run. 0 when opt-out was skipped (no eligible form-opt-out brokers). Only populated on terminal events.",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "power_saving": {
+                        "type": "string",
+                        "description": "Whether the device was in power saving mode at the start of the run",
+                        "enum": ["true", "false"]
+                    },
+                    "battery_optimizations": {
+                        "type": "string",
+                        "description": "Whether battery optimizations were enabled for the app at the start of the run",
+                        "enum": ["true", "false"]
+                    },
+                    "vpn_connection_state": {
+                        "type": "string",
+                        "description": "Reported VPN connection state at the start of the run",
+                        "enum": ["connected", "disconnected"]
+                    },
+                    "notifications_permission_granted": {
+                        "type": "string",
+                        "description": "Whether the user had granted the POST_NOTIFICATIONS runtime permission at the start of the run",
+                        "enum": ["true", "false"]
+                    },
+                    "tracker_blocking_state": {
+                        "type": "string",
+                        "description": "Whether tracker blocking was enabled or disabled during the run",
+                        "enum": ["enabled", "disabled"]
+                    },
+                    "last_step": {
+                        "type": "string",
+                        "description": "The last recorded step name when the flow terminated. Useful for understanding where flows drop off when status is FAILURE, CANCELLED, or UNKNOWN.",
+                        "enum": [
+                            "started",
+                            "progress_10",
+                            "progress_20",
+                            "progress_30",
+                            "progress_40",
+                            "progress_50",
+                            "progress_60",
+                            "progress_70",
+                            "progress_80",
+                            "progress_90",
+                            "scan_completed",
+                            "opt_out_started",
+                            "opt_out_completed",
+                            "opt_out_skipped"
+                        ]
+                    },
+                    "last_step_elapsed_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from run start to when last_step was reached, bucketed using the lower bucket boundary. Recorded on every step after 'started'. On UNKNOWN/killed runs this is the only signal for how long the run had been going before termination, since the total_*_duration intervals are never recorded when a run is killed.",
+                        "enum": [
+                            "0",
+                            "10000",
+                            "30000",
+                            "60000",
+                            "120000",
+                            "300000",
+                            "600000",
+                            "900000",
+                            "1800000",
+                            "3600000",
+                            "7200000",
+                            "14400000",
+                            "28800000"
+                        ]
+                    },
+                    "failure_reason": {
+                        "type": "string",
+                        "description": "Reason a run failed. Only present on FAILURE events. Specific exception types are mapped to bounded values; anything not in the known set falls back to unknown_error. The phase the run was in when it failed is recoverable from last_step.",
+                        "enum": [
+                            "no_active_brokers",
+                            "illegal_state_exception",
+                            "illegal_argument_exception",
+                            "null_pointer_exception",
+                            "io_exception",
+                            "sqlite_exception",
+                            "timeout_cancellation_exception",
+                            "renderer_gone",
+                            "unknown_error"
+                        ]
+                    },
+                    "did_crash": {
+                        "type": "string",
+                        "description": "Only present on renderer_gone failures. true = the WebView renderer actually crashed; false = the system reclaimed it (e.g. low memory).",
+                        "enum": ["true", "false"]
+                    },
+                    "cancellation_reason": "pirCancellationReason",
+                    "step.started": {
+                        "type": "string",
+                        "description": "Parameter present when the run body actually begins (after the no-profiles early return)",
+                        "enum": ["true"]
+                    },
+                    "step.progress_10": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 10%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_20": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 20%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_30": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 30%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_40": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 40%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_50": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 50%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_60": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 60%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_70": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 70%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_80": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 80%",
+                        "enum": ["true"]
+                    },
+                    "step.progress_90": {
+                        "type": "string",
+                        "description": "Parameter present when the rolling completed-scan-jobs count first crosses 90%",
+                        "enum": ["true"]
+                    },
+                    "step.scan_completed": {
+                        "type": "string",
+                        "description": "Parameter present when all scan jobs finish (signals the end of the scan portion; replaces a hypothetical progress_100)",
+                        "enum": ["true"]
+                    },
+                    "step.opt_out_started": {
+                        "type": "string",
+                        "description": "Parameter present when the opt-out scheduling phase begins (only when there is at least one eligible form-opt-out broker)",
+                        "enum": ["true"]
+                    },
+                    "step.opt_out_completed": {
+                        "type": "string",
+                        "description": "Parameter present when the opt-out scheduling phase finishes successfully",
+                        "enum": ["true"]
+                    },
+                    "step.opt_out_skipped": {
+                        "type": "string",
+                        "description": "Parameter present when the opt-out scheduling phase is skipped because there are no eligible form-opt-out brokers",
+                        "enum": ["true"]
+                    },
+                    "decile_0_10_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from run start to crossing 10% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_10_20_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 10% to crossing 20% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_20_30_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 20% to crossing 30% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_30_40_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 30% to crossing 40% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_40_50_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 40% to crossing 50% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_50_60_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 50% to crossing 60% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_60_70_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 60% to crossing 70% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_70_80_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 70% to crossing 80% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "decile_80_90_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from crossing 80% to crossing 90% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "opt_out_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time spent in the opt-out scheduling phase from opt_out_started to opt_out_completed, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "total_scan_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from run start to scan_completed — the full scan phase, including the final 90-100% band that the per-decile intervals don't cover — bucketed using the lower bucket boundary. Absent on runs that never reach scan_completed (e.g. UNKNOWN/killed runs). A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured.",
+                        "enum": [
+                            "-1",
+                            "0",
+                            "10000",
+                            "30000",
+                            "60000",
+                            "120000",
+                            "300000",
+                            "600000",
+                            "900000",
+                            "1800000",
+                            "3600000",
+                            "7200000",
+                            "14400000",
+                            "28800000"
+                        ]
+                    },
+                    "total_flow_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from run start to flow finish — end-to-end, including the opt-out scheduling phase — bucketed using the lower bucket boundary. Absent on runs finalized by the cleanup timeout (e.g. UNKNOWN/killed runs). A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured.",
+                        "enum": [
+                            "-1",
+                            "0",
+                            "10000",
+                            "30000",
+                            "60000",
+                            "120000",
+                            "300000",
+                            "600000",
+                            "900000",
+                            "1800000",
+                            "3600000",
+                            "7200000",
+                            "14400000",
+                            "28800000"
+                        ]
+                    }
+                }
+            }
+        },
+        "context": {
+            "name": ["funnel_pir_scheduled_android"]
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/pir-time-to-first-scan-complete.json5
+++ b/PixelDefinitions/wide_events/definitions/pir-time-to-first-scan-complete.json5
@@ -1,0 +1,104 @@
+{
+    "android-pir-time-to-first-scan-complete": {
+        "description": "Long-lived wide event measuring the wall-clock duration from the first time the user starts the initial PIR scan (MANUAL_INITIAL) to the moment every broker has at least one completed scan job (the dashboard's 'all done' state). Spans multiple foreground service runs and scheduled worker runs since the foreground service is frequently killed and the worker resumes the work later. One-shot per install (cleared only via PIR data reset). 30-day cleanup timeout records abandoned journeys as Unknown.",
+        "owners": ["karlenDimla", "landomen"],
+        "meta": {
+            "type": "android-pir-time-to-first-scan-complete",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "pir-time-to-first-scan-complete",
+            "status": ["SUCCESS", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "profile_queries_count": {
+                        "type": "string",
+                        "description": "Number of user profile queries at the moment the flow started (first MANUAL_INITIAL run)",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "broker_count": {
+                        "type": "string",
+                        "description": "Number of active brokers at the moment the flow started",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "total_scan_jobs": {
+                        "type": "string",
+                        "description": "Total number of (broker x profile) scan jobs eligible for execution at the moment the flow started",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "web_view_count": {
+                        "type": "string",
+                        "description": "Number of parallel WebView runners used at the start of the flow. Equals min(total_scan_jobs, MAX_DETACHED_WEBVIEW_COUNT=20). 0 when there are no eligible scan jobs.",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "power_saving": {
+                        "type": "string",
+                        "description": "Whether the device was in power saving mode at the moment the flow started",
+                        "enum": ["true", "false"]
+                    },
+                    "battery_optimizations": {
+                        "type": "string",
+                        "description": "Whether battery optimizations were enabled for the app at the moment the flow started",
+                        "enum": ["true", "false"]
+                    },
+                    "vpn_connection_state": {
+                        "type": "string",
+                        "description": "Reported VPN connection state at the moment the flow started",
+                        "enum": ["connected", "disconnected"]
+                    },
+                    "notifications_permission_granted": {
+                        "type": "string",
+                        "description": "Whether the user had granted the POST_NOTIFICATIONS runtime permission at the moment the flow started",
+                        "enum": ["true", "false"]
+                    },
+                    "tracker_blocking_state": {
+                        "type": "string",
+                        "description": "Whether tracker blocking was enabled or disabled at the moment the flow started",
+                        "enum": ["enabled", "disabled"]
+                    },
+                    "total_scan_jobs_at_finish": {
+                        "type": "string",
+                        "description": "Total number of valid scan jobs at the moment the flow completed. Can differ from total_scan_jobs because the user may edit their profile or brokers may be added/removed during the multi-day journey. Only present on Success events.",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "foreground_run_count": {
+                        "type": "string",
+                        "description": "Number of foreground service runs (MANUAL_INITIAL or MANUAL_EDIT_PROFILE) that contributed to the journey. Higher counts indicate the user re-opened the app multiple times to make progress. Only present on Success events.",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "scheduled_run_count": {
+                        "type": "string",
+                        "description": "Number of scheduled WorkManager runs that contributed to the journey. Higher counts indicate the foreground service was killed by the system and the work was picked up by background workers. Only present on Success events.",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "total_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Total wall-clock duration from the first MANUAL_INITIAL run starting to the moment every broker had a completed scan job. Bucketed using the lower bucket boundary. Only present on Success events. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured.",
+                        "enum": [
+                            "-1",
+                            "0",
+                            "60000",
+                            "300000",
+                            "600000",
+                            "1800000",
+                            "3600000",
+                            "10800000",
+                            "21600000",
+                            "43200000",
+                            "86400000",
+                            "172800000",
+                            "259200000",
+                            "432000000",
+                            "604800000",
+                            "864000000",
+                            "1209600000"
+                        ]
+                    }
+                }
+            }
+        },
+        "context": {
+            "name": ["funnel_pir_time_to_first_scan_complete_android"]
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/post_idle_session.json5
+++ b/PixelDefinitions/wide_events/definitions/post_idle_session.json5
@@ -1,0 +1,60 @@
+{
+    "android-post-idle-session": {
+        "description": "Captures a post-idle session — NTP (with hatch) or LUT shown after an idle return — from surface shown to terminal user action or app background.",
+        "owners": ["GerardPaligot"],
+        "meta": {
+            "type": "android-post-idle-session",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "post_idle_session",
+            "status": ["SUCCESS", "CANCELLED", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "surface": {
+                        "type": "string",
+                        "description": "Which post-idle surface was shown",
+                        "enum": ["ntp", "lut"]
+                    },
+                    "status_reason": {
+                        "type": "string",
+                        "description": "Reason the session ended",
+                        "enum": [
+                            "bar_used",
+                            "chat_selected",
+                            "return_to_page_tapped",
+                            "tab_switcher_selected",
+                            "app_backgrounded",
+                            "favorite_selected"
+                        ]
+                    },
+                    "session_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Duration from surface shown to session end, bucketed (lower end of bucket, in ms). -1 marks a negative interval caused by a wall-clock adjustment during measurement.",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "time_to_first_interaction_ms_bucketed": {
+                        "type": "string",
+                        "description": "Duration from surface shown to the first non-terminal interaction (page_engaged, toggle_used, or back_pressed), bucketed (lower end of bucket, in ms). -1 marks a negative interval caused by a wall-clock adjustment during measurement.",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "page_engaged": {
+                        "type": "string",
+                        "description": "Whether the user touched the page content during the session (NTP body or WebView)",
+                        "enum": ["true", "false"]
+                    },
+                    "toggle_used": {
+                        "type": "string",
+                        "description": "Whether the user switched between search and Duck.ai modes during the session",
+                        "enum": ["true", "false"]
+                    },
+                    "back_pressed": {
+                        "type": "string",
+                        "description": "Whether the user pressed back at least once during the session",
+                        "enum": ["true", "false"]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/return_session.json5
+++ b/PixelDefinitions/wide_events/definitions/return_session.json5
@@ -1,0 +1,116 @@
+{
+    "android-return-session": {
+        "description": "Captures every return to the app, from foreground to terminal user action or app background/termination.",
+        "owners": ["YoussefKeyrouz"],
+        "meta": {
+            "type": "android-return-session",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "return_session",
+            "status": ["SUCCESS", "CANCELLED", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "after_idle": {
+                        "type": "string",
+                        "description": "True when an after-idle treatment started the session; filtering true gives the population wide_post_idle_session reports on",
+                        "enum": ["true", "false"]
+                    },
+                    "landed_on": {
+                        "type": "string",
+                        "description": "Surface the user landed on. A resumed tab is reported as web, serp or duck_ai depending on its content; there is no lut value",
+                        "enum": ["ntp", "ntp_user_initiated", "web", "serp", "duck_ai"]
+                    },
+                    "time_away_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time away before this return, bucketed (lower end of bucket, in ms). Absent when there was no prior background timestamp/date",
+                        "enum": ["0", "60000", "300000", "900000", "1800000", "3600000"]
+                    },
+                    "status_reason": {
+                        "type": "string",
+                        "description": "Reason the session ended",
+                        "enum": [
+                            "search_submitted",
+                            "ai_prompt_submitted",
+                            "url_submitted",
+                            "return_to_page_tapped",
+                            "tab_switcher_selected",
+                            "favorite_selected",
+                            "chat_selected",
+                            "app_backgrounded",
+                            "app_terminated"
+                        ]
+                    },
+                    "session_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "Duration from foreground to session end, bucketed (lower end of bucket, in ms)",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "time_to_first_interaction_ms_bucketed": {
+                        "type": "string",
+                        "description": "Time from session start to the first user interaction with the landing surface, including a successful terminal action; absent if the session ends without interaction. Bucketed (lower end of bucket, in ms)",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "focused": {
+                        "type": "string",
+                        "description": "Whether the landing surface appeared with the address bar/native input focused",
+                        "enum": ["true", "false"]
+                    },
+                    "page_engaged": {
+                        "type": "string",
+                        "description": "Whether the user touched the page content during the session (NTP body or WebView)",
+                        "enum": ["true", "false"]
+                    },
+                    "back_pressed": {
+                        "type": "string",
+                        "description": "Whether the user pressed back at least once during the session",
+                        "enum": ["true", "false"]
+                    },
+                    "opening_screen_changed": {
+                        "type": "string",
+                        "description": "Whether the user changed the app-launch opening screen setting during the session",
+                        "enum": ["true", "false"]
+                    },
+                    "close_tab_tapped": {
+                        "type": "string",
+                        "description": "Whether the user tapped the close-tab action on the escape hatch during the session",
+                        "enum": ["true", "false"]
+                    },
+                    "burn_tab_tapped": {
+                        "type": "string",
+                        "description": "Whether the user tapped the burn-tab action on the escape hatch during the session",
+                        "enum": ["true", "false"]
+                    },
+                    "source": {
+                        "type": "string",
+                        "description": "The Duck.ai entry point that triggered the session's ai_prompt_submitted terminal. Omitted for every other status_reason or when unknown",
+                        "enum": [
+                            "address_bar_prompt",
+                            "address_bar_icon",
+                            "address_bar_shortcut_chip",
+                            "address_bar_editing_state",
+                            "suggestion_ask_ai",
+                            "browsing_menu_ntp",
+                            "browsing_menu_webpage",
+                            "tab_switcher",
+                            "chat_history_new_chat",
+                            "chat_history_open_chat",
+                            "voice",
+                            "onboarding",
+                            "direct_url",
+                            "serp",
+                            "icon_shortcut",
+                            "contextual_chat",
+                            "widget_quick_actions",
+                            "widget_favorite",
+                            "system_search",
+                            "digital_assistant",
+                            "deep_link_other",
+                            "paid_settings"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/subscription-plan-change.json5
+++ b/PixelDefinitions/wide_events/definitions/subscription-plan-change.json5
@@ -1,0 +1,105 @@
+{
+    "android-subscription-plan-change": {
+        "description": "User switches their Privacy Pro subscription to a different plan.",
+        "owners": ["lmac012"],
+        "meta": {
+            "type": "android-subscription-plan-change",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "subscription-plan-change",
+            "status": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "from_plan": {
+                        "type": "string",
+                        "description": "Play basePlan ID the user is switching from"
+                    },
+                    "to_plan": {
+                        "type": "string",
+                        "description": "Play basePlan ID the user is switching to"
+                    },
+                    "from_tier": {
+                        "type": "string",
+                        "description": "Subscription tier the user is switching from",
+                        "enum": ["plus", "pro", "unknown"]
+                    },
+                    "to_tier": {
+                        "type": "string",
+                        "description": "Subscription tier the user is switching to",
+                        "enum": ["plus", "pro", "unknown"]
+                    },
+                    "billing_cycle_switch_type": {
+                        "type": "string",
+                        "description": "Whether the billing cycle changes as part of the switch",
+                        "enum": ["upgrade", "downgrade", "none"]
+                    },
+                    "tier_change_type": {
+                        "type": "string",
+                        "description": "Direction of the tier change",
+                        "enum": ["upgrade", "downgrade", "crossgrade"]
+                    },
+                    "activation_latency_ms_bucketed": {
+                        "type": "string",
+                        "description": "Duration from the Play billing switch to subscription activation",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "failure_reason": "failureReason",
+                    "step.validate_current_subscription": {
+                        "type": "string",
+                        "description": "Whether the current subscription validated successfully",
+                        "enum": ["true", "false"]
+                    },
+                    "step.retrieve_target_plan": {
+                        "type": "string",
+                        "description": "Whether the target plan was found",
+                        "enum": ["true", "false"]
+                    },
+                    "step.billing_flow_init": {
+                        "type": "string",
+                        "description": "Whether the Play billing flow initialised successfully",
+                        "enum": ["true", "false"]
+                    },
+                    "step.billing_flow_switch": {
+                        "type": "string",
+                        "description": "Present if the Play billing switch succeeded",
+                        "enum": ["true"]
+                    },
+                    "step.confirm_switch": {
+                        "type": "string",
+                        "description": "Present if the backend confirmed the switch",
+                        "enum": ["true"]
+                    },
+                    "step.ui_refresh": {
+                        "type": "string",
+                        "description": "Present if the UI refreshed after the switch",
+                        "enum": ["true"]
+                    }
+                }
+            }
+        },
+        "context": {
+            "name": [
+                "",
+                "funnel_addressbar_android__aitoggle",
+                "funnel_addressbar_android__modelpicker",
+                "funnel_addressbar_android__reasoningdropdown",
+                "funnel_appmenu_android",
+                "funnel_appsettings_android",
+                "funnel_duckai_android__freelabel",
+                "funnel_duckai_android__modelpicker",
+                "funnel_duckai_android__reasoningdropdown",
+                "funnel_duckai_android__switchmodel",
+                "funnel_modal_android__skippedonboardingupsell",
+                "funnel_modal_android__subscriptionnudge",
+                "funnel_onboarding_android",
+                "funnel_playstore",
+                "funnel_purchase_offer_page_android",
+                "funnel_restore_android__viewplans",
+                "funnel_subscriptionsettings_android__viewplans",
+                "dev_settings",
+                "dev_settings_cancel_pending"
+            ]
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/subscription-purchase.json5
+++ b/PixelDefinitions/wide_events/definitions/subscription-purchase.json5
@@ -1,0 +1,136 @@
+{
+    "android-subscription-purchase": {
+        "description": "Monitors the subscription purchase flow from initiation through confirmation",
+        "owners": ["lmac012", "cmonfortep"],
+        "meta": {
+            "type": "android-subscription-purchase",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "subscription-purchase",
+            "status": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "subscription_identifier": {
+                        "type": "string",
+                        "description": "Identifier of the subscription the user is purchasing (offer ID when present, otherwise plan ID)"
+                    },
+                    "free_trial_eligible": {
+                        "type": "string",
+                        "description": "Whether the user is eligible for a free trial at purchase start",
+                        "enum": ["true", "false"]
+                    },
+                    "use_query_purchases": {
+                        "type": "string",
+                        "description": "Value of the `useQueryPurchases` feature flag at flow start. When true, storeLogin() reads from PlayBillingManager.getLatestPurchase() (queryPurchases, active subscriptions only) and may surface the new NoActivePurchase / PurchaseInfoNotAvailable failure types. When false, the legacy purchaseHistory path is used.",
+                        "enum": ["true", "false"]
+                    },
+                    "creation_latency_ms_bucketed": {
+                        "type": "string",
+                        "description": "Duration of the account-creation step in milliseconds, bucketed using the lower bucket boundary",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "activation_latency_ms_bucketed": {
+                        "type": "string",
+                        "description": "Duration from billing flow purchase to subscription activation in milliseconds, bucketed using the lower bucket boundary",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000", "1800000", "3600000", "14400000"]
+                    },
+                    "failure_reason": {
+                        "type": "string",
+                        "description": "Free-form failure reason. Only present on FAILURE events."
+                    },
+                    "missing_product_failure_reason": {
+                        "type": "string",
+                        "description": "Sub-classification of a missing-product-details failure. Only present when billing_flow_init fails for that reason.",
+                        "enum": ["no_products_loaded", "product_id_not_found", "offer_not_found"]
+                    },
+                    "requested_product_id": {
+                        "type": "string",
+                        "description": "Play product ID requested at billing_flow_init time. Diagnostic context for missing-product failures.",
+                        "enum": ["ddg_privacy_pro", "ddg_subscription_pro"]
+                    },
+                    "requested_plan_id": {
+                        "type": "string",
+                        "description": "Play basePlan ID requested at billing_flow_init time. Diagnostic context for missing-product failures.",
+                        "enum": [
+                            "ddg-privacy-pro-monthly-renews-us",
+                            "ddg-privacy-pro-monthly-renews-row",
+                            "ddg-privacy-pro-yearly-renews-us",
+                            "ddg-privacy-pro-yearly-renews-row",
+                            "ddg-subscription-pro-yearly-renews-us",
+                            "ddg-subscription-pro-monthly-renews-us",
+                            "ddg-subscription-pro-yearly-renews-row",
+                            "ddg-subscription-pro-monthly-renews-row"
+                        ]
+                    },
+                    "requested_offer_id": {
+                        "type": "string",
+                        "description": "Play offer ID requested at billing_flow_init time, or 'none' when no offer was requested. Diagnostic context for missing-product failures."
+                    },
+                    "loaded_products_count": {
+                        "type": "string",
+                        "description": "Number of products loaded from Play at the time of a missing-product-details failure.",
+                        "pattern": "^[0-9]+$"
+                    },
+                    "billing_client_ready": {
+                        "type": "string",
+                        "description": "Whether the Play billing client was ready at the time of a missing-product-details failure.",
+                        "enum": ["true", "false"]
+                    },
+                    "last_load_products_outcome": {
+                        "type": "string",
+                        "description": "Outcome of the most recent loadProducts() call before the missing-product-details failure. Distinguishes 'Play returned empty for this user' from 'loadProducts() failed with a Play BillingError we swallowed'. Format: 'never_attempted' (we never called Play, likely lifecycle issue), 'success_n=<count>' (Play replied success with this many products), 'failure_<BillingError>' (Play replied with this billing error enum).",
+                        "pattern": "^(never_attempted|success_n=\\d+|failure_[A-Z_]+)$",
+                        "examples": ["never_attempted", "success_n=0", "failure_BILLING_UNAVAILABLE"]
+                    },
+                    "step.refresh_subscription": {
+                        "type": "string",
+                        "description": "True if the refresh-subscription step succeeded, false if it failed",
+                        "enum": ["true", "false"]
+                    },
+                    "step.create_account": {
+                        "type": "string",
+                        "description": "True if the create-account step succeeded, false if it failed",
+                        "enum": ["true", "false"]
+                    },
+                    "step.billing_flow_init": {
+                        "type": "string",
+                        "description": "True if the billing-flow-init step succeeded, false if it failed",
+                        "enum": ["true", "false"]
+                    },
+                    "step.billing_flow_purchase": {
+                        "type": "string",
+                        "description": "True if the Play billing purchase step succeeded, false if it failed",
+                        "enum": ["true", "false"]
+                    },
+                    "step.confirm_purchase": {
+                        "type": "string",
+                        "description": "True if the BE purchase-confirmation step succeeded, false if it failed",
+                        "enum": ["true", "false"]
+                    }
+                }
+            }
+        },
+        "context": {
+            "name": [
+                "",
+                "funnel_addressbar_android__aitoggle",
+                "funnel_addressbar_android__modelpicker",
+                "funnel_addressbar_android__reasoningdropdown",
+                "funnel_appmenu_android",
+                "funnel_appsettings_android",
+                "funnel_duckai_android__freelabel",
+                "funnel_duckai_android__modelpicker",
+                "funnel_duckai_android__reasoningdropdown",
+                "funnel_duckai_android__switchmodel",
+                "funnel_modal_android__skippedonboardingupsell",
+                "funnel_modal_android__subscriptionnudge",
+                "funnel_onboarding_android",
+                "funnel_playstore",
+                "funnel_purchase_offer_page_android",
+                "funnel_restore_android__viewplans",
+                "funnel_subscriptionsettings_android__viewplans"
+            ]
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/subscription-restore.json5
+++ b/PixelDefinitions/wide_events/definitions/subscription-restore.json5
@@ -1,0 +1,60 @@
+{
+    "android-subscription-restore": {
+        "description": "User attempts to restore their Privacy Pro subscription",
+        "owners": ["lmac012"],
+        "meta": {
+            "type": "android-subscription-restore",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "subscription-restore",
+            "status": ["SUCCESS", "FAILURE", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "restore_platform": {
+                        "type": "string",
+                        "description": "The platform used to restore the subscription",
+                        "enum": ["google_play", "email_address"]
+                    },
+                    "is_purchase_attempt": {
+                        "type": "string",
+                        "description": "true if the restore was triggered during a purchase attempt, false otherwise",
+                        "enum": ["true", "false"]
+                    },
+                    "use_query_purchases": {
+                        "type": "string",
+                        "description": "Value of the `useQueryPurchases` feature flag at flow start. When true, storeLogin() reads from PlayBillingManager.getLatestPurchase() (queryPurchases, active subscriptions only) and may surface the new NoActivePurchase / PurchaseInfoNotAvailable failure types. When false, the legacy purchaseHistory path is used.",
+                        "enum": ["true", "false"]
+                    },
+                    "restore_latency_ms_bucketed": {
+                        "type": "string",
+                        "description": "The duration of the restore flow in milliseconds, bucketed using the lower bucket boundary",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "failure_reason": {
+                        "type": "string",
+                        "description": "Error message indicating cause of the failure. Only present on FAILURE events."
+                    },
+                    "step.activation_flow_started": {
+                        "type": "string",
+                        "description": "Parameter present if the activation flow page was displayed during restore using email address.",
+                        "enum": ["true"]
+                    },
+                    "step.email_address_input": {
+                        "type": "string",
+                        "description": "Parameter present if the email address input page was displayed during restore using email address.",
+                        "enum": ["true"]
+                    },
+                    "step.one_time_password_input": {
+                        "type": "string",
+                        "description": "Parameter present if the otp input page was displayed during restore using email address.",
+                        "enum": ["true"]
+                    }
+                }
+            }
+        },
+        "context": {
+            "name": ["funnel_appsettings_android", "funnel_purchase_offer_page_android"]
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/sync-setup.json5
+++ b/PixelDefinitions/wide_events/definitions/sync-setup.json5
@@ -1,0 +1,76 @@
+{
+    "android-sync-setup": {
+        "description": "User attempts to set up Sync via 'Sync and Back Up This Device'",
+        "owners": ["LukasPaczos"],
+        "meta": {
+            "type": "android-sync-setup",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "sync-setup",
+            "status": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "user_auth_required": {
+                        "type": "string",
+                        "description": "Whether device authentication is required for this Sync setup flow",
+                        "enum": ["true", "false"]
+                    },
+                    "ui_version": {
+                        "type": "string",
+                        "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                        "enum": ["v1", "v2"]
+                    },
+                    "account_creation_latency_ms_bucketed": {
+                        "type": "string",
+                        "description": "Latency of the account creation API call in milliseconds, bucketed",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "initial_sync_latency_ms_bucketed": {
+                        "type": "string",
+                        "description": "Latency of the initial sync in milliseconds, bucketed",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "failure_reason": {
+                        "type": "string",
+                        "description": "Reason for failure. Only present on FAILURE events.",
+                        "enum": ["account_creation_failed", "recovery_code_generation_failed"]
+                    },
+                    "step.device_auth_not_enrolled": {
+                        "type": "string",
+                        "description": "Parameter present if the device was detected as not having authentication enrolled",
+                        "enum": ["true"]
+                    },
+                    "step.user_auth": {
+                        "type": "string",
+                        "description": "Parameter present if the user was successfully authenticated via device auth",
+                        "enum": ["true"]
+                    },
+                    "step.intro_screen_shown": {
+                        "type": "string",
+                        "description": "Parameter present if the sync intro screen was displayed",
+                        "enum": ["true"]
+                    },
+                    "step.sync_enabled": {
+                        "type": "string",
+                        "description": "Parameter present if the user opted to enable sync",
+                        "enum": ["true"]
+                    },
+                    "step.account_created": {
+                        "type": "string",
+                        "description": "Parameter present if the account was successfully created and initial sync completed",
+                        "enum": ["true"]
+                    },
+                    "step.recovery_code_shown": {
+                        "type": "string",
+                        "description": "Parameter present if the recovery code screen was displayed",
+                        "enum": ["true"]
+                    }
+                }
+            }
+        },
+        "context": {
+            "name": ["promotion_passwords", "promotion_bookmarks"]
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/vpn-enable.json5
+++ b/PixelDefinitions/wide_events/definitions/vpn-enable.json5
@@ -1,0 +1,75 @@
+{
+    "android-vpn-enable": {
+        "description": "User attempts to enable VPN",
+        "owners": ["lmac012"],
+        "meta": {
+            "type": "android-vpn-enable",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "vpn-enable",
+            "status": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "subscription_status": {
+                        "type": "string",
+                        "description": "User's subscription status at the time of VPN enable attempt",
+                        "enum": ["Auto-Renewable", "Not Auto-Renewable", "Grace Period", "Inactive", "Expired", "Unknown", "Waiting"]
+                    },
+                    "is_first_setup": {
+                        "type": "string",
+                        "description": "true if the user is launching the VPN for the first time, false otherwise",
+                        "enum": ["true", "false"]
+                    },
+                    "cancellation_reason": {
+                        "type": "string",
+                        "description": "Reason for cancellation. Only present on CANCELLED events.",
+                        "enum": ["vpn_conflict", "permission_denied"]
+                    },
+                    "failure_reason": {
+                        "type": "string",
+                        "description": "Error message indicating cause of the failure. Based on VpnStopReason enum, but could be a different static message. Only present on FAILURE events."
+                    },
+                    "service_start_duration_ms_bucketed": {
+                        "type": "string",
+                        "description": "The duration of TrackerBlockingVpnService (re)start in milliseconds, bucketed using the lower bucket boundary",
+                        "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                    },
+                    "step.show_vpn_conflict_dialog": {
+                        "type": "string",
+                        "description": "Parameter present if the user was asked if they want to disable existing 3rd party VPN",
+                        "enum": ["true"]
+                    },
+                    "step.ask_for_vpn_permission": {
+                        "type": "string",
+                        "description": "Parameter present if the user was asked to grant the VPN permission",
+                        "enum": ["true"]
+                    },
+                    "step.vpn_start_attempt": {
+                        "type": "string",
+                        "description": "Parameter present if the app attempted to (re)start VPN service. This happens after ensuring app has VPN permissions",
+                        "enum": ["true"]
+                    },
+                    "step.notify_vpn_start": {
+                        "type": "string",
+                        "description": "Parameter present if notifyVpnStart() in TrackerBlockingVpnService completed successfully",
+                        "enum": ["true"]
+                    },
+                    "step.null_tunnel_created": {
+                        "type": "string",
+                        "description": "Parameter present if null tunnel was successfully created.",
+                        "enum": ["true"]
+                    },
+                    "step.network_stack_initialized": {
+                        "type": "string",
+                        "description": "Parameter present if network stack was successfully initialized.",
+                        "enum": ["true"]
+                    }
+                }
+            }
+        },
+        "context": {
+            "name": ["app_settings", "system_tile", "notification"]
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-auth-token-refresh-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-auth-token-refresh-1.0.0.json
@@ -1,0 +1,192 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "App refreshes the auth v2 token pair, from reading the stored refresh token through fetching, validating and saving the new tokens. CANCELLED means the account no longer exists in the backend and the user was signed out.",
+    "$comment": "{\"owners\":[\"lmac012\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-auth-token-refresh" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["auth-token-refresh"] },
+                "status": {
+                    "type": "string",
+                    "description": "The terminal status of the flow",
+                    "enum": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "subscription_status": {
+                                    "type": "string",
+                                    "description": "User's subscription status when the refresh started",
+                                    "enum": [
+                                        "Auto-Renewable",
+                                        "Not Auto-Renewable",
+                                        "Grace Period",
+                                        "Inactive",
+                                        "Expired",
+                                        "Unknown",
+                                        "Waiting"
+                                    ]
+                                },
+                                "process_name": {
+                                    "type": "string",
+                                    "description": "App process the refresh ran in. 'main' is the browser process, the others are the app's secondary processes. 'UNKNOWN'/'ERROR' mean the process name could not be resolved.",
+                                    "enum": ["main", ":vpn", ":pir", ":autofill", ":fire", "UNKNOWN", "ERROR"]
+                                },
+                                "netp_is_enabled": {
+                                    "type": "string",
+                                    "description": "Whether the VPN was enabled when the refresh started. Empty string if the value could not be read.",
+                                    "enum": ["true", "false", ""]
+                                },
+                                "netp_is_running": {
+                                    "type": "string",
+                                    "description": "Whether the VPN was running when the refresh started. Empty string if the value could not be read.",
+                                    "enum": ["true", "false", ""]
+                                },
+                                "serialization_enabled": {
+                                    "type": "string",
+                                    "description": "Whether refreshes were being serialized across processes with a cross-process lock, i.e. the value of the serializeTokenRefresh flag when the refresh started.",
+                                    "enum": ["true", "false"]
+                                },
+                                "lock_outcome": {
+                                    "type": "string",
+                                    "description": "Outcome of acquiring the cross-process refresh lock. 'timeout' means another process held it for longer than the wait limit; the refresh then proceeds unserialized.",
+                                    "enum": ["acquired", "timeout", "error"]
+                                },
+                                "token_refresh_lock_wait_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time spent waiting for the cross-process refresh lock in milliseconds",
+                                    "enum": ["-1", "0", "100", "500", "1000", "3000", "10000", "30000", "60000"]
+                                },
+                                "fetch_jwks_latency_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Duration of the JWKS fetch in milliseconds",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "refresh_access_token_latency_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Duration of the token request in milliseconds",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "total_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Duration of the whole refresh in milliseconds, including any lock wait",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "backend_error_response": {
+                                    "type": "string",
+                                    "description": "Backend-supplied error code from the `error` field of the token endpoint's error body. Free-form as far as the app is concerned - the app only special-cases 'unknown_account'.",
+                                    "examples": ["unknown_account", "invalid_token_request"]
+                                },
+                                "play_login_error": {
+                                    "type": "string",
+                                    "description": "Why the Play store login fallback failed. PurchaseInfoNotAvailable carries the reason Play could not be queried.",
+                                    "pattern": "^(NoActivePurchase|AccountExternalIdMismatch|AuthenticationError|TokenValidationFailed|UnknownError|PurchaseInfoNotAvailable - .+)$",
+                                    "examples": [
+                                        "NoActivePurchase",
+                                        "AuthenticationError",
+                                        "PurchaseInfoNotAvailable - billing_client_not_ready"
+                                    ]
+                                },
+                                "failure_reason": {
+                                    "type": "string",
+                                    "description": "Exception class name of the failure. Only present on FAILURE events."
+                                },
+                                "signed_out": {
+                                    "type": "string",
+                                    "description": "Whether the user was signed out after an irrecoverable error was encountered, such as an invalid refresh token.",
+                                    "enum": ["true", "false"]
+                                },
+                                "step.lock_acquire": {
+                                    "type": "string",
+                                    "description": "true if the cross-process refresh lock was acquired, false if it timed out or errored. A false value does not fail the refresh - see lock_outcome.",
+                                    "enum": ["true", "false"]
+                                },
+                                "step.token_read": {
+                                    "type": "string",
+                                    "description": "Parameter present if the stored refresh token was read successfully",
+                                    "enum": ["true"]
+                                },
+                                "step.jwks_fetch": {
+                                    "type": "string",
+                                    "description": "Parameter present if the JWKS needed to validate the new tokens was fetched successfully",
+                                    "enum": ["true"]
+                                },
+                                "step.token_request": {
+                                    "type": "string",
+                                    "description": "true if the token endpoint returned a new token pair, false if it returned an error. A false value can still end in SUCCESS when the Play store login fallback recovers the session.",
+                                    "enum": ["true", "false"]
+                                },
+                                "step.token_validation": {
+                                    "type": "string",
+                                    "description": "Parameter present if the newly fetched tokens passed validation",
+                                    "enum": ["true"]
+                                },
+                                "step.play_login": {
+                                    "type": "string",
+                                    "description": "true if the Play store login fallback recovered the session, false if it failed",
+                                    "enum": ["true", "false"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-bad-url-error-page-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-bad-url-error-page-1.0.0.json
@@ -1,0 +1,110 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Monitors the lifecycle of a BAD_URL (unresolved host) error page: whether a redirect suggestion was offered, whether the user clicked it, and how the error page was exited. Error pages shown in custom tabs are excluded, so the measured population is regular and fire tabs only.",
+    "$comment": "{\"owners\":[\"juandiana\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-bad-url-error-page" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["bad-url-error-page"] },
+                "status": {
+                    "type": "string",
+                    "description": "The terminal status of the flow",
+                    "enum": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "step.redirect_suggested": {
+                                    "type": "string",
+                                    "description": "Parameter present when a redirect suggestion (Did you mean www.example.com?) was displayed on the error page. Absent when no suggestion was shown.",
+                                    "enum": ["true"]
+                                },
+                                "step.redirect_clicked": {
+                                    "type": "string",
+                                    "description": "Parameter present when the user tapped the redirect suggestion. Absent when the suggestion was not shown or not clicked.",
+                                    "enum": ["true"]
+                                },
+                                "last_step": {
+                                    "type": "string",
+                                    "description": "Furthest step reached when the flow ended. Persisted as each step is recorded, so flows force-completed by the cleanup policy (UNKNOWN status) still carry it. Absent when the error page was exited before any step was recorded.",
+                                    "enum": ["redirect_suggested", "redirect_clicked"]
+                                },
+                                "cancel_reason": {
+                                    "type": "string",
+                                    "description": "Present only when the flow finished with CANCELLED status. recovered_on_refresh: the user refreshed the failed page and it loaded. error_replaced_on_refresh: the user refreshed and this error page was replaced by a different error page. abandoned: the user navigated back/forward or home, closed the tab, or submitted a new query. device_offline: the device was offline when the tapped redirect suggestion was looked up, so whether the suggested hostname resolves is unknowable.",
+                                    "enum": ["recovered_on_refresh", "abandoned", "error_replaced_on_refresh", "device_offline"]
+                                },
+                                "failure_reason": {
+                                    "type": "string",
+                                    "description": "Present only when the flow finished with FAILURE status, i.e. the tapped redirect suggestion hit another BAD_URL error because the suggested hostname did not resolve either.",
+                                    "enum": ["new_hostname_resolution_failed"]
+                                },
+                                "error_page_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "How long the error page was displayed before it was exited, bucketed. Uses lower end of the bucket; -1 records a negative measured duration (device clock changed mid-flow). Absent when the flow was force-completed by the cleanup policy.",
+                                    "enum": ["-1", "0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-data-clearing-1.1.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-data-clearing-1.1.0.json
@@ -1,0 +1,191 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "User clears browsing data through various entry points (Fire button, single tab burn, Duck.ai chat deletion, app shortcuts, automatic clearing)",
+    "$comment": "{\"owners\":[\"lmac012\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app", "context"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-data-clearing" }, "version": { "const": "1.1.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["data-clearing"] },
+                "status": { "type": "string", "description": "The terminal status of the flow", "enum": ["SUCCESS", "FAILURE", "UNKNOWN"] },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "clear_options": {
+                                    "type": "string",
+                                    "description": "Comma-separated list of data types being cleared. Values: tabs,data,duckai_chats"
+                                },
+                                "browser_mode": {
+                                    "type": "string",
+                                    "description": "Whether this clear applies to Fire Mode or Regular Mode. Absent for flows that clear both in one pass (automatic foreground/background clearing).",
+                                    "enum": ["regular", "fire"]
+                                },
+                                "tab_type": {
+                                    "type": "string",
+                                    "description": "Type of the active tab when the burn was confirmed. Only present for dialog-driven flows.",
+                                    "enum": ["web", "ai"]
+                                },
+                                "tab_count": {
+                                    "type": "string",
+                                    "description": "Number of open tabs when the burn was confirmed, bucketed like the tab_count pixel parameter. Only present for dialog-driven flows.",
+                                    "enum": ["1", "2-5", "6-10", "11-20", "21-40", "41-60", "61-80", "81+"]
+                                },
+                                "total_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Duration of the data clearing operation, bucketed using the lower bucket boundary. Does not include process restart duration.",
+                                    "enum": [
+                                        "-1",
+                                        "0",
+                                        "1000",
+                                        "2000",
+                                        "3000",
+                                        "4000",
+                                        "5000",
+                                        "10000",
+                                        "30000",
+                                        "60000",
+                                        "300000",
+                                        "600000"
+                                    ]
+                                },
+                                "failure_reason": {
+                                    "type": "string",
+                                    "description": "Reason for failure. Only present on FAILURE events. Exception class name, or feature_not_supported / tab_not_found when the clear ended without an exception."
+                                },
+                                "step.web_storage_clear_success": {
+                                    "type": "string",
+                                    "description": "true if the step completed successfully, false otherwise. The implementation swallows exceptions so it does not affect the overall outcome of the data clearing operation, represented by feature.status.",
+                                    "enum": ["true", "false"]
+                                },
+                                "web_storage_clear_error": {
+                                    "type": "string",
+                                    "description": "Error message (exception class) - only present if success=false for this step"
+                                },
+                                "step.webview_app_webview_clear_success": {
+                                    "type": "string",
+                                    "description": "true if the step completed successfully, false otherwise. The implementation swallows exceptions so it does not affect the overall outcome of the data clearing operation, represented by feature.status.",
+                                    "enum": ["true", "false"]
+                                },
+                                "webview_app_webview_clear_error": {
+                                    "type": "string",
+                                    "description": "Error message (exception class) - only present if success=false for this step"
+                                },
+                                "step.webview_default_clear_success": {
+                                    "type": "string",
+                                    "description": "true if the step completed successfully, false otherwise. The implementation swallows exceptions so it does not affect the overall outcome of the data clearing operation, represented by feature.status.",
+                                    "enum": ["true", "false"]
+                                },
+                                "webview_default_clear_error": {
+                                    "type": "string",
+                                    "description": "Error message (exception class) - only present if success=false for this step"
+                                },
+                                "step.indexeddb_clear_selective_success": {
+                                    "type": "string",
+                                    "description": "true if the step completed successfully, false otherwise. The implementation swallows exceptions so it does not affect the overall outcome of the data clearing operation, represented by feature.status.",
+                                    "enum": ["true", "false"]
+                                },
+                                "indexeddb_clear_selective_error": {
+                                    "type": "string",
+                                    "description": "Error message (exception class) - only present if success=false for this step"
+                                },
+                                "step.indexeddb_clear_duckai_only_success": {
+                                    "type": "string",
+                                    "description": "true if the step completed successfully, false otherwise. The implementation swallows exceptions so it does not affect the overall outcome of the data clearing operation, represented by feature.status.",
+                                    "enum": ["true", "false"]
+                                },
+                                "indexeddb_clear_duckai_only_error": {
+                                    "type": "string",
+                                    "description": "Error message (exception class) - only present if success=false for this step"
+                                },
+                                "step.app_cache_clear_success": {
+                                    "type": "string",
+                                    "description": "true if the step completed successfully, false otherwise. The implementation swallows exceptions so it does not affect the overall outcome of the data clearing operation, represented by feature.status.",
+                                    "enum": ["true", "false"]
+                                },
+                                "app_cache_clear_error": {
+                                    "type": "string",
+                                    "description": "Error message (exception class) - only present if success=false for this step"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "context": {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Entry point the flow was started from",
+                    "enum": [
+                        "single_tab_fire_dialog",
+                        "single_tab_burn",
+                        "duckai_chat_deletion",
+                        "app_shortcut",
+                        "fire_tabs_emptied",
+                        "auto_foreground",
+                        "auto_background"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-free-trial-conversion-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-free-trial-conversion-1.0.0.json
@@ -1,0 +1,114 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Monitors free trial user journey from activation to conversion or expiration",
+    "$comment": "{\"owners\":[\"nalcalag\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-free-trial-conversion" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["free-trial-conversion"] },
+                "status": { "type": "string", "description": "The terminal status of the flow", "enum": ["SUCCESS", "FAILURE"] },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "free_trial_plan": {
+                                    "type": "string",
+                                    "description": "The base plan ID of the free trial product activated",
+                                    "enum": [
+                                        "ddg-privacy-pro-monthly-renews-us",
+                                        "ddg-privacy-pro-monthly-renews-row",
+                                        "ddg-privacy-pro-yearly-renews-us",
+                                        "ddg-privacy-pro-yearly-renews-row",
+                                        "ddg-privacy-pro-sandbox-monthly-renews-us",
+                                        "ddg-privacy-pro-sandbox-monthly-renews-row",
+                                        "ddg-privacy-pro-sandbox-yearly-renews-us",
+                                        "ddg-privacy-pro-sandbox-yearly-renews-row",
+                                        "ddg-subscription-pro-yearly-renews-us",
+                                        "ddg-subscription-pro-monthly-renews-us",
+                                        "ddg-subscription-pro-yearly-renews-row",
+                                        "ddg-subscription-pro-monthly-renews-row"
+                                    ]
+                                },
+                                "failure_reason": {
+                                    "type": "string",
+                                    "description": "Reason for failure. Only present on FAILURE events.",
+                                    "enum": ["expired", "timeout"]
+                                },
+                                "step.vpn_activated_d1": {
+                                    "type": "string",
+                                    "description": "true if VPN was successfully activated within first day of Free Trial",
+                                    "enum": ["true", "false"]
+                                },
+                                "step.vpn_activated_d2_to_d7": {
+                                    "type": "string",
+                                    "description": "true if VPN was successfully activated between D2-D7 of Free Trial",
+                                    "enum": ["true", "false"]
+                                },
+                                "step.duck_ai_paid_used": {
+                                    "type": "string",
+                                    "description": "true if paid duck.ai model has been used within a Free Trial",
+                                    "enum": ["true", "false"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-input-screen-onboarding-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-input-screen-onboarding-1.0.0.json
@@ -1,0 +1,96 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "User enables Input Screen during onboarding",
+    "$comment": "{\"owners\":[\"joshliebe\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app", "context"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-input-screen-onboarding" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["input-screen-onboarding"] },
+                "status": {
+                    "type": "string",
+                    "description": "The terminal status of the flow",
+                    "enum": ["SUCCESS", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "reinstallUser": {
+                                    "type": "string",
+                                    "description": "true if the user tapped 'I've been here before', false otherwise",
+                                    "enum": ["true", "false"]
+                                },
+                                "enabled": {
+                                    "type": "string",
+                                    "description": "true if the Input Screen is enabled, false otherwise. Only present on CANCELLED events.",
+                                    "enum": ["true", "false"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "context": {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": { "name": { "type": "string", "description": "Entry point the flow was started from", "enum": ["onboarding"] } }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-page-load-1.0.1.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-page-load-1.0.1.json
@@ -1,0 +1,205 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Monitors page load performance across lifecycle phases to track stuck-at-progress issues and overall load times",
+    "$comment": "{\"owners\":[\"GerardPaligot\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-page-load" }, "version": { "const": "1.0.1" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["page-load"] },
+                "status": {
+                    "type": "string",
+                    "description": "The terminal status of the flow",
+                    "enum": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "elapsed_time_to_finish_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Total duration from page_start to page_finish, bucketed. Uses lower end of the bucket. -1 marks a negative interval caused by a wall-clock adjustment during measurement.",
+                                    "enum": ["-1", "0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
+                                },
+                                "elapsed_time_to_visible_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Duration from page_start to page_visible, bucketed. Uses lower end of the bucket. -1 marks a negative interval caused by a wall-clock adjustment during measurement.",
+                                    "enum": ["-1", "0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
+                                },
+                                "elapsed_time_to_escaped_fixed_progress_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Duration from page_start to page_escaped_fixed_progress, bucketed. Uses lower end of the bucket. -1 marks a negative interval caused by a wall-clock adjustment during measurement.",
+                                    "enum": ["-1", "0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
+                                },
+                                "elapsed_time_to_content_scope_experiments_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Duration from page_start until the active content scope experiments were resolved, bucketed. Uses lower end of the bucket. Recorded during the page_content_scope_experiments_resolved step, so it is absent when the navigation ended before the experiments resolved.",
+                                    "enum": ["-1", "0", "5", "10", "25", "50", "100", "200", "400", "800", "1600", "3200", "6400"]
+                                },
+                                "elapsed_time_to_js_injection_complete_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Duration from page_start until every JS injector plugin has run for the navigation, content scope scripts among them, bucketed. Also covers resolving the active experiments and the browser tab's own page-started handling, so it is an upper bound on content scope injection rather than a measure of it alone. Uses lower end of the bucket. Recorded during the page_js_injection_complete step, so it is absent when the navigation ended before injection completed.",
+                                    "enum": ["-1", "0", "5", "10", "25", "50", "100", "200", "400", "800", "1600", "3200", "6400"]
+                                },
+                                "content_scope_injection_optimized": {
+                                    "type": "string",
+                                    "description": "Whether the optimized content scope script assembly path is enabled. Temporary: recorded to compare the durations above across kill-switch states during rollout of the content scope performance work.",
+                                    "enum": ["true", "false"]
+                                },
+                                "content_scope_messaging_optimized": {
+                                    "type": "string",
+                                    "description": "Whether inbound content scope JS messages are queued off the WebView JavaBridge thread. Temporary: recorded to compare overall page load time across kill-switch states during rollout of the content scope performance work.",
+                                    "enum": ["true", "false"]
+                                },
+                                "content_scope_experiments_cached": {
+                                    "type": "string",
+                                    "description": "Whether resolved content scope experiments are held between privacy config updates. Temporary: recorded to compare the durations above across kill-switch states during rollout of the content scope performance work.",
+                                    "enum": ["true", "false"]
+                                },
+                                "webview_version": { "type": "string", "description": "WebView major version" },
+                                "cpm_enabled": {
+                                    "type": "string",
+                                    "description": "Whether Cookie Pop-up Management (autoconsent) is enabled",
+                                    "enum": ["true", "false"]
+                                },
+                                "tracker_optimization_enabled_v2": {
+                                    "type": "string",
+                                    "description": "Whether tracker evaluation optimization is enabled. Deprecated key sent by app versions released before the field was renamed to tracker_optimization_enabled_v3; kept so historical data still validates.",
+                                    "enum": ["true", "false"]
+                                },
+                                "tracker_optimization_enabled_v3": {
+                                    "type": "string",
+                                    "description": "Whether tracker evaluation optimization is enabled. Deprecated key sent by app versions released before the field was removed; kept so historical data still validates",
+                                    "enum": ["true", "false"]
+                                },
+                                "is_tab_in_foreground_on_finish": {
+                                    "type": "string",
+                                    "description": "Whether the tab was in foreground when page finished loading. Reported by the caller at finish, so it is absent on a cancelled load.",
+                                    "enum": ["true", "false"]
+                                },
+                                "active_requests_on_load_start": {
+                                    "type": "string",
+                                    "description": "Number of active network requests when page load started. Reported by the caller at finish, so it is absent on a cancelled load.",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "concurrent_requests_on_finish": {
+                                    "type": "string",
+                                    "description": "Number of concurrent network requests when page finished loading. Reported by the caller at finish, so it is absent on a cancelled load.",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "progress": {
+                                    "type": "string",
+                                    "description": "True if page became visible at or after fixed progress threshold (50%), false if before. Recorded during the page_visible step.",
+                                    "enum": ["true", "false"]
+                                },
+                                "outcome": {
+                                    "type": "string",
+                                    "description": "Final outcome of the page load. Recorded during the page_finish step.",
+                                    "enum": ["success", "error"]
+                                },
+                                "error_code": {
+                                    "type": "string",
+                                    "description": "WebViewClient error constant name (e.g., ERROR_HOST_LOOKUP, ERROR_CONNECT). Only present on error outcomes.",
+                                    "examples": ["ERROR_HOST_LOOKUP", "ERROR_CONNECT"]
+                                },
+                                "failure_reason": {
+                                    "type": "string",
+                                    "description": "Failure reason auto-attached by the wide event client when the flow finishes with FlowStatus.Failure. Mirrors error_code for page-load failures."
+                                },
+                                "cancellation_reason": {
+                                    "type": "string",
+                                    "description": "Why a load ended without finishing. Only present on CANCELLED loads, which are loads superseded by another main frame load in the same tab before they finished. superseded_same_url covers a reload or restart; superseded_different_url covers a redirect hop and the user navigating away - WebView does not distinguish them.",
+                                    "enum": ["superseded_same_url", "superseded_different_url"]
+                                },
+                                "step.page_start": {
+                                    "type": "string",
+                                    "description": "Parameter present when page load begins",
+                                    "enum": ["true"]
+                                },
+                                "step.page_content_scope_experiments_resolved": {
+                                    "type": "string",
+                                    "description": "Parameter present when the active content scope experiments have been resolved for the navigation",
+                                    "enum": ["true"]
+                                },
+                                "step.page_js_injection_complete": {
+                                    "type": "string",
+                                    "description": "Parameter present when every JS injector plugin has run for the navigation",
+                                    "enum": ["true"]
+                                },
+                                "step.page_visible": {
+                                    "type": "string",
+                                    "description": "Parameter present when page becomes visible",
+                                    "enum": ["true"]
+                                },
+                                "step.page_escaped_fixed_progress": {
+                                    "type": "string",
+                                    "description": "Parameter present when progress escapes the fixed progress zone (typically 50%)",
+                                    "enum": ["true"]
+                                },
+                                "step.page_finish": {
+                                    "type": "string",
+                                    "description": "Parameter present when page load completes or fails",
+                                    "enum": ["true", "false"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-pir-initial-scan-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-pir-initial-scan-1.0.0.json
@@ -1,0 +1,386 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Wide event tracking the lifecycle of a manually-triggered PIR run (initial scan or post-profile-edit), covering scan progress in 10% increments, scan completion, and the follow-on opt-out scheduling phase. Used to measure end-to-end success rate, drop-off, and per-phase latency.",
+    "$comment": "{\"owners\":[\"karlenDimla\",\"landomen\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app", "context"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-pir-initial-scan" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["pir-initial-scan"] },
+                "status": {
+                    "type": "string",
+                    "description": "The terminal status of the flow",
+                    "enum": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "execution_type": {
+                                    "type": "string",
+                                    "description": "Distinguishes the user's first manual scan after onboarding (manual_initial), a dashboard-triggered resume of an interrupted initial scan (manual_initial_resume), and a re-scan triggered by editing a saved profile (manual_edit_profile)",
+                                    "enum": ["manual_initial", "manual_edit_profile", "manual_initial_resume"]
+                                },
+                                "profile_queries_count": {
+                                    "type": "string",
+                                    "description": "Number of user profile queries used in the run",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "broker_count": {
+                                    "type": "string",
+                                    "description": "Number of active brokers at the start of the run",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "total_scan_jobs": {
+                                    "type": "string",
+                                    "description": "Total number of (broker x profile) scan jobs eligible for execution at the start of the run",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "web_view_count": {
+                                    "type": "string",
+                                    "description": "Number of parallel WebView runners used during the scan portion. Equals min(total_scan_jobs, MAX_DETACHED_WEBVIEW_COUNT=20). 0 when there are no eligible scan jobs.",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "scheduling": {
+                                    "type": "string",
+                                    "description": "How scan/opt-out steps were distributed across the WebView runners for this run, as resolved from the workQueueScheduling remote toggle at run start: a shared cost-ordered work queue (queue) or contiguous equal-count chunks per runner (static).",
+                                    "enum": ["queue", "static"]
+                                },
+                                "total_opt_out_jobs": {
+                                    "type": "string",
+                                    "description": "Total number of opt-out jobs executed during the run. 0 when opt-out was skipped (no eligible form-opt-out brokers). Only populated on terminal events.",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "power_saving": {
+                                    "type": "string",
+                                    "description": "Whether the device was in power saving mode at the start of the run",
+                                    "enum": ["true", "false"]
+                                },
+                                "battery_optimizations": {
+                                    "type": "string",
+                                    "description": "Whether battery optimizations were enabled for the app at the start of the run",
+                                    "enum": ["true", "false"]
+                                },
+                                "vpn_connection_state": {
+                                    "type": "string",
+                                    "description": "Reported VPN connection state at the start of the run",
+                                    "enum": ["connected", "disconnected"]
+                                },
+                                "notifications_permission_granted": {
+                                    "type": "string",
+                                    "description": "Whether the user had granted the POST_NOTIFICATIONS runtime permission at the start of the run",
+                                    "enum": ["true", "false"]
+                                },
+                                "tracker_blocking_state": {
+                                    "type": "string",
+                                    "description": "Whether tracker blocking was enabled or disabled during the run",
+                                    "enum": ["enabled", "disabled"]
+                                },
+                                "last_step": {
+                                    "type": "string",
+                                    "description": "The last recorded step name when the flow terminated. Useful for understanding where flows drop off when status is FAILURE, CANCELLED, or UNKNOWN.",
+                                    "enum": [
+                                        "started",
+                                        "progress_10",
+                                        "progress_20",
+                                        "progress_30",
+                                        "progress_40",
+                                        "progress_50",
+                                        "progress_60",
+                                        "progress_70",
+                                        "progress_80",
+                                        "progress_90",
+                                        "scan_completed",
+                                        "opt_out_started",
+                                        "opt_out_completed",
+                                        "opt_out_skipped"
+                                    ]
+                                },
+                                "last_step_elapsed_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from run start to when last_step was reached, bucketed using the lower bucket boundary. Recorded on every step after 'started'. On UNKNOWN/killed runs this is the only signal for how long the run had been going before termination, since the total_*_duration intervals are never recorded when a run is killed.",
+                                    "enum": [
+                                        "0",
+                                        "10000",
+                                        "30000",
+                                        "60000",
+                                        "120000",
+                                        "300000",
+                                        "600000",
+                                        "900000",
+                                        "1800000",
+                                        "3600000",
+                                        "7200000",
+                                        "14400000",
+                                        "28800000"
+                                    ]
+                                },
+                                "failure_reason": {
+                                    "type": "string",
+                                    "description": "Reason a run failed. Only present on FAILURE events. Specific exception types are mapped to bounded values; anything not in the known set falls back to unknown_error. The phase the run was in when it failed is recoverable from last_step.",
+                                    "enum": [
+                                        "no_active_brokers",
+                                        "illegal_state_exception",
+                                        "illegal_argument_exception",
+                                        "null_pointer_exception",
+                                        "io_exception",
+                                        "sqlite_exception",
+                                        "timeout_cancellation_exception",
+                                        "renderer_gone",
+                                        "unknown_error"
+                                    ]
+                                },
+                                "did_crash": {
+                                    "type": "string",
+                                    "description": "Only present on renderer_gone failures. true = the WebView renderer actually crashed; false = the system reclaimed it (e.g. low memory).",
+                                    "enum": ["true", "false"]
+                                },
+                                "cancellation_reason": {
+                                    "type": "string",
+                                    "description": "Reason a PIR run was cancelled. Only present on CANCELLED events. superseded_by_profile_edit (a profile-edit re-scan replaced this run), superseded_by_new_run (any other newer run replaced it), profile_deleted/foreground_start_failed and the eligibility reasons (feature_disabled, subscription_expired, entitlement_lost, repository_unavailable) are client-attributed; work_stopped is a generic coroutine/WorkManager cancellation. The phase the run was in when it was cancelled is recoverable from last_step.",
+                                    "enum": [
+                                        "superseded_by_new_run",
+                                        "superseded_by_profile_edit",
+                                        "profile_deleted",
+                                        "feature_disabled",
+                                        "subscription_expired",
+                                        "entitlement_lost",
+                                        "repository_unavailable",
+                                        "foreground_start_failed",
+                                        "work_stopped"
+                                    ]
+                                },
+                                "step.started": {
+                                    "type": "string",
+                                    "description": "Parameter present when the run body actually begins (after the no-profiles early return)",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_10": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 10%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_20": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 20%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_30": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 30%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_40": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 40%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_50": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 50%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_60": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 60%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_70": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 70%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_80": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 80%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_90": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 90%",
+                                    "enum": ["true"]
+                                },
+                                "step.scan_completed": {
+                                    "type": "string",
+                                    "description": "Parameter present when all scan jobs finish (signals the end of the scan portion; replaces a hypothetical progress_100)",
+                                    "enum": ["true"]
+                                },
+                                "step.opt_out_started": {
+                                    "type": "string",
+                                    "description": "Parameter present when the opt-out scheduling phase begins (only when there is at least one eligible form-opt-out broker)",
+                                    "enum": ["true"]
+                                },
+                                "step.opt_out_completed": {
+                                    "type": "string",
+                                    "description": "Parameter present when the opt-out scheduling phase finishes successfully",
+                                    "enum": ["true"]
+                                },
+                                "step.opt_out_skipped": {
+                                    "type": "string",
+                                    "description": "Parameter present when the opt-out scheduling phase is skipped because there are no eligible form-opt-out brokers",
+                                    "enum": ["true"]
+                                },
+                                "decile_0_10_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from run start to crossing 10% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_10_20_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 10% to crossing 20% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_20_30_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 20% to crossing 30% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_30_40_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 30% to crossing 40% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_40_50_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 40% to crossing 50% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_50_60_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 50% to crossing 60% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_60_70_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 60% to crossing 70% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_70_80_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 70% to crossing 80% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_80_90_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 80% to crossing 90% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "opt_out_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time spent in the opt-out scheduling phase from opt_out_started to opt_out_completed, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "total_scan_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from run start to scan_completed — the full scan phase, including the final 90-100% band that the per-decile intervals don't cover — bucketed using the lower bucket boundary. Absent on runs that never reach scan_completed (e.g. UNKNOWN/killed runs). A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured.",
+                                    "enum": [
+                                        "-1",
+                                        "0",
+                                        "10000",
+                                        "30000",
+                                        "60000",
+                                        "120000",
+                                        "300000",
+                                        "600000",
+                                        "900000",
+                                        "1800000",
+                                        "3600000",
+                                        "7200000",
+                                        "14400000",
+                                        "28800000"
+                                    ]
+                                },
+                                "total_flow_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from run start to flow finish — end-to-end, including the opt-out scheduling phase — bucketed using the lower bucket boundary. Absent on runs finalized by the cleanup timeout (e.g. UNKNOWN/killed runs). A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured.",
+                                    "enum": [
+                                        "-1",
+                                        "0",
+                                        "10000",
+                                        "30000",
+                                        "60000",
+                                        "120000",
+                                        "300000",
+                                        "600000",
+                                        "900000",
+                                        "1800000",
+                                        "3600000",
+                                        "7200000",
+                                        "14400000",
+                                        "28800000"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "context": {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Entry point the flow was started from",
+                    "enum": ["funnel_pir_initial_android", "funnel_pir_edit_profile_android", "funnel_pir_initial_resume_android"]
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-pir-scheduled-scan-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-pir-scheduled-scan-1.0.0.json
@@ -1,0 +1,386 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Wide event tracking the lifecycle of a scheduled (background, WorkManager-triggered) PIR run, covering scan progress in 10% increments, scan completion, and the follow-on opt-out scheduling phase. Sampled client-side at 20% (hardcoded in PirScanWideEventImpl.SCHEDULED_SCAN_SAMPLE_RATE) to keep pixel volume manageable.",
+    "$comment": "{\"owners\":[\"karlenDimla\",\"landomen\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app", "context"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-pir-scheduled-scan" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["pir-scheduled-scan"] },
+                "status": {
+                    "type": "string",
+                    "description": "The terminal status of the flow",
+                    "enum": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "execution_type": {
+                                    "type": "string",
+                                    "description": "Always 'scheduled' for this event; included for parity with the manual wide event so dashboards can union the two streams.",
+                                    "enum": ["scheduled"]
+                                },
+                                "profile_queries_count": {
+                                    "type": "string",
+                                    "description": "Number of user profile queries used in the run",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "broker_count": {
+                                    "type": "string",
+                                    "description": "Number of active brokers at the start of the run",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "total_scan_jobs": {
+                                    "type": "string",
+                                    "description": "Total number of (broker x profile) scan jobs eligible for execution at the start of the run",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "web_view_count": {
+                                    "type": "string",
+                                    "description": "Number of parallel WebView runners used during the scan portion. Equals min(total_scan_jobs, MAX_DETACHED_WEBVIEW_COUNT=20). 0 when there are no eligible scan jobs.",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "scheduling": {
+                                    "type": "string",
+                                    "description": "How scan/opt-out steps were distributed across the WebView runners for this run, as resolved from the workQueueScheduling remote toggle at run start: a shared cost-ordered work queue (queue) or contiguous equal-count chunks per runner (static).",
+                                    "enum": ["queue", "static"]
+                                },
+                                "total_opt_out_jobs": {
+                                    "type": "string",
+                                    "description": "Total number of opt-out jobs executed during the run. 0 when opt-out was skipped (no eligible form-opt-out brokers). Only populated on terminal events.",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "power_saving": {
+                                    "type": "string",
+                                    "description": "Whether the device was in power saving mode at the start of the run",
+                                    "enum": ["true", "false"]
+                                },
+                                "battery_optimizations": {
+                                    "type": "string",
+                                    "description": "Whether battery optimizations were enabled for the app at the start of the run",
+                                    "enum": ["true", "false"]
+                                },
+                                "vpn_connection_state": {
+                                    "type": "string",
+                                    "description": "Reported VPN connection state at the start of the run",
+                                    "enum": ["connected", "disconnected"]
+                                },
+                                "notifications_permission_granted": {
+                                    "type": "string",
+                                    "description": "Whether the user had granted the POST_NOTIFICATIONS runtime permission at the start of the run",
+                                    "enum": ["true", "false"]
+                                },
+                                "tracker_blocking_state": {
+                                    "type": "string",
+                                    "description": "Whether tracker blocking was enabled or disabled during the run",
+                                    "enum": ["enabled", "disabled"]
+                                },
+                                "last_step": {
+                                    "type": "string",
+                                    "description": "The last recorded step name when the flow terminated. Useful for understanding where flows drop off when status is FAILURE, CANCELLED, or UNKNOWN.",
+                                    "enum": [
+                                        "started",
+                                        "progress_10",
+                                        "progress_20",
+                                        "progress_30",
+                                        "progress_40",
+                                        "progress_50",
+                                        "progress_60",
+                                        "progress_70",
+                                        "progress_80",
+                                        "progress_90",
+                                        "scan_completed",
+                                        "opt_out_started",
+                                        "opt_out_completed",
+                                        "opt_out_skipped"
+                                    ]
+                                },
+                                "last_step_elapsed_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from run start to when last_step was reached, bucketed using the lower bucket boundary. Recorded on every step after 'started'. On UNKNOWN/killed runs this is the only signal for how long the run had been going before termination, since the total_*_duration intervals are never recorded when a run is killed.",
+                                    "enum": [
+                                        "0",
+                                        "10000",
+                                        "30000",
+                                        "60000",
+                                        "120000",
+                                        "300000",
+                                        "600000",
+                                        "900000",
+                                        "1800000",
+                                        "3600000",
+                                        "7200000",
+                                        "14400000",
+                                        "28800000"
+                                    ]
+                                },
+                                "failure_reason": {
+                                    "type": "string",
+                                    "description": "Reason a run failed. Only present on FAILURE events. Specific exception types are mapped to bounded values; anything not in the known set falls back to unknown_error. The phase the run was in when it failed is recoverable from last_step.",
+                                    "enum": [
+                                        "no_active_brokers",
+                                        "illegal_state_exception",
+                                        "illegal_argument_exception",
+                                        "null_pointer_exception",
+                                        "io_exception",
+                                        "sqlite_exception",
+                                        "timeout_cancellation_exception",
+                                        "renderer_gone",
+                                        "unknown_error"
+                                    ]
+                                },
+                                "did_crash": {
+                                    "type": "string",
+                                    "description": "Only present on renderer_gone failures. true = the WebView renderer actually crashed; false = the system reclaimed it (e.g. low memory).",
+                                    "enum": ["true", "false"]
+                                },
+                                "cancellation_reason": {
+                                    "type": "string",
+                                    "description": "Reason a PIR run was cancelled. Only present on CANCELLED events. superseded_by_profile_edit (a profile-edit re-scan replaced this run), superseded_by_new_run (any other newer run replaced it), profile_deleted/foreground_start_failed and the eligibility reasons (feature_disabled, subscription_expired, entitlement_lost, repository_unavailable) are client-attributed; work_stopped is a generic coroutine/WorkManager cancellation. The phase the run was in when it was cancelled is recoverable from last_step.",
+                                    "enum": [
+                                        "superseded_by_new_run",
+                                        "superseded_by_profile_edit",
+                                        "profile_deleted",
+                                        "feature_disabled",
+                                        "subscription_expired",
+                                        "entitlement_lost",
+                                        "repository_unavailable",
+                                        "foreground_start_failed",
+                                        "work_stopped"
+                                    ]
+                                },
+                                "step.started": {
+                                    "type": "string",
+                                    "description": "Parameter present when the run body actually begins (after the no-profiles early return)",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_10": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 10%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_20": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 20%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_30": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 30%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_40": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 40%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_50": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 50%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_60": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 60%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_70": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 70%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_80": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 80%",
+                                    "enum": ["true"]
+                                },
+                                "step.progress_90": {
+                                    "type": "string",
+                                    "description": "Parameter present when the rolling completed-scan-jobs count first crosses 90%",
+                                    "enum": ["true"]
+                                },
+                                "step.scan_completed": {
+                                    "type": "string",
+                                    "description": "Parameter present when all scan jobs finish (signals the end of the scan portion; replaces a hypothetical progress_100)",
+                                    "enum": ["true"]
+                                },
+                                "step.opt_out_started": {
+                                    "type": "string",
+                                    "description": "Parameter present when the opt-out scheduling phase begins (only when there is at least one eligible form-opt-out broker)",
+                                    "enum": ["true"]
+                                },
+                                "step.opt_out_completed": {
+                                    "type": "string",
+                                    "description": "Parameter present when the opt-out scheduling phase finishes successfully",
+                                    "enum": ["true"]
+                                },
+                                "step.opt_out_skipped": {
+                                    "type": "string",
+                                    "description": "Parameter present when the opt-out scheduling phase is skipped because there are no eligible form-opt-out brokers",
+                                    "enum": ["true"]
+                                },
+                                "decile_0_10_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from run start to crossing 10% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_10_20_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 10% to crossing 20% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_20_30_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 20% to crossing 30% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_30_40_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 30% to crossing 40% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_40_50_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 40% to crossing 50% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_50_60_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 50% to crossing 60% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_60_70_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 60% to crossing 70% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_70_80_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 70% to crossing 80% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "decile_80_90_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from crossing 80% to crossing 90% of scan jobs, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "opt_out_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time spent in the opt-out scheduling phase from opt_out_started to opt_out_completed, bucketed using the lower bucket boundary. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "total_scan_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from run start to scan_completed — the full scan phase, including the final 90-100% band that the per-decile intervals don't cover — bucketed using the lower bucket boundary. Absent on runs that never reach scan_completed (e.g. UNKNOWN/killed runs). A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured.",
+                                    "enum": [
+                                        "-1",
+                                        "0",
+                                        "10000",
+                                        "30000",
+                                        "60000",
+                                        "120000",
+                                        "300000",
+                                        "600000",
+                                        "900000",
+                                        "1800000",
+                                        "3600000",
+                                        "7200000",
+                                        "14400000",
+                                        "28800000"
+                                    ]
+                                },
+                                "total_flow_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from run start to flow finish — end-to-end, including the opt-out scheduling phase — bucketed using the lower bucket boundary. Absent on runs finalized by the cleanup timeout (e.g. UNKNOWN/killed runs). A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured.",
+                                    "enum": [
+                                        "-1",
+                                        "0",
+                                        "10000",
+                                        "30000",
+                                        "60000",
+                                        "120000",
+                                        "300000",
+                                        "600000",
+                                        "900000",
+                                        "1800000",
+                                        "3600000",
+                                        "7200000",
+                                        "14400000",
+                                        "28800000"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "context": {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Entry point the flow was started from",
+                    "enum": ["funnel_pir_scheduled_android"]
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-pir-time-to-first-scan-complete-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-pir-time-to-first-scan-complete-1.0.0.json
@@ -1,0 +1,171 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Long-lived wide event measuring the wall-clock duration from the first time the user starts the initial PIR scan (MANUAL_INITIAL) to the moment every broker has at least one completed scan job (the dashboard's 'all done' state). Spans multiple foreground service runs and scheduled worker runs since the foreground service is frequently killed and the worker resumes the work later. One-shot per install (cleared only via PIR data reset). 30-day cleanup timeout records abandoned journeys as Unknown.",
+    "$comment": "{\"owners\":[\"karlenDimla\",\"landomen\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app", "context"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-pir-time-to-first-scan-complete" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["pir-time-to-first-scan-complete"] },
+                "status": { "type": "string", "description": "The terminal status of the flow", "enum": ["SUCCESS", "UNKNOWN"] },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "profile_queries_count": {
+                                    "type": "string",
+                                    "description": "Number of user profile queries at the moment the flow started (first MANUAL_INITIAL run)",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "broker_count": {
+                                    "type": "string",
+                                    "description": "Number of active brokers at the moment the flow started",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "total_scan_jobs": {
+                                    "type": "string",
+                                    "description": "Total number of (broker x profile) scan jobs eligible for execution at the moment the flow started",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "web_view_count": {
+                                    "type": "string",
+                                    "description": "Number of parallel WebView runners used at the start of the flow. Equals min(total_scan_jobs, MAX_DETACHED_WEBVIEW_COUNT=20). 0 when there are no eligible scan jobs.",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "power_saving": {
+                                    "type": "string",
+                                    "description": "Whether the device was in power saving mode at the moment the flow started",
+                                    "enum": ["true", "false"]
+                                },
+                                "battery_optimizations": {
+                                    "type": "string",
+                                    "description": "Whether battery optimizations were enabled for the app at the moment the flow started",
+                                    "enum": ["true", "false"]
+                                },
+                                "vpn_connection_state": {
+                                    "type": "string",
+                                    "description": "Reported VPN connection state at the moment the flow started",
+                                    "enum": ["connected", "disconnected"]
+                                },
+                                "notifications_permission_granted": {
+                                    "type": "string",
+                                    "description": "Whether the user had granted the POST_NOTIFICATIONS runtime permission at the moment the flow started",
+                                    "enum": ["true", "false"]
+                                },
+                                "tracker_blocking_state": {
+                                    "type": "string",
+                                    "description": "Whether tracker blocking was enabled or disabled at the moment the flow started",
+                                    "enum": ["enabled", "disabled"]
+                                },
+                                "total_scan_jobs_at_finish": {
+                                    "type": "string",
+                                    "description": "Total number of valid scan jobs at the moment the flow completed. Can differ from total_scan_jobs because the user may edit their profile or brokers may be added/removed during the multi-day journey. Only present on Success events.",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "foreground_run_count": {
+                                    "type": "string",
+                                    "description": "Number of foreground service runs (MANUAL_INITIAL or MANUAL_EDIT_PROFILE) that contributed to the journey. Higher counts indicate the user re-opened the app multiple times to make progress. Only present on Success events.",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "scheduled_run_count": {
+                                    "type": "string",
+                                    "description": "Number of scheduled WorkManager runs that contributed to the journey. Higher counts indicate the foreground service was killed by the system and the work was picked up by background workers. Only present on Success events.",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "total_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Total wall-clock duration from the first MANUAL_INITIAL run starting to the moment every broker had a completed scan job. Bucketed using the lower bucket boundary. Only present on Success events. A value of -1 means the device clock moved backwards during the interval, so the duration could not be measured.",
+                                    "enum": [
+                                        "-1",
+                                        "0",
+                                        "60000",
+                                        "300000",
+                                        "600000",
+                                        "1800000",
+                                        "3600000",
+                                        "10800000",
+                                        "21600000",
+                                        "43200000",
+                                        "86400000",
+                                        "172800000",
+                                        "259200000",
+                                        "432000000",
+                                        "604800000",
+                                        "864000000",
+                                        "1209600000"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "context": {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Entry point the flow was started from",
+                    "enum": ["funnel_pir_time_to_first_scan_complete_android"]
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-post-idle-session-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-post-idle-session-1.0.0.json
@@ -1,0 +1,118 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Captures a post-idle session — NTP (with hatch) or LUT shown after an idle return — from surface shown to terminal user action or app background.",
+    "$comment": "{\"owners\":[\"GerardPaligot\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-post-idle-session" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["post_idle_session"] },
+                "status": {
+                    "type": "string",
+                    "description": "The terminal status of the flow",
+                    "enum": ["SUCCESS", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "surface": { "type": "string", "description": "Which post-idle surface was shown", "enum": ["ntp", "lut"] },
+                                "status_reason": {
+                                    "type": "string",
+                                    "description": "Reason the session ended",
+                                    "enum": [
+                                        "bar_used",
+                                        "chat_selected",
+                                        "return_to_page_tapped",
+                                        "tab_switcher_selected",
+                                        "app_backgrounded",
+                                        "favorite_selected"
+                                    ]
+                                },
+                                "session_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Duration from surface shown to session end, bucketed (lower end of bucket, in ms). -1 marks a negative interval caused by a wall-clock adjustment during measurement.",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "time_to_first_interaction_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Duration from surface shown to the first non-terminal interaction (page_engaged, toggle_used, or back_pressed), bucketed (lower end of bucket, in ms). -1 marks a negative interval caused by a wall-clock adjustment during measurement.",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "page_engaged": {
+                                    "type": "string",
+                                    "description": "Whether the user touched the page content during the session (NTP body or WebView)",
+                                    "enum": ["true", "false"]
+                                },
+                                "toggle_used": {
+                                    "type": "string",
+                                    "description": "Whether the user switched between search and Duck.ai modes during the session",
+                                    "enum": ["true", "false"]
+                                },
+                                "back_pressed": {
+                                    "type": "string",
+                                    "description": "Whether the user pressed back at least once during the session",
+                                    "enum": ["true", "false"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-return-session-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-return-session-1.0.0.json
@@ -1,0 +1,178 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Captures every return to the app, from foreground to terminal user action or app background/termination.",
+    "$comment": "{\"owners\":[\"YoussefKeyrouz\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-return-session" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["return_session"] },
+                "status": {
+                    "type": "string",
+                    "description": "The terminal status of the flow",
+                    "enum": ["SUCCESS", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "after_idle": {
+                                    "type": "string",
+                                    "description": "True when an after-idle treatment started the session; filtering true gives the population wide_post_idle_session reports on",
+                                    "enum": ["true", "false"]
+                                },
+                                "landed_on": {
+                                    "type": "string",
+                                    "description": "Surface the user landed on. A resumed tab is reported as web, serp or duck_ai depending on its content; there is no lut value",
+                                    "enum": ["ntp", "ntp_user_initiated", "web", "serp", "duck_ai"]
+                                },
+                                "time_away_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time away before this return, bucketed (lower end of bucket, in ms). Absent when there was no prior background timestamp/date",
+                                    "enum": ["0", "60000", "300000", "900000", "1800000", "3600000"]
+                                },
+                                "status_reason": {
+                                    "type": "string",
+                                    "description": "Reason the session ended",
+                                    "enum": [
+                                        "search_submitted",
+                                        "ai_prompt_submitted",
+                                        "url_submitted",
+                                        "return_to_page_tapped",
+                                        "tab_switcher_selected",
+                                        "favorite_selected",
+                                        "chat_selected",
+                                        "app_backgrounded",
+                                        "app_terminated"
+                                    ]
+                                },
+                                "session_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Duration from foreground to session end, bucketed (lower end of bucket, in ms)",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "time_to_first_interaction_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from session start to the first user interaction with the landing surface, including a successful terminal action; absent if the session ends without interaction. Bucketed (lower end of bucket, in ms)",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "focused": {
+                                    "type": "string",
+                                    "description": "Whether the landing surface appeared with the address bar/native input focused",
+                                    "enum": ["true", "false"]
+                                },
+                                "page_engaged": {
+                                    "type": "string",
+                                    "description": "Whether the user touched the page content during the session (NTP body or WebView)",
+                                    "enum": ["true", "false"]
+                                },
+                                "back_pressed": {
+                                    "type": "string",
+                                    "description": "Whether the user pressed back at least once during the session",
+                                    "enum": ["true", "false"]
+                                },
+                                "opening_screen_changed": {
+                                    "type": "string",
+                                    "description": "Whether the user changed the app-launch opening screen setting during the session",
+                                    "enum": ["true", "false"]
+                                },
+                                "close_tab_tapped": {
+                                    "type": "string",
+                                    "description": "Whether the user tapped the close-tab action on the escape hatch during the session",
+                                    "enum": ["true", "false"]
+                                },
+                                "burn_tab_tapped": {
+                                    "type": "string",
+                                    "description": "Whether the user tapped the burn-tab action on the escape hatch during the session",
+                                    "enum": ["true", "false"]
+                                },
+                                "source": {
+                                    "type": "string",
+                                    "description": "The Duck.ai entry point that triggered the session's ai_prompt_submitted terminal. Omitted for every other status_reason or when unknown",
+                                    "enum": [
+                                        "address_bar_prompt",
+                                        "address_bar_icon",
+                                        "address_bar_shortcut_chip",
+                                        "address_bar_editing_state",
+                                        "suggestion_ask_ai",
+                                        "browsing_menu_ntp",
+                                        "browsing_menu_webpage",
+                                        "tab_switcher",
+                                        "chat_history_new_chat",
+                                        "chat_history_open_chat",
+                                        "voice",
+                                        "onboarding",
+                                        "direct_url",
+                                        "serp",
+                                        "icon_shortcut",
+                                        "contextual_chat",
+                                        "widget_quick_actions",
+                                        "widget_favorite",
+                                        "system_search",
+                                        "digital_assistant",
+                                        "deep_link_other",
+                                        "paid_settings"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-subscription-plan-change-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-subscription-plan-change-1.0.0.json
@@ -1,0 +1,173 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "User switches their Privacy Pro subscription to a different plan.",
+    "$comment": "{\"owners\":[\"lmac012\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app", "context"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-subscription-plan-change" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["subscription-plan-change"] },
+                "status": {
+                    "type": "string",
+                    "description": "The terminal status of the flow",
+                    "enum": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "from_plan": { "type": "string", "description": "Play basePlan ID the user is switching from" },
+                                "to_plan": { "type": "string", "description": "Play basePlan ID the user is switching to" },
+                                "from_tier": {
+                                    "type": "string",
+                                    "description": "Subscription tier the user is switching from",
+                                    "enum": ["plus", "pro", "unknown"]
+                                },
+                                "to_tier": {
+                                    "type": "string",
+                                    "description": "Subscription tier the user is switching to",
+                                    "enum": ["plus", "pro", "unknown"]
+                                },
+                                "billing_cycle_switch_type": {
+                                    "type": "string",
+                                    "description": "Whether the billing cycle changes as part of the switch",
+                                    "enum": ["upgrade", "downgrade", "none"]
+                                },
+                                "tier_change_type": {
+                                    "type": "string",
+                                    "description": "Direction of the tier change",
+                                    "enum": ["upgrade", "downgrade", "crossgrade"]
+                                },
+                                "activation_latency_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Duration from the Play billing switch to subscription activation",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "failure_reason": {
+                                    "type": "string",
+                                    "description": "Exception class name of the failure. Only present on FAILURE events."
+                                },
+                                "step.validate_current_subscription": {
+                                    "type": "string",
+                                    "description": "Whether the current subscription validated successfully",
+                                    "enum": ["true", "false"]
+                                },
+                                "step.retrieve_target_plan": {
+                                    "type": "string",
+                                    "description": "Whether the target plan was found",
+                                    "enum": ["true", "false"]
+                                },
+                                "step.billing_flow_init": {
+                                    "type": "string",
+                                    "description": "Whether the Play billing flow initialised successfully",
+                                    "enum": ["true", "false"]
+                                },
+                                "step.billing_flow_switch": {
+                                    "type": "string",
+                                    "description": "Present if the Play billing switch succeeded",
+                                    "enum": ["true"]
+                                },
+                                "step.confirm_switch": {
+                                    "type": "string",
+                                    "description": "Present if the backend confirmed the switch",
+                                    "enum": ["true"]
+                                },
+                                "step.ui_refresh": {
+                                    "type": "string",
+                                    "description": "Present if the UI refreshed after the switch",
+                                    "enum": ["true"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "context": {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Entry point the flow was started from",
+                    "enum": [
+                        "",
+                        "funnel_addressbar_android__aitoggle",
+                        "funnel_addressbar_android__modelpicker",
+                        "funnel_addressbar_android__reasoningdropdown",
+                        "funnel_appmenu_android",
+                        "funnel_appsettings_android",
+                        "funnel_duckai_android__freelabel",
+                        "funnel_duckai_android__modelpicker",
+                        "funnel_duckai_android__reasoningdropdown",
+                        "funnel_duckai_android__switchmodel",
+                        "funnel_modal_android__skippedonboardingupsell",
+                        "funnel_modal_android__subscriptionnudge",
+                        "funnel_onboarding_android",
+                        "funnel_playstore",
+                        "funnel_purchase_offer_page_android",
+                        "funnel_restore_android__viewplans",
+                        "funnel_subscriptionsettings_android__viewplans",
+                        "dev_settings",
+                        "dev_settings_cancel_pending"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-subscription-purchase-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-subscription-purchase-1.0.0.json
@@ -1,0 +1,220 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Monitors the subscription purchase flow from initiation through confirmation",
+    "$comment": "{\"owners\":[\"lmac012\",\"cmonfortep\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app", "context"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-subscription-purchase" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["subscription-purchase"] },
+                "status": {
+                    "type": "string",
+                    "description": "The terminal status of the flow",
+                    "enum": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "subscription_identifier": {
+                                    "type": "string",
+                                    "description": "Identifier of the subscription the user is purchasing (offer ID when present, otherwise plan ID)"
+                                },
+                                "free_trial_eligible": {
+                                    "type": "string",
+                                    "description": "Whether the user is eligible for a free trial at purchase start",
+                                    "enum": ["true", "false"]
+                                },
+                                "use_query_purchases": {
+                                    "type": "string",
+                                    "description": "Value of the `useQueryPurchases` feature flag at flow start. When true, storeLogin() reads from PlayBillingManager.getLatestPurchase() (queryPurchases, active subscriptions only) and may surface the new NoActivePurchase / PurchaseInfoNotAvailable failure types. When false, the legacy purchaseHistory path is used.",
+                                    "enum": ["true", "false"]
+                                },
+                                "creation_latency_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Duration of the account-creation step in milliseconds, bucketed using the lower bucket boundary",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "activation_latency_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Duration from billing flow purchase to subscription activation in milliseconds, bucketed using the lower bucket boundary",
+                                    "enum": [
+                                        "-1",
+                                        "0",
+                                        "1000",
+                                        "5000",
+                                        "10000",
+                                        "30000",
+                                        "60000",
+                                        "300000",
+                                        "600000",
+                                        "1800000",
+                                        "3600000",
+                                        "14400000"
+                                    ]
+                                },
+                                "failure_reason": {
+                                    "type": "string",
+                                    "description": "Free-form failure reason. Only present on FAILURE events."
+                                },
+                                "missing_product_failure_reason": {
+                                    "type": "string",
+                                    "description": "Sub-classification of a missing-product-details failure. Only present when billing_flow_init fails for that reason.",
+                                    "enum": ["no_products_loaded", "product_id_not_found", "offer_not_found"]
+                                },
+                                "requested_product_id": {
+                                    "type": "string",
+                                    "description": "Play product ID requested at billing_flow_init time. Diagnostic context for missing-product failures.",
+                                    "enum": ["ddg_privacy_pro", "ddg_subscription_pro"]
+                                },
+                                "requested_plan_id": {
+                                    "type": "string",
+                                    "description": "Play basePlan ID requested at billing_flow_init time. Diagnostic context for missing-product failures.",
+                                    "enum": [
+                                        "ddg-privacy-pro-monthly-renews-us",
+                                        "ddg-privacy-pro-monthly-renews-row",
+                                        "ddg-privacy-pro-yearly-renews-us",
+                                        "ddg-privacy-pro-yearly-renews-row",
+                                        "ddg-subscription-pro-yearly-renews-us",
+                                        "ddg-subscription-pro-monthly-renews-us",
+                                        "ddg-subscription-pro-yearly-renews-row",
+                                        "ddg-subscription-pro-monthly-renews-row"
+                                    ]
+                                },
+                                "requested_offer_id": {
+                                    "type": "string",
+                                    "description": "Play offer ID requested at billing_flow_init time, or 'none' when no offer was requested. Diagnostic context for missing-product failures."
+                                },
+                                "loaded_products_count": {
+                                    "type": "string",
+                                    "description": "Number of products loaded from Play at the time of a missing-product-details failure.",
+                                    "pattern": "^[0-9]+$"
+                                },
+                                "billing_client_ready": {
+                                    "type": "string",
+                                    "description": "Whether the Play billing client was ready at the time of a missing-product-details failure.",
+                                    "enum": ["true", "false"]
+                                },
+                                "last_load_products_outcome": {
+                                    "type": "string",
+                                    "description": "Outcome of the most recent loadProducts() call before the missing-product-details failure. Distinguishes 'Play returned empty for this user' from 'loadProducts() failed with a Play BillingError we swallowed'. Format: 'never_attempted' (we never called Play, likely lifecycle issue), 'success_n=<count>' (Play replied success with this many products), 'failure_<BillingError>' (Play replied with this billing error enum).",
+                                    "pattern": "^(never_attempted|success_n=\\d+|failure_[A-Z_]+)$",
+                                    "examples": ["never_attempted", "success_n=0", "failure_BILLING_UNAVAILABLE"]
+                                },
+                                "step.refresh_subscription": {
+                                    "type": "string",
+                                    "description": "True if the refresh-subscription step succeeded, false if it failed",
+                                    "enum": ["true", "false"]
+                                },
+                                "step.create_account": {
+                                    "type": "string",
+                                    "description": "True if the create-account step succeeded, false if it failed",
+                                    "enum": ["true", "false"]
+                                },
+                                "step.billing_flow_init": {
+                                    "type": "string",
+                                    "description": "True if the billing-flow-init step succeeded, false if it failed",
+                                    "enum": ["true", "false"]
+                                },
+                                "step.billing_flow_purchase": {
+                                    "type": "string",
+                                    "description": "True if the Play billing purchase step succeeded, false if it failed",
+                                    "enum": ["true", "false"]
+                                },
+                                "step.confirm_purchase": {
+                                    "type": "string",
+                                    "description": "True if the BE purchase-confirmation step succeeded, false if it failed",
+                                    "enum": ["true", "false"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "context": {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Entry point the flow was started from",
+                    "enum": [
+                        "",
+                        "funnel_addressbar_android__aitoggle",
+                        "funnel_addressbar_android__modelpicker",
+                        "funnel_addressbar_android__reasoningdropdown",
+                        "funnel_appmenu_android",
+                        "funnel_appsettings_android",
+                        "funnel_duckai_android__freelabel",
+                        "funnel_duckai_android__modelpicker",
+                        "funnel_duckai_android__reasoningdropdown",
+                        "funnel_duckai_android__switchmodel",
+                        "funnel_modal_android__skippedonboardingupsell",
+                        "funnel_modal_android__subscriptionnudge",
+                        "funnel_onboarding_android",
+                        "funnel_playstore",
+                        "funnel_purchase_offer_page_android",
+                        "funnel_restore_android__viewplans",
+                        "funnel_subscriptionsettings_android__viewplans"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-subscription-restore-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-subscription-restore-1.0.0.json
@@ -1,0 +1,127 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "User attempts to restore their Privacy Pro subscription",
+    "$comment": "{\"owners\":[\"lmac012\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app", "context"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-subscription-restore" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["subscription-restore"] },
+                "status": { "type": "string", "description": "The terminal status of the flow", "enum": ["SUCCESS", "FAILURE", "UNKNOWN"] },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "restore_platform": {
+                                    "type": "string",
+                                    "description": "The platform used to restore the subscription",
+                                    "enum": ["google_play", "email_address"]
+                                },
+                                "is_purchase_attempt": {
+                                    "type": "string",
+                                    "description": "true if the restore was triggered during a purchase attempt, false otherwise",
+                                    "enum": ["true", "false"]
+                                },
+                                "use_query_purchases": {
+                                    "type": "string",
+                                    "description": "Value of the `useQueryPurchases` feature flag at flow start. When true, storeLogin() reads from PlayBillingManager.getLatestPurchase() (queryPurchases, active subscriptions only) and may surface the new NoActivePurchase / PurchaseInfoNotAvailable failure types. When false, the legacy purchaseHistory path is used.",
+                                    "enum": ["true", "false"]
+                                },
+                                "restore_latency_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "The duration of the restore flow in milliseconds, bucketed using the lower bucket boundary",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "failure_reason": {
+                                    "type": "string",
+                                    "description": "Error message indicating cause of the failure. Only present on FAILURE events."
+                                },
+                                "step.activation_flow_started": {
+                                    "type": "string",
+                                    "description": "Parameter present if the activation flow page was displayed during restore using email address.",
+                                    "enum": ["true"]
+                                },
+                                "step.email_address_input": {
+                                    "type": "string",
+                                    "description": "Parameter present if the email address input page was displayed during restore using email address.",
+                                    "enum": ["true"]
+                                },
+                                "step.one_time_password_input": {
+                                    "type": "string",
+                                    "description": "Parameter present if the otp input page was displayed during restore using email address.",
+                                    "enum": ["true"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "context": {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Entry point the flow was started from",
+                    "enum": ["funnel_appsettings_android", "funnel_purchase_offer_page_android"]
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-sync-setup-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-sync-setup-1.0.0.json
@@ -1,0 +1,147 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "User attempts to set up Sync via 'Sync and Back Up This Device'",
+    "$comment": "{\"owners\":[\"LukasPaczos\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app", "context"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-sync-setup" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["sync-setup"] },
+                "status": {
+                    "type": "string",
+                    "description": "The terminal status of the flow",
+                    "enum": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "user_auth_required": {
+                                    "type": "string",
+                                    "description": "Whether device authentication is required for this Sync setup flow",
+                                    "enum": ["true", "false"]
+                                },
+                                "ui_version": {
+                                    "type": "string",
+                                    "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
+                                    "enum": ["v1", "v2"]
+                                },
+                                "account_creation_latency_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Latency of the account creation API call in milliseconds, bucketed",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "initial_sync_latency_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Latency of the initial sync in milliseconds, bucketed",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "failure_reason": {
+                                    "type": "string",
+                                    "description": "Reason for failure. Only present on FAILURE events.",
+                                    "enum": ["account_creation_failed", "recovery_code_generation_failed"]
+                                },
+                                "step.device_auth_not_enrolled": {
+                                    "type": "string",
+                                    "description": "Parameter present if the device was detected as not having authentication enrolled",
+                                    "enum": ["true"]
+                                },
+                                "step.user_auth": {
+                                    "type": "string",
+                                    "description": "Parameter present if the user was successfully authenticated via device auth",
+                                    "enum": ["true"]
+                                },
+                                "step.intro_screen_shown": {
+                                    "type": "string",
+                                    "description": "Parameter present if the sync intro screen was displayed",
+                                    "enum": ["true"]
+                                },
+                                "step.sync_enabled": {
+                                    "type": "string",
+                                    "description": "Parameter present if the user opted to enable sync",
+                                    "enum": ["true"]
+                                },
+                                "step.account_created": {
+                                    "type": "string",
+                                    "description": "Parameter present if the account was successfully created and initial sync completed",
+                                    "enum": ["true"]
+                                },
+                                "step.recovery_code_shown": {
+                                    "type": "string",
+                                    "description": "Parameter present if the recovery code screen was displayed",
+                                    "enum": ["true"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "context": {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Entry point the flow was started from",
+                    "enum": ["promotion_passwords", "promotion_bookmarks"]
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-vpn-enable-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-vpn-enable-1.0.0.json
@@ -1,0 +1,154 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "User attempts to enable VPN",
+    "$comment": "{\"owners\":[\"lmac012\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app", "context"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-vpn-enable" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["vpn-enable"] },
+                "status": {
+                    "type": "string",
+                    "description": "The terminal status of the flow",
+                    "enum": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "subscription_status": {
+                                    "type": "string",
+                                    "description": "User's subscription status at the time of VPN enable attempt",
+                                    "enum": [
+                                        "Auto-Renewable",
+                                        "Not Auto-Renewable",
+                                        "Grace Period",
+                                        "Inactive",
+                                        "Expired",
+                                        "Unknown",
+                                        "Waiting"
+                                    ]
+                                },
+                                "is_first_setup": {
+                                    "type": "string",
+                                    "description": "true if the user is launching the VPN for the first time, false otherwise",
+                                    "enum": ["true", "false"]
+                                },
+                                "cancellation_reason": {
+                                    "type": "string",
+                                    "description": "Reason for cancellation. Only present on CANCELLED events.",
+                                    "enum": ["vpn_conflict", "permission_denied"]
+                                },
+                                "failure_reason": {
+                                    "type": "string",
+                                    "description": "Error message indicating cause of the failure. Based on VpnStopReason enum, but could be a different static message. Only present on FAILURE events."
+                                },
+                                "service_start_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "The duration of TrackerBlockingVpnService (re)start in milliseconds, bucketed using the lower bucket boundary",
+                                    "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "step.show_vpn_conflict_dialog": {
+                                    "type": "string",
+                                    "description": "Parameter present if the user was asked if they want to disable existing 3rd party VPN",
+                                    "enum": ["true"]
+                                },
+                                "step.ask_for_vpn_permission": {
+                                    "type": "string",
+                                    "description": "Parameter present if the user was asked to grant the VPN permission",
+                                    "enum": ["true"]
+                                },
+                                "step.vpn_start_attempt": {
+                                    "type": "string",
+                                    "description": "Parameter present if the app attempted to (re)start VPN service. This happens after ensuring app has VPN permissions",
+                                    "enum": ["true"]
+                                },
+                                "step.notify_vpn_start": {
+                                    "type": "string",
+                                    "description": "Parameter present if notifyVpnStart() in TrackerBlockingVpnService completed successfully",
+                                    "enum": ["true"]
+                                },
+                                "step.null_tunnel_created": {
+                                    "type": "string",
+                                    "description": "Parameter present if null tunnel was successfully created.",
+                                    "enum": ["true"]
+                                },
+                                "step.network_stack_initialized": {
+                                    "type": "string",
+                                    "description": "Parameter present if network stack was successfully initialized.",
+                                    "enum": ["true"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "context": {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Entry point the flow was started from",
+                    "enum": ["app_settings", "system_tile", "notification"]
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/props_dictionary.json
+++ b/PixelDefinitions/wide_events/props_dictionary.json
@@ -1,0 +1,21 @@
+{
+    "failureReason": {
+        "type": "string",
+        "description": "Exception class name of the failure. Only present on FAILURE events."
+    },
+    "pirCancellationReason": {
+        "type": "string",
+        "description": "Reason a PIR run was cancelled. Only present on CANCELLED events. superseded_by_profile_edit (a profile-edit re-scan replaced this run), superseded_by_new_run (any other newer run replaced it), profile_deleted/foreground_start_failed and the eligibility reasons (feature_disabled, subscription_expired, entitlement_lost, repository_unavailable) are client-attributed; work_stopped is a generic coroutine/WorkManager cancellation. The phase the run was in when it was cancelled is recoverable from last_step.",
+        "enum": [
+            "superseded_by_new_run",
+            "superseded_by_profile_edit",
+            "profile_deleted",
+            "feature_disabled",
+            "subscription_expired",
+            "entitlement_lost",
+            "repository_unavailable",
+            "foreground_start_failed",
+            "work_stopped"
+        ]
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205648422731273/task/1217586529674903
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

### Description

Adds `PixelDefinitions/wide_events/`, the registry that generates JSON Schemas for the wide events Android sends over the dedicated POST endpoint.

### Steps to test this PR

QA-optional

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds analytics schema definitions only; no app runtime or auth logic changes, though incorrect schemas could cause validation failures for posted events.
> 
> **Overview**
> Introduces **`PixelDefinitions/wide_events/`** as the source-of-truth for Android **wide events** sent on the dedicated POST endpoint: a shared **`base_event.json`** (app metadata, global sampling flags, feature name/status, optional context) plus per-flow **`.json5` definitions** that describe fields, enums, step markers, and bucketed timings.
> 
> The PR registers schemas for major product flows—**auth token refresh**, **data clearing**, **page load**, **BAD_URL error pages**, **return/post-idle sessions**, **VPN enable**, **Sync setup**, **subscription purchase/restore/plan change**, **free trial conversion**, **input screen onboarding**, and several **PIR** events (manual initial/scheduled scans and time-to-first-scan-complete)—each with owners and version metadata that combine with the base version into full schema IDs (e.g. **`1.0.0`**, **`1.1.0`**).
> 
> **Generated JSON Schema** files under **`generated_schemas/`** are added alongside the definitions so downstream processing can validate incoming payloads (strict **`additionalProperties: false`**, required sections, bounded enums/patterns).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 734c9e3855ad2a0081fe69c596cbd81caf29edf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->