### PR TITLE
Contextual: Add special handling for SERP + address shipreview comments

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1791,6 +1791,13 @@
         "suffixes": ["first_daily_count", "form_factor"],
         "parameters": ["appVersion"]
     },
+    "aichat_contextual_open_duckai_menu_tapped": {
+        "description": "Fired when the user selects Open Duck.ai in the contextual sheet chats menu",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "aichat_contextual_floating_input_opened": {
         "description": "Fired when the floating contextual input (entry) is opened",
         "owners": ["karlenDimla"],

--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1784,6 +1784,13 @@
         "suffixes": ["first_daily_count", "form_factor"],
         "parameters": ["appVersion"]
     },
+    "aichat_contextual_address_bar_menu_ask_about_search_selected": {
+        "description": "Fired when the user selects Ask About Search in the address bar Duck.ai menu",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "aichat_contextual_floating_input_opened": {
         "description": "Fired when the floating contextual input (entry) is opened",
         "owners": ["karlenDimla"],

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3102,10 +3102,11 @@ class BrowserTabFragment :
 
             is Command.ShowDuckAIContextualMode -> {
                 val tabId = it.tabId
+                val sourceUrl = it.sourceUrl
                 val anchor = duckChatButtonAnchor
                 duckChatButtonAnchor = null
                 viewLifecycleOwner.lifecycleScope.launch(dispatchers.main()) {
-                    duckChatContextual.launch(tabId, anchor) { showDuckChatContextualSheet(tabId) }
+                    duckChatContextual.launch(tabId, sourceUrl, anchor) { showDuckChatContextualSheet(tabId) }
                 }
             }
             is Command.StartAddressBarTrackersAnimation -> {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -5845,7 +5845,7 @@ class BrowserTabViewModel @Inject constructor(
             // unfocused omnibar. Once the omnibar is focused (composing), fall through to full-screen
             // Duck.ai.
             duckAiFeatureState.showContextualMode.value && !isNtp && !hasFocus -> {
-                command.value = Command.ShowDuckAIContextualMode(tabId)
+                command.value = Command.ShowDuckAIContextualMode(tabId, url)
             }
 
             else -> {

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -527,7 +527,7 @@ sealed class Command {
     data class EnableDuckAIFullScreen(val browserViewState: BrowserViewState) : Command()
     data class DuckAIFullScreenDisabled(val url: String) : Command()
 
-    data class ShowDuckAIContextualMode(val tabId: String) : Command()
+    data class ShowDuckAIContextualMode(val tabId: String, val sourceUrl: String?) : Command()
 
     data class StartAddressBarTrackersAnimation(val trackerEntities: List<Entity>?) : Command()
 

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatContextual.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatContextual.kt
@@ -37,6 +37,7 @@ interface DuckChatContextual {
      */
     suspend fun launch(
         sourceTabId: String,
+        sourceUrl: String?,
         anchor: View?,
         showChatSurface: () -> Unit,
     )

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewFragment.kt
@@ -689,6 +689,9 @@ class DuckChatContextualWebViewFragment :
         headerDivider.visibility = View.VISIBLE
         popup.onMenuItemClicked(newChatRow) { viewModel.onNewChatRequestedFromPopup() }
 
+        val openDuckAiRow = content.findViewById<PopupMenuItemView>(R.id.contextualChatsPopupOpenDuckAi)
+        popup.onMenuItemClicked(openDuckAiRow) { viewModel.onOpenDuckAiFromPopup() }
+
         val recentContainer = content.findViewById<LinearLayout>(R.id.contextualChatsPopupRecentContainer)
         recentContainer.removeAllViews()
         recentChats.forEach { chat ->

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -723,6 +723,13 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
         }
     }
 
+    fun onOpenDuckAiFromPopup() {
+        val url = duckChat.getDuckChatUrl(query = "", autoPrompt = false)
+        val sourceTabId = _viewState.value.tabId
+        duckChatInternal.reportDuckChatEntry(DuckChatEntryPoint.CONTEXTUAL_CHAT, opensNewTab = true, hasPrompt = false)
+        commandChannel.trySend(Command.OpenChatUrl(url = url, sourceTabId = sourceTabId))
+    }
+
     fun onRecentChatClicked(chatId: String) {
         duckChatPixels.reportContextualRecentChatSelected()
         val url = duckChatInternal.buildChatUrl(chatId)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModel.kt
@@ -724,6 +724,7 @@ class DuckChatContextualWebViewViewModel @Inject constructor(
     }
 
     fun onOpenDuckAiFromPopup() {
+        duckChatPixels.reportContextualOpenDuckAiMenuTapped()
         val url = duckChat.getDuckChatUrl(query = "", autoPrompt = false)
         val sourceTabId = _viewState.value.tabId
         duckChatInternal.reportDuckChatEntry(DuckChatEntryPoint.CONTEXTUAL_CHAT, opensNewTab = true, hasPrompt = false)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
@@ -116,7 +116,7 @@ class RealDuckChatContextual @Inject constructor(
         if (serpQuery != null) {
             askItem.setPrimaryText(activity.getString(R.string.duckChatContextualAskAboutSearch))
             popup.onMenuItemClicked(askItem) {
-                duckChatPixels.reportContextualAddressBarMenuAskAboutPageSelected()
+                duckChatPixels.reportContextualAddressBarMenuAskAboutSearchSelected()
                 openSearchChatInSheet(sourceTabId, serpQuery, onAskAboutPage)
             }
         } else {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
@@ -23,8 +23,10 @@ import android.view.LayoutInflater
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.findFragment
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.common.ui.menu.PopupMenu
+import com.duckduckgo.common.ui.view.PopupMenuItemView
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckChatContextual
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
@@ -43,10 +45,13 @@ class RealDuckChatContextual @Inject constructor(
     private val sessionTimeoutProvider: DuckChatContextualSessionTimeoutProvider,
     private val timeProvider: DuckChatContextualTimeProvider,
     private val duckChatPixels: DuckChatPixels,
+    private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector,
+    private val contextualEntryPromptStore: ContextualEntryPromptStore,
 ) : DuckChatContextual {
 
     override suspend fun launch(
         sourceTabId: String,
+        sourceUrl: String?,
         anchor: View?,
         showChatSurface: () -> Unit,
     ) {
@@ -58,7 +63,11 @@ class RealDuckChatContextual @Inject constructor(
             // The sheet would reopen the existing chat for this tab, so skip the entry menu and open it directly.
             showChatSurface()
         } else {
-            showMenu(sourceTabId, anchor, showChatSurface)
+            val serpQuery = sourceUrl
+                ?.takeIf { duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(it) }
+                ?.let { duckDuckGoUrlDetector.extractQuery(it) }
+                ?.takeIf { it.isNotBlank() }
+            showMenu(sourceTabId, anchor, serpQuery, showChatSurface)
         }
     }
 
@@ -93,6 +102,7 @@ class RealDuckChatContextual @Inject constructor(
     private fun showMenu(
         sourceTabId: String,
         anchor: View,
+        serpQuery: String?,
         onAskAboutPage: () -> Unit,
     ) {
         val activity = anchor.activity() ?: return
@@ -102,9 +112,18 @@ class RealDuckChatContextual @Inject constructor(
             duckChatPixels.reportContextualAddressBarMenuNewChatSelected()
             openNewChatTab(activity, sourceTabId)
         }
-        popup.onMenuItemClicked(content.findViewById(R.id.contextualChatMenuAskAboutPage)) {
-            duckChatPixels.reportContextualAddressBarMenuAskAboutPageSelected()
-            showEntryDialog(anchor, sourceTabId, onAskAboutPage)
+        val askItem = content.findViewById<PopupMenuItemView>(R.id.contextualChatMenuAskAboutPage)
+        if (serpQuery != null) {
+            askItem.setPrimaryText(activity.getString(R.string.duckChatContextualAskAboutSearch))
+            popup.onMenuItemClicked(askItem) {
+                duckChatPixels.reportContextualAddressBarMenuAskAboutPageSelected()
+                openSearchChatInSheet(sourceTabId, serpQuery, onAskAboutPage)
+            }
+        } else {
+            popup.onMenuItemClicked(askItem) {
+                duckChatPixels.reportContextualAddressBarMenuAskAboutPageSelected()
+                showEntryDialog(anchor, sourceTabId, onAskAboutPage)
+            }
         }
         popup.showAnchoredView(activity, anchor.rootView, anchor)
         duckChatPixels.reportContextualAddressBarMenuShown()
@@ -132,6 +151,24 @@ class RealDuckChatContextual @Inject constructor(
         val url = duckChatInternal.getDuckChatUrl(query = "", autoPrompt = false)
         duckChatInternal.reportDuckChatEntry(DuckChatEntryPoint.CONTEXTUAL_CHAT, opensNewTab = true, hasPrompt = false)
         browserNav.openInNewTab(activity, url, sourceTabId).also { activity.startActivity(it) }
+    }
+
+    private fun openSearchChatInSheet(
+        sourceTabId: String,
+        query: String,
+        showChatSurface: () -> Unit,
+    ) {
+        // Park the search terms as the entry prompt (no page context — a SERP has none) so the sheet
+        // opens straight into the chat and auto-submits them, mirroring the entry-dialog hand-off.
+        contextualEntryPromptStore.store(
+            ContextualEntryPrompt(
+                tabId = sourceTabId,
+                prompt = NativeInputPrompt(query, null, null, null, null, null),
+                serializedPageContext = null,
+            ),
+        )
+        duckChatInternal.reportDuckChatEntry(DuckChatEntryPoint.CONTEXTUAL_CHAT, opensNewTab = false, hasPrompt = true)
+        showChatSurface()
     }
 
     private fun View.activity(): Activity? {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -198,6 +198,7 @@ interface DuckChatPixels {
     fun reportContextualAddressBarMenuShown()
     fun reportContextualAddressBarMenuNewChatSelected()
     fun reportContextualAddressBarMenuAskAboutPageSelected()
+    fun reportContextualAddressBarMenuAskAboutSearchSelected()
     fun reportContextualFloatingInputShown()
     fun reportContextualFloatingInputDismissedWithoutSubmission()
     fun reportContextualFloatingInputPromotedToSheet()
@@ -761,6 +762,13 @@ class RealDuckChatPixels @Inject constructor(
         appCoroutineScope.launch(dispatcherProvider.io()) {
             pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_PAGE_SELECTED_COUNT)
             pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_PAGE_SELECTED_DAILY, type = Pixel.PixelType.Daily())
+        }
+    }
+
+    override fun reportContextualAddressBarMenuAskAboutSearchSelected() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_SEARCH_SELECTED_COUNT)
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_SEARCH_SELECTED_DAILY, type = Pixel.PixelType.Daily())
         }
     }
 
@@ -1398,6 +1406,8 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_NEW_CHAT_SELECTED_DAILY("aichat_contextual_address_bar_menu_new_chat_selected_daily"),
     DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_PAGE_SELECTED_COUNT("aichat_contextual_address_bar_menu_ask_about_page_selected_count"),
     DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_PAGE_SELECTED_DAILY("aichat_contextual_address_bar_menu_ask_about_page_selected_daily"),
+    DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_SEARCH_SELECTED_COUNT("aichat_contextual_address_bar_menu_ask_about_search_selected_count"),
+    DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_SEARCH_SELECTED_DAILY("aichat_contextual_address_bar_menu_ask_about_search_selected_daily"),
     DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_SHOWN_COUNT("aichat_contextual_floating_input_opened_count"),
     DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_SHOWN_DAILY("aichat_contextual_floating_input_opened_daily"),
     DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_DISMISSED_WITHOUT_SUBMISSION_COUNT("aichat_contextual_floating_input_dismissed_without_submission_count"),
@@ -1743,6 +1753,8 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_NEW_CHAT_SELECTED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_PAGE_SELECTED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_PAGE_SELECTED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_SEARCH_SELECTED_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_SEARCH_SELECTED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_SHOWN_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_SHOWN_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_DISMISSED_WITHOUT_SUBMISSION_COUNT.pixelName to PixelParameter.removeAtb(),

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -182,6 +182,7 @@ interface DuckChatPixels {
     fun reportContextualRecentChatsPopupDisplayed()
     fun reportContextualRecentChatSelected()
     fun reportContextualViewAllChatsTapped()
+    fun reportContextualOpenDuckAiMenuTapped()
     fun reportContextualPageContextInvalidEmpty()
     fun reportContextualPageContextInvalidNoTitle()
     fun reportContextualPageContextInvalidNoContent()
@@ -704,6 +705,13 @@ class RealDuckChatPixels @Inject constructor(
         appCoroutineScope.launch(dispatcherProvider.io()) {
             pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_VIEW_ALL_CHATS_TAPPED_COUNT)
             pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_VIEW_ALL_CHATS_TAPPED_DAILY, type = Pixel.PixelType.Daily())
+        }
+    }
+
+    override fun reportContextualOpenDuckAiMenuTapped() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_OPEN_DUCKAI_MENU_TAPPED_COUNT)
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_OPEN_DUCKAI_MENU_TAPPED_DAILY, type = Pixel.PixelType.Daily())
         }
     }
 
@@ -1408,6 +1416,8 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_PAGE_SELECTED_DAILY("aichat_contextual_address_bar_menu_ask_about_page_selected_daily"),
     DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_SEARCH_SELECTED_COUNT("aichat_contextual_address_bar_menu_ask_about_search_selected_count"),
     DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_SEARCH_SELECTED_DAILY("aichat_contextual_address_bar_menu_ask_about_search_selected_daily"),
+    DUCK_CHAT_CONTEXTUAL_OPEN_DUCKAI_MENU_TAPPED_COUNT("aichat_contextual_open_duckai_menu_tapped_count"),
+    DUCK_CHAT_CONTEXTUAL_OPEN_DUCKAI_MENU_TAPPED_DAILY("aichat_contextual_open_duckai_menu_tapped_daily"),
     DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_SHOWN_COUNT("aichat_contextual_floating_input_opened_count"),
     DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_SHOWN_DAILY("aichat_contextual_floating_input_opened_daily"),
     DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_DISMISSED_WITHOUT_SUBMISSION_COUNT("aichat_contextual_floating_input_dismissed_without_submission_count"),
@@ -1755,6 +1765,8 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_PAGE_SELECTED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_SEARCH_SELECTED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_ADDRESS_BAR_MENU_ASK_ABOUT_SEARCH_SELECTED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_OPEN_DUCKAI_MENU_TAPPED_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_OPEN_DUCKAI_MENU_TAPPED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_SHOWN_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_SHOWN_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FLOATING_INPUT_DISMISSED_WITHOUT_SUBMISSION_COUNT.pixelName to PixelParameter.removeAtb(),

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_webview.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_webview.xml
@@ -112,7 +112,7 @@
             app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/contextualTitle"
-            app:srcCompat="@drawable/ic_close_24_small" />
+            app:srcCompat="@drawable/ic_close_24" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chat_menu.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chat_menu.xml
@@ -20,6 +20,10 @@
     android:layout_height="wrap_content"
     android:background="@drawable/popup_menu_bg"
     android:orientation="vertical">
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        app:primaryText="@string/duck_chat_title"/>
 
     <com.duckduckgo.common.ui.view.PopupMenuItemView
         android:id="@+id/contextualChatMenuNewChat"

--- a/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chats_menu.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chats_menu.xml
@@ -28,6 +28,13 @@
         app:leadingIcon="@drawable/ic_compose_24"
         app:primaryText="@string/browserMenuNewChat" />
 
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/contextualChatsPopupOpenDuckAi"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_ai_chat_24"
+        app:primaryText="@string/duckChatContextualOpenDuckAi" />
+
     <com.duckduckgo.common.ui.view.divider.HorizontalDivider
         android:id="@+id/contextualChatsPopupHeaderDivider"
         android:layout_width="match_parent"

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -40,7 +40,7 @@
     <string name="duckChatOnboardingDuckAiStateOn">Turn Duck.ai On</string>
     <string name="duckChatOnboardingDuckAiStateOff">Keep Duck.ai Off</string>
 
-    <string name="duckChatContextualAskAboutPage">Ask About Page</string>
     <string name="duckChatContextualAskAboutSearch">Ask About Search</string>
+    <string name="duckChatContextualOpenDuckAi">Open Duck.ai</string>
 
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -40,4 +40,7 @@
     <string name="duckChatOnboardingDuckAiStateOn">Turn Duck.ai On</string>
     <string name="duckChatOnboardingDuckAiStateOff">Keep Duck.ai Off</string>
 
+    <string name="duckChatContextualAskAboutPage">Ask About Page</string>
+    <string name="duckChatContextualAskAboutSearch">Ask About Search</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -341,7 +341,6 @@
     <string name="duckAiSettingsTitle">Duck.ai Settings</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutPage">Ask About Page</string>
 
     <!-- Editing a message already sent to Duck.ai -->
     <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Edit message</string>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -346,4 +346,5 @@
     <string name="duck_ai_edit_prompt_title" instruction="Screen title: the user is editing a message they already sent to Duck.ai">Edit message</string>
     <string name="duck_ai_edit_prompt_lose_responses_warning" instruction="Warning shown while editing a sent message: the answer Duck.ai already gave will be discarded and answered again">Editing will replace the response with a new one.</string>
 
+    <string name="duckChatContextualAskAboutPage">Ask About Page</string>
 </resources>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -514,6 +514,24 @@ class DuckChatContextualWebViewViewModelTest {
     }
 
     @Test
+    fun `onOpenDuckAiFromPopup opens a new duck ai tab with no prompt`() = runTest {
+        (duckChat as FakeDuckChat).nextUrl = "https://duckduckgo.com/?ia=chat"
+        testee.onSheetOpened("tab-1")
+
+        testee.commands.test {
+            testee.onOpenDuckAiFromPopup()
+
+            val command = expectMostRecentItem()
+            assertTrue(command is DuckChatContextualWebViewViewModel.Command.OpenChatUrl)
+            command as DuckChatContextualWebViewViewModel.Command.OpenChatUrl
+            assertEquals("https://duckduckgo.com/?ia=chat", command.url)
+            assertEquals("tab-1", command.sourceTabId)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(duckChatInternal).reportDuckChatEntry(DuckChatEntryPoint.CONTEXTUAL_CHAT, opensNewTab = true, hasPrompt = false)
+    }
+
+    @Test
     fun `onChatsIconClicked with no recent chats launches chat history`() = runTest {
         testee.commands.test {
             testee.onChatsIconClicked()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewViewModelTest.kt
@@ -528,6 +528,7 @@ class DuckChatContextualWebViewViewModelTest {
             assertEquals("tab-1", command.sourceTabId)
             cancelAndIgnoreRemainingEvents()
         }
+        verify(duckChatPixels).reportContextualOpenDuckAiMenuTapped()
         verify(duckChatInternal).reportDuckChatEntry(DuckChatEntryPoint.CONTEXTUAL_CHAT, opensNewTab = true, hasPrompt = false)
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextualTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextualTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.duckchat.impl.contextual
 
 import android.view.View
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
@@ -36,6 +37,8 @@ class RealDuckChatContextualTest {
     private val sessionTimeoutProvider: DuckChatContextualSessionTimeoutProvider = mock()
     private val timeProvider: DuckChatContextualTimeProvider = mock()
     private val duckChatPixels: DuckChatPixels = mock()
+    private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector = mock()
+    private val contextualEntryPromptStore = RealContextualEntryPromptStore()
     private val anchor: View = mock()
 
     private val testee = RealDuckChatContextual(
@@ -45,6 +48,8 @@ class RealDuckChatContextualTest {
         sessionTimeoutProvider,
         timeProvider,
         duckChatPixels,
+        duckDuckGoUrlDetector,
+        contextualEntryPromptStore,
     )
 
     @Test
@@ -52,7 +57,7 @@ class RealDuckChatContextualTest {
         whenever(duckChatInternal.isContextualSheetRedesignEnabled()).thenReturn(false)
         var askAboutPageCount = 0
 
-        testee.launch("tabId", anchor) { askAboutPageCount++ }
+        testee.launch("tabId", sourceUrl = null, anchor = anchor) { askAboutPageCount++ }
 
         assertEquals(1, askAboutPageCount)
         verifyNoInteractions(browserNav)
@@ -63,7 +68,7 @@ class RealDuckChatContextualTest {
         whenever(duckChatInternal.isContextualSheetRedesignEnabled()).thenReturn(true)
         var askAboutPageCount = 0
 
-        testee.launch("tabId", anchor = null) { askAboutPageCount++ }
+        testee.launch("tabId", sourceUrl = null, anchor = null) { askAboutPageCount++ }
 
         assertEquals(1, askAboutPageCount)
         verifyNoInteractions(browserNav)
@@ -76,7 +81,7 @@ class RealDuckChatContextualTest {
         whenever(contextualDataStore.getTabClosedTimestamp("tabId")).thenReturn(null)
         var askAboutPageCount = 0
 
-        testee.launch("tabId", anchor) { askAboutPageCount++ }
+        testee.launch("tabId", sourceUrl = null, anchor = anchor) { askAboutPageCount++ }
 
         assertEquals(1, askAboutPageCount)
     }
@@ -90,7 +95,7 @@ class RealDuckChatContextualTest {
         whenever(timeProvider.currentTimeMillis()).thenReturn(1_000L)
         var askAboutPageCount = 0
 
-        testee.launch("tabId", anchor) { askAboutPageCount++ }
+        testee.launch("tabId", sourceUrl = null, anchor = anchor) { askAboutPageCount++ }
 
         // Session expired: the menu path is taken instead of opening the chat directly.
         assertEquals(0, askAboutPageCount)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217976041645708?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): https://app.asana.com/1/137249556945/project/1212087397361015/task/1218007111360563?focus=true

### Description
 - Contextual sheet now special-cases SERPs: on a search results page the entry menu's "_Ask About Page_" becomes "_Ask About Search_", which opens the contextual sheet with the search terms parked as a prompt and
auto-submitted (instead of opening a new tab).
- Added a section header to the contextual entry menu.
- Added an Open Duck.ai item to the contextual sheet's chats menu (after New Chat) that opens a fresh Duck.ai chat in a new browser tab with no prompt.
- New pixels: `aichat_contextual_address_bar_menu_ask_about_search_selected` (Ask About Search selected) and `aichat_contextual_open_duckai_menu_tapped` (Open Duck.ai tapped), each as a first-daily-count pair.
- Update icon for x to `ic_close_24` instead of `ic_close_24_small`

### Steps to test this PR

Filter logcat to: `Pixel sent: contextual`
- [x] Search any term in the search tab and wait for results (SERP)
- [x] Click contextual entry
- [x] Verify menu contains “Duck.ai” header
- [x] Verify menu has “Ask About Search” instead
- [x] Click on “Ask About Search”
- [x] Verify logcat shows `aichat_contextual_address_bar_menu_ask_about_search_selected`
- [x] Verify that search text is submitted as a prompt via the contextual sheet 
- [x] Close the sheet and reopen the entry again
- [x] Verify the sheet is reopened with the chat in progress
- [x] Open a new tab and load a website
- [x] Click contextual entry
- [x] Verify menu has “Ask About Page”
- [x] Click on “Ask About Page”
- [x] Verify that the sheet works as expected
- [x] Verify logcat shows `aichat_contextual_address_bar_menu_ask_about_page_selected`
- [x] When in the contextual chat sheet, open the chats menu
- [ ] Verify you see “Ask duck.ai” 
- [x] Click on it and verify it opens a new chat tab with no prompt.
- [x] Verify logcat shows `m_aichat_entry_point` and `aichat_contextual_open_duckai_menu_tapped`



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Unable to generate summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d959822f3caf2f0dfdd4c7ef8937e40507cc3ea1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->