### PR TITLE
Enable R8 for internal builds

### DIFF
--- a/android-design-system/design-system/build.gradle
+++ b/android-design-system/design-system/build.gradle
@@ -97,7 +97,7 @@ dependencies {
 
     api("org.jetbrains.kotlinx:kotlinx-collections-immutable:_")
 
-    api lintChecks("com.slack.lint.compose:compose-lint-checks:_")
+    lintChecks("com.slack.lint.compose:compose-lint-checks:_")
 
     // Lottie
     implementation "com.airbnb.android:lottie:_"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -171,6 +171,8 @@ android {
     productFlavors {
         internal {
             dimension "store"
+            // use a separate proguard file for internal
+            proguardFiles 'proguard-rules-internal.pro'
         }
         fdroid {
             dimension "store"
@@ -219,6 +221,15 @@ android {
             } else {
                 java.srcDirs += 'src/anvilDagger/java'
             }
+        }
+    }
+}
+
+androidComponents {
+    // only minify (enable R8) for internal release builds
+    beforeVariants(selector().withBuildType("release")) { variantBuilder ->
+        if (variantBuilder.productFlavors.any { it.second == "internal" }) {
+            variantBuilder.minifyEnabled = true
         }
     }
 }

--- a/app/proguard-rules-internal.pro
+++ b/app/proguard-rules-internal.pro
@@ -1,0 +1,27 @@
+# applied to internal builds only, play and fdroid are not minified
+
+# disable obfuscation
+-dontobfuscate
+
+# required for internal crash and ANR traces
+-keepattributes SourceFile,LineNumberTable
+
+# required for fasterxml.jackson
+-dontwarn java.beans.ConstructorProperties
+-dontwarn java.beans.Transient
+
+# required for Moshi (keeps Kotlin's generated default-value constructors)
+-keepclassmembers class com.duckduckgo.** {
+    <init>(...);
+}
+
+# required for reflective Dagger injection (used by AndroidInjector)
+-keepclassmembers class * {
+    void inject(***);
+}
+
+# required for layout inflation
+-keepclassmembers class * implements androidx.viewbinding.ViewBinding {
+    public static *** inflate(...);
+    public static *** bind(android.view.View);
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,3 +29,7 @@ android.lint.useK2Uast=false
 
 # DI framework: AnvilDagger (default) or Metro
 ddg.di=AnvilDagger
+
+# enables R8 compatibility mode
+# https://developer.android.com/topic/performance/app-optimization/full-mode
+android.enableR8.fullMode=false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1217975606507322?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

- Enables R8 (in compatibility mode) on internal builds
- e2e test run: https://github.com/duckduckgo/Android/actions/runs/33339201147 ✅

### Steps to test this PR

- [ ] General smoke test
- [ ] Smoke test sync
- [ ] Smoke test PIR
- [ ] Smoke test autofill
- [ ] Smoke test VPN
- [ ] Smoke test Duck.ai
- [ ] Smoke test downloads
- [ ] Smoke test crash reporting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enabling R8 on internal release can surface shrinker/reflection issues at runtime; rules are tailored for internal debugging but this is still a build-pipeline change for a primary distribution flavor.
> 
> **Overview**
> **Internal release** builds now run **R8** (minification) while **play** and **fdroid** release builds stay unchanged with minification off.
> 
> The app module wires this through `androidComponents.beforeVariants`: only variants with the **internal** store flavor and **release** build type get `minifyEnabled = true`. The **internal** flavor adds `proguard-rules-internal.pro`, which turns off obfuscation (`-dontobfuscate`), keeps line numbers for crash/ANR traces, and adds keep rules for Moshi, Dagger `inject`, and ViewBinding.
> 
> **gradle.properties** sets `android.enableR8.fullMode=false` for R8 compatibility mode. In **design-system**, compose lint checks are declared with `lintChecks` instead of `api lintChecks` so they are not propagated as a compile dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd28348516f87532bce0387e270ba6fe46a2b2a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->