### PR TITLE
Fix pixel validation failures for wide_page-load and wide_post_idle_session

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_page_load.json5
+++ b/PixelDefinitions/pixels/definitions/wide_page_load.json5
@@ -25,8 +25,8 @@
             },
             {
                 "key": "feature.data.ext.elapsed_time_to_finish_ms_bucketed",
-                "description": "Total duration from page_start to page_finish, bucketed. Uses lower end of the bucket.",
-                "enum": ["0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
+                "description": "Total duration from page_start to page_finish, bucketed. Uses lower end of the bucket. -1 marks a negative interval caused by a wall-clock adjustment during measurement.",
+                "enum": ["-1", "0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
             },
             {
                 "key": "feature.data.ext.elapsed_time_to_visible_ms_bucketed",
@@ -35,8 +35,8 @@
             },
             {
                 "key": "feature.data.ext.elapsed_time_to_escaped_fixed_progress_ms_bucketed",
-                "description": "Duration from page_start to page_escaped_fixed_progress, bucketed. Uses lower end of the bucket.",
-                "enum": ["0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
+                "description": "Duration from page_start to page_escaped_fixed_progress, bucketed. Uses lower end of the bucket. -1 marks a negative interval caused by a wall-clock adjustment during measurement.",
+                "enum": ["-1", "0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
             },
             {
                 "key": "feature.data.ext.elapsed_time_to_content_scope_experiments_ms_bucketed",
@@ -71,6 +71,16 @@
             {
                 "key": "feature.data.ext.cpm_enabled",
                 "description": "Whether Cookie Pop-up Management (autoconsent) is enabled",
+                "type": "boolean"
+            },
+            {
+                "key": "feature.data.ext.tracker_optimization_enabled_v2",
+                "description": "Whether tracker evaluation optimization is enabled. Deprecated key sent by app versions released before the field was renamed to tracker_optimization_enabled_v3; kept so historical data still validates.",
+                "type": "boolean"
+            },
+            {
+                "key": "feature.data.ext.tracker_optimization_enabled_v3",
+                "description": "Whether tracker evaluation optimization is enabled. Deprecated key sent by app versions released before the field was removed; kept so historical data still validates",
                 "type": "boolean"
             },
             {

--- a/PixelDefinitions/pixels/definitions/wide_page_load.json5
+++ b/PixelDefinitions/pixels/definitions/wide_page_load.json5
@@ -30,8 +30,8 @@
             },
             {
                 "key": "feature.data.ext.elapsed_time_to_visible_ms_bucketed",
-                "description": "Duration from page_start to page_visible, bucketed. Uses lower end of the bucket.",
-                "enum": ["0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
+                "description": "Duration from page_start to page_visible, bucketed. Uses lower end of the bucket. -1 marks a negative interval caused by a wall-clock adjustment during measurement.",
+                "enum": ["-1", "0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
             },
             {
                 "key": "feature.data.ext.elapsed_time_to_escaped_fixed_progress_ms_bucketed",

--- a/PixelDefinitions/pixels/definitions/wide_post_idle_session.json5
+++ b/PixelDefinitions/pixels/definitions/wide_post_idle_session.json5
@@ -47,14 +47,14 @@
             {
                 "key": "feature.data.ext.session_duration_ms_bucketed",
                 "type": "string",
-                "description": "Duration from surface shown to session end, bucketed (lower end of bucket, in ms)",
-                "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                "description": "Duration from surface shown to session end, bucketed (lower end of bucket, in ms). -1 marks a negative interval caused by a wall-clock adjustment during measurement.",
+                "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
             },
             {
                 "key": "feature.data.ext.time_to_first_interaction_ms_bucketed",
                 "type": "string",
-                "description": "Duration from surface shown to the first non-terminal interaction (page_engaged, toggle_used, or back_pressed), bucketed (lower end of bucket, in ms)",
-                "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                "description": "Duration from surface shown to the first non-terminal interaction (page_engaged, toggle_used, or back_pressed), bucketed (lower end of bucket, in ms). -1 marks a negative interval caused by a wall-clock adjustment during measurement.",
+                "enum": ["-1", "0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
             },
             {
                 "key": "feature.data.ext.page_engaged",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211850753229323/task/1217972651863065
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

Fixes live-validation failures on `wide_page-load` and `wide_post_idle_session`: declares the deprecated `tracker_optimization_enabled_v2` key still sent by app versions released before the field was renamed to `v3`, and adds the `-1` negative-interval bucket value emitted by the shared interval-bucketing helper when a wall-clock adjustment occurs mid-measurement.

### Steps to test this PR

Q/A optional

### UI changes

No user-facing UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only changes to pixel JSON5 definitions; no app or pipeline logic changes, only expanded allowed parameter values.
> 
> **Overview**
> Updates **wide pixel definitions** so live validation accepts values clients already emit for `wide_page-load` and `wide_post_idle_session`.
> 
> For **page-load**, three elapsed-time bucket fields (`elapsed_time_to_finish_ms_bucketed`, `elapsed_time_to_visible_ms_bucketed`, `elapsed_time_to_escaped_fixed_progress_ms_bucketed`) now include **`"-1"`** in their enums and document that it marks a negative interval from a wall-clock adjustment during measurement. The same **`"-1"`** bucket is added to **`session_duration_ms_bucketed`** and **`time_to_first_interaction_ms_bucketed`** on **post-idle session**.
> 
> **`wide_page-load`** also declares deprecated boolean ext fields **`tracker_optimization_enabled_v2`** and **`tracker_optimization_enabled_v3`** so older app builds that still send them pass validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12ae1827173ddfc3d76b56a697f6c897a651a00a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->