### PR TITLE
Update content scope scripts to version 17.0.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -550,9 +550,10 @@
     "hover",
     "trackerProtection",
     // only enabled on apple platforms
-    "textSelection"
+    "textSelection",
+    "uaChBrands"
   ];
-  var selfGatingFeatures = ["trackerProtection"];
+  var selfGatingFeatures = ["trackerProtection", "uaChBrands"];
   function isPlatformSpecificFeature(featureName) {
     return platformSpecificFeatures.includes(
       /** @type {import('./features.js').FeatureName} */
@@ -6900,35 +6901,6 @@
     };
   }
 
-  // src/detectors/detections/adwall-detection.js
-  function runAdwallDetection(config = {}) {
-    const results = [];
-    for (const [detectorId, detectorConfig] of Object.entries(config)) {
-      if (detectorConfig?.state !== "enabled") {
-        continue;
-      }
-      const detected = detectAdwall(detectorConfig);
-      if (detected) {
-        results.push({
-          detected: true,
-          detectorId
-        });
-      }
-    }
-    return {
-      detected: results.length > 0,
-      type: "adwallDetection",
-      results
-    };
-  }
-  function detectAdwall(patternConfig) {
-    const { textPatterns, textSources } = patternConfig;
-    if (checkTextPatterns(textPatterns, textSources)) {
-      return true;
-    }
-    return false;
-  }
-
   // src/detectors/detections/youtube-ad-detection.js
   var noopLogger = { info: () => {
   }, warn: () => {
@@ -7621,7 +7593,6 @@
           result.detectorData = {
             botDetection: runBotDetection(detectorSettings.botDetection),
             fraudDetection: runFraudDetection(detectorSettings.fraudDetection),
-            adwallDetection: runAdwallDetection(detectorSettings.adwallDetection),
             youtubeAds: runYoutubeAdDetection(detectorSettings.youtubeAds)
           };
         }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -2065,9 +2065,10 @@
     "hover",
     "trackerProtection",
     // only enabled on apple platforms
-    "textSelection"
+    "textSelection",
+    "uaChBrands"
   ];
-  var selfGatingFeatures = ["trackerProtection"];
+  var selfGatingFeatures = ["trackerProtection", "uaChBrands"];
   function isPlatformSpecificFeature(featureName) {
     return platformSpecificFeatures.includes(
       /** @type {import('./features.js').FeatureName} */

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2065,9 +2065,10 @@
     "hover",
     "trackerProtection",
     // only enabled on apple platforms
-    "textSelection"
+    "textSelection",
+    "uaChBrands"
   ];
-  var selfGatingFeatures = ["trackerProtection"];
+  var selfGatingFeatures = ["trackerProtection", "uaChBrands"];
   function isPlatformSpecificFeature(featureName) {
     return platformSpecificFeatures.includes(
       /** @type {import('./features.js').FeatureName} */

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1421,9 +1421,10 @@
     "hover",
     "trackerProtection",
     // only enabled on apple platforms
-    "textSelection"
+    "textSelection",
+    "uaChBrands"
   ];
-  var selfGatingFeatures = ["trackerProtection"];
+  var selfGatingFeatures = ["trackerProtection", "uaChBrands"];
   function isPlatformSpecificFeature(featureName) {
     return platformSpecificFeatures.includes(
       /** @type {import('./features.js').FeatureName} */
@@ -8830,36 +8831,6 @@
     };
   }
 
-  // src/detectors/detections/adwall-detection.js
-  init_define_import_meta_trackerLookup();
-  function runAdwallDetection(config = {}) {
-    const results = [];
-    for (const [detectorId, detectorConfig] of Object.entries(config)) {
-      if (detectorConfig?.state !== "enabled") {
-        continue;
-      }
-      const detected = detectAdwall(detectorConfig);
-      if (detected) {
-        results.push({
-          detected: true,
-          detectorId
-        });
-      }
-    }
-    return {
-      detected: results.length > 0,
-      type: "adwallDetection",
-      results
-    };
-  }
-  function detectAdwall(patternConfig) {
-    const { textPatterns, textSources } = patternConfig;
-    if (checkTextPatterns(textPatterns, textSources)) {
-      return true;
-    }
-    return false;
-  }
-
   // src/detectors/detections/youtube-ad-detection.js
   init_define_import_meta_trackerLookup();
   var noopLogger = { info: () => {
@@ -9546,9 +9517,6 @@
         if (types.includes("fraudDetection")) {
           results.fraudDetection = runFraudDetection(settings?.fraudDetection);
         }
-        if (types.includes("adwallDetection")) {
-          results.adwallDetection = runAdwallDetection(settings?.adwallDetection);
-        }
         return results;
       });
     }
@@ -9684,7 +9652,6 @@
           result.detectorData = {
             botDetection: runBotDetection(detectorSettings.botDetection),
             fraudDetection: runFraudDetection(detectorSettings.fraudDetection),
-            adwallDetection: runAdwallDetection(detectorSettings.adwallDetection),
             youtubeAds: runYoutubeAdDetection(detectorSettings.youtubeAds)
           };
         }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -532,9 +532,10 @@
     "hover",
     "trackerProtection",
     // only enabled on apple platforms
-    "textSelection"
+    "textSelection",
+    "uaChBrands"
   ];
-  var selfGatingFeatures = ["trackerProtection"];
+  var selfGatingFeatures = ["trackerProtection", "uaChBrands"];
   function isPlatformSpecificFeature(featureName) {
     return platformSpecificFeatures.includes(
       /** @type {import('./features.js').FeatureName} */

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
@@ -532,9 +532,10 @@
     "hover",
     "trackerProtection",
     // only enabled on apple platforms
-    "textSelection"
+    "textSelection",
+    "uaChBrands"
   ];
-  var selfGatingFeatures = ["trackerProtection"];
+  var selfGatingFeatures = ["trackerProtection", "uaChBrands"];
   function isPlatformSpecificFeature(featureName) {
     return platformSpecificFeatures.includes(
       /** @type {import('./features.js').FeatureName} */

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^16.29.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.15.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#17.0.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "16.29.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.29.0.tgz",
-      "integrity": "sha512-s62ngACWEiUQh2M/ERhc7TAQPUUOTvzHD0C68+PYTLG600J07l5RtlaafQSyAwp2ER4+8AleVglggQ2VSI4qUQ==",
+      "version": "16.32.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.32.0.tgz",
+      "integrity": "sha512-ch5GhKg+JZY1zm2CWbbMHW/IZi6yLwtczVhn1D2pEDCUjhNDRpvRfIvMx5qD6fZhggmfTVn1BoQQWEsa3Uxy3w==",
       "license": "MPL-2.0",
       "dependencies": {
         "tldts-experimental": "^7.4.3"
@@ -61,7 +61,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#f01af0ea02ce16070571ca474092bb115d569a04",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#e27d61495b3e8793e507a483d885b758e75c0732",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -196,9 +196,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
-      "integrity": "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -575,9 +575,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
-      "integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
+      "version": "5.51.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.51.2.tgz",
+      "integrity": "sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^16.29.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#16.15.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#17.0.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217966941690182

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run