### PR TITLE
Add Exchange v2.1 Host.Unknown status

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.flow
 import logcat.LogPriority.ERROR
 import logcat.logcat
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Wraps the BE relay endpoints with envelope encryption/decryption + a polling Flow.
@@ -160,7 +161,7 @@ class RealExchangeV2Channel @Inject constructor(
                     }
                 }
             }
-            delay(POLL_INTERVAL_MS)
+            delay(POLL_INTERVAL)
         }
     }
 
@@ -191,6 +192,6 @@ class RealExchangeV2Channel @Inject constructor(
     }
 
     companion object {
-        private const val POLL_INTERVAL_MS: Long = 1_000L
+        private val POLL_INTERVAL = 1.seconds
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -45,9 +45,14 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
 import logcat.logcat
+import org.json.JSONObject
 import java.util.Base64
 import java.util.UUID
 import javax.inject.Inject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Drives a single Exchange V2 pairing session, from the linking code to a terminal state.
@@ -189,9 +194,11 @@ class RealExchangeV2Runner @Inject constructor(
 
     @Volatile private var _linkingCode: String? = null
 
-    @Volatile private var pollJob: Job? = null
+    @Volatile private var messagePollJob: Job? = null
 
-    @Volatile private var timeoutJob: Job? = null
+    @Volatile private var syncTimeoutJob: Job? = null
+
+    @Volatile private var lateJoinerDeadlineJob: Job? = null
 
     @Volatile private var sentOwnAvailability: Boolean = false
 
@@ -356,13 +363,15 @@ class RealExchangeV2Runner @Inject constructor(
     /** Caller MUST hold [mutex]. The single teardown path, so field resets can't drift between
      *  call sites: stop the jobs, best-effort DELETE the channel, discard keys, clear all state. */
     private fun cancelLocked() {
-        if (session != null || pollJob != null) {
+        if (session != null || messagePollJob != null) {
             logcat { "Sync-ExchangeV2: teardown (was in state ${session?.currentState})" }
         }
-        pollJob?.cancel()
-        pollJob = null
-        timeoutJob?.cancel()
-        timeoutJob = null
+        messagePollJob?.cancel()
+        messagePollJob = null
+        lateJoinerDeadlineJob?.cancel()
+        lateJoinerDeadlineJob = null
+        syncTimeoutJob?.cancel()
+        syncTimeoutJob = null
         val channelId = ownChannelId
         val channelSecret = ownChannelSecret
         if (channelId != null) {
@@ -396,7 +405,7 @@ class RealExchangeV2Runner @Inject constructor(
         val ch = ownChannelId ?: return
         val key = ownKeyPair ?: return
         val sec = ownChannelSecret
-        pollJob = appScope.launch(dispatchers.io()) {
+        messagePollJob = appScope.launch(dispatchers.io()) {
             try {
                 // collect suspends per message so envelopes are handled in poll() seq order. A
                 // message driving the SM terminal cancels this very poll job; that
@@ -435,13 +444,44 @@ class RealExchangeV2Runner @Inject constructor(
      * spec's per-event cancel conditions, since those all drive the SM to a terminal state.
      */
     private fun startSessionTimer() {
-        timeoutJob = appScope.launch(dispatchers.io()) {
+        syncTimeoutJob = appScope.launch(dispatchers.io()) {
             delay(SESSION_TIMEOUT_MS)
             logcat { "Sync-ExchangeV2: session deadline (${SESSION_TIMEOUT_MS}ms) reached" }
             // Capture the phase we were stuck in before failSession() tears the state machine down
             val stage = mutex.withLock { session?.currentState?.toTimeoutStage() }
             failSession("Session timed out", kind = SessionErrorKind.SessionTimeout, timeoutStage = stage)
         }
+    }
+
+    /**
+     * Host-side deadline for the Joiner's report. Elapsing here is not a failure, it just moves us
+     * to [ExchangeV2State.Host.Unknown], where a late report is still accepted until the 5-minute
+     * session deadline.
+     */
+    private fun startLateJoinerDeadlineLocked() {
+        lateJoinerDeadlineJob?.cancel()
+        lateJoinerDeadlineJob = appScope.launch(dispatchers.io()) {
+            val deadline = lateJoinStatusDeadline()
+            delay(deadline)
+            mutex.withLock {
+                // The report may have landed while we were waiting on the lock.
+                if (session?.currentState != ExchangeV2State.Host.AwaitingStatus) return@withLock
+                logcat { "Sync-ExchangeV2: join status deadline ($deadline) reached" }
+                processLocalTriggerLocked(LocalTrigger.HostStatusDeadlineElapsed(deadline))
+            }
+        }
+    }
+
+    private fun lateJoinStatusDeadline(): Duration {
+        val configured = runCatching {
+            syncFeature.self().getSettings()?.let { settings ->
+                JSONObject(settings)
+                    .getLong(SETTING_JOIN_STATUS_DEADLINE_MS)
+                    .milliseconds
+                    .coerceIn(MIN_JOIN_STATUS_DEADLINE, MAX_JOIN_STATUS_DEADLINE)
+            }
+        }.getOrNull()
+        return configured ?: DEFAULT_JOIN_STATUS_DEADLINE
     }
 
     /**
@@ -452,7 +492,7 @@ class RealExchangeV2Runner @Inject constructor(
         ExchangeV2State.Negotiating -> TimeoutStage.WAITING_FOR_PEER_STATUS
         ExchangeV2State.Host.Confirming, ExchangeV2State.Joiner.Confirming -> TimeoutStage.WAITING_FOR_CONFIRMATION
         ExchangeV2State.Host.Sending, ExchangeV2State.Joiner.Waiting -> TimeoutStage.WAITING_FOR_RECOVERY_CODE
-        ExchangeV2State.Host.AwaitingStatus, ExchangeV2State.Joiner.Joining -> TimeoutStage.LOGGING_IN
+        ExchangeV2State.Host.AwaitingStatus, ExchangeV2State.Host.Unknown, ExchangeV2State.Joiner.Joining -> TimeoutStage.LOGGING_IN
         else -> null
     }
 
@@ -534,6 +574,10 @@ class RealExchangeV2Runner @Inject constructor(
             is SideEffect.SendRecoveryCodeDone -> {
                 logcat { "Sync-ExchangeV2: side effect → SendRecoveryCodeDone(${effect.reason.value})" }
                 sendMessage(ExchangeV2Message.RecoveryCodeDone.create(effect.reason))
+            }
+            SideEffect.AwaitJoinStatus -> {
+                logcat { "Sync-ExchangeV2: side effect → AwaitJoinStatus" }
+                startLateJoinerDeadlineLocked()
             }
         }
     }
@@ -972,6 +1016,12 @@ class RealExchangeV2Runner @Inject constructor(
 
         // Transport TD 1214486492252757 §Session Lifecycle: 5-minute client session deadline.
         private const val SESSION_TIMEOUT_MS = 5 * 60 * 1000L
+
+        // Spec 1216906888491126 §"Account join status": 30 seconds, remotely tunable.
+        private const val SETTING_JOIN_STATUS_DEADLINE_MS = "joinStatusDeadlineMs"
+        private val DEFAULT_JOIN_STATUS_DEADLINE = 30.seconds
+        private val MIN_JOIN_STATUS_DEADLINE = 5.seconds
+        private val MAX_JOIN_STATUS_DEADLINE = 2.minutes
 
         // Android is always a ddg-kind device.
         private const val OWN_DEVICE_KIND = "ddg"

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -445,8 +445,8 @@ class RealExchangeV2Runner @Inject constructor(
      */
     private fun startSessionTimer() {
         syncTimeoutJob = appScope.launch(dispatchers.io()) {
-            delay(SESSION_TIMEOUT_MS)
-            logcat { "Sync-ExchangeV2: session deadline (${SESSION_TIMEOUT_MS}ms) reached" }
+            delay(SESSION_TIMEOUT)
+            logcat { "Sync-ExchangeV2: session deadline ($SESSION_TIMEOUT) reached" }
             // Capture the phase we were stuck in before failSession() tears the state machine down
             val stage = mutex.withLock { session?.currentState?.toTimeoutStage() }
             failSession("Session timed out", kind = SessionErrorKind.SessionTimeout, timeoutStage = stage)
@@ -1015,7 +1015,7 @@ class RealExchangeV2Runner @Inject constructor(
         private const val EVENT_BUFFER_SIZE = 100
 
         // Transport TD 1214486492252757 §Session Lifecycle: 5-minute client session deadline.
-        private const val SESSION_TIMEOUT_MS = 5 * 60 * 1000L
+        private val SESSION_TIMEOUT = 5.minutes
 
         // Spec 1216906888491126 §"Account join status": 30 seconds, remotely tunable.
         private const val SETTING_JOIN_STATUS_DEADLINE_MS = "joinStatusDeadlineMs"

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2State.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2State.kt
@@ -119,6 +119,17 @@ sealed interface ExchangeV2State {
         data object AwaitingStatus : Host
 
         /**
+         * The status deadline passed without a report. The pairing may well have succeeded, so this
+         * is explicitly not a failure.
+         *
+         * Not terminal either: the session keeps polling, and a late `recovery_code_done` still
+         * promotes this to [Done].
+         *
+         * Since 2.1.
+         */
+        data object Unknown : Host
+
+        /**
          * Terminal. The Host side gave up: our user denied the prompt, no recovery code could be
          * produced, or the peer broke the message sequence.
          *

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
@@ -110,6 +110,7 @@ internal class RealExchangeV2StateMachine(
             ExchangeV2State.Bootstrapped -> receiveInBootstrapped(state, msg)
             ExchangeV2State.Negotiating -> receiveInNegotiating(state, msg)
             ExchangeV2State.Host.AwaitingStatus -> receiveInHostAwaitingStatus(state, msg)
+            ExchangeV2State.Host.Unknown -> receiveInHostUnknownStatus(state, msg)
             ExchangeV2State.Joiner.Confirming -> receiveInJoinerConfirming(state, msg)
             ExchangeV2State.Joiner.Waiting -> receiveInJoinerWaiting(state, msg)
             else -> abort(state, msg, RejectReason.ImplicitAbort)
@@ -121,6 +122,7 @@ internal class RealExchangeV2StateMachine(
             ExchangeV2State.Negotiating -> localTriggerInNegotiating(state, trigger)
             ExchangeV2State.Host.Confirming -> localTriggerInHostConfirming(state, trigger)
             ExchangeV2State.Host.Sending -> localTriggerInHostSending(state, trigger)
+            ExchangeV2State.Host.AwaitingStatus -> localTriggerInHostAwaitingStatus(state, trigger)
             ExchangeV2State.Joiner.Confirming -> localTriggerInJoinerConfirming(state, trigger)
             ExchangeV2State.Joiner.Joining -> localTriggerInJoinerJoining(state, trigger)
             else -> abortLocal(state, trigger)
@@ -167,6 +169,13 @@ internal class RealExchangeV2StateMachine(
     }
 
     private fun receiveInHostAwaitingStatus(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
+        return when (msg) {
+            is RecoveryCodeDone -> accept(state, ExchangeV2State.Host.Done, msg)
+            else -> abort(state, msg, RejectReason.ImplicitAbort)
+        }
+    }
+
+    private fun receiveInHostUnknownStatus(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
         return when (msg) {
             is RecoveryCodeDone -> accept(state, ExchangeV2State.Host.Done, msg)
             else -> abort(state, msg, RejectReason.ImplicitAbort)
@@ -244,13 +253,20 @@ internal class RealExchangeV2StateMachine(
             // report. A pre-2.1 peer never sends recovery_code_done, so waiting on one would turn a
             // successful pairing into a spinner that only ends at the session deadline.
             is LocalTrigger.HostSendComplete -> if (trigger.negotiatedVersion >= ExchangeProtocolVersion.V2_1) {
-                acceptLocal(state, ExchangeV2State.Host.AwaitingStatus, trigger)
+                acceptLocal(state, ExchangeV2State.Host.AwaitingStatus, trigger, sideEffects = listOf(SideEffect.AwaitJoinStatus))
             } else {
                 acceptLocal(state, ExchangeV2State.Host.Done, trigger)
             }
             // Host couldn't produce a recovery code (no account, no 3party credential, etc.).
             // Runner has already sent recovery_code_unavailable to peer; this just tears down.
             LocalTrigger.HostUnavailable -> acceptLocal(state, ExchangeV2State.Host.Aborted, trigger)
+            else -> abortLocal(state, trigger)
+        }
+    }
+
+    private fun localTriggerInHostAwaitingStatus(state: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
+        return when (trigger) {
+            is LocalTrigger.HostStatusDeadlineElapsed -> acceptLocal(state, ExchangeV2State.Host.Unknown, trigger)
             else -> abortLocal(state, trigger)
         }
     }
@@ -361,9 +377,21 @@ internal class RealExchangeV2StateMachine(
 
 /** Terminal state to drive into on an implicit abort from [this]. Terminals return themselves. */
 private fun ExchangeV2State.abortTerminal(): ExchangeV2State = when (this) {
-    ExchangeV2State.Host.Confirming, ExchangeV2State.Host.Sending, ExchangeV2State.Host.AwaitingStatus -> ExchangeV2State.Host.Aborted
-    ExchangeV2State.Joiner.Confirming, ExchangeV2State.Joiner.Waiting, ExchangeV2State.Joiner.Joining -> ExchangeV2State.Joiner.AbortedLocal
-    ExchangeV2State.Bootstrapped, ExchangeV2State.Negotiating -> ExchangeV2State.Aborted
+    ExchangeV2State.Host.Confirming,
+    ExchangeV2State.Host.Sending,
+    ExchangeV2State.Host.AwaitingStatus,
+    ExchangeV2State.Host.Unknown,
+    -> ExchangeV2State.Host.Aborted
+
+    ExchangeV2State.Joiner.Confirming,
+    ExchangeV2State.Joiner.Waiting,
+    ExchangeV2State.Joiner.Joining,
+    -> ExchangeV2State.Joiner.AbortedLocal
+
+    ExchangeV2State.Bootstrapped,
+    ExchangeV2State.Negotiating,
+    -> ExchangeV2State.Aborted
+
     ExchangeV2State.Aborted,
     ExchangeV2State.SameAccountAbort,
     ExchangeV2State.Host.Aborted,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/LocalTrigger.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/LocalTrigger.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.sync.impl.exchange.v2
 
 import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
+import kotlin.time.Duration
 
 /**
  * An input to the state machine that didn't come off the wire: a user decision, role election, or
@@ -77,6 +78,14 @@ sealed interface LocalTrigger {
      * so the state machine can both pick a terminal and declare the `recovery_code_done` to send.
      */
     data class JoinerJoinComplete(val reason: RecoveryCodeDone.Reason) : LocalTrigger
+
+    /**
+     * The Host waited [deadline] without receiving [ExchangeV2Message.RecoveryCodeDone].
+     * Drives [ExchangeV2State.Host.AwaitingStatus] to [ExchangeV2State.Host.Unknown]; neither is
+     * terminal, so a late report can still arrive. [deadline] carries how long was waited, since
+     * the value is remotely tunable and the transition event would otherwise not say.
+     */
+    data class HostStatusDeadlineElapsed(val deadline: Duration) : LocalTrigger
 
     /**
      * Host couldn't produce a recovery code for the peer (e.g. not signed in, or no 3party

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/SideEffect.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/SideEffect.kt
@@ -97,4 +97,13 @@ sealed interface SideEffect {
      * Since 2.1.
      */
     data class SendRecoveryCodeDone(val reason: RecoveryCodeDone.Reason) : SideEffect
+
+    /**
+     * Start the deadline after which the Host shows an unknown outcome for the Joiner's
+     * `recovery_code_done`. Elapsing changes only what the user sees: the session keeps waiting in
+     * [ExchangeV2State.Host.Unknown], and a late report still lands on the real outcome.
+     *
+     * Since 2.1.
+     */
+    data object AwaitJoinStatus : SideEffect
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
@@ -31,6 +31,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.time.Duration.Companion.seconds
 
 class ExchangeV2StateMachineTest {
 
@@ -247,12 +248,30 @@ class ExchangeV2StateMachineTest {
         assertSame(ExchangeV2State.Host.Aborted, machine.currentState)
     }
 
-    @Test fun `when HostSendComplete v2_1 in Host Sending then advances to Host AwaitingStatus`() {
+    @Test fun `when HostSendComplete v2_1 in Host Sending then advances to Host AwaitingStatus and starts the deadline`() {
         val machine = inHostSending()
         val result = machine.localTrigger(LocalTrigger.HostSendComplete(ExchangeProtocolVersion.V2_1))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
         assertSame(ExchangeV2State.Host.AwaitingStatus, machine.currentState)
+        assertEquals(listOf(SideEffect.AwaitJoinStatus), result.sideEffects)
+    }
+
+    @Test fun `when HostStatusDeadlineElapsed in Host AwaitingStatus then advances to Host Unknown`() {
+        val machine = inHostAwaitingStatus()
+        val result = machine.localTrigger(LocalTrigger.HostStatusDeadlineElapsed(30.seconds))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Host.Unknown, machine.currentState)
+        assertTrue("expected no side effects, got ${result.sideEffects}", result.sideEffects.isEmpty())
+    }
+
+    @Test fun `when out-of-sequence local trigger in Host AwaitingStatus then aborts to terminal Host Aborted`() {
+        val machine = inHostAwaitingStatus()
+        val result = machine.localTrigger(LocalTrigger.UserConfirmedHost)
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertSame(ExchangeV2State.Host.Aborted, machine.currentState)
     }
 
     @Test fun `when recovery_code_done received in Host AwaitingStatus then transitions to Host Done`() {
@@ -289,6 +308,42 @@ class ExchangeV2StateMachineTest {
 
         assertSame(TransitionOutcome.Dropped, result.outcome)
         assertSame(ExchangeV2State.Host.AwaitingStatus, machine.currentState)
+    }
+
+    @Test fun `when late recovery_code_done received in Host Unknown then transitions to Host Done`() {
+        val machine = inHostUnknown()
+        val done = RecoveryCodeDone.create(RecoveryCodeDone.Reason.Success)
+        val result = machine.receive(done)
+        val transition = result.event as ExchangeV2Event.Transition
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Host.Done, machine.currentState)
+        assertSame(ExchangeV2State.Host.Unknown, transition.from)
+        assertSame(done, transition.trigger)
+    }
+
+    @Test fun `when unexpected message received in Host Unknown then aborts to terminal Host Aborted`() {
+        val machine = inHostUnknown()
+        val result = machine.receive(RecoveryCodeResponse.fromJson("{}"))
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertSame(ExchangeV2State.Host.Aborted, machine.currentState)
+    }
+
+    @Test fun `when unknown message received in Host Unknown then dropped`() {
+        val machine = inHostUnknown()
+        val result = machine.receive(Unknown.fromJson("{}", "future"))
+
+        assertSame(TransitionOutcome.Dropped, result.outcome)
+        assertSame(ExchangeV2State.Host.Unknown, machine.currentState)
+    }
+
+    @Test fun `when local trigger in Host Unknown then aborts to terminal Host Aborted`() {
+        val machine = inHostUnknown()
+        val result = machine.localTrigger(LocalTrigger.HostStatusDeadlineElapsed(30.seconds))
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertSame(ExchangeV2State.Host.Aborted, machine.currentState)
     }
 
     @Test fun `when JoinerJoinComplete success in Joiner Joining then advances to Joiner Done`() {
@@ -335,13 +390,14 @@ class ExchangeV2StateMachineTest {
         assertSame(ExchangeV2State.Joiner.AbortedLocal, machine.currentState)
     }
 
-    @Test fun `when HostSendComplete v2_0 in Host Sending then advances to Host Done`() {
+    @Test fun `when HostSendComplete v2_0 in Host Sending then advances to Host Done without a deadline`() {
         val machine = inHostConfirming()
         machine.localTrigger(LocalTrigger.UserConfirmedHost)
         val result = machine.localTrigger(LocalTrigger.HostSendComplete(ExchangeProtocolVersion.V2_0))
 
         assertSame(TransitionOutcome.Accepted, result.outcome)
         assertSame(ExchangeV2State.Host.Done, machine.currentState)
+        assertTrue("expected no side effects, got ${result.sideEffects}", result.sideEffects.isEmpty())
     }
 
     @Test fun `when wire message received in Host states then aborts to terminal Host Aborted`() {
@@ -668,6 +724,11 @@ class ExchangeV2StateMachineTest {
     private fun inHostAwaitingStatus(): ExchangeV2StateMachine =
         inHostSending().also {
             it.localTrigger(LocalTrigger.HostSendComplete(ExchangeProtocolVersion.V2_1))
+        }
+
+    private fun inHostUnknown(): ExchangeV2StateMachine =
+        inHostAwaitingStatus().also {
+            it.localTrigger(LocalTrigger.HostStatusDeadlineElapsed(30.seconds))
         }
 
     private fun inJoinerJoining(): ExchangeV2StateMachine =

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeConfir
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
+import com.duckduckgo.sync.impl.pixels.SyncPixels.TimeoutStage
 import com.duckduckgo.sync.store.SyncStore
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
@@ -745,6 +746,101 @@ class RealExchangeV2RunnerTest {
         assertFalse("a completed session must not later emit a timeout", timedOut)
     }
 
+    // ---- Late joiner deadline ----
+
+    @Test fun `Host moves to Host_Unknown when the join status deadline elapses without a report`() = coroutineTestRule.testScope.runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenHostCanProduceRecoveryCode()
+        val runner = newRunner()
+        runner.reachHostAwaitingStatus()
+        assertSame(ExchangeV2State.Host.AwaitingStatus, runner.currentState)
+
+        advanceTimeBy(31_000L)
+
+        assertSame(ExchangeV2State.Host.Unknown, runner.currentState)
+        verify(channel, never()).deleteChannel(any(), anyOrNull())
+    }
+
+    @Test fun `a late recovery_code_done still lands the Host on the real outcome after the deadline`() = coroutineTestRule.testScope.runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenHostCanProduceRecoveryCode()
+        val runner = newRunner()
+        runner.reachHostAwaitingStatus()
+        advanceTimeBy(31_000L)
+        assertSame(ExchangeV2State.Host.Unknown, runner.currentState)
+
+        runner.deliverIncomingMessage(RecoveryCodeDone.create(RecoveryCodeDone.Reason.Success))
+
+        val lastTransition = runner.events.replayCache.filterIsInstance<ExchangeV2Event.Transition>().last()
+        assertSame(ExchangeV2State.Host.Done, lastTransition.to)
+        assertNull(runner.currentState)
+    }
+
+    @Test fun `a report arriving before the deadline means Host_Unknown is never entered`() = coroutineTestRule.testScope.runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenHostCanProduceRecoveryCode()
+        val runner = newRunner()
+        runner.reachHostAwaitingStatus()
+
+        runner.deliverIncomingMessage(RecoveryCodeDone.create(RecoveryCodeDone.Reason.Success))
+        advanceTimeBy(31_000L)
+
+        val enteredUnknown = runner.events.replayCache
+            .filterIsInstance<ExchangeV2Event.Transition>()
+            .any { it.to == ExchangeV2State.Host.Unknown }
+        assertFalse("a reported outcome must not later degrade to Unknown", enteredUnknown)
+    }
+
+    @Test fun `the join status deadline is read from the sync feature settings`() = coroutineTestRule.testScope.runTest {
+        syncFeature.self().setRawStoredState(State(settings = """{"joinStatusDeadlineMs": 60000}"""))
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenHostCanProduceRecoveryCode()
+        val runner = newRunner()
+        runner.reachHostAwaitingStatus()
+
+        advanceTimeBy(31_000L)
+        assertSame(ExchangeV2State.Host.AwaitingStatus, runner.currentState)
+
+        advanceTimeBy(30_000L)
+        assertSame(ExchangeV2State.Host.Unknown, runner.currentState)
+    }
+
+    @Test
+    @TestParameters(
+        "{configuredMs: 1000, clampedMs: 5000}",
+        "{configuredMs: 1000000, clampedMs: 120000}",
+    )
+    fun `an out-of-bounds remote deadline is clamped`(configuredMs: Long, clampedMs: Long) = coroutineTestRule.testScope.runTest {
+        syncFeature.self().setRawStoredState(State(settings = """{"joinStatusDeadlineMs": $configuredMs}"""))
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenHostCanProduceRecoveryCode()
+        val runner = newRunner()
+        runner.reachHostAwaitingStatus()
+
+        advanceTimeBy(clampedMs - 100L)
+        assertSame(ExchangeV2State.Host.AwaitingStatus, runner.currentState)
+
+        advanceTimeBy(200L)
+        assertSame(ExchangeV2State.Host.Unknown, runner.currentState)
+    }
+
+    @Test fun `the session deadline tears down a Host left in Host_Unknown`() = coroutineTestRule.testScope.runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenHostCanProduceRecoveryCode()
+        val runner = newRunner()
+        runner.reachHostAwaitingStatus()
+        advanceTimeBy(31_000L)
+        assertSame(ExchangeV2State.Host.Unknown, runner.currentState)
+
+        advanceTimeBy(5 * 60 * 1000L)
+
+        assertNull(runner.currentState)
+        val timedOut = runner.events.replayCache
+            .filterIsInstance<ExchangeV2Event.SessionError>()
+            .single { it.kind == SessionErrorKind.SessionTimeout }
+        assertEquals(TimeoutStage.LOGGING_IN, timedOut.timeoutStage)
+    }
+
     // ---- Poll-loop error handling ----
 
     @Test fun `an unexpected poll error tears down the session with a SessionError`() = runTest {
@@ -932,6 +1028,13 @@ class RealExchangeV2RunnerTest {
 
     private suspend fun RealExchangeV2Runner.deliverHello(version: ExchangeProtocolVersion) {
         deliverIncomingMessage(Hello.create(channelId = "peer-channel", publicKey = "peer-pubkey", version = version))
+    }
+
+    private suspend fun RealExchangeV2Runner.reachHostAwaitingStatus() {
+        startPresent()
+        deliverHello(ExchangeProtocolVersion.V2_1)
+        deliverIncomingMessage(RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"))
+        localTrigger(LocalTrigger.UserConfirmedHost)
     }
 
     private fun String.toProtocolVersion() = ExchangeProtocolVersion.parse(this).getOrThrow()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -66,6 +66,9 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.Base64
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 @RunWith(TestParameterInjector::class)
 class RealExchangeV2RunnerTest {
@@ -713,7 +716,7 @@ class RealExchangeV2RunnerTest {
         runner.startPresent()
         assertSame(ExchangeV2State.Bootstrapped, runner.currentState)
 
-        advanceTimeBy(6 * 60 * 1000L) // past the 5-min session deadline
+        advanceTimeBy(6.minutes) // past the 5-min session deadline
 
         val sessionErrors = runner.events.replayCache.filterIsInstance<ExchangeV2Event.SessionError>()
         val timedOut = sessionErrors.singleOrNull { it.message.contains("timed out", ignoreCase = true) }
@@ -738,7 +741,7 @@ class RealExchangeV2RunnerTest {
         runner.localTrigger(LocalTrigger.JoinerJoinComplete(RecoveryCodeDone.Reason.Success))
         assertNull(runner.currentState)
 
-        advanceTimeBy(6 * 60 * 1000L)
+        advanceTimeBy(6.minutes)
 
         val timedOut = runner.events.replayCache
             .filterIsInstance<ExchangeV2Event.SessionError>()
@@ -755,7 +758,7 @@ class RealExchangeV2RunnerTest {
         runner.reachHostAwaitingStatus()
         assertSame(ExchangeV2State.Host.AwaitingStatus, runner.currentState)
 
-        advanceTimeBy(31_000L)
+        advanceTimeBy(31.seconds)
 
         assertSame(ExchangeV2State.Host.Unknown, runner.currentState)
         verify(channel, never()).deleteChannel(any(), anyOrNull())
@@ -766,7 +769,7 @@ class RealExchangeV2RunnerTest {
         givenHostCanProduceRecoveryCode()
         val runner = newRunner()
         runner.reachHostAwaitingStatus()
-        advanceTimeBy(31_000L)
+        advanceTimeBy(31.seconds)
         assertSame(ExchangeV2State.Host.Unknown, runner.currentState)
 
         runner.deliverIncomingMessage(RecoveryCodeDone.create(RecoveryCodeDone.Reason.Success))
@@ -783,7 +786,7 @@ class RealExchangeV2RunnerTest {
         runner.reachHostAwaitingStatus()
 
         runner.deliverIncomingMessage(RecoveryCodeDone.create(RecoveryCodeDone.Reason.Success))
-        advanceTimeBy(31_000L)
+        advanceTimeBy(31.seconds)
 
         val enteredUnknown = runner.events.replayCache
             .filterIsInstance<ExchangeV2Event.Transition>()
@@ -798,10 +801,10 @@ class RealExchangeV2RunnerTest {
         val runner = newRunner()
         runner.reachHostAwaitingStatus()
 
-        advanceTimeBy(31_000L)
+        advanceTimeBy(31.seconds)
         assertSame(ExchangeV2State.Host.AwaitingStatus, runner.currentState)
 
-        advanceTimeBy(30_000L)
+        advanceTimeBy(30.seconds)
         assertSame(ExchangeV2State.Host.Unknown, runner.currentState)
     }
 
@@ -817,10 +820,10 @@ class RealExchangeV2RunnerTest {
         val runner = newRunner()
         runner.reachHostAwaitingStatus()
 
-        advanceTimeBy(clampedMs - 100L)
+        advanceTimeBy(clampedMs.milliseconds - 100.milliseconds)
         assertSame(ExchangeV2State.Host.AwaitingStatus, runner.currentState)
 
-        advanceTimeBy(200L)
+        advanceTimeBy(200.milliseconds)
         assertSame(ExchangeV2State.Host.Unknown, runner.currentState)
     }
 
@@ -829,10 +832,10 @@ class RealExchangeV2RunnerTest {
         givenHostCanProduceRecoveryCode()
         val runner = newRunner()
         runner.reachHostAwaitingStatus()
-        advanceTimeBy(31_000L)
+        advanceTimeBy(31.seconds)
         assertSame(ExchangeV2State.Host.Unknown, runner.currentState)
 
-        advanceTimeBy(5 * 60 * 1000L)
+        advanceTimeBy(5.minutes)
 
         assertNull(runner.currentState)
         val timedOut = runner.events.replayCache

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
@@ -651,6 +651,7 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         ExchangeV2State.Host.Confirming -> "Host.Confirming"
         ExchangeV2State.Host.Sending -> "Host.Sending"
         ExchangeV2State.Host.AwaitingStatus -> "Host.AwaitingStatus"
+        ExchangeV2State.Host.Unknown -> "Host.Unknown"
         ExchangeV2State.Host.Aborted -> "Host.Aborted"
         ExchangeV2State.Host.Done -> "Host.Done"
         ExchangeV2State.Joiner.Confirming -> "Joiner.Confirming"
@@ -671,6 +672,7 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         is LocalTrigger.JoinerJoinComplete -> "JoinerJoinComplete(${trigger.reason.value})"
         LocalTrigger.HostUnavailable -> "HostUnavailable"
         is LocalTrigger.RoleElected -> "RoleElected(${trigger.role})"
+        is LocalTrigger.HostStatusDeadlineElapsed -> "HostStatusDeadlineElapsed(${trigger.deadline})"
     }
 
     private fun labelFor(reason: RejectReason): String = when (reason) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1217367677188805
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1217626160385689
API Proposals URL(s) (if applicable): N/A

### Description

In Exchange v2.1 the Host no longer assumes success after delivering the recovery code, it waits for the Joiner's `recovery_code_done` report. This PR adds the deadline for that wait: when the report does not arrive in time, the session moves to a new `Host.Unknown` state.

- After sending the recovery code to a v2.1 peer, the Host enters `Host.AwaitingStatus` and starts a deadline timer, 30 seconds by default.
- When the deadline elapses without a report, the session moves to the new `Host.Unknown` state.
- A `recovery_code_done` arriving late, while in `Host.Unknown`, still moves the session to `Host.Done`.
- The deadline is read from the sync feature settings as `joinStatusDeadlineMs`, so it can be tuned remotely. It is clamped to between 5 seconds and 2 minutes, so a bad configuration cannot make the Host give up instantly or wait for minutes.

### Steps to test this PR

_Host moves to Unknown when the Joiner never reports_
- [ ] Install an internal build on two devices.
- [ ] On both devices, open the internal sync settings.
- [ ] On both devices, tap "V2 Pairing Debug".
- [ ] On both devices, tap "Change" next to "Protocol version".
- [ ] On both devices, select the 2.1 protocol.
- [ ] On the device that should share its account, tap "Start as Presenter".
- [ ] Tap "Copy linking code".
- [ ] On the other device disable "Auto-approve confirmations".
- [ ] On the other device, paste the code into the URL field.
- [ ] Tap "Start as Scanner".
- [x] Verify the Host log shows a transition to `Host.AwaitingStatus`.
- [x] Wait 30 seconds.
- [x] Verify the Host log shows a transition from `Host.AwaitingStatus` to `Host.Unknown`.
- [x] Verify no error is shown and the session is not torn down.
- [x] Wait until 5 minutes have passed since the pairing started.
- [x] Verify the session times out with the usual timeout error.

_A v2.1 pairing that completes in time is unchanged_
- [ ] Enable "Auto-approve confirmations" on both devices.
- [ ] Repeat the pairing steps above with the 2.1 protocol on both devices.
- [ ] Verify the Joiner logs in.
- [x] Verify the Host log shows `recovery_code_done` received and a transition to `Host.Done` without entering `Host.Unknown`.

### UI changes
N/A  

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pairing session lifecycle and remotely tunable deadlines in sync exchange v2.1; incorrect timing or state handling could leave hosts waiting or mis-report outcomes, though v2.0 paths stay unchanged.
> 
> **Overview**
> For **Exchange v2.1**, the Host no longer treats “recovery code sent” as the end of the story: after a v2.1 peer gets the code it enters **`Host.AwaitingStatus`** and waits for the Joiner’s `recovery_code_done`. This PR adds what happens when that report never arrives in time.
> 
> When the join-status deadline fires (default **30s**, tunable via sync feature **`joinStatusDeadlineMs`**, clamped between 5s and 2 minutes), the session moves to a new non-terminal **`Host.Unknown`** state instead of failing or tearing down. Polling continues, and a late `recovery_code_done` still transitions to **`Host.Done`**. Entering **`AwaitingStatus`** now emits **`SideEffect.AwaitJoinStatus`**, which the runner handles with a dedicated timer job alongside the existing 5-minute session deadline.
> 
> The state machine, runner teardown, timeout staging (`LOGGING_IN` for **`Unknown`**), internal pairing debug labels, and unit tests are updated accordingly. Poll and session timers also switch from raw millisecond constants to **`kotlin.time.Duration`** in the touched exchange code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59ee864592d945e6874cfdf99bfc9784d3901eac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->