### PR TITLE
Fail pixel validation when generated schemas are out of date

### DIFF
--- a/.github/workflows/pixel-validation.yml
+++ b/.github/workflows/pixel-validation.yml
@@ -48,3 +48,20 @@ jobs:
               run: npm run validate-defs-without-formatting -- -g ../internal-github-asana-utils/user_map.yml
               working-directory: PixelDefinitions
 
+            # Validation regenerates generated_schemas/ in place and exits 0 either way.
+            # If there are any changes after previous steps, it means the committed schemas
+            # no longer match the definitions they come from.
+            - name: Check generated schemas match definitions
+              run: |
+                changes=$(git status --porcelain -- PixelDefinitions)
+                if [ -n "$changes" ]; then
+                  echo 'Generated schemas do not match the pixel definitions.'
+                  echo
+                  echo "$changes"
+                  echo
+                  git --no-pager diff -- PixelDefinitions
+                  echo
+                  echo 'Run "npm run validate-defs-without-formatting" in PixelDefinitions and commit the result.'
+                  exit 1
+                fi
+


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1218093302988752?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

### Description

Pixel validation regenerates `generated_schemas/` in place and exits 0 either way, so a stale or hand-edited schema passed CI unnoticed. This fails the job when validation changes or creates anything under `PixelDefinitions`.

### Steps to test this PR

QA-optional

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI guardrail and a narrower analytics enum on JWKS latency bucketing; no runtime auth logic changes in this diff.
> 
> **Overview**
> Pixel validation CI now **fails** if anything under `PixelDefinitions` is still modified after `npm run validate-defs-without-formatting` runs. Validation regenerates `generated_schemas/` in place and always exits 0, so committed schemas could drift from definitions without blocking merges; the new step uses `git status`/`git diff` and tells contributors to re-run validation and commit.
> 
> The PR also aligns **auth-token-refresh** with that check: `fetch_jwks_latency_ms_bucketed` drops the `"600000"` bucket in `auth-token-refresh.json5` and the matching `android-auth-token-refresh-1.0.0.json` generated schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b6a32c4a14cffae100c44196ab85d82caa687ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->