### PR TITLE
Fix onboarding pixel validation failures for variant and value params

### DIFF
--- a/PixelDefinitions/pixels/definitions/onboarding.json5
+++ b/PixelDefinitions/pixels/definitions/onboarding.json5
@@ -167,7 +167,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            "duckAiOnboardingBranchVariant",
+            "inputPreviewAction",
             {
                 "key": "value",
                 "type": "string",
@@ -253,7 +253,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            "duckAiOnboardingBranchVariant",
+            "inputPreviewAction",
             {
                 "key": "value",
                 "type": "string",
@@ -369,7 +369,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            "duckAiOnboardingBranchVariant",
+            "inputPreviewAction",
             {
                 "key": "value",
                 "type": "string",
@@ -425,7 +425,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            "duckAiOnboardingBranchVariant",
+            "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
@@ -451,7 +451,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            "duckAiOnboardingBranchVariant",
+            "inputPreviewAction",
             {
                 "key": "value",
                 "type": "string",
@@ -482,7 +482,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            "duckAiOnboardingBranchVariant",
+            "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
@@ -508,7 +508,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            "duckAiOnboardingBranchVariant",
+            "inputPreviewAction",
             {
                 "key": "value",
                 "type": "string",
@@ -539,7 +539,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            "duckAiOnboardingBranchVariant",
+            "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
@@ -565,7 +565,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            "duckAiOnboardingBranchVariant",
+            "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
@@ -591,7 +591,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            "duckAiOnboardingBranchVariant",
+            "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     }

--- a/PixelDefinitions/pixels/definitions/onboarding.json5
+++ b/PixelDefinitions/pixels/definitions/onboarding.json5
@@ -168,6 +168,12 @@
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
             {
+                "key": "variant",
+                "type": "string",
+                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step, which precedes this step in the custom Duck.ai flow.",
+                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
+            },
+            {
                 "key": "value",
                 "type": "string",
                 "description": "Set to engage when event=clicked. When event=confirmed, the resulting default browser. Absent for shown.",
@@ -196,7 +202,8 @@
                 "enum": ["0", "1-3", "4-10", "11-28", "28+"]
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] }
+            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage"] }
         ]
     },
     "onboarding_widget-prompt": {
@@ -251,6 +258,12 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            {
+                "key": "variant",
+                "type": "string",
+                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step, which precedes this step in the custom Duck.ai flow.",
+                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
+            },
             {
                 "key": "value",
                 "type": "string",
@@ -369,7 +382,7 @@
             {
                 "key": "variant",
                 "type": "string",
-                "description": "Duck.ai search/chat branch. Set only in the custom Duck.ai flow.",
+                "description": "Duck.ai search/chat branch. This step is the branching step, so its clicked event carries the branch just selected.",
                 "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
             },
             {
@@ -406,7 +419,7 @@
         ]
     },
     "onboarding_fire-button": {
-        "description": "Fire-button demo step. shown when the in-browser fire-button demo is presented; clicked engage when the demo completes. Displayed both in the Duck.ai flow, on the chat tab, and in the regular flow in the browser tab.",
+        "description": "Fire-button step. In the custom Duck.ai flow: shown when the in-browser fire-button demo is presented, clicked engage when the demo completes. In contextual onboarding: shown when the fire-button DAX dialog is displayed, clicked engage when the user taps the fire button (via Got it or the toolbar fire icon), dismiss when the user closes. Unique once per user per (event, value).",
         "owners": ["catalinradoiu"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
@@ -430,10 +443,10 @@
             {
                 "key": "variant",
                 "type": "string",
-                "description": "Duck.ai search/chat branch. Set only in the custom Duck.ai flow.",
+                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step.",
                 "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
             },
-            { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage"] }
+            { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
     "onboarding_search": {
@@ -458,6 +471,12 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            {
+                "key": "variant",
+                "type": "string",
+                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step.",
+                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
+            },
             {
                 "key": "value",
                 "type": "string",
@@ -488,6 +507,12 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            {
+                "key": "variant",
+                "type": "string",
+                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step.",
+                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
+            },
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
@@ -513,6 +538,12 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            {
+                "key": "variant",
+                "type": "string",
+                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step.",
+                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
+            },
             {
                 "key": "value",
                 "type": "string",
@@ -543,31 +574,12 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
-        ]
-    },
-    "onboarding_fire-button": {
-        "description": "Contextual onboarding fire-button step. shown when the fire-button DAX dialog is displayed; clicked engage when the user taps the fire button (via Got it or the toolbar fire icon), dismiss when the user closes. Unique once per user per (event, value).",
-        "owners": ["catalinradoiu"],
-        "triggers": ["other"],
-        "suffixes": ["form_factor"],
-        "parameters": [
-            "appVersion",
             {
-                "key": "event",
+                "key": "variant",
                 "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
+                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step.",
+                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
             },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
@@ -593,6 +605,12 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            {
+                "key": "variant",
+                "type": "string",
+                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step.",
+                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
+            },
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
@@ -618,6 +636,12 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            {
+                "key": "variant",
+                "type": "string",
+                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step.",
+                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
+            },
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     }

--- a/PixelDefinitions/pixels/definitions/onboarding.json5
+++ b/PixelDefinitions/pixels/definitions/onboarding.json5
@@ -167,12 +167,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            {
-                "key": "variant",
-                "type": "string",
-                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step, which precedes this step in the custom Duck.ai flow.",
-                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
-            },
+            "duckAiOnboardingBranchVariant",
             {
                 "key": "value",
                 "type": "string",
@@ -258,12 +253,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            {
-                "key": "variant",
-                "type": "string",
-                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step, which precedes this step in the custom Duck.ai flow.",
-                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
-            },
+            "duckAiOnboardingBranchVariant",
             {
                 "key": "value",
                 "type": "string",
@@ -379,12 +369,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            {
-                "key": "variant",
-                "type": "string",
-                "description": "Duck.ai search/chat branch. This step is the branching step, so its clicked event carries the branch just selected.",
-                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
-            },
+            "duckAiOnboardingBranchVariant",
             {
                 "key": "value",
                 "type": "string",
@@ -440,12 +425,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            {
-                "key": "variant",
-                "type": "string",
-                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step.",
-                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
-            },
+            "duckAiOnboardingBranchVariant",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
@@ -471,12 +451,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            {
-                "key": "variant",
-                "type": "string",
-                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step.",
-                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
-            },
+            "duckAiOnboardingBranchVariant",
             {
                 "key": "value",
                 "type": "string",
@@ -507,12 +482,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            {
-                "key": "variant",
-                "type": "string",
-                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step.",
-                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
-            },
+            "duckAiOnboardingBranchVariant",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
@@ -538,12 +508,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            {
-                "key": "variant",
-                "type": "string",
-                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step.",
-                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
-            },
+            "duckAiOnboardingBranchVariant",
             {
                 "key": "value",
                 "type": "string",
@@ -574,12 +539,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            {
-                "key": "variant",
-                "type": "string",
-                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step.",
-                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
-            },
+            "duckAiOnboardingBranchVariant",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
@@ -605,12 +565,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            {
-                "key": "variant",
-                "type": "string",
-                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step.",
-                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
-            },
+            "duckAiOnboardingBranchVariant",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
@@ -636,12 +591,7 @@
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
             { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            {
-                "key": "variant",
-                "type": "string",
-                "description": "Duck.ai search/chat branch. Set only after the user passes the search/chat branching step.",
-                "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
-            },
+            "duckAiOnboardingBranchVariant",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     }

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -15,10 +15,10 @@
         "description": "The Unified Input surface the pixel was fired from, distinguishing the contextual chat sheet from the Duck.ai tab and the address bar",
         "enum": ["address_bar", "duck_ai", "contextual_chat"]
     },
-    "duckAiOnboardingBranchVariant": {
+    "inputPreviewAction": {
         "key": "variant",
         "type": "string",
-        "description": "Onboarding Duck.ai search/chat branch. Set on every onboarding pixel fired after the user passes the search/chat branching step (the input-screen preview); absent for pixels fired before that step or for users who never see it.",
+        "description": "Onboarding Duck.ai search/chat branch, chosen at the input-screen preview step. Set on every onboarding pixel fired after the user passes that step; absent for pixels fired before it or for users who never see it.",
         "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
     },
     "contextualSuggestionsPageType": {

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -15,6 +15,12 @@
         "description": "The Unified Input surface the pixel was fired from, distinguishing the contextual chat sheet from the Duck.ai tab and the address bar",
         "enum": ["address_bar", "duck_ai", "contextual_chat"]
     },
+    "duckAiOnboardingBranchVariant": {
+        "key": "variant",
+        "type": "string",
+        "description": "Onboarding Duck.ai search/chat branch. Set on every onboarding pixel fired after the user passes the search/chat branching step (the input-screen preview); absent for pixels fired before that step or for users who never see it.",
+        "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
+    },
     "contextualSuggestionsPageType": {
         "key": "pageType",
         "type": "string",

--- a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
@@ -124,6 +124,10 @@ class NewUserOnboardingPlanProvider @Inject constructor(
         // Side-effecting (creates the DDG downloads dir, persists reinstall state) and must always run
         ctx.isReinstall = appBuildConfig.isAppReinstall()
 
+        // A restarted run replays from before the branching step, so a branch persisted by a previous
+        // run must not label this run's pre-branch pixels as branched.
+        onboardingPixelSender.clearBranchSelection()
+
         return if (customAiOnboardingResolver.resolve()) {
             // in custom AI onboarding path, the input toggle is enabled by default
             duckChat.setCosmeticInputScreenUserSetting(enabled = true)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingPixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingPixelSender.kt
@@ -90,6 +90,13 @@ interface OnboardingPixelSender {
      * attached as the `variant` param to every subsequent onboarding pixel.
      * */
     fun chatBranchSelected()
+
+    /**
+     * Clears any persisted branch selection. Called when a new linear onboarding run starts: a run
+     * restarted after an app kill replays from before the branching step, so a branch persisted by a
+     * previous run must not label this run's pre-branch pixels as branched.
+     */
+    fun clearBranchSelection()
 }
 
 @ContributesBinding(AppScope::class)
@@ -119,6 +126,10 @@ class RealOnboardingPixelSender @Inject constructor(
 
     override fun chatBranchSelected() {
         variantPrefs.edit().putString(PREFS_KEY_VARIANT, PREFS_VARIANT_CHAT).apply()
+    }
+
+    override fun clearBranchSelection() {
+        variantPrefs.edit().remove(PREFS_KEY_VARIANT).apply()
     }
 
     override fun fire(pixelName: OnboardingPixelName, action: OnboardingPixelAction) {

--- a/app/src/test/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProviderTest.kt
@@ -1026,6 +1026,13 @@ class NewUserOnboardingPlanProviderTest {
     }
 
     @Test
+    fun `when a new onboarding run starts then any persisted branch selection is cleared`() = runTest {
+        start()
+
+        verify(onboardingPixelSender).clearBranchSelection()
+    }
+
+    @Test
     fun `when onboarding path then custom ai plan walks to completed`() = runTest {
         whenever(customAiOnboardingResolver.resolve()).thenReturn(true)
         start()

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/RealOnboardingPixelSenderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/RealOnboardingPixelSenderTest.kt
@@ -533,6 +533,41 @@ class RealOnboardingPixelSenderTest {
     }
 
     @Test
+    fun whenBranchSelectionClearedThenVariantParamNotSent() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
+        whenever(mockCustomAiOnboardingStore.isEnabled()).thenReturn(true)
+        val prefs = InMemorySharedPreferences()
+        val variantTestee = RealOnboardingPixelSender(
+            appCoroutineScope = coroutineRule.testScope,
+            pixel = mockPixel,
+            dispatchers = coroutineRule.testDispatcherProvider,
+            appInstallStore = mockAppInstallStore,
+            customAiOnboardingStore = mockCustomAiOnboardingStore,
+            sharedPreferencesProvider = mock { on { getSharedPreferences(any(), any(), any()) } doReturn prefs },
+            defaultBrowserDetector = mockDefaultBrowserDetector,
+            widgetCapabilities = mockWidgetCapabilities,
+            deviceInfo = mockDeviceInfo,
+            appBuildConfig = mockAppBuildConfig,
+        )
+        variantTestee.chatBranchSelected()
+
+        variantTestee.clearBranchSelection()
+        variantTestee.fire(ONBOARDING_AI_INTRO, OnboardingPixelAction.Shown)
+
+        verify(mockPixel).fire(
+            ONBOARDING_AI_INTRO,
+            mapOf(
+                "installType" to "new",
+                "flow" to "duckai",
+                "pixelSource" to "phone",
+                "daysSinceInstall" to "0",
+                "event" to "shown",
+            ),
+            type = Unique(tag = "onboarding_ai-intro_shown"),
+        )
+    }
+
+    @Test
     fun whenFireSyncRestoreShownThenStandardShownParams() = runTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1217987198101581
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

### Description

Fixes the live pixel-validation failures reported for the onboarding instrumentation pixels (10 pixels rejected with "must NOT have additional properties"). Three distinct causes, three fixes:

1. **Duplicate `onboarding_fire-button` definition**: `onboarding.json5` defined the pixel twice; the second (contextual) entry silently shadowed the first (Duck.ai demo) entry, dropping its `variant` param. Merged into a single definition covering both firing contexts, with `variant` and `value: engage|dismiss`.
2. **Missing `variant` in definitions for legitimately-branched pixels**: in the custom Duck.ai flow the branching step (search/chat input preview) precedes the set-default and address-bar-position steps, and all contextual DAX CTA pixels fire after linear onboarding — so these pixels correctly carry `variant` per the Onboarding Instrumentation Standard, but their definitions didn't allow it. Added `variant` to `onboarding_set-default`, `onboarding_address-bar-position`, `onboarding_end`, `onboarding_search-results`, `onboarding_subscription-promo`, `onboarding_trackers-blocked`, `onboarding_visit-site`, and (proactively, same contextual family) `onboarding_search`. Also added the missing `value` param (`engage`) to `onboarding_add-to-dock`.
3. **Stale `variant` on pre-branch pixels** (`onboarding_ai-intro`): the persisted branch selection was never cleared, so an onboarding run restarted after an app kill could label pre-branch pixels with a variant persisted by a previous run. `NewUserOnboardingPlanProvider.buildRootPlan` now clears the branch selection at the start of every run via the new `OnboardingPixelSender.clearBranchSelection()`. `onboarding_ai-intro`'s definition intentionally stays variant-free.

### Steps to test this PR
QA-optional

### UI changes
| Before  | After |
| ------ | ----- |
|No UI changes|No UI changes|

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to analytics pixel definitions and clearing onboarding branch prefs at plan start; no user-facing behavior or security-sensitive paths.
> 
> **Overview**
> Fixes onboarding pixel validation rejections by aligning **PixelDefinitions** with what the app actually sends, and by stopping restarted runs from attaching a **stale `variant`** to pre-branch steps.
> 
> **Schema updates:** Introduces shared param `inputPreviewAction` in `params_dictionary.json` (maps to `variant` for Duck.ai search vs chat branch) and references it on the post-branch onboarding pixels instead of ad-hoc inline `variant` blocks. Merges the duplicate `onboarding_fire-button` entry into one definition covering both the Duck.ai demo and contextual DAX flows, with `value: engage|dismiss`. Adds missing `value: engage` on `onboarding_add-to-dock`.
> 
> **Runtime fix:** `buildRootPlan` now calls `OnboardingPixelSender.clearBranchSelection()` so a killed-and-restarted onboarding replay does not persist a branch from a prior attempt onto pixels fired before the input-preview branch (e.g. `onboarding_ai-intro`, which stays variant-free in the schema).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2a56a8c1515bd0a4c267747f4dc9620a49dd117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->