### PR TITLE
Remove CHANGE_JOURNAL_ON_OPEN callback for app.db

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/DatabaseModule.kt
@@ -62,7 +62,6 @@ object DatabaseModule {
         return Room.databaseBuilder(context, AppDatabase::class.java, "app.db")
             .addMigrations(*migrationsProvider.ALL_MIGRATIONS.toTypedArray())
             .addCallback(migrationsProvider.BOOKMARKS_DB_ON_CREATE)
-            .addCallback(migrationsProvider.CHANGE_JOURNAL_ON_OPEN)
             .addCallback(databaseBookmarksMigrationCallbackProvider.provideCallbacks())
             .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
             .enableMultiInstanceInvalidation()

--- a/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
@@ -817,12 +817,6 @@ class MigrationsProvider(val context: Context, val settingsDataStore: SettingsDa
         }
     }
 
-    val CHANGE_JOURNAL_ON_OPEN = object : RoomDatabase.Callback() {
-        override fun onOpen(db: SupportSQLiteDatabase) {
-            db.query("PRAGMA journal_mode=DELETE;").use { cursor -> cursor.moveToFirst() }
-        }
-    }
-
     val ALL_MIGRATIONS: List<Migration>
         get() = listOf(
             MIGRATION_1_TO_2,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218092504907754?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
More info in https://app.asana.com/1/137249556945/project/488551667048375/task/1218092504907754?focus=true

### Steps to test this PR

- [x] Install and open build
- [ ] Ensure app.db journal file does not exist
- [x] Open a tab with gizmodo.com
- [x] Use the Fire button
- [x] Download app.db file
- [x] Open with a text editor
- [x] Check that there is no trace of the previously opened tab

Optionally run the privacy audit too https://app.asana.com/1/137249556945/project/547792610048271/task/1216911263448138?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SQLite journal mode behavior for the main app database on existing installs; worth validating persistence and multi-process access, though TRUNCATE was already the intended Room configuration.
> 
> **Overview**
> Removes the **`CHANGE_JOURNAL_ON_OPEN`** Room callback and its registration on **`app.db`**, so the database is no longer forced to **`PRAGMA journal_mode=DELETE`** on every open.
> 
> Journal behavior for **`AppDatabase`** now comes only from **`setJournalMode(RoomDatabase.JournalMode.TRUNCATE)`** in **`DatabaseModule`**, eliminating the redundant open-time override that could conflict with that setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbbf1802c471d41bda629ae905c43072cfc09780. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->