### PR TITLE
[Segmented Onboarding] Pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/onboarding.json5
+++ b/PixelDefinitions/pixels/definitions/onboarding.json5
@@ -397,6 +397,23 @@
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
+    "onboarding_end-try-duckai": {
+        "description": "Onboarding end step for the segmented onboarding's search path Try Duck.ai offer, shown only on the New Tab Page. Shown when the bubble is displayed; clicked engage when the user taps Try Duck.ai, dismiss when the user taps Skip or close button. Unique once per user per (event, value).",
+        "owners": ["LukasPaczos"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
+            "inputPreviewAction",
+            { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
+        ]
+    },
     "onboarding_password-import": {
         "description": "Password-import-from-Google onboarding step. shown when the page is displayed; clicked engage/dismiss on the Import / Skip CTAs; confirmed carries the import outcome. Unique once per user per (event, value).",
         "owners": ["catalinradoiu"],

--- a/PixelDefinitions/pixels/definitions/onboarding.json5
+++ b/PixelDefinitions/pixels/definitions/onboarding.json5
@@ -55,36 +55,11 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
-            },
-            {
-                "key": "installType",
-                "type": "string",
-                "description": "Install type",
-                "enum": ["new", "reinstall"]
-            },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            {
-                "key": "flow",
-                "type": "string",
-                "description": "Onboarding flow type",
-                "enum": ["default", "duckai"]
-            },
-            {
-                "key": "pixelSource",
-                "type": "string",
-                "description": "Device form factor",
-                "enum": ["phone", "tablet"]
-            },
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
             {
                 "key": "value",
                 "type": "string",
@@ -127,21 +102,11 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
@@ -152,21 +117,12 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked", "confirmed"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEventWithConfirmed",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
             "inputPreviewAction",
             {
                 "key": "value",
@@ -183,21 +139,11 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage"] }
         ]
     },
@@ -208,21 +154,11 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked", "confirmed"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEventWithConfirmed",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
             {
                 "key": "value",
                 "type": "string",
@@ -238,21 +174,12 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
             "inputPreviewAction",
             {
                 "key": "value",
@@ -269,21 +196,12 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
             {
                 "key": "value",
                 "type": "string",
@@ -299,21 +217,11 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
@@ -330,15 +238,10 @@
                 "description": "Event type for the onboarding instrumentation standard",
                 "enum": ["shown", "confirmed"]
             },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
             {
                 "key": "value",
                 "type": "string",
@@ -354,21 +257,12 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
             "inputPreviewAction",
             {
                 "key": "value",
@@ -385,21 +279,11 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage"] }
         ]
     },
@@ -410,21 +294,12 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
             "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
@@ -436,22 +311,11 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
-            "inputPreviewAction",
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
             {
                 "key": "value",
                 "type": "string",
@@ -467,21 +331,12 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
             "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
@@ -493,21 +348,12 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
             "inputPreviewAction",
             {
                 "key": "value",
@@ -524,21 +370,12 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
             "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
@@ -550,21 +387,12 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
             "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
@@ -576,21 +404,11 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked", "confirmed"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEventWithConfirmed",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
             {
                 "key": "value",
                 "type": "string",
@@ -606,23 +424,178 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "event",
-                "type": "string",
-                "description": "Event type for the onboarding instrumentation standard",
-                "enum": ["shown", "clicked"]
-            },
-            { "key": "installType", "type": "string", "description": "Install type", "enum": ["new", "reinstall"] },
-            {
-                "key": "daysSinceInstall",
-                "type": "string",
-                "description": "Days since install, bucketed.",
-                "enum": ["0", "1-3", "4-10", "11-28", "28+"]
-            },
-            { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
             "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
+        ]
+    },
+    "onboarding_download-choice": {
+        "description": "Download-reason step of the segmented onboarding flow. shown when the download-reason screen is displayed; clicked when the user confirms a reason, which is also the point the reason starts being reported as variant_segmented. Unique once per user per (event, value).",
+        "owners": ["LukasPaczos"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
+            {
+                "key": "value",
+                "type": "string",
+                "description": "Only set when event=clicked. The download reason the user picked.",
+                "enum": ["search", "ai-chat", "no-ai", "ad-blocking"]
+            }
+        ]
+    },
+    "onboarding_preferences_serp": {
+        "description": "Search-preferences step of the search path of the segmented onboarding flow. shown when the step is displayed; clicked when the user confirms, with one param per offered toggle. A toggle the run did not offer is absent. Unique once per user per event.",
+        "owners": ["LukasPaczos"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
+            {
+                "key": "recently_visited_sites_enabled",
+                "type": "boolean",
+                "description": "Only set when event=clicked. Whether recently visited sites are kept."
+            },
+            {
+                "key": "safe_search_enabled",
+                "type": "boolean",
+                "description": "Only set when event=clicked. Whether safe search is on."
+            }
+        ]
+    },
+    "onboarding_preferences_ai-model": {
+        "description": "Duck.ai model-provider step of the AI path of the segmented onboarding flow. shown when the step is displayed; clicked when the user confirms a provider. Unique once per user per (event, value).",
+        "owners": ["LukasPaczos"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
+            {
+                "key": "value",
+                "type": "string",
+                "description": "Only set when event=clicked. The provider of the chosen Duck.ai model.",
+                "enum": ["openai", "anthropic", "mistral"]
+            }
+        ]
+    },
+    "onboarding_preferences_ai-toggle-mode": {
+        "description": "Duck.ai new-tab toggle-position step of the AI path of the segmented onboarding flow. shown when the step is displayed; clicked when the user confirms a position. Unique once per user per (event, value).",
+        "owners": ["LukasPaczos"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
+            {
+                "key": "value",
+                "type": "string",
+                "description": "Only set when event=clicked. Which mode a new tab opens in.",
+                "enum": ["duckAI", "lastUsed"]
+            }
+        ]
+    },
+    "onboarding_preferences_ai-search": {
+        "description": "AI preferences step of the no-AI path of the segmented onboarding flow. shown when the step is displayed; clicked when the user confirms, with one param per offered toggle. A toggle the run did not offer is absent. Unique once per user per event.",
+        "owners": ["LukasPaczos"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
+            {
+                "key": "search_assist_enabled",
+                "type": "boolean",
+                "description": "Only set when event=clicked. Whether search assist is on."
+            },
+            {
+                "key": "ai_generated_images_enabled",
+                "type": "boolean",
+                "description": "Only set when event=clicked. Whether AI-generated images are shown."
+            }
+        ]
+    },
+    "onboarding_preferences_duck-ai": {
+        "description": "Keep-Duck.ai step of the no-AI path of the segmented onboarding flow. shown when the step is displayed; clicked when the user confirms. Unique once per user per (event, value).",
+        "owners": ["LukasPaczos"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
+            {
+                "key": "value",
+                "type": "string",
+                "description": "Only set when event=clicked. Whether the user kept Duck.ai on.",
+                "enum": ["on", "off"]
+            }
+        ]
+    },
+    "onboarding_preferences_ad-blocking": {
+        "description": "Ad-blocking and cookie preferences step of the ad-blocking path of the segmented onboarding flow. shown when the step is displayed; clicked when the user confirms, with one param per offered toggle. A toggle the run did not offer is absent. Unique once per user per event.",
+        "owners": ["LukasPaczos"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            "onboardingEvent",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingFlow",
+            "onboardingPixelSource",
+            "onboardingSegmentedVariant",
+            {
+                "key": "youtube_ad_blocking_enabled",
+                "type": "boolean",
+                "description": "Only set when event=clicked. Whether YouTube ad blocking is on."
+            },
+            {
+                "key": "cookie_popup_protection_enabled",
+                "type": "boolean",
+                "description": "Only set when event=clicked. Whether cookie pop-up protection is on."
+            },
+            {
+                "key": "popups_without_optouts_enabled",
+                "type": "boolean",
+                "description": "Only set when event=clicked. Whether cookie pop-ups without opt-outs are auto-accepted."
+            }
         ]
     }
 }

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -15,11 +15,53 @@
         "description": "The Unified Input surface the pixel was fired from, distinguishing the contextual chat sheet from the Duck.ai tab and the address bar",
         "enum": ["address_bar", "duck_ai", "contextual_chat"]
     },
+    "onboardingFlow": {
+        "key": "flow",
+        "type": "string",
+        "description": "Onboarding flow type",
+        "enum": ["default", "duckai", "tailored_by_download_reason"]
+    },
+    "onboardingEvent": {
+        "key": "event",
+        "type": "string",
+        "description": "Event type for the onboarding instrumentation standard",
+        "enum": ["shown", "clicked"]
+    },
+    "onboardingEventWithConfirmed": {
+        "key": "event",
+        "type": "string",
+        "description": "Event type for the onboarding instrumentation standard, for steps whose outcome is resolved outside the app (an OS prompt or an external flow) and reported as a separate confirmed event",
+        "enum": ["shown", "clicked", "confirmed"]
+    },
+    "onboardingInstallType": {
+        "key": "installType",
+        "type": "string",
+        "description": "Install type",
+        "enum": ["new", "reinstall"]
+    },
+    "onboardingDaysSinceInstall": {
+        "key": "daysSinceInstall",
+        "type": "string",
+        "description": "Days since install, bucketed.",
+        "enum": ["0", "1-3", "4-10", "11-28", "28+"]
+    },
+    "onboardingPixelSource": {
+        "key": "pixelSource",
+        "type": "string",
+        "description": "Device form factor",
+        "enum": ["phone", "tablet"]
+    },
     "inputPreviewAction": {
         "key": "variant",
         "type": "string",
         "description": "Onboarding Duck.ai search/chat branch, chosen at the input-screen preview step. Set on every onboarding pixel fired after the user passes that step; absent for pixels fired before it or for users who never see it.",
         "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
+    },
+    "onboardingSegmentedVariant": {
+        "key": "variant_segmented",
+        "type": "string",
+        "description": "Download reason picked on the download-choice screen of the segmented onboarding flow. Set on every onboarding pixel fired after that screen; absent for pixels fired before it and for flows that never show it. Independent of the search/chat branch reported by `variant`, since a run can make both choices.",
+        "enum": ["download_reason_search", "download_reason_ai-chat", "download_reason_no-ai", "download_reason_ad-blocking"]
     },
     "contextualSuggestionsPageType": {
         "key": "pageType",

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3922,7 +3922,7 @@ class BrowserTabViewModel @Inject constructor(
     fun onUserClickCtaSecondaryButton(cta: Cta) {
         releaseAddWidgetModalSlot(cta)
         viewModelScope.launch {
-            ctaViewModel.onUserDismissedCta(cta)
+            ctaViewModel.onUserDismissedCta(cta, viaSkipBtn = true)
             if (cta is BrokenSitePromptDialogCta) {
                 onBrokenSiteCtaDismissButtonClicked(cta)
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -5524,7 +5524,7 @@ class BrowserTabViewModel @Inject constructor(
                 refresh()
             }
             is DaxEndBrandDesignUpdateBubbleCta -> {
-                if (cta.segmentedPath == SegmentedOnboardingPath.SEARCH) {
+                if (cta.segmentedPathWithAiInput == SegmentedOnboardingPath.SEARCH) {
                     viewModelScope.launch {
                         ctaViewState.value = currentCtaViewState().copy(cta = null)
                         command.value = HideOnboardingDaxBubbleCta(cta)

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.app.onboarding.CustomAiOnboardingStore
 import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingPlanProvider
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.OnboardingStore
+import com.duckduckgo.app.onboarding.store.SegmentedOnboardingPath
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.store.daxOnboardingActive
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPixelAction
@@ -153,29 +154,36 @@ class CtaViewModel @Inject constructor(
      */
     private fun isInputScreenEnabled(): Boolean = duckAiFeatureState.showInputScreen.value
 
-    private fun contextualOnboardingPixelName(cta: Cta): OnboardingPixelName? = when (cta) {
-        is DaxTryASearchBrandDesignUpdateBubbleCta -> OnboardingPixelName.ONBOARDING_SEARCH
+    private fun contextualOnboardingPixelNames(cta: Cta): List<OnboardingPixelName> = when (cta) {
+        is DaxTryASearchBrandDesignUpdateBubbleCta -> listOf(OnboardingPixelName.ONBOARDING_SEARCH)
         is DaxVisitSiteOptionsBrandDesignUpdateBubbleCta,
         is DaxSiteSuggestionsBrandDesignUpdateContextualCta,
-        -> OnboardingPixelName.ONBOARDING_VISIT_SITE
+        -> listOf(OnboardingPixelName.ONBOARDING_VISIT_SITE)
 
-        is DaxSerpBrandDesignUpdateContextualCta -> OnboardingPixelName.ONBOARDING_SEARCH_RESULTS
+        is DaxSerpBrandDesignUpdateContextualCta -> listOf(OnboardingPixelName.ONBOARDING_SEARCH_RESULTS)
         is DaxTrackersBlockedBrandDesignUpdateContextualCta,
         is DaxMainNetworkBrandDesignUpdateContextualCta,
         is DaxNoTrackersBrandDesignUpdateContextualCta,
-        -> OnboardingPixelName.ONBOARDING_TRACKERS_BLOCKED
+        -> listOf(OnboardingPixelName.ONBOARDING_TRACKERS_BLOCKED)
 
         is DaxFireButtonBrandDesignUpdateContextualCta,
         is DaxDuckAiFireButtonBrandDesignUpdateContextualCta,
-        -> OnboardingPixelName.ONBOARDING_FIRE_BUTTON
+        -> listOf(OnboardingPixelName.ONBOARDING_FIRE_BUTTON)
 
-        is DaxEndBrandDesignUpdateBubbleCta,
+        // Only NTP offers the End dialog with Try Duck.ai / Skip for the segmented onboarding's search path.
+        // The contextual End dialog doesn't offer this.
+        is DaxEndBrandDesignUpdateBubbleCta -> if (cta.segmentedPathWithAiInput == SegmentedOnboardingPath.SEARCH) {
+            listOf(OnboardingPixelName.ONBOARDING_END, OnboardingPixelName.ONBOARDING_END_TRY_DUCK_AI)
+        } else {
+            listOf(OnboardingPixelName.ONBOARDING_END)
+        }
+
         is DaxEndBrandDesignUpdateContextualCta,
         is DaxDuckAiEndBrandDesignUpdateBubbleCta,
-        -> OnboardingPixelName.ONBOARDING_END
+        -> listOf(OnboardingPixelName.ONBOARDING_END)
 
-        is DaxSubscriptionBrandDesignUpdateBubbleCta -> OnboardingPixelName.ONBOARDING_SUBSCRIPTION_PROMO
-        else -> null
+        is DaxSubscriptionBrandDesignUpdateBubbleCta -> listOf(OnboardingPixelName.ONBOARDING_SUBSCRIPTION_PROMO)
+        else -> emptyList()
     }
 
     // Exposed for onboarding dev settings and tests. Used internally for completion checks
@@ -220,7 +228,7 @@ class CtaViewModel @Inject constructor(
 
     suspend fun onCtaShown(cta: Cta) {
         withContext(dispatchers.io()) {
-            contextualOnboardingPixelName(cta)?.let { onboardingPixelSender.fireContextual(it, OnboardingPixelAction.Shown) }
+            contextualOnboardingPixelNames(cta).forEach { onboardingPixelSender.fireContextual(it, OnboardingPixelAction.Shown) }
             cta.shownPixel?.let {
                 val canSendPixel = when (cta) {
                     is DaxCta -> cta.canSendShownPixel()
@@ -260,7 +268,7 @@ class CtaViewModel @Inject constructor(
     ) {
         withContext(dispatchers.io()) {
             if (viaCloseBtn || viaSkipBtn) {
-                contextualOnboardingPixelName(cta)?.let {
+                contextualOnboardingPixelNames(cta).forEach {
                     onboardingPixelSender.fireContextual(it, OnboardingPixelAction.Clicked(engaged = false))
                 }
             }
@@ -284,7 +292,7 @@ class CtaViewModel @Inject constructor(
     }
 
     suspend fun onUserClickCtaOkButton(cta: Cta) {
-        contextualOnboardingPixelName(cta)?.let {
+        contextualOnboardingPixelNames(cta).forEach {
             onboardingPixelSender.fireContextual(it, OnboardingPixelAction.Clicked(engaged = true))
         }
         cta.okPixel?.let {
@@ -458,8 +466,8 @@ class CtaViewModel @Inject constructor(
             // End
             canShowDaxCtaEndOfJourney() -> {
                 if (isBrandDesignUpdateEnabled()) {
-                    val segmentedPath = onboardingStore.getSegmentedPathWithAiInput()
-                    if (segmentedPath != null) {
+                    val segmentedPathWithAiInput = onboardingStore.getSegmentedPathWithAiInput()
+                    if (segmentedPathWithAiInput != null) {
                         setInputToggleStateForDuckAiEndCta()
                     }
                     DaxEndBrandDesignUpdateBubbleCta(
@@ -470,7 +478,7 @@ class CtaViewModel @Inject constructor(
                         onboardingImprovementsEnabled = isOnboardingImprovementsEnabled(),
                         onboardingImprovementsV2Enabled = isOnboardingImprovementsV2Enabled(),
                         isOmnibarBottom = settingsDataStore.omnibarType == OmnibarType.SINGLE_BOTTOM,
-                        segmentedPath = segmentedPath,
+                        segmentedPathWithAiInput = segmentedPathWithAiInput,
                     )
                 } else {
                     DaxBubbleCta.DaxEndCta(onboardingStore, appInstallStore)

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -256,9 +256,10 @@ class CtaViewModel @Inject constructor(
     suspend fun onUserDismissedCta(
         cta: Cta,
         viaCloseBtn: Boolean = false,
+        viaSkipBtn: Boolean = false,
     ) {
         withContext(dispatchers.io()) {
-            if (viaCloseBtn) {
+            if (viaCloseBtn || viaSkipBtn) {
                 contextualOnboardingPixelName(cta)?.let {
                     onboardingPixelSender.fireContextual(it, OnboardingPixelAction.Clicked(engaged = false))
                 }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
@@ -34,7 +34,7 @@ import com.duckduckgo.common.utils.device.DeviceInfo
 import com.google.android.material.button.MaterialButton
 import com.duckduckgo.mobile.android.R as CommonR
 
-data class DaxEndBrandDesignUpdateBubbleCta(
+data class DaxEndBrandDesignUpdateBubbleCta constructor(
     override val onboardingStore: OnboardingStore,
     override val appInstallStore: AppInstallStore,
     override val isLightTheme: Boolean,
@@ -42,14 +42,14 @@ data class DaxEndBrandDesignUpdateBubbleCta(
     override val onboardingImprovementsEnabled: Boolean,
     override val onboardingImprovementsV2Enabled: Boolean,
     val isOmnibarBottom: Boolean,
-    val segmentedPath: SegmentedOnboardingPath?,
+    val segmentedPathWithAiInput: SegmentedOnboardingPath?,
 ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
     ctaId = CtaId.DAX_END,
-    title = when (segmentedPath) {
+    title = when (segmentedPathWithAiInput) {
         SEARCH -> R.string.searchPathWithToggleEnabledContextualEndTitle
         AI, null -> R.string.onboardingEndDaxDialogTitle
     },
-    description = when (segmentedPath) {
+    description = when (segmentedPathWithAiInput) {
         SEARCH -> R.string.searchPathWithToggleEnabledContextualEndDescription
         AI, null -> R.string.onboardingEndDaxDialogDescription
     },
@@ -68,7 +68,7 @@ data class DaxEndBrandDesignUpdateBubbleCta(
     override val backgroundFillSpec = BackgroundFillSpec(fillHeightDp = 280f, tabletFillHeightDp = 320f, maxHeightFraction = 0.3f)
     override val activeIncludeIds: List<Int> = listOfNotNull(
         R.id.primaryCta,
-        R.id.secondaryCta.takeIf { segmentedPath == SEARCH },
+        R.id.secondaryCta.takeIf { segmentedPathWithAiInput == SEARCH },
     )
     override val showArrow: Boolean = true
     override val wavingDaxSpec = WavingDaxSpec(
@@ -84,7 +84,7 @@ data class DaxEndBrandDesignUpdateBubbleCta(
 
     override fun configureContentViews(view: View) {
         val primaryCtaTextRes: Int
-        if (segmentedPath == SEARCH) {
+        if (segmentedPathWithAiInput == SEARCH) {
             view.findViewById<ImageView>(R.id.brandDesignHeaderImage)?.apply {
                 setImageResource(CommonR.drawable.ic_duckai)
                 isVisible = true
@@ -102,5 +102,5 @@ data class DaxEndBrandDesignUpdateBubbleCta(
         view.findViewById<MaterialButton>(R.id.primaryCta)?.setText(primaryCtaTextRes)
     }
 
-    override fun shouldDropAddressBarFocusWhenShown(): Boolean = segmentedPath == SEARCH
+    override fun shouldDropAddressBarFocusWhenShown(): Boolean = segmentedPathWithAiInput == SEARCH
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
@@ -132,7 +132,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
 
         // A restarted run replays from before the branching step, so a branch persisted by a previous
         // run must not label this run's pre-branch pixels as branched.
-        onboardingPixelSender.clearBranchSelection()
+        onboardingPixelSender.clearFlowAttribution()
 
         return if (customAiOnboardingResolver.resolve()) {
             // in custom AI onboarding path, the input toggle is enabled by default
@@ -281,6 +281,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
         onCompleted: suspend () -> Unit,
         onSkipped: suspend () -> Unit,
     ): LinearOnboardingPlan {
+        onboardingPixelSender.segmentedFlowStarted()
         val firstDialog = SuspendMemo { FirstDialog.INITIAL }
         val modelProviderChoice = singleChoiceDataPlugin(OnboardingSingleChoiceDataPlugin.Id.DuckAiModelProvider)
         val togglePositionChoice = singleChoiceDataPlugin(OnboardingSingleChoiceDataPlugin.Id.DuckAiNewTabTogglePosition)
@@ -534,9 +535,10 @@ class NewUserOnboardingPlanProvider @Inject constructor(
         togglePositionChoice: OnboardingSingleChoiceDataPlugin?,
         duckAiStateChoice: OnboardingSingleChoiceDataPlugin?,
     ): NewUserOnboardingActivityStep {
+        val pixelName = OnboardingPixelName.ONBOARDING_DOWNLOAD_CHOICE
         return NewUserOnboardingActivityStep(
             id = NewUserOnboardingStepIds.DOWNLOAD_REASON,
-            pixelName = null,
+            pixelName = pixelName,
             resolveDialog = { NewUserOnboardingActivityDialog.DownloadReason },
             transition = { event ->
                 when {
@@ -549,6 +551,9 @@ class NewUserOnboardingPlanProvider @Inject constructor(
                             }
                             DownloadReasonSelection.SEARCH
                         }
+
+                        onboardingPixelSender.fire(pixelName, OnboardingPixelAction.DownloadReasonClicked(selection))
+                        onboardingPixelSender.downloadReasonSelected(selection)
 
                         when (selection) {
                             DownloadReasonSelection.SEARCH -> SwitchTo(segmentedSearchPlan(ctx))
@@ -573,6 +578,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
                 defaultBrowserPromptStep(),
                 preferenceSelectorStep(
                     ctx = ctx,
+                    pixelName = OnboardingPixelName.ONBOARDING_PREFERENCES_SERP,
                     titleRes = R.string.searchPathPreferenceSelectorTitle,
                     listOf(
                         OnboardingPreference.SEARCH_HISTORY,
@@ -628,6 +634,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
                 defaultBrowserPromptStep(),
                 preferenceSelectorStep(
                     ctx = ctx,
+                    pixelName = OnboardingPixelName.ONBOARDING_PREFERENCES_AI_SEARCH,
                     titleRes = R.string.noAiPathPreferenceSelectorTitle,
                     listOf(
                         OnboardingPreference.SEARCH_ASSIST,
@@ -651,6 +658,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
                 defaultBrowserPromptStep(),
                 preferenceSelectorStep(
                     ctx = ctx,
+                    pixelName = OnboardingPixelName.ONBOARDING_PREFERENCES_AD_BLOCKING,
                     titleRes = R.string.blockAdsPathPreferenceSelectorTitle,
                     listOf(
                         OnboardingPreference.BLOCK_ADS,
@@ -676,6 +684,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
 
     private fun preferenceSelectorStep(
         ctx: NewUserOnboardingPlanContext,
+        pixelName: OnboardingPixelName,
         @StringRes titleRes: Int,
         offered: List<OnboardingPreference>,
         @StringRes caption: Int? = null,
@@ -685,7 +694,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
         val rows = SuspendMemo { onboardingPreferenceCatalog.offer(offered) }
         return NewUserOnboardingActivityStep(
             id = NewUserOnboardingStepIds.PREFERENCE_SELECTOR,
-            pixelName = null,
+            pixelName = pixelName,
             indicator = StepIndicatorMode.COUNTED,
             precondition = { rows().isNotEmpty() },
             resolveDialog = {
@@ -698,6 +707,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
             transition = { event ->
                 when (event) {
                     is NewUserOnboardingEvent.PreferenceSelectorConfirmed -> {
+                        onboardingPixelSender.fire(pixelName, OnboardingPixelAction.PreferencesClicked(event.selections))
                         // Committed only once the run ends, so preferences a path seeds its own way don't
                         // survive a process death into the path a restarted onboarding takes.
                         ctx.onFinish { onboardingPreferenceCatalog.apply(event.selections) }
@@ -714,10 +724,11 @@ class NewUserOnboardingPlanProvider @Inject constructor(
         singleChoiceDataPlugins.getPlugins().firstOrNull { it.id == id }
 
     private fun modelProviderStep(plugin: OnboardingSingleChoiceDataPlugin?): NewUserOnboardingActivityStep {
+        val pixelName = OnboardingPixelName.ONBOARDING_PREFERENCES_AI_MODEL
         val options = SuspendMemo { plugin?.options().orEmpty() }
         return NewUserOnboardingActivityStep(
             id = NewUserOnboardingStepIds.MODEL_PROVIDER,
-            pixelName = null,
+            pixelName = pixelName,
             indicator = StepIndicatorMode.COUNTED,
             precondition = { options().size > 1 },
             resolveDialog = {
@@ -731,6 +742,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
                 when (event) {
                     is NewUserOnboardingEvent.SingleChoiceConfirmed -> {
                         logcat { "Model provider confirmed: ${event.option.id}" }
+                        onboardingPixelSender.fire(pixelName, OnboardingPixelAction.SingleChoiceClicked(event.option.id))
                         plugin?.apply(event.option)
                         Advance
                     }
@@ -742,10 +754,11 @@ class NewUserOnboardingPlanProvider @Inject constructor(
     }
 
     private fun togglePositionStep(plugin: OnboardingSingleChoiceDataPlugin?): NewUserOnboardingActivityStep {
+        val pixelName = OnboardingPixelName.ONBOARDING_PREFERENCES_AI_TOGGLE_MODE
         val options = SuspendMemo { plugin?.options().orEmpty() }
         return NewUserOnboardingActivityStep(
             id = NewUserOnboardingStepIds.TOGGLE_POSITION,
-            pixelName = null,
+            pixelName = pixelName,
             indicator = StepIndicatorMode.COUNTED,
             precondition = { options().size > 1 },
             resolveDialog = { NewUserOnboardingActivityDialog.TogglePosition(options()) },
@@ -753,6 +766,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
                 when (event) {
                     is NewUserOnboardingEvent.SingleChoiceConfirmed -> {
                         logcat { "Toggle position confirmed: ${event.option.id}" }
+                        onboardingPixelSender.fire(pixelName, OnboardingPixelAction.SingleChoiceClicked(event.option.id))
                         plugin?.apply(event.option)
                         Advance
                     }
@@ -767,10 +781,11 @@ class NewUserOnboardingPlanProvider @Inject constructor(
         ctx: NewUserOnboardingPlanContext,
         plugin: OnboardingSingleChoiceDataPlugin?,
     ): NewUserOnboardingActivityStep {
+        val pixelName = OnboardingPixelName.ONBOARDING_PREFERENCES_DUCK_AI
         val options = SuspendMemo { plugin?.options().orEmpty() }
         return NewUserOnboardingActivityStep(
             id = NewUserOnboardingStepIds.DUCK_AI_STATE,
-            pixelName = null,
+            pixelName = pixelName,
             indicator = StepIndicatorMode.COUNTED,
             precondition = { options().size > 1 },
             resolveDialog = { NewUserOnboardingActivityDialog.DuckAiState(options()) },
@@ -778,6 +793,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
                 when (event) {
                     is NewUserOnboardingEvent.SingleChoiceConfirmed -> {
                         logcat { "Duck.ai state confirmed: ${event.option.id}" }
+                        onboardingPixelSender.fire(pixelName, OnboardingPixelAction.SingleChoiceClicked(event.option.id))
                         // Committed only once the run ends, so a pick abandoned by a process death doesn't
                         // leak into the path a restarted onboarding takes.
                         ctx.onFinish { plugin?.apply(event.option) }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingPixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingPixelSender.kt
@@ -22,7 +22,9 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.install.daysInstalled
 import com.duckduckgo.app.onboarding.CustomAiOnboardingStore
+import com.duckduckgo.app.onboarding.OnboardingPreference
 import com.duckduckgo.app.onboarding.orchestrator.PasswordImportOutcome
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
 import com.duckduckgo.app.pixels.OnboardingPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
@@ -68,6 +70,12 @@ sealed interface OnboardingPixelAction {
     ) : OnboardingPixelAction
 
     data class PasswordImportConfirmed(val outcome: PasswordImportOutcome) : OnboardingPixelAction
+
+    data class DownloadReasonClicked(val reason: DownloadReasonSelection) : OnboardingPixelAction
+
+    data class PreferencesClicked(val selections: Map<OnboardingPreference, Boolean>) : OnboardingPixelAction
+
+    data class SingleChoiceClicked(val optionId: String) : OnboardingPixelAction
 }
 
 interface OnboardingPixelSender {
@@ -95,11 +103,23 @@ interface OnboardingPixelSender {
     fun chatBranchSelected()
 
     /**
-     * Clears any persisted branch selection. Called when a new linear onboarding run starts: a run
-     * restarted after an app kill replays from before the branching step, so a branch persisted by a
-     * previous run must not label this run's pre-branch pixels as branched.
+     * Records that this run is the download-reason segmented flow, so every pixel it fires carries
+     * `flow=tailored_by_download_reason` instead of the default.
      */
-    fun clearBranchSelection()
+    fun segmentedFlowStarted()
+
+    /**
+     * Records the download reason the user picked. Persisted so it can be attached as the
+     * `variant_segmented` param to every subsequent onboarding pixel.
+     */
+    fun downloadReasonSelected(reason: DownloadReasonSelection)
+
+    /**
+     * Clears the persisted flow and variant attribution. Called when a new linear onboarding run
+     * starts: a run restarted after an app kill replays from before the branching step, so
+     * attribution persisted by a previous run must not label this run's pre-branch pixels.
+     */
+    fun clearFlowAttribution()
 }
 
 @ContributesBinding(AppScope::class)
@@ -131,8 +151,20 @@ class RealOnboardingPixelSender @Inject constructor(
         variantPrefs.edit().putString(PREFS_KEY_VARIANT, PREFS_VARIANT_CHAT).apply()
     }
 
-    override fun clearBranchSelection() {
-        variantPrefs.edit().remove(PREFS_KEY_VARIANT).apply()
+    override fun segmentedFlowStarted() {
+        variantPrefs.edit().putBoolean(PREFS_KEY_SEGMENTED_FLOW, true).apply()
+    }
+
+    override fun downloadReasonSelected(reason: DownloadReasonSelection) {
+        variantPrefs.edit().putString(PREFS_KEY_DOWNLOAD_REASON, downloadReasonToken(reason)).apply()
+    }
+
+    override fun clearFlowAttribution() {
+        variantPrefs.edit()
+            .remove(PREFS_KEY_VARIANT)
+            .remove(PREFS_KEY_DOWNLOAD_REASON)
+            .remove(PREFS_KEY_SEGMENTED_FLOW)
+            .apply()
     }
 
     override fun fire(pixelName: OnboardingPixelName, action: OnboardingPixelAction) {
@@ -169,6 +201,15 @@ class RealOnboardingPixelSender @Inject constructor(
 
             is OnboardingPixelAction.PasswordImportConfirmed ->
                 fireStep(pixelName, PIXEL_EVENT_CONFIRMED, action.outcome.value)
+
+            is OnboardingPixelAction.DownloadReasonClicked ->
+                fireStep(pixelName, PIXEL_EVENT_CLICKED, downloadReasonToken(action.reason))
+
+            is OnboardingPixelAction.PreferencesClicked ->
+                fireStep(pixelName, PIXEL_EVENT_CLICKED, extraParams = preferenceParams(action.selections))
+
+            is OnboardingPixelAction.SingleChoiceClicked ->
+                fireStep(pixelName, PIXEL_EVENT_CLICKED, action.optionId)
         }
     }
 
@@ -217,11 +258,13 @@ class RealOnboardingPixelSender @Inject constructor(
         event: String,
         value: String? = null,
         includeValueInTag: Boolean = true,
+        extraParams: Map<String, String> = emptyMap(),
     ) {
         appCoroutineScope.launch {
             val params = buildStandardParams().toMutableMap()
             params[PIXEL_PARAM_EVENT] = event
             value?.let { params[PIXEL_PARAM_VALUE] = it }
+            params.putAll(extraParams)
             val tag = buildString {
                 append(pixelName.pixelName).append("_").append(event)
                 if (includeValueInTag) {
@@ -236,24 +279,25 @@ class RealOnboardingPixelSender @Inject constructor(
         // source/flow are install-level facts: CustomAiOnboardingStore is the canonical source (a
         // side-effect-free read of the decision persisted at plan build time).
         val reinstall = isReinstallUser.await()
-        val (days, isCustomAiFlow, variant) = withContext(dispatchers.io()) {
+        val (days, isCustomAiFlow, attribution) = withContext(dispatchers.io()) {
             Triple(
                 appInstallStore.daysInstalled(),
                 customAiOnboardingStore.isEnabled(),
-                when (variantPrefs.getString(PREFS_KEY_VARIANT, null)) {
-                    PREFS_VARIANT_SEARCH -> VARIANT_SEARCH
-                    PREFS_VARIANT_CHAT -> VARIANT_CHAT
-                    else -> null
-                },
+                resolveFlowAttribution(),
             )
         }
         val params = mutableMapOf(
             PIXEL_PARAM_INSTALL_TYPE to if (reinstall) INSTALL_TYPE_REINSTALL else INSTALL_TYPE_NEW,
             // PIXEL_PARAM_SOURCE to null, - this will be added in a follow-up PR
-            PIXEL_PARAM_FLOW to if (isCustomAiFlow) FLOW_DUCKAI else ONBOARDING_DEFAULT,
+            PIXEL_PARAM_FLOW to when {
+                attribution.isSegmentedFlow -> FLOW_TAILORED_BY_DOWNLOAD_REASON
+                isCustomAiFlow -> FLOW_DUCKAI
+                else -> ONBOARDING_DEFAULT
+            },
             PIXEL_PARAM_PIXEL_SOURCE to deviceInfo.formFactor().description,
         )
-        variant?.let { params[PIXEL_PARAM_VARIANT] = it }
+        attribution.branchVariant?.let { params[PIXEL_PARAM_VARIANT] = it }
+        attribution.segmentedVariant?.let { params[PIXEL_PARAM_VARIANT_SEGMENTED] = it }
         params[PIXEL_PARAM_DAYS_SINCE_INSTALL] = daysSinceInstallBucket(days)
         return params
     }
@@ -265,6 +309,53 @@ class RealOnboardingPixelSender @Inject constructor(
         days <= 28L -> DAYS_SINCE_INSTALL_11_28
         else -> DAYS_SINCE_INSTALL_OVER_28
     }
+
+    private fun resolveFlowAttribution() = FlowAttribution(
+        isSegmentedFlow = variantPrefs.getBoolean(PREFS_KEY_SEGMENTED_FLOW, false),
+        branchVariant = when (variantPrefs.getString(PREFS_KEY_VARIANT, null)) {
+            PREFS_VARIANT_SEARCH -> VARIANT_SEARCH
+            PREFS_VARIANT_CHAT -> VARIANT_CHAT
+            else -> null
+        },
+        segmentedVariant = variantPrefs.getString(PREFS_KEY_DOWNLOAD_REASON, null)
+            ?.let { "$VARIANT_DOWNLOAD_REASON_PREFIX$it" },
+    )
+
+    /**
+     * The download reason and the search/chat branch are independent choices a segmented run can make
+     * both of, so each gets its own param: a single one would have to encode the pairs, and its enum
+     * would be the cross-product of the two.
+     */
+    private data class FlowAttribution(
+        val isSegmentedFlow: Boolean,
+        val branchVariant: String?,
+        val segmentedVariant: String?,
+    )
+
+    private fun downloadReasonToken(reason: DownloadReasonSelection): String = when (reason) {
+        DownloadReasonSelection.SEARCH -> DOWNLOAD_REASON_SEARCH
+        DownloadReasonSelection.AI_CHAT -> DOWNLOAD_REASON_AI_CHAT
+        DownloadReasonSelection.NO_AI -> DOWNLOAD_REASON_NO_AI
+        DownloadReasonSelection.BLOCK_ADS -> DOWNLOAD_REASON_AD_BLOCKING
+    }
+
+    private fun preferenceParams(selections: Map<OnboardingPreference, Boolean>): Map<String, String> =
+        selections.entries.associate { (preference, enabled) ->
+            // Duck.ai's row is worded as hiding AI images, but the param reports whether they're shown
+            val reported = if (preference == OnboardingPreference.HIDE_AI_GENERATED_IMAGES) !enabled else enabled
+            preference.pixelParamKey to reported.toString()
+        }
+
+    private val OnboardingPreference.pixelParamKey: String
+        get() = when (this) {
+            OnboardingPreference.SEARCH_HISTORY -> PARAM_RECENTLY_VISITED_SITES_ENABLED
+            OnboardingPreference.SAFE_SEARCH -> PARAM_SAFE_SEARCH_ENABLED
+            OnboardingPreference.SEARCH_ASSIST -> PARAM_SEARCH_ASSIST_ENABLED
+            OnboardingPreference.HIDE_AI_GENERATED_IMAGES -> PARAM_AI_GENERATED_IMAGES_ENABLED
+            OnboardingPreference.BLOCK_ADS -> PARAM_YOUTUBE_AD_BLOCKING_ENABLED
+            OnboardingPreference.REJECT_OPTIONAL_COOKIES -> PARAM_COOKIE_POPUP_PROTECTION_ENABLED
+            OnboardingPreference.ACCEPT_NON_OPT_OUT_COOKIES -> PARAM_POPUPS_WITHOUT_OPTOUTS_ENABLED
+        }
 
     private fun engageOrDismiss(engaged: Boolean): String = if (engaged) VALUE_ENGAGE else VALUE_DISMISS
 
@@ -289,6 +380,7 @@ class RealOnboardingPixelSender @Inject constructor(
         private const val PIXEL_PARAM_DAYS_SINCE_INSTALL = "daysSinceInstall"
         private const val PIXEL_PARAM_FLOW = "flow"
         private const val PIXEL_PARAM_VARIANT = "variant"
+        private const val PIXEL_PARAM_VARIANT_SEGMENTED = "variant_segmented"
         private const val PIXEL_PARAM_PIXEL_SOURCE = "pixelSource"
 
         private const val PIXEL_EVENT_SHOWN = "shown"
@@ -300,14 +392,31 @@ class RealOnboardingPixelSender @Inject constructor(
 
         private const val ONBOARDING_DEFAULT = "default"
         private const val FLOW_DUCKAI = "duckai"
+        private const val FLOW_TAILORED_BY_DOWNLOAD_REASON = "tailored_by_download_reason"
 
         private const val VARIANT_SEARCH = "search_plus_duckai-search"
         private const val VARIANT_CHAT = "search_plus_duckai-chat"
+        private const val VARIANT_DOWNLOAD_REASON_PREFIX = "download_reason_"
 
         private const val PREFS_VARIANT_FILENAME = "com.duckduckgo.app.onboarding.variant"
         private const val PREFS_KEY_VARIANT = "variant"
+        private const val PREFS_KEY_DOWNLOAD_REASON = "downloadReason"
+        private const val PREFS_KEY_SEGMENTED_FLOW = "segmentedFlow"
         private const val PREFS_VARIANT_SEARCH = "search"
         private const val PREFS_VARIANT_CHAT = "chat"
+
+        private const val DOWNLOAD_REASON_SEARCH = "search"
+        private const val DOWNLOAD_REASON_AI_CHAT = "ai-chat"
+        private const val DOWNLOAD_REASON_NO_AI = "no-ai"
+        private const val DOWNLOAD_REASON_AD_BLOCKING = "ad-blocking"
+
+        private const val PARAM_RECENTLY_VISITED_SITES_ENABLED = "recently_visited_sites_enabled"
+        private const val PARAM_SAFE_SEARCH_ENABLED = "safe_search_enabled"
+        private const val PARAM_SEARCH_ASSIST_ENABLED = "search_assist_enabled"
+        private const val PARAM_AI_GENERATED_IMAGES_ENABLED = "ai_generated_images_enabled"
+        private const val PARAM_YOUTUBE_AD_BLOCKING_ENABLED = "youtube_ad_blocking_enabled"
+        private const val PARAM_COOKIE_POPUP_PROTECTION_ENABLED = "cookie_popup_protection_enabled"
+        private const val PARAM_POPUPS_WITHOUT_OPTOUTS_ENABLED = "popups_without_optouts_enabled"
 
         private const val VALUE_ENGAGE = "engage"
         private const val VALUE_DISMISS = "dismiss"

--- a/app/src/main/java/com/duckduckgo/app/pixels/OnboardingPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/OnboardingPixelName.kt
@@ -35,6 +35,7 @@ enum class OnboardingPixelName(override val pixelName: String) : Pixel.PixelName
     ONBOARDING_VISIT_SITE("onboarding_visit-site"),
     ONBOARDING_TRACKERS_BLOCKED("onboarding_trackers-blocked"),
     ONBOARDING_END("onboarding_end"),
+    ONBOARDING_END_TRY_DUCK_AI("onboarding_end-try-duckai"),
     ONBOARDING_SUBSCRIPTION_PROMO("onboarding_subscription-promo"),
     ONBOARDING_PASSWORD_IMPORT("onboarding_password-import"),
     ONBOARDING_DOWNLOAD_CHOICE("onboarding_download-choice"),

--- a/app/src/main/java/com/duckduckgo/app/pixels/OnboardingPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/OnboardingPixelName.kt
@@ -37,4 +37,11 @@ enum class OnboardingPixelName(override val pixelName: String) : Pixel.PixelName
     ONBOARDING_END("onboarding_end"),
     ONBOARDING_SUBSCRIPTION_PROMO("onboarding_subscription-promo"),
     ONBOARDING_PASSWORD_IMPORT("onboarding_password-import"),
+    ONBOARDING_DOWNLOAD_CHOICE("onboarding_download-choice"),
+    ONBOARDING_PREFERENCES_SERP("onboarding_preferences_serp"),
+    ONBOARDING_PREFERENCES_AI_MODEL("onboarding_preferences_ai-model"),
+    ONBOARDING_PREFERENCES_AI_TOGGLE_MODE("onboarding_preferences_ai-toggle-mode"),
+    ONBOARDING_PREFERENCES_AI_SEARCH("onboarding_preferences_ai-search"),
+    ONBOARDING_PREFERENCES_DUCK_AI("onboarding_preferences_duck-ai"),
+    ONBOARDING_PREFERENCES_AD_BLOCKING("onboarding_preferences_ad-blocking"),
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/OnboardingPixelParamRemovalPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/OnboardingPixelParamRemovalPlugin.kt
@@ -44,6 +44,13 @@ class OnboardingPixelParamRemovalPlugin @Inject constructor() : PixelParamRemova
             OnboardingPixelName.ONBOARDING_SUBSCRIPTION_PROMO.pixelName to PixelParameter.removeAtb(),
             OnboardingPixelName.ONBOARDING_WIDGET_PROMPT.pixelName to PixelParameter.removeAtb(),
             OnboardingPixelName.ONBOARDING_PASSWORD_IMPORT.pixelName to PixelParameter.removeAtb(),
+            OnboardingPixelName.ONBOARDING_DOWNLOAD_CHOICE.pixelName to PixelParameter.removeAtb(),
+            OnboardingPixelName.ONBOARDING_PREFERENCES_SERP.pixelName to PixelParameter.removeAtb(),
+            OnboardingPixelName.ONBOARDING_PREFERENCES_AI_MODEL.pixelName to PixelParameter.removeAtb(),
+            OnboardingPixelName.ONBOARDING_PREFERENCES_AI_TOGGLE_MODE.pixelName to PixelParameter.removeAtb(),
+            OnboardingPixelName.ONBOARDING_PREFERENCES_AI_SEARCH.pixelName to PixelParameter.removeAtb(),
+            OnboardingPixelName.ONBOARDING_PREFERENCES_DUCK_AI.pixelName to PixelParameter.removeAtb(),
+            OnboardingPixelName.ONBOARDING_PREFERENCES_AD_BLOCKING.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/OnboardingPixelParamRemovalPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/OnboardingPixelParamRemovalPlugin.kt
@@ -41,6 +41,7 @@ class OnboardingPixelParamRemovalPlugin @Inject constructor() : PixelParamRemova
             OnboardingPixelName.ONBOARDING_VISIT_SITE.pixelName to PixelParameter.removeAtb(),
             OnboardingPixelName.ONBOARDING_TRACKERS_BLOCKED.pixelName to PixelParameter.removeAtb(),
             OnboardingPixelName.ONBOARDING_END.pixelName to PixelParameter.removeAtb(),
+            OnboardingPixelName.ONBOARDING_END_TRY_DUCK_AI.pixelName to PixelParameter.removeAtb(),
             OnboardingPixelName.ONBOARDING_SUBSCRIPTION_PROMO.pixelName to PixelParameter.removeAtb(),
             OnboardingPixelName.ONBOARDING_WIDGET_PROMPT.pixelName to PixelParameter.removeAtb(),
             OnboardingPixelName.ONBOARDING_PASSWORD_IMPORT.pixelName to PixelParameter.removeAtb(),

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -4173,7 +4173,7 @@ class BrowserTabViewModelTest {
         onboardingImprovementsEnabled = true,
         onboardingImprovementsV2Enabled = true,
         isOmnibarBottom = false,
-        segmentedPath = segmentedPath,
+        segmentedPathWithAiInput = segmentedPath,
     )
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignBackgroundFillSpecTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignBackgroundFillSpecTest.kt
@@ -48,7 +48,7 @@ class BrandDesignBackgroundFillSpecTest {
                 onboardingImprovementsEnabled = true,
                 onboardingImprovementsV2Enabled = true,
                 isOmnibarBottom = false,
-                segmentedPath = null,
+                segmentedPathWithAiInput = null,
             )
         assertEquals(280f, cta.backgroundFillSpec?.fillHeightDp)
     }

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -2462,6 +2462,24 @@ class CtaViewModelTest {
         verify(mockOnboardingPixelSender).fireContextual(ONBOARDING_SUBSCRIPTION_PROMO, OnboardingPixelAction.Clicked(engaged = false))
     }
 
+    @Test
+    fun whenBrandDesignEndBubbleSkippedThenClickedDismissFired() = runTest {
+        val cta = daxEndBrandDesignUpdateBubbleCta()
+
+        testee.onUserDismissedCta(cta, viaSkipBtn = true)
+
+        verify(mockOnboardingPixelSender).fireContextual(ONBOARDING_END, OnboardingPixelAction.Clicked(engaged = false))
+    }
+
+    @Test
+    fun whenBrandDesignEndBubbleSkippedThenClosePixelNotFired() = runTest {
+        val cta = daxEndBrandDesignUpdateBubbleCta()
+
+        testee.onUserDismissedCta(cta, viaSkipBtn = true)
+
+        verify(mockPixel, never()).fire(eq(ONBOARDING_DAX_CTA_DISMISS_BUTTON), any(), any(), eq(Count))
+    }
+
     private fun subscriptionPromoBubbleCta() = DaxSubscriptionBrandDesignUpdateBubbleCta(
         mockOnboardingStore,
         mockAppInstallStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -49,6 +49,7 @@ import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardi
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_END
+import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_END_TRY_DUCK_AI
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_FIRE_BUTTON
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_SEARCH
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_SEARCH_RESULTS
@@ -1465,7 +1466,7 @@ class CtaViewModelTest {
             brokenSitePromptUrl = null,
         )
 
-        assertEquals(SegmentedOnboardingPath.SEARCH, (value as DaxEndBrandDesignUpdateBubbleCta).segmentedPath)
+        assertEquals(SegmentedOnboardingPath.SEARCH, (value as DaxEndBrandDesignUpdateBubbleCta).segmentedPathWithAiInput)
         verify(mockDuckChat).setInputScreenUserSetting(true)
     }
 
@@ -1486,7 +1487,7 @@ class CtaViewModelTest {
         )
 
         value as DaxEndBrandDesignUpdateBubbleCta
-        assertEquals(SegmentedOnboardingPath.AI, value.segmentedPath)
+        assertEquals(SegmentedOnboardingPath.AI, value.segmentedPathWithAiInput)
         // The AI path's own copy lives on the Duck.ai End CTA, which it reaches by submitting a chat.
         assertEquals(R.string.onboardingEndDaxDialogDescription, value.description)
         verify(mockDuckChat).setInputScreenUserSetting(true)
@@ -1508,7 +1509,7 @@ class CtaViewModelTest {
             brokenSitePromptUrl = null,
         )
 
-        assertNull((value as DaxEndBrandDesignUpdateBubbleCta).segmentedPath)
+        assertNull((value as DaxEndBrandDesignUpdateBubbleCta).segmentedPathWithAiInput)
         verify(mockDuckChat, never()).setInputScreenUserSetting(any())
     }
 
@@ -2400,6 +2401,56 @@ class CtaViewModelTest {
     }
 
     @Test
+    fun whenSegmentedSearchPathEndBubbleShownThenBothEndAndTryDuckAiShownPixelsFired() = runTest {
+        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = SegmentedOnboardingPath.SEARCH)
+
+        testee.onCtaShown(cta)
+
+        verify(mockOnboardingPixelSender).fireContextual(ONBOARDING_END, OnboardingPixelAction.Shown)
+        verify(mockOnboardingPixelSender).fireContextual(ONBOARDING_END_TRY_DUCK_AI, OnboardingPixelAction.Shown)
+    }
+
+    @Test
+    fun whenSegmentedSearchPathEndBubbleOkClickedThenBothEndAndTryDuckAiClickedEngageFired() = runTest {
+        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = SegmentedOnboardingPath.SEARCH)
+
+        testee.onUserClickCtaOkButton(cta)
+
+        verify(mockOnboardingPixelSender).fireContextual(ONBOARDING_END, OnboardingPixelAction.Clicked(engaged = true))
+        verify(mockOnboardingPixelSender).fireContextual(ONBOARDING_END_TRY_DUCK_AI, OnboardingPixelAction.Clicked(engaged = true))
+    }
+
+    @Test
+    fun whenSegmentedSearchPathEndBubbleSkippedThenBothEndAndTryDuckAiClickedDismissFired() = runTest {
+        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = SegmentedOnboardingPath.SEARCH)
+
+        testee.onUserDismissedCta(cta, viaSkipBtn = true)
+
+        verify(mockOnboardingPixelSender).fireContextual(ONBOARDING_END, OnboardingPixelAction.Clicked(engaged = false))
+        verify(mockOnboardingPixelSender).fireContextual(ONBOARDING_END_TRY_DUCK_AI, OnboardingPixelAction.Clicked(engaged = false))
+    }
+
+    @Test
+    fun whenSegmentedAiPathEndBubbleShownThenTryDuckAiPixelNotFired() = runTest {
+        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = SegmentedOnboardingPath.AI)
+
+        testee.onCtaShown(cta)
+
+        verify(mockOnboardingPixelSender).fireContextual(ONBOARDING_END, OnboardingPixelAction.Shown)
+        verify(mockOnboardingPixelSender, never()).fireContextual(eq(ONBOARDING_END_TRY_DUCK_AI), any())
+    }
+
+    @Test
+    fun whenEndContextualDialogShownThenTryDuckAiPixelNotFired() = runTest {
+        val cta = daxEndBrandDesignUpdateContextualCta()
+
+        testee.onCtaShown(cta)
+
+        verify(mockOnboardingPixelSender).fireContextual(ONBOARDING_END, OnboardingPixelAction.Shown)
+        verify(mockOnboardingPixelSender, never()).fireContextual(eq(ONBOARDING_END_TRY_DUCK_AI), any())
+    }
+
+    @Test
     fun whenBrandDesignDuckAiEndBubbleShownThenOnboardingShownPixelFired() = runTest {
         val cta = daxDuckAiEndBrandDesignUpdateBubbleCta()
 
@@ -2492,7 +2543,7 @@ class CtaViewModelTest {
         onboardingImprovementsV2Enabled = true,
     )
 
-    private fun daxEndBrandDesignUpdateBubbleCta() = DaxEndBrandDesignUpdateBubbleCta(
+    private fun daxEndBrandDesignUpdateBubbleCta(segmentedPath: SegmentedOnboardingPath? = null) = DaxEndBrandDesignUpdateBubbleCta(
         mockOnboardingStore,
         mockAppInstallStore,
         isLightTheme = true,
@@ -2500,7 +2551,14 @@ class CtaViewModelTest {
         onboardingImprovementsEnabled = false,
         onboardingImprovementsV2Enabled = true,
         isOmnibarBottom = false,
-        segmentedPath = null,
+        segmentedPathWithAiInput = segmentedPath,
+    )
+
+    private fun daxEndBrandDesignUpdateContextualCta() = DaxEndBrandDesignUpdateContextualCta(
+        mockOnboardingStore,
+        mockAppInstallStore,
+        isLightTheme = true,
+        deviceInfo = mockDeviceInfo,
     )
 
     private fun daxDuckAiEndBrandDesignUpdateBubbleCta() = DaxDuckAiEndBrandDesignUpdateBubbleCta(

--- a/app/src/test/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProviderTest.kt
@@ -52,9 +52,16 @@ import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SKIP_ONBOARDING_PRES
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SYNC_RESTORE_TAPPED_UNIQUE
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_ADDRESS_BAR_POSITION
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_AI_INTRO
+import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_DOWNLOAD_CHOICE
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_FIRE_BUTTON
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_NOTIFICATIONS
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_PASSWORD_IMPORT
+import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_PREFERENCES_AD_BLOCKING
+import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_PREFERENCES_AI_MODEL
+import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_PREFERENCES_AI_SEARCH
+import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_PREFERENCES_AI_TOGGLE_MODE
+import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_PREFERENCES_DUCK_AI
+import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_PREFERENCES_SERP
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_QUICK_SETUP
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_SEARCH_CHAT_TOGGLE
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_SEARCH_EXPERIENCE
@@ -131,7 +138,7 @@ class NewUserOnboardingPlanProviderTest {
         id = OnboardingSingleChoiceDataPlugin.Id.DuckAiNewTabTogglePosition,
         options = togglePositionOptions,
     )
-    private val duckAiStateOptions = listOf(TestOption("duck_ai_on"), TestOption("duck_ai_off"))
+    private val duckAiStateOptions = listOf(TestOption("on"), TestOption("off"))
     private val duckAiStatePlugin = FakeOnboardingSingleChoiceDataPlugin(
         id = OnboardingSingleChoiceDataPlugin.Id.DuckAiState,
         options = duckAiStateOptions,
@@ -1114,7 +1121,7 @@ class NewUserOnboardingPlanProviderTest {
     fun `when a new onboarding run starts then any persisted branch selection is cleared`() = runTest {
         start()
 
-        verify(onboardingPixelSender).clearBranchSelection()
+        verify(onboardingPixelSender).clearFlowAttribution()
     }
 
     @Test
@@ -1843,6 +1850,151 @@ class NewUserOnboardingPlanProviderTest {
 
         assertEquals(NewUserOnboardingActivityDialog.ImportComplete(PasswordImportResult.Terminal.Failed), currentDialog())
     }
+
+    // region segmented onboarding pixels
+
+    @Test
+    fun `when the segmented plan is built then the flow is attributed to the download reason`() = runTest {
+        startSegmentedAtDownloadReason()
+
+        verify(onboardingPixelSender).segmentedFlowStarted()
+    }
+
+    @Test
+    fun `when the download reason step is presented then fires DownloadChoiceShown pixel`() = runTest {
+        startSegmentedAtDownloadReason()
+
+        orchestrator.onEvent(NewUserOnboardingEvent.Presented)
+
+        verify(onboardingPixelSender).fire(ONBOARDING_DOWNLOAD_CHOICE, OnboardingPixelAction.Shown)
+    }
+
+    @Test
+    fun `when a download reason is confirmed then the clicked pixel fires and the variant is established`() = runTest {
+        startSegmentedAtDownloadReason()
+
+        orchestrator.onEvent(NewUserOnboardingEvent.DownloadReasonConfirmed(DownloadReasonSelection.BLOCK_ADS))
+
+        verify(onboardingPixelSender).fire(
+            ONBOARDING_DOWNLOAD_CHOICE,
+            OnboardingPixelAction.DownloadReasonClicked(DownloadReasonSelection.BLOCK_ADS),
+        )
+        verify(onboardingPixelSender).downloadReasonSelected(DownloadReasonSelection.BLOCK_ADS)
+    }
+
+    @Test
+    fun `when the search path preferences are confirmed then fires the serp preferences pixel`() = runTest {
+        val selections = mapOf(
+            OnboardingPreference.SEARCH_HISTORY to true,
+            OnboardingPreference.SAFE_SEARCH to false,
+        )
+        whenever(onboardingPreferenceCatalog.offer(any())).thenReturn(
+            listOf(
+                preferenceRow(OnboardingPreference.SEARCH_HISTORY, initiallyEnabled = true),
+                preferenceRow(OnboardingPreference.SAFE_SEARCH, initiallyEnabled = true),
+            ),
+        )
+        startSegmentedAtDownloadReason()
+        orchestrator.onEvent(NewUserOnboardingEvent.DownloadReasonConfirmed(DownloadReasonSelection.SEARCH))
+        orchestrator.onEvent(NewUserOnboardingEvent.ContinueClicked)
+        orchestrator.onEvent(NewUserOnboardingEvent.DefaultBrowserPromptFinished(isDefaultBrowser = false))
+        assertStep(NewUserOnboardingStepIds.PREFERENCE_SELECTOR)
+        orchestrator.onEvent(NewUserOnboardingEvent.Presented)
+
+        orchestrator.onEvent(NewUserOnboardingEvent.PreferenceSelectorConfirmed(selections))
+
+        verify(onboardingPixelSender).fire(ONBOARDING_PREFERENCES_SERP, OnboardingPixelAction.Shown)
+        verify(onboardingPixelSender).fire(ONBOARDING_PREFERENCES_SERP, OnboardingPixelAction.PreferencesClicked(selections))
+    }
+
+    @Test
+    fun `when the no ai path preferences are confirmed then fires the ai search preferences pixel`() = runTest {
+        val selections = mapOf(
+            OnboardingPreference.SEARCH_ASSIST to true,
+            OnboardingPreference.HIDE_AI_GENERATED_IMAGES to false,
+        )
+        whenever(onboardingPreferenceCatalog.offer(any())).thenReturn(
+            listOf(
+                preferenceRow(OnboardingPreference.SEARCH_ASSIST, initiallyEnabled = true),
+                preferenceRow(OnboardingPreference.HIDE_AI_GENERATED_IMAGES, initiallyEnabled = false),
+            ),
+        )
+        startSegmentedAtDuckAiState()
+        assertStep(NewUserOnboardingStepIds.PREFERENCE_SELECTOR)
+
+        orchestrator.onEvent(NewUserOnboardingEvent.PreferenceSelectorConfirmed(selections))
+
+        verify(onboardingPixelSender).fire(ONBOARDING_PREFERENCES_AI_SEARCH, OnboardingPixelAction.PreferencesClicked(selections))
+    }
+
+    @Test
+    fun `when the ad blocking path preferences are confirmed then fires the ad blocking preferences pixel`() = runTest {
+        val selections = mapOf(
+            OnboardingPreference.BLOCK_ADS to true,
+            OnboardingPreference.REJECT_OPTIONAL_COOKIES to true,
+            OnboardingPreference.ACCEPT_NON_OPT_OUT_COOKIES to false,
+        )
+        whenever(onboardingPreferenceCatalog.offer(any())).thenReturn(
+            listOf(
+                preferenceRow(OnboardingPreference.BLOCK_ADS, initiallyEnabled = true),
+                preferenceRow(OnboardingPreference.REJECT_OPTIONAL_COOKIES, initiallyEnabled = true),
+                preferenceRow(OnboardingPreference.ACCEPT_NON_OPT_OUT_COOKIES, initiallyEnabled = false),
+            ),
+        )
+        startSegmentedAtDownloadReason()
+        orchestrator.onEvent(NewUserOnboardingEvent.DownloadReasonConfirmed(DownloadReasonSelection.BLOCK_ADS))
+        orchestrator.onEvent(NewUserOnboardingEvent.ContinueClicked)
+        orchestrator.onEvent(NewUserOnboardingEvent.DefaultBrowserPromptFinished(isDefaultBrowser = false))
+        assertStep(NewUserOnboardingStepIds.PREFERENCE_SELECTOR)
+
+        orchestrator.onEvent(NewUserOnboardingEvent.PreferenceSelectorConfirmed(selections))
+
+        verify(onboardingPixelSender).fire(ONBOARDING_PREFERENCES_AD_BLOCKING, OnboardingPixelAction.PreferencesClicked(selections))
+    }
+
+    @Test
+    fun `when a model provider is confirmed then fires the ai model pixel with the option id`() = runTest {
+        startSegmentedAtAiProviderChoice()
+        assertStep(NewUserOnboardingStepIds.MODEL_PROVIDER)
+        orchestrator.onEvent(NewUserOnboardingEvent.Presented)
+
+        orchestrator.onEvent(NewUserOnboardingEvent.SingleChoiceConfirmed(providerOptions[1]))
+
+        verify(onboardingPixelSender).fire(ONBOARDING_PREFERENCES_AI_MODEL, OnboardingPixelAction.Shown)
+        verify(onboardingPixelSender).fire(
+            ONBOARDING_PREFERENCES_AI_MODEL,
+            OnboardingPixelAction.SingleChoiceClicked(providerOptions[1].id),
+        )
+    }
+
+    @Test
+    fun `when a toggle position is confirmed then fires the ai toggle mode pixel with the option id`() = runTest {
+        startSegmentedAtTogglePosition()
+
+        orchestrator.onEvent(NewUserOnboardingEvent.SingleChoiceConfirmed(togglePositionOptions[1]))
+
+        verify(onboardingPixelSender).fire(
+            ONBOARDING_PREFERENCES_AI_TOGGLE_MODE,
+            OnboardingPixelAction.SingleChoiceClicked(togglePositionOptions[1].id),
+        )
+    }
+
+    @Test
+    fun `when a duck ai state is confirmed then fires the duck ai preferences pixel with the option id`() = runTest {
+        whenever(onboardingPreferenceCatalog.offer(any())).thenReturn(emptyList())
+        startSegmentedAtDuckAiState()
+        assertStep(NewUserOnboardingStepIds.DUCK_AI_STATE)
+
+        orchestrator.onEvent(NewUserOnboardingEvent.SingleChoiceConfirmed(duckAiStateOptions[1]))
+
+        verify(onboardingPixelSender).fire(
+            ONBOARDING_PREFERENCES_DUCK_AI,
+            OnboardingPixelAction.SingleChoiceClicked(duckAiStateOptions[1].id),
+        )
+    }
+
+    // endregion
+
     private fun preferenceRow(
         preference: OnboardingPreference,
         initiallyEnabled: Boolean,

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/RealOnboardingPixelSenderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/RealOnboardingPixelSenderTest.kt
@@ -20,11 +20,19 @@ import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.CustomAiOnboardingStore
+import com.duckduckgo.app.onboarding.OnboardingPreference
 import com.duckduckgo.app.onboarding.orchestrator.PasswordImportOutcome
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_ADDRESS_BAR_POSITION
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_AI_INTRO
+import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_DOWNLOAD_CHOICE
+import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_END
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_NOTIFICATIONS
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_PASSWORD_IMPORT
+import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_PREFERENCES_AD_BLOCKING
+import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_PREFERENCES_AI_MODEL
+import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_PREFERENCES_AI_SEARCH
+import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_PREFERENCES_SERP
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_QUICK_SETUP
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_SEARCH
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_SEARCH_CHAT_TOGGLE
@@ -553,7 +561,7 @@ class RealOnboardingPixelSenderTest {
         )
         variantTestee.chatBranchSelected()
 
-        variantTestee.clearBranchSelection()
+        variantTestee.clearFlowAttribution()
         variantTestee.fire(ONBOARDING_AI_INTRO, OnboardingPixelAction.Shown)
 
         verify(mockPixel).fire(
@@ -933,6 +941,280 @@ class RealOnboardingPixelSenderTest {
                 "value" to "error",
             ),
             type = Unique(tag = "onboarding_password-import_confirmed_error"),
+        )
+    }
+
+    @Test
+    fun whenSegmentedFlowStartedThenFlowParamIsTailoredByDownloadReason() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
+
+        testee.segmentedFlowStarted()
+        testee.fire(ONBOARDING_DOWNLOAD_CHOICE, OnboardingPixelAction.Shown)
+
+        verify(mockPixel).fire(
+            ONBOARDING_DOWNLOAD_CHOICE,
+            mapOf(
+                "installType" to "new",
+                "flow" to "tailored_by_download_reason",
+                "pixelSource" to "phone",
+                "daysSinceInstall" to "0",
+                "event" to "shown",
+            ),
+            type = Unique(tag = "onboarding_download-choice_shown"),
+        )
+    }
+
+    @Test
+    fun whenSegmentedFlowStartedThenItWinsOverTheCustomAiFlow() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
+        whenever(mockCustomAiOnboardingStore.isEnabled()).thenReturn(true)
+
+        testee.segmentedFlowStarted()
+        testee.fire(ONBOARDING_WELCOME, OnboardingPixelAction.Shown)
+
+        verify(mockPixel).fire(
+            ONBOARDING_WELCOME,
+            mapOf(
+                "installType" to "new",
+                "flow" to "tailored_by_download_reason",
+                "pixelSource" to "phone",
+                "daysSinceInstall" to "0",
+                "event" to "shown",
+            ),
+            type = Unique(tag = "onboarding_welcome_shown"),
+        )
+    }
+
+    @Test
+    fun whenDownloadReasonSelectedThenSegmentedVariantParamIsThatReason() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
+
+        testee.downloadReasonSelected(DownloadReasonSelection.AI_CHAT)
+        testee.fire(ONBOARDING_SET_DEFAULT, OnboardingPixelAction.Shown)
+
+        verify(mockPixel).fire(
+            ONBOARDING_SET_DEFAULT,
+            mapOf(
+                "installType" to "new",
+                "flow" to "default",
+                "variant_segmented" to "download_reason_ai-chat",
+                "pixelSource" to "phone",
+                "daysSinceInstall" to "0",
+                "event" to "shown",
+            ),
+            type = Unique(tag = "onboarding_set-default_shown"),
+        )
+    }
+
+    @Test
+    fun whenBothDownloadReasonAndBranchSelectedThenEachGetsItsOwnParam() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
+
+        testee.downloadReasonSelected(DownloadReasonSelection.BLOCK_ADS)
+        testee.chatBranchSelected()
+        testee.fire(ONBOARDING_END, OnboardingPixelAction.Shown)
+
+        verify(mockPixel).fire(
+            ONBOARDING_END,
+            mapOf(
+                "installType" to "new",
+                "flow" to "default",
+                "variant" to "search_plus_duckai-chat",
+                "variant_segmented" to "download_reason_ad-blocking",
+                "pixelSource" to "phone",
+                "daysSinceInstall" to "0",
+                "event" to "shown",
+            ),
+            type = Unique(tag = "onboarding_end_shown"),
+        )
+    }
+
+    @Test
+    fun whenOnlyTheBranchIsSelectedThenSegmentedVariantIsAbsent() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
+
+        testee.searchBranchSelected()
+        testee.fire(ONBOARDING_END, OnboardingPixelAction.Shown)
+
+        verify(mockPixel).fire(
+            ONBOARDING_END,
+            mapOf(
+                "installType" to "new",
+                "flow" to "default",
+                "variant" to "search_plus_duckai-search",
+                "pixelSource" to "phone",
+                "daysSinceInstall" to "0",
+                "event" to "shown",
+            ),
+            type = Unique(tag = "onboarding_end_shown"),
+        )
+    }
+
+    @Test
+    fun whenFlowAttributionClearedThenSegmentedFlowAndReasonAreBothDropped() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
+
+        testee.segmentedFlowStarted()
+        testee.downloadReasonSelected(DownloadReasonSelection.SEARCH)
+        testee.clearFlowAttribution()
+        testee.fire(ONBOARDING_WELCOME, OnboardingPixelAction.Shown)
+
+        verify(mockPixel).fire(
+            ONBOARDING_WELCOME,
+            mapOf("installType" to "new", "flow" to "default", "pixelSource" to "phone", "daysSinceInstall" to "0", "event" to "shown"),
+            type = Unique(tag = "onboarding_welcome_shown"),
+        )
+    }
+
+    @Test
+    fun whenFireDownloadReasonClickedThenValueIsTheReasonToken() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
+
+        testee.fire(ONBOARDING_DOWNLOAD_CHOICE, OnboardingPixelAction.DownloadReasonClicked(DownloadReasonSelection.NO_AI))
+
+        verify(mockPixel).fire(
+            ONBOARDING_DOWNLOAD_CHOICE,
+            mapOf(
+                "installType" to "new",
+                "flow" to "default",
+                "pixelSource" to "phone",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
+                "value" to "no-ai",
+            ),
+            type = Unique(tag = "onboarding_download-choice_clicked_no-ai"),
+        )
+    }
+
+    /** The reason is persisted as the choice is confirmed, so the step's own clicked pixel already carries it. */
+    @Test
+    fun whenFireDownloadReasonClickedAfterTheReasonIsPersistedThenTheSegmentedVariantIsAlsoSent() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
+
+        testee.downloadReasonSelected(DownloadReasonSelection.NO_AI)
+        testee.fire(ONBOARDING_DOWNLOAD_CHOICE, OnboardingPixelAction.DownloadReasonClicked(DownloadReasonSelection.NO_AI))
+
+        verify(mockPixel).fire(
+            ONBOARDING_DOWNLOAD_CHOICE,
+            mapOf(
+                "installType" to "new",
+                "flow" to "default",
+                "variant_segmented" to "download_reason_no-ai",
+                "pixelSource" to "phone",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
+                "value" to "no-ai",
+            ),
+            type = Unique(tag = "onboarding_download-choice_clicked_no-ai"),
+        )
+    }
+
+    @Test
+    fun whenFireSerpPreferencesClickedThenEachToggleIsItsOwnParam() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
+
+        testee.fire(
+            ONBOARDING_PREFERENCES_SERP,
+            OnboardingPixelAction.PreferencesClicked(
+                mapOf(
+                    OnboardingPreference.SEARCH_HISTORY to true,
+                    OnboardingPreference.SAFE_SEARCH to false,
+                ),
+            ),
+        )
+
+        verify(mockPixel).fire(
+            ONBOARDING_PREFERENCES_SERP,
+            mapOf(
+                "installType" to "new",
+                "flow" to "default",
+                "pixelSource" to "phone",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
+                "recently_visited_sites_enabled" to "true",
+                "safe_search_enabled" to "false",
+            ),
+            type = Unique(tag = "onboarding_preferences_serp_clicked"),
+        )
+    }
+
+    @Test
+    fun whenFireAiSearchPreferencesClickedThenHideAiImagesIsInvertedIntoImagesEnabled() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
+
+        testee.fire(
+            ONBOARDING_PREFERENCES_AI_SEARCH,
+            OnboardingPixelAction.PreferencesClicked(
+                mapOf(
+                    OnboardingPreference.SEARCH_ASSIST to true,
+                    OnboardingPreference.HIDE_AI_GENERATED_IMAGES to true,
+                ),
+            ),
+        )
+
+        verify(mockPixel).fire(
+            ONBOARDING_PREFERENCES_AI_SEARCH,
+            mapOf(
+                "installType" to "new",
+                "flow" to "default",
+                "pixelSource" to "phone",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
+                "search_assist_enabled" to "true",
+                "ai_generated_images_enabled" to "false",
+            ),
+            type = Unique(tag = "onboarding_preferences_ai-search_clicked"),
+        )
+    }
+
+    @Test
+    fun whenFireAdBlockingPreferencesClickedThenAllThreeTogglesAreSent() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
+
+        testee.fire(
+            ONBOARDING_PREFERENCES_AD_BLOCKING,
+            OnboardingPixelAction.PreferencesClicked(
+                mapOf(
+                    OnboardingPreference.BLOCK_ADS to true,
+                    OnboardingPreference.REJECT_OPTIONAL_COOKIES to true,
+                    OnboardingPreference.ACCEPT_NON_OPT_OUT_COOKIES to false,
+                ),
+            ),
+        )
+
+        verify(mockPixel).fire(
+            ONBOARDING_PREFERENCES_AD_BLOCKING,
+            mapOf(
+                "installType" to "new",
+                "flow" to "default",
+                "pixelSource" to "phone",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
+                "youtube_ad_blocking_enabled" to "true",
+                "cookie_popup_protection_enabled" to "true",
+                "popups_without_optouts_enabled" to "false",
+            ),
+            type = Unique(tag = "onboarding_preferences_ad-blocking_clicked"),
+        )
+    }
+
+    @Test
+    fun whenFireSingleChoiceClickedThenValueIsTheOptionIdVerbatim() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
+
+        testee.fire(ONBOARDING_PREFERENCES_AI_MODEL, OnboardingPixelAction.SingleChoiceClicked("anthropic"))
+
+        verify(mockPixel).fire(
+            ONBOARDING_PREFERENCES_AI_MODEL,
+            mapOf(
+                "installType" to "new",
+                "flow" to "default",
+                "pixelSource" to "phone",
+                "daysSinceInstall" to "0",
+                "event" to "clicked",
+                "value" to "anthropic",
+            ),
+            type = Unique(tag = "onboarding_preferences_ai-model_clicked_anthropic"),
         )
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/onboarding/OnboardingDuckAiStateDataPluginImpl.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/onboarding/OnboardingDuckAiStateDataPluginImpl.kt
@@ -80,12 +80,12 @@ class OnboardingDuckAiStateDataPluginImpl @Inject constructor(
         /** Display order, first entry is the default. Ids are the step's pixel values, so they must not change. */
         val OFFERED = listOf(
             StateSpec(
-                id = "duck_ai_on",
+                id = "on",
                 enabled = true,
                 labelRes = R.string.duckChatOnboardingDuckAiStateOn,
             ),
             StateSpec(
-                id = "duck_ai_off",
+                id = "off",
                 enabled = false,
                 labelRes = R.string.duckChatOnboardingDuckAiStateOff,
             ),

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/onboarding/OnboardingDuckAiStateDataPluginImplTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/onboarding/OnboardingDuckAiStateDataPluginImplTest.kt
@@ -49,7 +49,7 @@ class OnboardingDuckAiStateDataPluginImplTest {
     /** The ids are the pixel values for the step, so they are pinned here rather than left to follow a rename. */
     @Test
     fun `when options offered then their ids are the shipped ones`() = runTest {
-        assertEquals(listOf("duck_ai_on", "duck_ai_off"), testee.options().map { it.id })
+        assertEquals(listOf("on", "off"), testee.options().map { it.id })
     }
 
     @Test
@@ -75,7 +75,7 @@ class OnboardingDuckAiStateDataPluginImplTest {
     fun `when an option from another plugin is applied then nothing is written`() = runTest {
         testee.apply(
             object : Option {
-                override val id: String = "duck_ai_on"
+                override val id: String = "on"
                 override val label: String = "Turn Duck.ai On"
                 override val iconRes: Int? = null
             },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1218000206280127?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

### Description
Instrumentation for the segmented onboarding flow, following the shared onboarding instrumentation standard.

- Adds pixels for the screens the segmented flow introduces — the download-choice screen and each preference / single-choice screen — all with ATB removed.
- Adds flow attribution for segmented runs: they report their own `flow` value, and the download reason the user picks is persisted and attached to every later onboarding pixel as `variant_segmented`. It's a separate param from `variant` because the download reason and the search/chat branch are independent choices.
- Preference screens report the final state of each offered toggle as its own boolean param.
- Contextual End dialog that's shown for the search + toggle path has a "Skip" button that now fires the same dismiss pixel the close button did.
- Pixel definitions: the parameter blocks repeated across every onboarding pixel are extracted into shared entries in `params_dictionary.json`, so the new enums are defined once.

### Steps to test this PR

_Prep_
- [x] Apply below diff:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/SegmentedOnboardingExperimentManager.kt b/app/src/main/java/com/duckduckgo/app/onboarding/SegmentedOnboardingExperimentManager.kt
index 5cecc0bb48..908629ae24 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/SegmentedOnboardingExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/SegmentedOnboardingExperimentManager.kt
@@ -47,2 +47,3 @@ class SegmentedOnboardingExperimentManagerImpl @Inject constructor(
     override suspend fun enroll(): SegmentedOnboardingExperimentVariant? = withContext(dispatcherProvider.io()) {
+        return@withContext SegmentedOnboardingExperimentVariant.TREATMENT
         if (onboardingPrivacyConfigPersistedGate.awaitPersisted() && checkPrerequisites()) {

```
- [x] Filter logcat by `message~:"Pixel sent: onboarding"`.

_Segmented flow attribution_
- [x] Run onboarding from a fresh install
- [x] Verify every onboarding pixel from the start of the run carries `flow=tailored_by_download_reason`
- [x] On the download-choice screen pick a reason; verify `onboarding_download-choice` fires with `event=clicked` and `value` matching the pick (`search`, `ai-chat`, `no-ai`, `ad-blocking`)
- [x] Verify every pixel fired after that screen carries `variant_segmented=download_reason_<pick>`
- [x] Kill the app mid-onboarding and relaunch; verify the replayed run's pre-branch pixels carry no `variant` / `variant_segmented`

_Preference and single-choice screens_
- [x] Walk each path (search, ai-chat, no-ai, ad-blocking) and verify each preference screen fires its `onboarding_preferences_*` pixel with `event=shown` and, on confirm, `event=clicked` plus one boolean param per offered toggle
- [x] Flip the "hide AI-generated images" row on and verify `ai_generated_images_enabled=false`
- [x] On the model-provider, toggle-position and Duck.ai-state screens verify `event=clicked` with `value` set to the chosen option id

_Contextual dialog skip_
- [x] In the search flow, enable the toggle in the linear flow (the default) and submit a search query
- [x] Continue until the end dialog
- [x] Dismiss the dialog via its secondary "Skip" button
- [x] Verify the dialog's contextual pixel fires with `event=clicked, value=dismiss`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad analytics contract changes (new pixels, `flow`/`variant_segmented`, and Duck.ai state value tokens) can skew dashboards if client and definitions drift; behavior is telemetry-only, not security-critical.
> 
> **Overview**
> Adds **segmented onboarding instrumentation**: new pixels for download-reason choice, path-specific preference/single-choice steps, and the NTP **Try Duck.ai** end offer (`onboarding_end-try-duckai`). Existing onboarding pixels are refactored to reference shared params in `params_dictionary.json` (including `flow=tailored_by_download_reason` and `variant_segmented` for download reason).
> 
> **`RealOnboardingPixelSender`** now persists segmented-flow attribution (`segmentedFlowStarted`, `downloadReasonSelected`), attaches `variant_segmented` separately from the search/chat `variant`, clears attribution via `clearFlowAttribution()` on new runs, and supports preference toggles and single-choice clicks as extra params. **`NewUserOnboardingPlanProvider`** fires these pixels at each segmented step.
> 
> **Contextual CTAs**: on the segmented **search** path, the end bubble fires both `onboarding_end` and `onboarding_end-try-duckai`; **Skip** on secondary CTA counts as dismiss (same as close). Duck.ai keep/on-off step pixel values change from `duck_ai_on`/`duck_ai_off` to **`on`**/**`off`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0df9b67390e49dfcda7726fefbbe5aab48250062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->