### PR TITLE
Add feature flags to allow for dialog dismissing

### DIFF
--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInActivity.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInActivity.kt
@@ -102,6 +102,11 @@ class CookiePopupOptInActivity : DuckDuckGoActivity() {
         }
     }
 
+    override fun onDestroy() {
+        backNavigationCallback = null
+        super.onDestroy()
+    }
+
     override fun finish() {
         super.finish()
         if (SDK_INT < 34) {

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInActivity.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInActivity.kt
@@ -61,6 +61,7 @@ class CookiePopupOptInActivity : DuckDuckGoActivity() {
     private val viewModel: CookiePopupOptInViewModel by bindViewModel()
 
     private var lockedInPortraitMode: Boolean = false
+    private var backNavigationCallback: OnBackPressedCallback? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -115,35 +116,36 @@ class CookiePopupOptInActivity : DuckDuckGoActivity() {
     }
 
     /**
-     * The prompt is a required choice unless explicitly made dismissible through remote config.
+     * Blocks system Back unless Back dismissal is enabled through remote config.
      */
     private fun setupOnBackNavigation() {
-        if (viewModel.viewState.value.isBackNavigationEnabled) return
-
-        onBackPressedDispatcher.addCallback(
-            object : OnBackPressedCallback(true) {
-                override fun handleOnBackPressed() = Unit
-            },
-        )
+        val callback = object : OnBackPressedCallback(!viewModel.viewState.value.isBackDismissEnabled) {
+            override fun handleOnBackPressed() = Unit
+        }
+        backNavigationCallback = callback
+        onBackPressedDispatcher.addCallback(this, callback)
     }
 
     private fun setupListeners() {
         binding.cookiePopupOptInCloseButton.setOnClickListener {
+            disableActions()
             viewModel.onCloseClicked()
         }
         binding.cookiePopupOptInAcceptButton.setOnClickListener {
-            disableButtons()
+            disableActions()
             viewModel.onAcceptClicked()
         }
         binding.cookiePopupOptInDeclineButton.setOnClickListener {
-            disableButtons()
+            disableActions()
             viewModel.onDeclineClicked()
         }
     }
 
-    private fun disableButtons() {
+    private fun disableActions() {
         binding.cookiePopupOptInAcceptButton.isEnabled = false
         binding.cookiePopupOptInDeclineButton.isEnabled = false
+        binding.cookiePopupOptInCloseButton.isEnabled = false
+        backNavigationCallback?.isEnabled = true
     }
 
     private fun setupObservers() {

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInActivity.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInActivity.kt
@@ -27,6 +27,7 @@ import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.StringRes
 import androidx.core.graphics.drawable.toDrawable
+import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -114,9 +115,11 @@ class CookiePopupOptInActivity : DuckDuckGoActivity() {
     }
 
     /**
-     * The prompt is a required choice, so back must not dismiss it.
+     * The prompt is a required choice unless explicitly made dismissible through remote config.
      */
     private fun setupOnBackNavigation() {
+        if (viewModel.viewState.value.isBackNavigationEnabled) return
+
         onBackPressedDispatcher.addCallback(
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() = Unit
@@ -125,6 +128,9 @@ class CookiePopupOptInActivity : DuckDuckGoActivity() {
     }
 
     private fun setupListeners() {
+        binding.cookiePopupOptInCloseButton.setOnClickListener {
+            viewModel.onCloseClicked()
+        }
         binding.cookiePopupOptInAcceptButton.setOnClickListener {
             disableButtons()
             viewModel.onAcceptClicked()
@@ -154,6 +160,7 @@ class CookiePopupOptInActivity : DuckDuckGoActivity() {
 
     private fun render(viewState: ViewState) {
         val text = viewState.variant.textResources()
+        binding.cookiePopupOptInCloseButton.isVisible = viewState.isCloseButtonVisible
         binding.cookiePopupOptInTitle.setText(text.title)
         binding.cookiePopupOptInDescription.setText(text.description)
         binding.cookiePopupOptInAcceptButton.text = getString(text.acceptButton)

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInViewModel.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInViewModel.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autoconsent.api.Autoconsent
 import com.duckduckgo.autoconsent.impl.pixels.AutoConsentPixel
 import com.duckduckgo.autoconsent.impl.pixels.AutoconsentPixelParameters
+import com.duckduckgo.autoconsent.impl.remoteconfig.AutoconsentFeature
 import com.duckduckgo.autoconsent.impl.store.AutoconsentSettingsRepository
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -45,6 +46,7 @@ class CookiePopupOptInViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val currentTimeProvider: CurrentTimeProvider,
     private val pixel: Pixel,
+    autoconsentFeature: AutoconsentFeature,
 ) : ViewModel() {
 
     /**
@@ -53,7 +55,11 @@ class CookiePopupOptInViewModel @Inject constructor(
      */
     enum class Variant { PROTECTION_ON, PROTECTION_OFF }
 
-    data class ViewState(val variant: Variant)
+    data class ViewState(
+        val variant: Variant,
+        val isBackNavigationEnabled: Boolean,
+        val isCloseButtonVisible: Boolean,
+    )
 
     sealed class Command {
         data object Close : Command()
@@ -64,6 +70,8 @@ class CookiePopupOptInViewModel @Inject constructor(
     private val viewStateFlow = MutableStateFlow(
         ViewState(
             variant = if (autoconsent.isSettingEnabled()) Variant.PROTECTION_ON else Variant.PROTECTION_OFF,
+            isBackNavigationEnabled = autoconsentFeature.cookiePopUpOptInPromptDismissible().isEnabled(),
+            isCloseButtonVisible = autoconsentFeature.cookiePopUpOptInPromptCloseButton().isEnabled(),
         ),
     )
     val viewState: StateFlow<ViewState> = viewStateFlow
@@ -110,6 +118,12 @@ class CookiePopupOptInViewModel @Inject constructor(
                 settingsRepository.optInPromptChoiceMade = true
                 fireOptionConfirmedPixel(if (protectionWasOn()) "default" else "off")
             }
+            command.send(Command.Close)
+        }
+    }
+
+    fun onCloseClicked() {
+        viewModelScope.launch {
             command.send(Command.Close)
         }
     }

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInViewModel.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInViewModel.kt
@@ -57,7 +57,7 @@ class CookiePopupOptInViewModel @Inject constructor(
 
     data class ViewState(
         val variant: Variant,
-        val isBackNavigationEnabled: Boolean,
+        val isBackDismissEnabled: Boolean,
         val isCloseButtonVisible: Boolean,
     )
 
@@ -70,7 +70,7 @@ class CookiePopupOptInViewModel @Inject constructor(
     private val viewStateFlow = MutableStateFlow(
         ViewState(
             variant = if (autoconsent.isSettingEnabled()) Variant.PROTECTION_ON else Variant.PROTECTION_OFF,
-            isBackNavigationEnabled = autoconsentFeature.cookiePopUpOptInPromptDismissible().isEnabled(),
+            isBackDismissEnabled = autoconsentFeature.cookiePopUpOptInPromptDismissible().isEnabled(),
             isCloseButtonVisible = autoconsentFeature.cookiePopUpOptInPromptCloseButton().isEnabled(),
         ),
     )

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/remoteconfig/AutoconsentFeature.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/remoteconfig/AutoconsentFeature.kt
@@ -71,4 +71,16 @@ interface AutoconsentFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun cookiePopUpOptInPrompt(): Toggle
+
+    /**
+     * Allows the Cookie Pop-up Protection opt-in prompt to be dismissed with the back button.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun cookiePopUpOptInPromptDismissible(): Toggle
+
+    /**
+     * Shows a close button on the Cookie Pop-up Protection opt-in prompt.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun cookiePopUpOptInPromptCloseButton(): Toggle
 }

--- a/autoconsent/autoconsent-impl/src/main/res/drawable/background_cookie_popup_close_button.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/drawable/background_cookie_popup_close_button.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="?attr/onboardingSurfaceTertiary" />
+    <stroke
+        android:width="1.5dp"
+        android:color="?attr/onboardingAccentAltPrimary" />
+</shape>

--- a/autoconsent/autoconsent-impl/src/main/res/layout/activity_cookie_popup_opt_in.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/layout/activity_cookie_popup_opt_in.xml
@@ -161,25 +161,36 @@
 
             </com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleBrandDesignUpdateCardView>
 
-            <ImageView
+            <FrameLayout
                 android:id="@+id/cookiePopupOptInCloseButton"
-                android:layout_width="32dp"
-                android:layout_height="32dp"
-                android:layout_marginTop="-4dp"
-                android:layout_marginEnd="-4dp"
-                android:background="@drawable/background_cookie_popup_close_button"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_marginTop="-12dp"
+                android:layout_marginEnd="-12dp"
+                android:clickable="true"
                 android:contentDescription="@string/closeButtonContentDescription"
                 android:foreground="?attr/selectableItemBackgroundBorderless"
-                android:outlineProvider="none"
-                android:padding="8dp"
+                android:focusable="true"
                 android:theme="@style/ThemeOverlay.DuckDuckGo.Onboarding"
                 android:translationZ="8dp"
                 android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="@id/cookiePopupOptInBubble"
                 app:layout_constraintTop_toTopOf="@id/cookiePopupOptInBubble"
-                app:srcCompat="@drawable/ic_close_16"
-                app:tint="?attr/onboardingIconsPrimary"
-                tools:visibility="visible" />
+                tools:visibility="visible">
+
+                <ImageView
+                    android:id="@+id/cookiePopupOptInCloseIcon"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_gravity="center"
+                    android:background="@drawable/background_cookie_popup_close_button"
+                    android:importantForAccessibility="no"
+                    android:outlineProvider="none"
+                    android:padding="8dp"
+                    app:srcCompat="@drawable/ic_close_16"
+                    app:tint="?attr/onboardingIconsPrimary" />
+
+            </FrameLayout>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/autoconsent/autoconsent-impl/src/main/res/layout/activity_cookie_popup_opt_in.xml
+++ b/autoconsent/autoconsent-impl/src/main/res/layout/activity_cookie_popup_opt_in.xml
@@ -161,6 +161,26 @@
 
             </com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleBrandDesignUpdateCardView>
 
+            <ImageView
+                android:id="@+id/cookiePopupOptInCloseButton"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:layout_marginTop="-4dp"
+                android:layout_marginEnd="-4dp"
+                android:background="@drawable/background_cookie_popup_close_button"
+                android:contentDescription="@string/closeButtonContentDescription"
+                android:foreground="?attr/selectableItemBackgroundBorderless"
+                android:outlineProvider="none"
+                android:padding="8dp"
+                android:theme="@style/ThemeOverlay.DuckDuckGo.Onboarding"
+                android:translationZ="8dp"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="@id/cookiePopupOptInBubble"
+                app:layout_constraintTop_toTopOf="@id/cookiePopupOptInBubble"
+                app:srcCompat="@drawable/ic_close_16"
+                app:tint="?attr/onboardingIconsPrimary"
+                tools:visibility="visible" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </ScrollView>

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInLayoutTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInLayoutTest.kt
@@ -20,10 +20,12 @@ import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.autoconsent.impl.databinding.ActivityCookiePopupOptInBinding
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
+import kotlin.math.roundToInt
 import com.duckduckgo.mobile.android.R as CommonR
 
 /**
@@ -52,4 +54,17 @@ class CookiePopupOptInLayoutTest {
         assertNotNull(binding.cookiePopupOptInAcceptButton.background)
         assertNotNull(binding.cookiePopupOptInDeclineButton.background)
     }
+
+    @Test
+    fun whenInflatedThenCloseButtonHasLargerTouchTargetThanItsVisual() {
+        val binding = ActivityCookiePopupOptInBinding.inflate(LayoutInflater.from(context))
+
+        assertEquals(48.dp, binding.cookiePopupOptInCloseButton.layoutParams.width)
+        assertEquals(48.dp, binding.cookiePopupOptInCloseButton.layoutParams.height)
+        assertEquals(32.dp, binding.cookiePopupOptInCloseIcon.layoutParams.width)
+        assertEquals(32.dp, binding.cookiePopupOptInCloseIcon.layoutParams.height)
+    }
+
+    private val Int.dp: Int
+        get() = (this * context.resources.displayMetrics.density).roundToInt()
 }

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInViewModelTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInViewModelTest.kt
@@ -24,8 +24,11 @@ import com.duckduckgo.autoconsent.impl.pixels.AutoConsentPixel
 import com.duckduckgo.autoconsent.impl.pixels.AutoconsentPixelParameters
 import com.duckduckgo.autoconsent.impl.prompt.CookiePopupOptInViewModel.Command
 import com.duckduckgo.autoconsent.impl.prompt.CookiePopupOptInViewModel.Variant
+import com.duckduckgo.autoconsent.impl.remoteconfig.AutoconsentFeature
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -47,6 +50,7 @@ class CookiePopupOptInViewModelTest {
     val coroutineRule = CoroutineTestRule()
 
     private val autoconsent: Autoconsent = mock()
+    private val feature = FakeFeatureToggleFactory.create(AutoconsentFeature::class.java)
     private val settingsRepository = FakeSettingsRepository()
     private val now = System.currentTimeMillis()
     private val currentTimeProvider: CurrentTimeProvider = mock {
@@ -56,11 +60,12 @@ class CookiePopupOptInViewModelTest {
 
     private val testee by lazy {
         CookiePopupOptInViewModel(
-            autoconsent,
-            settingsRepository,
-            coroutineRule.testDispatcherProvider,
-            currentTimeProvider,
-            pixel,
+            autoconsent = autoconsent,
+            settingsRepository = settingsRepository,
+            dispatchers = coroutineRule.testDispatcherProvider,
+            currentTimeProvider = currentTimeProvider,
+            pixel = pixel,
+            autoconsentFeature = feature,
         )
     }
 
@@ -76,6 +81,44 @@ class CookiePopupOptInViewModelTest {
         whenever(autoconsent.isSettingEnabled()).thenReturn(false)
 
         assertEquals(Variant.PROTECTION_OFF, testee.viewState.value.variant)
+    }
+
+    @Test
+    fun whenCloseButtonFlagEnabledThenCloseButtonIsVisible() {
+        feature.cookiePopUpOptInPromptCloseButton().setRawStoredState(Toggle.State(enable = true))
+
+        assertTrue(testee.viewState.value.isCloseButtonVisible)
+    }
+
+    @Test
+    fun whenCloseButtonFlagDisabledThenCloseButtonIsHidden() {
+        feature.cookiePopUpOptInPromptCloseButton().setRawStoredState(Toggle.State(enable = false))
+
+        assertFalse(testee.viewState.value.isCloseButtonVisible)
+    }
+
+    @Test
+    fun whenBackNavigationFlagEnabledThenBackNavigationIsEnabled() {
+        feature.cookiePopUpOptInPromptDismissible().setRawStoredState(Toggle.State(enable = true))
+
+        assertTrue(testee.viewState.value.isBackNavigationEnabled)
+    }
+
+    @Test
+    fun whenBackNavigationFlagDisabledThenBackNavigationIsDisabled() {
+        feature.cookiePopUpOptInPromptDismissible().setRawStoredState(Toggle.State(enable = false))
+
+        assertFalse(testee.viewState.value.isBackNavigationEnabled)
+    }
+
+    @Test
+    fun whenCloseButtonClickedThenCloseCommandEmitted() = runTest {
+        testee.commands().test {
+            testee.onCloseClicked()
+
+            assertEquals(Command.Close, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInViewModelTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInViewModelTest.kt
@@ -98,17 +98,17 @@ class CookiePopupOptInViewModelTest {
     }
 
     @Test
-    fun whenBackNavigationFlagEnabledThenBackNavigationIsEnabled() {
+    fun whenBackDismissFlagEnabledThenBackDismissIsEnabled() {
         feature.cookiePopUpOptInPromptDismissible().setRawStoredState(Toggle.State(enable = true))
 
-        assertTrue(testee.viewState.value.isBackNavigationEnabled)
+        assertTrue(testee.viewState.value.isBackDismissEnabled)
     }
 
     @Test
-    fun whenBackNavigationFlagDisabledThenBackNavigationIsDisabled() {
+    fun whenBackDismissFlagDisabledThenBackDismissIsDisabled() {
         feature.cookiePopUpOptInPromptDismissible().setRawStoredState(Toggle.State(enable = false))
 
-        assertFalse(testee.viewState.value.isBackNavigationEnabled)
+        assertFalse(testee.viewState.value.isBackDismissEnabled)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1217975335313560?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

### Steps to test this PR

_Pre-requisites_
- [x] Apply patch 1

_Flags off, can't dismiss dialog_
- [x] With `cookiePopUpOptInPromptDismissible` and `cookiePopUpOptInPromptCloseButton` off (default state), check popup doesn't have a close button and can't be dismissed using the back button

_Dismiss flag on, can dismiss dialog_
- [x] From previous scenario, kill and reopen the app. 
- [x] Open settings and enable `cookiePopUpOptInPromptDismissible`
- [x] Scroll all the way down to the bottom of settings and reset modal coordinator cooldown
- [x] Kill and reopen the app
- [x] Check the popup doesn't have a close button but can be dismissed using the back button

_Close flag on, can close dialog_
- [x] From previous scenario, kill and reopen the app. 
- [x] Open settings and enable `cookiePopUpOptInPromptCloseButton`
- [x] Scroll all the way down to the bottom of settings and reset modal coordinator cooldown
- [x] Kill and reopen the app
- [x] Check the popup has a close button and can be dismissed using it 

### Patch 1 
```
Subject: [PATCH] Make CPM testing easier by removing constraints
---
Index: autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInEvaluator.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInEvaluator.kt b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInEvaluator.kt
--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInEvaluator.kt	(revision 57d0ac8267ffd0bc4234943e8f193bc7efaefeca)
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInEvaluator.kt	(date 1788186681780)
@@ -56,7 +56,7 @@
     private val appInstallTimeProvider: AppInstallTimeProvider,
 ) : ModalEvaluator {
 
-    override val priority: Int = 6
+    override val priority: Int = 1
 
     override val evaluatorId: String = "cookie_popup_opt_in"
 
@@ -72,7 +72,7 @@
             return@withContext ModalEvaluator.EvaluationResult.Skipped
         }
 
-        if (daysSinceInstall() < MIN_DAYS_SINCE_INSTALL) {
+        if (installAgeMillis() < MIN_INSTALL_AGE) {
             return@withContext ModalEvaluator.EvaluationResult.Skipped
         }
 
@@ -85,10 +85,6 @@
             return@withContext ModalEvaluator.EvaluationResult.Skipped
         }
 
-        if (settingsRepository.optInPromptShownCount >= MAX_PROMPT_DISPLAYS) {
-            return@withContext ModalEvaluator.EvaluationResult.Skipped
-        }
-
         delay(MODAL_DISPLAY_DELAY)
         appCoroutineScope.launch(dispatchers.main()) {
             val intent = CookiePopupOptInActivity.intent(applicationContext).apply {
@@ -101,14 +97,10 @@
         return@withContext ModalEvaluator.EvaluationResult.ModalShown
     }
 
-    private fun daysSinceInstall(): Long {
-        val elapsed = currentTimeProvider.currentTimeMillis() - appInstallTimeProvider.firstInstallTimeMillis()
-        return TimeUnit.MILLISECONDS.toDays(elapsed)
-    }
+    private fun installAgeMillis(): Long = currentTimeProvider.currentTimeMillis() - appInstallTimeProvider.firstInstallTimeMillis()
 
     companion object {
         private const val MODAL_DISPLAY_DELAY = 250L
-        private const val MIN_DAYS_SINCE_INSTALL = 2
-        private const val MAX_PROMPT_DISPLAYS = 3
+        private val MIN_INSTALL_AGE = TimeUnit.MINUTES.toMillis(2)
     }
 }
```


### UI changes
| Before  | After |
| ------ | ----- |
|<img width="1080" height="2340" alt="Screenshot_20260831_162208" src="https://github.com/user-attachments/assets/b4b1001b-7196-48d9-9855-fd77f9ac8891" />|<img width="1080" height="2340" alt="Screenshot_20260831_161416" src="https://github.com/user-attachments/assets/2239fca1-9b63-4f2d-8591-2fc14330e78c" />|

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are gated behind feature flags with safe defaults; dismiss paths avoid altering stored opt-in preference or analytics tied to explicit choices.
> 
> **Overview**
> The Cookie Pop-up Protection opt-in prompt used to block system Back and offered no close control. This PR adds **two remote-config toggles** on `AutoconsentFeature`: `cookiePopUpOptInPromptDismissible` (Back can dismiss) and `cookiePopUpOptInPromptCloseButton` (shows a close affordance). Both default to off, preserving the required-choice behavior.
> 
> `CookiePopupOptInViewModel` exposes those flags in `ViewState` and adds `onCloseClicked()`, which dismisses the screen **without** recording an opt-in choice or firing the confirm pixel (unlike Accept/Decline). The activity wires a new close button in the layout, toggles its visibility from state, and only registers a blocking `OnBackPressedCallback` when Back dismissal is disabled.
> 
> Tests cover flag-driven state, close command emission, and close-button touch-target sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa40bf3d09b7058b5cc4ac09cffcc6f93cd3f985. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->