### PR TITLE
Add DaxContextMenu Compose component

### DIFF
--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/Component.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/Component.kt
@@ -47,4 +47,5 @@ enum class Component {
     SETTINGS_LIST_ITEM,
     SECTION_DIVIDER,
     PROGRESS_SPINNER,
+    CONTEXT_MENU,
 }

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
@@ -71,6 +71,7 @@ import com.duckduckgo.common.ui.compose.button.DaxIconButton
 import com.duckduckgo.common.ui.compose.cards.DaxCard
 import com.duckduckgo.common.ui.compose.cards.DaxSurface
 import com.duckduckgo.common.ui.compose.checkbox.DaxCheckbox
+import com.duckduckgo.common.ui.compose.contextmenu.DaxContextMenu
 import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
 import com.duckduckgo.common.ui.compose.divider.DaxVerticalDivider
 import com.duckduckgo.common.ui.compose.layout.DaxScaffold
@@ -95,9 +96,11 @@ import com.duckduckgo.common.ui.compose.text.DaxText
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 import com.duckduckgo.common.ui.internal.R
 import com.duckduckgo.common.ui.internal.ui.setupThemedComposeView
+import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.ui.view.MessageCta
 import com.duckduckgo.common.ui.view.MessageCta.Message
 import com.duckduckgo.common.ui.view.MessageCta.MessageType.REMOTE_PROMO_MESSAGE
+import com.duckduckgo.common.ui.view.PopupMenuItemView
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.listitem.OneLineListItem
 import com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
@@ -532,6 +535,108 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
     class PopupMenuItemComponentViewHolder(
         parent: ViewGroup,
     ) : ComponentViewHolder(inflate(parent, R.layout.component_popup_menu_item))
+
+    class ContextMenuComponentViewHolder(
+        parent: ViewGroup,
+        private val isDarkTheme: Boolean,
+    ) : ComponentViewHolder(inflate(parent, R.layout.component_context_menu)) {
+        @SuppressLint("ShowToast")
+        override fun bind(component: Component) {
+            view.setupThemedComposeView(id = R.id.compose_context_menu_list_item, isDarkTheme = isDarkTheme) {
+                val context = LocalContext.current
+                Column {
+                    var firstMenuExpanded by remember { mutableStateOf(false) }
+                    DaxTwoLineListItem(
+                        primaryText = "Bookmark this page",
+                        secondaryText = "duckduckgo.com",
+                        leadingContent = {
+                            Icon(painterResource(CommonR.drawable.ic_globe_24), contentDescription = null)
+                        },
+                        trailingContent = {
+                            DaxContextMenu(
+                                anchor = {
+                                    Icon(
+                                        painter = painterResource(CommonR.drawable.ic_menu_vertical_24),
+                                        contentDescription = "More options",
+                                        onClick = { firstMenuExpanded = true },
+                                    )
+                                },
+                                expanded = firstMenuExpanded,
+                                onDismissRequest = { firstMenuExpanded = false },
+                            ) {
+                                DaxIconItem(
+                                    text = "Bookmark",
+                                    painterLeadingIcon = painterResource(CommonR.drawable.ic_bookmark_24),
+                                    onClick = { Toast.makeText(context, "Bookmark pressed", Toast.LENGTH_SHORT).show() },
+                                    showDivider = true,
+                                )
+                                DaxInsetItem(
+                                    text = "Copy link",
+                                    onClick = { Toast.makeText(context, "Copy link pressed", Toast.LENGTH_SHORT).show() },
+                                    trailingIcon = { Icon(painterResource(CommonR.drawable.ic_copy_24), null) },
+                                    showDivider = true,
+                                )
+                                DaxDefaultItem(text = "Unavailable", onClick = {}, enabled = false)
+                            }
+                        },
+                        onClick = {},
+                    )
+
+                    var secondMenuExpanded by remember { mutableStateOf(false) }
+                    DaxTwoLineListItem(
+                        primaryText = "Open in new tab",
+                        secondaryText = "example.com",
+                        leadingContent = {
+                            Icon(painterResource(CommonR.drawable.ic_globe_24), contentDescription = null)
+                        },
+                        trailingContent = {
+                            DaxContextMenu(
+                                anchor = {
+                                    Icon(
+                                        painter = painterResource(CommonR.drawable.ic_menu_vertical_24),
+                                        contentDescription = "More options",
+                                        onClick = { secondMenuExpanded = true },
+                                    )
+                                },
+                                expanded = secondMenuExpanded,
+                                onDismissRequest = { secondMenuExpanded = false },
+                            ) {
+                                DaxDefaultItem(
+                                    text = "Share",
+                                    onClick = { Toast.makeText(context, "Share pressed", Toast.LENGTH_SHORT).show() },
+                                    showDivider = true,
+                                )
+                                DaxDefaultItem(
+                                    text = "Delete",
+                                    onClick = { Toast.makeText(context, "Delete pressed", Toast.LENGTH_SHORT).show() },
+                                    isDestructive = true,
+                                )
+                            }
+                        },
+                        onClick = {},
+                    )
+                }
+            }
+
+            view.findViewById<TwoLineListItem>(R.id.xml_context_menu_list_item).setTrailingIconClickListener { anchor ->
+                val popupMenu = PopupMenu(LayoutInflater.from(view.context), R.layout.popup_component_context_menu)
+                val menuView = popupMenu.contentView
+                popupMenu.apply {
+                    onMenuItemClicked(menuView.findViewById(R.id.bookmark)) {
+                        Toast.makeText(view.context, "Bookmark pressed", Toast.LENGTH_SHORT).show()
+                    }
+                    onMenuItemClicked(menuView.findViewById(R.id.copyLink)) {
+                        Toast.makeText(view.context, "Copy link pressed", Toast.LENGTH_SHORT).show()
+                    }
+                    menuView.findViewById<PopupMenuItemView>(R.id.unavailable).setDisabled()
+                    onMenuItemClicked(menuView.findViewById(R.id.delete)) {
+                        Toast.makeText(view.context, "Delete pressed", Toast.LENGTH_SHORT).show()
+                    }
+                }
+                popupMenu.show(view, anchor)
+            }
+        }
+    }
 
     class HeaderSectionComponentViewHolder(
         parent: ViewGroup,
@@ -1029,6 +1134,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 Component.CARD -> CardComponentViewHolder(parent, isDarkTheme)
                 Component.SCAFFOLD -> ScaffoldComponentViewHolder(parent, isDarkTheme)
                 Component.SETTINGS_LIST_ITEM -> SettingsListItemComponentViewHolder(parent, isDarkTheme)
+                Component.CONTEXT_MENU -> ContextMenuComponentViewHolder(parent, isDarkTheme)
                 else -> {
                     TODO()
                 }

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/listitems/ComponentListItemsElementsFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/listitems/ComponentListItemsElementsFragment.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.common.ui.internal.ui.component.listitems
 
 import com.duckduckgo.common.ui.internal.ui.component.Component
+import com.duckduckgo.common.ui.internal.ui.component.Component.CONTEXT_MENU
 import com.duckduckgo.common.ui.internal.ui.component.Component.MENU_ITEM
 import com.duckduckgo.common.ui.internal.ui.component.Component.POPUP_MENU_ITEM
 import com.duckduckgo.common.ui.internal.ui.component.Component.SECTION_HEADER_LIST_ITEM
@@ -27,6 +28,14 @@ import com.duckduckgo.common.ui.internal.ui.component.ComponentFragment
 
 class ComponentListItemsElementsFragment : ComponentFragment() {
     override fun getComponents(): List<Component> {
-        return listOf(SECTION_HEADER_LIST_ITEM, SINGLE_LINE_LIST_ITEM, TWO_LINE_LIST_ITEM, SETTINGS_LIST_ITEM, MENU_ITEM, POPUP_MENU_ITEM)
+        return listOf(
+            SECTION_HEADER_LIST_ITEM,
+            SINGLE_LINE_LIST_ITEM,
+            TWO_LINE_LIST_ITEM,
+            SETTINGS_LIST_ITEM,
+            MENU_ITEM,
+            POPUP_MENU_ITEM,
+            CONTEXT_MENU,
+        )
     }
 }

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/templates/TemplatesPane.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/templates/TemplatesPane.kt
@@ -34,6 +34,10 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.duckduckgo.common.ui.compose.Status
+import com.duckduckgo.common.ui.compose.appbars.DaxTopAppBar
+import com.duckduckgo.common.ui.compose.appbars.DaxTopAppBarNavigationIcon
+import com.duckduckgo.common.ui.compose.button.DaxIconButton
+import com.duckduckgo.common.ui.compose.contextmenu.DaxContextMenuIconButton
 import com.duckduckgo.common.ui.compose.template.DaxPageHeader
 import com.duckduckgo.common.ui.compose.text.DaxText
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
@@ -96,6 +100,60 @@ fun TemplatesPane(modifier: Modifier = Modifier) {
                 body = "DuckDuckGo Private Search is your default search engine, so you can search the web without being tracked.",
                 learnMoreClick = {
                     Toast.makeText(context, "Learn more clicked", Toast.LENGTH_SHORT).show()
+                },
+            )
+        }
+        item {
+            DaxText(
+                text = "Top App Bar with a context menu",
+                style = DuckDuckGoTheme.typography.h4,
+                color = DuckDuckGoTheme.colors.text.tertiary,
+                modifier = Modifier.padding(vertical = keyline4),
+            )
+        }
+        item {
+            DaxTopAppBar(
+                title = "Bookmarks",
+                navigationIcon = DaxTopAppBarNavigationIcon.Back { },
+                actions = {
+                    DaxIconButton(
+                        onClick = { },
+                        iconPainter = painterResource(CommonR.drawable.ic_find_search_24),
+                        contentDescription = "Search",
+                    )
+                    DaxContextMenuIconButton(
+                        contentDescription = "More options",
+                    ) {
+                        DaxIconItem(
+                            text = "Bookmark",
+                            painterLeadingIcon = painterResource(CommonR.drawable.ic_bookmark_24),
+                            onClick = {
+                                Toast.makeText(context, "Bookmark clicked", Toast.LENGTH_SHORT).show()
+                            },
+                            showDivider = true,
+                        )
+                        DaxInsetItem(
+                            text = "Copy link",
+                            onClick = {
+                                Toast.makeText(context, "Copy link clicked", Toast.LENGTH_SHORT).show()
+                            },
+                            trailingIcon = { Icon(painterResource(CommonR.drawable.ic_copy_24), null) },
+                            showDivider = true,
+                        )
+                        DaxDefaultItem(
+                            text = "Unavailable",
+                            onClick = { },
+                            enabled = false,
+                            showDivider = true,
+                        )
+                        DaxDefaultItem(
+                            text = "Delete",
+                            onClick = {
+                                Toast.makeText(context, "Delete clicked", Toast.LENGTH_SHORT).show()
+                            },
+                            isDestructive = true,
+                        )
+                    }
                 },
             )
         }

--- a/android-design-system/design-system-internal/src/main/res/layout/component_context_menu.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/component_context_menu.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="Context menu anchored to a list item" />
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_context_menu_list_item"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/keyline_5"
+        app:primaryText="XML PopupMenu, for comparison" />
+
+    <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+        android:id="@+id/xml_context_menu_list_item"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_globe_24"
+        app:primaryText="Bookmark this page"
+        app:secondaryText="duckduckgo.com"
+        app:trailingIcon="@drawable/ic_menu_vertical_24" />
+
+</LinearLayout>

--- a/android-design-system/design-system-internal/src/main/res/layout/popup_component_context_menu.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/popup_component_context_menu.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/popup_menu_bg"
+    android:orientation="vertical">
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/bookmark"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_bookmark_24"
+        app:primaryText="Bookmark" />
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/copyLink"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="Copy link"
+        app:trailingIcon="@drawable/ic_copy_24" />
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/unavailable"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="Unavailable" />
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/delete"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="Delete"
+        app:primaryTextType="destructive" />
+
+</LinearLayout>

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxContextMenu.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxContextMenu.kt
@@ -103,12 +103,12 @@ fun DaxContextMenuIconButton(
                 onClick = { expanded = true },
                 iconPainter = painterResource(R.drawable.ic_menu_vertical_24),
                 contentDescription = contentDescription,
+                modifier = modifier,
                 enabled = enabled,
             )
         },
         expanded = expanded,
         onDismissRequest = { expanded = false },
-        modifier = modifier,
         content = content,
     )
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxContextMenu.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxContextMenu.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.contextmenu
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.duckduckgo.common.ui.compose.button.DaxIconButton
+import com.duckduckgo.common.ui.compose.tools.PreviewBox
+import com.duckduckgo.mobile.android.R
+
+/**
+ * DuckDuckGo themed context menu, the Compose counterpart of the XML `com.duckduckgo.common.ui.menu.PopupMenu`.
+ *
+ * @param anchor The composable the menu is positioned relative to.
+ * @param expanded Whether the menu is currently shown.
+ * @param onDismissRequest Called when the user dismisses the menu (outside touch, back press, or an item tap).
+ * @param modifier Modifier applied to the menu's container.
+ * @param content Menu rows — use [DaxContextMenuScope] members.
+ *
+ * Asana task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1217926175939990?focus=true
+ * Figma reference: https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?node-id=14346-56668&m=dev
+ */
+@Composable
+fun DaxContextMenu(
+    anchor: @Composable () -> Unit,
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable DaxContextMenuScope.() -> Unit,
+) {
+    Box {
+        anchor()
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = onDismissRequest,
+            offset = DaxContextMenuDefaults.Offset,
+            modifier = modifier.widthIn(min = DaxContextMenuDefaults.MinWidth),
+            shape = DaxContextMenuDefaults.Shape,
+            containerColor = DaxContextMenuDefaults.ContainerColor,
+            tonalElevation = DaxContextMenuDefaults.TonalElevation,
+            shadowElevation = DaxContextMenuDefaults.ContainerElevation,
+        ) {
+            Column {
+                CompositionLocalProvider(LocalDaxContextMenuOnDismissRequest provides onDismissRequest) {
+                    DaxContextMenuScope.content()
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Convenience [DaxContextMenu] wrapper anchored to a [DaxIconButton], for the common case of a menu triggered
+ * by tapping an overflow icon.
+ *
+ * Unlike [DaxContextMenu], this owns its own expanded state internally rather than hoisting it.
+ *
+ * @param contentDescription Accessibility description for the anchor button, or null if decorative.
+ * @param modifier Modifier applied to the anchor button.
+ * @param enabled Whether the anchor button is enabled.
+ * @param content Menu rows — use [DaxContextMenuScope] members.
+ *
+ * Asana task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1217926175939990?focus=true
+ * Figma reference: https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?node-id=14346-56668&m=dev
+ */
+@Composable
+fun DaxContextMenuIconButton(
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    content: @Composable DaxContextMenuScope.() -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    DaxContextMenu(
+        anchor = {
+            DaxIconButton(
+                onClick = { expanded = true },
+                iconPainter = painterResource(R.drawable.ic_menu_vertical_24),
+                contentDescription = contentDescription,
+                enabled = enabled,
+            )
+        },
+        expanded = expanded,
+        onDismissRequest = { expanded = false },
+        modifier = modifier,
+        content = content,
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxContextMenuIconButtonClosedPreview() {
+    PreviewBox {
+        DaxContextMenuIconButton(
+            contentDescription = "More options",
+        ) {
+            DaxDefaultItem(text = "Share", onClick = {})
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxContextMenuIconButtonDisabledPreview() {
+    PreviewBox {
+        DaxContextMenuIconButton(
+            contentDescription = "More options",
+            enabled = false,
+        ) {
+            DaxDefaultItem(text = "Share", onClick = {})
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxContextMenuIconButtonExpandedPreview() {
+    PreviewBox {
+        DaxContextMenu(
+            anchor = {
+                DaxIconButton(
+                    onClick = {},
+                    iconPainter = painterResource(R.drawable.ic_menu_vertical_24),
+                    contentDescription = "More options",
+                )
+            },
+            expanded = true,
+            onDismissRequest = {},
+        ) {
+            DaxIconItem(
+                text = "Bookmark",
+                painterLeadingIcon = painterResource(R.drawable.ic_bookmark_24),
+                onClick = {},
+                showDivider = true,
+            )
+            DaxInsetItem(
+                text = "Copy link",
+                onClick = {},
+                trailingIcon = { Icon(painterResource(R.drawable.ic_copy_24), null) },
+                showDivider = true,
+            )
+            DaxDefaultItem(text = "Delete", onClick = {}, isDestructive = true)
+        }
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxContextMenuDefaults.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxContextMenuDefaults.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.contextmenu
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+
+internal object DaxContextMenuDefaults {
+    val Offset: DpOffset = DpOffset(0.dp, 0.dp)
+
+    val MinWidth: Dp = 240.dp
+
+    val ContainerElevation: Dp = 4.dp
+
+    val TonalElevation: Dp = 0.dp
+
+    val Shape: Shape
+        @Composable
+        get() = DuckDuckGoTheme.shapes.small
+
+    val ContainerColor: Color
+        @Composable
+        get() = DuckDuckGoTheme.colors.backgrounds.window
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxContextMenuItem.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxContextMenuItem.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.contextmenu
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.Dp
+import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
+import com.duckduckgo.common.ui.compose.text.DaxText
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import androidx.compose.material3.Icon as M3Icon
+
+/**
+ * Layout core shared by every context-menu-item variant ([DaxDefaultContextMenuItem],
+ * [DaxIconContextMenuItem], [DaxInsetContextMenuItem]).
+ *
+ * @param text Item label.
+ * @param onClick Called when the row is tapped.
+ * @param modifier Modifier applied to the row.
+ * @param startPadding Leading edge padding; distinguishes the three public variants.
+ * @param endPadding Trailing edge padding.
+ * @param leadingIcon Optional leading icon artwork, only rendered by [DaxIconContextMenuItem].
+ * @param showDivider Whether a [DaxHorizontalDivider] is rendered below the row.
+ * @param isDestructive Whether the text defaults colour to the destructive token.
+ * @param enabled Whether the row is enabled and interactive. Disabled rows use the disabled text and
+ * icon tokens, and the trailing scope passes the state on to its members.
+ * @param textColor Label colour; must be a [DuckDuckGoTheme] colour (lint-enforced).
+ * @param trailingIcon Optional trailing slot — use [DaxContextMenuItemTrailingScope] members.
+ */
+@Composable
+internal fun DaxContextMenuItem(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    startPadding: Dp = DaxContextMenuItemDefaults.DefaultStartPadding,
+    endPadding: Dp = DaxContextMenuItemDefaults.DefaultEndPadding,
+    leadingIcon: Painter? = null,
+    showDivider: Boolean = false,
+    isDestructive: Boolean = false,
+    enabled: Boolean = true,
+    textColor: Color = DaxContextMenuItemDefaults.textColor(enabled = enabled, isDestructive = isDestructive),
+    trailingIcon: (@Composable DaxContextMenuItemTrailingScope.() -> Unit)? = null,
+) {
+    val colors = DaxContextMenuItemDefaults.colors
+    val trailingScope = DaxContextMenuItemTrailingScope(enabled)
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(enabled = enabled, onClick = onClick)
+                .padding(
+                    start = startPadding,
+                    end = endPadding,
+                    top = DaxContextMenuItemDefaults.VerticalPadding,
+                    bottom = DaxContextMenuItemDefaults.VerticalPadding,
+                ),
+        ) {
+            if (leadingIcon != null) {
+                M3Icon(
+                    painter = leadingIcon,
+                    contentDescription = null,
+                    tint = if (enabled) colors.icon else colors.disabledIcon,
+                    modifier = Modifier.size(DaxContextMenuItemDefaults.LeadingIconSize),
+                )
+                Spacer(Modifier.width(DaxContextMenuItemDefaults.ContentGap))
+            }
+
+            DaxText(
+                text = text,
+                style = DaxContextMenuItemDefaults.textStyle,
+                color = textColor,
+                modifier = Modifier.weight(1f),
+            )
+
+            if (trailingIcon != null) {
+                Spacer(Modifier.width(DaxContextMenuItemDefaults.ContentGap))
+                trailingScope.trailingIcon()
+            }
+        }
+
+        if (showDivider) {
+            Spacer(Modifier.height(DaxContextMenuItemDefaults.DividerSpacing))
+            DaxHorizontalDivider()
+            Spacer(Modifier.height(DaxContextMenuItemDefaults.DividerSpacing))
+        }
+    }
+}
+
+/**
+ * Receiver scope for a context-menu item's trailing slot.
+ *
+ * Typing the slot as a receiver on this scope restricts trailing content to the design system's
+ * own composables, matching the pattern used by `DaxListItemTrailingScope`.
+ *
+ * @param parentEnabled Whether the owning item is enabled; carried through so the scope's [Icon]
+ * defaults to the disabled icon tint when the parent item is disabled.
+ */
+@Stable
+class DaxContextMenuItemTrailingScope internal constructor(
+    private val parentEnabled: Boolean,
+) {
+
+    /**
+     * Trailing icon, fixed at the context-menu-item trailing size.
+     *
+     * @param painter Icon artwork.
+     * @param contentDescription Accessibility description; `null` for a decorative icon.
+     * @param modifier Modifier applied to the icon.
+     * @param tint Icon tint; defaults to the disabled icon token when the parent item is disabled.
+     */
+    @Composable
+    fun Icon(
+        painter: Painter,
+        contentDescription: String?,
+        modifier: Modifier = Modifier,
+        tint: Color = if (parentEnabled) DaxContextMenuItemDefaults.colors.icon else DaxContextMenuItemDefaults.colors.disabledIcon,
+    ) {
+        M3Icon(
+            painter = painter,
+            contentDescription = contentDescription,
+            tint = tint,
+            modifier = modifier.size(DaxContextMenuItemDefaults.TrailingIconSize),
+        )
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxContextMenuItemDefaults.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxContextMenuItemDefaults.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.contextmenu
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTextStyle
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+
+internal object DaxContextMenuItemDefaults {
+    val VerticalPadding: Dp = 12.dp
+    val ContentGap: Dp = 16.dp
+    val DividerSpacing: Dp = 4.dp
+
+    val DefaultStartPadding: Dp = 16.dp
+    val DefaultEndPadding: Dp = 16.dp
+
+    val IconStartPadding: Dp = 12.dp
+    val IconEndPadding: Dp = 16.dp
+    val LeadingIconSize: Dp = 24.dp
+
+    val InsetStartPadding: Dp = 48.dp
+    val InsetEndPadding: Dp = 16.dp
+
+    val TrailingIconSize: Dp = 24.dp
+
+    val textStyle: DuckDuckGoTextStyle
+        @Composable
+        get() = DuckDuckGoTheme.typography.body1
+
+    @Composable
+    fun textColor(enabled: Boolean, isDestructive: Boolean): Color = when {
+        !enabled -> DuckDuckGoTheme.textColors.disabled
+        isDestructive -> DuckDuckGoTheme.textColors.destructive
+        else -> DuckDuckGoTheme.textColors.primary
+    }
+
+    val colors: DaxContextMenuItemColors
+        @Composable
+        get() = DaxContextMenuItemColors(
+            icon = DuckDuckGoTheme.iconColors.primary,
+            disabledIcon = DuckDuckGoTheme.iconColors.disabled,
+        )
+}
+
+@Immutable
+internal data class DaxContextMenuItemColors(
+    val icon: Color,
+    val disabledIcon: Color,
+)

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxContextMenuScope.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxContextMenuScope.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.contextmenu
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+
+/**
+ * Composition local carrying the enclosing [DaxContextMenu]'s `onDismissRequest`, so [DaxContextMenuScope]'s
+ * members can dismiss the menu after firing the caller's `onClick`. [DaxContextMenuScope] is a singleton
+ * object, so it cannot carry that callback as instance state the way `DaxContextMenuItemTrailingScope` does.
+ */
+internal val LocalDaxContextMenuOnDismissRequest = staticCompositionLocalOf<() -> Unit> { {} }
+
+/**
+ * Receiver scope for a [DaxContextMenu]'s content: the only way to add rows to the menu, restricting
+ * content to the design system's own context-menu items and ensuring every row dismisses the menu once
+ * tapped.
+ */
+@Stable
+object DaxContextMenuScope {
+
+    /** Delegates to [DaxDefaultContextMenuItem], dismissing the enclosing menu after [onClick]. */
+    @Composable
+    fun DaxDefaultItem(
+        text: String,
+        onClick: () -> Unit,
+        modifier: Modifier = Modifier,
+        showDivider: Boolean = false,
+        isDestructive: Boolean = false,
+        enabled: Boolean = true,
+        trailingIcon: (@Composable DaxContextMenuItemTrailingScope.() -> Unit)? = null,
+    ) {
+        val onDismissRequest = LocalDaxContextMenuOnDismissRequest.current
+        DaxDefaultContextMenuItem(
+            text = text,
+            onClick = {
+                onClick()
+                onDismissRequest()
+            },
+            modifier = modifier,
+            showDivider = showDivider,
+            isDestructive = isDestructive,
+            enabled = enabled,
+            trailingIcon = trailingIcon,
+        )
+    }
+
+    /** Delegates to [DaxIconContextMenuItem], dismissing the enclosing menu after [onClick]. */
+    @Composable
+    fun DaxIconItem(
+        text: String,
+        painterLeadingIcon: Painter,
+        onClick: () -> Unit,
+        modifier: Modifier = Modifier,
+        showDivider: Boolean = false,
+        isDestructive: Boolean = false,
+        enabled: Boolean = true,
+        trailingIcon: (@Composable DaxContextMenuItemTrailingScope.() -> Unit)? = null,
+    ) {
+        val onDismissRequest = LocalDaxContextMenuOnDismissRequest.current
+        DaxIconContextMenuItem(
+            text = text,
+            painterLeadingIcon = painterLeadingIcon,
+            onClick = {
+                onClick()
+                onDismissRequest()
+            },
+            modifier = modifier,
+            showDivider = showDivider,
+            isDestructive = isDestructive,
+            enabled = enabled,
+            trailingIcon = trailingIcon,
+        )
+    }
+
+    /** Delegates to [DaxInsetContextMenuItem], dismissing the enclosing menu after [onClick]. */
+    @Composable
+    fun DaxInsetItem(
+        text: String,
+        onClick: () -> Unit,
+        modifier: Modifier = Modifier,
+        showDivider: Boolean = false,
+        isDestructive: Boolean = false,
+        enabled: Boolean = true,
+        trailingIcon: (@Composable DaxContextMenuItemTrailingScope.() -> Unit)? = null,
+    ) {
+        val onDismissRequest = LocalDaxContextMenuOnDismissRequest.current
+        DaxInsetContextMenuItem(
+            text = text,
+            onClick = {
+                onClick()
+                onDismissRequest()
+            },
+            modifier = modifier,
+            showDivider = showDivider,
+            isDestructive = isDestructive,
+            enabled = enabled,
+            trailingIcon = trailingIcon,
+        )
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxDefaultContextMenuItem.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxDefaultContextMenuItem.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.contextmenu
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.duckduckgo.common.ui.compose.button.DaxButtonStateParameterProvider
+import com.duckduckgo.common.ui.compose.tools.PreviewSurface
+import com.duckduckgo.mobile.android.R
+
+/**
+ * Context-menu item with no leading content.
+ *
+ * @param text Item label.
+ * @param onClick Called when the row is tapped.
+ * @param modifier Modifier applied to the row.
+ * @param showDivider Whether a horizontal divider is rendered below the row.
+ * @param isDestructive Whether the label colours to the destructive token.
+ * @param enabled Whether the row is enabled and interactive.
+ * @param trailingIcon Optional trailing slot — use [DaxContextMenuItemTrailingScope] members.
+ *
+ * Asana task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1217926175939990?focus=true
+ * Figma reference: https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?node-id=14346-56668&m=dev
+ */
+@Composable
+fun DaxDefaultContextMenuItem(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    showDivider: Boolean = false,
+    isDestructive: Boolean = false,
+    enabled: Boolean = true,
+    trailingIcon: (@Composable DaxContextMenuItemTrailingScope.() -> Unit)? = null,
+) {
+    DaxContextMenuItem(
+        text = text,
+        onClick = onClick,
+        modifier = modifier,
+        startPadding = DaxContextMenuItemDefaults.DefaultStartPadding,
+        endPadding = DaxContextMenuItemDefaults.DefaultEndPadding,
+        isDestructive = isDestructive,
+        enabled = enabled,
+        trailingIcon = trailingIcon,
+        showDivider = showDivider,
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxDefaultContextMenuItemPreview(
+    @PreviewParameter(DaxButtonStateParameterProvider::class) enabled: Boolean,
+) {
+    PreviewSurface {
+        DaxDefaultContextMenuItem(text = "Share", onClick = {}, enabled = enabled)
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxDefaultContextMenuItemWithTrailingIconPreview() {
+    PreviewSurface {
+        DaxDefaultContextMenuItem(
+            text = "Bookmark",
+            onClick = {},
+            trailingIcon = { Icon(painterResource(R.drawable.ic_bookmark_24), null) },
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxDefaultContextMenuItemDestructivePreview() {
+    PreviewSurface {
+        DaxDefaultContextMenuItem(text = "Delete", onClick = {}, isDestructive = true)
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxDefaultContextMenuItemWithDividerPreview() {
+    PreviewSurface {
+        Column {
+            DaxDefaultContextMenuItem(text = "Share", onClick = {}, showDivider = true)
+            DaxDefaultContextMenuItem(text = "Delete", onClick = {}, isDestructive = true)
+        }
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxIconContextMenuItem.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxIconContextMenuItem.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.contextmenu
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.duckduckgo.common.ui.compose.button.DaxButtonStateParameterProvider
+import com.duckduckgo.common.ui.compose.tools.PreviewSurface
+import com.duckduckgo.mobile.android.R
+
+/**
+ * Context-menu item with a leading icon.
+ *
+ * @param text Item label.
+ * @param painterLeadingIcon Leading icon artwork.
+ * @param onClick Called when the row is tapped.
+ * @param modifier Modifier applied to the row.
+ * @param showDivider Whether a horizontal divider is rendered below the row.
+ * @param isDestructive Whether the label and leading icon colour to the destructive token.
+ * @param enabled Whether the row is enabled and interactive.
+ * @param trailingIcon Optional trailing slot — use [DaxContextMenuItemTrailingScope] members.
+ *
+ * Asana task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1217926175939990?focus=true
+ * Figma reference: https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?node-id=14346-56668&m=dev
+ */
+@Composable
+fun DaxIconContextMenuItem(
+    text: String,
+    painterLeadingIcon: Painter,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    showDivider: Boolean = false,
+    isDestructive: Boolean = false,
+    enabled: Boolean = true,
+    trailingIcon: (@Composable DaxContextMenuItemTrailingScope.() -> Unit)? = null,
+) {
+    DaxContextMenuItem(
+        text = text,
+        onClick = onClick,
+        modifier = modifier,
+        startPadding = DaxContextMenuItemDefaults.IconStartPadding,
+        endPadding = DaxContextMenuItemDefaults.IconEndPadding,
+        leadingIcon = painterLeadingIcon,
+        isDestructive = isDestructive,
+        enabled = enabled,
+        trailingIcon = trailingIcon,
+        showDivider = showDivider,
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxIconContextMenuItemPreview(
+    @PreviewParameter(DaxButtonStateParameterProvider::class) enabled: Boolean,
+) {
+    PreviewSurface {
+        DaxIconContextMenuItem(
+            text = "Bookmark",
+            painterLeadingIcon = painterResource(R.drawable.ic_bookmark_24),
+            onClick = {},
+            enabled = enabled,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxIconContextMenuItemWithTrailingIconPreview() {
+    PreviewSurface {
+        DaxIconContextMenuItem(
+            text = "Open in new tab",
+            painterLeadingIcon = painterResource(R.drawable.ic_globe_24),
+            onClick = {},
+            trailingIcon = { Icon(painterResource(R.drawable.ic_open_in_16), null) },
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxIconContextMenuItemDestructivePreview() {
+    PreviewSurface {
+        DaxIconContextMenuItem(
+            text = "Delete",
+            painterLeadingIcon = painterResource(R.drawable.ic_trash_24),
+            onClick = {},
+            isDestructive = true,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxIconContextMenuItemWithDividerPreview() {
+    PreviewSurface {
+        Column {
+            DaxIconContextMenuItem(
+                text = "Bookmark",
+                painterLeadingIcon = painterResource(R.drawable.ic_bookmark_24),
+                onClick = {},
+                showDivider = true,
+            )
+            DaxIconContextMenuItem(
+                text = "Delete",
+                painterLeadingIcon = painterResource(R.drawable.ic_trash_24),
+                onClick = {},
+                isDestructive = true,
+            )
+        }
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxInsetContextMenuItem.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/contextmenu/DaxInsetContextMenuItem.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.contextmenu
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.duckduckgo.common.ui.compose.button.DaxButtonStateParameterProvider
+import com.duckduckgo.common.ui.compose.tools.PreviewSurface
+import com.duckduckgo.mobile.android.R
+
+/**
+ * Context-menu item inset to align its label with a sibling [DaxIconContextMenuItem]'s text,
+ * for use when a row has no leading icon of its own but sits in a menu where other rows do.
+ *
+ * @param text Item label.
+ * @param onClick Called when the row is tapped.
+ * @param modifier Modifier applied to the row.
+ * @param showDivider Whether a horizontal divider is rendered below the row.
+ * @param isDestructive Whether the label colours to the destructive token.
+ * @param enabled Whether the row is enabled and interactive.
+ * @param trailingIcon Optional trailing slot — use [DaxContextMenuItemTrailingScope] members.
+ *
+ * Asana task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1217926175939990?focus=true
+ * Figma reference: https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?node-id=14346-56668&m=dev
+ */
+@Composable
+fun DaxInsetContextMenuItem(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    showDivider: Boolean = false,
+    isDestructive: Boolean = false,
+    enabled: Boolean = true,
+    trailingIcon: (@Composable DaxContextMenuItemTrailingScope.() -> Unit)? = null,
+) {
+    DaxContextMenuItem(
+        text = text,
+        onClick = onClick,
+        modifier = modifier,
+        startPadding = DaxContextMenuItemDefaults.InsetStartPadding,
+        endPadding = DaxContextMenuItemDefaults.InsetEndPadding,
+        isDestructive = isDestructive,
+        enabled = enabled,
+        trailingIcon = trailingIcon,
+        showDivider = showDivider,
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxInsetContextMenuItemPreview(
+    @PreviewParameter(DaxButtonStateParameterProvider::class) enabled: Boolean,
+) {
+    PreviewSurface {
+        DaxInsetContextMenuItem(text = "Share", onClick = {}, enabled = enabled)
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxInsetContextMenuItemWithTrailingIconPreview() {
+    PreviewSurface {
+        DaxInsetContextMenuItem(
+            text = "Copy link",
+            onClick = {},
+            trailingIcon = { Icon(painterResource(R.drawable.ic_copy_24), null) },
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxInsetContextMenuItemDestructivePreview() {
+    PreviewSurface {
+        DaxInsetContextMenuItem(text = "Remove", onClick = {}, isDestructive = true)
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxInsetContextMenuItemWithDividerPreview() {
+    PreviewSurface {
+        Column {
+            DaxInsetContextMenuItem(text = "Share", onClick = {}, showDivider = true)
+            DaxInsetContextMenuItem(text = "Remove", onClick = {}, isDestructive = true)
+        }
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
@@ -48,6 +48,8 @@ import com.duckduckgo.lint.strings.PlaceholderDetector.Companion.PLACEHOLDER_MIS
 import com.duckduckgo.lint.ui.ColorAttributeInXmlDetector.Companion.INVALID_COLOR_ATTRIBUTE
 import com.duckduckgo.lint.ui.DaxButtonStylingDetector.Companion.INVALID_DAX_BUTTON_DUCK_SANS
 import com.duckduckgo.lint.ui.DaxButtonStylingDetector.Companion.INVALID_DAX_BUTTON_PROPERTY
+import com.duckduckgo.lint.ui.DaxContextMenuContentDetector.Companion.INVALID_DAX_CONTEXT_MENU_CONTENT_USAGE
+import com.duckduckgo.lint.ui.DaxContextMenuItemContentDetector.Companion.INVALID_DAX_CONTEXT_MENU_ITEM_CONTENT_USAGE
 import com.duckduckgo.lint.ui.DaxDividerColorUsageDetector.Companion.INVALID_DAX_DIVIDER_COLOR_USAGE
 import com.duckduckgo.lint.ui.DaxListItemColorUsageDetector.Companion.INVALID_DAX_LIST_ITEM_COLOR_USAGE
 import com.duckduckgo.lint.ui.DaxListItemContentDetector.Companion.INVALID_DAX_LIST_ITEM_CONTENT_USAGE
@@ -130,6 +132,8 @@ class DuckDuckGoIssueRegistry : IssueRegistry() {
             INVALID_DAX_SECURE_TEXT_FIELD_TRAILING_ICON_USAGE,
             INVALID_DAX_LIST_ITEM_CONTENT_USAGE,
             INVALID_DAX_LIST_ITEM_COLOR_USAGE,
+            INVALID_DAX_CONTEXT_MENU_ITEM_CONTENT_USAGE,
+            INVALID_DAX_CONTEXT_MENU_CONTENT_USAGE,
             NO_MATERIAL3_SWITCH_USAGE,
             NO_MATERIAL3_TOP_APP_BAR_USAGE,
             NO_MATERIAL3_RADIO_BUTTON_USAGE,

--- a/lint-rules/src/main/java/com/duckduckgo/lint/ui/DaxContextMenuContentDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/ui/DaxContextMenuContentDetector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 DuckDuckGo
+ * Copyright (c) 2026 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.jetbrains.uast.visitor.AbstractUastVisitor
 import java.util.EnumSet
 
 @Suppress("UnstableApiUsage")
-class DaxListItemContentDetector : Detector(), SourceCodeScanner {
+class DaxContextMenuContentDetector : Detector(), SourceCodeScanner {
 
     override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
 
@@ -42,19 +42,17 @@ class DaxListItemContentDetector : Detector(), SourceCodeScanner {
     internal class Handler(private val context: JavaContext) : UElementHandler() {
 
         override fun visitCallExpression(node: UCallExpression) {
-            if (node.methodName !in LIST_ITEM_COMPOSABLES) return
-            check(node, "leadingContent", LEADING_SCOPE)
-            check(node, "trailingContent", TRAILING_SCOPE, allowedOwners = TRAILING_CONTENT_ALLOWED_OWNERS)
-            check(node, "inlineContent", INLINE_SCOPE)
+            if (node.methodName !in CONTEXT_MENU_COMPOSABLES) return
+            check(node, "content", CONTEXT_MENU_SCOPE)
         }
 
-        private fun check(node: UCallExpression, paramName: String, scope: String, allowedOwners: Set<String> = emptySet()) {
+        private fun check(node: UCallExpression, paramName: String, scope: String) {
             val arg = node.valueArguments.find { node.getParameterForArgument(it)?.name == paramName } ?: return
             var violation = false
             arg.accept(object : AbstractUastVisitor() {
                 override fun visitCallExpression(node: UCallExpression): Boolean {
                     val owner = node.resolve()?.containingClass?.qualifiedName
-                    if (owner != null && owner != scope && owner !in allowedOwners) violation = true
+                    if (owner != null && owner != scope) violation = true
                     // Judge only what the slot emits, so a call's own arguments are left unvisited.
                     return true
                 }
@@ -64,31 +62,27 @@ class DaxListItemContentDetector : Detector(), SourceCodeScanner {
 
         private fun report(arg: UExpression) {
             context.report(
-                issue = INVALID_DAX_LIST_ITEM_CONTENT_USAGE,
+                issue = INVALID_DAX_CONTEXT_MENU_CONTENT_USAGE,
                 location = context.getLocation(arg),
-                message = INVALID_DAX_LIST_ITEM_CONTENT_USAGE.getExplanation(TextFormat.RAW),
+                message = INVALID_DAX_CONTEXT_MENU_CONTENT_USAGE.getExplanation(TextFormat.RAW),
             )
         }
     }
 
     companion object {
-        private const val LEADING_SCOPE = "com.duckduckgo.common.ui.compose.listitem.DaxListItemLeadingScope"
-        private const val TRAILING_SCOPE = "com.duckduckgo.common.ui.compose.listitem.DaxListItemTrailingScope"
-        private const val INLINE_SCOPE = "com.duckduckgo.common.ui.compose.listitem.DaxListItemInlineScope"
-        private val LIST_ITEM_COMPOSABLES = setOf("DaxOneLineListItem", "DaxTwoLineListItem", "DaxSettingsListItem")
+        private const val CONTEXT_MENU_SCOPE = "com.duckduckgo.common.ui.compose.contextmenu.DaxContextMenuScope"
+        private val CONTEXT_MENU_COMPOSABLES = setOf(
+            "DaxContextMenu",
+            "DaxContextMenuIconButton",
+        )
 
-        // DaxContextMenu is itself design-system-controlled and validates its own content via
-        // DaxContextMenuContentDetector, so anchoring it on the trailing icon is allowed.
-        private val TRAILING_CONTENT_ALLOWED_OWNERS = setOf("com.duckduckgo.common.ui.compose.contextmenu.DaxContextMenuKt")
-
-        val INVALID_DAX_LIST_ITEM_CONTENT_USAGE: Issue = Issue
+        val INVALID_DAX_CONTEXT_MENU_CONTENT_USAGE: Issue = Issue
             .create(
-                id = "InvalidDaxListItemContentUsage",
-                briefDescription = "List-item slots should only use DaxListItem*Scope composables",
+                id = "InvalidDaxContextMenuContentUsage",
+                briefDescription = "Context-menu content slot should only use DaxContextMenuScope composables",
                 explanation = """
-                    Use composables from DaxListItemLeadingScope / DaxListItemTrailingScope / DaxListItemInlineScope
-                    for the leadingContent / trailingContent / inlineContent slots, to keep list items consistent
-                    with the design system.
+                    Use composables from DaxContextMenuScope (DefaultItem, IconItem, InsetItem) for the content
+                    slot, to keep context menus consistent with the design system.
                 """.trimIndent(),
                 moreInfo = "",
                 category = CUSTOM_LINT_CHECKS,
@@ -96,7 +90,7 @@ class DaxListItemContentDetector : Detector(), SourceCodeScanner {
                 severity = Severity.WARNING,
                 androidSpecific = true,
                 implementation = Implementation(
-                    DaxListItemContentDetector::class.java,
+                    DaxContextMenuContentDetector::class.java,
                     EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
                 ),
             )

--- a/lint-rules/src/main/java/com/duckduckgo/lint/ui/DaxContextMenuItemContentDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/ui/DaxContextMenuItemContentDetector.kt
@@ -75,6 +75,9 @@ class DaxContextMenuItemContentDetector : Detector(), SourceCodeScanner {
             "DaxDefaultContextMenuItem",
             "DaxIconContextMenuItem",
             "DaxInsetContextMenuItem",
+            "DaxDefaultItem",
+            "DaxIconItem",
+            "DaxInsetItem",
         )
 
         val INVALID_DAX_CONTEXT_MENU_ITEM_CONTENT_USAGE: Issue = Issue

--- a/lint-rules/src/main/java/com/duckduckgo/lint/ui/DaxContextMenuItemContentDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/ui/DaxContextMenuItemContentDetector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 DuckDuckGo
+ * Copyright (c) 2026 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.jetbrains.uast.visitor.AbstractUastVisitor
 import java.util.EnumSet
 
 @Suppress("UnstableApiUsage")
-class DaxListItemContentDetector : Detector(), SourceCodeScanner {
+class DaxContextMenuItemContentDetector : Detector(), SourceCodeScanner {
 
     override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
 
@@ -42,19 +42,17 @@ class DaxListItemContentDetector : Detector(), SourceCodeScanner {
     internal class Handler(private val context: JavaContext) : UElementHandler() {
 
         override fun visitCallExpression(node: UCallExpression) {
-            if (node.methodName !in LIST_ITEM_COMPOSABLES) return
-            check(node, "leadingContent", LEADING_SCOPE)
-            check(node, "trailingContent", TRAILING_SCOPE, allowedOwners = TRAILING_CONTENT_ALLOWED_OWNERS)
-            check(node, "inlineContent", INLINE_SCOPE)
+            if (node.methodName !in CONTEXT_MENU_ITEM_COMPOSABLES) return
+            check(node, "trailingIcon", TRAILING_SCOPE)
         }
 
-        private fun check(node: UCallExpression, paramName: String, scope: String, allowedOwners: Set<String> = emptySet()) {
+        private fun check(node: UCallExpression, paramName: String, scope: String) {
             val arg = node.valueArguments.find { node.getParameterForArgument(it)?.name == paramName } ?: return
             var violation = false
             arg.accept(object : AbstractUastVisitor() {
                 override fun visitCallExpression(node: UCallExpression): Boolean {
                     val owner = node.resolve()?.containingClass?.qualifiedName
-                    if (owner != null && owner != scope && owner !in allowedOwners) violation = true
+                    if (owner != null && owner != scope) violation = true
                     // Judge only what the slot emits, so a call's own arguments are left unvisited.
                     return true
                 }
@@ -64,31 +62,28 @@ class DaxListItemContentDetector : Detector(), SourceCodeScanner {
 
         private fun report(arg: UExpression) {
             context.report(
-                issue = INVALID_DAX_LIST_ITEM_CONTENT_USAGE,
+                issue = INVALID_DAX_CONTEXT_MENU_ITEM_CONTENT_USAGE,
                 location = context.getLocation(arg),
-                message = INVALID_DAX_LIST_ITEM_CONTENT_USAGE.getExplanation(TextFormat.RAW),
+                message = INVALID_DAX_CONTEXT_MENU_ITEM_CONTENT_USAGE.getExplanation(TextFormat.RAW),
             )
         }
     }
 
     companion object {
-        private const val LEADING_SCOPE = "com.duckduckgo.common.ui.compose.listitem.DaxListItemLeadingScope"
-        private const val TRAILING_SCOPE = "com.duckduckgo.common.ui.compose.listitem.DaxListItemTrailingScope"
-        private const val INLINE_SCOPE = "com.duckduckgo.common.ui.compose.listitem.DaxListItemInlineScope"
-        private val LIST_ITEM_COMPOSABLES = setOf("DaxOneLineListItem", "DaxTwoLineListItem", "DaxSettingsListItem")
+        private const val TRAILING_SCOPE = "com.duckduckgo.common.ui.compose.contextmenu.DaxContextMenuItemTrailingScope"
+        private val CONTEXT_MENU_ITEM_COMPOSABLES = setOf(
+            "DaxDefaultContextMenuItem",
+            "DaxIconContextMenuItem",
+            "DaxInsetContextMenuItem",
+        )
 
-        // DaxContextMenu is itself design-system-controlled and validates its own content via
-        // DaxContextMenuContentDetector, so anchoring it on the trailing icon is allowed.
-        private val TRAILING_CONTENT_ALLOWED_OWNERS = setOf("com.duckduckgo.common.ui.compose.contextmenu.DaxContextMenuKt")
-
-        val INVALID_DAX_LIST_ITEM_CONTENT_USAGE: Issue = Issue
+        val INVALID_DAX_CONTEXT_MENU_ITEM_CONTENT_USAGE: Issue = Issue
             .create(
-                id = "InvalidDaxListItemContentUsage",
-                briefDescription = "List-item slots should only use DaxListItem*Scope composables",
+                id = "InvalidDaxContextMenuItemContentUsage",
+                briefDescription = "Context-menu-item trailing slot should only use DaxContextMenuItemTrailingScope composables",
                 explanation = """
-                    Use composables from DaxListItemLeadingScope / DaxListItemTrailingScope / DaxListItemInlineScope
-                    for the leadingContent / trailingContent / inlineContent slots, to keep list items consistent
-                    with the design system.
+                    Use composables from DaxContextMenuItemTrailingScope for the trailingIcon slot, to keep
+                    context menu items consistent with the design system.
                 """.trimIndent(),
                 moreInfo = "",
                 category = CUSTOM_LINT_CHECKS,
@@ -96,7 +91,7 @@ class DaxListItemContentDetector : Detector(), SourceCodeScanner {
                 severity = Severity.WARNING,
                 androidSpecific = true,
                 implementation = Implementation(
-                    DaxListItemContentDetector::class.java,
+                    DaxContextMenuItemContentDetector::class.java,
                     EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
                 ),
             )

--- a/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxContextMenuContentDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxContextMenuContentDetectorTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+class DaxContextMenuContentDetectorTest {
+
+    private val scopeStubs = kotlin(
+        """
+        package com.duckduckgo.common.ui.compose.contextmenu
+        class DaxContextMenuScope {
+            fun DaxDefaultItem(text: String) {}
+            fun DaxIconItem(text: String) {}
+            fun DaxInsetItem(text: String) {}
+        }
+        fun painterResource(id: Int): Int = id
+        fun DaxContextMenu(
+            expanded: Boolean,
+            onDismissRequest: () -> Unit,
+            content: (DaxContextMenuScope.() -> Unit)? = null,
+        ) {}
+        fun DaxContextMenuIconButton(
+            iconPainter: Int,
+            content: (DaxContextMenuScope.() -> Unit)? = null,
+        ) {}
+        """,
+    ).indented()
+
+    private fun caller(body: String) = kotlin(
+        """
+        package com.test
+        import com.duckduckgo.common.ui.compose.contextmenu.*
+        fun Text(text: String) {}
+        fun Button(text: String) {}
+        fun Column(content: () -> Unit) {}
+        fun screen() { $body }
+        """,
+    ).indented()
+
+    private fun run(body: String) = lint()
+        .files(scopeStubs, caller(body))
+        .issues(DaxContextMenuContentDetector.INVALID_DAX_CONTEXT_MENU_CONTENT_USAGE)
+        .run()
+
+    @Test
+    fun whenContextMenuContentUsesScopeMemberThenNoWarning() {
+        run("""DaxContextMenu(expanded = true, onDismissRequest = {}, content = { DaxDefaultItem("x") })""").expectClean()
+    }
+
+    @Test
+    fun whenIconButtonContentUsesScopeMemberThenNoWarning() {
+        run("""DaxContextMenuIconButton(iconPainter = 0, content = { DaxIconItem("x") })""").expectClean()
+    }
+
+    @Test
+    fun whenContextMenuContentUsesArbitraryComposableThenWarning() {
+        run("""DaxContextMenu(expanded = true, onDismissRequest = {}, content = { Text("x") })""").expectWarningCount(1)
+    }
+
+    @Test
+    fun whenIconButtonContentUsesArbitraryComposableThenWarning() {
+        run("""DaxContextMenuIconButton(iconPainter = 0, content = { Button("x") })""").expectWarningCount(1)
+    }
+
+    @Test
+    fun whenContextMenuContentMixesAllowedAndArbitraryThenWarning() {
+        run(
+            """DaxContextMenu(expanded = true, onDismissRequest = {}, content = { DaxDefaultItem("x"); Text("x") })""",
+        ).expectWarningCount(1)
+    }
+
+    @Test
+    fun whenIconButtonContentMixesAllowedAndArbitraryThenWarning() {
+        run("""DaxContextMenuIconButton(iconPainter = 0, content = { DaxIconItem("x"); Button("x") })""").expectWarningCount(1)
+    }
+
+    @Test
+    fun whenScopeClassUnresolvedThenClean() {
+        lint()
+            .files(caller("""DaxContextMenu(expanded = true, onDismissRequest = {}, content = { Text("x") })"""))
+            .issues(DaxContextMenuContentDetector.INVALID_DAX_CONTEXT_MENU_CONTENT_USAGE)
+            .allowCompilationErrors()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenScopeMemberTakesNonScopeValueArgumentThenNoWarning() {
+        run(
+            """DaxContextMenu(expanded = true, onDismissRequest = {}, content = { DaxDefaultItem(painterResource(1).toString()) })""",
+        ).expectClean()
+    }
+
+    @Test
+    fun whenContextMenuContentWrapsScopeMemberInLayoutThenWarning() {
+        run("""DaxContextMenu(expanded = true, onDismissRequest = {}, content = { Column { DaxDefaultItem("x") } })""").expectWarningCount(1)
+    }
+
+    @Test
+    fun whenIconButtonContentWrapsScopeMemberInLayoutThenWarning() {
+        run("""DaxContextMenuIconButton(iconPainter = 0, content = { Column { DaxIconItem("x") } })""").expectWarningCount(1)
+    }
+}

--- a/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxContextMenuItemContentDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxContextMenuItemContentDetectorTest.kt
@@ -39,6 +39,21 @@ class DaxContextMenuItemContentDetectorTest {
             text: String,
             trailingIcon: (DaxContextMenuItemTrailingScope.() -> Unit)? = null,
         ) {}
+        object DaxContextMenuScope {
+            fun DaxDefaultItem(
+                text: String,
+                trailingIcon: (DaxContextMenuItemTrailingScope.() -> Unit)? = null,
+            ) {}
+            fun DaxIconItem(
+                text: String,
+                trailingIcon: (DaxContextMenuItemTrailingScope.() -> Unit)? = null,
+            ) {}
+            fun DaxInsetItem(
+                text: String,
+                trailingIcon: (DaxContextMenuItemTrailingScope.() -> Unit)? = null,
+            ) {}
+        }
+        fun DaxContextMenu(content: DaxContextMenuScope.() -> Unit) {}
         """,
     ).indented()
 
@@ -101,5 +116,25 @@ class DaxContextMenuItemContentDetectorTest {
     @Test
     fun whenTrailingIconWrapsScopeMemberInLayoutThenWarning() {
         run("""DaxDefaultContextMenuItem(text = "x", trailingIcon = { Column { Icon() } })""").expectWarningCount(1)
+    }
+
+    @Test
+    fun whenScopedDefaultItemTrailingIconArbitraryThenWarning() {
+        run("""DaxContextMenu { DaxDefaultItem(text = "x", trailingIcon = { Text("x") }) }""").expectWarningCount(1)
+    }
+
+    @Test
+    fun whenScopedIconItemTrailingIconArbitraryThenWarning() {
+        run("""DaxContextMenu { DaxIconItem(text = "x", trailingIcon = { Image(1) }) }""").expectWarningCount(1)
+    }
+
+    @Test
+    fun whenScopedInsetItemTrailingIconArbitraryThenWarning() {
+        run("""DaxContextMenu { DaxInsetItem(text = "x", trailingIcon = { Text("x") }) }""").expectWarningCount(1)
+    }
+
+    @Test
+    fun whenScopedItemTrailingIconUsesScopeMemberThenNoWarning() {
+        run("""DaxContextMenu { DaxIconItem(text = "x", trailingIcon = { Icon() }) }""").expectClean()
     }
 }

--- a/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxContextMenuItemContentDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxContextMenuItemContentDetectorTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+class DaxContextMenuItemContentDetectorTest {
+
+    private val scopeStubs = kotlin(
+        """
+        package com.duckduckgo.common.ui.compose.contextmenu
+        class DaxContextMenuItemTrailingScope { fun Icon(painter: Int = 0) {} }
+        fun painterResource(id: Int): Int = id
+        fun DaxDefaultContextMenuItem(
+            text: String,
+            trailingIcon: (DaxContextMenuItemTrailingScope.() -> Unit)? = null,
+        ) {}
+        fun DaxIconContextMenuItem(
+            text: String,
+            trailingIcon: (DaxContextMenuItemTrailingScope.() -> Unit)? = null,
+        ) {}
+        fun DaxInsetContextMenuItem(
+            text: String,
+            trailingIcon: (DaxContextMenuItemTrailingScope.() -> Unit)? = null,
+        ) {}
+        """,
+    ).indented()
+
+    private fun caller(body: String) = kotlin(
+        """
+        package com.test
+        import com.duckduckgo.common.ui.compose.contextmenu.*
+        fun Text(text: String) {}
+        fun Image(painter: Int) {}
+        fun Column(content: () -> Unit) {}
+        fun screen() { $body }
+        """,
+    ).indented()
+
+    private fun run(body: String) = lint()
+        .files(scopeStubs, caller(body))
+        .issues(DaxContextMenuItemContentDetector.INVALID_DAX_CONTEXT_MENU_ITEM_CONTENT_USAGE)
+        .run()
+
+    @Test
+    fun whenTrailingIconUsesScopeMemberThenNoWarning() {
+        run("""DaxDefaultContextMenuItem(text = "x", trailingIcon = { Icon() })""").expectClean()
+    }
+
+    @Test
+    fun whenTrailingIconUsesArbitraryComposableThenWarning() {
+        run("""DaxDefaultContextMenuItem(text = "x", trailingIcon = { Text("x") })""").expectWarningCount(1)
+    }
+
+    @Test
+    fun whenIconContextMenuItemTrailingIconArbitraryThenWarning() {
+        run("""DaxIconContextMenuItem(text = "x", trailingIcon = { Image(1) })""").expectWarningCount(1)
+    }
+
+    @Test
+    fun whenInsetContextMenuItemTrailingIconArbitraryThenWarning() {
+        run("""DaxInsetContextMenuItem(text = "x", trailingIcon = { Text("x") })""").expectWarningCount(1)
+    }
+
+    @Test
+    fun whenTrailingIconMixesAllowedAndArbitraryThenWarning() {
+        run("""DaxDefaultContextMenuItem(text = "x", trailingIcon = { Icon(); Text("x") })""").expectWarningCount(1)
+    }
+
+    @Test
+    fun whenScopeClassUnresolvedThenClean() {
+        lint()
+            .files(caller("""DaxDefaultContextMenuItem(text = "x", trailingIcon = { Text("x") })"""))
+            .issues(DaxContextMenuItemContentDetector.INVALID_DAX_CONTEXT_MENU_ITEM_CONTENT_USAGE)
+            .allowCompilationErrors()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenScopeMemberTakesNonScopeValueArgumentThenNoWarning() {
+        run("""DaxDefaultContextMenuItem(text = "x", trailingIcon = { Icon(painterResource(1)) })""").expectClean()
+    }
+
+    @Test
+    fun whenTrailingIconWrapsScopeMemberInLayoutThenWarning() {
+        run("""DaxDefaultContextMenuItem(text = "x", trailingIcon = { Column { Icon() } })""").expectWarningCount(1)
+    }
+}

--- a/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxListItemContentDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxListItemContentDetectorTest.kt
@@ -49,10 +49,19 @@ class DaxListItemContentDetectorTest {
         """,
     ).indented()
 
+    private val contextMenuStub = kotlin(
+        "src/com/duckduckgo/common/ui/compose/contextmenu/DaxContextMenu.kt",
+        """
+        package com.duckduckgo.common.ui.compose.contextmenu
+        fun DaxContextMenu(anchor: () -> Unit, expanded: Boolean, onDismissRequest: () -> Unit) {}
+        """,
+    ).indented()
+
     private fun caller(body: String) = kotlin(
         """
         package com.test
         import com.duckduckgo.common.ui.compose.listitem.*
+        import com.duckduckgo.common.ui.compose.contextmenu.DaxContextMenu
         fun BadSwitch() {}
         fun BadIcon() {}
         fun BadPill() {}
@@ -62,7 +71,7 @@ class DaxListItemContentDetectorTest {
     ).indented()
 
     private fun run(body: String) = lint()
-        .files(scopeStubs, caller(body))
+        .files(scopeStubs, contextMenuStub, caller(body))
         .issues(DaxListItemContentDetector.INVALID_DAX_LIST_ITEM_CONTENT_USAGE)
         .run()
 
@@ -129,5 +138,17 @@ class DaxListItemContentDetectorTest {
     @Test
     fun whenSlotWrapsScopeMemberInLayoutThenWarning() {
         run("""DaxOneLineListItem(text = "x", trailingContent = { Column { Icon() } })""").expectWarningCount(1)
+    }
+
+    @Test
+    fun whenTrailingContentUsesDaxContextMenuThenNoWarning() {
+        run(
+            """DaxOneLineListItem(text = "x", trailingContent = { DaxContextMenu(anchor = {}, expanded = false, onDismissRequest = {}) })""",
+        ).expectClean()
+    }
+
+    @Test
+    fun whenTrailingContentUsesNonScopeComposableOtherThanDaxContextMenuThenWarning() {
+        run("""DaxOneLineListItem(text = "x", trailingContent = { BadSwitch() })""").expectWarningCount(1)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1215496415658080/task/1211659112661237?focus=true 
Tech Design URL (if applicable):  None
API Proposals URL(s) (if applicable): None

### Description

Adds `DaxContextMenu`, the Compose counterpart of the XML `PopupMenu`, with a `DaxContextMenuIconButton` convenience wrapper and three item variants (default, icon, inset). Content is restricted to design-system rows via `DaxContextMenuScope`, which also auto-dismisses the menu on tap.

### Steps to test this PR

> [!NOTE]
> - Install Internal Debug
> - Open the ADS gallery (design-system-internal)

_Happy path_
- [ ] Open **List Items** tab → find the Context Menu example → tap the trailing icon → confirm the Compose menu opens anchored to the icon, shows default/icon/inset rows, dismisses on outside tap and on row tap
- [ ] In the same example, tap the trailing icon on the XML `PopupMenu` comparison row → confirm it opens and behaves the same way, for visual comparison against the Compose menu
- [ ] Open **Templates** tab → find the Top App Bar example → tap the overflow icon → confirm the menu opens with a disabled row and a destructive row styled correctly

### UI changes
<img width="300" alt="image" src="https://github.com/user-attachments/assets/399da0a3-a314-4e8f-af0c-de36fbdbab32" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/eccdc2b0-f925-439c-b21c-4580b2a8b5ca" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/eac049a9-0a40-4694-ab45-1aa87f46cbc2" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New design-system UI and internal gallery demos with lint enforcement; no changes to auth, networking, or production app flows in this diff.
> 
> **Overview**
> Introduces **Compose context menus** as the themed counterpart to the XML `PopupMenu`, so overflow and list-item actions can follow the same design tokens as other Dax components.
> 
> **`DaxContextMenu`** anchors a Material3 `DropdownMenu` to any composable, with **`DaxContextMenuIconButton`** for the usual vertical overflow icon and internal expanded state. Rows are built through **`DaxContextMenuScope`** (`DaxDefaultItem`, `DaxIconItem`, `DaxInsetItem`), which dismisses the menu after a tap. Public item composables cover default, leading-icon, and inset layouts, with support for dividers, disabled rows, destructive styling, and trailing icons via **`DaxContextMenuItemTrailingScope`**.
> 
> The **ADS internal gallery** adds a **Context Menu** list-items example (Compose menus on two-line rows plus an XML popup for comparison) and a **Templates** sample top app bar with search and overflow menu. **Custom lint** enforces scope-only content for menu and item trailing slots; **`DaxListItemContentDetector`** now allows **`DaxContextMenu`** in list item trailing content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d94625682e2c3e97b3bb8b0cc5bd029ab9dce7d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->