### PR TITLE
[Brand design updates - Core App Components] Ship review amendments

### DIFF
--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/ViewExtension.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/ViewExtension.kt
@@ -274,14 +274,12 @@ fun View.addBottomShadow(
     val offsetY = offsetYDp.toPx(context)
     val inset = insetDp.toPx(context).toInt()
 
-    // Get corner radius if view is a card
-    val cornerRadius = when (this) {
-        is MaterialCardView -> this.radius
-        else -> 0f
-    }
-
     outlineProvider = object : ViewOutlineProvider() {
         override fun getOutline(view: View, outline: Outline) {
+            val cornerRadius = when (view) {
+                is MaterialCardView -> view.radius
+                else -> 0f
+            }
             // Create outline with rounded corners that match the view
             outline.setRoundRect(
                 -inset,

--- a/android-design-system/design-system/src/main/res/color/status_indicator_color_selector.xml
+++ b/android-design-system/design-system/src/main/res/color/status_indicator_color_selector.xml
@@ -15,6 +15,6 @@
   -->
 
 <selector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
-    <item android:color="@color/gray50"  android:state_enabled="false" tools:ignore="InvalidColorAttribute" />
-    <item android:color="@color/alertGreen"  android:state_enabled="true" tools:ignore="InvalidColorAttribute" />
+    <item android:color="?attr/daxColorStatusIndicatorOff"  android:state_enabled="false" tools:ignore="InvalidColorAttribute" />
+    <item android:color="?attr/daxColorStatusIndicatorOn"  android:state_enabled="true" tools:ignore="InvalidColorAttribute" />
 </selector>

--- a/android-design-system/design-system/src/main/res/values/design-system-rebrand.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-rebrand.xml
@@ -42,6 +42,9 @@
     <attr name="daxColorRebrandButtonDestructiveGhostContainerPressed" format="color" />
     <attr name="daxColorRebrandButtonDestructiveGhostText" format="color" />
     <attr name="daxColorRebrandAccentBlue" format="color" />
+    <attr name="daxColorStatusIndicatorOn" format="color" />
+    <attr name="daxColorStatusIndicatorOff" format="color" />
+    <attr name="daxColorRebrandStatusIndicatorOff" format="color" />
     <attr name="daxColorStatusRed" format="color" />
 
     <dimen name="rebrandButtonSmallHeight">48dp</dimen>
@@ -156,6 +159,8 @@
         <item name="daxButtonLargeTopPadding">@dimen/rebrandButtonLargeTopPadding</item>
         <item name="daxButtonSmallVerticalInset">@dimen/rebrandButtonSmallVerticalInset</item>
         <item name="daxButtonLargeVerticalInset">@dimen/rebrandButtonLargeVerticalInset</item>
+        <item name="daxColorStatusIndicatorOn">@color/rb_green40</item>
+        <item name="daxColorStatusIndicatorOff">?attr/daxColorRebrandStatusIndicatorOff</item>
     </style>
 
     <style name="ThemeOverlay.Rebrand.AddressBarAnimation" parent="">

--- a/android-design-system/design-system/src/main/res/values/design-system-theming.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-theming.xml
@@ -284,9 +284,9 @@
         <item name="daxColorRebrandButtonDestructiveContainer">@color/rb_red40</item>
         <item name="daxColorRebrandButtonDestructiveContainerPressed">@color/rb_red60</item>
         <item name="daxColorRebrandButtonDestructiveText">@color/black</item>
-        <item name="daxColorRebrandButtonDestructiveSecondaryText">@color/rb_red20</item>
+        <item name="daxColorRebrandButtonDestructiveSecondaryText">@color/rb_red40</item>
         <item name="daxColorRebrandButtonDestructiveGhostContainerPressed">@color/destructive_glow_secondary_dark</item>
-        <item name="daxColorRebrandButtonDestructiveGhostText">@color/rb_red20</item>
+        <item name="daxColorRebrandButtonDestructiveGhostText">@color/rb_red40</item>
 
         <!-- Fab -->
         <item name="daxColorFabPrimaryContainer">@color/blue20</item>

--- a/android-design-system/design-system/src/main/res/values/design-system-theming.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-theming.xml
@@ -143,6 +143,8 @@
         <item name="daxColorDim">@color/black60</item>
         <item name="daxColorWhite">@color/white</item>
         <item name="daxColorBlack">@color/black84</item>
+        <item name="daxColorStatusIndicatorOn">@color/alertGreen</item>
+        <item name="daxColorStatusIndicatorOff">@color/gray50</item>
         <item name="daxColorFireModeAccentLight">@color/mandarin50</item>
         <item name="daxColorFireModeAccentDark">@color/mandarin40</item>
         <item name="daxColorFireModeAccentLightTranslucent">@color/mandarin50_translucent</item>
@@ -338,6 +340,7 @@
         <item name="daxColorInputModeIndicatorShadow">@color/black</item>
 
         <!--Rebrand Status-->
+        <item name="daxColorRebrandStatusIndicatorOff">@color/white40</item>
         <item name="daxColorStatusRed">@color/alertRedOnDarkDefault</item>
     </style>
 
@@ -502,6 +505,7 @@
         <item name="daxColorInputModeIndicatorShadow">@color/gray60</item>
 
         <!--Rebrand Status-->
+        <item name="daxColorRebrandStatusIndicatorOff">@color/black36</item>
         <item name="daxColorStatusRed">@color/rb_red50</item>
     </style>
 

--- a/android-design-system/design-system/src/test/java/com/duckduckgo/common/ui/ThemingRebrandOverlayTest.kt
+++ b/android-design-system/design-system/src/test/java/com/duckduckgo/common/ui/ThemingRebrandOverlayTest.kt
@@ -171,4 +171,58 @@ class ThemingRebrandOverlayTest {
             resolveColor(activity, R.attr.daxColorSwitchTrackOn),
         )
     }
+
+    @Test
+    fun whenBrandDesignUpdateThenStatusIndicatorOnColorIsRebrandGreen40() {
+        val activity = themedActivity()
+        activity.applyTheme(DuckDuckGoTheme.LIGHT, applyBrandDesignUpdate = true)
+
+        assertEquals(
+            colorOf(R.color.rb_green40),
+            resolveStatusIndicatorColor(activity, enabled = true),
+        )
+    }
+
+    @Test
+    fun whenLightThemeWithBrandDesignUpdateThenStatusIndicatorOffColorIsBlack36() {
+        val activity = themedActivity()
+        activity.applyTheme(DuckDuckGoTheme.LIGHT, applyBrandDesignUpdate = true)
+
+        assertEquals(
+            colorOf(R.color.black36),
+            resolveStatusIndicatorColor(activity, enabled = false),
+        )
+    }
+
+    @Test
+    fun whenDarkThemeWithBrandDesignUpdateThenStatusIndicatorOffColorIsWhite40() {
+        val activity = themedActivity()
+        activity.applyTheme(DuckDuckGoTheme.DARK, applyBrandDesignUpdate = true)
+
+        assertEquals(
+            colorOf(R.color.white40),
+            resolveStatusIndicatorColor(activity, enabled = false),
+        )
+    }
+
+    @Test
+    fun whenWithoutBrandDesignUpdateThenStatusIndicatorOffColorRemainsGray50() {
+        val activity = themedActivity()
+        activity.applyTheme(DuckDuckGoTheme.LIGHT)
+
+        assertEquals(
+            colorOf(R.color.gray50),
+            resolveStatusIndicatorColor(activity, enabled = false),
+        )
+    }
+
+    private fun resolveStatusIndicatorColor(
+        activity: AppCompatActivity,
+        enabled: Boolean,
+    ): Int {
+        val state = if (enabled) android.R.attr.state_enabled else -android.R.attr.state_enabled
+        return activity.resources
+            .getColorStateList(R.color.status_indicator_color_selector, activity.theme)
+            .getColorForState(intArrayOf(state), 0)
+    }
 }

--- a/android-design-system/design-system/src/test/java/com/duckduckgo/common/ui/view/BottomShadowTest.kt
+++ b/android-design-system/design-system/src/test/java/com/duckduckgo/common/ui/view/BottomShadowTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.view
+
+import android.content.Context
+import android.graphics.Outline
+import android.view.View
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.mobile.android.R
+import com.google.android.material.card.MaterialCardView
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BottomShadowTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>().apply {
+        setTheme(R.style.Theme_DuckDuckGo_Light)
+    }
+
+    @Test
+    fun whenMaterialCardHasStaticRadiusThenBottomShadowUsesMaterialCardRadius() {
+        val card = RadiusReportingMaterialCardView(context).apply {
+            outlineRadius = 7f
+            shapeAppearanceModel = shapeAppearanceModel.withCornerSize(18f)
+            layout(0, 0, 100, 40)
+            addBottomShadow()
+        }
+
+        assertEquals(7f, card.bottomShadowOutline().radius, 0f)
+    }
+
+    @Test
+    fun whenMaterialCardRadiusChangesAfterAddingBottomShadowThenOutlineUsesUpdatedRadius() {
+        val card = MaterialCardView(context).apply {
+            shapeAppearanceModel = shapeAppearanceModel.withCornerSize(7f)
+            layout(0, 0, 100, 40)
+            addBottomShadow()
+        }
+
+        card.shapeAppearanceModel = card.shapeAppearanceModel.withCornerSize(16f)
+
+        assertEquals(16f, card.radius, 0f)
+        assertEquals(16f, card.bottomShadowOutline().radius, 0f)
+    }
+
+    @Test
+    fun whenViewIsNotMaterialCardThenBottomShadowUsesSquareOutline() {
+        val view = View(context).apply {
+            layout(0, 0, 100, 40)
+            addBottomShadow()
+        }
+
+        assertEquals(0f, view.bottomShadowOutline().radius, 0f)
+    }
+
+    private fun View.bottomShadowOutline(): Outline = Outline().also { outline ->
+        outlineProvider.getOutline(this, outline)
+    }
+
+    private class RadiusReportingMaterialCardView(context: Context) : MaterialCardView(context) {
+        var outlineRadius: Float = 0f
+
+        override fun getRadius(): Float = outlineRadius
+    }
+}

--- a/app/src/internal/res/drawable/avd_check_green_24.xml
+++ b/app/src/internal/res/drawable/avd_check_green_24.xml
@@ -1,0 +1,34 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+
+    <aapt:attr name="android:drawable">
+        <vector
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <path
+                android:pathData="M12,2C6.477,2 2,6.477 2,12s4.477,10 10,10 10,-4.477 10,-10S17.523,2 12,2Z"
+                android:fillColor="@color/rb_green40" />
+            <path
+                android:name="tick"
+                android:pathData="M7.43,11.5 L10.75,14.82 L16.5,9.07"
+                android:strokeColor="#fff"
+                android:strokeWidth="1.5"
+                android:strokeLineCap="round"
+                android:strokeLineJoin="round"
+                android:trimPathEnd="0" />
+        </vector>
+    </aapt:attr>
+
+    <target android:name="tick">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:propertyName="trimPathEnd"
+                android:valueFrom="0"
+                android:valueTo="1"
+                android:duration="200"
+                android:interpolator="@android:interpolator/decelerate_quad" />
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/app/src/internal/res/drawable/ic_check_green_24.xml
+++ b/app/src/internal/res/drawable/ic_check_green_24.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,2C6.477,2 2,6.477 2,12s4.477,10 10,10 10,-4.477 10,-10S17.523,2 12,2Z"
+      android:fillColor="@color/rb_green40"/>
+  <path
+      android:pathData="M17.03,8.541a0.75,0.75 0,0 1,0 1.06l-4.866,4.867a2,2 0,0 1,-2.828 0L6.898,12.03a0.75,0.75 0,0 1,1.061 -1.06l2.438,2.437a0.5,0.5 0,0 0,0.707 0l4.866,-4.866a0.75,0.75 0,0 1,1.06 0Z"
+      android:fillColor="#fff"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -30,6 +30,7 @@ import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.di.scopes.FragmentScope
 import com.google.android.material.card.MaterialCardView
+import com.google.android.material.shape.RelativeCornerSize
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
@@ -98,6 +99,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
 
     private var omnibarCornerRadius = 0f
     private var widgetCornerRadius = 0f
+    private var widgetUsesRelativeCornerSize = false
     private var widgetCardElevation = 0f
     private var widgetCompatPaddingWidth = 0
     private var widgetCompatPaddingHeight = 0
@@ -327,7 +329,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
 
                 widgetCard.translationX = lerpF(holdTranslation.x, endTranslation.x, fraction)
                 widgetCard.translationY = lerpF(holdTranslation.y, endTranslation.y, fraction)
-                (widgetCard as? MaterialCardView)?.radius = lerpF(widgetCornerRadius, omnibarCornerRadius, fraction)
+                animateCornerRadius(widgetCard, lerpF(widgetCornerRadius, omnibarCornerRadius, fraction))
                 widgetContent?.alpha = 1 - fraction
                 omnibarCard.alpha = fraction
                 onUpdate(fraction)
@@ -375,9 +377,11 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
     }
 
     private fun captureCardProperties(widgetCard: View, omnibarCard: View) {
-        widgetCornerRadius = (widgetCard as? MaterialCardView)?.radius ?: 0f
+        val materialCard = widgetCard as? MaterialCardView
+        widgetUsesRelativeCornerSize = materialCard?.shapeAppearanceModel?.topLeftCornerSize is RelativeCornerSize
+        widgetCornerRadius = materialCard?.radius ?: 0f
         omnibarCornerRadius = (omnibarCard as? MaterialCardView)?.radius ?: 0f
-        widgetCardElevation = (widgetCard as? MaterialCardView)?.cardElevation ?: 0f
+        widgetCardElevation = materialCard?.cardElevation ?: 0f
         widgetCompatPaddingWidth = widgetCard.paddingLeft + widgetCard.paddingRight
         widgetCompatPaddingHeight = widgetCard.paddingTop + widgetCard.paddingBottom
     }
@@ -441,14 +445,18 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         val materialCard = card as? MaterialCardView
         val savedRadius = materialCard?.radius ?: 0f
         val savedMaxElevation = materialCard?.maxCardElevation ?: 0f
-        materialCard?.apply {
-            radius = widgetCornerRadius
-            maxCardElevation = savedMaxElevation
+        if (!widgetUsesRelativeCornerSize) {
+            materialCard?.apply {
+                radius = widgetCornerRadius
+                maxCardElevation = savedMaxElevation
+            }
         }
         val fullHeight = measureUnconstrainedHeight(card, fullWidth)
-        materialCard?.apply {
-            radius = savedRadius
-            maxCardElevation = savedMaxElevation
+        if (!widgetUsesRelativeCornerSize) {
+            materialCard?.apply {
+                radius = savedRadius
+                maxCardElevation = savedMaxElevation
+            }
         }
 
         runAnimator(
@@ -462,7 +470,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
 
                 card.translationX = offsetToOmnibar.x * (1 - fraction)
                 card.translationY = offsetToOmnibar.y * (1 - fraction)
-                (card as? MaterialCardView)?.radius = lerpF(omnibarCornerRadius, widgetCornerRadius, fraction)
+                animateCornerRadius(card, lerpF(omnibarCornerRadius, widgetCornerRadius, fraction))
                 widgetContent?.alpha = fraction
                 omnibarCard.alpha = 1 - fraction
                 onUpdate(fraction)
@@ -521,6 +529,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
     }
 
     private fun animateCornerRadius(card: View, topRadius: Float) {
+        if (widgetUsesRelativeCornerSize) return
         val materialCard = card as? MaterialCardView ?: return
         materialCard.radius = topRadius
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -1317,12 +1317,16 @@ class OmnibarLayout @JvmOverloads constructor(
                 useLightAnimation,
                 isAddressBarRebrandEnabled,
             )
-            if (boxed) {
+            val rebrandLayout = resolveRebrandPrivacyShieldLayout(privacyShieldState, isAddressBarRebrandEnabled)
+            if (boxed && rebrandLayout != null) {
+                val slotSize = rebrandLayout.slotSizeDp.toPx(context)
+                val contentInset = rebrandLayout.contentInsetDp.toPx(context)
                 shieldIconView.updateLayoutParams<MarginLayoutParams> {
-                    width = shieldIconBoxSize
-                    height = shieldIconBoxSize
-                    marginStart = 2.toPx(context)
+                    width = slotSize
+                    height = slotSize
+                    marginStart = 0
                 }
+                shieldIconView.setPadding(contentInset, contentInset, contentInset, contentInset)
                 shieldIconView.scaleType = ImageView.ScaleType.CENTER_INSIDE
             } else if (privacyShieldState != PrivacyShieldState.UNKNOWN) {
                 val isNewCustomTab =
@@ -1336,6 +1340,7 @@ class OmnibarLayout @JvmOverloads constructor(
                     height = LayoutParams.MATCH_PARENT
                     marginStart = 0
                 }
+                shieldIconView.setPadding(0, 0, 0, 0)
                 shieldIconView.scaleType =
                     if (isNewCustomTab) {
                         ImageView.ScaleType.MATRIX
@@ -1826,6 +1831,26 @@ internal fun shouldUseCustomTabToolbarColorForShield(
     !isNewCustomTabEnabled || !isDefaultToolbarColor
 } else {
     isNewCustomTabEnabled && !isDefaultToolbarColor
+}
+
+internal data class RebrandPrivacyShieldLayout(
+    val slotSizeDp: Int,
+    val contentInsetDp: Int,
+)
+
+internal fun resolveRebrandPrivacyShieldLayout(
+    privacyShieldState: PrivacyShieldState,
+    isAddressBarRebrandEnabled: Boolean,
+): RebrandPrivacyShieldLayout? {
+    if (!isAddressBarRebrandEnabled) return null
+
+    return when (privacyShieldState) {
+        PrivacyShieldState.PROTECTED -> RebrandPrivacyShieldLayout(slotSizeDp = 44, contentInsetDp = 0)
+        PrivacyShieldState.UNPROTECTED,
+        PrivacyShieldState.MALICIOUS,
+        -> RebrandPrivacyShieldLayout(slotSizeDp = 44, contentInsetDp = 2)
+        PrivacyShieldState.UNKNOWN -> null
+    }
 }
 
 /**

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/AddressBarTrackersAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/AddressBarTrackersAnimator.kt
@@ -37,6 +37,8 @@ import androidx.core.view.updateLayoutParams
 import com.airbnb.lottie.LottieAnimationView
 import com.airbnb.lottie.RenderMode
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.omnibar.resolveRebrandPrivacyShieldLayout
+import com.duckduckgo.app.global.model.PrivacyShield.PROTECTED
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.store.AppBrandDesignUpdateToggles
@@ -98,14 +100,15 @@ class AddressBarTrackersAnimator @Inject constructor(
         } else {
             RenderMode.AUTOMATIC
         }
-        if (addressBarRebrandEnabled) {
-            val boxSize = addressBarTrackersBlockedAnimationShieldIcon.resources.getDimensionPixelSize(CommonR.dimen.toolbarIcon)
+        resolveRebrandPrivacyShieldLayout(PROTECTED, addressBarRebrandEnabled)?.let { shieldLayout ->
+            val boxSize = shieldLayout.slotSizeDp.toPx(context)
             addressBarTrackersBlockedAnimationShieldIcon.setAnimation(R.raw.shield_color_24)
             addressBarTrackersBlockedAnimationShieldIcon.updateLayoutParams<ViewGroup.MarginLayoutParams> {
                 width = boxSize
                 height = boxSize
-                marginStart = 2.toPx(context)
+                marginStart = 0
             }
+            addressBarTrackersBlockedAnimationShieldIcon.setPadding(0, 0, 0, 0)
             addressBarTrackersBlockedAnimationShieldIcon.scaleType = ImageView.ScaleType.FIT_CENTER
         }
         addressBarTrackersBlockedAnimationShieldIcon.show()

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -92,6 +92,8 @@ import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.QUICK_SETUP
 import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.SKIP_ONBOARDING_OPTION
 import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.SYNC_RESTORE
 import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.WIDGET_PROMPT
+import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.applyInputScreenPreviewInsets
+import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.applyInputScreenPreviewShape
 import com.duckduckgo.app.onboarding.ui.view.OnboardingStepIndicatorView
 import com.duckduckgo.app.onboardingquicksetup.ui.BrandDesignInputScreenPicker
 import com.duckduckgo.app.onboardingquicksetup.ui.QuickSetupAddressBarPositionBottomSheet
@@ -100,6 +102,7 @@ import com.duckduckgo.app.onboardingquicksetup.ui.RemoveWidgetInstructionsBottom
 import com.duckduckgo.app.widget.AddWidgetLauncher
 import com.duckduckgo.app.widget.AddWidgetSource
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.common.ui.store.AppBrandDesignUpdateToggles
 import com.duckduckgo.common.ui.store.AppTheme
 import com.duckduckgo.common.ui.view.addBottomShadow
 import com.duckduckgo.common.ui.view.text.DaxTextView
@@ -140,6 +143,9 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
 
     @Inject
     lateinit var appTheme: AppTheme
+
+    @Inject
+    lateinit var appBrandDesignUpdateToggles: AppBrandDesignUpdateToggles
 
     @Inject
     lateinit var addWidgetLauncher: AddWidgetLauncher
@@ -2832,6 +2838,14 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
     ) {
         currentInputMode = inputMode
         val previewContent = binding.daxDialogCta.inputScreenPreviewContent
+        val isAddressBarRebrandEnabled = appBrandDesignUpdateToggles.addressBar().isEnabled()
+        previewContent.inputModeDemoCard.applyInputScreenPreviewShape(
+            isAddressBarRebrandEnabled = isAddressBarRebrandEnabled,
+        )
+        previewContent.inputText.applyInputScreenPreviewInsets(
+            isAddressBarRebrandEnabled = isAddressBarRebrandEnabled,
+            actionIcon = previewContent.inputModeDemoActionIcon,
+        )
 
         listOf(previewContent.suggestion1, previewContent.suggestion2, previewContent.suggestion3)
             .forEachIndexed { index, button ->

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -1569,7 +1569,10 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     binding.daxDialogCta.inputScreenPreviewContent.inputModeToggle.addOnTabSelectedListener(
                         object : com.google.android.material.tabs.TabLayout.OnTabSelectedListener {
                             override fun onTabSelected(tab: com.google.android.material.tabs.TabLayout.Tab) {
-                                val changeBounds = ChangeBounds().apply { duration = DIALOG_TRANSITION_DURATION }
+                                val changeBounds = ChangeBounds().apply {
+                                    duration = DIALOG_TRANSITION_DURATION
+                                    excludeTarget(R.id.inputText, true)
+                                }
                                 TransitionManager.beginDelayedTransition(
                                     binding.daxDialogCta.cardView,
                                     changeBounds,
@@ -2273,7 +2276,10 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 previewContent.inputModeToggle.addOnTabSelectedListener(
                     object : com.google.android.material.tabs.TabLayout.OnTabSelectedListener {
                         override fun onTabSelected(tab: com.google.android.material.tabs.TabLayout.Tab) {
-                            val changeBounds = ChangeBounds().apply { duration = DIALOG_TRANSITION_DURATION }
+                            val changeBounds = ChangeBounds().apply {
+                                duration = DIALOG_TRANSITION_DURATION
+                                excludeTarget(R.id.inputText, true)
+                            }
                             TransitionManager.beginDelayedTransition(
                                 binding.daxDialogCta.cardView,
                                 changeBounds,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -1569,10 +1569,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     binding.daxDialogCta.inputScreenPreviewContent.inputModeToggle.addOnTabSelectedListener(
                         object : com.google.android.material.tabs.TabLayout.OnTabSelectedListener {
                             override fun onTabSelected(tab: com.google.android.material.tabs.TabLayout.Tab) {
-                                val changeBounds = ChangeBounds().apply {
-                                    duration = DIALOG_TRANSITION_DURATION
-                                    excludeTarget(R.id.inputText, true)
-                                }
+                                val changeBounds = ChangeBounds().apply { duration = DIALOG_TRANSITION_DURATION }
                                 TransitionManager.beginDelayedTransition(
                                     binding.daxDialogCta.cardView,
                                     changeBounds,
@@ -2276,10 +2273,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 previewContent.inputModeToggle.addOnTabSelectedListener(
                     object : com.google.android.material.tabs.TabLayout.OnTabSelectedListener {
                         override fun onTabSelected(tab: com.google.android.material.tabs.TabLayout.Tab) {
-                            val changeBounds = ChangeBounds().apply {
-                                duration = DIALOG_TRANSITION_DURATION
-                                excludeTarget(R.id.inputText, true)
-                            }
+                            val changeBounds = ChangeBounds().apply { duration = DIALOG_TRANSITION_DURATION }
                             TransitionManager.beginDelayedTransition(
                                 binding.daxDialogCta.cardView,
                                 changeBounds,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -94,6 +94,7 @@ import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.SYNC_RESTOR
 import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.WIDGET_PROMPT
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.applyInputScreenPreviewInsets
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.applyInputScreenPreviewShape
+import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.updateInputModePreservingSelection
 import com.duckduckgo.app.onboarding.ui.view.OnboardingStepIndicatorView
 import com.duckduckgo.app.onboardingquicksetup.ui.BrandDesignInputScreenPicker
 import com.duckduckgo.app.onboardingquicksetup.ui.QuickSetupAddressBarPositionBottomSheet
@@ -2873,30 +2874,32 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
             }
         }
 
-        when (inputMode) {
-            InputMode.SEARCH -> {
-                previewContent.inputText.minLines = 1
-                previewContent.inputText.maxLines = 1
-                previewContent.inputText.inputType = InputType.TYPE_CLASS_TEXT
-                previewContent.inputText.imeOptions = EditorInfo.IME_ACTION_SEARCH
-                previewContent.inputText.setHint(R.string.preOnboardingInputModeDemoSearchHint)
-                previewContent.inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_find_search_24)
+        previewContent.inputText.updateInputModePreservingSelection {
+            when (inputMode) {
+                InputMode.SEARCH -> {
+                    minLines = 1
+                    maxLines = 1
+                    inputType = InputType.TYPE_CLASS_TEXT
+                    imeOptions = EditorInfo.IME_ACTION_SEARCH
+                    setHint(R.string.preOnboardingInputModeDemoSearchHint)
+                    previewContent.inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_find_search_24)
+                }
+                InputMode.CHAT -> {
+                    minLines = 3
+                    maxLines = 3
+                    inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+                    imeOptions = EditorInfo.IME_ACTION_UNSPECIFIED
+                    setHint(R.string.preOnboardingInputModeDemoChatHint)
+                    previewContent.inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_arrow_right_24)
+                }
             }
-            InputMode.CHAT -> {
-                previewContent.inputText.minLines = 3
-                previewContent.inputText.maxLines = 3
-                previewContent.inputText.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
-                previewContent.inputText.imeOptions = EditorInfo.IME_ACTION_UNSPECIFIED
-                previewContent.inputText.setHint(R.string.preOnboardingInputModeDemoChatHint)
-                previewContent.inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_arrow_right_24)
-            }
-        }
 
-        // Toggling modes changes inputType/imeOptions while the EditText may be focused with the keyboard shown;
-        // restart input so the IME picks up the new action/Enter behavior immediately.
-        if (previewContent.inputText.hasFocus()) {
-            context?.let { ctx ->
-                ContextCompat.getSystemService(ctx, InputMethodManager::class.java)?.restartInput(previewContent.inputText)
+            // Toggling modes changes inputType/imeOptions while the EditText may be focused with the keyboard shown;
+            // restart input so the IME picks up the new action/Enter behavior immediately.
+            if (hasFocus()) {
+                this@BrandDesignUpdateWelcomePage.context?.let { ctx ->
+                    ContextCompat.getSystemService(ctx, InputMethodManager::class.java)?.restartInput(this)
+                }
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -31,7 +31,6 @@ import android.graphics.Typeface
 import android.graphics.drawable.AnimatedVectorDrawable
 import android.media.MediaPlayer
 import android.os.Bundle
-import android.text.InputType
 import android.util.TypedValue
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
@@ -94,6 +93,7 @@ import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.SYNC_RESTOR
 import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.WIDGET_PROMPT
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.applyInputScreenPreviewInsets
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.applyInputScreenPreviewShape
+import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.applyInputTextMode
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.updateInputModePreservingSelection
 import com.duckduckgo.app.onboarding.ui.view.OnboardingStepIndicatorView
 import com.duckduckgo.app.onboardingquicksetup.ui.BrandDesignInputScreenPicker
@@ -2881,19 +2881,14 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         }
 
         previewContent.inputText.updateInputModePreservingSelection {
+            applyInputTextMode(inputMode == InputMode.SEARCH)
             when (inputMode) {
                 InputMode.SEARCH -> {
-                    minLines = 1
-                    maxLines = 1
-                    inputType = InputType.TYPE_CLASS_TEXT
                     imeOptions = EditorInfo.IME_ACTION_SEARCH
                     setHint(R.string.preOnboardingInputModeDemoSearchHint)
                     previewContent.inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_find_search_24)
                 }
                 InputMode.CHAT -> {
-                    minLines = 3
-                    maxLines = 3
-                    inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
                     imeOptions = EditorInfo.IME_ACTION_UNSPECIFIED
                     setHint(R.string.preOnboardingInputModeDemoChatHint)
                     previewContent.inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_arrow_right_24)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
@@ -64,6 +64,7 @@ import com.duckduckgo.app.widget.AddWidgetSource
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.autofill.api.AutofillImportLaunchSource.Onboarding
 import com.duckduckgo.autofill.api.AutofillScreens.AutofillImportPasswordsScreen
+import com.duckduckgo.common.ui.store.AppBrandDesignUpdateToggles
 import com.duckduckgo.common.ui.store.AppTheme
 import com.duckduckgo.common.ui.view.dialog.DaxAlertDialog
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
@@ -96,6 +97,9 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
 
     @Inject
     lateinit var appTheme: AppTheme
+
+    @Inject
+    lateinit var appBrandDesignUpdateToggles: AppBrandDesignUpdateToggles
 
     @Inject
     lateinit var addWidgetLauncher: AddWidgetLauncher
@@ -187,6 +191,7 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
                 contentValues = viewModel.contentValues,
                 onContentBound = viewModel::onContentBound,
                 isLightMode = { appTheme.isLightModeEnabled() },
+                isAddressBarRebrandEnabled = { appBrandDesignUpdateToggles.addressBar().isEnabled() },
             ),
             cardStage = CardStageImpl(binding),
             background = BackgroundControllerImpl(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
@@ -59,7 +59,7 @@ import com.duckduckgo.mobile.android.R as CommonR
  */
 class InputScreenPreviewBinder(
     private val binding: IncludeBrandDesignInputScreenPreviewBinding,
-    private val isAddressBarRebrandEnabled: Boolean,
+    private val isAddressBarRebrandEnabled: () -> Boolean,
 ) : StatefulDialogBinder<ContentConfig.InputScreenPreview, InputScreenPreviewContentState> {
 
     override val view: View = binding.root
@@ -122,6 +122,7 @@ class InputScreenPreviewBinder(
         isSearchSelected: Boolean,
         scope: BindScope,
     ) = with(binding) {
+        val isAddressBarRebrandEnabled = isAddressBarRebrandEnabled()
         inputModeDemoCard.applyInputScreenPreviewShape(isAddressBarRebrandEnabled)
         inputText.applyInputScreenPreviewInsets(isAddressBarRebrandEnabled, inputModeDemoActionIcon)
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
@@ -149,17 +149,12 @@ class InputScreenPreviewBinder(
         }
 
         inputText.updateInputModePreservingSelection {
+            applyInputTextMode(isSearchSelected)
             if (isSearchSelected) {
-                minLines = 1
-                maxLines = 1
-                inputType = InputType.TYPE_CLASS_TEXT
                 imeOptions = EditorInfo.IME_ACTION_SEARCH
                 setHint(R.string.preOnboardingInputModeDemoSearchHint)
                 inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_find_search_24)
             } else {
-                minLines = CHAT_INPUT_LINES
-                maxLines = CHAT_INPUT_LINES
-                inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
                 imeOptions = EditorInfo.IME_ACTION_UNSPECIFIED
                 setHint(R.string.preOnboardingInputModeDemoChatHint)
                 inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_arrow_right_24)
@@ -247,7 +242,6 @@ class InputScreenPreviewBinder(
     private companion object {
         const val SEARCH_TAB_INDEX = 0
         const val CHAT_TAB_INDEX = 1
-        const val CHAT_INPUT_LINES = 3
         const val SUGGESTION_FADE_DURATION_MS = 500L
         const val MODE_SWITCH_DURATION_MS = 400L
         const val SUGGESTIONS_START_DELAY_MS = 500L
@@ -299,6 +293,18 @@ internal fun EditText.applyInputScreenPreviewInsets(
         actionIcon.updateLayoutParams<ViewGroup.MarginLayoutParams> {
             marginEnd = actionIconMarginEnd
         }
+    }
+}
+
+internal fun EditText.applyInputTextMode(isSearchSelected: Boolean) {
+    if (isSearchSelected) {
+        inputType = InputType.TYPE_CLASS_TEXT
+        minLines = 1
+        maxLines = 1
+    } else {
+        inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+        minLines = 3
+        maxLines = Int.MAX_VALUE
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
@@ -147,26 +147,28 @@ class InputScreenPreviewBinder(
             }
         }
 
-        if (isSearchSelected) {
-            inputText.minLines = 1
-            inputText.maxLines = 1
-            inputText.inputType = InputType.TYPE_CLASS_TEXT
-            inputText.imeOptions = EditorInfo.IME_ACTION_SEARCH
-            inputText.setHint(R.string.preOnboardingInputModeDemoSearchHint)
-            inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_find_search_24)
-        } else {
-            inputText.minLines = CHAT_INPUT_LINES
-            inputText.maxLines = CHAT_INPUT_LINES
-            inputText.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
-            inputText.imeOptions = EditorInfo.IME_ACTION_UNSPECIFIED
-            inputText.setHint(R.string.preOnboardingInputModeDemoChatHint)
-            inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_arrow_right_24)
-        }
+        inputText.updateInputModePreservingSelection {
+            if (isSearchSelected) {
+                minLines = 1
+                maxLines = 1
+                inputType = InputType.TYPE_CLASS_TEXT
+                imeOptions = EditorInfo.IME_ACTION_SEARCH
+                setHint(R.string.preOnboardingInputModeDemoSearchHint)
+                inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_find_search_24)
+            } else {
+                minLines = CHAT_INPUT_LINES
+                maxLines = CHAT_INPUT_LINES
+                inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+                imeOptions = EditorInfo.IME_ACTION_UNSPECIFIED
+                setHint(R.string.preOnboardingInputModeDemoChatHint)
+                inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_arrow_right_24)
+            }
 
-        // A mode switch can land while the field is already focused, so the IME has to be told to pick up the
-        // new action and Enter behaviour.
-        if (inputText.hasFocus()) {
-            ContextCompat.getSystemService(root.context, InputMethodManager::class.java)?.restartInput(inputText)
+            // A mode switch can land while the field is already focused, so the IME has to be told to pick up the
+            // new action and Enter behaviour.
+            if (hasFocus()) {
+                ContextCompat.getSystemService(root.context, InputMethodManager::class.java)?.restartInput(this)
+            }
         }
     }
 
@@ -296,6 +298,21 @@ internal fun EditText.applyInputScreenPreviewInsets(
         actionIcon.updateLayoutParams<ViewGroup.MarginLayoutParams> {
             marginEnd = actionIconMarginEnd
         }
+    }
+}
+
+internal inline fun EditText.updateInputModePreservingSelection(updateInputMode: EditText.() -> Unit) {
+    val previousSelectionStart = selectionStart
+    val previousSelectionEnd = selectionEnd
+
+    updateInputMode()
+
+    if (previousSelectionStart >= 0 && previousSelectionEnd >= 0) {
+        val textLength = text.length
+        setSelection(
+            previousSelectionStart.coerceAtMost(textLength),
+            previousSelectionEnd.coerceAtMost(textLength),
+        )
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/binders/InputScreenPreviewBinder.kt
@@ -23,12 +23,15 @@ import android.animation.ObjectAnimator
 import android.os.Build
 import android.text.InputType
 import android.view.View
+import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.IncludeBrandDesignInputScreenPreviewBinding
 import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
@@ -39,6 +42,8 @@ import com.duckduckgo.app.onboarding.ui.page.configdriven.ContentInteraction
 import com.duckduckgo.app.onboarding.ui.page.configdriven.InputScreenPreviewContentState
 import com.duckduckgo.app.onboarding.ui.page.configdriven.StatefulDialogBinder
 import com.duckduckgo.common.ui.view.addBottomShadow
+import com.google.android.material.card.MaterialCardView
+import com.google.android.material.shape.ShapeAppearanceModel
 import com.google.android.material.tabs.TabLayout
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectIndexed
@@ -54,6 +59,7 @@ import com.duckduckgo.mobile.android.R as CommonR
  */
 class InputScreenPreviewBinder(
     private val binding: IncludeBrandDesignInputScreenPreviewBinding,
+    private val isAddressBarRebrandEnabled: Boolean,
 ) : StatefulDialogBinder<ContentConfig.InputScreenPreview, InputScreenPreviewContentState> {
 
     override val view: View = binding.root
@@ -116,6 +122,9 @@ class InputScreenPreviewBinder(
         isSearchSelected: Boolean,
         scope: BindScope,
     ) = with(binding) {
+        inputModeDemoCard.applyInputScreenPreviewShape(isAddressBarRebrandEnabled)
+        inputText.applyInputScreenPreviewInsets(isAddressBarRebrandEnabled, inputModeDemoActionIcon)
+
         bindSuggestionButtons(
             suggestions = if (isSearchSelected) content.searchSuggestions else content.chatSuggestions,
             isSearchSelected = isSearchSelected,
@@ -242,3 +251,62 @@ class InputScreenPreviewBinder(
         const val MIN_SCREEN_HEIGHT_FOR_KEYBOARD_DP = 600
     }
 }
+
+internal fun MaterialCardView.applyInputScreenPreviewShape(
+    isAddressBarRebrandEnabled: Boolean,
+) {
+    shapeAppearanceModel = inputScreenPreviewShape(
+        baseShape = shapeAppearanceModel,
+        isAddressBarRebrandEnabled = isAddressBarRebrandEnabled,
+        // The full input radius keeps the taller Duck.ai preview pill-shaped; half leaves straight sides.
+        rebrandCornerSize = resources.getDimension(CommonR.dimen.rebrandInputRadius) / 2f,
+        legacyCornerSize = resources.getDimension(CommonR.dimen.largeShapeCornerRadius),
+    )
+    clipToOutline = false
+    invalidateOutline()
+}
+
+internal fun EditText.applyInputScreenPreviewInsets(
+    isAddressBarRebrandEnabled: Boolean,
+    actionIcon: View,
+) {
+    if (!isAddressBarRebrandEnabled) return
+
+    val container = parent as View
+    val horizontalInset = resources.getDimensionPixelSize(CommonR.dimen.keyline_4)
+    val verticalInset = resources.getDimensionPixelSize(CommonR.dimen.keyline_3)
+    val inputMarginStart = (horizontalInset - container.paddingStart).coerceAtLeast(0)
+    if ((layoutParams as ViewGroup.MarginLayoutParams).marginStart != inputMarginStart) {
+        updateLayoutParams<ViewGroup.MarginLayoutParams> {
+            marginStart = inputMarginStart
+        }
+    }
+    val inputPaddingTop = (verticalInset - container.paddingTop).coerceAtLeast(0)
+    val inputPaddingBottom = (verticalInset - container.paddingBottom).coerceAtLeast(0)
+    if (paddingStart != 0 || paddingTop != inputPaddingTop || paddingEnd != 0 || paddingBottom != inputPaddingBottom) {
+        setPaddingRelative(0, inputPaddingTop, 0, inputPaddingBottom)
+    }
+
+    val actionIconContentInset = (
+        resources.getDimensionPixelSize(CommonR.dimen.toolbarIcon) -
+            resources.getDimensionPixelSize(CommonR.dimen.toolbarIconSize)
+        ) / 2
+    val actionIconMarginEnd = (horizontalInset - container.paddingEnd - actionIconContentInset).coerceAtLeast(0)
+    if ((actionIcon.layoutParams as ViewGroup.MarginLayoutParams).marginEnd != actionIconMarginEnd) {
+        actionIcon.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+            marginEnd = actionIconMarginEnd
+        }
+    }
+}
+
+internal fun inputScreenPreviewShape(
+    baseShape: ShapeAppearanceModel,
+    isAddressBarRebrandEnabled: Boolean,
+    rebrandCornerSize: Float,
+    legacyCornerSize: Float,
+): ShapeAppearanceModel =
+    if (isAddressBarRebrandEnabled) {
+        baseShape.withCornerSize(rebrandCornerSize)
+    } else {
+        baseShape.withCornerSize(legacyCornerSize)
+    }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/CardStage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/CardStage.kt
@@ -28,6 +28,7 @@ import androidx.transition.ChangeBounds
 import androidx.transition.Transition
 import androidx.transition.TransitionListenerAdapter
 import androidx.transition.TransitionManager
+import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ContentOnboardingWelcomePageUpdateBinding
 import com.duckduckgo.app.onboarding.ui.page.configdriven.CtaConfig
 import com.duckduckgo.common.ui.view.button.DaxButton
@@ -135,7 +136,11 @@ class CardStageImpl(private val binding: ContentOnboardingWelcomePageUpdateBindi
     override fun beginBoundsTransition(durationMs: Long) {
         // A view that has never been laid out has zero bounds, which the transition would tween the card out of.
         if (!morphScene.isLaidOut) return
-        TransitionManager.beginDelayedTransition(morphScene, ChangeBounds().setDuration(durationMs))
+        val transition = ChangeBounds().apply {
+            duration = durationMs
+            excludeTarget(R.id.inputText, true)
+        }
+        TransitionManager.beginDelayedTransition(morphScene, transition)
     }
 
     override fun showCtaButtons(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/CardStage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/CardStage.kt
@@ -28,7 +28,6 @@ import androidx.transition.ChangeBounds
 import androidx.transition.Transition
 import androidx.transition.TransitionListenerAdapter
 import androidx.transition.TransitionManager
-import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ContentOnboardingWelcomePageUpdateBinding
 import com.duckduckgo.app.onboarding.ui.page.configdriven.CtaConfig
 import com.duckduckgo.common.ui.view.button.DaxButton
@@ -136,11 +135,7 @@ class CardStageImpl(private val binding: ContentOnboardingWelcomePageUpdateBindi
     override fun beginBoundsTransition(durationMs: Long) {
         // A view that has never been laid out has zero bounds, which the transition would tween the card out of.
         if (!morphScene.isLaidOut) return
-        val transition = ChangeBounds().apply {
-            duration = durationMs
-            excludeTarget(R.id.inputText, true)
-        }
-        TransitionManager.beginDelayedTransition(morphScene, transition)
+        TransitionManager.beginDelayedTransition(morphScene, ChangeBounds().setDuration(durationMs))
     }
 
     override fun showCtaButtons(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
@@ -64,7 +64,7 @@ class ContentControllerImpl(
     private val comparisonChart = ComparisonChartBinder(binding.comparisonChartContent)
     private val addressBar = AddressBarBinder(binding.addressBarContent, isLightMode)
     private val inputScreen = InputScreenBinder(binding.inputScreenContent, isLightMode)
-    private val inputScreenPreview = InputScreenPreviewBinder(binding.inputScreenPreviewContent, isAddressBarRebrandEnabled.invoke())
+    private val inputScreenPreview = InputScreenPreviewBinder(binding.inputScreenPreviewContent, isAddressBarRebrandEnabled)
     private val quickSetup = QuickSetupBinder(binding.reinstallerQuickSetupContent)
     private val welcome = WelcomeBinder(binding.welcomeContent)
     private val addToDock = AddToDockBinder(binding.addToDockContent)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
@@ -58,12 +58,13 @@ class ContentControllerImpl(
     private val contentValues: ContentValueStore,
     private val onContentBound: (LinearOnboardingStepId, ContentConfig) -> Unit,
     isLightMode: () -> Boolean,
+    isAddressBarRebrandEnabled: () -> Boolean,
 ) : ContentController {
 
     private val comparisonChart = ComparisonChartBinder(binding.comparisonChartContent)
     private val addressBar = AddressBarBinder(binding.addressBarContent, isLightMode)
     private val inputScreen = InputScreenBinder(binding.inputScreenContent, isLightMode)
-    private val inputScreenPreview = InputScreenPreviewBinder(binding.inputScreenPreviewContent)
+    private val inputScreenPreview = InputScreenPreviewBinder(binding.inputScreenPreviewContent, isAddressBarRebrandEnabled.invoke())
     private val quickSetup = QuickSetupBinder(binding.reinstallerQuickSetupContent)
     private val welcome = WelcomeBinder(binding.welcomeContent)
     private val addToDock = AddToDockBinder(binding.addToDockContent)

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -51,6 +51,7 @@ import com.duckduckgo.app.browser.newtab.FavoritesQuickAccessAdapter
 import com.duckduckgo.app.browser.newtab.FavoritesQuickAccessAdapter.Companion.QUICK_ACCESS_GRID_MAX_COLUMNS
 import com.duckduckgo.app.browser.newtab.FavoritesQuickAccessAdapter.Companion.QUICK_ACCESS_ITEM_MAX_SIZE_DP
 import com.duckduckgo.app.browser.newtab.QuickAccessDragTouchItemListener
+import com.duckduckgo.app.browser.omnibar.applyAddressBarRebrandRadius
 import com.duckduckgo.app.fire.DataClearerForegroundAppRestartPixel
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppReturnPixelSender
@@ -162,6 +163,7 @@ class SystemSearchActivity : DuckDuckGoActivity() {
     private lateinit var voiceSearch: ImageView
     private lateinit var clearTextButton: ImageView
     private lateinit var shadowContainer: MaterialCardView
+    private lateinit var inputContainer: MaterialCardView
     private lateinit var logo: ImageView
     private lateinit var duckAi: ImageView
     private lateinit var omnibarDivider: View
@@ -184,6 +186,14 @@ class SystemSearchActivity : DuckDuckGoActivity() {
         voiceSearch = if (isOmnibarAtTop) binding.voiceSearchButton else binding.voiceSearchButtonBottom
         clearTextButton = if (isOmnibarAtTop) binding.clearTextButton else binding.clearTextButtonBottom
         shadowContainer = if (isOmnibarAtTop) binding.omniBarContainerShadow else binding.omniBarContainerShadowBottom
+        inputContainer = if (isOmnibarAtTop) binding.omniBarContainer else binding.omniBarContainerBottom
+        applyAddressBarRebrandRadius(
+            isEnabled = appBrandDesignUpdateToggles.addressBar().isEnabled(),
+            rebrandRadius = resources.getDimension(CommonR.dimen.rebrandInputRadius),
+            legacyRadius = resources.getDimension(CommonR.dimen.largeShapeCornerRadius),
+            shadowContainer,
+            inputContainer,
+        )
         logo = if (isOmnibarAtTop) binding.logo else binding.logoBottom
         duckAi = if (isOmnibarAtTop) binding.aiChatIconMenu else binding.aiChatIconMenuBottom
         omnibarDivider = if (isOmnibarAtTop) binding.verticalDivider else binding.verticalDividerBottom

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputAnimatorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputAnimatorTest.kt
@@ -24,11 +24,20 @@ import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.material.card.MaterialCardView
+import com.google.android.material.shape.RelativeCornerSize
+import com.google.android.material.shape.ShapeAppearanceModel
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
 class RealNativeInputAnimatorTest {
@@ -101,6 +110,32 @@ class RealNativeInputAnimatorTest {
         val margins = testee.init(card, omnibarCard, omnibarCard.width, omnibarCard.height, isBottom = false)
 
         assertNotNull(margins)
+    }
+
+    @Test
+    fun whenInitWithRelativeWidgetCornersThenPreservesShapeAndCompatPadding() {
+        val params = LinearLayout.LayoutParams(0, WRAP_CONTENT, 1f)
+        val relativeShape = ShapeAppearanceModel.builder().setAllCornerSizes(ShapeAppearanceModel.PILL).build()
+        val card = mock<MaterialCardView> {
+            on { layoutParams } doReturn params
+            on { shapeAppearanceModel } doReturn relativeShape
+            on { radius } doReturn 0f
+            on { cardElevation } doReturn 6f
+            on { paddingLeft } doReturn 8
+            on { paddingTop } doReturn 12
+            on { paddingRight } doReturn 8
+            on { paddingBottom } doReturn 12
+        }
+        val omnibarCard = mock<MaterialCardView> {
+            on { radius } doReturn 48f
+        }
+
+        val margins = testee.init(card, omnibarCard, omnibarWidth = 300, omnibarHeight = 48, isBottom = false)
+
+        assertNotNull(margins)
+        assertTrue(card.shapeAppearanceModel.topLeftCornerSize is RelativeCornerSize)
+        verify(card, never()).radius = any()
+        assertEquals(72, params.height)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/RebrandPrivacyShieldLayoutTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/RebrandPrivacyShieldLayoutTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.omnibar
+
+import com.duckduckgo.app.global.model.PrivacyShield.MALICIOUS
+import com.duckduckgo.app.global.model.PrivacyShield.PROTECTED
+import com.duckduckgo.app.global.model.PrivacyShield.UNKNOWN
+import com.duckduckgo.app.global.model.PrivacyShield.UNPROTECTED
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RebrandPrivacyShieldLayoutTest {
+
+    @Test
+    fun whenAddressBarRebrandEnabledAndShieldProtectedThenAnimationFillsSlot() {
+        assertEquals(
+            RebrandPrivacyShieldLayout(slotSizeDp = 44, contentInsetDp = 0),
+            resolveRebrandPrivacyShieldLayout(PROTECTED, isAddressBarRebrandEnabled = true),
+        )
+    }
+
+    @Test
+    fun whenAddressBarRebrandEnabledAndShieldUnprotectedThenIconIsCenteredInSlot() {
+        assertEquals(
+            RebrandPrivacyShieldLayout(slotSizeDp = 44, contentInsetDp = 2),
+            resolveRebrandPrivacyShieldLayout(UNPROTECTED, isAddressBarRebrandEnabled = true),
+        )
+    }
+
+    @Test
+    fun whenAddressBarRebrandEnabledAndShieldMaliciousThenIconIsCenteredInSlot() {
+        assertEquals(
+            RebrandPrivacyShieldLayout(slotSizeDp = 44, contentInsetDp = 2),
+            resolveRebrandPrivacyShieldLayout(MALICIOUS, isAddressBarRebrandEnabled = true),
+        )
+    }
+
+    @Test
+    fun whenAddressBarRebrandDisabledThenRebrandLayoutIsNotApplied() {
+        assertNull(resolveRebrandPrivacyShieldLayout(PROTECTED, isAddressBarRebrandEnabled = false))
+        assertNull(resolveRebrandPrivacyShieldLayout(UNPROTECTED, isAddressBarRebrandEnabled = false))
+        assertNull(resolveRebrandPrivacyShieldLayout(MALICIOUS, isAddressBarRebrandEnabled = false))
+    }
+
+    @Test
+    fun whenShieldUnknownThenRebrandLayoutIsNotApplied() {
+        assertNull(resolveRebrandPrivacyShieldLayout(UNKNOWN, isAddressBarRebrandEnabled = true))
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/InputScreenPreviewShapeTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/InputScreenPreviewShapeTest.kt
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.page
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.res.Resources
+import android.graphics.RectF
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.LinearLayout
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.applyInputScreenPreviewInsets
+import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.applyInputScreenPreviewShape
+import com.google.android.material.card.MaterialCardView
+import com.google.android.material.shape.RelativeCornerSize
+import com.google.android.material.shape.ShapeAppearanceModel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import com.duckduckgo.mobile.android.R as CommonR
+
+@RunWith(AndroidJUnit4::class)
+class InputScreenPreviewShapeTest {
+
+    private val baseContext = ApplicationProvider.getApplicationContext<Context>()
+    private val baseShape = ShapeAppearanceModel.builder().build()
+
+    @Test
+    fun whenAddressBarRebrandEnabledThenUsesHalfTheRebrandInputRadius() {
+        val suppliedRebrandInputRadius = 10f
+        val card = card(
+            shapeResources(
+                rebrandInputRadius = suppliedRebrandInputRadius,
+                legacyRadius = 3f,
+            ),
+        )
+
+        card.applyInputScreenPreviewShape(isAddressBarRebrandEnabled = true)
+
+        val shape = argumentCaptor<ShapeAppearanceModel>()
+        verify(card).shapeAppearanceModel = shape.capture()
+        assertFixedCorners(shape.firstValue, suppliedRebrandInputRadius / 2f)
+        verify(card.resources).getDimension(CommonR.dimen.rebrandInputRadius)
+        verify(card, never()).radius = any()
+        verify(card).clipToOutline = false
+        verify(card).invalidateOutline()
+    }
+
+    @Test
+    fun whenAddressBarRebrandDisabledThenUsesLegacyRadius() {
+        val suppliedLegacyRadius = 3f
+        val card = card(
+            shapeResources(
+                rebrandInputRadius = 10f,
+                legacyRadius = suppliedLegacyRadius,
+            ),
+        )
+
+        card.applyInputScreenPreviewShape(isAddressBarRebrandEnabled = false)
+
+        val shape = argumentCaptor<ShapeAppearanceModel>()
+        verify(card).shapeAppearanceModel = shape.capture()
+        assertFixedCorners(shape.firstValue, suppliedLegacyRadius)
+        verify(card.resources).getDimension(CommonR.dimen.largeShapeCornerRadius)
+    }
+
+    @Test
+    fun whenAddressBarRebrandEnabledThenUsesConfiguredHorizontalAndVerticalInsets() {
+        val horizontalInset = 31
+        val verticalInset = 17
+        val context = contextWithInsets(
+            horizontalInset = horizontalInset,
+            verticalInset = verticalInset,
+        )
+        val (container, input) = inputFixture(context)
+        val actionIcon = container.getChildAt(1)
+
+        input.applyInputScreenPreviewInsets(isAddressBarRebrandEnabled = true, actionIcon = actionIcon)
+
+        val inputMargins = input.layoutParams as ViewGroup.MarginLayoutParams
+        assertEquals(horizontalInset, container.paddingStart + inputMargins.marginStart + input.paddingStart)
+        val actionIconMargin = (actionIcon.layoutParams as ViewGroup.MarginLayoutParams).marginEnd
+        val actionIconContentInset = (
+            actionIcon.layoutParams.width -
+                context.resources.getDimensionPixelSize(CommonR.dimen.toolbarIconSize)
+            ) / 2
+        assertEquals(horizontalInset, container.paddingEnd + actionIconMargin + actionIconContentInset)
+        assertEquals(verticalInset, container.paddingTop + input.paddingTop)
+        assertEquals(verticalInset, container.paddingBottom + input.paddingBottom)
+        verify(context.resources).getDimensionPixelSize(CommonR.dimen.keyline_4)
+        verify(context.resources).getDimensionPixelSize(CommonR.dimen.keyline_3)
+    }
+
+    @Test
+    fun whenAddressBarRebrandEnabledAndInputAlreadyHasStartPaddingThenUsesConfiguredInsetOnce() {
+        val horizontalInset = 31
+        val context = contextWithInsets(horizontalInset = horizontalInset)
+        val (container, input) = inputFixture(context, inputStartPadding = horizontalInset)
+
+        input.applyInputScreenPreviewInsets(isAddressBarRebrandEnabled = true, actionIcon = container.getChildAt(1))
+
+        val margins = input.layoutParams as ViewGroup.MarginLayoutParams
+        assertEquals(horizontalInset, container.paddingStart + margins.marginStart + input.paddingStart)
+    }
+
+    @Test
+    fun whenAddressBarRebrandDisabledThenKeepsExistingInsets() {
+        val context = contextWithInsets()
+        val (container, input) = inputFixture(context)
+        val actionIcon = container.getChildAt(1)
+        val initialInputMarginStart = (input.layoutParams as ViewGroup.MarginLayoutParams).marginStart
+        val initialActionIconMarginEnd = (actionIcon.layoutParams as ViewGroup.MarginLayoutParams).marginEnd
+        val initialInputPadding = listOf(input.paddingStart, input.paddingTop, input.paddingEnd, input.paddingBottom)
+        val initialContainerPadding = listOf(container.paddingStart, container.paddingTop, container.paddingEnd, container.paddingBottom)
+
+        input.applyInputScreenPreviewInsets(isAddressBarRebrandEnabled = false, actionIcon = actionIcon)
+
+        assertEquals(initialInputMarginStart, (input.layoutParams as ViewGroup.MarginLayoutParams).marginStart)
+        assertEquals(initialActionIconMarginEnd, (actionIcon.layoutParams as ViewGroup.MarginLayoutParams).marginEnd)
+        assertEquals(initialInputPadding, listOf(input.paddingStart, input.paddingTop, input.paddingEnd, input.paddingBottom))
+        assertEquals(initialContainerPadding, listOf(container.paddingStart, container.paddingTop, container.paddingEnd, container.paddingBottom))
+        verify(context.resources, never()).getDimensionPixelSize(CommonR.dimen.keyline_4)
+        verify(context.resources, never()).getDimensionPixelSize(CommonR.dimen.keyline_3)
+    }
+
+    private fun shapeResources(
+        rebrandInputRadius: Float,
+        legacyRadius: Float,
+    ): Resources = mock {
+        on { getDimension(CommonR.dimen.rebrandInputRadius) } doReturn rebrandInputRadius
+        on { getDimension(CommonR.dimen.largeShapeCornerRadius) } doReturn legacyRadius
+    }
+
+    private fun card(resources: Resources): MaterialCardView = mock {
+        on { shapeAppearanceModel } doReturn baseShape
+        on { getResources() } doReturn resources
+    }
+
+    private fun contextWithInsets(
+        horizontalInset: Int = 31,
+        verticalInset: Int = 17,
+        containerInset: Int = 5,
+        actionIconContainerSize: Int = 29,
+        actionIconSize: Int = 13,
+    ): Context {
+        val resources = spy(baseContext.resources)
+        doReturn(horizontalInset).whenever(resources).getDimensionPixelSize(CommonR.dimen.keyline_4)
+        doReturn(verticalInset).whenever(resources).getDimensionPixelSize(CommonR.dimen.keyline_3)
+        doReturn(containerInset).whenever(resources).getDimensionPixelSize(CommonR.dimen.keyline_0)
+        doReturn(actionIconContainerSize).whenever(resources).getDimensionPixelSize(CommonR.dimen.toolbarIcon)
+        doReturn(actionIconSize).whenever(resources).getDimensionPixelSize(CommonR.dimen.toolbarIconSize)
+        return object : ContextWrapper(baseContext) {
+            override fun getResources(): Resources = resources
+        }
+    }
+
+    private fun inputFixture(
+        context: Context,
+        inputStartPadding: Int = 0,
+    ): Pair<LinearLayout, EditText> {
+        val containerInset = context.resources.getDimensionPixelSize(CommonR.dimen.keyline_0)
+        val actionIconContainerSize = context.resources.getDimensionPixelSize(CommonR.dimen.toolbarIcon)
+        val container = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            setPaddingRelative(containerInset, containerInset, containerInset, containerInset)
+        }
+        val input = EditText(context).apply {
+            layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f).apply {
+                gravity = Gravity.CENTER_VERTICAL
+            }
+            background = null
+            minHeight = actionIconContainerSize
+            minLines = 1
+            maxLines = 1
+            setPaddingRelative(inputStartPadding, 0, 0, 0)
+        }
+        container.addView(input)
+        container.addView(
+            View(context),
+            LinearLayout.LayoutParams(actionIconContainerSize, actionIconContainerSize),
+        )
+        return container to input
+    }
+
+    private fun assertFixedCorners(
+        shape: ShapeAppearanceModel,
+        expected: Float,
+    ) {
+        val corners = listOf(
+            shape.topLeftCornerSize,
+            shape.topRightCornerSize,
+            shape.bottomLeftCornerSize,
+            shape.bottomRightCornerSize,
+        )
+        assertFalse(corners.any { it is RelativeCornerSize })
+        corners.forEach { assertEquals(expected, it.getCornerSize(RectF()), 0f) }
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/InputScreenPreviewShapeTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/InputScreenPreviewShapeTest.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.res.Resources
 import android.graphics.RectF
+import android.text.InputType
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -29,6 +30,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.applyInputScreenPreviewInsets
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.applyInputScreenPreviewShape
+import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.updateInputModePreservingSelection
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.shape.RelativeCornerSize
 import com.google.android.material.shape.ShapeAppearanceModel
@@ -148,6 +150,38 @@ class InputScreenPreviewShapeTest {
         assertEquals(initialContainerPadding, listOf(container.paddingStart, container.paddingTop, container.paddingEnd, container.paddingBottom))
         verify(context.resources, never()).getDimensionPixelSize(CommonR.dimen.keyline_4)
         verify(context.resources, never()).getDimensionPixelSize(CommonR.dimen.keyline_3)
+    }
+
+    @Test
+    fun whenSwitchingFromSearchToDuckAiThenKeepsCursorAtEnd() {
+        val input = EditText(baseContext).apply {
+            inputType = InputType.TYPE_CLASS_TEXT
+            setText("typed query")
+            setSelection(11)
+        }
+
+        input.updateInputModePreservingSelection {
+            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+        }
+
+        assertEquals(11, input.selectionStart)
+        assertEquals(11, input.selectionEnd)
+    }
+
+    @Test
+    fun whenSwitchingFromDuckAiToSearchThenKeepsCursorAtEnd() {
+        val input = EditText(baseContext).apply {
+            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+            setText("typed query")
+            setSelection(11)
+        }
+
+        input.updateInputModePreservingSelection {
+            inputType = InputType.TYPE_CLASS_TEXT
+        }
+
+        assertEquals(11, input.selectionStart)
+        assertEquals(11, input.selectionEnd)
     }
 
     private fun shapeResources(

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/InputScreenPreviewShapeTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/InputScreenPreviewShapeTest.kt
@@ -30,6 +30,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.applyInputScreenPreviewInsets
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.applyInputScreenPreviewShape
+import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.applyInputTextMode
 import com.duckduckgo.app.onboarding.ui.page.configdriven.binders.updateInputModePreservingSelection
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.shape.RelativeCornerSize
@@ -182,6 +183,23 @@ class InputScreenPreviewShapeTest {
 
         assertEquals(11, input.selectionStart)
         assertEquals(11, input.selectionEnd)
+    }
+
+    @Test
+    fun whenDuckAiModeIsRestoredThenKeepsTheSameExpandableLineBounds() {
+        val switchedInput = EditText(baseContext).apply {
+            applyInputTextMode(isSearchSelected = true)
+            applyInputTextMode(isSearchSelected = false)
+        }
+        val restoredInput = EditText(baseContext).apply {
+            maxLines = 1
+            applyInputTextMode(isSearchSelected = false)
+        }
+
+        assertEquals(3, restoredInput.minLines)
+        assertEquals(Int.MAX_VALUE, restoredInput.maxLines)
+        assertEquals(switchedInput.minLines, restoredInput.minLines)
+        assertEquals(switchedInput.maxLines, restoredInput.maxLines)
     }
 
     private fun shapeResources(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1732,7 +1732,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val lp = card.layoutParams as? MarginLayoutParams ?: return
         val isBrowserSearchOnly = state.inputContext == NativeInputState.InputContext.BROWSER && !state.toggleVisible
         val usesRebrandPill = isBrowserSearchOnly && appBrandDesignUpdateToggles.addressBar().isEnabled()
-        if (usesRebrandPill) {
+        if (usesRebrandPill && state.isBottom) {
+            card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.rebrandInputRadius)
+        } else if (usesRebrandPill) {
             card.shapeAppearanceModel = card.shapeAppearanceModel.withCornerSize(ShapeAppearanceModel.PILL)
         } else if (isBrowserSearchOnly || state.isBottom) {
             card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1730,20 +1730,16 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val state = nativeInputState ?: return
         val card = parent as? MaterialCardView ?: return
         val lp = card.layoutParams as? MarginLayoutParams ?: return
-        // Only the top browser search-only omnibar takes the wide-omnibar shape; isBottom is part of this
-        // condition (not an early return) so a bottom Duck.ai frame still reaches the reset below.
         val isBrowserSearchOnly = state.inputContext == NativeInputState.InputContext.BROWSER && !state.toggleVisible
-        if (state.isBottom) {
+        val usesRebrandPill = isBrowserSearchOnly && appBrandDesignUpdateToggles.addressBar().isEnabled()
+        if (usesRebrandPill) {
+            card.shapeAppearanceModel = card.shapeAppearanceModel.withCornerSize(ShapeAppearanceModel.PILL)
+        } else if (isBrowserSearchOnly || state.isBottom) {
             card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)
         }
         if (isBrowserSearchOnly && !state.isBottom) {
             val targetTopMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginTop)
             val targetHorizontalMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginHorizontal)
-            if (appBrandDesignUpdateToggles.addressBar().isEnabled()) {
-                card.shapeAppearanceModel = card.shapeAppearanceModel.withCornerSize(ShapeAppearanceModel.PILL)
-            } else {
-                card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)
-            }
             lp.topMargin = targetTopMargin - card.paddingTop
             lp.marginStart = targetHorizontalMargin - card.paddingLeft
             lp.marginEnd = targetHorizontalMargin - card.paddingRight

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1730,18 +1730,24 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val state = nativeInputState ?: return
         val card = parent as? MaterialCardView ?: return
         val lp = card.layoutParams as? MarginLayoutParams ?: return
+        // Only the top browser search-only omnibar takes the wide-omnibar shape; isBottom is part of this
+        // condition (not an early return) so a bottom Duck.ai frame still reaches the reset below.
         val isBrowserSearchOnly = state.inputContext == NativeInputState.InputContext.BROWSER && !state.toggleVisible
-        val usesRebrandPill = isBrowserSearchOnly && appBrandDesignUpdateToggles.addressBar().isEnabled()
-        if (usesRebrandPill && state.isBottom) {
-            card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.rebrandInputRadius)
-        } else if (usesRebrandPill) {
-            card.shapeAppearanceModel = card.shapeAppearanceModel.withCornerSize(ShapeAppearanceModel.PILL)
-        } else if (isBrowserSearchOnly || state.isBottom) {
-            card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)
+        if (state.isBottom) {
+            if (isBrowserSearchOnly && appBrandDesignUpdateToggles.addressBar().isEnabled()) {
+                card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.rebrandInputRadius)
+            } else {
+                card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)
+            }
         }
         if (isBrowserSearchOnly && !state.isBottom) {
             val targetTopMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginTop)
             val targetHorizontalMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginHorizontal)
+            if (appBrandDesignUpdateToggles.addressBar().isEnabled()) {
+                card.shapeAppearanceModel = card.shapeAppearanceModel.withCornerSize(ShapeAppearanceModel.PILL)
+            } else {
+                card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)
+            }
             lp.topMargin = targetTopMargin - card.paddingTop
             lp.marginStart = targetHorizontalMargin - card.paddingLeft
             lp.marginEnd = targetHorizontalMargin - card.paddingRight

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetShapeTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetShapeTest.kt
@@ -57,6 +57,27 @@ class NativeInputModeWidgetShapeTest {
     }
 
     @Test
+    fun `when address bar rebrand is enabled bottom browser search-only state uses pill shape`() {
+        val subject = createSubject(inputPosition = NativeInputState.InputPosition.BOTTOM)
+
+        subject.render(rebrandEnabled = true)
+
+        assertEquals(32f, subject.cornerSize())
+    }
+
+    @Test
+    fun `when address bar rebrand is disabled bottom browser search-only state uses legacy radius`() {
+        val subject = createSubject(inputPosition = NativeInputState.InputPosition.BOTTOM)
+
+        subject.render(rebrandEnabled = false)
+
+        assertEquals(
+            subject.context.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius),
+            subject.cornerSize(),
+        )
+    }
+
+    @Test
     fun `enabling address bar rebrand does not change top browser search-only card height`() {
         val subject = createSubject()
 
@@ -82,6 +103,19 @@ class NativeInputModeWidgetShapeTest {
     }
 
     @Test
+    fun `when bottom browser search-only transitions to bottom Duck AI it restores the fixed corner radius`() {
+        val subject = createSubject(inputPosition = NativeInputState.InputPosition.BOTTOM)
+
+        subject.render(rebrandEnabled = true)
+        subject.renderDuckAi()
+
+        assertEquals(
+            subject.context.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius),
+            subject.cornerSize(),
+        )
+    }
+
+    @Test
     fun `when rebrand changes from enabled to disabled top browser search-only restores the fixed corner radius`() {
         val subject = createSubject()
 
@@ -94,7 +128,7 @@ class NativeInputModeWidgetShapeTest {
         )
     }
 
-    private fun createSubject(): Subject {
+    private fun createSubject(inputPosition: NativeInputState.InputPosition = NativeInputState.InputPosition.TOP): Subject {
         val context = ContextThemeWrapper(
             RuntimeEnvironment.getApplication(),
             com.duckduckgo.mobile.android.R.style.Theme_DuckDuckGo_Light,
@@ -115,7 +149,7 @@ class NativeInputModeWidgetShapeTest {
                 NativeInputState(
                     inputMode = NativeInputState.InputMode.SEARCH_ONLY,
                     inputContext = NativeInputState.InputContext.BROWSER,
-                    inputPosition = NativeInputState.InputPosition.TOP,
+                    inputPosition = inputPosition,
                 ),
             )
         }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetShapeTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetShapeTest.kt
@@ -27,7 +27,10 @@ import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.google.android.material.card.MaterialCardView
+import com.google.android.material.shape.RelativeCornerSize
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
@@ -53,6 +56,7 @@ class NativeInputModeWidgetShapeTest {
 
         subject.render(rebrandEnabled = true)
 
+        assertTrue(subject.card.shapeAppearanceModel.topLeftCornerSize is RelativeCornerSize)
         assertEquals(32f, subject.cornerSize())
     }
 
@@ -62,7 +66,11 @@ class NativeInputModeWidgetShapeTest {
 
         subject.render(rebrandEnabled = true)
 
-        assertEquals(32f, subject.cornerSize())
+        assertEquals(
+            subject.context.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.rebrandInputRadius),
+            subject.card.radius,
+        )
+        assertFalse(subject.card.useCompatPadding)
     }
 
     @Test
@@ -78,15 +86,21 @@ class NativeInputModeWidgetShapeTest {
     }
 
     @Test
-    fun `enabling address bar rebrand does not change top browser search-only card height`() {
+    fun `enabling address bar rebrand preserves top browser search-only geometry`() {
         val subject = createSubject()
 
         subject.render(rebrandEnabled = false)
         val legacyHeight = subject.measureHeight()
+        val legacyPaddingTop = subject.card.paddingTop
+        val legacyTop = subject.visibleTop()
+        assertTrue(legacyPaddingTop > 0)
 
         subject.render(rebrandEnabled = true)
 
+        assertTrue(subject.card.useCompatPadding)
         assertEquals(legacyHeight, subject.measureHeight())
+        assertEquals(legacyPaddingTop, subject.card.paddingTop)
+        assertEquals(legacyTop, subject.visibleTop())
     }
 
     @Test
@@ -133,9 +147,13 @@ class NativeInputModeWidgetShapeTest {
             RuntimeEnvironment.getApplication(),
             com.duckduckgo.mobile.android.R.style.Theme_DuckDuckGo_Light,
         )
+        val isBottom = inputPosition == NativeInputState.InputPosition.BOTTOM
+        val elevation = (if (isBottom) 3f else 6f) * context.resources.displayMetrics.density
         val card = MaterialCardView(context).apply {
             layoutParams = ViewGroup.MarginLayoutParams(200, ViewGroup.LayoutParams.WRAP_CONTENT)
-            useCompatPadding = true
+            useCompatPadding = !isBottom
+            maxCardElevation = elevation
+            cardElevation = elevation
             radius = context.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)
         }
         val widget = NativeInputModeWidget(context)
@@ -199,6 +217,11 @@ class NativeInputModeWidgetShapeTest {
         fun measureHeight(): Int {
             card.measure(widthSpec, heightSpec)
             return card.measuredHeight
+        }
+
+        fun visibleTop(): Int {
+            val params = card.layoutParams as ViewGroup.MarginLayoutParams
+            return params.topMargin + card.paddingTop
         }
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetShapeTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetShapeTest.kt
@@ -61,7 +61,7 @@ class NativeInputModeWidgetShapeTest {
     }
 
     @Test
-    fun `when address bar rebrand is enabled bottom browser search-only state uses pill shape`() {
+    fun `when address bar rebrand is enabled bottom browser search-only state uses rebrand radius`() {
         val subject = createSubject(inputPosition = NativeInputState.InputPosition.BOTTOM)
 
         subject.render(rebrandEnabled = true)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1217684000188483
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

- Updates rebrand status indicators and the dark theme destructive secondary and ghost button colours. The existing colours remain when the theme update is disabled.
- Uses the updated green check icons in the internal onboarding comparison screens.
- Corrects the rebrand privacy shield size and alignment across its browser states.
- Keeps the native browser input and System Search rounding stable across top and bottom address bar positions. The existing radius remains when `appBrandDesignUpdate.addressBar` is disabled.
- Refines both rebrand onboarding renderers so the input preview has fixed 24dp corners, 16dp horizontal spacing and 12dp vertical spacing. Search and Duck.ai keep the same corner radius and text position while the card changes height, without clipping the text or bottom shadow.

### Steps to test this PR

_Preparation_

- [x] Install an Internal debug build from this branch.

The rebrand flags are enabled by default in Internal builds.

_Theme colours, enabled_

- [x] Open `Settings`.
- [x] Verify the `Always On` indicators uses the updated green.
- [x] Open `Private Search`.
- [x] Verify the `Always On` indicator uses the updated green.
- [x] Open `Settings > Internal Features > Android Design System Preview`.
- [x] Enable `Brand design update` in the preview.
- [x] Enable `Dark Theme` in the preview.
- [x] Open the `Buttons` tab.
- [x] Verify the View destructive secondary button text uses the updated rebrand red.
- [x] Verify the View destructive ghost button text uses the updated rebrand red.
- [ ] Open the `List items` tab.
- [ ] Scroll to the View `Settings List Item` examples.
- [ ] Verify the `On` indicator uses the updated green.
- [ ] Verify the `Off` indicator uses the dark theme rebrand colour.
- [x] Disable `Dark Theme` in the preview.
- [x] Return to the View `Settings List Item` examples.
- [ ] Verify the `Off` indicator uses the light theme rebrand colour.

_Browser address bar, enabled_

- [x] Open `Settings > AI Features`.
- [x] Select `Search Only` for the address bar input.
- [x] Open `Settings > Appearance > Address Bar`.
- [x] Select `Top`.
- [x] Open a new tab.
- [x] Tap the address bar.
- [x] Verify the expanded Search input remains pill-shaped.
- [x] Verify the Search input does not jump vertically during the morph.
- [x] Dismiss the Search input.
- [ ] Verify the input returns to the address bar without a corner jump.
- [ ] Verify the input returns to the address bar without a shadow jump.
- [x] Load `https://privacy-test-pages.site/privacy-protections/request-blocking/?run`.
- [x] Verify the animated privacy shield is centred in its address bar slot.
- [x] Tap the address bar.
- [x] Verify the focused address bar has rounded corners instead of extending squarely to the device edges.
- [x] Press back.
- [x] Disable protections for `privacy-test-pages.site` from the privacy dashboard.
- [x] Verify the unprotected shield remains centred in the same slot.
- [x] Re-enable protections for `privacy-test-pages.site`.
- [x] Open `Settings > Appearance > Address Bar`.
- [x] Select `Bottom`.
- [x] Open a new tab.
- [x] Tap the address bar.
- [x] Verify the bottom Search input uses the rebrand rounded shape.
- [x] Verify the bottom shadow follows the rounded shape without being clipped.

_System Search, enabled_

- [x] Add the DuckDuckGo Search widget to the device Home screen.
- [x] Tap the DuckDuckGo Search widget.
- [x] Verify the bottom System Search input uses the rebrand rounded shape.
- [x] Select `Top` in `Settings > Appearance > Address Bar`.
- [x] Tap the DuckDuckGo Search widget.
- [x] Verify the top System Search input uses the rebrand rounded shape.

_Onboarding input preview, both renderers_

Run this scenario twice:

1. Use the default Internal flags for the config-driven renderer.
2. Disable `onboardingBrandDesignUpdate.configDrivenDialogs` for the existing brand design renderer using this patch

```
Index: app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt	(revision 42a6172c516a355a8fa4146f6911f4591d9edd8d)
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt	(date 1788423062311)
@@ -58,6 +58,6 @@
     /**
      * Selects the config-driven renderer for the brand-design onboarding dialogs.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun configDrivenDialogs(): Toggle
 }
```

Cursor preservation is not controlled by the address bar rebrand flag, so it only needs to be checked in these two renderer runs.

- [x] Clear data, restart app
- [x] Progress to the browser comparison screen.
- [x] Verify the comparison checks use the updated green.
- [x] Progress to the address bar input choice.
- [x] Select `Toggle between Search and Duck.ai`.
- [x] Progress to `Ready to get started? Try a search or AI chat!`.
- [x] Select `Search`.
- [ ] Verify the cursor starts 16dp from the start of the input card.
- [ ] Verify the search icon has 16dp spacing from the end of the input card.
- [ ] Verify the text has 12dp spacing above and below it.
- [x] Verify the input text is not clipped.
- [x] Enter `test query` and leave the cursor after the final character.
- [x] Select `Duck.ai`.
- [x] Verify the cursor remains after the final character instead of moving to the start.
- [ ] Verify the card grows with straight sides between its 24dp corners.
- [x] Verify the text keeps the same top position as Search.
- [x] Verify the input text is not clipped.
- [x] Verify the bottom shadow follows the card corners.
- [x] Select `Search`.
- [x] Verify the cursor still remains after the final character.
- [x] Verify the card returns to its shorter height.
- [x] Verify the corner radius does not change when returning to Search.
- [x] Tap `Skip Onboarding`.
- [ ] Disable/Re-enable `onboardingBrandDesignUpdate.configDrivenDialogs` using the patch after testing the existing brand design renderer. Run the steps again.

_Theme colours, flag disabled_

- [x] Open `Settings > Internal Features > Android Design System Preview`.
- [ ] Disable `Brand design update` in the preview.
- [ ] Enable `Dark Theme` in the preview.
- [ ] Open the `Buttons` tab.
- [ ] Verify the View destructive secondary button text uses its existing red.
- [ ] Verify the View destructive ghost button text uses its existing red.
- [ ] Open the `List items` tab.
- [ ] Scroll to the View `Settings List Item` examples.
- [ ] Verify the `On` indicator uses its existing colour.
- [ ] Verify the `Off` indicator uses its existing dark theme colour.
- [ ] Disable `Dark Theme` in the preview.
- [ ] Return to the View `Settings List Item` examples.
- [ ] Verify the `Off` indicator uses its existing light theme colour.
- [ ] Open `Settings > Internal Features > Feature Flag Inventory`.
- [ ] Disable the `theme` child flag under `appBrandDesignUpdate`.
- [ ] Force-stop the app.
- [ ] Relaunch the app.
- [ ] Open `Settings`.
- [ ] Verify the `Always On` indicator uses the existing green.
- [ ] Open `Private Search`.
- [ ] Verify the `Always On` indicator uses the existing green.
- [ ] Re-enable the `theme` child flag under `appBrandDesignUpdate`.

_Address bar, flag disabled_

- [ ] Open `Settings > Internal Features > Feature Flag Inventory`.
- [ ] Disable the `addressBar` child flag under `appBrandDesignUpdate`.
- [ ] Force-stop the app.
- [ ] Relaunch the app.
- [x] Ensure `Search only` is selected in `Settings > AI Features`.
- [x] Select `Top` in `Settings > Appearance > Address Bar`.
- [x] Open a new tab.
- [x] Tap the address bar.
- [x] Verify the top Search input uses the existing corner radius.
- [x] Dismiss the Search input.
- [x] Load `https://privacy-test-pages.site/privacy-protections/request-blocking/?run`.
- [x] Verify the protected shield uses its existing size.
- [x] Verify the protected shield uses its existing alignment.
- [x] Disable protections for `privacy-test-pages.site` from the privacy dashboard.
- [x] Verify the unprotected shield uses its existing size.
- [x] Verify the unprotected shield uses its existing alignment.
- [x] Re-enable protections for `privacy-test-pages.site`.
- [x] Tap the DuckDuckGo Search widget.
- [x] Verify top System Search uses the existing corner radius.
- [x] Select `Bottom` in `Settings > Appearance > Address Bar`.
- [x] Open a new tab.
- [x] Tap the address bar.
- [x] Verify the bottom Search input uses the existing corner radius.
- [x] Dismiss the Search input.
- [x] Tap the DuckDuckGo Search widget.
- [x] Verify bottom System Search uses the existing corner radius.

Run the onboarding checks below twice:

1. Use the default Internal flags for the config-driven renderer.
2. Disable `onboardingBrandDesignUpdate.configDrivenDialogs` for the existing brand design renderer using this patch

```
Index: app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt	(revision 42a6172c516a355a8fa4146f6911f4591d9edd8d)
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt	(date 1788423062311)
@@ -58,6 +58,6 @@
     /**
      * Selects the config-driven renderer for the brand-design onboarding dialogs.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun configDrivenDialogs(): Toggle
 }
```

- [ ] Clear app data
- [ ] Apply this patch and install

```
Index: android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/store/AppBrandDesignUpdateToggles.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/store/AppBrandDesignUpdateToggles.kt b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/store/AppBrandDesignUpdateToggles.kt
--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/store/AppBrandDesignUpdateToggles.kt	(revision 42a6172c516a355a8fa4146f6911f4591d9edd8d)
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/store/AppBrandDesignUpdateToggles.kt	(date 1788369723765)
@@ -51,7 +51,7 @@
      * Gates the address bar radius, Lotties: shield, cookies, ad-blocking and Duck Player
      * assets, the 40dp shield icon box, and the home screen widget search bar, previews, and promo artwork.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun addressBar(): Toggle
 
     /**
```
- [ ] Progress to the address bar input choice.
- [ ] Select `Toggle between Search and Duck.ai`.
- [ ] Progress to `Ready to get started? Try a search or AI chat!`.
- [ ] Select `Search`.
- [ ] Verify the Search input preview uses the existing corner radius.
- [ ] Verify the Search input preview uses the existing spacing.
- [ ] Select `Duck.ai`.
- [ ] Verify the Duck.ai input preview uses the existing corner radius.
- [ ] Verify the Duck.ai input preview uses the existing spacing.
- [ ] Tap `Skip Onboarding`.
- [ ] Disable/Re-enable `onboardingBrandDesignUpdate.configDrivenDialogs` using the patch after testing the existing brand design renderer. Run the steps again.

### UI changes

See [design ship review and substasks](https://app.asana.com/1/137249556945/inbox/1207908161520961/item/1217694440797799/story/1217900499865432)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly visual/theming behind feature toggles with broad unit test coverage; native input animator changes touch omnibar transitions but are scoped to corner-radius handling.
> 
> **Overview**
> Ship-review follow-ups for the **brand design update**: theme tokens, address bar chrome, onboarding input preview, and a few animation/shadow fixes.
> 
> **Design system & theming** wires status indicators through `daxColorStatusIndicatorOn` / `Off` (rebrand green and light/dark off colors) instead of hardcoded grays and greens, with matching overlay tests. Dark theme **destructive secondary and ghost** button text moves from `rb_red20` to `rb_red40`. Internal onboarding comparison screens get new **rb_green40** check drawables.
> 
> **Address bar rebrand** standardizes the privacy shield in a **44dp slot** with state-specific padding (`resolveRebrandPrivacyShieldLayout`), used in the omnibar and tracker-blocked animation. **System Search** and **native input** pick up rebrand corner radii when the address-bar flag is on; bottom **search-only** cards use `rebrandInputRadius`. **Native input morph** skips animating corner radius when the widget uses a **pill (`RelativeCornerSize`)** so geometry and shadows stay stable. **`addBottomShadow`** reads `MaterialCardView` radius inside `getOutline` so shadows track live corner changes.
> 
> **Onboarding input preview** (brand welcome + config-driven binder) shares helpers for **24dp-equivalent corners** (half `rebrandInputRadius`), **16dp / 12dp** insets when rebrand is on, **cursor-preserving** search/chat mode switches, and **unclipped** card outline for bottom shadow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f82d34958e3dd72b3b1c970e2852d412115bf78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->