### PR TITLE
Update PIR broker bundle - 2026-08-31

### DIFF
--- a/pir/pir-impl/src/main/assets/brokers/advancedbackgroundchecks.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/advancedbackgroundchecks.com.json
@@ -1,8 +1,8 @@
 {
   "name": "AdvancedBackgroundChecks",
   "url": "advancedbackgroundchecks.com",
-  "version": "0.11.0",
-  "parent": "cyberbackgroundchecks.com",
+  "version": "0.12.0",
+  "parent": "peoplefinders.com",
   "addedDatetime": 1678060800000,
   "optOutUrl": "https://www.advancedbackgroundchecks.com/opt-out",
   "steps": [

--- a/pir/pir-impl/src/main/assets/brokers/cyberbackgroundchecks.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/cyberbackgroundchecks.com.json
@@ -1,9 +1,10 @@
 {
   "name": "Cyber Background Checks",
   "url": "cyberbackgroundchecks.com",
-  "version": "0.9.0",
+  "version": "0.10.0",
+  "parent": "peoplefinders.com",
   "addedDatetime": 1705644000000,
-  "optOutUrl": "https://www.cyberbackgroundchecks.com/removal",
+  "optOutUrl": "https://cyberbackgroundchecks.com/donotsellmyinfo",
   "steps": [
     {
       "stepType": "scan",
@@ -36,7 +37,6 @@
           "id": "131315c4-a434-480e-a5d4-27f73bfafc7a"
         },
         {
-          "_comment": "addressFull/addressFullList retain the street and zip of each parsed address as address extras (C-S-S #2907). The opt-out form fills a street from those extras, so this extraction must stay in place. Note parse-address drops any address it can't read a street from, current or previous.",
           "actionType": "extract",
           "id": "d6c07b68-7a33-45a4-9e8e-ae6f9262ef29",
           "selector": ".card",
@@ -74,192 +74,8 @@
     },
     {
       "stepType": "optOut",
-      "optOutType": "formOptOut",
-      "actions": [
-        {
-          "actionType": "navigate",
-          "url": "https://www.cyberbackgroundchecks.com/removal",
-          "id": "5e78e1f8-7e99-466f-99f0-9ea8bb5feec9"
-        },
-        {
-          "actionType": "expectation",
-          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//body[not(.//script[contains(@src, '/cdn-cgi/challenge-platform/')]) and not(.//script[contains(., '_cf_chl_opt')])]"
-            }
-          ],
-          "id": "cfc-2edeb6a2-4108-4acc-b957-04300fbc64c8"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "text",
-              "selector": "body",
-              "expect": "CyberBackgroundChecks Opt-Out Form"
-            }
-          ],
-          "id": "37662209-3966-4cbd-810b-b39975018b14"
-        },
-        {
-          "actionType": "fillForm",
-          "selector": "//form[.//input[@id='chk-agree-to-terms']]",
-          "dataSource": "userProfile",
-          "elements": [
-            {
-              "type": "firstName",
-              "selector": ".//input[@id='FirstName']"
-            },
-            {
-              "type": "middleName",
-              "selector": ".//input[@id='MiddleName']"
-            },
-            {
-              "type": "lastName",
-              "selector": ".//input[@id='LastName']"
-            }
-          ],
-          "id": "b2bc6f6b-cf8d-4a71-917b-35d57c8ad4fe"
-        },
-        {
-          "actionType": "fillForm",
-          "selector": "//form[.//input[@id='chk-agree-to-terms']]",
-          "elements": [
-            {
-              "type": "email",
-              "selector": ".//input[@id='Email']"
-            }
-          ],
-          "id": "6fea94b2-5a0a-4284-b5a5-ca14f4638dcf"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "//input[@id='chk-agree-to-terms']"
-            }
-          ],
-          "id": "8849659f-e933-4675-b44a-ecfce314764c"
-        },
-        {
-          "actionType": "getCaptchaInfo",
-          "selector": ".g-recaptcha",
-          "id": "7eb64802-9932-42b6-a168-f7ba99e2ad36"
-        },
-        {
-          "actionType": "solveCaptcha",
-          "selector": ".g-recaptcha",
-          "id": "f917ed01-dc20-4659-9459-9199e3010d49"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "//form[.//input[@id='chk-agree-to-terms']]//button[@type='submit']"
-            }
-          ],
-          "id": "e818d1f7-2ed8-45f8-b4f9-c140d3606c0a"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "text",
-              "selector": "body",
-              "expect": "Email Sent"
-            }
-          ],
-          "id": "19b19939-5579-4790-944f-3a18c03019bb"
-        },
-        {
-          "actionType": "emailConfirmation",
-          "pollingTime": 30,
-          "id": "a2873b49-942f-4ef8-b0ca-2dd1d3509bb9"
-        },
-        {
-          "actionType": "expectation",
-          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//body[not(.//script[contains(@src, '/cdn-cgi/challenge-platform/')]) and not(.//script[contains(., '_cf_chl_opt')])]"
-            }
-          ],
-          "id": "cfc-050935e2-af10-4d36-8354-400321d773b9"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "text",
-              "selector": "body",
-              "expect": "Record Suppression Form"
-            }
-          ],
-          "id": "4c462039-aa57-4cf2-b97d-cec42ecdd46c"
-        },
-        {
-          "_comment": "CBC verifies the submitted address against the record it holds, so street/city/state come from the address extracted during the scan rather than from generated values, which this cluster rejects. fillForm resolves them from whichever extracted address matches the user profile's city/state, which is not necessarily the record's current address. Date of Birth is required and is a single date input, so it uses $generated_dob$, which derives a date from the extracted age (or the profile's age when the record shows none).",
-          "actionType": "fillForm",
-          "selector": "#contact-form",
-          "dataSource": "extractedProfile",
-          "elements": [
-            {
-              "type": "$generated_dob$",
-              "selector": ".//input[@id='Dob']"
-            },
-            {
-              "type": "street",
-              "selector": ".//input[@id='StreetAddress']"
-            },
-            {
-              "type": "city",
-              "selector": ".//input[@id='City']"
-            },
-            {
-              "type": "state",
-              "selector": ".//input[@id='State']"
-            }
-          ],
-          "id": "6a54b508-9f50-4a0c-9e0c-0674621075c2"
-        },
-        {
-          "actionType": "getCaptchaInfo",
-          "selector": ".g-recaptcha",
-          "id": "8573a11e-b931-4b1b-a92a-b652344945bb"
-        },
-        {
-          "actionType": "solveCaptcha",
-          "selector": ".g-recaptcha",
-          "id": "daa1b0f7-ebbb-4588-9357-d70fcfd553fa"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "//form[@id='contact-form']//button[@type='submit']"
-            }
-          ],
-          "id": "3d61d592-dee7-499f-a028-3da00c7de071"
-        },
-        {
-          "_comment": "Assert on the success copy specifically: CBC renders rejections as in-page messages rather than errors, so a weaker check would false-positive.",
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "text",
-              "selector": "body",
-              "expect": "Opt-Out Request Received"
-            }
-          ],
-          "id": "dafcee39-4fa6-41a5-b958-9de0a53ebf5b"
-        }
-      ]
+      "optOutType": "parentSiteOptOut",
+      "actions": []
     }
   ],
   "schedulingConfig": {

--- a/pir/pir-impl/src/main/assets/brokers/fastbackgroundcheck.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/fastbackgroundcheck.com.json
@@ -1,8 +1,8 @@
 {
   "name": "FastBackgroundCheck.com",
   "url": "fastbackgroundcheck.com",
-  "version": "0.9.0",
-  "parent": "cyberbackgroundchecks.com",
+  "version": "0.10.0",
+  "parent": "peoplefinders.com",
   "addedDatetime": 1706248800000,
   "optOutUrl": "https://www.fastbackgroundcheck.com/opt-out",
   "steps": [

--- a/pir/pir-impl/src/main/assets/brokers/fastpeoplesearch.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/fastpeoplesearch.com.json
@@ -1,8 +1,8 @@
 {
   "name": "FastPeopleSearch",
   "url": "fastpeoplesearch.com",
-  "version": "0.9.0",
-  "parent": "cyberbackgroundchecks.com",
+  "version": "0.10.0",
+  "parent": "peoplefinders.com",
   "addedDatetime": 1675317600000,
   "optOutUrl": "https://www.fastpeoplesearch.com/removal",
   "steps": [

--- a/pir/pir-impl/src/main/assets/brokers/peoplefinders.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplefinders.com.json
@@ -1,8 +1,7 @@
 {
   "name": "PeopleFinders",
   "url": "peoplefinders.com",
-  "version": "0.11.0",
-  "parent": "cyberbackgroundchecks.com",
+  "version": "0.12.0",
   "addedDatetime": 1677132000000,
   "optOutUrl": "https://www.peoplefinders.com/opt-out",
   "steps": [
@@ -71,8 +70,211 @@
     },
     {
       "stepType": "optOut",
-      "optOutType": "parentSiteOptOut",
-      "actions": []
+      "optOutType": "formOptOut",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "id": "da658a1f-254b-42c6-b78a-f93655048db8",
+          "url": "https://www.peoplefinders.com/opt-out"
+        },
+        {
+          "_comment": "Turnstile auto-completes. This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-29020501-0911-42c4-be7e-58e3b7ddd75a"
+        },
+        {
+          "_comment": "Wait for CF challenge interstitial to complete",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": ".v-opt-out-wrapper"
+            }
+          ],
+          "id": "623b0022-8c67-4cef-8a11-4481c34229b7"
+        },
+        {
+          "actionType": "click",
+          "id": "c15a2587-ff08-4ec6-b7c0-0744273d57a9",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//button[@class='btn btn-success opt-out-button']"
+            }
+          ]
+        },
+        {
+          "actionType": "fillForm",
+          "id": "5685d436-32d5-4de0-a2b8-d5bbb4fa778d",
+          "selector": ".v-out-out-form",
+          "dataSource": "userProfile",
+          "elements": [
+            {
+              "type": "firstName",
+              "selector": ".//input[@placeholder='First Name']"
+            },
+            {
+              "type": "lastName",
+              "selector": ".//input[@placeholder='Last Name']"
+            }
+          ]
+        },
+        {
+          "actionType": "fillForm",
+          "selector": ".v-out-out-form",
+          "elements": [
+            {
+              "type": "email",
+              "selector": ".//input[@type='email']"
+            }
+          ],
+          "id": "45b04749-beb1-4567-a95f-649c2966b810"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//div[@class='terms-wrapper']/input[@type='checkbox']"
+            }
+          ],
+          "id": "5ec1e28f-c179-424d-a50c-8808040668c3"
+        },
+        {
+          "actionType": "getCaptchaInfo",
+          "id": "fcf4b0cf-9bb4-42e6-a2a9-68e4f2a25a2c",
+          "selector": ".v-recaptcha"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "id": "25c7fbb0-0508-4f93-aeb8-3642ecef8c33",
+          "selector": ".v-recaptcha"
+        },
+        {
+          "actionType": "click",
+          "id": "4ac6a176-ddaf-437f-8d8f-2dde0fe6b0ed",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//button[@class='btn btn-primary']"
+            }
+          ]
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "text",
+              "selector": "body",
+              "expect": "Email Sent"
+            }
+          ],
+          "id": "31e2af63-840f-4040-8f35-35d8d0156201"
+        },
+        {
+          "actionType": "emailConfirmation",
+          "id": "6f43425f-a49d-4eac-bec2-794c5f6bd687",
+          "pollingTime": 30
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "text",
+              "selector": "body",
+              "expect": "Record Suppression Form"
+            }
+          ],
+          "id": "c39dbadc-e398-4068-93cb-bb3c1a2b047e"
+        },
+        {
+          "actionType": "fillForm",
+          "selector": ".v-out-out-record-removal-form",
+          "dataSource": "userProfile",
+          "elements": [
+            {
+              "type": "$generated_phone_number$",
+              "selector": ".//input[@type='tel']"
+            },
+            {
+              "type": "$generated_random_number$",
+              "selector": ".//select[option[1][text()='Month']]",
+              "min": "1",
+              "max": "12"
+            },
+            {
+              "type": "$generated_random_number$",
+              "selector": ".//input[@name='day']",
+              "min": "1",
+              "max": "28"
+            },
+            {
+              "type": "birthYear",
+              "selector": ".//input[@name='year']"
+            },
+            {
+              "type": "$generated_street_address$",
+              "selector": ".//input[@placeholder='Street Address']"
+            },
+            {
+              "type": "city",
+              "selector": ".//input[@placeholder='City']"
+            },
+            {
+              "type": "state",
+              "selector": ".//select[option[1][text()='State']]"
+            }
+          ],
+          "id": "6ba153e8-676c-4b81-8a4b-5b6689fd978c"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//div[contains(@class, 'opt-out-card')]//input[@type='checkbox']"
+            }
+          ],
+          "id": "3a6a98ff-0ad6-4d0e-9537-a0844ced4598"
+        },
+        {
+          "actionType": "getCaptchaInfo",
+          "id": "45f59ed0-3a36-4ab6-9c45-e906471fb3e4",
+          "selector": ".v-recaptcha"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "id": "85469ad1-8870-449d-961e-22ea10738ec0",
+          "selector": ".v-recaptcha"
+        },
+        {
+          "actionType": "click",
+          "id": "cab0438c-1770-4dac-930d-041d44772172",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//button[@class='btn btn-primary']"
+            }
+          ]
+        },
+        {
+          "actionType": "expectation",
+          "id": "bc09540c-8aeb-4d9f-b515-0ebb6f4583a5",
+          "expectations": [
+            {
+              "type": "text",
+              "selector": "body",
+              "expect": "Opt-Out Request Confirmation"
+            }
+          ]
+        }
+      ]
     }
   ],
   "schedulingConfig": {

--- a/pir/pir-impl/src/main/assets/brokers/peoplesearchnow.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplesearchnow.com.json
@@ -1,8 +1,8 @@
 {
   "name": "People Search Now",
   "url": "peoplesearchnow.com",
-  "version": "0.8.0",
-  "parent": "cyberbackgroundchecks.com",
+  "version": "0.9.0",
+  "parent": "peoplefinders.com",
   "addedDatetime": 1705989600000,
   "optOutUrl": "https://www.peoplesearchnow.com/opt-out",
   "steps": [

--- a/pir/pir-impl/src/main/assets/brokers/quickpeopletrace.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/quickpeopletrace.com.json
@@ -1,8 +1,8 @@
 {
   "name": "Quick People Trace",
   "url": "quickpeopletrace.com",
-  "version": "0.7.0",
-  "parent": "cyberbackgroundchecks.com",
+  "version": "0.8.0",
+  "parent": "peoplefinders.com",
   "addedDatetime": 1674540000000,
   "optOutUrl": "https://www.quickpeopletrace.com/contact-us/",
   "steps": [

--- a/pir/pir-impl/src/main/assets/brokers/searchpeoplefree.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/searchpeoplefree.com.json
@@ -1,8 +1,8 @@
 {
   "name": "Search People FREE",
   "url": "searchpeoplefree.com",
-  "version": "0.10.0",
-  "parent": "cyberbackgroundchecks.com",
+  "version": "0.11.0",
+  "parent": "peoplefinders.com",
   "addedDatetime": 1703052000000,
   "optOutUrl": "https://www.searchpeoplefree.com/opt-out",
   "steps": [

--- a/pir/pir-impl/src/main/assets/brokers/smartbackgroundchecks.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/smartbackgroundchecks.com.json
@@ -1,8 +1,8 @@
 {
   "name": "SmartBackgroundChecks",
   "url": "smartbackgroundchecks.com",
-  "version": "0.9.0",
-  "parent": "cyberbackgroundchecks.com",
+  "version": "0.10.0",
+  "parent": "peoplefinders.com",
   "addedDatetime": 1678082400000,
   "optOutUrl": "https://www.smartbackgroundchecks.com/optout",
   "steps": [

--- a/pir/pir-impl/src/main/assets/brokers/truepeoplesearch.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/truepeoplesearch.com.json
@@ -1,8 +1,8 @@
 {
   "name": "TruePeopleSearch",
   "url": "truepeoplesearch.com",
-  "version": "0.11.0",
-  "parent": "cyberbackgroundchecks.com",
+  "version": "0.12.0",
+  "parent": "peoplefinders.com",
   "addedDatetime": 1703138400000,
   "optOutUrl": "https://www.truepeoplesearch.com/removal",
   "steps": [

--- a/pir/pir-impl/src/main/assets/brokers/usa-people-search.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/usa-people-search.com.json
@@ -1,8 +1,8 @@
 {
   "name": "USA People Search",
   "url": "usa-people-search.com",
-  "version": "0.9.0",
-  "parent": "cyberbackgroundchecks.com",
+  "version": "0.10.0",
+  "parent": "peoplefinders.com",
   "addedDatetime": 1678082400000,
   "optOutUrl": "https://www.usa-people-search.com/manage",
   "steps": [

--- a/pir/pir-impl/src/main/assets/brokers/usatrace.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/usatrace.com.json
@@ -1,8 +1,8 @@
 {
   "name": "USA Trace",
   "url": "usatrace.com",
-  "version": "0.8.0",
-  "parent": "cyberbackgroundchecks.com",
+  "version": "0.9.0",
+  "parent": "peoplefinders.com",
   "addedDatetime": 1674540000000,
   "optOutUrl": "https://www.usatrace.com/contact-us/",
   "steps": [

--- a/pir/pir-impl/src/main/assets/brokers/usphonebook.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/usphonebook.com.json
@@ -1,8 +1,8 @@
 {
   "name": "USPhoneBook",
   "url": "usphonebook.com",
-  "version": "0.8.0",
-  "parent": "cyberbackgroundchecks.com",
+  "version": "0.9.0",
+  "parent": "peoplefinders.com",
   "addedDatetime": 1678082400000,
   "optOutUrl": "https://www.usphonebook.com/opt-out",
   "steps": [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1217982385907229

## PIR Broker Bundle Update

Automated update of PIR broker JSON files from the remote bundle.

### Changes

**Updated (13):**
- advancedbackgroundchecks.com.json (0.11.0 → 0.12.0)
- cyberbackgroundchecks.com.json (0.9.0 → 0.10.0)
- fastbackgroundcheck.com.json (0.9.0 → 0.10.0)
- fastpeoplesearch.com.json (0.9.0 → 0.10.0)
- peoplefinders.com.json (0.11.0 → 0.12.0)
- peoplesearchnow.com.json (0.8.0 → 0.9.0)
- quickpeopletrace.com.json (0.7.0 → 0.8.0)
- searchpeoplefree.com.json (0.10.0 → 0.11.0)
- smartbackgroundchecks.com.json (0.9.0 → 0.10.0)
- truepeoplesearch.com.json (0.11.0 → 0.12.0)
- usa-people-search.com.json (0.9.0 → 0.10.0)
- usatrace.com.json (0.8.0 → 0.9.0)
- usphonebook.com.json (0.8.0 → 0.9.0)

### Checklist

- [x] Verify broker changes look correct
- [x] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Opt-out routing for a large broker cluster moves to a new parent and replaces CBC’s direct automation with delegated opt-out, which can break or change real user data-removal outcomes if the new flow or parent linkage is wrong.
> 
> **Overview**
> **Reorganizes the PeopleFinders-related broker cluster** so **PeopleFinders** is the shared opt-out parent instead of **Cyber Background Checks**, with version bumps across 13 broker JSON assets.
> 
> **PeopleFinders** now runs a full **`formOptOut`** flow (Cloudflare/Turnstile waits, initial opt-out form, reCAPTCHA, email confirmation, record suppression form with generated phone/DOB/address fields, and confirmation text). It no longer defers to a parent site and is no longer listed under `cyberbackgroundchecks.com`.
> 
> **Cyber Background Checks** drops its long **`formOptOut`** automation (removal URL, dual captcha flows, extracted-address suppression form) and switches to **`parentSiteOptOut`**, with **`optOutUrl`** updated to `donotsellmyinfo` and **`parent`** set to `peoplefinders.com`.
> 
> **Twelve sibling brokers** (e.g. TruePeopleSearch, FastPeopleSearch, AdvancedBackgroundChecks) only change **`parent`** from `cyberbackgroundchecks.com` to **`peoplefinders.com`** and bump versions; their scan steps and existing **`parentSiteOptOut`** behavior stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acfc93b75b72828367853c6a938391372e921eaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->