### PR TITLE
Publish the release tag last

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -280,25 +280,28 @@ platform :android do
         end
 
         sh("git add #{appVersionFilePath}")
-        sh("git commit -am 'Updated version number for new release - #{app_version}'")
-        sh "git push origin #{branch_name}"
+        # A retry after a failed tag push can find the bump already on develop, reached
+        # through a newer LGC, leaving nothing to commit.
+        if sh("git status --porcelain", log: false).strip.empty?
+            UI.important("version.properties is already at #{app_version}, skipping the bump commit")
+        else
+            sh("git commit -am 'Updated version number for new release - #{app_version}'")
+        end
 
-        # Merge release branch into main and tag it
-        sh "git checkout main"
-        sh "git merge --no-ff release/#{app_version}"
-        sh "git tag -a #{app_version} -m #{app_version}"
-        sh "git push origin main --tags"
-        UI.header("#{app_version} tag has been successfully created. 🎉")
-
-        # Merge changes into develop
+        # develop before main: a push rejected here must not leave a published tag behind
         sh "git checkout develop"
         sh "git pull origin develop"
-        sh "git merge --no-ff release/#{app_version}"
+        sh "git merge --no-ff #{branch_name}"
         sh "git push origin develop"
 
-        # Clean up branches
-        sh "git push -d origin release/#{app_version}"
-        sh "git branch -d release/#{app_version}"
+        # The tag is the last thing to become public, and lands with main or not at all
+        sh "git checkout main"
+        sh "git merge --no-ff #{branch_name}"
+        sh "git tag -a #{app_version} -m #{app_version}"
+        sh "git push --atomic origin main refs/tags/#{app_version}"
+        UI.header("#{app_version} tag has been successfully created. 🎉")
+
+        sh "git branch -d #{branch_name}"
     end
 
     # Note, this currently relies on having `git flow` tools installed.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -256,6 +256,13 @@ platform :android do
     lane :tag_and_push_release_version do |options|
         app_version = options[:app_version]
         ref = options[:ref]
+
+        # app_version reaches git through interpolated shell commands below, and the
+        # workflow input is a free-form string, so require the production release format.
+        unless app_version.to_s =~ /\A\d+\.\d+\.\d+\z/
+            UI.user_error!("app_version must be X.Y.Z, got #{app_version.inspect}")
+        end
+
         branch_name = "release/#{app_version}"
 
         # Checkout all branches are available
@@ -272,8 +279,9 @@ platform :android do
 
         # Create a new release branch. Deliberately never pushed: the bump commit is
         # regenerated from `ref` on every run, and a remote release branch rejects the
-        # same-version retry as non-fast-forward.
-        sh("git checkout -b #{branch_name}")
+        # same-version retry as non-fast-forward. -B resets a branch a previous local
+        # attempt left behind, which reset and clean do not remove.
+        sh("git checkout -B #{branch_name}")
         UI.success("Release branch #{branch_name} created successfully!")
 
         # Update version properties file and push release branch

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -270,7 +270,9 @@ platform :android do
         sh("git reset --hard")
         sh("git clean -f -fxd")
 
-        # Create a new release branch
+        # Create a new release branch. Deliberately never pushed: the bump commit is
+        # regenerated from `ref` on every run, and a remote release branch rejects the
+        # same-version retry as non-fast-forward.
         sh("git checkout -b #{branch_name}")
         UI.success("Release branch #{branch_name} created successfully!")
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -283,11 +283,12 @@ platform :android do
 
         sh("git add #{appVersionFilePath}")
         # A retry after a failed tag push can find the bump already on develop, reached
-        # through a newer LGC, leaving nothing to commit.
-        if sh("git status --porcelain", log: false).strip.empty?
+        # through a newer LGC, leaving nothing to stage. Test the index rather than the
+        # worktree, so an unrelated modification cannot turn this into an empty commit.
+        if sh("git diff --cached --name-only", log: false).strip.empty?
             UI.important("version.properties is already at #{app_version}, skipping the bump commit")
         else
-            sh("git commit -am 'Updated version number for new release - #{app_version}'")
+            sh("git commit -m 'Updated version number for new release - #{app_version}'")
         end
 
         # develop before main: a push rejected here must not leave a published tag behind.
@@ -302,7 +303,9 @@ platform :android do
         sh "git checkout main"
         sh "git pull --ff-only origin main"
         sh "git merge --no-ff #{branch_name}"
-        sh "git tag -a #{app_version} -m #{app_version}"
+        # -f: reset/clean do not remove tags, so a previous local attempt can leave one
+        # behind. The remote still refuses a tag it already has, so this cannot mispublish.
+        sh "git tag -f -a #{app_version} -m #{app_version}"
         sh "git push --atomic origin main refs/tags/#{app_version}"
         UI.header("#{app_version} tag has been successfully created. 🎉")
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -252,7 +252,7 @@ platform :android do
 
         end
 
-    desc "Create a new release branch and update the version"
+    desc "Cut a local release branch, merge it into develop then main, and publish the tag last"
     lane :tag_and_push_release_version do |options|
         app_version = options[:app_version]
         ref = options[:ref]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -288,14 +288,17 @@ platform :android do
             sh("git commit -am 'Updated version number for new release - #{app_version}'")
         end
 
-        # develop before main: a push rejected here must not leave a published tag behind
+        # develop before main: a push rejected here must not leave a published tag behind.
+        # --ff-only on both pulls: a plain pull on a diverged local branch would quietly
+        # merge and push that merge.
         sh "git checkout develop"
-        sh "git pull origin develop"
+        sh "git pull --ff-only origin develop"
         sh "git merge --no-ff #{branch_name}"
         sh "git push origin develop"
 
         # The tag is the last thing to become public, and lands with main or not at all
         sh "git checkout main"
+        sh "git pull --ff-only origin main"
         sh "git merge --no-ff #{branch_name}"
         sh "git tag -a #{app_version} -m #{app_version}"
         sh "git push --atomic origin main refs/tags/#{app_version}"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -61,7 +61,7 @@ Deploy APK to GitHub
 [bundle exec] fastlane android tag_and_push_release_version
 ```
 
-Create a new release branch and update the version
+Cut a local release branch, merge it into develop then main, and publish the tag last
 
 ### android release
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1218089357738501?focus=true 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
* PUblish the release tag last and make pushing main and the tag atomic. This makes the workflow more resilient against failures
### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core release git flow used by CI; mistakes could block or mis-order merges/tags, though atomic push and develop-before-main reduce partial-publish risk.
> 
> **Overview**
> Reworks the **`tag_and_push_release_version`** Fastlane lane so release tagging is safer to retry and does not publish a tag before **`develop`** is updated.
> 
> The release branch stays **local only** (`checkout -B`, no remote push/delete), **`app_version`** must match **`X.Y.Z`**, and the version bump commit is skipped when **`version.properties`** is already staged at that version. Merges run **`develop` first** then **`main`**, with **`git pull --ff-only`** on both. The version tag is created last and pushed together with **`main`** via **`git push --atomic`**, using **`git tag -f`** only for leftover local tags. Fastlane README text matches the new lane description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd570c8461d8bf0e7a1bf3c1acb136077699981e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->