### PR TITLE
Send and receive Exchange v2.1 bye message

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -331,7 +331,10 @@ class RealSyncCodeDispatcher @Inject constructor(
             else -> DispatchOutcome.Failed("peer_aborted", PAIRING_REJECTED.code)
         }
         ExchangeV2State.Joiner.AbortedLocal -> joinerAbortedLocalToOutcome(transition.localTrigger, transition.trigger)
-        ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", UNEXPECTED_EVENT.code)
+        ExchangeV2State.Aborted -> when (val wireTrigger = transition.trigger) {
+            is ExchangeV2Message.Bye -> wireTrigger.toPeerLeftOutcome()
+            else -> DispatchOutcome.Failed("negotiation_aborted", UNEXPECTED_EVENT.code)
+        }
         else -> null
     }
 
@@ -384,6 +387,7 @@ class RealSyncCodeDispatcher @Inject constructor(
     ): DispatchOutcome = when {
         localTrigger == LocalTrigger.UserDeniedHost -> DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code)
         localTrigger == LocalTrigger.HostUnavailable -> DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code)
+        wireTrigger is ExchangeV2Message.Bye -> wireTrigger.toPeerLeftOutcome()
         wireTrigger != null -> DispatchOutcome.Failed("host_protocol_error", UNEXPECTED_EVENT.code)
         else -> DispatchOutcome.Failed("host_aborted", NEGOTIATION_ABORTED.code)
     }
@@ -393,6 +397,7 @@ class RealSyncCodeDispatcher @Inject constructor(
         wireTrigger: ExchangeV2Message?,
     ): DispatchOutcome = when {
         localTrigger == LocalTrigger.UserDeniedJoiner -> DispatchOutcome.Failed("user_denied_joiner", PAIRING_CANCELLED.code)
+        wireTrigger is ExchangeV2Message.Bye -> wireTrigger.toPeerLeftOutcome()
         wireTrigger != null -> DispatchOutcome.Failed("joiner_protocol_error", UNEXPECTED_EVENT.code)
         else -> DispatchOutcome.Failed("joiner_local_aborted", PAIRING_FAILED.code)
     }
@@ -522,6 +527,14 @@ class RealSyncCodeDispatcher @Inject constructor(
             }
         }
     }
+
+    private fun ExchangeV2Message.Bye.toPeerLeftOutcome(): DispatchOutcome.Failed = DispatchOutcome.Failed(
+        "peer_left(${reason.value})",
+        code = when (reason) {
+            ExchangeV2Message.Bye.Reason.Error -> PAIRING_FAILED.code
+            else -> PAIRING_REJECTED.code
+        },
+    )
 
     /**
      * Re-encode a v2 ddg recovery (userId + secret) as a v1-shape `{recovery:{primary_key,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Event.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Event.kt
@@ -53,6 +53,20 @@ sealed interface ExchangeV2Event {
     ) : ExchangeV2Event
 
     /**
+     * An outbound message never reached the relay, whether sending failed or was skipped
+     * deliberately. The counterpart of [MessageSent] and just as observational: when the failure
+     * also ends the session, a separate [SessionError] follows. A teardown `bye` never produces
+     * one, since it is best-effort by contract. [messageType] is always set; [message] is null
+     * when sending failed before the message was built, see [NotSentReason.OwnChannelNotConfigured].
+     */
+    data class MessageNotSent(
+        override val timestampMs: Long,
+        val reason: NotSentReason,
+        val messageType: String,
+        val message: ExchangeV2Message?,
+    ) : ExchangeV2Event
+
+    /**
      * [message] was received but not acted on in [state]: either an unknown message type dropped to keep
      * the session alive, or a protocol violation aborting a session already in a terminal state (an abort
      * from an active state surfaces as a [Transition] instead). See [RejectReason].
@@ -112,6 +126,21 @@ enum class RejectReason {
 
     /** An unrecognized message type, ignored so a newer peer's extra messages can't kill the session. */
     UnknownMessageDropped,
+
+    /** The peer sent `bye` before the exchange completed. Not a protocol violation: the peer is simply gone. */
+    PeerLeft,
+}
+
+/** Why an outbound message never reached the relay. See [ExchangeV2Event.MessageNotSent]. */
+sealed interface NotSentReason {
+    /** Sending was attempted without a bootstrapped session, so there was no channel pair to write over. */
+    data object OwnChannelNotConfigured : NotSentReason
+
+    /** The relay rejected the write with HTTP [code]. */
+    data class HttpError(val code: Int) : NotSentReason
+
+    /** Deliberate skip: the message requires a newer protocol than [negotiatedVersion], so the peer could not process it. */
+    data class TooHighProtocol(val negotiatedVersion: ExchangeProtocolVersion.V2) : NotSentReason
 }
 
 /**

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Message.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Message.kt
@@ -51,6 +51,8 @@ sealed interface ExchangeV2Message {
     /**
      * Sent by the Scanner to the Presenter's relay channel to open the session.
      *
+     * Since 2.0.
+     *
      * @param channelId Scanner's own relay channel ID — the Presenter learns this here and uses
      *  it as the address for replies.
      * @param publicKey Scanner's session public key (base64url-encoded SPKI DER); used to
@@ -109,6 +111,8 @@ sealed interface ExchangeV2Message {
     /**
      * Sent by either device during negotiation to declare it has a sync account.
      *
+     * Since 2.0.
+     *
      * @param userId Identifies the sender's account. If both sides send the same [userId] the
      *  session must be aborted — the devices are already on the same account.
      * @param name Human-readable device name shown to the peer.
@@ -166,6 +170,8 @@ sealed interface ExchangeV2Message {
      * Sent by either device during negotiation to declare it has no sync account. No user_id
      * accompanies it.
      *
+     * Since 2.0.
+     *
      * @param name Human-readable device name shown to the peer.
      * @param kind Device kind, "ddg" or "3party"; drives cross-kind role election.
      */
@@ -211,6 +217,8 @@ sealed interface ExchangeV2Message {
      *
      * The Joiner already confirmed locally before entering the message loop, so no action is
      * required. A UI may use it to show a hint such as "Check the other device".
+     *
+     * Since 2.0.
      */
     data class RecoveryCodeAwaitingConfirmation(
         override val rawJson: String,
@@ -232,6 +240,8 @@ sealed interface ExchangeV2Message {
      *
      * The Joiner must accept [RecoveryCodeResponse] regardless of whether this message was seen
      * first.
+     *
+     * Since 2.0.
      */
     data class RecoveryCodeConfirmed(
         override val rawJson: String,
@@ -251,6 +261,8 @@ sealed interface ExchangeV2Message {
     /**
      * Sent by the Host when its user declined to share the recovery code. The Joiner must abort the
      * session on receiving this.
+     *
+     * Since 2.0.
      */
     data class RecoveryCodeDenied(
         override val rawJson: String,
@@ -270,6 +282,8 @@ sealed interface ExchangeV2Message {
     /**
      * Sent by the Host when it cannot supply a recovery code (e.g. no account exists and creation
      * failed). The Joiner must abort the session on receiving this.
+     *
+     * Since 2.0.
      */
     data class RecoveryCodeUnavailable(
         override val rawJson: String,
@@ -289,6 +303,8 @@ sealed interface ExchangeV2Message {
     /**
      * Sent by the Host carrying the actual recovery code. Terminal message of a successful pairing
      * exchange.
+     *
+     * Since 2.0.
      *
      * @param recoveryCode base64url-encoded recovery code payload.
      */
@@ -321,6 +337,8 @@ sealed interface ExchangeV2Message {
     /**
      * Sent by the Joiner once it has finished using the recovery code, carrying the real outcome so
      * the Host can show it instead of assuming success. Only valid after `recovery_code_response`.
+     *
+     * Since 2.1.
      */
     data class RecoveryCodeDone(
         override val rawJson: String,
@@ -380,10 +398,76 @@ sealed interface ExchangeV2Message {
     }
 
     /**
+     * Sent by either peer as the last message it writes before leaving the exchange, so the other
+     * side doesn't sit waiting on a device that has gone.
+     *
+     * Never an instruction to stop: a Host may send `bye(Done)` on a completely successful pairing
+     * while the Joiner is still logging in, and work already in flight continues.
+     *
+     * Since 2.1.
+     */
+    data class Bye(
+        override val rawJson: String,
+        val reason: Reason,
+    ) : ExchangeV2Message {
+        override val messageType get() = TYPE
+        override val protocolVersion get() = ExchangeProtocolVersion.V2_1
+
+        sealed interface Reason {
+            val value: String
+
+            data object Done : Reason {
+                override val value = "done"
+            }
+
+            data object Cancelled : Reason {
+                override val value = "cancelled"
+            }
+
+            data object Error : Reason {
+                override val value = "error"
+            }
+
+            data class Unknown(val rawValue: String) : Reason {
+                override val value get() = rawValue
+            }
+
+            companion object {
+                fun fromJsonValue(value: String): Reason = when (value) {
+                    Done.value -> Done
+                    Cancelled.value -> Cancelled
+                    Error.value -> Error
+                    else -> Unknown(value)
+                }
+            }
+        }
+
+        companion object {
+            const val TYPE = "bye"
+            private const val FIELD_REASON = "reason"
+
+            fun create(reason: Reason) = Bye(
+                rawJson = buildMessageJson(TYPE) { put(FIELD_REASON, reason.value) },
+                reason = reason,
+            )
+
+            fun fromJson(rawJson: String): Bye {
+                val json = JSONObject(rawJson)
+                return Bye(
+                    rawJson = rawJson,
+                    reason = Reason.fromJsonValue(json.optString(FIELD_REASON, "")),
+                )
+            }
+        }
+    }
+
+    /**
      * Forward-compatibility variant: a message whose type field doesn't match any known
      * value. The SM drops these without changing state per the spec's forward-compat rule.
      *
      * Inbound only — we never send a type we don't know so there is no `create`.
+     *
+     * Not tied to a protocol version. Any unrecognized type from any version parses as this.
      */
     data class Unknown(
         override val rawJson: String,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2MessageParser.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2MessageParser.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Bye
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAvailable
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAwaitingConfirmation
@@ -52,6 +53,7 @@ class JsonExchangeV2MessageParser @Inject constructor() : ExchangeV2MessageParse
                 RecoveryCodeUnavailable.TYPE -> RecoveryCodeUnavailable.fromJson(rawJson)
                 RecoveryCodeResponse.TYPE -> RecoveryCodeResponse.fromJson(rawJson)
                 RecoveryCodeDone.TYPE -> RecoveryCodeDone.fromJson(rawJson)
+                Bye.TYPE -> Bye.fromJson(rawJson)
                 else -> UnknownMessage.fromJson(rawJson, messageType = type)
             }
         }.getOrElse { UnknownMessage.fromJson(rawJson, messageType = type) }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -221,12 +221,12 @@ class RealExchangeV2Runner @Inject constructor(
                 return@launch
             }
             mutex.withLock {
-                cancelLocked() // abandon any prior session
+                cancelLocked(ExchangeV2Message.Bye.Reason.Cancelled) // abandon any prior session
                 ownData = OwnData(PairingRole.Scanner, linkingCode = null)
                 peerChannel = PeerChannelData(parsed.channelId, parsed.publicKey)
                 bootstrapLocked(PairingRole.Scanner)
                 if (ownChannel == null) {
-                    cancelLocked() // bootstrap already emitted the error; just clear the half-set state
+                    cancelLocked(ExchangeV2Message.Bye.Reason.Error) // bootstrap already emitted the error; just clear the half-set state
                     return@launch
                 }
                 negotiatedVersion = negotiateProtocolVersion(parsed.version, PeerVersionSource.LinkingCode)
@@ -239,7 +239,7 @@ class RealExchangeV2Runner @Inject constructor(
             emitSessionStarted()
             if (!sendHello()) {
                 // sendHello already emitted a SessionError (incomplete state or HTTP status)
-                cancel()
+                cancel(ExchangeV2Message.Bye.Reason.Error)
                 return@launch
             }
             sendOwnAvailability()
@@ -254,10 +254,10 @@ class RealExchangeV2Runner @Inject constructor(
             // No pre-flight account check: per spec §"Exchange Share Recovery Code" a Host without
             // an account creates one mid-flow ([sendRecoveryCodeResponse] at Host.Sending).
             mutex.withLock {
-                cancelLocked() // abandon any prior session
+                cancelLocked(ExchangeV2Message.Bye.Reason.Cancelled) // abandon any prior session
                 bootstrapLocked(PairingRole.Presenter)
                 val own = ownChannel ?: run {
-                    cancelLocked() // bootstrap already emitted the error; just clear the half-set state
+                    cancelLocked(ExchangeV2Message.Bye.Reason.Error) // bootstrap already emitted the error; just clear the half-set state
                     return@launch
                 }
                 val linkingCode = qrCode.buildLinkingCode(
@@ -312,10 +312,12 @@ class RealExchangeV2Runner @Inject constructor(
         return
     }
 
-    override suspend fun cancel() {
+    override suspend fun cancel() = cancel(ExchangeV2Message.Bye.Reason.Cancelled)
+
+    private suspend fun cancel(byeReason: ExchangeV2Message.Bye.Reason) {
         // NonCancellable: teardown must finish even when the caller's coroutine is itself being
         // cancelled (e.g. the dispatcher cancels this from a flow's onCompletion).
-        withContext(NonCancellable) { mutex.withLock { cancelLocked() } }
+        withContext(NonCancellable) { mutex.withLock { cancelLocked(byeReason) } }
     }
 
     /**
@@ -344,12 +346,13 @@ class RealExchangeV2Runner @Inject constructor(
     ) {
         if (session == null) return
         emitSessionError(reason, kind, timeoutStage)
-        cancelLocked()
+        cancelLocked(ExchangeV2Message.Bye.Reason.Error)
     }
 
     /** Caller MUST hold [mutex]. The single teardown path, so field resets can't drift between
-     *  call sites: stop the jobs, best-effort DELETE the channel, discard keys, clear all state. */
-    private fun cancelLocked() {
+     *  call sites: stop the jobs, say [byeReason] to the peer, best-effort DELETE the channel,
+     *  discard keys, clear all state. */
+    private fun cancelLocked(byeReason: ExchangeV2Message.Bye.Reason) {
         if (session != null || messagePollJob != null) {
             logcat { "Sync-ExchangeV2: teardown (was in state ${session?.currentState})" }
         }
@@ -361,8 +364,16 @@ class RealExchangeV2Runner @Inject constructor(
         syncTimeoutJob = null
         val own = ownChannel
         if (own != null) {
-            // Best-effort DELETE.
+            val peer = peerChannel
+            val version = negotiatedVersion
             appScope.launch(dispatchers.io()) {
+                // Sequenced before the DELETE so the peer can learn we've gone rather than
+                // discovering it when its next write 404s. Sent once, never retried, and delivery
+                // is never depended on.
+                if (peer != null) {
+                    runCatching { sendMessage(ExchangeV2Message.Bye.create(byeReason), own, peer, version) }
+                }
+                // Best-effort DELETE.
                 runCatching { channel.deleteChannel(own.id, own.secret) }
             }
         }
@@ -523,7 +534,7 @@ class RealExchangeV2Runner @Inject constructor(
             sendOwnAvailability()
         }
 
-        if (sm.currentState.isTerminal()) onTerminalReachedLocked(sm.currentState)
+        if (sm.currentState.isTerminal()) onTerminalReachedLocked(sm.currentState, localTrigger = null, message)
     }
 
     /**
@@ -579,7 +590,7 @@ class RealExchangeV2Runner @Inject constructor(
                 val r = s.localTrigger(terminalTrigger)
                 emit(r.event)
                 r.sideEffects.forEach { applySideEffectLocked(it) }
-                if (s.currentState.isTerminal()) onTerminalReachedLocked(s.currentState)
+                if (s.currentState.isTerminal()) onTerminalReachedLocked(s.currentState, terminalTrigger, peerTrigger = null)
             }
         }
     }
@@ -699,13 +710,36 @@ class RealExchangeV2Runner @Inject constructor(
         if (priorState == ExchangeV2State.Joiner.Confirming) {
             replayBufferedJoinerMessagesLocked(newState = sm.currentState)
         }
-        if (sm.currentState.isTerminal()) onTerminalReachedLocked(sm.currentState)
+        if (sm.currentState.isTerminal()) onTerminalReachedLocked(sm.currentState, trigger, peerTrigger = null)
     }
 
     /** On a terminal SM state, tear down via [cancelLocked]. Caller holds [mutex]. */
-    private fun onTerminalReachedLocked(terminal: ExchangeV2State) {
-        logcat { "Sync-ExchangeV2: session reached terminal state $terminal, tearing down" }
-        cancelLocked()
+    private fun onTerminalReachedLocked(
+        terminalState: ExchangeV2State,
+        localTrigger: LocalTrigger?,
+        peerTrigger: ExchangeV2Message?,
+    ) {
+        logcat { "Sync-ExchangeV2: session reached terminal state $terminalState, tearing down" }
+        cancelLocked(computeByeReason(terminalState, localTrigger, peerTrigger))
+    }
+
+    /**
+     * Per Messages spec 1216906886019334: `done` is nothing left to do, `cancelled` is the user
+     * backing out, `error` is a local failure. The trigger is checked first because the same
+     * terminal is reachable both ways: a denied prompt and a protocol error both land on
+     * [ExchangeV2State.Host.Aborted] / [ExchangeV2State.Joiner.AbortedLocal]. A teardown answering
+     * the peer's own `bye` is not a local failure either, even when it lands on an error terminal:
+     * the peer left and there is simply nothing left to do.
+     */
+    private fun computeByeReason(
+        state: ExchangeV2State,
+        localTrigger: LocalTrigger?,
+        peerTrigger: ExchangeV2Message?,
+    ): ExchangeV2Message.Bye.Reason = when {
+        localTrigger in CANCELLED_BYE_TRIGGERS -> ExchangeV2Message.Bye.Reason.Cancelled
+        peerTrigger is ExchangeV2Message.Bye -> ExchangeV2Message.Bye.Reason.Done
+        state in ERROR_BYE_STATES -> ExchangeV2Message.Bye.Reason.Error
+        else -> ExchangeV2Message.Bye.Reason.Done
     }
 
     /**
@@ -844,34 +878,43 @@ class RealExchangeV2Runner @Inject constructor(
         return recoveryCodeProvider.getThirdPartyRecoveryCode()
     }
 
-    private fun sendMessage(message: ExchangeV2Message): Boolean {
-        return sendMessage(message.messageType) { _, _ -> message }
+    private fun sendMessage(
+        message: ExchangeV2Message,
+        ownChannel: OwnChannelData? = this.ownChannel,
+        peerChannel: PeerChannelData? = this.peerChannel,
+        negotiatedVersion: ExchangeProtocolVersion.V2 = this.negotiatedVersion,
+    ): Boolean {
+        return sendMessage(message.messageType, ownChannel, peerChannel, negotiatedVersion) { _, _ -> message }
     }
 
     private fun sendMessage(
         messageType: String,
+        ownChannel: OwnChannelData? = this.ownChannel,
+        peerChannel: PeerChannelData? = this.peerChannel,
+        negotiatedVersion: ExchangeProtocolVersion.V2 = this.negotiatedVersion,
         message: (OwnChannelData, PeerChannelData) -> ExchangeV2Message,
     ): Boolean {
-        val own = ownChannel
-        val peer = peerChannel
-        if (own == null || peer == null) {
-            logcat(ERROR) { "Sync-ExchangeV2: cannot send $messageType — no channel pair" }
+        if (ownChannel == null || peerChannel == null) {
+            emit(ExchangeV2Event.MessageNotSent(clock.nowMs(), NotSentReason.OwnChannelNotConfigured, messageType, message = null))
             return false
         }
 
-        val message = message(own, peer)
+        val message = message(ownChannel, peerChannel)
         if (message.protocolVersion > negotiatedVersion) {
-            logcat { "Sync-ExchangeV2: skipping ${message.messageType} (needs v${message.protocolVersion}, negotiated v$negotiatedVersion)" }
+            emit(ExchangeV2Event.MessageNotSent(clock.nowMs(), NotSentReason.TooHighProtocol(negotiatedVersion), messageType, message))
             return false
         }
 
-        return when (val r = channel.sendMessage(message, peer.id, peer.publicKey, own.id, own.secret)) {
+        return when (val r = channel.sendMessage(message, peerChannel.id, peerChannel.publicKey, ownChannel.id, ownChannel.secret)) {
             is Result.Success -> {
                 recordSentMessage(message)
                 true
             }
             is Result.Error -> {
-                emitSessionError("Failed to send message to peer over channel (${r.code})", r.code.toSendFailureKind())
+                emit(ExchangeV2Event.MessageNotSent(clock.nowMs(), NotSentReason.HttpError(r.code), message.messageType, message))
+                if (messageType != ExchangeV2Message.Bye.TYPE) {
+                    emitSessionError("Failed to send message '$messageType' to peer over channel (${r.code})", r.code.toSendFailureKind())
+                }
                 false
             }
         }
@@ -906,6 +949,9 @@ class RealExchangeV2Runner @Inject constructor(
                 "Sync-ExchangeV2: rejected ${event.message.messageType} in ${event.state} reason=${event.reason}"
             }
             is ExchangeV2Event.MessageSent -> Unit
+            is ExchangeV2Event.MessageNotSent -> logcat {
+                "Sync-ExchangeV2: not sent ${event.messageType} reason=${event.reason}"
+            }
             is ExchangeV2Event.SessionStarted -> logcat {
                 val codeLine = event.linkingCode?.let { " linkingCode=$it" } ?: ""
                 "Sync-ExchangeV2: session started role=${event.pairingRole} channel_id=${event.ownChannelId}$codeLine"
@@ -1003,6 +1049,20 @@ class RealExchangeV2Runner @Inject constructor(
         private const val HTTP_CONFLICT = 409
 
         private val BASELINE_PROTOCOL_VERSION get() = ExchangeProtocolVersion.V2_0
+
+        // Triggers that make a terminal state a user cancellation rather than a failure.
+        private val CANCELLED_BYE_TRIGGERS: Set<LocalTrigger> = setOf(
+            LocalTrigger.UserDeniedHost,
+            LocalTrigger.UserDeniedJoiner,
+        )
+
+        // Terminal states we only reach because something went wrong on this device.
+        private val ERROR_BYE_STATES: Set<ExchangeV2State> = setOf(
+            ExchangeV2State.Aborted,
+            ExchangeV2State.Host.Aborted,
+            ExchangeV2State.Joiner.AbortedLocal,
+            ExchangeV2State.Joiner.JoinFailed,
+        )
     }
 }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Bye
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAvailable
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAwaitingConfirmation
@@ -113,7 +114,8 @@ internal class RealExchangeV2StateMachine(
             ExchangeV2State.Host.Unknown -> receiveInHostUnknownStatus(state, msg)
             ExchangeV2State.Joiner.Confirming -> receiveInJoinerConfirming(state, msg)
             ExchangeV2State.Joiner.Waiting -> receiveInJoinerWaiting(state, msg)
-            else -> abort(state, msg, RejectReason.ImplicitAbort)
+            ExchangeV2State.Joiner.Joining -> receiveInJoinerJoining(state, msg)
+            else -> if (msg is Bye) receiveBye(state, msg) else abort(state, msg, RejectReason.ImplicitAbort)
         }
     }
 
@@ -130,6 +132,7 @@ internal class RealExchangeV2StateMachine(
     }
 
     private fun receiveInBootstrapped(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
+        if (msg is Bye) return receiveBye(state, msg)
         return if (msg is Hello) {
             accept(state, ExchangeV2State.Negotiating, msg)
         } else {
@@ -164,6 +167,7 @@ internal class RealExchangeV2StateMachine(
             is RecoveryCodeResponse,
             is RecoveryCodeDone,
             -> abort(state, msg, RejectReason.ImplicitAbort)
+            is Bye -> receiveBye(state, msg)
             is UnknownMessage -> drop(msg)
         }
     }
@@ -171,6 +175,7 @@ internal class RealExchangeV2StateMachine(
     private fun receiveInHostAwaitingStatus(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
         return when (msg) {
             is RecoveryCodeDone -> accept(state, ExchangeV2State.Host.Done, msg)
+            is Bye -> receiveBye(state, msg)
             else -> abort(state, msg, RejectReason.ImplicitAbort)
         }
     }
@@ -178,6 +183,7 @@ internal class RealExchangeV2StateMachine(
     private fun receiveInHostUnknownStatus(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
         return when (msg) {
             is RecoveryCodeDone -> accept(state, ExchangeV2State.Host.Done, msg)
+            is Bye -> receiveBye(state, msg)
             else -> abort(state, msg, RejectReason.ImplicitAbort)
         }
     }
@@ -188,6 +194,7 @@ internal class RealExchangeV2StateMachine(
         return when (msg) {
             is RecoveryCodeDenied -> accept(state, ExchangeV2State.Joiner.AbortedByHost, msg)
             is RecoveryCodeUnavailable -> accept(state, ExchangeV2State.Joiner.AbortedByHost, msg)
+            is Bye -> receiveBye(state, msg)
             else -> abort(state, msg, RejectReason.ImplicitAbort)
         }
     }
@@ -204,8 +211,36 @@ internal class RealExchangeV2StateMachine(
             is RecoveryCodeRequest,
             is RecoveryCodeDone,
             -> abort(state, msg, RejectReason.ImplicitAbort)
+            is Bye -> receiveBye(state, msg)
             is UnknownMessage -> drop(msg)
         }
+    }
+
+    private fun receiveInJoinerJoining(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
+        return when (msg) {
+            is Bye -> receiveBye(state, msg)
+            else -> abort(state, msg, RejectReason.ImplicitAbort)
+        }
+    }
+
+    /**
+     * `bye` is accepted in every state and is the only exception to the implicit abort rule: a peer
+     * saying goodbye is not a protocol error, so it never reports [RejectReason.ImplicitAbort].
+     * Delivery is not guaranteed, so no state may depend on having received one.
+     *
+     * Spec: Asana 1216906888491126 §Rules.
+     */
+    private fun receiveBye(state: ExchangeV2State, msg: Bye): TransitionResult = when (state) {
+        // No report is coming, but the peer may well have joined; never a failure.
+        ExchangeV2State.Host.AwaitingStatus,
+        ExchangeV2State.Host.Unknown,
+        -> accept(state, ExchangeV2State.Host.Unknown, msg)
+        // Past the point of no return: the peer going away is not a reason to abandon a login,
+        // upgrade or sync that is already running. The later recovery_code_done just won't land.
+        ExchangeV2State.Joiner.Joining -> accept(state, state, msg)
+        // Before the recovery code is released there is nobody left to pair with. In an already
+        // terminal state abort() keeps the state and only records the message.
+        else -> abort(state, msg, RejectReason.PeerLeft)
     }
 
     private fun localTriggerInNegotiating(state: ExchangeV2State, trigger: LocalTrigger): TransitionResult {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -1062,6 +1062,67 @@ class RealSyncCodeDispatcherTest {
         }
     }
 
+    @Test fun `Presenter emits Failed peer_left PAIRING_REJECTED when Joiner_AbortedLocal driven by a bye`() = runTest {
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.AbortedLocal,
+                    trigger = ExchangeV2Message.Bye.create(ExchangeV2Message.Bye.Reason.Cancelled),
+                ),
+            )
+            assertEquals(
+                DispatchOutcome.Failed(
+                    "peer_left(cancelled)",
+                    PAIRING_REJECTED.code,
+                    path = SetupPath.PAIRING,
+                    myRole = SetupRole.JOINER,
+                ),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `Presenter emits Failed peer_left PAIRING_FAILED when Host_Aborted driven by a bye with reason error`() = runTest {
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    trigger = ExchangeV2Message.Bye.create(ExchangeV2Message.Bye.Reason.Error),
+                ),
+            )
+            assertEquals(
+                DispatchOutcome.Failed(
+                    "peer_left(error)",
+                    PAIRING_FAILED.code,
+                    path = SetupPath.PAIRING,
+                    myRole = SetupRole.HOST,
+                ),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `Presenter emits Failed peer_left PAIRING_REJECTED when Aborted driven by a bye during negotiation`() = runTest {
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Negotiating,
+                    to = ExchangeV2State.Aborted,
+                    trigger = ExchangeV2Message.Bye.create(ExchangeV2Message.Bye.Reason.Cancelled),
+                ),
+            )
+            assertEquals(
+                DispatchOutcome.Failed("peer_left(cancelled)", PAIRING_REJECTED.code, path = SetupPath.PAIRING),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     @Test fun `Presenter calls runner_startPresent when Flow is collected`() = runTest {
         val flow = dispatcher.presentV2()
         verify(runner, never()).startPresent()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Bye
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAvailable
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAwaitingConfirmation
@@ -695,6 +696,187 @@ class ExchangeV2StateMachineTest {
 
         assertTrue(result.outcome is TransitionOutcome.Aborted)
         assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
+    }
+
+    @Test fun `when bye received in Host AwaitingStatus then transitions to Host Unknown`() {
+        val machine = inHostAwaitingStatus()
+        val bye = Bye.create(Bye.Reason.Done)
+        val result = machine.receive(bye)
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Host.Unknown, machine.currentState)
+        val transition = result.event as ExchangeV2Event.Transition
+        assertSame(ExchangeV2State.Host.AwaitingStatus, transition.from)
+        assertSame(ExchangeV2State.Host.Unknown, transition.to)
+        assertSame(bye, transition.trigger)
+    }
+
+    @Test fun `when bye with reason error received in Host AwaitingStatus then still transitions to Host Unknown`() {
+        val machine = inHostAwaitingStatus()
+        val result = machine.receive(Bye.create(Bye.Reason.Error))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Host.Unknown, machine.currentState)
+    }
+
+    @Test fun `when bye with unrecognised reason received in Host AwaitingStatus then still transitions to Host Unknown`() {
+        val machine = inHostAwaitingStatus()
+        val result = machine.receive(Bye.create(Bye.Reason.Unknown("future_reason")))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Host.Unknown, machine.currentState)
+    }
+
+    @Test fun `when bye received in Host Unknown then stays in Host Unknown`() {
+        val machine = inHostUnknown()
+        val result = machine.receive(Bye.create(Bye.Reason.Done))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Host.Unknown, machine.currentState)
+    }
+
+    @Test fun `when bye received in Joiner Joining then stays in Joiner Joining so work in flight continues`() {
+        val machine = inJoinerJoining()
+        val result = machine.receive(Bye.create(Bye.Reason.Done))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Joiner.Joining, machine.currentState)
+        assertTrue("expected no side effects, got ${result.sideEffects}", result.sideEffects.isEmpty())
+    }
+
+    @Test fun `when bye received in Joiner Joining then JoinerJoinComplete still reaches its terminal`() {
+        val machine = inJoinerJoining()
+        machine.receive(Bye.create(Bye.Reason.Done))
+
+        val result = machine.localTrigger(LocalTrigger.JoinerJoinComplete(RecoveryCodeDone.Reason.Success))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
+        assertEquals(listOf(SideEffect.SendRecoveryCodeDone(RecoveryCodeDone.Reason.Success)), result.sideEffects)
+    }
+
+    @Test fun `when bye received in Bootstrapped then aborts with PeerLeft to terminal Aborted`() {
+        val machine = sm()
+        val bye = Bye.create(Bye.Reason.Cancelled)
+        val result = machine.receive(bye)
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertEquals(RejectReason.PeerLeft, (result.outcome as TransitionOutcome.Aborted).reason)
+        assertSame(ExchangeV2State.Aborted, machine.currentState)
+
+        val transition = result.event as ExchangeV2Event.Transition
+        assertSame(ExchangeV2State.Bootstrapped, transition.from)
+        assertSame(ExchangeV2State.Aborted, transition.to)
+        assertSame(bye, transition.trigger)
+    }
+
+    @Test fun `when bye received in Negotiating then aborts with PeerLeft to terminal Aborted`() {
+        val machine = sm()
+        machine.receive(Hello.fromJson("{}"))
+        val bye = Bye.create(Bye.Reason.Cancelled)
+        val result = machine.receive(bye)
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertEquals(RejectReason.PeerLeft, (result.outcome as TransitionOutcome.Aborted).reason)
+        assertSame(ExchangeV2State.Aborted, machine.currentState)
+
+        val transition = result.event as ExchangeV2Event.Transition
+        assertSame(ExchangeV2State.Negotiating, transition.from)
+        assertSame(ExchangeV2State.Aborted, transition.to)
+        assertSame(bye, transition.trigger)
+    }
+
+    @Test fun `when bye received in Host Confirming then aborts with PeerLeft to terminal Host Aborted`() {
+        val machine = inHostConfirming()
+        val bye = Bye.create(Bye.Reason.Cancelled)
+        val result = machine.receive(bye)
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertEquals(RejectReason.PeerLeft, (result.outcome as TransitionOutcome.Aborted).reason)
+        assertSame(ExchangeV2State.Host.Aborted, machine.currentState)
+
+        val transition = result.event as ExchangeV2Event.Transition
+        assertSame(ExchangeV2State.Host.Confirming, transition.from)
+        assertSame(ExchangeV2State.Host.Aborted, transition.to)
+        assertSame(bye, transition.trigger)
+    }
+
+    @Test fun `when bye received in Host Sending then aborts with PeerLeft to terminal Host Aborted`() {
+        val machine = inHostSending()
+        val bye = Bye.create(Bye.Reason.Cancelled)
+        val result = machine.receive(bye)
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertEquals(RejectReason.PeerLeft, (result.outcome as TransitionOutcome.Aborted).reason)
+        assertSame(ExchangeV2State.Host.Aborted, machine.currentState)
+
+        val transition = result.event as ExchangeV2Event.Transition
+        assertSame(ExchangeV2State.Host.Sending, transition.from)
+        assertSame(ExchangeV2State.Host.Aborted, transition.to)
+        assertSame(bye, transition.trigger)
+    }
+
+    @Test fun `when bye received in Joiner Confirming then aborts with PeerLeft to terminal Joiner AbortedLocal`() {
+        val machine = inJoinerConfirming()
+        val bye = Bye.create(Bye.Reason.Cancelled)
+        val result = machine.receive(bye)
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertEquals(RejectReason.PeerLeft, (result.outcome as TransitionOutcome.Aborted).reason)
+        assertSame(ExchangeV2State.Joiner.AbortedLocal, machine.currentState)
+
+        val transition = result.event as ExchangeV2Event.Transition
+        assertSame(ExchangeV2State.Joiner.Confirming, transition.from)
+        assertSame(ExchangeV2State.Joiner.AbortedLocal, transition.to)
+        assertSame(bye, transition.trigger)
+    }
+
+    @Test fun `when bye received in Joiner Waiting then aborts with PeerLeft to terminal Joiner AbortedLocal`() {
+        val machine = inJoinerWaiting()
+        val bye = Bye.create(Bye.Reason.Cancelled)
+        val result = machine.receive(bye)
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertEquals(RejectReason.PeerLeft, (result.outcome as TransitionOutcome.Aborted).reason)
+        assertSame(ExchangeV2State.Joiner.AbortedLocal, machine.currentState)
+
+        val transition = result.event as ExchangeV2Event.Transition
+        assertSame(ExchangeV2State.Joiner.Waiting, transition.from)
+        assertSame(ExchangeV2State.Joiner.AbortedLocal, transition.to)
+        assertSame(bye, transition.trigger)
+    }
+
+    @Test fun `when bye received in Host Done then state unchanged`() {
+        val machine = inHostSending()
+        machine.localTrigger(LocalTrigger.HostSendComplete(ExchangeProtocolVersion.V2_0))
+        assertSame(ExchangeV2State.Host.Done, machine.currentState)
+
+        val result = machine.receive(Bye.create(Bye.Reason.Done))
+
+        assertSame(ExchangeV2State.Host.Done, machine.currentState)
+        assertEquals(RejectReason.PeerLeft, (result.event as ExchangeV2Event.MessageRejected).reason)
+    }
+
+    @Test fun `when bye received in Joiner Done then state unchanged`() {
+        val machine = inJoinerJoining()
+        machine.localTrigger(LocalTrigger.JoinerJoinComplete(RecoveryCodeDone.Reason.Success))
+        assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
+
+        val result = machine.receive(Bye.create(Bye.Reason.Done))
+
+        assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
+        assertEquals(RejectReason.PeerLeft, (result.event as ExchangeV2Event.MessageRejected).reason)
+    }
+
+    @Test fun `when bye received in Host Aborted then state unchanged`() {
+        val machine = inHostConfirming()
+        machine.localTrigger(LocalTrigger.UserDeniedHost)
+        assertSame(ExchangeV2State.Host.Aborted, machine.currentState)
+
+        val result = machine.receive(Bye.create(Bye.Reason.Done))
+
+        assertSame(ExchangeV2State.Host.Aborted, machine.currentState)
+        assertEquals(RejectReason.PeerLeft, (result.event as ExchangeV2Event.MessageRejected).reason)
     }
 
     private fun inHostConfirming(): ExchangeV2StateMachine =

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/JsonExchangeV2MessageParserTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/JsonExchangeV2MessageParserTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Bye
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
@@ -104,6 +105,46 @@ class JsonExchangeV2MessageParserTest {
         val parsed = parser.parse(json) as RecoveryCodeDone
 
         assertEquals(case.expectedReason, parsed.reason)
+    }
+
+    enum class ByeCase(
+        val rawReason: String,
+        val expectedReason: Bye.Reason,
+    ) {
+        Done(
+            rawReason = "done",
+            expectedReason = Bye.Reason.Done,
+        ),
+        Cancelled(
+            rawReason = "cancelled",
+            expectedReason = Bye.Reason.Cancelled,
+        ),
+        Error(
+            rawReason = "error",
+            expectedReason = Bye.Reason.Error,
+        ),
+        Unknown(
+            rawReason = "future_reason",
+            expectedReason = Bye.Reason.Unknown("future_reason"),
+        ),
+    }
+
+    @Test
+    fun `parses bye with reason`(
+        @TestParameter case: ByeCase,
+    ) {
+        val json = """{"type":"bye","reason":"${case.rawReason}"}"""
+
+        val parsed = parser.parse(json) as Bye
+
+        assertEquals(case.expectedReason, parsed.reason)
+        assertEquals(json, parsed.rawJson)
+    }
+
+    @Test fun `bye without a reason still parses as Bye`() {
+        // An unrecognised or absent reason must not abort the parse (spec 1216906886019334 §Unknown reason values).
+        val parsed = parser.parse("""{"type":"bye"}""") as Bye
+        assertEquals(Bye.Reason.Unknown(""), parsed.reason)
     }
 
     @Test fun `parses bodyless types awaiting_confirmation confirmed denied unavailable`() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.crypto.RsaKeyPair
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Bye
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAvailable
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAwaitingConfirmation
@@ -1011,6 +1012,230 @@ class RealExchangeV2RunnerTest {
         verify(channel).createChannel(any(), eq("fn4_Pz4-c2VjcmV0IQ"))
     }
 
+    // ---- Bye on teardown ----
+
+    @Test fun `teardown says bye to a v2_1 peer`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_1)
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.cancel()
+
+        verify(channel).sendMessage(
+            argThat { this is Bye && reason == Bye.Reason.Cancelled },
+            any(),
+            any(),
+            any(),
+            anyOrNull(),
+        )
+    }
+
+    @Test fun `teardown after a v2_0 session sends no bye`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_0)
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.cancel()
+
+        verify(channel, never()).sendMessage(argThat { this is Bye }, any(), any(), any(), anyOrNull())
+    }
+
+    @Test fun `a completed Host session says bye with reason done`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenHostCanProduceRecoveryCode()
+        val runner = newRunner()
+        runner.reachHostAwaitingStatus()
+
+        runner.deliverIncomingMessage(RecoveryCodeDone.create(RecoveryCodeDone.Reason.Success))
+
+        verify(channel).sendMessage(
+            argThat { this is Bye && reason == Bye.Reason.Done },
+            any(),
+            any(),
+            any(),
+            anyOrNull(),
+        )
+    }
+
+    @Test fun `a denied Joiner prompt says bye with reason cancelled`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_1)
+        whenever(syncStore.userId).thenReturn(null)
+        val runner = newRunner()
+        runner.startScan("")
+        runner.deliverIncomingMessage(RecoveryCodeAvailable.create(userId = "host-user", name = "Host", kind = "ddg"))
+
+        runner.localTrigger(LocalTrigger.UserDeniedJoiner)
+
+        verify(channel).sendMessage(
+            argThat { this is Bye && reason == Bye.Reason.Cancelled },
+            any(),
+            any(),
+            any(),
+            anyOrNull(),
+        )
+    }
+
+    @Test fun `a Host that cannot send the recovery code says bye with reason error`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenHostCanProduceRecoveryCode()
+        whenever(
+            channel.sendMessage(any<RecoveryCodeResponse>(), any(), any(), any(), anyOrNull()),
+        ).thenReturn(Result.Error(reason = "relay unreachable"))
+
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverHello(ExchangeProtocolVersion.V2_1)
+        runner.deliverIncomingMessage(RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"))
+        runner.localTrigger(LocalTrigger.UserConfirmedHost)
+
+        verify(channel).sendMessage(
+            argThat { this is Bye && reason == Bye.Reason.Error },
+            any(),
+            any(),
+            any(),
+            anyOrNull(),
+        )
+    }
+
+    @Test fun `an undeliverable bye emits MessageNotSent but no session error`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_1)
+        whenever(channel.sendMessage(any<Bye>(), any(), any(), any(), anyOrNull()))
+            .thenReturn(Result.Error(code = 404, reason = "channel gone"))
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.cancel()
+
+        assertTrue(runner.events.replayCache.filterIsInstance<ExchangeV2Event.SessionError>().isEmpty())
+        val notSent = runner.events.replayCache.filterIsInstance<ExchangeV2Event.MessageNotSent>().single()
+        assertEquals(NotSentReason.HttpError(404), notSent.reason)
+        assertEquals(Bye.TYPE, notSent.messageType)
+        assertTrue(notSent.message is Bye)
+    }
+
+    @Test fun `a bye skipped on a v2_0 session emits MessageNotSent with TooHighProtocol`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_0)
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.cancel()
+
+        val notSent = runner.events.replayCache.filterIsInstance<ExchangeV2Event.MessageNotSent>().single()
+        assertEquals(NotSentReason.TooHighProtocol(ExchangeProtocolVersion.V2_0), notSent.reason)
+        assertEquals(Bye.TYPE, notSent.messageType)
+    }
+
+    @Test fun `a failed send emits MessageNotSent alongside the session error`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_1)
+        whenever(channel.sendMessage(any<Hello>(), any(), any(), any(), anyOrNull()))
+            .thenReturn(Result.Error(code = 500, reason = "relay unavailable"))
+        val runner = newRunner()
+
+        runner.startScan("")
+
+        val notSent = runner.events.replayCache.filterIsInstance<ExchangeV2Event.MessageNotSent>().single()
+        assertEquals(NotSentReason.HttpError(500), notSent.reason)
+        assertEquals(Hello.TYPE, notSent.messageType)
+        assertTrue(runner.events.replayCache.filterIsInstance<ExchangeV2Event.SessionError>().isNotEmpty())
+    }
+
+    @Test fun `a received bye still gets our own farewell on teardown, and it says done rather than error`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_1)
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.deliverIncomingMessage(Bye.create(Bye.Reason.Cancelled))
+
+        assertNull(runner.currentState)
+        verify(channel).sendMessage(
+            argThat { this is Bye && reason == Bye.Reason.Done },
+            any(),
+            any(),
+            any(),
+            anyOrNull(),
+        )
+    }
+
+    @Test fun `a failed hello send says bye with reason error`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_1)
+        whenever(channel.sendMessage(any<Hello>(), any(), any(), any(), anyOrNull()))
+            .thenReturn(Result.Error(reason = "relay unreachable"))
+        val runner = newRunner()
+
+        runner.startScan("")
+
+        assertNull(runner.currentState)
+        verify(channel).sendMessage(
+            argThat { this is Bye && reason == Bye.Reason.Error },
+            any(),
+            any(),
+            any(),
+            anyOrNull(),
+        )
+    }
+
+    // ---- Bye on receipt ----
+
+    @Test fun `a bye received in Host AwaitingStatus moves the session to Host Unknown, not a failure`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenHostCanProduceRecoveryCode()
+        val runner = newRunner()
+        runner.reachHostAwaitingStatus()
+
+        runner.deliverIncomingMessage(Bye.create(Bye.Reason.Done))
+
+        assertSame(ExchangeV2State.Host.Unknown, runner.currentState)
+        assertTrue(runner.events.replayCache.filterIsInstance<ExchangeV2Event.SessionError>().isEmpty())
+        verify(channel, never()).sendMessage(argThat { this is Bye }, any(), any(), any(), anyOrNull())
+    }
+
+    @Test fun `a bye received while the Joiner is joining does not end the session`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_1)
+        whenever(syncStore.userId).thenReturn(null)
+        val runner = newRunner()
+        runner.reachJoinerJoining()
+
+        runner.deliverIncomingMessage(Bye.create(Bye.Reason.Done))
+
+        assertSame(ExchangeV2State.Joiner.Joining, runner.currentState)
+    }
+
+    @Test fun `a Joiner that got a bye mid-join still reports recovery_code_done before its own farewell`() = runTest {
+        givenOurVersion(ExchangeProtocolVersion.V2_1)
+        givenLinkingCodeVersion(ExchangeProtocolVersion.V2_1)
+        whenever(syncStore.userId).thenReturn(null)
+        val runner = newRunner()
+        runner.reachJoinerJoining()
+        runner.deliverIncomingMessage(Bye.create(Bye.Reason.Done))
+
+        runner.localTrigger(LocalTrigger.JoinerJoinComplete(RecoveryCodeDone.Reason.Success))
+
+        assertNull(runner.currentState)
+        verify(channel).sendMessage(
+            argThat { this is RecoveryCodeDone && reason == RecoveryCodeDone.Reason.Success },
+            any(),
+            any(),
+            any(),
+            anyOrNull(),
+        )
+        verify(channel).sendMessage(
+            argThat { this is Bye && reason == Bye.Reason.Done },
+            any(),
+            any(),
+            any(),
+            anyOrNull(),
+        )
+    }
+
     // ---- Helpers ----
 
     private fun givenOurVersion(version: ExchangeProtocolVersion.V2) {
@@ -1038,6 +1263,14 @@ class RealExchangeV2RunnerTest {
         deliverHello(ExchangeProtocolVersion.V2_1)
         deliverIncomingMessage(RecoveryCodeRequest.create(name = "Joiner", kind = "ddg"))
         localTrigger(LocalTrigger.UserConfirmedHost)
+    }
+
+    // Caller must stub a null [SyncStore.userId] first so role election picks Joiner.
+    private suspend fun RealExchangeV2Runner.reachJoinerJoining() {
+        startScan("")
+        deliverIncomingMessage(RecoveryCodeAvailable.create(userId = "host-user", name = "Host", kind = "ddg"))
+        localTrigger(LocalTrigger.UserConfirmedJoiner)
+        deliverIncomingMessage(RecoveryCodeResponse.create("the-code"))
     }
 
     private fun String.toProtocolVersion() = ExchangeProtocolVersion.parse(this).getOrThrow()

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.NotSentReason
 import com.duckduckgo.sync.impl.exchange.v2.PairingRole
 import com.duckduckgo.sync.impl.exchange.v2.PeerVersionSource
 import com.duckduckgo.sync.impl.exchange.v2.RejectReason
@@ -603,6 +604,7 @@ class SyncV2PairingDebugViewModel @Inject constructor(
             append("Sent ${event.message.messageType}")
             appendPeerDetails(event.message)
         }
+        is ExchangeV2Event.MessageNotSent -> "Not sent ${event.messageType}: ${labelFor(event.reason)}"
         is ExchangeV2Event.MessageRejected -> buildString {
             append("${labelFor(event.reason)} on ${event.message.messageType}")
             appendPeerDetails(event.message)
@@ -631,6 +633,10 @@ class SyncV2PairingDebugViewModel @Inject constructor(
             else -> LogDetails.Json(trigger.rawJson)
         }
         is ExchangeV2Event.MessageSent -> LogDetails.Json(event.message.rawJson)
+        is ExchangeV2Event.MessageNotSent -> when (val message = event.message) {
+            null -> LogDetails.PlainText(labelFor(event.reason))
+            else -> LogDetails.Json(message.rawJson)
+        }
         is ExchangeV2Event.MessageRejected -> LogDetails.Json(event.message.rawJson)
         is ExchangeV2Event.SessionStarted -> when (val linkingCode = event.linkingCode) {
             null -> LogDetails.PlainText("no linking code — Scanner side")
@@ -676,9 +682,16 @@ class SyncV2PairingDebugViewModel @Inject constructor(
     }
 
     private fun labelFor(reason: RejectReason): String = when (reason) {
-        RejectReason.ImplicitAbort -> "Aborted"
-        RejectReason.SameAccount -> "SameAccountAbort"
-        RejectReason.UnknownMessageDropped -> "Dropped (unknown)"
+        RejectReason.ImplicitAbort -> "ImplicitAbort"
+        RejectReason.SameAccount -> "SameAccount"
+        RejectReason.UnknownMessageDropped -> "UnknownMessageDropped"
+        RejectReason.PeerLeft -> "PeerLeft"
+    }
+
+    private fun labelFor(reason: NotSentReason): String = when (reason) {
+        NotSentReason.OwnChannelNotConfigured -> "OwnChannelNotConfigured"
+        is NotSentReason.HttpError -> "HttpError(${reason.code})"
+        is NotSentReason.TooHighProtocol -> "TooHighProtocol(negotiated ${reason.negotiatedVersion.prettyPrint()})"
     }
 
     private fun labelFor(peerSource: PeerVersionSource): String = when (peerSource) {

--- a/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
+++ b/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.NotSentReason
 import com.duckduckgo.sync.impl.exchange.v2.PairingRole
 import com.duckduckgo.sync.impl.exchange.v2.RealAdvertisedExchangeV2Version
 import com.duckduckgo.sync.impl.exchange.v2.RejectReason
@@ -145,6 +146,24 @@ class SyncV2PairingDebugViewModelTest {
         }
     }
 
+    @Test fun `MessageNotSent event labelled as Not sent with reason`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.viewState().test {
+            awaitItem()
+            eventFlow.emit(
+                ExchangeV2Event.MessageNotSent(
+                    timestampMs = 0L,
+                    reason = NotSentReason.HttpError(404),
+                    messageType = ExchangeV2Message.Bye.TYPE,
+                    message = ExchangeV2Message.Bye.create(ExchangeV2Message.Bye.Reason.Done),
+                ),
+            )
+            val state = awaitItem()
+            assertEquals(1, state.rows.size)
+            assertEquals("Not sent bye: HttpError(404)", state.rows.single().summary)
+        }
+    }
+
     @Test fun `MessageRejected with SameAccount labelled SameAccountAbort`() = runTest {
         val viewModel = newViewModel()
         viewModel.viewState().test {
@@ -162,7 +181,7 @@ class SyncV2PairingDebugViewModelTest {
                 ),
             )
             val state = awaitItem()
-            assertTrue(state.rows.single().summary.startsWith("SameAccountAbort"))
+            assertTrue(state.rows.single().summary.startsWith("SameAccount"))
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1217367677188794?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1217626160385689?focus=true
API Proposals URL(s) (if applicable): N/A

### Description

Adds the v2.1 `bye` message to the Exchange pairing protocol, in both directions. A device leaving the exchange now tells its peer it is gone before deleting its relay channel.

Sending:
- Every session teardown now writes a `bye` as its last message before the channel is deleted.
- The reason says why the device left: `done` when there is nothing left to do, `cancelled` when the user backed out, `error` on a local failure.
- The message is sent once, never retried, and delivery is never depended on.
- A message that is skipped or fails to send is now recorded as a `MessageNotSent` event; an undeliverable `bye` produces no session error, since the peer usually deletes its channel first.

Receiving:
- A peer's `bye` is accepted at any point of the exchange.
- Received before the recovery code was handed over, it ends the session immediately as a peer-left failure instead of leaving the device waiting for the five-minute deadline.
- A host waiting for the joiner's status report treats it as outcome unknown, not as a failure, because the joiner may well have succeeded.
- A joiner that is already signing in with the received recovery code carries on unaffected. Its final report is simply never delivered to the peer that left.

### Steps to test this PR

_Cancelling mid-exchange ends the peer's session immediately_
- [ ] Install this build on two devices, neither signed in to Sync & Backup.
- [ ] Open Sync Dev Settings on both devices.
- [ ] Tap "V2 Pairing Debug" on both devices.
- [ ] Tap "Change" next to "Protocol version" on both devices.
- [x] Select v2.1 on both devices.
- [ ] On the first device, turn off "Auto-approve confirmations".
- [ ] On the first device, tap "Start as Presenter".
- [ ] On the first device, tap "Copy linking code".
- [ ] Transfer the linking code to the second device's clipboard.
- [ ] On the second device, tap "Paste & Go".
- [ ] Wait for the "Confirm pairing (Host)" dialog on the first device.
- [ ] On the second device, tap "Cancel".
- [ ] Verify the second device's event log shows a sent `bye` with `reason=cancelled`.
- [ ] Verify the first device fails the pairing immediately, without waiting for the five-minute deadline.
- [ ] Verify the first device's event log shows the received `bye` as PeerLeft.

_Successful v2.1 pairing says bye with reason done_
- [ ] On the first device, turn "Auto-approve confirmations" back on.
- [ ] On the first device, tap "Start as Presenter".
- [ ] On the first device, tap "Copy linking code".
- [ ] Transfer the linking code to the second device's clipboard.
- [ ] On the second device, tap "Paste & Go".
- [ ] Verify pairing completes on both devices.
- [ ] Verify each device's event log shows a sent `bye` with `reason=done`, or a "Not sent bye" row when the peer's channel was already gone.

### UI changes
N/A

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core v2 pairing teardown, state-machine transitions, and failure telemetry mapping; behavior differs by negotiated protocol version and pairing phase, with broad test coverage but real multi-device edge cases remain.
> 
> **Overview**
> Adds the v2.1 **`bye`** wire message so a device can signal it is leaving the exchange before deleting its relay channel, instead of leaving the peer on a long timeout.
> 
> **Outbound:** Session teardown now sends a best-effort `bye` (once, before channel DELETE) with reason **`done`**, **`cancelled`**, or **`error`** depending on how the session ended. Peers on negotiated v2.0 skip sending `bye` (too high protocol). Failed or skipped sends emit **`MessageNotSent`**; a failed `bye` does not raise **`SessionError`**.
> 
> **Inbound:** The state machine accepts `bye` in every state. Early in pairing it ends the session as **peer left** (`RejectReason.PeerLeft`); on the host waiting for join status it moves to **Host.Unknown**; while the joiner is logging in it **does not** stop in-flight work. **`RealSyncCodeDispatcher`** maps peer-driven aborts to **`peer_left(...)`** failures with **`PAIRING_REJECTED`** or **`PAIRING_FAILED`** when the bye reason is error.
> 
> Debug UI labels for reject/not-sent reasons are updated for the new events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aba25c8261935209c0c1d334ef831993e5d6def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->