### PR TITLE
Enable sync unified device list feature flags

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -115,13 +115,13 @@ interface SyncFeature {
     /**
      * Gates writing `device_info`
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun canWriteUnifiedDeviceList(): Toggle
 
     /**
      * Gates reading from `device_info`
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun canReadUnifiedDeviceList(): Toggle
 
     /**

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -1170,6 +1170,7 @@ class AppSyncAccountRepositoryTest {
     fun whenPatchEndpointForLegacyRenameIsKillSwitchedThenReRegisterViaLogin() = runTest {
         givenAuthenticatedDevice()
         prepareForLoginSuccess()
+        syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = false))
         syncFeature.canUsePatchEndpointForLegacyDeviceRename().setRawStoredState(State(enable = false))
 
         val result = syncRepo.renameDevice(connectedDevice)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptorTest.kt
@@ -53,6 +53,7 @@ class ThirdPartyDeviceListDecryptorTest {
 
     @Before
     fun before() {
+        syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(enable = false))
         decryptor = RealThirdPartyDeviceListDecryptor(fieldDecryptor, thirdPartyCredentialManager, deviceInfoDecryptor, syncFeature, syncStore)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1217908938987892?focus=true 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Sets the default state for sync unified device list to be enabled.

### Steps to test this PR
- qa optional

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default sync device-list behavior for all installs unless remote toggles override; scoped to unified device_info read/write, not core auth flows.
> 
> **Overview**
> Turns on the **unified device list** remote toggles by default: `canWriteUnifiedDeviceList` and `canReadUnifiedDeviceList` now default to **true** instead of false, so clients will read and write encrypted `device_info` on the v2 device-list path when other gates (e.g. v2 connect) allow it.
> 
> Tests that assert **legacy** behavior now pin flags explicitly—legacy rename via `POST /sync/login` disables write unified list in `AppSyncAccountRepositoryTest`, and `ThirdPartyDeviceListDecryptorTest` starts with read unified list off in `@Before` so “flag off” cases stay valid after the default flip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef9eb734132429f42a16a94d90b0cc03ed4e6b74. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->