### PR TITLE
Add shared petal pixel parameter and value constants

### DIFF
--- a/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -455,7 +455,7 @@
                 "description": "What triggered this foreground transition",
                 "enum": ["standard", "url", "shortcut", "widget", "other"]
             },
-            "petal_randomize"
+            "petal"
         ]
     }
 }

--- a/PixelDefinitions/pixels/definitions/site_permissions.json5
+++ b/PixelDefinitions/pixels/definitions/site_permissions.json5
@@ -19,7 +19,7 @@
                 "description": "Policy rule that produced the automatic grant",
                 "enum": ["allow_list", "protections_off"]
             },
-            "petal_randomize"
+            "petal"
         ]
     }
 }

--- a/PixelDefinitions/pixels/definitions/webview_capabilities.json5
+++ b/PixelDefinitions/pixels/definitions/webview_capabilities.json5
@@ -1,0 +1,27 @@
+{
+    "webview_capabilities": {
+        "description": "Fired at most once daily on app start, when the reportWebViewCapabilities feature flag is enabled, reporting which APIs the installed WebView supports. Stripped of appVersion and ATB at send time via WebViewCapabilityPixelParamRemovalPlugin.",
+        "owners": ["LukasPaczos"],
+        "triggers": ["startup"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            {
+                "key": "version",
+                "type": "string",
+                "description": "Full version of the installed WebView package",
+                "examples": ["126.0.6478.40"]
+            },
+            {
+                "key": "multi_profile",
+                "type": "boolean",
+                "description": "Whether the installed WebView supports multiple profiles"
+            },
+            {
+                "key": "delete_browsing_data",
+                "type": "boolean",
+                "description": "Whether the installed WebView supports the delete browsing data API"
+            },
+            "petal"
+        ]
+    }
+}

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -178,12 +178,6 @@
     "petal": {
         "key": "petal",
         "type": "string",
-        "description": "Signals the pixel processing pipeline (deprecated)",
-        "enum": ["true"]
-    },
-    "petal_randomize": {
-        "key": "petal",
-        "type": "string",
         "description": "Routes the pixel through the PETAL timestamp-randomization pipeline",
         "enum": ["randomize", "kanon"]
     },

--- a/app/src/main/java/com/duckduckgo/app/browser/RealWebViewCapabilityChecker.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/RealWebViewCapabilityChecker.kt
@@ -71,7 +71,7 @@ class RealWebViewCapabilityChecker @Inject constructor(
                     "version" to webViewVersionProvider.getFullVersion(),
                     "multi_profile" to isMultiProfileSupported().toString(),
                     "delete_browsing_data" to isDeleteBrowsingDataSupported().toString(),
-                    "petal" to "true",
+                    Pixel.PixelParameter.PETAL to Pixel.PixelValues.PETAL_KANON,
                 )
                 pixel.fire(pixel = WebViewCapabilityPixelName.WEBVIEW_CAPABILITIES, parameters = params, type = Pixel.PixelType.Daily())
             }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppReturnPixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppReturnPixelSender.kt
@@ -119,7 +119,7 @@ class RealAppReturnPixelSender @Inject constructor(
                 put(AppReturnPixelParameters.UNIFIED_INPUT_AVAILABLE, duckAiFeatureState.nativeInputFieldEnabled.value.toString())
                 put(AppReturnPixelParameters.TOGGLE_VISIBLE, toggleVisible.toString())
                 put(AppReturnPixelParameters.LAUNCH_SOURCE, launchSource)
-                put(AppReturnPixelParameters.PETAL, PetalValues.RANDOMIZE)
+                put(Pixel.PixelParameter.PETAL, Pixel.PixelValues.PETAL_RANDOMIZE)
             }
 
             pixel.get().fire(pixel = AppPixelName.APP_RETURN_COUNT, parameters = params)
@@ -156,12 +156,6 @@ object AppReturnPixelParameters {
     const val UNIFIED_INPUT_AVAILABLE = "unified_input_available"
     const val TOGGLE_VISIBLE = "toggle_visible"
     const val LAUNCH_SOURCE = "launch_source"
-    const val PETAL = "petal"
-}
-
-object PetalValues {
-    const val RANDOMIZE = "randomize"
-    const val KANON = "kanon"
 }
 
 object LaunchSourceValues {

--- a/app/src/test/java/com/duckduckgo/app/pixels/AppReturnPixelSenderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/pixels/AppReturnPixelSenderTest.kt
@@ -101,7 +101,7 @@ class AppReturnPixelSenderTest {
             AppReturnPixelParameters.UNIFIED_INPUT_AVAILABLE to "false",
             AppReturnPixelParameters.TOGGLE_VISIBLE to "false",
             AppReturnPixelParameters.LAUNCH_SOURCE to "standard",
-            AppReturnPixelParameters.PETAL to "randomize",
+            Pixel.PixelParameter.PETAL to Pixel.PixelValues.PETAL_RANDOMIZE,
         )
         verify(pixel).fire(pixel = AppPixelName.APP_RETURN_COUNT, parameters = params)
         verify(pixel).fire(pixel = AppPixelName.APP_RETURN_DAILY, parameters = params, type = Pixel.PixelType.Daily())

--- a/lint-rules/src/main/java/com/duckduckgo/lint/NoHardcodedPetalPixelParamDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/NoHardcodedPetalPixelParamDetector.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope.JAVA_FILE
+import com.android.tools.lint.detector.api.Scope.TEST_SOURCES
+import com.android.tools.lint.detector.api.Severity.ERROR
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.uast.ULiteralExpression
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.getContainingUClass
+import java.util.EnumSet
+
+class NoHardcodedPetalPixelParamDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableUastTypes(): List<Class<out UElement>> = listOf(ULiteralExpression::class.java)
+
+    override fun createUastHandler(context: JavaContext) = object : UElementHandler() {
+        override fun visitLiteralExpression(node: ULiteralExpression) {
+            val literal = node.value as? String ?: return
+            val containingClass = node.getContainingUClass()?.qualifiedName.orEmpty()
+            if (containingClass.startsWith(PIXEL_API_CLASS)) return
+
+            if (literal == PETAL_KEY) {
+                context.report(NO_HARDCODED_PETAL_PIXEL_PARAM, node, context.getLocation(node), KEY_MESSAGE)
+                return
+            }
+
+            if (literal in PETAL_VALUES && isPetalValue(node, containingClass)) {
+                context.report(NO_HARDCODED_PETAL_PIXEL_PARAM, node, context.getLocation(node), VALUE_MESSAGE)
+            }
+        }
+    }
+
+    /**
+     * A value such as "randomize" only belongs to the petal parameter when it sits next to the petal
+     * key — `PETAL to "randomize"`, `put(PETAL, "randomize")` — or when it is declared in a
+     * feature-local petal constants holder, which is the re-declaration this rule exists to stop.
+     */
+    private fun isPetalValue(node: ULiteralExpression, containingClass: String): Boolean =
+        isPairedWithPetalKey(node) || containingClass.substringAfterLast('.').contains(PETAL_HOLDER, ignoreCase = true)
+
+    private fun isPairedWithPetalKey(node: ULiteralExpression): Boolean {
+        // sourcePsi of a Kotlin string literal is the template entry, so step out to the expression first.
+        val psi = node.sourcePsi ?: return false
+        val literal = psi as? KtStringTemplateExpression ?: psi.parent as? KtStringTemplateExpression ?: return false
+
+        (literal.parent as? KtBinaryExpression)?.let { pair ->
+            return pair.left?.text?.contains(PETAL_CONSTANT) == true
+        }
+
+        val argument = literal.parent as? KtValueArgument ?: return false
+        val call = argument.parent?.parent as? KtCallExpression ?: return false
+        val precedingArgument = call.valueArguments.indexOf(argument).takeIf { it > 0 }
+            ?.let { call.valueArguments[it - 1] } ?: return false
+        return precedingArgument.text.contains(PETAL_CONSTANT)
+    }
+
+    companion object {
+        const val ERROR_ID = "NoHardcodedPetalPixelParam"
+        const val ERROR_DESCRIPTION = "Hardcoded petal pixel parameter"
+        const val KEY_MESSAGE = "Use Pixel.PixelParameter.PETAL instead of hardcoding the petal parameter key"
+        const val VALUE_MESSAGE = "Use Pixel.PixelValues.PETAL_RANDOMIZE or Pixel.PixelValues.PETAL_KANON " +
+            "instead of hardcoding the petal parameter value"
+
+        private const val PETAL_KEY = "petal"
+        private const val PETAL_CONSTANT = "PETAL"
+        private const val PETAL_HOLDER = "petal"
+        private const val PIXEL_API_CLASS = "com.duckduckgo.app.statistics.pixels.Pixel"
+        private val PETAL_VALUES = setOf("randomize", "kanon", "true")
+
+        val NO_HARDCODED_PETAL_PIXEL_PARAM = Issue.create(
+            ERROR_ID,
+            ERROR_DESCRIPTION,
+            "The petal parameter routes a pixel through a backend processing pipeline, so its key and values are " +
+                "shared constants in Pixel.PixelParameter and Pixel.PixelValues. Re-declaring or hardcoding them " +
+                "lets the two sides drift apart. Note that PETAL_KANON is only for pixels where k-anonymity was " +
+                "explicitly requested in privacy triage.",
+            Category.CORRECTNESS, 10, ERROR,
+            Implementation(NoHardcodedPetalPixelParamDetector::class.java, EnumSet.of(JAVA_FILE, TEST_SOURCES)),
+        )
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.lint.DenyListedApiDetector
 import com.duckduckgo.lint.NoDispatcherComputation.Companion.ISSUE_AVOID_COMPUTATION
 import com.duckduckgo.lint.NoFragmentDetector.Companion.NO_FRAGMENT_ISSUE
 import com.duckduckgo.lint.NoHardcodedCoroutineDispatcherDetector.Companion.NO_HARCODED_COROUTINE_DISPATCHER
+import com.duckduckgo.lint.NoHardcodedPetalPixelParamDetector.Companion.NO_HARDCODED_PETAL_PIXEL_PARAM
 import com.duckduckgo.lint.NoImplImportsInAppModuleDetector.Companion.NO_IMPL_IMPORTS_IN_APP_MODULE_ISSUE
 import com.duckduckgo.lint.MetricsPixelNumericValueDetector.Companion.NUMERIC_VALUE_REQUIRED
 import com.duckduckgo.lint.MissingContributesToOnModuleDetector.Companion.MISSING_CONTRIBUTES_TO_ON_MODULE
@@ -91,6 +92,7 @@ class DuckDuckGoIssueRegistry : IssueRegistry() {
             NO_FRAGMENT_ISSUE,
             NO_SYSTEM_LOAD_LIBRARY,
             NO_HARCODED_COROUTINE_DISPATCHER,
+            NO_HARDCODED_PETAL_PIXEL_PARAM,
             NO_IMPL_IMPORTS_IN_APP_MODULE_ISSUE,
             NO_METRICS_PIXEL_EXTENSION_USAGE,
             NUMERIC_VALUE_REQUIRED,

--- a/lint-rules/src/test/java/com/duckduckgo/lint/NoHardcodedPetalPixelParamDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/NoHardcodedPetalPixelParamDetectorTest.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFile
+import com.android.tools.lint.checks.infrastructure.TestFiles.kt
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.android.tools.lint.checks.infrastructure.TestMode
+import com.duckduckgo.lint.NoHardcodedPetalPixelParamDetector.Companion.ERROR_ID
+import com.duckduckgo.lint.NoHardcodedPetalPixelParamDetector.Companion.KEY_MESSAGE
+import com.duckduckgo.lint.NoHardcodedPetalPixelParamDetector.Companion.NO_HARDCODED_PETAL_PIXEL_PARAM
+import com.duckduckgo.lint.NoHardcodedPetalPixelParamDetector.Companion.VALUE_MESSAGE
+import org.junit.Test
+
+@Suppress("UnstableApiUsage")
+class NoHardcodedPetalPixelParamDetectorTest {
+
+    @Test
+    fun whenPetalKeyHardcodedInPixelParametersThenDetectedAsAViolation() {
+        val callSite = """
+            package com.duckduckgo.feature.impl
+
+            import com.duckduckgo.app.statistics.pixels.Pixel
+
+            class Duck(private val pixel: Pixel) {
+                fun quack() {
+                    pixel.fire("m_duck_quack", mapOf("petal" to "randomize"))
+                }
+            }
+        """
+
+        assertLintError(listOf(kt(callSite).indented(), pixelStub), KEY_MESSAGE)
+    }
+
+    @Test
+    fun whenPetalKeyHardcodedInPutCallThenDetectedAsAViolation() {
+        val callSite = """
+            package com.duckduckgo.feature.impl
+
+            class Duck {
+                fun quack(): Map<String, String> = buildMap {
+                    put("petal", "randomize")
+                }
+            }
+        """
+
+        assertLintError(listOf(kt(callSite).indented(), pixelStub), KEY_MESSAGE)
+    }
+
+    @Test
+    fun whenPetalKeyRedeclaredInFeatureModuleThenDetectedAsAViolation() {
+        val callSite = """
+            package com.duckduckgo.feature.impl
+
+            object DuckPixelParameters {
+                const val PETAL = "petal"
+            }
+        """
+
+        assertLintError(listOf(kt(callSite).indented(), pixelStub), KEY_MESSAGE)
+    }
+
+    @Test
+    fun whenPetalValueHardcodedAlongsideSharedKeyThenDetectedAsAViolation() {
+        val callSite = """
+            package com.duckduckgo.feature.impl
+
+            import com.duckduckgo.app.statistics.pixels.Pixel
+
+            class Duck(private val pixel: Pixel) {
+                fun quack() {
+                    pixel.fire("m_duck_quack", mapOf(Pixel.PixelParameter.PETAL to "randomize"))
+                }
+            }
+        """
+
+        assertLintError(listOf(kt(callSite).indented(), pixelStub), VALUE_MESSAGE)
+    }
+
+    @Test
+    fun whenDeprecatedPetalValueHardcodedThenDetectedAsAViolation() {
+        val callSite = """
+            package com.duckduckgo.feature.impl
+
+            import com.duckduckgo.app.statistics.pixels.Pixel
+
+            class Duck(private val pixel: Pixel) {
+                fun quack() {
+                    pixel.fire("m_duck_quack", mapOf(Pixel.PixelParameter.PETAL to "true"))
+                }
+            }
+        """
+
+        assertLintError(listOf(kt(callSite).indented(), pixelStub), VALUE_MESSAGE)
+    }
+
+    @Test
+    fun whenPetalValuesRedeclaredInFeatureModuleThenDetectedAsAViolation() {
+        val callSite = """
+            package com.duckduckgo.feature.impl
+
+            object PetalValues {
+                const val RANDOMIZE = "randomize"
+            }
+        """
+
+        assertLintError(listOf(kt(callSite).indented(), pixelStub), VALUE_MESSAGE)
+    }
+
+    @Test
+    fun whenSharedConstantsUsedThenNotDetectedAsAViolation() {
+        val callSite = """
+            package com.duckduckgo.feature.impl
+
+            import com.duckduckgo.app.statistics.pixels.Pixel
+
+            class Duck(private val pixel: Pixel) {
+                fun quack() {
+                    pixel.fire(
+                        "m_duck_quack",
+                        mapOf(Pixel.PixelParameter.PETAL to Pixel.PixelValues.PETAL_RANDOMIZE),
+                    )
+                }
+            }
+        """
+
+        assertNoLintError(listOf(kt(callSite).indented(), pixelStub))
+    }
+
+    @Test
+    fun whenPixelApiDeclaresPetalConstantsThenNotDetectedAsAViolation() {
+        assertNoLintError(listOf(pixelStub))
+    }
+
+    @Test
+    fun whenUnrelatedParameterUsesTheSameValueThenNotDetectedAsAViolation() {
+        val callSite = """
+            package com.duckduckgo.feature.impl
+
+            import com.duckduckgo.app.statistics.pixels.Pixel
+
+            class Duck(private val pixel: Pixel) {
+                fun quack() {
+                    pixel.fire("m_duck_quack", mapOf(Pixel.PixelParameter.SOURCE to "randomize"))
+                }
+            }
+        """
+
+        assertNoLintError(listOf(kt(callSite).indented(), pixelStub))
+    }
+
+    private fun assertLintError(files: List<TestFile>, message: String) {
+        lint()
+            .files(*files.toTypedArray())
+            .issues(NO_HARDCODED_PETAL_PIXEL_PARAM)
+            .testModes(TestMode.DEFAULT)
+            .allowCompilationErrors()
+            .run()
+            .expectContains("$message [$ERROR_ID]")
+    }
+
+    private fun assertNoLintError(files: List<TestFile>) {
+        lint()
+            .files(*files.toTypedArray())
+            .issues(NO_HARDCODED_PETAL_PIXEL_PARAM)
+            .testModes(TestMode.DEFAULT)
+            .allowCompilationErrors()
+            .run()
+            .expectClean()
+    }
+
+    private val pixelStub = kt(
+        """
+        package com.duckduckgo.app.statistics.pixels
+
+        interface Pixel {
+            object PixelParameter {
+                const val SOURCE = "source"
+                const val PETAL = "petal"
+            }
+
+            object PixelValues {
+                const val PETAL_RANDOMIZE = "randomize"
+                const val PETAL_KANON = "kanon"
+            }
+
+            fun fire(pixelName: String, parameters: Map<String, String> = emptyMap())
+        }
+        """,
+    ).indented()
+}

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerImpl.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerImpl.kt
@@ -197,7 +197,7 @@ class SitePermissionsManagerImpl @Inject constructor(
             mapOf(
                 SitePermissionsPixelParameters.PERMISSION_TYPE to SitePermissionsPixelValues.DRM,
                 SitePermissionsPixelParameters.REASON to reason,
-                SitePermissionsPixelParameters.PETAL to SitePermissionsPetalValues.RANDOMIZE,
+                Pixel.PixelParameter.PETAL to Pixel.PixelValues.PETAL_RANDOMIZE,
             ),
         )
     }

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsPixelName.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsPixelName.kt
@@ -28,7 +28,6 @@ object SitePermissionsPixelParameters {
     const val PERMISSION_TYPE = "type"
     const val PERMISSION_SELECTION = "selection"
     const val REASON = "reason"
-    const val PETAL = "petal"
 }
 
 object SitePermissionsPixelValues {
@@ -43,8 +42,4 @@ object SitePermissionsPixelValues {
     const val DENY_ONCE = "deny_once"
     const val ALLOW_LIST = "allow_list"
     const val PROTECTIONS_OFF = "protections_off"
-}
-
-object SitePermissionsPetalValues {
-    const val RANDOMIZE = "randomize"
 }

--- a/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerTest.kt
+++ b/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerTest.kt
@@ -161,7 +161,7 @@ class SitePermissionsManagerTest {
             mapOf(
                 SitePermissionsPixelParameters.PERMISSION_TYPE to SitePermissionsPixelValues.DRM,
                 SitePermissionsPixelParameters.REASON to SitePermissionsPixelValues.ALLOW_LIST,
-                SitePermissionsPixelParameters.PETAL to SitePermissionsPetalValues.RANDOMIZE,
+                Pixel.PixelParameter.PETAL to Pixel.PixelValues.PETAL_RANDOMIZE,
             ),
         )
     }
@@ -184,7 +184,7 @@ class SitePermissionsManagerTest {
             mapOf(
                 SitePermissionsPixelParameters.PERMISSION_TYPE to SitePermissionsPixelValues.DRM,
                 SitePermissionsPixelParameters.REASON to SitePermissionsPixelValues.PROTECTIONS_OFF,
-                SitePermissionsPixelParameters.PETAL to SitePermissionsPetalValues.RANDOMIZE,
+                Pixel.PixelParameter.PETAL to Pixel.PixelValues.PETAL_RANDOMIZE,
             ),
         )
     }

--- a/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -78,6 +78,7 @@ interface Pixel {
         const val FREE_TRIAL = "free_trial"
         const val BROWSER_MODE = "browser_mode"
         const val SOURCE = "source"
+        const val PETAL = "petal"
     }
 
     object PixelValues {
@@ -105,6 +106,8 @@ interface Pixel {
         const val FIRE_ANIMATION_AIRSTREAM = "faas"
         const val FIRE_ANIMATION_WHIRLPOOL = "fawp"
         const val FIRE_ANIMATION_NONE = "fann"
+        const val PETAL_RANDOMIZE = "randomize"
+        const val PETAL_KANON = "kanon"
     }
 
     sealed class PixelType {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
@@ -364,7 +364,6 @@ object SubscriptionPixelParameter {
     const val ERROR_TYPE = "errorType"
     const val REASON = "reason"
     const val OS_VERSION = "os_version"
-    const val PETAL = "petal"
     const val ACTIVATION_DAY = "activation_day"
     const val ACTIVATION_PLATFORM = "activation_platform"
     const val DAYS_SINCE_INSTALL = "days_since_install"

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
@@ -162,7 +162,7 @@ class SubscriptionPixelSenderImpl @Inject constructor(
             SUBSCRIPTION_ACTIVE,
             mapOf(
                 SubscriptionPixelParameter.OS_VERSION to appBuildConfig.sdkInt.toString(),
-                SubscriptionPixelParameter.PETAL to "true",
+                Pixel.PixelParameter.PETAL to Pixel.PixelValues.PETAL_KANON,
             ),
         )
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200905986587319/task/1218094175552596?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): https://app.asana.com/1/137249556945/project/1200905986587319/task/1217859606554933

### Description

`petal` is the pixel parameter that tells the backend which processing pipeline a pixel should be routed through. The key and its values had no shared definition on the Kotlin side — they were re-declared in four independent places across three modules (`AppReturnPixelSender`, `RealWebViewCapabilityChecker`, `SubscriptionPixel`, `SitePermissionsPixelName`).

This adds them to `:statistics-api` as `Pixel.PixelParameter.PETAL`, `Pixel.PixelValues.PETAL_RANDOMIZE` and `Pixel.PixelValues.PETAL_KANON`, and points every call site at the shared constants, deleting the local re-declarations.

The two remaining `petal=true` call sites now send `petal=kanon`. Per the API proposal thread, `petal=true` and `petal=kanon` route through the same k-anonymity pipeline, so this is a no-op on the wire semantics. `petal=randomize` (the timestamp-randomization pipeline) is the default for new pixels; `PETAL_KANON` is only for pixels where k-anonymity was explicitly requested in privacy triage.

Pixel registry changes:

- the deprecated `petal` dictionary entry (`enum ["true"]`) and `petal_randomize` are collapsed into a single `petal` entry allowing `randomize` and `kanon`, with the two definitions that referenced `petal_randomize` repointed at it
- `webview_capabilities` is now registered — it was being fired without a definition entry, so its parameters were undocumented and unvalidated

Second commit adds a lint rule, `NoHardcodedPetalPixelParam`, so the constants can't drift apart again: it reports the petal key and its values when they are hardcoded or re-declared in a feature module. The value half only reports when the literal is paired with the petal key, so unrelated parameters that happen to use the same value are left alone.

### Steps to test this PR

_Unit tests and pixel definitions_

- [ ] ` Tests are passing`
- [ ] ` Pixel definitions are valid`



_Lint rule_

- [ ] Temporarily replace the `Pixel.PixelParameter.PETAL to Pixel.PixelValues.PETAL_RANDOMIZE` pair in `SitePermissionsManagerImpl` with `"petal" to "randomize"`, then run `./gradlew -q :site-permissions-impl:lint`: it fails with `Error: Use Pixel.PixelParameter.PETAL instead of hardcoding the petal parameter key [NoHardcodedPetalPixelParam]`. Revert.
- [ ] `./gradlew -q :site-permissions-impl:lint` on the unmodified branch passes

### NO UI changes

<!-- CURSOR_SUMMARY -->

---

> [!NOTE]
> **Low Risk**
> Changes are limited to analytics parameter naming and documentation; `true`→`kanon` is intended to be wire-equivalent for k-anonymity pixels. Risk is mainly mis-routing if a call site picks the wrong PETAL value.
>
> **Overview**
> Centralizes the **`petal`** analytics parameter in **`statistics-api`** as `Pixel.PixelParameter.PETAL` with values `PETAL_RANDOMIZE` and `PETAL_KANON`, and updates app return, WebView capabilities, site-permissions auto-grant, and subscription-active pixels to use those constants instead of module-local duplicates (removed from app, site-permissions, and subscriptions).
>
> **Wire behavior:** subscription active and WebView capabilities now send `petal=kanon` instead of deprecated `petal=true` (same k-anonymity pipeline per privacy triage). App return and DRM auto-grant continue to use `petal=randomize`.
>
> **Pixel registry:** collapses the params dictionary into one `petal` entry (`randomize` / `kanon`), repoints affected definitions from `petal_randomize`, and adds a **`webview_capabilities`** definition for a pixel that was already firing undocumented.
>
> Adds **`NoHardcodedPetalPixelParam`** lint (ERROR) to block hardcoded `petal` keys/values and feature-local re-declarations, with unit tests and registry registration.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d94ca07d4668c919bfedf96a4b2bca7b2d7ecae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- /CURSOR_SUMMARY -->