### PR TITLE
Remove customizeResponses toggle

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -105,13 +105,6 @@ interface DuckChatFeature {
     fun nativeInputField(): Toggle
 
     /**
-     * @return `true` when the "Customize Responses" action is shown in the Duck.ai unified input options menu.
-     * If the remote feature is not present defaults to `internal`.
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
-    fun customizeResponses(): Toggle
-
-    /**
      * @return `true` when Duck.ai should use the native chat input integration
      * (the `native-input` URL param plus the `supportsNativeChatInput` /
      * `supportsNativePrompt` JS flags). Has no effect unless [nativeInputField]

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -37,7 +37,6 @@ import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.R
-import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import dagger.android.support.AndroidSupportInjection
@@ -53,8 +52,6 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
     @Inject lateinit var viewModelFactory: ViewViewModelFactory
 
     @Inject lateinit var nativeInputStateProvider: NativeInputStateProvider
-
-    @Inject lateinit var duckChatFeature: DuckChatFeature
 
     private val viewModel by lazy {
         ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[OptionsViewModel::class.java]
@@ -144,8 +141,7 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
     }
 
     private fun isCustomizeResponsesAvailable(): Boolean =
-        duckChatFeature.customizeResponses().isEnabled() &&
-            lastNativeInputState?.inputContext == NativeInputState.InputContext.DUCK_AI
+        lastNativeInputState?.inputContext == NativeInputState.InputContext.DUCK_AI
 
     private fun refreshOptionsButtonVisibility(visibleTools: Set<Tool> = viewModel.visibleTools.value) {
         optionsButton.isVisible = visibleTools.isNotEmpty() || isCustomizeResponsesAvailable()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1216109044092832?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

- Removes `customizeResponses` feature toggle

### Steps to test this PR

- [ ] Open full screen Duck.ai
- [ ] Verify that “Customize Responses” option is available in the native input

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small feature-flag cleanup with no auth or data-path changes; Customize Responses becomes always on for Duck.ai native input instead of remote-gated.
> 
> **Overview**
> Removes the **`customizeResponses()`** remote feature toggle from **`DuckChatFeature`**, so remote config can no longer hide the **Customize Responses** entry in the Duck.ai native unified input options menu.
> 
> In **`OptionsView`**, the feature flag injection and **`duckChatFeature.customizeResponses().isEnabled()`** check are dropped. **Customize Responses** is now available whenever the native input context is **`DUCK_AI`** (same menu row and **`customizeResponsesClicked()`** behavior as before when the toggle was on).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63407e0e9181e7ae35502d354e7db9f05506f927. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->