### PR TITLE
Add wide event to measure the Suggest Redirect feature

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_bad_url_error_page.json5
+++ b/PixelDefinitions/pixels/definitions/wide_bad_url_error_page.json5
@@ -1,0 +1,57 @@
+// Wide event pixel for the BAD_URL error page
+{
+    "wide_bad-url-error-page": {
+        "description": "Monitors the lifecycle of a BAD_URL (unresolved host) error page: whether a redirect suggestion was offered, whether the user clicked it, and how the error page was exited. Error pages shown in custom tabs are excluded, so the measured population is regular and fire tabs only.",
+        "owners": ["juandiana"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": [
+            "widePixelPlatform",
+            "widePixelType",
+            "widePixelSampleRate",
+            "widePixelFeatureStatus",
+            "widePixelAppVersion",
+            "widePixelAppName",
+            "widePixelFormFactor",
+            "widePixelDevMode",
+            "widePixelMetaType",
+            "widePixelMetaVersion",
+            "widePixelIsFirstDailyOccurrence",
+            {
+                "key": "feature.name",
+                "description": "Feature identifier for this wide event",
+                "enum": ["bad-url-error-page"]
+            },
+            {
+                "key": "feature.data.ext.step.redirect_suggested",
+                "description": "Parameter present when a redirect suggestion (Did you mean www.example.com?) was displayed on the error page. Absent when no suggestion was shown.",
+                "type": "boolean"
+            },
+            {
+                "key": "feature.data.ext.step.redirect_clicked",
+                "description": "Parameter present when the user tapped the redirect suggestion. Absent when the suggestion was not shown or not clicked.",
+                "type": "boolean"
+            },
+            {
+                "key": "feature.data.ext.cancel_reason",
+                "description": "Present only when the flow finished with CANCELLED status. recovered_on_refresh: the user refreshed the failed page and it loaded. error_replaced_on_refresh: the user refreshed and the hostname resolved but the page failed another way, replacing this error page with a different one. abandoned: the user navigated back/forward or home, closed the tab, or submitted a new query.",
+                "enum": ["recovered_on_refresh", "abandoned", "error_replaced_on_refresh"]
+            },
+            {
+                "key": "feature.data.ext.failure_reason",
+                "description": "Present only when the flow finished with FAILURE status, i.e. the tapped redirect suggestion hit another BAD_URL error because the suggested hostname did not resolve either.",
+                "enum": ["new_hostname_resolution_failed"]
+            },
+            {
+                "key": "feature.data.ext.last_step",
+                "description": "Furthest step reached when the flow ended. Persisted as each step is recorded, so flows force-completed by the cleanup policy (UNKNOWN status) still carry it. Absent when the error page was exited before any step was recorded.",
+                "enum": ["redirect_suggested", "redirect_clicked"]
+            },
+            {
+                "key": "feature.data.ext.error_page_duration_ms_bucketed",
+                "description": "How long the error page was displayed before it was exited, bucketed. Uses lower end of the bucket; -1 records a negative measured duration (device clock changed mid-flow). Absent when the flow was force-completed by the cleanup policy.",
+                "enum": ["-1", "0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
+            }
+        ]
+    }
+}

--- a/PixelDefinitions/pixels/definitions/wide_bad_url_error_page.json5
+++ b/PixelDefinitions/pixels/definitions/wide_bad_url_error_page.json5
@@ -34,8 +34,8 @@
             },
             {
                 "key": "feature.data.ext.cancel_reason",
-                "description": "Present only when the flow finished with CANCELLED status. recovered_on_refresh: the user refreshed the failed page and it loaded. error_replaced_on_refresh: the user refreshed and the hostname resolved but the page failed another way, replacing this error page with a different one. abandoned: the user navigated back/forward or home, closed the tab, or submitted a new query.",
-                "enum": ["recovered_on_refresh", "abandoned", "error_replaced_on_refresh"]
+                "description": "Present only when the flow finished with CANCELLED status. recovered_on_refresh: the user refreshed the failed page and it loaded. error_replaced_on_refresh: the user refreshed and this error page was replaced by a different error page. abandoned: the user navigated back/forward or home, closed the tab, or submitted a new query. device_offline: the device was offline when the tapped redirect suggestion was looked up, so whether the suggested hostname resolves is unknowable.",
+                "enum": ["recovered_on_refresh", "abandoned", "error_replaced_on_refresh", "device_offline"]
             },
             {
                 "key": "feature.data.ext.failure_reason",

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -64,8 +64,10 @@ import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.NonHttpAppLink
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.ShouldLaunchDuckChatLink
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.ShouldLaunchSubscriptionLink
 import com.duckduckgo.app.browser.WebViewErrorResponse.BAD_URL
+import com.duckduckgo.app.browser.WebViewErrorResponse.CONNECTION
 import com.duckduckgo.app.browser.WebViewErrorResponse.LOADING
 import com.duckduckgo.app.browser.WebViewErrorResponse.OMITTED
+import com.duckduckgo.app.browser.WebViewErrorResponse.SSL_PROTOCOL_ERROR
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.animations.AddressBarTrackersAnimationManager
 import com.duckduckgo.app.browser.api.OmnibarRepository
@@ -184,6 +186,7 @@ import com.duckduckgo.app.browser.defaultbrowsing.prompts.AdditionalDefaultBrows
 import com.duckduckgo.app.browser.duckplayer.DUCK_PLAYER_FEATURE_NAME
 import com.duckduckgo.app.browser.duckplayer.DUCK_PLAYER_PAGE_FEATURE_NAME
 import com.duckduckgo.app.browser.duckplayer.DuckPlayerJSHelper
+import com.duckduckgo.app.browser.errorpage.BadUrlErrorPageWideEvent
 import com.duckduckgo.app.browser.favicon.FaviconFetchingFixFeature
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.favicon.FaviconSource.ImageFavicon
@@ -609,6 +612,7 @@ class BrowserTabViewModel @Inject constructor(
     private val newTabPageModalTrigger: NewTabPageModalTrigger,
     private val suggestRedirectOnUnresolvedErrorFeature: SuggestRedirectOnUnresolvedErrorFeature,
     private val suggestRedirectEvaluator: SuggestRedirectEvaluator,
+    private val badUrlErrorPageWideEvent: BadUrlErrorPageWideEvent,
 ) : ViewModel(),
     WebViewClientListener,
     EditSavedSiteListener,
@@ -1633,6 +1637,13 @@ class BrowserTabViewModel @Inject constructor(
                 forceExpand = true,
             )
         suggestRedirectJob.cancel()
+        // Re-submitting the tab's current URL (session restoration, crash recovery, user retry)
+        // reloads the page rather than exiting it
+        if (query != url) {
+            badUrlErrorPageWideEvent.onBadUrlErrorPageExited(tabId)
+        } else {
+            badUrlErrorPageWideEvent.onErrorPageRefreshed(tabId)
+        }
         browserViewState.value =
             currentBrowserViewState().copy(
                 browserShowing = true,
@@ -1865,6 +1876,7 @@ class BrowserTabViewModel @Inject constructor(
             browserViewState.value = browserStateModifier.copyForBrowserShowing(currentBrowserViewState())
             command.value = NavigationCommand.Refresh
         } else {
+            badUrlErrorPageWideEvent.onBadUrlErrorPageExited(tabId)
             command.value = NavigationCommand.NavigateForward
         }
     }
@@ -1991,6 +2003,7 @@ class BrowserTabViewModel @Inject constructor(
         }
 
         if (navigation.canGoBack) {
+            badUrlErrorPageWideEvent.onBadUrlErrorPageExited(tabId)
             command.value = NavigationCommand.NavigateBack(navigation.stepsToPreviousPage)
             return true
         } else if (hasSourceTab && !isCustomTab) {
@@ -2024,6 +2037,7 @@ class BrowserTabViewModel @Inject constructor(
         }
         pdfDownloadJob.cancel()
         suggestRedirectJob.cancel()
+        badUrlErrorPageWideEvent.onBadUrlErrorPageExited(tabId)
         site = null
         onSiteChanged()
         webNavigationState = null
@@ -2627,6 +2641,10 @@ class BrowserTabViewModel @Inject constructor(
 
         if (newProgress == 100) {
             hasCompletedPageLoad = true
+            when (currentBrowserViewState().browserError) {
+                OMITTED, LOADING -> badUrlErrorPageWideEvent.onPageLoadFinished(tabId)
+                BAD_URL, CONNECTION, SSL_PROTOCOL_ERROR -> Unit
+            }
             command.value = RefreshUserAgent(url, currentBrowserViewState().isDesktopBrowsingMode)
             navigationAwareLoginDetector.onEvent(NavigationEvent.PageFinished)
         }
@@ -2942,6 +2960,7 @@ class BrowserTabViewModel @Inject constructor(
                 logcat { "SSLError: received ssl error for a page we are not loading, cancelling request" }
                 handler.cancel()
             } else {
+                badUrlErrorPageWideEvent.onOtherErrorPageDisplayed(tabId)
                 browserViewState.value =
                     currentBrowserViewState().copy(
                         browserShowing = false,
@@ -3560,6 +3579,7 @@ class BrowserTabViewModel @Inject constructor(
 
         val targetUrl = if (desktop && uri.isMobileSite) uri.toDesktopUri().toString() else uri.toString()
         logcat(INFO) { "Reloading $targetUrl in ${if (desktop) "desktop" else "mobile"} mode" }
+        badUrlErrorPageWideEvent.onBadUrlErrorPageExited(tabId)
         command.value = NavigationCommand.Navigate(targetUrl, getUrlHeaders(targetUrl))
     }
 
@@ -3628,6 +3648,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     override fun historicalPageSelected(stackIndex: Int) {
+        badUrlErrorPageWideEvent.onBadUrlErrorPageExited(tabId)
         command.value = NavigationCommand.NavigateToHistory(stackIndex)
     }
 
@@ -4568,6 +4589,7 @@ class BrowserTabViewModel @Inject constructor(
     fun refreshBrowserError() {
         suggestRedirectJob.cancel()
         if (currentBrowserViewState().browserError != OMITTED && currentBrowserViewState().browserError != LOADING) {
+            badUrlErrorPageWideEvent.onErrorPageRefreshed(tabId)
             browserViewState.value = currentBrowserViewState().copy(browserError = LOADING, redirectSuggestion = null)
         }
         if (currentBrowserViewState().sslError != NONE) {
@@ -4667,12 +4689,19 @@ class BrowserTabViewModel @Inject constructor(
             command.value = WebViewError(errorType, url)
             suggestRedirectJob.cancel() // Cancel previous in-flight job as the new errorType might not be BAD_URL
         }
+        when (errorType) {
+            BAD_URL -> badUrlErrorPageWideEvent.onBadUrlErrorPageDisplayed(tabId)
+            CONNECTION, SSL_PROTOCOL_ERROR -> badUrlErrorPageWideEvent.onOtherErrorPageDisplayed(tabId)
+            OMITTED -> badUrlErrorPageWideEvent.onOmittedErrorReceived(tabId)
+            LOADING -> Unit
+        }
         if (errorType == BAD_URL &&
             suggestRedirectOnUnresolvedErrorFeature.self().isEnabled() &&
             suggestRedirectOnUnresolvedErrorFeature.suggestRedirect().isEnabled()
         ) {
             suggestRedirectJob += viewModelScope.launch {
                 suggestRedirectEvaluator.suggestRedirect(url)?.let { suggestion ->
+                    badUrlErrorPageWideEvent.onRedirectSuggested(tabId)
                     browserViewState.value = currentBrowserViewState().copy(redirectSuggestion = suggestion)
                 }
             }
@@ -4707,6 +4736,7 @@ class BrowserTabViewModel @Inject constructor(
         )
 
         if (!exempted) {
+            badUrlErrorPageWideEvent.onOtherErrorPageDisplayed(tabId)
             if (currentBrowserViewState().maliciousSiteBlocked && previousSite?.url == url.toString()) {
                 logcat { "maliciousSiteBlocked already shown for $url, previousSite: ${previousSite.url}" }
             } else {
@@ -5988,6 +6018,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onRedirectSuggestionClicked(url: String) {
+        badUrlErrorPageWideEvent.onRedirectClicked(tabId)
         resetBrowserError()
         command.value = NavigationCommand.Navigate(url, getUrlHeaders(url))
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1638,8 +1638,10 @@ class BrowserTabViewModel @Inject constructor(
             )
         suggestRedirectJob.cancel()
         // Re-submitting the tab's current URL (session restoration, crash recovery, user retry)
-        // reloads the page rather than exiting it
-        if (query != url) {
+        // reloads the page rather than exiting it.
+        // The normalized URL is compared instead of the raw input so that retyping a failed hostname
+        // ("example.com") matches the tab's normalized URL ("http://example.com") and counts as a retry.
+        if (urlToNavigate != url) {
             badUrlErrorPageWideEvent.onBadUrlErrorPageExited(tabId)
         } else {
             badUrlErrorPageWideEvent.onErrorPageRefreshed(tabId)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2641,10 +2641,6 @@ class BrowserTabViewModel @Inject constructor(
 
         if (newProgress == 100) {
             hasCompletedPageLoad = true
-            when (currentBrowserViewState().browserError) {
-                OMITTED, LOADING -> badUrlErrorPageWideEvent.onPageLoadFinished(tabId)
-                BAD_URL, CONNECTION, SSL_PROTOCOL_ERROR -> Unit
-            }
             command.value = RefreshUserAgent(url, currentBrowserViewState().isDesktopBrowsingMode)
             navigationAwareLoginDetector.onEvent(NavigationEvent.PageFinished)
         }
@@ -2655,6 +2651,10 @@ class BrowserTabViewModel @Inject constructor(
         webViewNavigationState: WebViewNavigationState,
         url: String?,
     ) {
+        when (currentBrowserViewState().browserError) {
+            OMITTED, LOADING -> badUrlErrorPageWideEvent.onPageLoadFinished(tabId)
+            BAD_URL, CONNECTION, SSL_PROTOCOL_ERROR -> Unit
+        }
         if (!currentBrowserViewState().maliciousSiteBlocked && site != null) {
             navigationStateChanged(webViewNavigationState)
             url?.let { prefetchFavicon(url) }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -4691,7 +4691,8 @@ class BrowserTabViewModel @Inject constructor(
         }
         when (errorType) {
             BAD_URL -> badUrlErrorPageWideEvent.onBadUrlErrorPageDisplayed(tabId)
-            CONNECTION, SSL_PROTOCOL_ERROR -> badUrlErrorPageWideEvent.onOtherErrorPageDisplayed(tabId)
+            CONNECTION -> badUrlErrorPageWideEvent.onConnectionErrorPageDisplayed(tabId)
+            SSL_PROTOCOL_ERROR -> badUrlErrorPageWideEvent.onOtherErrorPageDisplayed(tabId)
             OMITTED -> badUrlErrorPageWideEvent.onOmittedErrorReceived(tabId)
             LOADING -> Unit
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1637,11 +1637,10 @@ class BrowserTabViewModel @Inject constructor(
                 forceExpand = true,
             )
         suggestRedirectJob.cancel()
-        // Re-submitting the tab's current URL (session restoration, crash recovery, user retry)
-        // reloads the page rather than exiting it.
-        // The normalized URL is compared instead of the raw input so that retyping a failed hostname
-        // ("example.com") matches the tab's normalized URL ("http://example.com") and counts as a retry.
-        if (urlToNavigate != url) {
+        // We compare the newly submitted URL and the current URL, stripping the ending slash from both. before comparing them.
+        // This lets us classify re-submission of a same URL as a refresh instead of a user exiting from the BAD_URL error page.
+        // This also covers session restoration or crash recovery.
+        if (urlToNavigate.trimEnd('/') != url?.trimEnd('/')) {
             badUrlErrorPageWideEvent.onBadUrlErrorPageExited(tabId)
         } else {
             badUrlErrorPageWideEvent.onErrorPageRefreshed(tabId)

--- a/app/src/main/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEvent.kt
@@ -94,7 +94,7 @@ interface BadUrlErrorPageWideEvent {
     fun onErrorPageRefreshed(tabId: String)
 
     /**
-     * Must be invoked when a page load settles (reaches full progress) without an error page being displayed.
+     * Must be invoked when a page load finishes without an error page being displayed.
      * @param tabId Indicates the current tab ID.
      */
     fun onPageLoadFinished(tabId: String)

--- a/app/src/main/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEvent.kt
@@ -37,6 +37,8 @@ import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -309,9 +311,10 @@ class RealBadUrlErrorPageWideEvent @Inject constructor(
                 regularTabRepository.flowTabs,
                 fireTabRepository.flowTabs,
             ) { regularTabs, fireTabs -> (regularTabs + fireTabs) }
-                .collect { activeTabs ->
+                .map { activeTabs -> activeTabs.map { it.tabId } }
+                .distinctUntilChanged()
+                .collect { activeTabIds ->
                     mutex.withLock {
-                        val activeTabIds = activeTabs.map { it.tabId }
                         val inactiveTabIds = activeFlows.keys.filter { it !in activeTabIds }
                         for (tabId in inactiveTabIds) {
                             finishFlow(tabId, Cancelled, mapOf(KEY_CANCEL_REASON to CancelReason.ABANDONED.value))

--- a/app/src/main/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEvent.kt
@@ -160,7 +160,7 @@ class RealBadUrlErrorPageWideEvent @Inject constructor(
                     }
                     // The clicked redirect landed on another BAD_URL page: the redirect failed,
                     // and the freshly shown error page starts a flow of its own.
-                    finishFlow(tabId, Failure(reason = FAILURE_REASON_NEW_HOSTNAME_RESOLUTION_FAILED))
+                    failFlow(tabId, FailureReason.NEW_HOSTNAME_RESOLUTION_FAILED)
                 }
                 // The feature flag only gates starting new flows. Flows already in flight always resolve,
                 // here and in every other callback, so no stale state survives a mid-journey flag change.
@@ -178,9 +178,9 @@ class RealBadUrlErrorPageWideEvent @Inject constructor(
                 val state = activeFlows[tabId] ?: return@launch
                 if (state.awaitingRedirectOutcome) {
                     // The device went offline before the suggested hostname could be looked up. It's neither a success nor a feature failure
-                    finishFlow(tabId, Cancelled, mapOf(KEY_CANCEL_REASON to CancelReason.DEVICE_OFFLINE.value))
+                    cancelFlow(tabId, CancelReason.DEVICE_OFFLINE)
                 } else {
-                    finishFlow(tabId, Cancelled, mapOf(KEY_CANCEL_REASON to CancelReason.ERROR_REPLACED_ON_REFRESH.value))
+                    cancelFlow(tabId, CancelReason.ERROR_REPLACED_ON_REFRESH)
                 }
             }
         }
@@ -194,7 +194,7 @@ class RealBadUrlErrorPageWideEvent @Inject constructor(
                     // The suggested hostname resolved. Whatever failed afterwards is out of scope.
                     finishFlow(tabId, Success)
                 } else {
-                    finishFlow(tabId, Cancelled, mapOf(KEY_CANCEL_REASON to CancelReason.ERROR_REPLACED_ON_REFRESH.value))
+                    cancelFlow(tabId, CancelReason.ERROR_REPLACED_ON_REFRESH)
                 }
             }
         }
@@ -236,7 +236,7 @@ class RealBadUrlErrorPageWideEvent @Inject constructor(
                         } else {
                             CancelReason.RECOVERED_ON_REFRESH
                         }
-                        finishFlow(tabId, Cancelled, mapOf(KEY_CANCEL_REASON to cancelReason.value))
+                        cancelFlow(tabId, cancelReason)
                     }
                     else -> Unit // The error page is still displayed, so the flow stays open
                 }
@@ -266,7 +266,7 @@ class RealBadUrlErrorPageWideEvent @Inject constructor(
     override fun onBadUrlErrorPageExited(tabId: String) {
         coroutineScope.launch {
             mutex.withLock {
-                finishFlow(tabId, Cancelled, mapOf(KEY_CANCEL_REASON to CancelReason.ABANDONED.value))
+                cancelFlow(tabId, CancelReason.ABANDONED)
             }
         }
     }
@@ -301,6 +301,14 @@ class RealBadUrlErrorPageWideEvent @Inject constructor(
             metadata = mapOf(KEY_LAST_STEP to stepName),
         )
         logcat { "Recorded $stepName for flowId=${state.flowId}" }
+    }
+
+    private suspend fun cancelFlow(tabId: String, reason: CancelReason) {
+        finishFlow(tabId, Cancelled, mapOf(KEY_CANCEL_REASON to reason.value))
+    }
+
+    private suspend fun failFlow(tabId: String, reason: FailureReason) {
+        finishFlow(tabId, Failure(reason = reason.value))
     }
 
     private suspend fun finishFlow(
@@ -339,7 +347,7 @@ class RealBadUrlErrorPageWideEvent @Inject constructor(
                     mutex.withLock {
                         val inactiveTabIds = activeFlows.keys.filter { it !in activeTabIds }
                         for (tabId in inactiveTabIds) {
-                            finishFlow(tabId, Cancelled, mapOf(KEY_CANCEL_REASON to CancelReason.ABANDONED.value))
+                            cancelFlow(tabId, CancelReason.ABANDONED)
                         }
                     }
                 }
@@ -372,6 +380,10 @@ class RealBadUrlErrorPageWideEvent @Inject constructor(
         DEVICE_OFFLINE("device_offline"),
     }
 
+    private enum class FailureReason(val value: String) {
+        NEW_HOSTNAME_RESOLUTION_FAILED("new_hostname_resolution_failed"),
+    }
+
     private companion object {
         val ERROR_PAGE_INTERVAL_BUCKETS: Set<Duration> = setOf(
             1.seconds,
@@ -389,6 +401,5 @@ class RealBadUrlErrorPageWideEvent @Inject constructor(
         const val KEY_CANCEL_REASON = "cancel_reason"
         const val KEY_LAST_STEP = "last_step"
         const val KEY_ERROR_PAGE_DURATION = "error_page_duration_ms_bucketed"
-        const val FAILURE_REASON_NEW_HOSTNAME_RESOLUTION_FAILED = "new_hostname_resolution_failed"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEvent.kt
@@ -1,0 +1,368 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.errorpage
+
+import android.annotation.SuppressLint
+import com.duckduckgo.app.browser.customtabs.CustomTabViewModel.Companion.CUSTOM_TAB_NAME_PREFIX
+import com.duckduckgo.app.browser.suggestredirect.SuggestRedirectOnUnresolvedErrorFeature
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.statistics.wideevents.CleanupPolicy
+import com.duckduckgo.app.statistics.wideevents.FlowStatus
+import com.duckduckgo.app.statistics.wideevents.FlowStatus.Cancelled
+import com.duckduckgo.app.statistics.wideevents.FlowStatus.Failure
+import com.duckduckgo.app.statistics.wideevents.FlowStatus.Success
+import com.duckduckgo.app.statistics.wideevents.WideEventClient
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.FireMode
+import com.duckduckgo.browsermode.api.RegularMode
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.Lazy
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import logcat.logcat
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Monitors the lifecycle of a BAD_URL (unresolved host) error page as a Wide Event flow, measuring
+ * whether a redirect suggestion was offered, whether the user took it, and whether the suggested
+ * hostname resolved. A successful flow outcome occurs when a redirect suggestion is offered, the
+ * user takes it and the new hostname resolves correctly.
+ *
+ * A repeat BAD_URL error after a refresh keeps the existing flow rather than starting a new one. A
+ * repeat BAD_URL after the redirect suggestion was clicked instead finishes the flow as a failure
+ * and starts a new one for the new BAD_URL error page.
+ */
+interface BadUrlErrorPageWideEvent {
+    /**
+     * Must be invoked when a BAD_URL error page is displayed.
+     * @param tabId Indicates the current tab ID.
+     */
+    fun onBadUrlErrorPageDisplayed(tabId: String)
+
+    /**
+     * Must be invoked when a non-BAD_URL error page (connection, SSL, malicious site) is displayed.
+     * @param tabId Indicates the current tab ID.
+     */
+    fun onOtherErrorPageDisplayed(tabId: String)
+
+    /**
+     * Must be invoked when an OMITTED error (one that does not display an error page) is received.
+     * @param tabId Indicates the current tab ID.
+     */
+    fun onOmittedErrorReceived(tabId: String)
+
+    /**
+     * Must be invoked when an error page is refreshed.
+     * @param tabId Indicates the current tab ID.
+     */
+    fun onErrorPageRefreshed(tabId: String)
+
+    /**
+     * Must be invoked when a page load settles (reaches full progress) without an error page being displayed.
+     * @param tabId Indicates the current tab ID.
+     */
+    fun onPageLoadFinished(tabId: String)
+
+    /**
+     * Must be invoked when a redirect suggestion is displayed on the error page.
+     * @param tabId Indicates the current tab ID.
+     */
+    fun onRedirectSuggested(tabId: String)
+
+    /**
+     * Must be invoked when a redirect suggestion is clicked by the user.
+     * @param tabId Indicates the current tab ID.
+     */
+    fun onRedirectClicked(tabId: String)
+
+    /**
+     * Must be invoked when the user exits the BAD_URL error page by navigating away.
+     * @param tabId Indicates the current tab ID.
+     */
+    fun onBadUrlErrorPageExited(tabId: String)
+}
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealBadUrlErrorPageWideEvent @Inject constructor(
+    private val wideEventClient: WideEventClient,
+    private val badUrlErrorPageWideEventFeature: Lazy<BadUrlErrorPageWideEventFeature>,
+    private val suggestRedirectFeature: SuggestRedirectOnUnresolvedErrorFeature,
+    @param:RegularMode private val regularTabRepository: TabRepository,
+    @param:FireMode private val fireTabRepository: TabRepository,
+    private val dispatchers: DispatcherProvider,
+    @AppCoroutineScope appCoroutineScope: CoroutineScope,
+) : BadUrlErrorPageWideEvent {
+    // This is to ensure modifications of the wide event are serialized
+    @SuppressLint("AvoidComputationUsage")
+    private val coroutineScope = CoroutineScope(
+        context = appCoroutineScope.coroutineContext +
+            dispatchers.computation().limitedParallelism(1),
+    )
+
+    private val mutex = Mutex()
+    private val activeFlows = ConcurrentHashMap<String, FlowState>()
+
+    // No synchronization needed for this job var as it's only mutated inside a lock
+    private var closedTabsObserverJob: Job? = null
+
+    override fun onBadUrlErrorPageDisplayed(tabId: String) {
+        coroutineScope.launch {
+            mutex.withLock {
+                // Custom tabs are excluded: they never register in the tab repositories, so the
+                // closed-tabs observer would cancel their flows as abandoned immediately.
+                if (tabId.startsWith(CUSTOM_TAB_NAME_PREFIX)) {
+                    return@launch
+                }
+                val existingFlow = activeFlows[tabId]
+                if (existingFlow != null) {
+                    if (!existingFlow.awaitingRedirectOutcome) {
+                        // A refresh that was awaiting its outcome concluded in the same error
+                        existingFlow.awaitingRefreshOutcome = false
+                        logcat { "Bad URL error page flow already active for tabId=$tabId, keeping it" }
+                        return@launch
+                    }
+                    // The clicked redirect landed on another BAD_URL page: the redirect failed,
+                    // and the freshly shown error page starts a flow of its own.
+                    finishFlow(tabId, Failure(reason = FAILURE_REASON_NEW_HOSTNAME_RESOLUTION_FAILED))
+                }
+                // The feature flag only gates starting new flows. Flows already in flight always resolve,
+                // here and in every other callback, so no stale state survives a mid-journey flag change.
+                if (!isRecordingEnabled()) {
+                    return@launch
+                }
+                startFlow(tabId)
+            }
+        }
+    }
+
+    override fun onOtherErrorPageDisplayed(tabId: String) {
+        coroutineScope.launch {
+            mutex.withLock {
+                val state = activeFlows[tabId] ?: return@launch
+                if (state.awaitingRedirectOutcome) {
+                    // The suggested hostname resolved. Whatever failed afterwards is out of scope.
+                    finishFlow(tabId, Success)
+                } else {
+                    finishFlow(tabId, Cancelled, mapOf(KEY_CANCEL_REASON to CancelReason.ERROR_REPLACED_ON_REFRESH.value))
+                }
+            }
+        }
+    }
+
+    override fun onOmittedErrorReceived(tabId: String) {
+        coroutineScope.launch {
+            mutex.withLock {
+                val state = activeFlows[tabId] ?: return@launch
+                state.omittedErrorReceived = true
+            }
+        }
+    }
+
+    override fun onErrorPageRefreshed(tabId: String) {
+        coroutineScope.launch {
+            mutex.withLock {
+                val state = activeFlows[tabId] ?: return@launch
+                state.awaitingRefreshOutcome = true
+                // Only errors received after the refresh began count towards its outcome
+                state.omittedErrorReceived = false
+            }
+        }
+    }
+
+    override fun onPageLoadFinished(tabId: String) {
+        coroutineScope.launch {
+            mutex.withLock {
+                val state = activeFlows[tabId] ?: return@launch
+                when {
+                    state.awaitingRedirectOutcome -> {
+                        // The suggested hostname resolved. Whatever failed afterwards is out of scope.
+                        finishFlow(tabId, Success)
+                    }
+                    state.awaitingRefreshOutcome -> {
+                        // Transient errors can be reclassified mid-load, so the load outcome is decided only once the load settles fully.
+                        val cancelReason = if (state.omittedErrorReceived) {
+                            CancelReason.ERROR_REPLACED_ON_REFRESH
+                        } else {
+                            CancelReason.RECOVERED_ON_REFRESH
+                        }
+                        finishFlow(tabId, Cancelled, mapOf(KEY_CANCEL_REASON to cancelReason.value))
+                    }
+                    else -> Unit // The error page is still displayed, so the flow stays open
+                }
+            }
+        }
+    }
+
+    override fun onRedirectSuggested(tabId: String) {
+        coroutineScope.launch {
+            mutex.withLock {
+                val state = activeFlows[tabId] ?: return@launch
+                recordStep(state, STEP_REDIRECT_SUGGESTED)
+            }
+        }
+    }
+
+    override fun onRedirectClicked(tabId: String) {
+        coroutineScope.launch {
+            mutex.withLock {
+                val state = activeFlows[tabId] ?: return@launch
+                state.awaitingRedirectOutcome = true
+                recordStep(state, STEP_REDIRECT_CLICKED)
+            }
+        }
+    }
+
+    override fun onBadUrlErrorPageExited(tabId: String) {
+        coroutineScope.launch {
+            mutex.withLock {
+                finishFlow(tabId, Cancelled, mapOf(KEY_CANCEL_REASON to CancelReason.ABANDONED.value))
+            }
+        }
+    }
+
+    private suspend fun startFlow(tabId: String) {
+        wideEventClient.flowStart(
+            name = FLOW_NAME,
+            cleanupPolicy = CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
+            samplingProbability = 1.0f,
+        ).onSuccess { flowId ->
+            activeFlows[tabId] = FlowState(flowId)
+            startClosedTabsObserverJob()
+            logcat { "Bad URL error page flow started: tabId=$tabId, flowId=$flowId" }
+            wideEventClient.intervalStart(
+                wideEventId = flowId,
+                key = KEY_ERROR_PAGE_DURATION,
+                buckets = ERROR_PAGE_INTERVAL_BUCKETS,
+            )
+        }.onFailure { error ->
+            logcat { "Failed to start bad URL error page flow for tabId=$tabId: ${error.message}" }
+        }
+    }
+
+    private suspend fun recordStep(state: FlowState, stepName: String) {
+        if (!state.recordedSteps.add(stepName)) {
+            logcat { "Ignoring repeat $stepName for flowId=${state.flowId}" }
+            return
+        }
+        wideEventClient.flowStep(
+            wideEventId = state.flowId,
+            stepName = stepName,
+            metadata = mapOf(KEY_LAST_STEP to stepName),
+        )
+        logcat { "Recorded $stepName for flowId=${state.flowId}" }
+    }
+
+    private suspend fun finishFlow(
+        tabId: String,
+        status: FlowStatus,
+        metadata: Map<String, String> = emptyMap(),
+    ) {
+        val state = activeFlows.remove(tabId) ?: return
+        wideEventClient.intervalEnd(
+            wideEventId = state.flowId,
+            key = KEY_ERROR_PAGE_DURATION,
+        )
+        wideEventClient.flowFinish(
+            wideEventId = state.flowId,
+            status = status,
+            metadata = metadata,
+        )
+        logcat { "Bad URL error page flow finished: tabId=$tabId, flowId=${state.flowId}, status=$status, metadata=$metadata" }
+        if (activeFlows.isEmpty()) {
+            stopClosedTabsObserverJob()
+        }
+    }
+
+    private fun startClosedTabsObserverJob() {
+        if (closedTabsObserverJob != null) {
+            return
+        }
+        closedTabsObserverJob = coroutineScope.launch {
+            combine(
+                regularTabRepository.flowTabs,
+                fireTabRepository.flowTabs,
+            ) { regularTabs, fireTabs -> (regularTabs + fireTabs) }
+                .collect { activeTabs ->
+                    mutex.withLock {
+                        val activeTabIds = activeTabs.map { it.tabId }
+                        val inactiveTabIds = activeFlows.keys.filter { it !in activeTabIds }
+                        for (tabId in inactiveTabIds) {
+                            finishFlow(tabId, Cancelled, mapOf(KEY_CANCEL_REASON to CancelReason.ABANDONED.value))
+                        }
+                    }
+                }
+        }
+    }
+
+    private fun stopClosedTabsObserverJob() {
+        closedTabsObserverJob?.cancel()
+        closedTabsObserverJob = null
+    }
+
+    private suspend fun isRecordingEnabled(): Boolean = withContext(dispatchers.io()) {
+        // Suggest redirect feature conditions to be removed once we remove its feature flag
+        badUrlErrorPageWideEventFeature.get().self().isEnabled() &&
+            suggestRedirectFeature.self().isEnabled() &&
+            suggestRedirectFeature.suggestRedirect().isEnabled()
+    }
+
+    private class FlowState(val flowId: Long) {
+        val recordedSteps: MutableSet<String> = mutableSetOf()
+        var awaitingRedirectOutcome: Boolean = false
+        var awaitingRefreshOutcome: Boolean = false
+        var omittedErrorReceived: Boolean = false
+    }
+
+    private enum class CancelReason(val value: String) {
+        RECOVERED_ON_REFRESH("recovered_on_refresh"),
+        ABANDONED("abandoned"),
+        ERROR_REPLACED_ON_REFRESH("error_replaced_on_refresh"),
+    }
+
+    private companion object {
+        val ERROR_PAGE_INTERVAL_BUCKETS: Set<Duration> = setOf(
+            1.seconds,
+            2.seconds,
+            3.seconds,
+            4.seconds,
+            5.seconds,
+            10.seconds,
+            30.seconds,
+            1.minutes,
+        )
+        const val FLOW_NAME = "bad-url-error-page"
+        const val STEP_REDIRECT_SUGGESTED = "redirect_suggested"
+        const val STEP_REDIRECT_CLICKED = "redirect_clicked"
+        const val KEY_CANCEL_REASON = "cancel_reason"
+        const val KEY_LAST_STEP = "last_step"
+        const val KEY_ERROR_PAGE_DURATION = "error_page_duration_ms_bucketed"
+        const val FAILURE_REASON_NEW_HOSTNAME_RESOLUTION_FAILED = "new_hostname_resolution_failed"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEvent.kt
@@ -68,7 +68,15 @@ interface BadUrlErrorPageWideEvent {
     fun onBadUrlErrorPageDisplayed(tabId: String)
 
     /**
-     * Must be invoked when a non-BAD_URL error page (connection, SSL, malicious site) is displayed.
+     * Must be invoked when a connection error page (device offline during host lookup) is
+     * displayed. Unlike other non-BAD_URL error pages, it does not prove the hostname resolved.
+     * @param tabId Indicates the current tab ID.
+     */
+    fun onConnectionErrorPageDisplayed(tabId: String)
+
+    /**
+     * Must be invoked when a non-BAD_URL error page that proves the hostname resolved (SSL,
+     * malicious site) is displayed.
      * @param tabId Indicates the current tab ID.
      */
     fun onOtherErrorPageDisplayed(tabId: String)
@@ -160,6 +168,20 @@ class RealBadUrlErrorPageWideEvent @Inject constructor(
                     return@launch
                 }
                 startFlow(tabId)
+            }
+        }
+    }
+
+    override fun onConnectionErrorPageDisplayed(tabId: String) {
+        coroutineScope.launch {
+            mutex.withLock {
+                val state = activeFlows[tabId] ?: return@launch
+                if (state.awaitingRedirectOutcome) {
+                    // The device went offline before the suggested hostname could be looked up. It's neither a success nor a feature failure
+                    finishFlow(tabId, Cancelled, mapOf(KEY_CANCEL_REASON to CancelReason.DEVICE_OFFLINE.value))
+                } else {
+                    finishFlow(tabId, Cancelled, mapOf(KEY_CANCEL_REASON to CancelReason.ERROR_REPLACED_ON_REFRESH.value))
+                }
             }
         }
     }
@@ -347,6 +369,7 @@ class RealBadUrlErrorPageWideEvent @Inject constructor(
         RECOVERED_ON_REFRESH("recovered_on_refresh"),
         ABANDONED("abandoned"),
         ERROR_REPLACED_ON_REFRESH("error_replaced_on_refresh"),
+        DEVICE_OFFLINE("device_offline"),
     }
 
     private companion object {

--- a/app/src/main/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEventFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEventFeature.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.errorpage
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+/**
+ * Controls whether [BadUrlErrorPageWideEvent] sends the `bad-url-error-page` wide event.
+ */
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "badUrlErrorPageWideEvent",
+)
+interface BadUrlErrorPageWideEventFeature {
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun self(): Toggle
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -112,6 +112,7 @@ import com.duckduckgo.app.browser.defaultbrowsing.prompts.AdditionalDefaultBrows
 import com.duckduckgo.app.browser.duckplayer.DUCK_PLAYER_FEATURE_NAME
 import com.duckduckgo.app.browser.duckplayer.DUCK_PLAYER_PAGE_FEATURE_NAME
 import com.duckduckgo.app.browser.duckplayer.DuckPlayerJSHelper
+import com.duckduckgo.app.browser.errorpage.BadUrlErrorPageWideEvent
 import com.duckduckgo.app.browser.favicon.FaviconFetchingFixFeature
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.favicon.FaviconSource
@@ -744,6 +745,7 @@ class BrowserTabViewModelTest {
     private val fakeRememberDesktopModeFeature = FakeFeatureToggleFactory.create(RememberDesktopModeFeature::class.java)
     private val fakeSuggestRedirectFeature = FakeFeatureToggleFactory.create(SuggestRedirectOnUnresolvedErrorFeature::class.java)
     private val mockSuggestRedirectEvaluator: SuggestRedirectEvaluator = mock()
+    private val mockBadUrlErrorPageWideEvent: BadUrlErrorPageWideEvent = mock()
     private val mockInlinePdfHandler: InlinePdfHandler = mock()
     private val mockPdfDownloadTooltipDataStore: PdfDownloadTooltipDataStore = mock()
     private val mockCachedFileDownloader: CachedFileDownloader = mock()
@@ -1093,6 +1095,7 @@ class BrowserTabViewModelTest {
                 newTabPageModalTrigger = mockNewTabPageModalTrigger,
                 suggestRedirectOnUnresolvedErrorFeature = fakeSuggestRedirectFeature,
                 suggestRedirectEvaluator = mockSuggestRedirectEvaluator,
+                badUrlErrorPageWideEvent = mockBadUrlErrorPageWideEvent,
             )
 
         testee.loadData("abc", null, false, false)
@@ -9079,6 +9082,247 @@ class BrowserTabViewModelTest {
         advanceUntilIdle()
 
         assertEquals(redirectSuggestion, browserViewState().redirectSuggestion)
+    }
+
+    @Test
+    fun whenBadUrlErrorReceivedAndNoRedirectSuggestionFoundThenWideEventErrorPageDisplayedWithoutSuggestion() = runTest {
+        fakeSuggestRedirectFeature.apply {
+            self().setRawStoredState(State(enable = true))
+            suggestRedirect().setRawStoredState(State(enable = true))
+        }
+        whenever(mockSuggestRedirectEvaluator.suggestRedirect(any()))
+            .thenReturn(null)
+
+        testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+
+        // redirect_suggested must mean a suggestion was shown to the user, not that the check ran
+        verify(mockBadUrlErrorPageWideEvent).onBadUrlErrorPageDisplayed("abc")
+        verify(mockBadUrlErrorPageWideEvent, never()).onRedirectSuggested(any())
+    }
+
+    @Test
+    fun whenBadUrlErrorReceivedAndSuggestRedirectDisabledThenWideEventErrorPageDisplayedStillReported() = runTest {
+        fakeSuggestRedirectFeature.suggestRedirect().setRawStoredState(State(enable = false))
+
+        testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+
+        // The hook reports every BAD_URL error page, whether to record is gated centrally in the wide event implementation, not here.
+        verify(mockBadUrlErrorPageWideEvent).onBadUrlErrorPageDisplayed("abc")
+        verify(mockBadUrlErrorPageWideEvent, never()).onRedirectSuggested(any())
+    }
+
+    @Test
+    fun whenBadUrlErrorReceivedAndRedirectSuggestionFoundThenWideEventRedirectSuggested() = runTest {
+        fakeSuggestRedirectFeature.apply {
+            self().setRawStoredState(State(enable = true))
+            suggestRedirect().setRawStoredState(State(enable = true))
+        }
+        whenever(mockSuggestRedirectEvaluator.suggestRedirect(any()))
+            .thenReturn(RedirectSuggestion(domain = "www.example.com", url = "http://www.example.com"))
+
+        testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+
+        verify(mockBadUrlErrorPageWideEvent).onRedirectSuggested("abc")
+    }
+
+    @Test
+    fun whenRedirectSuggestionClickedThenWideEventRedirectClickedAndNoExitReported() = runTest {
+        testee.onRedirectSuggestionClicked("http://www.example.com")
+
+        // The flow must stay open awaiting the redirect outcome, so no exit is reported here.
+        verify(mockBadUrlErrorPageWideEvent).onRedirectClicked("abc")
+        verify(mockBadUrlErrorPageWideEvent, never()).onBadUrlErrorPageExited(any())
+    }
+
+    @Test
+    fun whenPageLoadCompletesThenWideEventPageLoadFinished() = runTest {
+        loadUrl("http://www.example.com")
+
+        testee.progressChanged(100, WebViewNavigationState(mockStack, 100))
+
+        verify(mockBadUrlErrorPageWideEvent).onPageLoadFinished("abc")
+    }
+
+    @Test
+    fun whenPageLoadCompletesWhileErrorPageShowingThenWideEventPageLoadFinishedNotCalled() = runTest {
+        loadUrl("http://example.com")
+        testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+
+        testee.progressChanged(100, WebViewNavigationState(mockStack, 100))
+
+        verify(mockBadUrlErrorPageWideEvent, never()).onPageLoadFinished(any())
+    }
+
+    @Test
+    fun whenWebViewRefreshedWhileErrorPageShowingThenWideEventErrorPageRefreshed() = runTest {
+        testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+
+        testee.onWebViewRefreshed()
+
+        verify(mockBadUrlErrorPageWideEvent).onErrorPageRefreshed("abc")
+    }
+
+    @Test
+    fun whenWebViewRefreshedWithoutErrorPageThenWideEventErrorPageRefreshedNotCalled() = runTest {
+        testee.onWebViewRefreshed()
+
+        verify(mockBadUrlErrorPageWideEvent, never()).onErrorPageRefreshed(any())
+    }
+
+    @Test
+    fun whenOmittedErrorReceivedThenWideEventOmittedErrorReceived() = runTest {
+        testee.onReceivedError(OMITTED, "http://example.com", "ERROR_CONNECT")
+
+        verify(mockBadUrlErrorPageWideEvent).onOmittedErrorReceived("abc")
+    }
+
+    @Test
+    fun whenPageLoadCompletesWhileErrorPageRefreshingThenWideEventPageLoadFinished() = runTest {
+        loadUrl("http://example.com")
+        testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+        testee.onWebViewRefreshed()
+
+        testee.progressChanged(100, WebViewNavigationState(mockStack, 100))
+
+        verify(mockBadUrlErrorPageWideEvent).onPageLoadFinished("abc")
+    }
+
+    @Test
+    fun whenTransientErrorPrecedesBadUrlErrorThenWideEventPageLoadFinishedNotCalled() = runTest {
+        loadUrl("http://example.com")
+        testee.onReceivedError(OMITTED, "http://www.example.com", "ERROR_UNKNOWN")
+        testee.onReceivedError(BAD_URL, "http://www.example.com", "ERROR_HOST_LOOKUP")
+
+        testee.progressChanged(100, WebViewNavigationState(mockStack, 100))
+
+        verify(mockBadUrlErrorPageWideEvent).onBadUrlErrorPageDisplayed("abc")
+        verify(mockBadUrlErrorPageWideEvent, never()).onPageLoadFinished(any())
+    }
+
+    @Test
+    fun whenUserSubmittedQueryWithNewUrlThenWideEventBadUrlErrorPageExited() = runTest {
+        loadUrl("http://example.com")
+        whenever(mockOmnibarConverter.convertQueryToUrl("http://another-site.com", null))
+            .thenReturn("http://another-site.com")
+
+        testee.onUserSubmittedQuery("http://another-site.com")
+
+        verify(mockBadUrlErrorPageWideEvent).onBadUrlErrorPageExited("abc")
+        verify(mockBadUrlErrorPageWideEvent, never()).onErrorPageRefreshed(any())
+    }
+
+    @Test
+    fun whenUserSubmittedQueryWithCurrentUrlThenWideEventErrorPageRefreshedAndNoExitReported() = runTest {
+        loadUrl("http://example.com")
+        whenever(mockOmnibarConverter.convertQueryToUrl("http://example.com", null))
+            .thenReturn("http://example.com")
+
+        testee.onUserSubmittedQuery("http://example.com")
+
+        // Re-submitting the failing URL is a retry of the same journey, not an exit.
+        verify(mockBadUrlErrorPageWideEvent).onErrorPageRefreshed("abc")
+        verify(mockBadUrlErrorPageWideEvent, never()).onBadUrlErrorPageExited(any())
+    }
+
+    @Test
+    fun whenNonBadUrlErrorReceivedThenWideEventOtherErrorPageDisplayed() = runTest {
+        testee.onReceivedError(CONNECTION, "http://example.com", "ERROR_CONNECT")
+
+        verify(mockBadUrlErrorPageWideEvent).onOtherErrorPageDisplayed("abc")
+    }
+
+    @Test
+    fun whenSslWarningShownThenWideEventOtherErrorPageDisplayed() {
+        whenever(mockEnabledToggle.isEnabled())
+            .thenReturn(true)
+        val url = exampleUrl
+        givenCurrentSite(url)
+        val certificate = aRSASslCertificate()
+        val sslErrorResponse = SslErrorResponse(SslError(SslError.SSL_EXPIRED, certificate, url), EXPIRED, url)
+
+        testee.onReceivedSslError(aHandler(), sslErrorResponse)
+
+        // givenCurrentSite reloads the ViewModel under the "TAB_ID" tab
+        verify(mockBadUrlErrorPageWideEvent).onOtherErrorPageDisplayed("TAB_ID")
+    }
+
+    @Test
+    fun whenMaliciousSiteWarningShownThenWideEventOtherErrorPageDisplayed() = runTest {
+        testee.onReceivedMaliciousSiteWarning(
+            "https://www.malicious.com".toUri(),
+            Feed.PHISHING,
+            exempted = false,
+            clientSideHit = false,
+            isMainframe = true,
+        )
+
+        verify(mockBadUrlErrorPageWideEvent).onOtherErrorPageDisplayed("abc")
+    }
+
+    @Test
+    fun whenMaliciousSiteWarningExemptedThenWideEventOtherErrorPageDisplayedNotCalled() = runTest {
+        testee.onReceivedMaliciousSiteWarning(
+            "https://www.malicious.com".toUri(),
+            Feed.PHISHING,
+            exempted = true,
+            clientSideHit = false,
+            isMainframe = true,
+        )
+
+        verify(mockBadUrlErrorPageWideEvent, never()).onOtherErrorPageDisplayed(any())
+    }
+
+    @Test
+    fun whenUserPressedBackAndCanGoBackThenWideEventBadUrlErrorPageExited() = runTest {
+        setupNavigation(isBrowsing = true, canGoBack = true)
+
+        testee.onUserPressedBack()
+
+        verify(mockBadUrlErrorPageWideEvent).onBadUrlErrorPageExited("abc")
+    }
+
+    @Test
+    fun whenUserPressedBackAndNavigatesHomeThenWideEventBadUrlErrorPageExited() = runTest {
+        setupNavigation(isBrowsing = true, canGoBack = false)
+
+        testee.onUserPressedBack()
+
+        verify(mockBadUrlErrorPageWideEvent).onBadUrlErrorPageExited("abc")
+    }
+
+    @Test
+    fun whenUserPressedForwardThenWideEventBadUrlErrorPageExited() = runTest {
+        setBrowserShowing(true)
+
+        testee.onUserPressedForward()
+
+        verify(mockBadUrlErrorPageWideEvent).onBadUrlErrorPageExited("abc")
+    }
+
+    @Test
+    fun whenUserOnErrorPagePressesForwardThenWideEventExitNotReported() = runTest {
+        // Forward from an error page reloads the failing page rather than navigating away
+        setBrowserShowing(false)
+
+        testee.onUserPressedForward()
+
+        verify(mockBadUrlErrorPageWideEvent, never()).onBadUrlErrorPageExited(any())
+    }
+
+    @Test
+    fun whenHistoricalPageSelectedThenWideEventBadUrlErrorPageExited() = runTest {
+        testee.historicalPageSelected(stackIndex = 1)
+
+        verify(mockBadUrlErrorPageWideEvent).onBadUrlErrorPageExited("abc")
+    }
+
+    @Test
+    fun whenBrowserModeChangedThenWideEventBadUrlErrorPageExited() = runTest {
+        loadUrl("http://example.com")
+
+        testee.onChangeBrowserModeClicked()
+
+        verify(mockBadUrlErrorPageWideEvent).onBadUrlErrorPageExited("abc")
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -9252,6 +9252,19 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenUserSubmittedQueryRetypesFailedHostnameThenWideEventErrorPageRefreshedAndNoExitReported() = runTest {
+        loadUrl("http://example.com")
+        whenever(mockOmnibarConverter.convertQueryToUrl("example.com", null))
+            .thenReturn("http://example.com")
+
+        testee.onUserSubmittedQuery("example.com")
+
+        // The raw input differs from the tab's URL only by normalization, so it's a retry, not an exit.
+        verify(mockBadUrlErrorPageWideEvent).onErrorPageRefreshed("abc")
+        verify(mockBadUrlErrorPageWideEvent, never()).onBadUrlErrorPageExited(any())
+    }
+
+    @Test
     fun whenConnectionErrorReceivedThenWideEventConnectionErrorPageDisplayed() = runTest {
         testee.onReceivedError(CONNECTION, "http://example.com", "ERROR_CONNECT")
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -77,6 +77,7 @@ import com.duckduckgo.app.browser.WebViewErrorResponse.BAD_URL
 import com.duckduckgo.app.browser.WebViewErrorResponse.CONNECTION
 import com.duckduckgo.app.browser.WebViewErrorResponse.LOADING
 import com.duckduckgo.app.browser.WebViewErrorResponse.OMITTED
+import com.duckduckgo.app.browser.WebViewErrorResponse.SSL_PROTOCOL_ERROR
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.animations.AddressBarTrackersAnimationManager
 import com.duckduckgo.app.browser.api.OmnibarRepository
@@ -9225,10 +9226,19 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenNonBadUrlErrorReceivedThenWideEventOtherErrorPageDisplayed() = runTest {
+    fun whenConnectionErrorReceivedThenWideEventConnectionErrorPageDisplayed() = runTest {
         testee.onReceivedError(CONNECTION, "http://example.com", "ERROR_CONNECT")
 
+        verify(mockBadUrlErrorPageWideEvent).onConnectionErrorPageDisplayed("abc")
+        verify(mockBadUrlErrorPageWideEvent, never()).onOtherErrorPageDisplayed(any())
+    }
+
+    @Test
+    fun whenSslProtocolErrorReceivedThenWideEventOtherErrorPageDisplayed() = runTest {
+        testee.onReceivedError(SSL_PROTOCOL_ERROR, "http://example.com", "ERROR_FAILED_SSL_HANDSHAKE")
+
         verify(mockBadUrlErrorPageWideEvent).onOtherErrorPageDisplayed("abc")
+        verify(mockBadUrlErrorPageWideEvent, never()).onConnectionErrorPageDisplayed(any())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -9136,18 +9136,27 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenPageLoadCompletesThenWideEventPageLoadFinished() = runTest {
+    fun whenPageFinishedThenWideEventPageLoadFinished() = runTest {
         loadUrl("http://www.example.com")
 
-        testee.progressChanged(100, WebViewNavigationState(mockStack, 100))
+        testee.pageFinished(mockWebView, WebViewNavigationState(mockStack, 100), "http://www.example.com")
 
         verify(mockBadUrlErrorPageWideEvent).onPageLoadFinished("abc")
     }
 
     @Test
-    fun whenPageLoadCompletesWhileErrorPageShowingThenWideEventPageLoadFinishedNotCalled() = runTest {
+    fun whenPageFinishedWhileErrorPageShowingThenWideEventPageLoadFinishedNotCalled() = runTest {
         loadUrl("http://example.com")
         testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+
+        testee.pageFinished(mockWebView, WebViewNavigationState(mockStack, 100), "http://example.com")
+
+        verify(mockBadUrlErrorPageWideEvent, never()).onPageLoadFinished(any())
+    }
+
+    @Test
+    fun whenProgressReaches100ThenWideEventPageLoadFinishedNotCalled() = runTest {
+        loadUrl("http://www.example.com")
 
         testee.progressChanged(100, WebViewNavigationState(mockStack, 100))
 
@@ -9178,12 +9187,12 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenPageLoadCompletesWhileErrorPageRefreshingThenWideEventPageLoadFinished() = runTest {
+    fun whenPageFinishedWhileErrorPageRefreshingThenWideEventPageLoadFinished() = runTest {
         loadUrl("http://example.com")
         testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
         testee.onWebViewRefreshed()
 
-        testee.progressChanged(100, WebViewNavigationState(mockStack, 100))
+        testee.pageFinished(mockWebView, WebViewNavigationState(mockStack, 100), "http://example.com")
 
         verify(mockBadUrlErrorPageWideEvent).onPageLoadFinished("abc")
     }
@@ -9194,10 +9203,27 @@ class BrowserTabViewModelTest {
         testee.onReceivedError(OMITTED, "http://www.example.com", "ERROR_UNKNOWN")
         testee.onReceivedError(BAD_URL, "http://www.example.com", "ERROR_HOST_LOOKUP")
 
-        testee.progressChanged(100, WebViewNavigationState(mockStack, 100))
+        testee.pageFinished(mockWebView, WebViewNavigationState(mockStack, 100), "http://www.example.com")
 
         verify(mockBadUrlErrorPageWideEvent).onBadUrlErrorPageDisplayed("abc")
         verify(mockBadUrlErrorPageWideEvent, never()).onPageLoadFinished(any())
+    }
+
+    @Test
+    fun whenProgressReaches100BeforeRepeatBadUrlErrorDuringRefreshThenWideEventPageLoadFinishedNotCalled() = runTest {
+        // Reproduces the reload race: Chromium can report full progress before dispatching the
+        // main-frame error, which must not settle the refresh as recovered.
+        loadUrl("http://example.com")
+        testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+        testee.onWebViewRefreshed()
+
+        testee.progressChanged(100, WebViewNavigationState(mockStack, 100))
+        testee.onReceivedError(BAD_URL, "http://example.com", "ERROR_HOST_LOOKUP")
+        testee.pageFinished(mockWebView, WebViewNavigationState(mockStack, 100), "http://example.com")
+
+        verify(mockBadUrlErrorPageWideEvent, never()).onPageLoadFinished(any())
+        verify(mockBadUrlErrorPageWideEvent, times(2)).onBadUrlErrorPageDisplayed("abc")
+        verify(mockBadUrlErrorPageWideEvent).onErrorPageRefreshed("abc")
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEventTest.kt
@@ -1,0 +1,717 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.errorpage
+
+import com.duckduckgo.app.browser.customtabs.CustomTabViewModel.Companion.CUSTOM_TAB_NAME_PREFIX
+import com.duckduckgo.app.browser.suggestredirect.SuggestRedirectOnUnresolvedErrorFeature
+import com.duckduckgo.app.statistics.wideevents.CleanupPolicy
+import com.duckduckgo.app.statistics.wideevents.FlowStatus
+import com.duckduckgo.app.statistics.wideevents.WideEventClient
+import com.duckduckgo.app.tabs.model.TabEntity
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import kotlin.time.Duration.Companion.milliseconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BadUrlErrorPageWideEventTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule(StandardTestDispatcher())
+
+    private val wideEventClient: WideEventClient = mock()
+    private val badUrlErrorPageWideEventFeature = FakeFeatureToggleFactory.create(BadUrlErrorPageWideEventFeature::class.java)
+    private val suggestRedirectFeature = FakeFeatureToggleFactory.create(SuggestRedirectOnUnresolvedErrorFeature::class.java)
+    private val regularTabRepository: TabRepository = mock()
+    private val fireTabRepository: TabRepository = mock()
+    private val openTabs = MutableStateFlow(listOf(TabEntity(tabId = TAB_ID), TabEntity(tabId = OTHER_TAB_ID)))
+
+    private lateinit var testee: RealBadUrlErrorPageWideEvent
+
+    @Before
+    fun setup() = runTest {
+        badUrlErrorPageWideEventFeature.self().setRawStoredState(Toggle.State(enable = true))
+        suggestRedirectFeature.self().setRawStoredState(Toggle.State(enable = true))
+        suggestRedirectFeature.suggestRedirect().setRawStoredState(Toggle.State(enable = true))
+
+        whenever(
+            wideEventClient.flowStart(
+                any(),
+                anyOrNull(),
+                any(),
+                any(),
+                any(),
+                any(),
+            ),
+        ).thenReturn(Result.success(FLOW_ID))
+        whenever(
+            wideEventClient.flowStep(
+                any(),
+                any(),
+                any(),
+                any(),
+            ),
+        ).thenReturn(Result.success(Unit))
+        whenever(
+            wideEventClient.intervalStart(
+                any(),
+                any(),
+                anyOrNull(),
+                any(),
+            ),
+        ).thenReturn(Result.success(Unit))
+        whenever(
+            wideEventClient.intervalEnd(
+                any(),
+                any(),
+            ),
+        ).thenReturn(Result.success(100.milliseconds))
+        whenever(
+            wideEventClient.flowFinish(
+                any(),
+                any(),
+                any(),
+            ),
+        ).thenReturn(Result.success(Unit))
+
+        whenever(regularTabRepository.flowTabs).thenReturn(openTabs)
+        whenever(fireTabRepository.flowTabs).thenReturn(MutableStateFlow(emptyList()))
+
+        testee = RealBadUrlErrorPageWideEvent(
+            wideEventClient = wideEventClient,
+            badUrlErrorPageWideEventFeature = { badUrlErrorPageWideEventFeature },
+            suggestRedirectFeature = suggestRedirectFeature,
+            regularTabRepository = regularTabRepository,
+            fireTabRepository = fireTabRepository,
+            dispatchers = coroutineRule.testDispatcherProvider,
+            appCoroutineScope = coroutineRule.testScope,
+        )
+    }
+
+    //region Wide event Feature Flag tests
+    @Test
+    fun `when wide event feature disabled, then error page displayed does not start flow`() = runTest {
+        badUrlErrorPageWideEventFeature.self().setRawStoredState(Toggle.State(enable = false))
+
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient, never()).flowStart(
+            any(),
+            anyOrNull(),
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test
+    fun `when suggest redirect feature disabled, then error page displayed does not start flow`() = runTest {
+        suggestRedirectFeature.suggestRedirect().setRawStoredState(Toggle.State(enable = false))
+
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient, never()).flowStart(
+            any(),
+            anyOrNull(),
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test
+    fun `when feature disabled mid-flow, then active flows still finish`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        advanceUntilIdle()
+        badUrlErrorPageWideEventFeature.self().setRawStoredState(Toggle.State(enable = false))
+
+        testee.onBadUrlErrorPageExited(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf("cancel_reason" to "abandoned"),
+        )
+    }
+
+    @Test
+    fun `when feature disabled mid-flow, then a repeat BAD_URL after redirect click still finishes as failure without a new flow`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onRedirectClicked(TAB_ID)
+        advanceUntilIdle()
+        badUrlErrorPageWideEventFeature.self().setRawStoredState(Toggle.State(enable = false))
+
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Failure(reason = "new_hostname_resolution_failed"),
+            metadata = emptyMap(),
+        )
+        verify(wideEventClient, times(1)).flowStart(
+            any(),
+            anyOrNull(),
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+    }
+    //endregion
+
+    //region Wide event flow start tests
+    @Test
+    fun `when error page displayed, then flow started and duration interval started`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).flowStart(
+            name = "bad-url-error-page",
+            cleanupPolicy = CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
+        )
+        verify(wideEventClient).intervalStart(
+            eq(FLOW_ID),
+            eq("error_page_duration_ms_bucketed"),
+            anyOrNull(),
+            any(),
+        )
+    }
+
+    @Test
+    fun `when error page displayed while flow active for tab, then no new flow started`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient, times(1)).flowStart(
+            any(),
+            anyOrNull(),
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test
+    fun `when error page displayed on two tabs, then each tab tracked by its own flow`() = runTest {
+        whenever(
+            wideEventClient.flowStart(
+                any(),
+                anyOrNull(),
+                any(),
+                any(),
+                any(),
+                any(),
+            ),
+        ).thenReturn(
+            Result.success(FLOW_ID),
+            Result.success(OTHER_FLOW_ID),
+        )
+
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onBadUrlErrorPageDisplayed(OTHER_TAB_ID)
+        testee.onBadUrlErrorPageExited(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient, times(2)).flowStart(
+            any(),
+            anyOrNull(),
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verify(wideEventClient).flowFinish(
+            eq(FLOW_ID),
+            any(),
+            any(),
+        )
+        verify(wideEventClient, never()).flowFinish(
+            eq(OTHER_FLOW_ID),
+            any(),
+            any(),
+        )
+    }
+
+    @Test
+    fun `when error page displayed after exit, then new flow started`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onBadUrlErrorPageExited(TAB_ID)
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient, times(2)).flowStart(
+            any(),
+            anyOrNull(),
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test
+    fun `when flow start fails, then subsequent events are no-ops`() = runTest {
+        whenever(
+            wideEventClient.flowStart(
+                any(),
+                anyOrNull(),
+                any(),
+                any(),
+                any(),
+                any(),
+            ),
+        ).thenReturn(Result.failure(RuntimeException("Error!")))
+
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onRedirectSuggested(TAB_ID)
+        testee.onBadUrlErrorPageExited(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient, never()).flowStep(
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verify(wideEventClient, never()).flowFinish(
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test
+    fun `when error page displayed on a custom tab, then no wide event is started`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(CUSTOM_TAB_ID)
+        testee.onRedirectSuggested(CUSTOM_TAB_ID)
+        testee.onBadUrlErrorPageExited(CUSTOM_TAB_ID)
+        advanceUntilIdle()
+
+        verifyNoInteractions(wideEventClient)
+    }
+    //endregion
+
+    //region No active flow tests
+    @Test
+    fun `when events arrive without an active flow, then nothing is recorded`() = runTest {
+        testee.onRedirectSuggested(TAB_ID)
+        testee.onRedirectClicked(TAB_ID)
+        testee.onOtherErrorPageDisplayed(TAB_ID)
+        testee.onOmittedErrorReceived(TAB_ID)
+        testee.onPageLoadFinished(TAB_ID)
+        testee.onErrorPageRefreshed(TAB_ID)
+        testee.onBadUrlErrorPageExited(TAB_ID)
+        advanceUntilIdle()
+
+        verifyNoInteractions(wideEventClient)
+    }
+    //endregion
+
+    //region Wide event Redirect Suggested step tests
+    @Test
+    fun `when redirect suggested, then step recorded once with last_step metadata`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onRedirectSuggested(TAB_ID)
+        testee.onRedirectSuggested(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient, times(1)).flowStep(
+            wideEventId = FLOW_ID,
+            stepName = "redirect_suggested",
+            metadata = mapOf("last_step" to "redirect_suggested"),
+        )
+    }
+
+    @Test
+    fun `when redirect suggested again after a kept retry error, then step not recorded again`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onRedirectSuggested(TAB_ID)
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onRedirectSuggested(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient, times(1)).flowStep(
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+    }
+    //endregion
+
+    //region Wide event Redirect Clicked step tests
+    @Test
+    fun `when redirect clicked, then step recorded and flow stays open awaiting the outcome`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onRedirectClicked(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).flowStep(
+            wideEventId = FLOW_ID,
+            stepName = "redirect_clicked",
+            metadata = mapOf("last_step" to "redirect_clicked"),
+        )
+        verify(wideEventClient, never()).intervalEnd(
+            any(),
+            any(),
+        )
+        verify(wideEventClient, never()).flowFinish(
+            any(),
+            any(),
+            any(),
+        )
+    }
+    //endregion
+
+    //region Wide event flow finish tests
+    @Test
+    fun `when page load finishes after redirect clicked, then flow finished with success`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onRedirectClicked(TAB_ID)
+        testee.onPageLoadFinished(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).intervalEnd(
+            FLOW_ID,
+            "error_page_duration_ms_bucketed",
+        )
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Success,
+            metadata = emptyMap(),
+        )
+    }
+
+    @Test
+    fun `when other error page displayed after redirect clicked, then flow finished with success`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onRedirectClicked(TAB_ID)
+        testee.onOtherErrorPageDisplayed(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Success,
+            metadata = emptyMap(),
+        )
+    }
+
+    @Test
+    fun `when other error page displayed without redirect clicked, then flow cancelled as error_replaced_on_refresh`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onOtherErrorPageDisplayed(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf("cancel_reason" to "error_replaced_on_refresh"),
+        )
+    }
+
+    @Test
+    fun `when new BAD_URL error displayed after redirect clicked, then flow finished with failure and a new flow started`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onRedirectClicked(TAB_ID)
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Failure(reason = "new_hostname_resolution_failed"),
+            metadata = emptyMap(),
+        )
+        verify(wideEventClient, times(2)).flowStart(
+            any(),
+            anyOrNull(),
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verify(wideEventClient, times(2)).intervalStart(
+            any(),
+            any(),
+            anyOrNull(),
+            any(),
+        )
+    }
+
+    @Test
+    fun `when error page exited after redirect clicked, then flow finished as abandoned`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onRedirectClicked(TAB_ID)
+        testee.onBadUrlErrorPageExited(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf("cancel_reason" to "abandoned"),
+        )
+    }
+
+    @Test
+    fun `when error page exited, then flow finished as abandoned`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onBadUrlErrorPageExited(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).intervalEnd(
+            FLOW_ID,
+            "error_page_duration_ms_bucketed",
+        )
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf("cancel_reason" to "abandoned"),
+        )
+    }
+
+    @Test
+    fun `when page load finishes without omitted error after error page refreshed, then flow finished as recovered_on_refresh`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onErrorPageRefreshed(TAB_ID)
+        testee.onPageLoadFinished(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).intervalEnd(
+            FLOW_ID,
+            "error_page_duration_ms_bucketed",
+        )
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf("cancel_reason" to "recovered_on_refresh"),
+        )
+    }
+
+    @Test
+    fun `when page load finishes with omitted error after error page refreshed, then flow finished as error_replaced_on_refresh`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onErrorPageRefreshed(TAB_ID)
+        testee.onOmittedErrorReceived(TAB_ID)
+        testee.onPageLoadFinished(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf("cancel_reason" to "error_replaced_on_refresh"),
+        )
+    }
+
+    @Test
+    fun `when omitted error received before refresh, then refresh outcome still recovered_on_refresh`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onOmittedErrorReceived(TAB_ID)
+        testee.onErrorPageRefreshed(TAB_ID)
+        testee.onPageLoadFinished(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf("cancel_reason" to "recovered_on_refresh"),
+        )
+    }
+
+    @Test
+    fun `when page load finishes without redirect clicked, then flow not finished`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onPageLoadFinished(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient, never()).flowFinish(
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test
+    fun `when page load finishes with omitted error without refresh or redirect click, then flow not finished`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onOmittedErrorReceived(TAB_ID)
+        testee.onPageLoadFinished(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient, never()).flowFinish(
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test
+    fun `when page load finishes with omitted error after redirect clicked, then flow finished with success`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onRedirectClicked(TAB_ID)
+        testee.onOmittedErrorReceived(TAB_ID)
+        testee.onPageLoadFinished(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Success,
+            metadata = emptyMap(),
+        )
+    }
+
+    @Test
+    fun `when refresh hits the same BAD_URL error, then flow kept and a later page load does not finish it`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onErrorPageRefreshed(TAB_ID)
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onPageLoadFinished(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient, times(1)).flowStart(
+            any(),
+            anyOrNull(),
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verify(wideEventClient, never()).flowFinish(
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test
+    fun `when page load finishes after the flow already finished, then nothing finished again`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onRedirectClicked(TAB_ID)
+        testee.onBadUrlErrorPageExited(TAB_ID)
+        testee.onPageLoadFinished(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient, times(1)).flowFinish(
+            any(),
+            any(),
+            any(),
+        )
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf("cancel_reason" to "abandoned"),
+        )
+    }
+    //endregion
+
+    //region Closed tab detection tests
+    @Test
+    fun `when tab with active flow is removed, then flow finished as abandoned`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        advanceUntilIdle()
+
+        openTabs.value = listOf(TabEntity(tabId = OTHER_TAB_ID))
+        advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf("cancel_reason" to "abandoned"),
+        )
+    }
+
+    @Test
+    fun `when tab without active flow is removed, then its removal finishes nothing`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        advanceUntilIdle()
+
+        openTabs.value = listOf(TabEntity(tabId = TAB_ID))
+        advanceUntilIdle()
+
+        verify(wideEventClient, never()).flowFinish(
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test
+    fun `when tab removed during a second flow started after the first finished, then second flow finished as abandoned`() = runTest {
+        whenever(
+            wideEventClient.flowStart(
+                any(),
+                anyOrNull(),
+                any(),
+                any(),
+                any(),
+                any(),
+            ),
+        ).thenReturn(
+            Result.success(FLOW_ID),
+            Result.success(OTHER_FLOW_ID),
+        )
+
+        // Finishing the only active flow stops the closed-tab detection. A second flow should re-launch it
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onErrorPageRefreshed(TAB_ID)
+        testee.onPageLoadFinished(TAB_ID)
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        advanceUntilIdle()
+
+        openTabs.value = listOf(TabEntity(tabId = OTHER_TAB_ID))
+        advanceUntilIdle()
+
+        // Check that the closed-tab detection was re-launched by verifying that it triggered the second flow to finish after closing the tab
+        verify(wideEventClient).flowFinish(
+            wideEventId = OTHER_FLOW_ID,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf("cancel_reason" to "abandoned"),
+        )
+    }
+    //endregion
+
+    private companion object {
+        const val FLOW_ID = 123L
+        const val OTHER_FLOW_ID = 456L
+        const val TAB_ID = "tab_1"
+        const val OTHER_TAB_ID = "tab_2"
+        const val CUSTOM_TAB_ID = "${CUSTOM_TAB_NAME_PREFIX}tab_3"
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/errorpage/BadUrlErrorPageWideEventTest.kt
@@ -336,6 +336,7 @@ class BadUrlErrorPageWideEventTest {
         testee.onRedirectSuggested(TAB_ID)
         testee.onRedirectClicked(TAB_ID)
         testee.onOtherErrorPageDisplayed(TAB_ID)
+        testee.onConnectionErrorPageDisplayed(TAB_ID)
         testee.onOmittedErrorReceived(TAB_ID)
         testee.onPageLoadFinished(TAB_ID)
         testee.onErrorPageRefreshed(TAB_ID)
@@ -432,6 +433,33 @@ class BadUrlErrorPageWideEventTest {
             wideEventId = FLOW_ID,
             status = FlowStatus.Success,
             metadata = emptyMap(),
+        )
+    }
+
+    @Test
+    fun `when connection error page displayed after redirect clicked, then flow cancelled as device_offline`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onRedirectClicked(TAB_ID)
+        testee.onConnectionErrorPageDisplayed(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf("cancel_reason" to "device_offline"),
+        )
+    }
+
+    @Test
+    fun `when connection error page displayed without redirect clicked, then flow cancelled as error_replaced_on_refresh`() = runTest {
+        testee.onBadUrlErrorPageDisplayed(TAB_ID)
+        testee.onConnectionErrorPageDisplayed(TAB_ID)
+        advanceUntilIdle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = FLOW_ID,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf("cancel_reason" to "error_replaced_on_refresh"),
         )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217396665225423?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/72649045549333/task/1217396665225421?focus=true

## Description
### Goal
We're introducing a new wide event, `BadUrlErrorPageWideEvent`, with the goal of measuring how the new [suggestion on unresolved bare domains](https://app.asana.com/1/137249556945/project/72649045549333/task/1216998526866684?focus=true) feature is used by our users and what impact it's having.

### Feature flag for the wide event
For this new wide event, we're also introducing a new feature flag, `BadUrlErrorPageWideEventFeature`,  which will let us control whether the wide event is enabled or not independently. This way, after we remove the feature flag for the suggest redirect feature, we can still control whether this wide event is enabled or not. Note that whether the wide event is enabled will depend also depend on the suggest redirect feature flag until we remove the latter.

### What it does?
It monitors the lifecycle of a `BAD_URL` (unresolved host) error page, measuring:
- Whether a redirect suggestion was offered
- Whether the user took it
- Whether the suggested hostname resolved or not

A **successful flow outcome** occurs when a redirect suggestion is offered, the user takes it and the new hostname resolves correctly.

The following diagram depicts the possible cases:
 
<img width="1640" height="1348" alt="bad_url_error_page_wide_event_flow" src="https://github.com/user-attachments/assets/f8328b31-92fd-412b-a256-6cb08c70593f" />

## Steps to test this PR
These test cases cover all important flows we discussed.

### Setup
1. Make sure you have the feature flags enabled in the DDG app:
    1. Go to `Settings` > `Internal developer settings` > `Feature flag inventory`.
    2. Enable `suggestRedirectOnUnresolvedError` and its sub-feature `suggestRedirect` (both default to off).
    3. Confirm `badUrlErrorPageWideEvent` is enabled (defaults on for internal builds).
    4. Confirm `wideEvents` are enabled (defaults on). 

2. Set up this handy filter on Android Studio's logcat (optional)
```
message:"bad url error page flow" | message:"Recorded redirect" | message: "Ignoring repeat" | message: "wide_bad-url-error-page"
```

### Test 1: No suggestion displayed, then navigated away → `Cancelled (abandoned)`
#### Steps
1. Open a new tab and navigate to `notfound.gov`.
2. Confirm the `BAD_URL` error page is displayed with no redirect suggestion.
3. Press `Back`.

#### Expected logs
```text
On error page:  Bad URL error page flow started: tabId=…, flowId=N
On back:        Bad URL error page flow finished: … flowId=N, status=Cancelled, metadata={cancel_reason=abandoned}
Shortly after:  Pixel sent: … wide_bad-url-error-page_c … feature.status=CANCELLED … cancel_reason=abandoned
```

### Test 2: Suggestion displayed, then navigated away → `Cancelled (abandoned)`
#### Steps
1. Open a new tab and navigate to `airnow.gov`.
2. Confirm the `BAD_URL` error page is displayed with the `Did you mean www.airnow.gov?` redirect suggestion.
3. Tap the address bar, type any other search or URL, and submit it.

#### Expected logs
```text
On error page:  Bad URL error page flow started: … flowId=N
On suggestion:  Recorded redirect_suggested for flowId=N
On new query:   Bad URL error page flow finished: … status=Cancelled, metadata={cancel_reason=abandoned}
Shortly after:  Pixel sent: … wide_bad-url-error-page_c … feature.status=CANCELLED … step.redirect_suggested=true … last_step=redirect_suggested, cancel_reason=abandoned
```

### Test 3: Suggestion displayed, then closed tab → `Cancelled (abandoned)`
#### Steps
1. Open a new tab and navigate to `airnow.gov`.
2. Confirm the `BAD_URL` error page is displayed with the `Did you mean www.airnow.gov?` redirect suggestion.
3. Open the tab switcher and close that tab.

#### Expected logs
```text
On error page:  Bad URL error page flow started: … flowId=N
On suggestion:  Recorded redirect_suggested for flowId=N
On tab closed:  Bad URL error page flow finished: … status=Cancelled, metadata={cancel_reason=abandoned}
Shortly after:  Pixel sent: … wide_bad-url-error-page_c … CANCELLED … step.redirect_suggested=true, cancel_reason=abandoned
```

### Test 4: Refreshed BAD_URL error page, then same BAD_URL error displayed → `No new flow`
#### Steps
1. Open a new tab and navigate to `notfound.gov`. Note the flowId in the started line.
2. Refresh the error page (pull-to-refresh or the menu's refresh action).
3. Confirm the same `BAD_URL` error page is displayed again.
4. Press `Back`.

#### Expected logs
```text
On error page:     Bad URL error page flow started: tabId=…, flowId=N
On refresh error:  Bad URL error page flow already active for tabId=…, keeping it
On back:           Bad URL error page flow finished: … flowId=N, status=Cancelled, metadata={cancel_reason=abandoned}
Shortly after:     Pixel sent: … wide_bad-url-error-page_c … CANCELLED … cancel_reason=abandoned
```

### Test 5: Refreshed BAD_URL error page, then page loaded → `Cancelled (recovered_on_refresh)`
#### Steps
1. In Android's `Settings` > `Network & internet` > `Private DNS`, set the provider hostname to `invalid.dns.test` (or any bogus hostname there breaks all DNS resolution).
2. In a new tab navigate to a known-good site, e.g. `example.com`.
3. Confirm the `BAD_URL` error page is displayed with no redirect suggestion.
4. Restore `Private DNS` to `Automatic`.
5. Back in the app, refresh the error page.
6. Confirm the page now loads.

#### Expected logs
```text
On error page:         Bad URL error page flow started: … flowId=N
After refresh + load:  Bad URL error page flow finished: … status=Cancelled, metadata={cancel_reason=recovered_on_refresh}
Shortly after:         Pixel sent: … wide_bad-url-error-page_c … CANCELLED … cancel_reason=recovered_on_refresh
```

### Test 6: Refreshed BAD_URL error page, then different error page displayed → `Cancelled (error_replaced_on_refresh)`
#### Steps
1. In Android's `Settings` > `Network & internet` > `Private DNS`, set the provider hostname to `invalid.dns.test` (or any bogus hostname there breaks all DNS resolution).
2. In a new tab navigate to `expired.badssl.com`.
3. Confirm the `BAD_URL` error page is displayed (the DNS lookup failed).
4. Restore `Private DNS` to `Automatic`.
5. Refresh the error page.
6. Confirm the SSL warning page is displayed instead (the hostname now resolves but the certificate is expired).

#### Expected logs
```text
On error page:   Bad URL error page flow started: … flowId=N
On SSL warning:  Bad URL error page flow finished: … status=Cancelled, metadata={cancel_reason=error_replaced_on_refresh}
Shortly after:   Pixel sent: … wide_bad-url-error-page_c … CANCELLED … cancel_reason=error_replaced_on_refresh
```

### Test 7: Suggestion tapped, then new hostname resolved → `Success`
#### Steps
1. Open a new tab and navigate to `airnow.gov`.
2. Confirm the `BAD_URL` error page is displayed with the `Did you mean www.airnow.gov?` redirect suggestion.
3. Tap the suggestion.
4. Confirm the `www.airnow.gov` page loads.

#### Expected logs
```text
On error page:  Bad URL error page flow started: … flowId=N
On suggestion:  Recorded redirect_suggested for flowId=N
On tap:         Recorded redirect_clicked for flowId=N
On page load:   Bad URL error page flow finished: … status=Success, metadata={}
Shortly after:  Pixel sent: … wide_bad-url-error-page_c … feature.status=SUCCESS … step.redirect_suggested=true, step.redirect_clicked=true … last_step=redirect_clicked
```

### Test 8: Suggestion tapped, then new hostname resolved → `Success`
#### Steps
1. Close the app (swipe it away from Recents) and relaunch it, to clear the app's DNS resolution caches.
2. Open a new tab and navigate to `airnow.gov`.
3. Confirm the `BAD_URL` error page is displayed with the `Did you mean www.airnow.gov?` redirect suggestion. Do not tap it yet.
4. Switch to Android's `Settings` > `Network & internet` > `Private DNS` and set the provider hostname to `invalid.dns.test` (or any bogus hostname there breaks all DNS resolution), then return to the app.
5. Tap the suggestion.
6. Confirm a `BAD_URL` error page is displayed again (the www. lookup now fails).
7. Cleanup: restore `Private DNS` to `Automatic`.

#### Expected logs
```text
On error page:    Bad URL error page flow started: … flowId=N
On suggestion:    Recorded redirect_suggested for flowId=N
On tap:           Recorded redirect_clicked for flowId=N
On second error:  Bad URL error page flow finished: … flowId=N, status=Failure(reason=new_hostname_resolution_failed)
                  Bad URL error page flow started: … flowId=M (new flow)
Shortly after:    Pixel sent: … wide_bad-url-error-page_c … feature.status=FAILURE … step.redirect_suggested=true, step.redirect_clicked=true … failure_reason=new_hostname_resolution_failed, last_step=redirect_clicked
```

### Test 9: App killed mid-flow → `Unknown`
#### Steps
1. Open a new tab and navigate to `airnow.gov`.
2. Confirm the `BAD_URL` error page is displayed with the `Did you mean www.airnow.gov?` redirect suggestion.
3. Kill the app: swipe it away from Recents.
4. Relaunch the app and watch logcat.

#### Expected logs
```text
On error page:           Bad URL error page flow started: … flowId=N
On suggestion:           Recorded redirect_suggested for flowId=N
On kill:                 no "flow finished" line — the cleanup itself is silent
Shortly after relaunch:  Pixel sent: … wide_bad-url-error-page_c … feature.status=UNKNOWN … step.redirect_suggested=true, last_step=redirect_suggested
On restored error page:  Bad URL error page flow started: … flowId=M (new flow)
                         Recorded redirect_suggested for flowId=M
```

### Test 10: Custom tabs excluded → `Now new flows`
#### Steps
1. In the app's `Settings`, go to `Developer Settings` > `Custom Tabs`.
2. The custom tab opens in the device's default browser: if the `Default Browser` row doesn't say DuckDuckGo, tap it and set DuckDuckGo as default.
3. Enter `notfound.gov` in the URL field and tap `Load Custom Tab`.
4. Confirm the `BAD_URL` error page is displayed inside the DuckDuckGo custom tab UI.

#### Expected logs
No related logs should appear.

### Test 11: Custom tabs excluded → `Now new flows`
#### Steps
1. In the app's `Settings` > `Developer Settings` > `Feature Flag Inventory`, disable `badUrlErrorPageWideEvent`.
2. Open a new tab and navigate to `notfound.gov`. Then press `Back`.
3. Re-enable the flag afterwards.

#### Expected logs
No related logs should appear.

### Test 12: Wide event feature flag disabled mid-flow → `Cancelled (abandoned)`
#### Steps
1. With `badUrlErrorPageWideEvent` enabled, open a new tab and navigate to `notfound.gov`.
2. Disable `badUrlErrorPageWideEvent` in the flag inventory.
3. Return to the tab and press `Back`.
4. Navigate to `notfound.gov` again in the same tab.
5. Re-enable the flag afterwards.

#### Expected logs
```text
On error page:      Bad URL error page flow started: … flowId=N
On back:            Bad URL error page flow finished: … status=Cancelled, metadata={cancel_reason=abandoned}
Shortly after:      Pixel sent: … wide_bad-url-error-page_c … CANCELLED … cancel_reason=abandoned
On new navigation:  no new "flow started" line
```

### Test 13: Suggestion tapped while the device is offline → `Cancelled (device_offline)`
#### Steps
1. Open a new tab and navigate to `airnow.gov`.
2. Confirm the `BAD_URL` error page is displayed with the `Did you mean www.airnow.gov?` redirect suggestion. Do not tap it yet.
3. Enable `Airplane mode` so the device is offline and return to the app.
4. Tap the suggestion.
5. Confirm the connection error page ("The internet connection appears to be offline.") is displayed.
6. Cleanup: restore connectivity.

#### Expected logs
```text
On error page:     Bad URL error page flow started: … flowId=N
On suggestion:     Recorded redirect_suggested for flowId=N
On tap:            Recorded redirect_clicked for flowId=N
On offline error:  Bad URL error page flow finished: … flowId=N, status=Cancelled, metadata={cancel_reason=device_offline}
Shortly after:     Pixel sent: … wide_bad-url-error-page_c … CANCELLED … step.redirect_suggested=true, step.redirect_clicked=true … last_step=redirect_clicked, cancel_reason=device_offline
```

### UI changes
N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are analytics and navigation hook wiring around existing error-page behavior; no auth or payment paths. Risk is mainly misclassified flows or extra callbacks if browser state races, covered by extensive unit tests.
> 
> **Overview**
> Adds **wide event telemetry** for unresolved-host (`BAD_URL`) error pages so product can measure the suggest-redirect feature: whether a “Did you mean …?” suggestion was shown, tapped, and whether the suggested host resolved.
> 
> A new **`BadUrlErrorPageWideEvent`** flow (`bad-url-error-page`) tracks per-tab journeys (regular and fire tabs only; custom tabs excluded), records steps `redirect_suggested` / `redirect_clicked`, buckets time on the error page, and finishes as **Success**, **Failure** (`new_hostname_resolution_failed`), or **Cancelled** (`abandoned`, `recovered_on_refresh`, `error_replaced_on_refresh`, `device_offline`). Recording is gated by **`badUrlErrorPageWideEvent`** plus the existing suggest-redirect flags; in-flight flows still complete if flags flip mid-journey.
> 
> **`BrowserTabViewModel`** is wired at error display, refresh, redirect tap, successful `pageFinished`, navigation away (back, home, forward, history, desktop mode toggle, new URL vs same-URL resubmit), SSL/malicious/connection errors, and tab close via repository observation. Pixel schema is defined in **`wide_bad_url_error_page.json5`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 742f18b2f6c7a06089e56f2b1fab870d6bfd44f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->