### PR TITLE
Stop enrolling users in the dock only variant of the add to dock/ widget prompt onboarding experiment

### DIFF
--- a/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
+++ b/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
@@ -960,7 +960,7 @@
                         },
                         {
                             "name": "treatmentDockOnly",
-                            "weight": 1
+                            "weight": 0
                         },
                         {
                             "name": "treatmentWidgetOnly",


### PR DESCRIPTION
Task/Issue URL:https://app.asana.com/1/137249556945/project/72649045549333/task/1218044639614461?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

Sets the weight of the `treatmentDockOnly` experiment variant to `0`, effectively disabling enrollment into this variant while keeping it defined in the configuration.

### Steps to test this PR

_QA-optional_

### UI changes

| Before | After |
| --- | --- |
| N/A | N/A |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON cohort weight change with no application code changes; low risk aside from shifting onboarding experiment traffic.
> 
> **Overview**
> Updates **`privacy_config.json`** for the **`addToDockAndWidgetExperimentJul25`** onboarding experiment by setting the **`treatmentDockOnly`** cohort weight from **1** to **0**.
> 
> New users will no longer be assigned to the dock-only treatment; **control**, **widget-only**, and **dock-and-widget** cohorts keep their existing weights. The variant remains in the config so already-enrolled users and metrics wiring are unaffected—only enrollment distribution changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac0e6abc5c770939c186c7685297b71cc334d8cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->