### PR TITLE
Fix: Auto-burn when last Fire tab closed

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
@@ -78,6 +78,7 @@ class DataClearing @Inject constructor(
     private val contextualDataStore: DuckChatContextualDataStore,
     private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
     private val dataClearingTrigger: DataClearingTrigger,
+    private val fireModeDataClearingState: FireModeDataClearingState,
 ) : ManualDataClearing, AutomaticDataClearing {
 
     override suspend fun clearSingleTabData(tabId: String, replaceCurrentTab: Boolean, browserMode: BrowserMode): ClearDataResult {
@@ -319,12 +320,16 @@ class DataClearing @Inject constructor(
 
         val fireModeCleared = fireModeAvailability.isAvailable()
         if (fireModeCleared) {
-            val fireTypes = setOf(
-                ClearableData.Tabs.AllForMode(BrowserMode.FIRE),
-                ClearableData.BrowserData.AllForMode(BrowserMode.FIRE),
-                ClearableData.DuckChats.AllForMode(BrowserMode.FIRE),
+            // avoids duplicate burn when tabs removed
+            fireModeDataClearingState.onDataCleared()
+
+            dataClearingTrigger.clearData(
+                setOf(
+                    ClearableData.Tabs.AllForMode(BrowserMode.FIRE),
+                    ClearableData.BrowserData.AllForMode(BrowserMode.FIRE),
+                    ClearableData.DuckChats.AllForMode(BrowserMode.FIRE),
+                ),
             )
-            dataClearingTrigger.clearData(fireTypes)
         }
 
         logcat { "Fire mode clear completed" }

--- a/app/src/main/java/com/duckduckgo/app/fire/FireModeLastTabObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/FireModeLastTabObserver.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.fire
+
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.adclick.api.AdClickManager
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.fire.wideevents.DataClearingWideEvent
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.settings.clear.FireClearOption
+import com.duckduckgo.app.tabs.db.TabsDao
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.FireMode
+import com.duckduckgo.browsermode.api.FireModeAvailability
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import logcat.LogPriority.WARN
+import logcat.asLog
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * Whether Fire mode holds browsing data that has not been burned yet.
+ *
+ * A Fire burn deletes the Fire tabs itself, so [FireModeLastTabObserver] cannot tell that apart from the
+ * user closing the last tab. This is what does: only an emptying that follows real browsing owes a burn.
+ */
+@SingleInstanceIn(AppScope::class)
+class FireModeDataClearingState @Inject constructor() {
+    private val _hasUnclearedData = MutableStateFlow(false)
+    val hasUnclearedData: StateFlow<Boolean> = _hasUnclearedData.asStateFlow()
+
+    fun markDataForClearing() {
+        _hasUnclearedData.value = true
+    }
+
+    fun onDataCleared() {
+        _hasUnclearedData.value = false
+    }
+}
+
+/**
+ * Burns Fire mode data once the last Fire tab is gone.
+ *
+ * The trigger is a count of the Fire tab rows rather than the tab lists: open and pending-undo rows are
+ * separate queries over the same write, so their emissions interleave and a close briefly looks like an
+ * emptying. One count is one fact, and only reaches zero once the close is committed.
+ */
+@ContributesMultibinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class FireModeLastTabObserver @Inject constructor(
+    @param:FireMode private val fireTabsDao: TabsDao,
+    @param:FireMode private val fireTabRepository: TabRepository,
+    private val adClickManager: AdClickManager,
+    private val dataClearing: ManualDataClearing,
+    private val dataClearingWideEvent: DataClearingWideEvent,
+    private val fireModeDataClearingState: FireModeDataClearingState,
+    private val fireModeAvailability: FireModeAvailability,
+    @param:AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+) : MainProcessLifecycleObserver {
+
+    override fun onCreate(owner: LifecycleOwner) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            commitPendingFireCloses()
+            if (!fireModeAvailability.isAvailable()) return@launch
+
+            fireTabsDao.flowTabCount()
+                .map { it == 0 }
+                .distinctUntilChanged()
+                .collect { fireModeEmpty ->
+                    if (!fireModeEmpty) {
+                        fireModeDataClearingState.markDataForClearing()
+                    } else if (fireModeDataClearingState.hasUnclearedData.value) {
+                        burnFireData()
+                    }
+                }
+        }
+    }
+
+    // Fire mode's share of the startup tab purge; arms the burn before a pending close's row disappears
+    override fun onStart(owner: LifecycleOwner) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            commitPendingFireCloses()
+        }
+    }
+
+    private suspend fun commitPendingFireCloses() {
+        val pendingCloses = fireTabRepository.getDeletableTabIds()
+        if (pendingCloses.isEmpty()) return
+
+        pendingCloses.forEach { adClickManager.clearTabId(it) }
+        if (fireModeAvailability.isAvailable()) {
+            fireModeDataClearingState.markDataForClearing()
+        }
+        fireTabRepository.purgeDeletableTabs()
+    }
+
+    private suspend fun burnFireData() {
+        dataClearingWideEvent.start(
+            entryPoint = DataClearingWideEvent.EntryPoint.FIRE_TABS_EMPTIED,
+            clearOptions = setOf(
+                FireClearOption.TABS,
+                FireClearOption.DATA,
+                FireClearOption.DUCKAI_CHATS,
+            ),
+            browserMode = BrowserMode.FIRE,
+        )
+        try {
+            dataClearing.clearDataUsingManualFireOptions(
+                shouldRestartIfRequired = false,
+                browserMode = BrowserMode.FIRE,
+            )
+            dataClearingWideEvent.finishSuccess()
+        } catch (e: Exception) {
+            logcat(WARN) { "Failed to burn Fire data after the last Fire tab was closed: ${e.asLog()}" }
+            dataClearingWideEvent.finishFailure(e)
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/fire/FireModeLastTabObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/FireModeLastTabObserver.kt
@@ -44,10 +44,11 @@ import logcat.logcat
 import javax.inject.Inject
 
 /**
- * Whether Fire mode holds browsing data that has not been burned yet.
+ * Keeps a state Fire mode has browsing data that still needs burning.
  *
- * A Fire burn deletes the Fire tabs itself, so [FireModeLastTabObserver] cannot tell that apart from the
- * user closing the last tab. This is what does: only an emptying that follows real browsing owes a burn.
+ * Set while a Fire tab exists, cleared once a burn runs. [FireModeLastTabObserver] needs it because a burn
+ * deletes the Fire tabs itself, which would otherwise look exactly like the user closing the last tab and
+ * start a second burn.
  */
 @SingleInstanceIn(AppScope::class)
 class FireModeDataClearingState @Inject constructor() {
@@ -65,10 +66,6 @@ class FireModeDataClearingState @Inject constructor() {
 
 /**
  * Burns Fire mode data once the last Fire tab is gone.
- *
- * The trigger is a count of the Fire tab rows rather than the tab lists: open and pending-undo rows are
- * separate queries over the same write, so their emissions interleave and a close briefly looks like an
- * emptying. One count is one fact, and only reaches zero once the close is committed.
  */
 @ContributesMultibinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
@@ -102,7 +99,7 @@ class FireModeLastTabObserver @Inject constructor(
         }
     }
 
-    // Fire mode's share of the startup tab purge; arms the burn before a pending close's row disappears
+    // Fire mode's startup tab purge, which marks the data for auto-burn
     override fun onStart(owner: LifecycleOwner) {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             commitPendingFireCloses()

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
@@ -50,7 +50,6 @@ abstract class TabsDao {
     @Query("select * from tabs where deletable is 1 order by position")
     abstract fun flowDeletableTabs(): Flow<List<TabEntity>>
 
-    /** Open and pending-undo rows alike, so "are there any tabs left" is one value from one write. */
     @Query("select count(*) from tabs")
     abstract fun flowTabCount(): Flow<Int>
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
@@ -50,6 +50,10 @@ abstract class TabsDao {
     @Query("select * from tabs where deletable is 1 order by position")
     abstract fun flowDeletableTabs(): Flow<List<TabEntity>>
 
+    /** Open and pending-undo rows alike, so "are there any tabs left" is one value from one write. */
+    @Query("select count(*) from tabs")
+    abstract fun flowTabCount(): Flow<Int>
+
     @Query("select * from tabs where tabId = :tabId")
     abstract fun tab(tabId: String): TabEntity?
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
@@ -21,7 +21,6 @@ import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.tabs.model.TabRepository
-import com.duckduckgo.browsermode.api.FireMode
 import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -33,7 +32,6 @@ import javax.inject.Inject
 @SingleInstanceIn(AppScope::class)
 class TabsDbSanitizer @Inject constructor(
     @RegularMode private val regularTabRepository: TabRepository,
-    @FireMode private val fireTabRepository: TabRepository,
     private val dispatchers: DispatcherProvider,
     private val adClickManager: AdClickManager,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
@@ -42,7 +40,6 @@ class TabsDbSanitizer @Inject constructor(
     override fun onStart(owner: LifecycleOwner) {
         appCoroutineScope.launch(dispatchers.main()) {
             sanitize(regularTabRepository)
-            sanitize(fireTabRepository)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -26,15 +26,12 @@ import com.duckduckgo.app.browser.api.OmnibarRepository
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.fire.ManualDataClearing
 import com.duckduckgo.app.fire.promo.FireTabsPromos
-import com.duckduckgo.app.fire.wideevents.DataClearingWideEvent
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED
 import com.duckduckgo.app.pixels.AppPixelName.TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED
 import com.duckduckgo.app.pixels.BrowserModeSwitchSource
 import com.duckduckgo.app.pixels.duckchat.createWasUsedBeforePixelParams
-import com.duckduckgo.app.settings.clear.FireClearOption
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.tabs.model.TabEntity
@@ -90,7 +87,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -117,8 +113,6 @@ class TabSwitcherViewModel @Inject constructor(
     private val trackersAnimationInfoPanelPixels: TrackersAnimationInfoPanelPixels,
     private val omnibarRepository: OmnibarRepository,
     private val tabTitleResolver: TabTitleResolver,
-    private val dataClearing: ManualDataClearing,
-    private val dataClearingWideEvent: DataClearingWideEvent,
     @param:AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val fireTabsPromos: FireTabsPromos,
     private val remoteMessageModel: RemoteMessageModel,
@@ -157,7 +151,6 @@ class TabSwitcherViewModel @Inject constructor(
     )
 
     private var tabSwitcherPromoHandled = false
-    private var fireDataCleared = false
 
     init {
         viewModelScope.launch {
@@ -209,10 +202,6 @@ class TabSwitcherViewModel @Inject constructor(
             browserMode = browserMode,
             regularTabCount = regularTabCount,
         )
-    }.onEach { state ->
-        if (!state.showFireTabsEmptyState) {
-            fireDataCleared = false
-        }
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(),
@@ -311,34 +300,6 @@ class TabSwitcherViewModel @Inject constructor(
         _viewState.update { it.copy(isFireTabsPromoVisible = false) }
     }
 
-    private fun clearFireModeTabsAndDataIfNeeded() {
-        if (viewState.value.showFireTabsEmptyState && !fireDataCleared) {
-            fireDataCleared = true
-            appCoroutineScope.launch(dispatcherProvider.io()) {
-                dataClearingWideEvent.start(
-                    entryPoint = DataClearingWideEvent.EntryPoint.FIRE_TABS_EMPTIED,
-                    clearOptions = setOf(
-                        FireClearOption.TABS,
-                        FireClearOption.DATA,
-                        FireClearOption.DUCKAI_CHATS,
-                    ),
-                    browserMode = BrowserMode.FIRE,
-                )
-                try {
-                    dataClearing.clearDataUsingManualFireOptions(
-                        shouldRestartIfRequired = false,
-                        browserMode = BrowserMode.FIRE,
-                    )
-                    dataClearingWideEvent.finishSuccess()
-                } catch (e: Exception) {
-                    fireDataCleared = false
-                    dataClearingWideEvent.finishFailure(e)
-                    throw e
-                }
-            }
-        }
-    }
-
     suspend fun onTabSelected(tabId: String) {
         val mode = viewState.value.mode as? Selection ?: Normal
         if (mode is Selection) {
@@ -366,8 +327,6 @@ class TabSwitcherViewModel @Inject constructor(
 
     private suspend fun deleteTabs(tabIds: List<String>) {
         tabRepository.deleteTabs(tabIds.filterNot { it == TRACKER_ANIMATION_PANEL_ID })
-
-        clearFireModeTabsAndDataIfNeeded()
     }
 
     private fun triggerEmptySelectionMode() {
@@ -609,7 +568,6 @@ class TabSwitcherViewModel @Inject constructor(
         if (viewState.value.mode is Selection) {
             triggerNormalMode()
         } else if (viewState.value.showFireTabsEmptyState) {
-            clearFireModeTabsAndDataIfNeeded()
             command.value = Command.SwitchToRegularModeAndClose
         } else {
             command.value = Command.Close
@@ -622,7 +580,6 @@ class TabSwitcherViewModel @Inject constructor(
         if (viewState.value.mode is Selection) {
             triggerNormalMode()
         } else if (viewState.value.showFireTabsEmptyState) {
-            clearFireModeTabsAndDataIfNeeded()
             command.value = Command.SwitchToRegularModeAndClose
         } else {
             command.value = Command.Close

--- a/app/src/test/java/com/duckduckgo/app/fire/DataClearingTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/DataClearingTest.kt
@@ -130,6 +130,8 @@ class DataClearingTest {
     @Mock
     private lateinit var mockDataClearingTrigger: DataClearingTrigger
 
+    private val fireModeDataClearingState = FireModeDataClearingState()
+
     private val showClearDuckAIChatHistoryFlow = MutableStateFlow(true)
     private val showOnAppLaunchOptionFlow = MutableStateFlow<ShowOnAppLaunchOption>(ShowOnAppLaunchOption.LastOpenedTab)
 
@@ -144,6 +146,7 @@ class DataClearingTest {
         // test explicitly enables it.
         whenever(mockFireModeAvailability.isAvailable()).thenReturn(false)
         whenever(mockTabRepositoryProvider.forMode(any())).thenReturn(mockTabRepository)
+        fireModeDataClearingState.markDataForClearing()
         runBlocking {
             whenever(mockClearDataAction.clearDataForSpecificDomains(any())).thenReturn(ClearDataResult.Success)
             whenever(mockFireDataStore.getManualClearOptions()).thenReturn(emptySet())
@@ -165,6 +168,7 @@ class DataClearingTest {
             contextualDataStore = mockContextualDataStore,
             showOnAppLaunchOptionDataStore = mockShowOnAppLaunchOptionDataStore,
             dataClearingTrigger = mockDataClearingTrigger,
+            fireModeDataClearingState = fireModeDataClearingState,
         )
     }
 
@@ -1181,6 +1185,51 @@ class DataClearingTest {
                 ),
             ),
         )
+    }
+
+    @Test
+    fun `fire burn marks the fire profile clean so the auto burner does not burn again`() = runTest {
+        whenever(mockFireModeAvailability.isAvailable()).thenReturn(true)
+        configureManualOptions(setOf(FireClearOption.TABS, FireClearOption.DATA, FireClearOption.DUCKAI_CHATS))
+
+        testee.clearDataUsingManualFireOptions(shouldRestartIfRequired = false, wasAppUsedSinceLastClear = true, browserMode = BrowserMode.FIRE)
+
+        assertFalse(fireModeDataClearingState.hasUnclearedData.value)
+    }
+
+    @Test
+    fun `fire profile is marked clean before the clear runs so emptying the fire tabs does not burn again`() = runTest {
+        whenever(mockFireModeAvailability.isAvailable()).thenReturn(true)
+        configureManualOptions(setOf(FireClearOption.TABS, FireClearOption.DATA, FireClearOption.DUCKAI_CHATS))
+        var dirtyWhileClearing: Boolean? = null
+        whenever(mockDataClearingTrigger.clearData(any())).thenAnswer {
+            dirtyWhileClearing = fireModeDataClearingState.hasUnclearedData.value
+            Unit
+        }
+
+        testee.clearDataUsingManualFireOptions(shouldRestartIfRequired = false, wasAppUsedSinceLastClear = true, browserMode = BrowserMode.FIRE)
+
+        assertEquals(false, dirtyWhileClearing)
+    }
+
+    @Test
+    fun `automatic clear marks the fire profile clean`() = runTest {
+        whenever(mockFireModeAvailability.isAvailable()).thenReturn(true)
+        configureAutomaticOptions(setOf(FireClearOption.TABS, FireClearOption.DATA))
+
+        testee.clearDataUsingAutomaticFireOptions(killProcessIfNeeded = false)
+
+        assertFalse(fireModeDataClearingState.hasUnclearedData.value)
+    }
+
+    @Test
+    fun `clear with fire mode unavailable leaves the fire profile dirty`() = runTest {
+        whenever(mockFireModeAvailability.isAvailable()).thenReturn(false)
+        configureManualOptions(setOf(FireClearOption.TABS, FireClearOption.DATA, FireClearOption.DUCKAI_CHATS))
+
+        testee.clearDataUsingManualFireOptions(shouldRestartIfRequired = false, wasAppUsedSinceLastClear = true, browserMode = BrowserMode.FIRE)
+
+        assertTrue(fireModeDataClearingState.hasUnclearedData.value)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/fire/FireModeLastTabObserverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/FireModeLastTabObserverTest.kt
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.fire
+
+import com.duckduckgo.adclick.api.AdClickManager
+import com.duckduckgo.app.fire.wideevents.DataClearingWideEvent
+import com.duckduckgo.app.settings.clear.FireClearOption
+import com.duckduckgo.app.tabs.db.TabsDao
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.FireModeAvailability
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.verification.VerificationMode
+
+class FireModeLastTabObserverTest {
+
+    @get:Rule val coroutineRule = CoroutineTestRule()
+
+    /** Open and pending-undo rows alike, exactly as `select count(*) from tabs` reports them. */
+    private val fireTabCount = MutableStateFlow(1)
+    private var pendingUndoIds = emptyList<String>()
+
+    private val fireTabsDao: TabsDao = mock {
+        on { it.flowTabCount() } doReturn fireTabCount
+    }
+    private val fireTabRepository: TabRepository = mock()
+    private val adClickManager: AdClickManager = mock()
+    private val dataClearing: ManualDataClearing = mock()
+    private val dataClearingWideEvent: DataClearingWideEvent = mock()
+    private val fireModeAvailability: FireModeAvailability = mock {
+        on { it.isAvailable() } doReturn true
+    }
+    private val fireModeDataClearingState = FireModeDataClearingState()
+
+    private val testee = FireModeLastTabObserver(
+        fireTabsDao = fireTabsDao,
+        fireTabRepository = fireTabRepository,
+        adClickManager = adClickManager,
+        dataClearing = dataClearing,
+        dataClearingWideEvent = dataClearingWideEvent,
+        fireModeDataClearingState = fireModeDataClearingState,
+        fireModeAvailability = fireModeAvailability,
+        appCoroutineScope = coroutineRule.testScope,
+        dispatcherProvider = coroutineRule.testDispatcherProvider,
+    )
+
+    @Test
+    fun whenLastFireTabIsRemovedThenFireDataIsBurned() = runTest {
+        startObserving()
+
+        fireTabCount.value = 0
+
+        verifyBurned(times(1))
+        verify(dataClearingWideEvent).start(
+            entryPoint = DataClearingWideEvent.EntryPoint.FIRE_TABS_EMPTIED,
+            clearOptions = setOf(FireClearOption.TABS, FireClearOption.DATA, FireClearOption.DUCKAI_CHATS),
+            browserMode = BrowserMode.FIRE,
+        )
+        verify(dataClearingWideEvent).finishSuccess()
+    }
+
+    @Test
+    fun whenAClosedFireTabIsStillPendingUndoThenFireDataIsNotBurned() = runTest {
+        startObserving()
+
+        // the row is still counted while it is only marked deletable
+        fireTabCount.value = 1
+
+        verifyBurned(never())
+    }
+
+    @Test
+    fun whenFireTabsRemainThenFireDataIsNotBurned() = runTest {
+        startObserving()
+
+        fireTabCount.value = 2
+
+        verifyBurned(never())
+    }
+
+    @Test
+    fun whenOnlySomeFireTabsAreDeletedMidClearThenTheBurnIsNotReArmed() = runTest {
+        fireTabCount.value = 2
+        startObserving()
+
+        // a clear marks the profile clean, then its plugins empty the tabs in two steps
+        fireModeDataClearingState.onDataCleared()
+        fireTabCount.value = 1
+        fireTabCount.value = 0
+
+        verifyBurned(never())
+    }
+
+    @Test
+    fun whenFireModeIsAlreadyEmptyAndCleanThenNothingIsBurned() = runTest {
+        fireTabCount.value = 0
+
+        startObserving()
+
+        verifyBurned(never())
+    }
+
+    @Test
+    fun whenDataIsAlreadyOwedThenAnEmptyFireModeIsBurnedAsSoonAsObservingStarts() = runTest {
+        fireTabCount.value = 0
+        fireModeDataClearingState.markDataForClearing()
+
+        startObserving()
+
+        verifyBurned(times(1))
+    }
+
+    @Test
+    fun whenAPreviousProcessLeftAFireClosePendingThenItIsCommittedAndBurned() = runTest {
+        pendingUndoIds = listOf("fire-1")
+        whenever(fireTabRepository.purgeDeletableTabs()).thenAnswer {
+            fireTabCount.value = 0
+            Unit
+        }
+
+        startObserving()
+
+        verify(adClickManager).clearTabId("fire-1")
+        verify(fireTabRepository).purgeDeletableTabs()
+        verifyBurned(times(1))
+    }
+
+    @Test
+    fun whenNoFireCloseIsPendingThenStartupPurgesNothing() = runTest {
+        fireTabCount.value = 0
+
+        startObserving()
+
+        verify(fireTabRepository, never()).purgeDeletableTabs()
+        verifyBurned(never())
+    }
+
+    @Test
+    fun whenFireIsUsedAgainAfterABurnThenEmptyingBurnsAgain() = runTest {
+        startObserving()
+
+        fireTabCount.value = 0
+        fireTabCount.value = 1
+        fireTabCount.value = 0
+
+        verifyBurned(times(2))
+    }
+
+    @Test
+    fun whenFireModeIsUnavailableThenNothingIsBurned() = runTest {
+        whenever(fireModeAvailability.isAvailable()).thenReturn(false)
+
+        startObserving()
+        fireTabCount.value = 0
+
+        verifyBurned(never())
+    }
+
+    @Test
+    fun whenTheBurnFailsThenItIsNotRetriedInALoop() = runTest {
+        whenever(dataClearing.clearDataUsingManualFireOptions(any(), any(), any()))
+            .thenThrow(RuntimeException("boom"))
+        startObserving()
+
+        fireTabCount.value = 0
+
+        verifyBurned(times(1))
+        verify(dataClearingWideEvent).finishFailure(any<Throwable>())
+    }
+
+    private suspend fun startObserving() {
+        whenever(fireTabRepository.getDeletableTabIds()).thenAnswer { pendingUndoIds }
+        testee.onCreate(mock())
+    }
+
+    private suspend fun verifyBurned(mode: VerificationMode) {
+        verify(dataClearing, mode).clearDataUsingManualFireOptions(
+            shouldRestartIfRequired = false,
+            browserMode = BrowserMode.FIRE,
+        )
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/fire/FireModeLastTabObserverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/FireModeLastTabObserverTest.kt
@@ -151,6 +151,22 @@ class FireModeLastTabObserverTest {
     }
 
     @Test
+    fun whenTheAppIsForegroundedWithAFireClosePendingThenItIsCommittedAndBurned() = runTest {
+        startObserving()
+        // the user closed the last Fire tab, so its row is still counted while it waits on Undo
+        pendingUndoIds = listOf("fire-1")
+        whenever(fireTabRepository.purgeDeletableTabs()).thenAnswer {
+            fireTabCount.value = 0
+            Unit
+        }
+
+        testee.onStart(mock())
+
+        verify(adClickManager).clearTabId("fire-1")
+        verifyBurned(times(1))
+    }
+
+    @Test
     fun whenNoFireCloseIsPendingThenStartupPurgesNothing() = runTest {
         fireTabCount.value = 0
 

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -26,12 +26,9 @@ import app.cash.turbine.test
 import com.duckduckgo.app.browser.api.OmnibarRepository
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.omnibar.OmnibarType
-import com.duckduckgo.app.fire.ManualDataClearing
 import com.duckduckgo.app.fire.promo.FireTabsPromos
-import com.duckduckgo.app.fire.wideevents.DataClearingWideEvent
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.BrowserModeSwitchSource
-import com.duckduckgo.app.settings.clear.FireClearOption
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
@@ -104,7 +101,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doSuspendableAnswer
@@ -175,10 +171,6 @@ class TabSwitcherViewModelTest {
     private val mockOmnibarFeatureRepository: OmnibarRepository = mock()
 
     private val mockTabTitleResolver: TabTitleResolver = mock()
-
-    private val mockDataClearing: ManualDataClearing = mock()
-
-    private val mockDataClearingWideEvent: DataClearingWideEvent = mock()
 
     private val swipingTabsFeature = FakeFeatureToggleFactory.create(SwipingTabsFeature::class.java)
     private val swipingTabsFeatureProvider = SwipingTabsFeatureProvider(swipingTabsFeature)
@@ -254,8 +246,6 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
-            mockDataClearing,
-            mockDataClearingWideEvent,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,
@@ -754,7 +744,7 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun `when back pressed in fire mode with no fire tabs then clears fire data and switches to regular mode`() = runTest {
+    fun `when back pressed in fire mode with no fire tabs then switches to regular mode`() = runTest {
         whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
         whenever(mockFireTabRepository.flowTabs).thenReturn(flowOf(emptyList()))
         whenever(mockFireTabRepository.flowSelectedTab).thenReturn(flowOf<TabEntity?>(null))
@@ -772,14 +762,10 @@ class TabSwitcherViewModelTest {
 
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         assertEquals(Command.SwitchToRegularModeAndClose, commandCaptor.lastValue)
-        verify(mockDataClearing).clearDataUsingManualFireOptions(
-            shouldRestartIfRequired = false,
-            browserMode = BrowserMode.FIRE,
-        )
     }
 
     @Test
-    fun `when up pressed in fire mode with no fire tabs then clears fire data and switches to regular mode`() = runTest {
+    fun `when up pressed in fire mode with no fire tabs then switches to regular mode`() = runTest {
         whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
         whenever(mockFireTabRepository.flowTabs).thenReturn(flowOf(emptyList()))
         whenever(mockFireTabRepository.flowSelectedTab).thenReturn(flowOf<TabEntity?>(null))
@@ -797,10 +783,6 @@ class TabSwitcherViewModelTest {
 
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         assertEquals(Command.SwitchToRegularModeAndClose, commandCaptor.lastValue)
-        verify(mockDataClearing).clearDataUsingManualFireOptions(
-            shouldRestartIfRequired = false,
-            browserMode = BrowserMode.FIRE,
-        )
     }
 
     @Test
@@ -2105,7 +2087,7 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun `when closing the last fire tab then shows undo without clearing fire data`() = runTest {
+    fun `when closing the last fire tab then shows undo`() = runTest {
         val fireTab = TabEntity("fire-1", url = "https://fire.example", position = 1)
         whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
         whenever(mockFireTabRepository.flowTabs).thenReturn(flowOf(listOf(fireTab)))
@@ -2126,12 +2108,10 @@ class TabSwitcherViewModelTest {
         verify(mockFireTabRepository).markDeletable(fireTab)
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         assertEquals(Command.ShowUndoDeleteTabsMessage(listOf("fire-1")), commandCaptor.lastValue)
-        verify(mockDataClearingWideEvent, never()).start(any(), any(), anyOrNull(), anyOrNull(), anyOrNull())
-        verify(mockDataClearing, never()).clearDataUsingManualFireOptions(any(), any(), any())
     }
 
     @Test
-    fun `when closing all fire tabs then shows undo without clearing fire data`() = runTest {
+    fun `when closing all fire tabs then shows undo`() = runTest {
         val fireTabs = listOf(
             TabEntity("fire-1", url = "https://fire.example/1", position = 1),
             TabEntity("fire-2", url = "https://fire.example/2", position = 2),
@@ -2154,136 +2134,18 @@ class TabSwitcherViewModelTest {
         verify(mockFireTabRepository).markDeletable(fireTabs.map { it.tabId })
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         assertEquals(Command.ShowUndoDeleteTabsMessage(fireTabs.map { it.tabId }), commandCaptor.lastValue)
-        verify(mockDataClearingWideEvent, never()).start(any(), any(), anyOrNull(), anyOrNull(), anyOrNull())
-        verify(mockDataClearing, never()).clearDataUsingManualFireOptions(any(), any(), any())
     }
 
     @Test
-    fun `when undo snackbar dismissed in fire mode and no fire tabs remain then fire data is cleared`() = runTest {
-        whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
-        whenever(mockFireTabRepository.flowTabs).thenReturn(flowOf(emptyList()))
-        whenever(mockFireTabRepository.flowSelectedTab).thenReturn(flowOf<TabEntity?>(null))
-        whenever(mockFireTabRepository.flowDeletableTabs).thenReturn(flowOf(emptyList()))
-        whenever(mockFireTabRepository.tabSwitcherData).thenReturn(flowOf(tabSwitcherData))
-        whenever(mockFireTabRepository.getDeletableTabIds()).thenReturn(listOf("fire-1"))
-
-        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            testee.viewState.collect()
-        }
-        currentModeFlow.value = BrowserMode.FIRE
-        advanceUntilIdle()
-
-        testee.onUndoDeleteSnackbarDismissed(listOf("fire-1"))
-        advanceUntilIdle()
-
-        verify(mockFireTabRepository).deleteTabs(listOf("fire-1"))
-        verify(mockDataClearingWideEvent).start(
-            entryPoint = DataClearingWideEvent.EntryPoint.FIRE_TABS_EMPTIED,
-            clearOptions = setOf(FireClearOption.TABS, FireClearOption.DATA, FireClearOption.DUCKAI_CHATS),
-            browserMode = BrowserMode.FIRE,
-        )
-        verify(mockDataClearing).clearDataUsingManualFireOptions(
-            shouldRestartIfRequired = false,
-            browserMode = BrowserMode.FIRE,
-        )
-        verify(mockDataClearingWideEvent).finishSuccess()
-    }
-
-    @Test
-    fun `when undo snackbar dismissed in fire mode with fire tabs remaining then fire data is not cleared`() = runTest {
-        val remainingTab = TabEntity("fire-2", url = "https://fire.example/2", position = 2)
-        whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
-        whenever(mockFireTabRepository.flowTabs).thenReturn(flowOf(listOf(remainingTab)))
-        whenever(mockFireTabRepository.flowSelectedTab).thenReturn(flowOf(remainingTab))
-        whenever(mockFireTabRepository.flowDeletableTabs).thenReturn(flowOf(emptyList()))
-        whenever(mockFireTabRepository.tabSwitcherData).thenReturn(flowOf(tabSwitcherData))
-
-        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            testee.viewState.collect()
-        }
-        currentModeFlow.value = BrowserMode.FIRE
-        advanceUntilIdle()
-
-        testee.onUndoDeleteSnackbarDismissed(listOf("fire-1"))
-        advanceUntilIdle()
-
-        verify(mockFireTabRepository).deleteTabs(listOf("fire-1"))
-        verify(mockDataClearingWideEvent, never()).start(any(), any(), anyOrNull(), anyOrNull(), anyOrNull())
-        verify(mockDataClearing, never()).clearDataUsingManualFireOptions(any(), any(), any())
-    }
-
-    @Test
-    fun `when undo snackbar dismissed in regular mode then fire data is not cleared`() = runTest {
+    fun `when undo snackbar dismissed in regular mode then tabs are deleted`() = runTest {
         testee.onUndoDeleteSnackbarDismissed(listOf("1"))
         advanceUntilIdle()
 
         verify(mockTabRepository).deleteTabs(listOf("1"))
-        verify(mockDataClearingWideEvent, never()).start(any(), any(), anyOrNull(), anyOrNull(), anyOrNull())
-        verify(mockDataClearing, never()).clearDataUsingManualFireOptions(any(), any(), any())
     }
 
     @Test
-    fun `when multiple empty-state triggers fire while empty then fire data is cleared only once`() = runTest {
-        whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
-        whenever(mockFireTabRepository.flowTabs).thenReturn(flowOf(emptyList()))
-        whenever(mockFireTabRepository.flowSelectedTab).thenReturn(flowOf<TabEntity?>(null))
-        whenever(mockFireTabRepository.flowDeletableTabs).thenReturn(flowOf(emptyList()))
-        whenever(mockFireTabRepository.tabSwitcherData).thenReturn(flowOf(tabSwitcherData))
-
-        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            testee.viewState.collect()
-        }
-        currentModeFlow.value = BrowserMode.FIRE
-        advanceUntilIdle()
-
-        testee.onUndoDeleteSnackbarDismissed(listOf("fire-1"))
-        advanceUntilIdle()
-        testee.onBackButtonPressed()
-        advanceUntilIdle()
-
-        verify(mockDataClearingWideEvent, times(1)).start(any(), any(), anyOrNull(), anyOrNull(), anyOrNull())
-        verify(mockDataClearing, times(1)).clearDataUsingManualFireOptions(
-            shouldRestartIfRequired = false,
-            browserMode = BrowserMode.FIRE,
-        )
-    }
-
-    @Test
-    fun `when fire is repopulated after clearing then a later empty state clears again`() = runTest {
-        val fireTabsFlow = MutableStateFlow<List<TabEntity>>(emptyList())
-        val fireTab = TabEntity("fire-1", url = "https://fire.example", position = 1)
-        whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
-        whenever(mockFireTabRepository.flowTabs).thenReturn(fireTabsFlow)
-        whenever(mockFireTabRepository.flowSelectedTab).thenReturn(flowOf<TabEntity?>(null))
-        whenever(mockFireTabRepository.flowDeletableTabs).thenReturn(flowOf(emptyList()))
-        whenever(mockFireTabRepository.tabSwitcherData).thenReturn(flowOf(tabSwitcherData))
-
-        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            testee.viewState.collect()
-        }
-        currentModeFlow.value = BrowserMode.FIRE
-        advanceUntilIdle()
-
-        testee.onBackButtonPressed()
-        advanceUntilIdle()
-
-        // Fire repopulated then emptied again re-arms the guard
-        fireTabsFlow.value = listOf(fireTab)
-        advanceUntilIdle()
-        fireTabsFlow.value = emptyList()
-        advanceUntilIdle()
-
-        testee.onBackButtonPressed()
-        advanceUntilIdle()
-
-        verify(mockDataClearing, times(2)).clearDataUsingManualFireOptions(
-            shouldRestartIfRequired = false,
-            browserMode = BrowserMode.FIRE,
-        )
-    }
-
-    @Test
-    fun `when deletable tabs purged in fire mode then delegates to fire repo without clearing fire data`() = runTest {
+    fun `when deletable tabs purged in fire mode then delegates to fire repo`() = runTest {
         whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
         whenever(mockFireTabRepository.flowTabs).thenReturn(flowOf(emptyList()))
         whenever(mockFireTabRepository.flowSelectedTab).thenReturn(flowOf<TabEntity?>(null))
@@ -2300,42 +2162,14 @@ class TabSwitcherViewModelTest {
         advanceUntilIdle()
 
         verify(mockFireTabRepository).purgeDeletableTabs()
-        verify(mockDataClearingWideEvent, never()).start(any(), any(), anyOrNull(), anyOrNull(), anyOrNull())
-        verify(mockDataClearing, never()).clearDataUsingManualFireOptions(any(), any(), any())
     }
 
     @Test
-    fun `when deletable tabs purged in regular mode then fire data is not cleared`() = runTest {
+    fun `when deletable tabs purged in regular mode then delegates to regular repo`() = runTest {
         testee.purgeDeletableTabs()
         advanceUntilIdle()
 
         verify(mockTabRepository).purgeDeletableTabs()
-        verify(mockDataClearingWideEvent, never()).start(any(), any(), anyOrNull(), anyOrNull(), anyOrNull())
-        verify(mockDataClearing, never()).clearDataUsingManualFireOptions(any(), any(), any())
-    }
-
-    @Test
-    fun `when toggling to regular mode with fire tabs present then does not clear fire data`() = runTest {
-        val fireTabs = listOf(
-            TabEntity("fire-1", url = "https://fire.example/1", position = 1),
-            TabEntity("fire-2", url = "https://fire.example/2", position = 2),
-        )
-        whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
-        whenever(mockFireTabRepository.flowTabs).thenReturn(flowOf(fireTabs))
-        whenever(mockFireTabRepository.flowSelectedTab).thenReturn(flowOf(fireTabs.first()))
-        whenever(mockFireTabRepository.flowDeletableTabs).thenReturn(flowOf(emptyList()))
-        whenever(mockFireTabRepository.tabSwitcherData).thenReturn(flowOf(tabSwitcherData))
-
-        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            testee.viewState.collect()
-        }
-        currentModeFlow.value = BrowserMode.FIRE
-        advanceUntilIdle()
-
-        testee.onBrowserModeToggled(BrowserMode.REGULAR, BrowserModeSwitchSource.TAB_SWITCHER_TOGGLE)
-        advanceUntilIdle()
-
-        verify(mockDataClearing, never()).clearDataUsingManualFireOptions(any(), any(), any())
     }
 
     @Test
@@ -2365,8 +2199,6 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
-            mockDataClearing,
-            mockDataClearingWideEvent,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,
@@ -2412,8 +2244,6 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
-            mockDataClearing,
-            mockDataClearingWideEvent,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,
@@ -2488,8 +2318,6 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
-            mockDataClearing,
-            mockDataClearingWideEvent,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,

--- a/data-clearing/data-clearing-impl/src/main/java/com/duckduckgo/dataclearing/impl/plugin/DataClearingOrchestrator.kt
+++ b/data-clearing/data-clearing-impl/src/main/java/com/duckduckgo/dataclearing/impl/plugin/DataClearingOrchestrator.kt
@@ -42,7 +42,7 @@ class DataClearingOrchestrator @Inject constructor(
                 plugin.onClearData(types)
             } catch (e: Exception) {
                 currentCoroutineContext().ensureActive()
-                logcat(ERROR) { "Plugin ${plugin::class.simpleName} failed: ${e.asLog()}" }
+                logcat(ERROR) { "Plugin ${plugin::class.simpleName} failed to clear $types: ${e.asLog()}" }
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1218116524445094?focus=true

### Description

Fixes an issue when Fire mode auto-burn is not executed in certain edge cases when the last Fire tab is closed.

### Steps to test this PR

_Fire data is burned when leaving via the mode toggle_
- [x] In the tab switcher -> switch to Fire mode -> open a Fire tab
- [x] Visit `https://httpbin.org/cookies/set/ddgtest/1` — the page shows `"ddgtest": "1"`
- [x] Open the tab switcher and close the Fire tab with the X
- [x] Immediately tap the Regular tabs segment of the mode toggle, before the Undo snackbar disappears
- [x] Switch back to Fire mode
- [x] Open a new Fire tab and visit `https://httpbin.org/cookies`
- [x] Verify the cookie list is empty

_Fire data is burned after the app is killed_
- [x] In Fire mode -> open a Fire tab 
- [x] Visit `https://httpbin.org/cookies/set/ddgtest/2`
- [x] Open the tab switcher
- [x] Close the Fire tab, then immediately swipe the app away from recents
- [x] Reopen the app -> switch to Fire mode -> open a new Fire tab
- [x] Visit `https://httpbin.org/cookies` 
- [x] Verify the cookie list is empty

_Undo still restores the tab and its session_
- [x] In Fire mode, open a Fire tab and visit `https://httpbin.org/cookies/set/ddgtest/3`
- [x] Open the tab switcher, close the tab, and tap Undo on the snackbar
- [x] The tab is restored and still shows `"ddgtest": "3"` after a refresh

_Delete Tabs and Data burns exactly once_
- [x] In Fire mode with at least one Fire tab open, tap the fire button 
- [x] Choose Delete All
- [x] You land on the empty Fire tab switcher
- [x] Press back
- [x] Run `adb logcat | grep "Performing Fire mode data clear"` 
- [x] Verify exactly one line appears across both steps

_Regular mode is unaffected (optional)_
- [x] In Regular mode, sign in to a site or set the cookie above, close the tab and reopen it — the session is still there
- [x] Tap the fire button in Regular mode and Delete All — Regular data is cleared and the app restarts as before



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how Fire profile data is wiped (lifecycle-driven, including after process death), which is privacy-sensitive; scope is limited to Fire mode with guards against duplicate burns and broad test coverage.
> 
> **Overview**
> Fire mode **auto-burn** is moved out of the tab switcher UI into a **process-level observer** so cookies and other Fire profile data are cleared reliably when the last Fire tab goes away—including if the user switches modes before Undo expires or the app is killed after closing a tab.
> 
> A new **`FireModeDataClearingState`** tracks whether Fire browsing data still needs burning. **`FireModeLastTabObserver`** watches **`flowTabCount()`** (all tab rows, including undo-pending deletable ones), marks data dirty while any Fire tab exists, commits pending closes on startup/foreground, and runs **`clearDataUsingManualFireOptions`** when the count hits zero while data is still owed. **`DataClearing.performFireModeClear`** calls **`onDataCleared()`** *before* the clear pipeline runs so tab deletion during burn does not trigger a second burn.
> 
> **`TabSwitcherViewModel`** no longer invokes data clearing on back/up, snackbar dismiss, or tab delete; it only navigates (e.g. switch to Regular when the Fire empty state is shown). Fire tab purge on startup is removed from **`TabsDbSanitizer`** (Fire path only). **`DataClearingOrchestrator`** logs which clear types failed when a plugin errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52f447bde550bee3a643f3d7989e6dfeeeafc51f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->