### PR TITLE
Add Exchange v2.1 pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -15,8 +15,8 @@
             {
                 "key": "flow_version",
                 "type": "string",
-                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
-                "enum": ["v1", "v2"]
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled, v2.1 when canUseExchangeV2Point1 is also enabled)",
+                "enum": ["v1", "v2", "v2.1"]
             },
             {
                 "key": "ui_version",
@@ -48,8 +48,8 @@
             {
                 "key": "flow_version",
                 "type": "string",
-                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
-                "enum": ["v1", "v2"]
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled, v2.1 when canUseExchangeV2Point1 is also enabled)",
+                "enum": ["v1", "v2", "v2.1"]
             },
             {
                 "key": "ui_version",
@@ -81,8 +81,8 @@
             {
                 "key": "flow_version",
                 "type": "string",
-                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
-                "enum": ["v1", "v2"]
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled, v2.1 when canUseExchangeV2Point1 is also enabled)",
+                "enum": ["v1", "v2", "v2.1"]
             },
             {
                 "key": "ui_version",
@@ -126,8 +126,8 @@
             {
                 "key": "flow_version",
                 "type": "string",
-                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
-                "enum": ["v1", "v2"]
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled, v2.1 when canUseExchangeV2Point1 is also enabled)",
+                "enum": ["v1", "v2", "v2.1"]
             },
             {
                 "key": "ui_version",
@@ -171,8 +171,8 @@
             {
                 "key": "flow_version",
                 "type": "string",
-                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
-                "enum": ["v1", "v2"]
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled, v2.1 when canUseExchangeV2Point1 is also enabled)",
+                "enum": ["v1", "v2", "v2.1"]
             },
             {
                 "key": "ui_version",
@@ -204,8 +204,8 @@
             {
                 "key": "flow_version",
                 "type": "string",
-                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
-                "enum": ["v1", "v2"]
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled, v2.1 when canUseExchangeV2Point1 is also enabled)",
+                "enum": ["v1", "v2", "v2.1"]
             },
             {
                 "key": "ui_version",
@@ -243,8 +243,8 @@
             {
                 "key": "flow_version",
                 "type": "string",
-                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
-                "enum": ["v1", "v2"]
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled, v2.1 when canUseExchangeV2Point1 is also enabled)",
+                "enum": ["v1", "v2", "v2.1"]
             },
             {
                 "key": "ui_version",
@@ -282,8 +282,8 @@
             {
                 "key": "flow_version",
                 "type": "string",
-                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
-                "enum": ["v1", "v2"]
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled, v2.1 when canUseExchangeV2Point1 is also enabled)",
+                "enum": ["v1", "v2", "v2.1"]
             },
             {
                 "key": "ui_version",
@@ -373,8 +373,8 @@
             {
                 "key": "flow_version",
                 "type": "string",
-                "description": "Which sync setup protocol stack the device is on. Always v2 for this pixel",
-                "enum": ["v1", "v2"]
+                "description": "Which sync setup protocol stack the device is on. Always v2 or v2.1 for this pixel",
+                "enum": ["v1", "v2", "v2.1"]
             },
             {
                 "key": "ui_version",
@@ -430,8 +430,8 @@
             {
                 "key": "flow_version",
                 "type": "string",
-                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
-                "enum": ["v1", "v2"]
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled, v2.1 when canUseExchangeV2Point1 is also enabled)",
+                "enum": ["v1", "v2", "v2.1"]
             },
             {
                 "key": "ui_version",
@@ -444,6 +444,82 @@
                 "type": "string",
                 "description": "This device's credential kind. Always ddg for the native client",
                 "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_joiner_recovery_code_done_success": {
+        "description": "The Joiner's join report (recovery_code_done with reason success) was accepted by the relay after a v2.1 pairing, so the Host had a chance to receive it",
+        "owners": ["MiSikora"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "host_has_account",
+                "type": "boolean",
+                "description": "Whether the Host side was already signed in to sync when roles were elected"
+            },
+            {
+                "key": "host_kind",
+                "type": "string",
+                "description": "The Host device's credential kind",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "joiner_has_account",
+                "type": "boolean",
+                "description": "Whether the Joiner side was already signed in to sync when roles were elected"
+            },
+            {
+                "key": "joiner_kind",
+                "type": "string",
+                "description": "The Joiner device's credential kind. Always ddg from this client, since only the Joiner fires this pixel",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "protocol_version",
+                "type": "string",
+                "description": "Exchange protocol version negotiated for the session. recovery_code_done exists since 2.1, so never lower",
+                "pattern": "^[0-9]+(\\.[0-9]+)?$",
+                "examples": ["2.1"]
+            }
+        ]
+    },
+    "sync_setup_joiner_recovery_code_done_failed": {
+        "description": "The Joiner's join report (recovery_code_done with a non-success reason such as login_failed or scope_rejected) was accepted by the relay after a v2.1 pairing",
+        "owners": ["MiSikora"],
+        "triggers": ["exception"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "host_has_account",
+                "type": "boolean",
+                "description": "Whether the Host side was already signed in to sync when roles were elected"
+            },
+            {
+                "key": "host_kind",
+                "type": "string",
+                "description": "The Host device's credential kind",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "joiner_has_account",
+                "type": "boolean",
+                "description": "Whether the Joiner side was already signed in to sync when roles were elected"
+            },
+            {
+                "key": "joiner_kind",
+                "type": "string",
+                "description": "The Joiner device's credential kind. Always ddg from this client, since only the Joiner fires this pixel",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "protocol_version",
+                "type": "string",
+                "description": "Exchange protocol version negotiated for the session. recovery_code_done exists since 2.1, so never lower",
+                "pattern": "^[0-9]+(\\.[0-9]+)?$",
+                "examples": ["2", "2.1", "3.0"]
             }
         ]
     }

--- a/PixelDefinitions/pixels/definitions/wide_sync_setup.json5
+++ b/PixelDefinitions/pixels/definitions/wide_sync_setup.json5
@@ -38,6 +38,11 @@
                 "enum": ["v1", "v2"]
             },
             {
+                "key": "feature.data.ext.flow_version",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled, v2.1 when canUseExchangeV2Point1 is also enabled)",
+                "enum": ["v1", "v2", "v2.1"]
+            },
+            {
                 "key": "feature.data.ext.account_creation_latency_ms_bucketed",
                 "description": "Latency of the account creation API call in milliseconds, bucketed",
                 "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]

--- a/PixelDefinitions/wide_events/definitions/sync-setup.json5
+++ b/PixelDefinitions/wide_events/definitions/sync-setup.json5
@@ -21,6 +21,11 @@
                         "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
                         "enum": ["v1", "v2"]
                     },
+                    "flow_version": {
+                        "type": "string",
+                        "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled, v2.1 when canUseExchangeV2Point1 is also enabled)",
+                        "enum": ["v1", "v2", "v2.1"]
+                    },
                     "account_creation_latency_ms_bucketed": {
                         "type": "string",
                         "description": "Latency of the account creation API call in milliseconds, bucketed",

--- a/PixelDefinitions/wide_events/generated_schemas/android-sync-setup-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-sync-setup-1.0.0.json
@@ -80,6 +80,11 @@
                                     "description": "Which sync setup UI the user is on: v2 when the simplified sync UI is enabled (useSimplifiedSync), v1 on the legacy setup screens",
                                     "enum": ["v1", "v2"]
                                 },
+                                "flow_version": {
+                                    "type": "string",
+                                    "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled, v2.1 when canUseExchangeV2Point1 is also enabled)",
+                                    "enum": ["v1", "v2", "v2.1"]
+                                },
                                 "account_creation_latency_ms_bucketed": {
                                     "type": "string",
                                     "description": "Latency of the account creation API call in milliseconds, bucketed",

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/ExchangeV2RecoverCodeDonePixelObserver.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/ExchangeV2RecoverCodeDonePixelObserver.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.pixels
+
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import logcat.logcat
+import javax.inject.Inject
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+class ExchangeV2RecoverCodeDonePixelObserver @Inject constructor(
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+    private val runner: ExchangeV2Runner,
+    private val syncPixels: SyncPixels,
+) : MainProcessLifecycleObserver {
+
+    // Never cleared, only overwritten. A session can only send recovery_code_done after emitting
+    // its own ExchangeV2Event.RoleElected and ExchangeV2Event.VersionNegotiated, so the context
+    // is always fresh when read.
+    private var sessionContext = SessionContext()
+
+    override fun onCreate(owner: LifecycleOwner) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            runner.events.collect(::handleEvent)
+        }
+    }
+
+    private fun handleEvent(event: ExchangeV2Event) {
+        when (event) {
+            is ExchangeV2Event.RoleElected -> {
+                sessionContext = sessionContext.copy(
+                    ownSignedIn = event.ownSignedIn,
+                    ownKind = event.ownKind.toPeerKind(),
+                    peerSignedIn = event.peerSignedIn,
+                    peerKind = event.peerKind.toPeerKind(),
+                )
+            }
+
+            is ExchangeV2Event.VersionNegotiated -> {
+                sessionContext = sessionContext.copy(
+                    negotiatedVersion = event.negotiatedVersion,
+                )
+            }
+
+            is ExchangeV2Event.MessageSent -> {
+                val message = event.message
+                if (message is RecoveryCodeDone) {
+                    fireJoinerReport(message.reason)
+                }
+            }
+
+            else -> Unit
+        }
+    }
+
+    private fun fireJoinerReport(reason: RecoveryCodeDone.Reason) {
+        val context = sessionContext
+        val joinerKind = context.ownKind
+        val hostKind = context.peerKind
+        val negotiatedVersion = context.negotiatedVersion
+        if (joinerKind == null || hostKind == null || negotiatedVersion == null) {
+            logcat { "$TAG: recovery_code_done sent without full session context; skipping joiner report pixel" }
+            return
+        }
+
+        if (reason == RecoveryCodeDone.Reason.Success) {
+            syncPixels.fireSyncSetupJoinerSuccess(
+                hostHasAccount = context.peerSignedIn,
+                hostKind = hostKind,
+                joinerHasAccount = context.ownSignedIn,
+                joinerKind = joinerKind,
+                negotiatedVersion = negotiatedVersion,
+            )
+        } else {
+            syncPixels.fireSyncSetupJoinerFailure(
+                hostHasAccount = context.peerSignedIn,
+                hostKind = hostKind,
+                joinerHasAccount = context.ownSignedIn,
+                joinerKind = joinerKind,
+                negotiatedVersion = negotiatedVersion,
+            )
+        }
+    }
+
+    private fun String?.toPeerKind(): PeerKind? = when (this) {
+        PeerKind.DDG.value -> PeerKind.DDG
+        PeerKind.THIRD_PARTY.value -> PeerKind.THIRD_PARTY
+        else -> null
+    }
+
+    private data class SessionContext(
+        val ownSignedIn: Boolean = false,
+        val ownKind: PeerKind? = null,
+        val peerSignedIn: Boolean = false,
+        val peerKind: PeerKind? = null,
+        val negotiatedVersion: ExchangeProtocolVersion? = null,
+    )
+
+    companion object {
+        private const val TAG = "Sync-ExchangeV2"
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
@@ -59,6 +59,11 @@ class SyncPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugi
             SyncPixelName.SYNC_SETUP_ENDED_SUCCESS.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_ENDED_FAILED.pixelName to PixelParameter.removeAtb(),
 
+            SyncPixelName.SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_SUCCESS.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_SUCCESS_DAILY.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_FAILED.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_FAILED_DAILY.pixelName to PixelParameter.removeAtb(),
+
             SyncPixelName.SYNC_AUTO_RESTORE_TOGGLE_SHOWN.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_AUTO_RESTORE_TOGGLE_OPTED_OUT.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_AUTO_RESTORE_SETTINGS_READY_SHOWN.pixelName to PixelParameter.removeAtb(),

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -1125,9 +1125,9 @@ enum class SyncPixelName(override val pixelName: String) : PixelName {
     SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_CONFIRMED("sync_setup_promo_bookmark_added_dialog_confirmed"),
     SYNC_SETUP_ANOTHER_DEVICE_PROMPT_SHOWN("m_settings_sync_another_device_prompt_shown"),
     SYNC_SETUP_ANOTHER_DEVICE_PROMPT_OPTION_TAPPED("m_settings_sync_another_device_prompt_option_tapped"),
-    SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_SUCCESS("sync_setup_joiner_recovery_code_done_success"),
+    SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_SUCCESS("sync_setup_joiner_recovery_code_done_success_count"),
     SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_SUCCESS_DAILY("sync_setup_joiner_recovery_code_done_success_daily"),
-    SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_FAILED("sync_setup_joiner_recovery_code_done_failed"),
+    SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_FAILED("sync_setup_joiner_recovery_code_done_failed_count"),
     SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_FAILED_DAILY("sync_setup_joiner_recovery_code_done_failed_daily"),
     SYNC_AI_CHAT_ACTIVE("sync_ai_chat_active"),
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -19,6 +19,8 @@ package com.duckduckgo.sync.impl.pixels
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter.Companion.removeAtb
@@ -28,9 +30,13 @@ import com.duckduckgo.sync.api.engine.SyncFeatureType
 import com.duckduckgo.sync.impl.API_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes
 import com.duckduckgo.sync.impl.DispatchOutcome
+import com.duckduckgo.sync.impl.DispatchOutcome.AlreadyConnected
+import com.duckduckgo.sync.impl.DispatchOutcome.Failed
+import com.duckduckgo.sync.impl.DispatchOutcome.UpgradeRequired
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.SyncCodeType
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_DAILY
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_DAILY_SUCCESS_RATE_PIXEL
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_OBJECT_LIMIT_EXCEEDED_DAILY
@@ -62,6 +68,7 @@ import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import java.time.Instant
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import javax.inject.Inject
@@ -155,6 +162,22 @@ interface SyncPixels {
         myRole: SetupRole? = null,
         peerKind: PeerKind? = null,
         timeoutStage: TimeoutStage? = null,
+    )
+
+    fun fireSyncSetupJoinerSuccess(
+        hostHasAccount: Boolean,
+        hostKind: PeerKind,
+        joinerHasAccount: Boolean,
+        joinerKind: PeerKind,
+        negotiatedVersion: ExchangeProtocolVersion,
+    )
+
+    fun fireSyncSetupJoinerFailure(
+        hostHasAccount: Boolean,
+        hostKind: PeerKind,
+        joinerHasAccount: Boolean,
+        joinerKind: PeerKind,
+        negotiatedVersion: ExchangeProtocolVersion,
     )
 
     enum class ScreenType(val value: String) {
@@ -421,28 +444,28 @@ class RealSyncPixels @Inject constructor(
             API_CODE.COUNT_LIMIT.code -> {
                 pixel.fire(
                     String.format(Locale.US, SYNC_OBJECT_LIMIT_EXCEEDED_DAILY.pixelName, feature.field),
-                    type = Pixel.PixelType.Daily(),
+                    type = PixelType.Daily(),
                 )
             }
 
             API_CODE.CONTENT_TOO_LARGE.code -> {
                 pixel.fire(
                     String.format(Locale.US, SyncPixelName.SYNC_REQUEST_SIZE_LIMIT_EXCEEDED_DAILY.pixelName, feature.field),
-                    type = Pixel.PixelType.Daily(),
+                    type = PixelType.Daily(),
                 )
             }
 
             API_CODE.VALIDATION_ERROR.code -> {
                 pixel.fire(
                     String.format(Locale.US, SyncPixelName.SYNC_VALIDATION_ERROR_DAILY.pixelName, feature.field),
-                    type = Pixel.PixelType.Daily(),
+                    type = PixelType.Daily(),
                 )
             }
 
             API_CODE.TOO_MANY_REQUESTS_1.code, API_CODE.TOO_MANY_REQUESTS_2.code -> {
                 pixel.fire(
                     String.format(Locale.US, SyncPixelName.SYNC_TOO_MANY_REQUESTS_DAILY.pixelName, feature.field),
-                    type = Pixel.PixelType.Daily(),
+                    type = PixelType.Daily(),
                 )
             }
         }
@@ -515,7 +538,7 @@ class RealSyncPixels @Inject constructor(
 
     private fun getUtcIsoLocalDate(): String {
         // returns YYYY-MM-dd
-        return Instant.now().atOffset(java.time.ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE)
+        return Instant.now().atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE)
     }
 
     private fun String.appendTimestampSuffix(): String {
@@ -776,7 +799,7 @@ class RealSyncPixels @Inject constructor(
     }
 
     override fun fireAiChatActive() {
-        pixel.fire(SyncPixelName.SYNC_AI_CHAT_ACTIVE, type = Pixel.PixelType.Daily())
+        pixel.fire(SyncPixelName.SYNC_AI_CHAT_ACTIVE, type = PixelType.Daily())
     }
 
     override fun fireAiChatsRescopeTokenError(error: Error) {
@@ -936,10 +959,80 @@ class RealSyncPixels @Inject constructor(
             event.pixelName,
             parameters = parameter?.let { mapOf(it.first to it.second) }.orEmpty(),
             type = if (event.isDaily) {
-                Pixel.PixelType.Daily(tag = event.tag)
+                PixelType.Daily(tag = event.tag)
             } else {
-                Pixel.PixelType.Count
+                PixelType.Count
             },
+        )
+    }
+
+    override fun fireSyncSetupJoinerSuccess(
+        hostHasAccount: Boolean,
+        hostKind: PeerKind,
+        joinerHasAccount: Boolean,
+        joinerKind: PeerKind,
+        negotiatedVersion: ExchangeProtocolVersion,
+    ) {
+        val pixels = mapOf(
+            SyncPixelName.SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_SUCCESS to PixelType.Count,
+            SyncPixelName.SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_SUCCESS_DAILY to PixelType.Daily(),
+        )
+        for ((name, type) in pixels) {
+            fireSyncSetupJoinerOutcome(
+                pixelName = name,
+                pixelType = type,
+                hostHasAccount = hostHasAccount,
+                hostKind = hostKind,
+                joinerHasAccount = joinerHasAccount,
+                joinerKind = joinerKind,
+                negotiatedVersion = negotiatedVersion,
+            )
+        }
+    }
+
+    override fun fireSyncSetupJoinerFailure(
+        hostHasAccount: Boolean,
+        hostKind: PeerKind,
+        joinerHasAccount: Boolean,
+        joinerKind: PeerKind,
+        negotiatedVersion: ExchangeProtocolVersion,
+    ) {
+        val pixels = mapOf(
+            SyncPixelName.SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_FAILED to PixelType.Count,
+            SyncPixelName.SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_FAILED_DAILY to PixelType.Daily(),
+        )
+        for ((name, type) in pixels) {
+            fireSyncSetupJoinerOutcome(
+                pixelName = name,
+                pixelType = type,
+                hostHasAccount = hostHasAccount,
+                hostKind = hostKind,
+                joinerHasAccount = joinerHasAccount,
+                joinerKind = joinerKind,
+                negotiatedVersion = negotiatedVersion,
+            )
+        }
+    }
+
+    private fun fireSyncSetupJoinerOutcome(
+        pixelName: SyncPixelName,
+        pixelType: PixelType,
+        hostHasAccount: Boolean,
+        hostKind: PeerKind,
+        joinerHasAccount: Boolean,
+        joinerKind: PeerKind,
+        negotiatedVersion: ExchangeProtocolVersion,
+    ) {
+        pixel.fire(
+            pixelName,
+            parameters = mapOf(
+                SyncPixelParameters.SYNC_SETUP_HOST_HAS_ACCOUNT to hostHasAccount.toString(),
+                SyncPixelParameters.SYNC_SETUP_HOST_KIND to hostKind.value,
+                SyncPixelParameters.SYNC_SETUP_JOINER_HAS_ACCOUNT to joinerHasAccount.toString(),
+                SyncPixelParameters.SYNC_SETUP_JOINER_KIND to joinerKind.value,
+                SyncPixelParameters.SYNC_SETUP_PROTOCOL_VERSION to negotiatedVersion.toString(),
+            ),
+            type = pixelType,
         )
     }
 
@@ -969,7 +1062,7 @@ enum class SyncAccountOperation {
 }
 
 // https://app.asana.com/0/72649045549333/1205649300615861
-enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
+enum class SyncPixelName(override val pixelName: String) : PixelName {
     SYNC_DAILY("m_sync_daily"),
     SYNC_DAILY_SUCCESS_RATE_PIXEL("m_sync_success_rate_daily"),
     SYNC_TIMESTAMP_RESOLUTION_TRIGGERED("m_sync_%s_local_timestamp_resolution_triggered"),
@@ -1032,6 +1125,10 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_CONFIRMED("sync_setup_promo_bookmark_added_dialog_confirmed"),
     SYNC_SETUP_ANOTHER_DEVICE_PROMPT_SHOWN("m_settings_sync_another_device_prompt_shown"),
     SYNC_SETUP_ANOTHER_DEVICE_PROMPT_OPTION_TAPPED("m_settings_sync_another_device_prompt_option_tapped"),
+    SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_SUCCESS("sync_setup_joiner_recovery_code_done_success"),
+    SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_SUCCESS_DAILY("sync_setup_joiner_recovery_code_done_success_daily"),
+    SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_FAILED("sync_setup_joiner_recovery_code_done_failed"),
+    SYNC_SETUP_JOINER_RECOVERY_CODE_DONE_FAILED_DAILY("sync_setup_joiner_recovery_code_done_failed_daily"),
     SYNC_AI_CHAT_ACTIVE("sync_ai_chat_active"),
 
     SYNC_UNIFIED_DEVICES_OWN_ROW_RESOLVED_DEVICE_INFO("sync_unified_devices_own_row_resolved_device_info"),
@@ -1100,6 +1197,11 @@ object SyncPixelParameters {
     const val SYNC_SETUP_PEER_KIND = "peer_kind"
     const val SYNC_SETUP_REASON = "reason"
     const val SYNC_SETUP_TIMEOUT_STAGE = "timeout_stage"
+    const val SYNC_SETUP_HOST_HAS_ACCOUNT = "host_has_account"
+    const val SYNC_SETUP_HOST_KIND = "host_kind"
+    const val SYNC_SETUP_JOINER_HAS_ACCOUNT = "joiner_has_account"
+    const val SYNC_SETUP_JOINER_KIND = "joiner_kind"
+    const val SYNC_SETUP_PROTOCOL_VERSION = "protocol_version"
     const val CONNECTED_DEVICES_WHEN_DELETING = "connected_devices"
 
     const val AUTO_RESTORE_SOURCE = "source"
@@ -1167,14 +1269,14 @@ internal fun Int.toSetupFailureReason(): SetupFailureReason = when (this) {
 
 internal fun SyncPixels.fireSetupFailed(screenType: ScreenType, outcome: DispatchOutcome) {
     when (outcome) {
-        is DispatchOutcome.UpgradeRequired ->
+        is UpgradeRequired ->
             fireSyncSetupFailed(screenType, SetupFailureReason.NEEDS_UPGRADE, outcome.path, outcome.myRole, outcome.peerKind)
-        is DispatchOutcome.AlreadyConnected ->
+        is AlreadyConnected ->
             // v2 same-account case: both devices exchanged intros and discovered a matching user_id.
             // Per spec, we report a failed pixel with reason=already_paired even though the user-facing
             // outcome is a benign "Connected" — the flow did not produce a new pairing.
             fireSyncSetupFailed(screenType, SetupFailureReason.ALREADY_PAIRED, path = SetupPath.PAIRING)
-        is DispatchOutcome.Failed -> {
+        is Failed -> {
             if (outcome.code == AccountErrorCodes.PAIRING_CANCELLED.code || outcome.code == AccountErrorCodes.PAIRING_REJECTED.code) {
                 return
             }
@@ -1195,7 +1297,7 @@ internal fun SyncPixels.fireSetupFailed(screenType: ScreenType, outcome: Dispatc
 // setup ended via denial. PAIRING_CANCELLED is this device's own denial; PAIRING_REJECTED is the peer's
 // denial received on the wire.
 internal fun SyncPixels.fireSetupCancelledIfDenied(screenType: ScreenType, outcome: DispatchOutcome) {
-    if (outcome is DispatchOutcome.Failed &&
+    if (outcome is Failed &&
         (outcome.code == AccountErrorCodes.PAIRING_CANCELLED.code || outcome.code == AccountErrorCodes.PAIRING_REJECTED.code)
     ) {
         fireSyncSetupAbandoned(screenType, CancellationReason.CONFIRMATION_DENIED)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -288,7 +288,16 @@ class RealSyncPixels @Inject constructor(
      * - [SYNC_SETUP_MY_KIND]: always "ddg" — this is the native DuckDuckGo client.
      */
     private fun setupFlowMetadata(): Map<String, String> = buildMap {
-        put(SYNC_SETUP_FLOW_VERSION, if (syncFeature.canUseV2ConnectFlow().isEnabled()) FLOW_VERSION_V2 else FLOW_VERSION_V1)
+        val flowVersion = if (syncFeature.canUseV2ConnectFlow().isEnabled()) {
+            if (syncFeature.canUseExchangeV2Point1().isEnabled()) {
+                FLOW_VERSION_V2_1
+            } else {
+                FLOW_VERSION_V2
+            }
+        } else {
+            FLOW_VERSION_V1
+        }
+        put(SYNC_SETUP_FLOW_VERSION, flowVersion)
         put(SYNC_SETUP_MY_KIND, MY_KIND_DDG)
         putAll(setupUiMetadata())
     }
@@ -936,8 +945,9 @@ class RealSyncPixels @Inject constructor(
 
     companion object {
         private const val SYNC_PIXELS_PREF_FILE = "com.duckduckgo.sync.pixels.v1"
-        private const val FLOW_VERSION_V1 = "v1"
-        private const val FLOW_VERSION_V2 = "v2"
+        const val FLOW_VERSION_V1 = "v1"
+        const val FLOW_VERSION_V2 = "v2"
+        const val FLOW_VERSION_V2_1 = "v2.1"
         const val UI_VERSION_V2 = "v2"
         private const val MY_KIND_DDG = "ddg"
         private const val CODE_TYPE_RECOVERY = "recovery"

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/wideevents/SyncSetupWideEvent.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/wideevents/SyncSetupWideEvent.kt
@@ -23,8 +23,13 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.auth.DeviceAuthenticator
+import com.duckduckgo.sync.impl.pixels.RealSyncPixels.Companion.FLOW_VERSION_V1
+import com.duckduckgo.sync.impl.pixels.RealSyncPixels.Companion.FLOW_VERSION_V2
+import com.duckduckgo.sync.impl.pixels.RealSyncPixels.Companion.FLOW_VERSION_V2_1
 import com.duckduckgo.sync.impl.pixels.RealSyncPixels.Companion.UI_VERSION_V2
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_FLOW_VERSION
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_UI_VERSION
+import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEventImpl.Companion.STEP_DEVICE_AUTH_NOT_ENROLLED
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.Lazy
 import dagger.SingleInstanceIn
@@ -93,6 +98,7 @@ class SyncSetupWideEventImpl @Inject constructor(
             metadata = buildMap {
                 put(KEY_USER_AUTH_REQUIRED, deviceAuthenticator.isAuthenticationRequired().toString())
                 putAll(uiMetadata())
+                putAll(flowMetadata())
             },
             cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
         ).getOrNull()
@@ -243,6 +249,20 @@ class SyncSetupWideEventImpl @Inject constructor(
     }
 
     private fun uiMetadata(): Map<String, String> = mapOf(SYNC_SETUP_UI_VERSION to UI_VERSION_V2)
+
+    private fun flowMetadata(): Map<String, String> = buildMap {
+        val feature = syncFeature.get()
+        val flowVersion = if (feature.canUseV2ConnectFlow().isEnabled()) {
+            if (feature.canUseExchangeV2Point1().isEnabled()) {
+                FLOW_VERSION_V2_1
+            } else {
+                FLOW_VERSION_V2
+            }
+        } else {
+            FLOW_VERSION_V1
+        }
+        put(SYNC_SETUP_FLOW_VERSION, flowVersion)
+    }
 
     private companion object {
         const val FLOW_NAME = "sync-setup"

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/ExchangeV2RecoverCodeDonePixelObserverTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/ExchangeV2RecoverCodeDonePixelObserverTest.kt
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.pixels
+
+import androidx.lifecycle.LifecycleOwner
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDone
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.PairingRole
+import com.duckduckgo.sync.impl.exchange.v2.PeerVersionSource
+import com.duckduckgo.sync.impl.exchange.v2.Role
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class ExchangeV2RecoverCodeDonePixelObserverTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val runnerEvents = MutableSharedFlow<ExchangeV2Event>()
+    private val runner: ExchangeV2Runner = mock()
+    private val syncPixels: SyncPixels = mock()
+    private val lifecycleOwner: LifecycleOwner = mock()
+
+    private val testee = ExchangeV2RecoverCodeDonePixelObserver(
+        appCoroutineScope = coroutineTestRule.testScope,
+        dispatcherProvider = coroutineTestRule.testDispatcherProvider,
+        runner = runner,
+        syncPixels = syncPixels,
+    )
+
+    @Before
+    fun setup() {
+        whenever(runner.events).thenReturn(runnerEvents)
+        testee.onCreate(lifecycleOwner)
+    }
+
+    @Test
+    fun `recovery_code_done with Success sent - fires success pixel`() = runTest {
+        runnerEvents.emit(roleElected(ownSignedIn = false, peerKind = "3party", peerSignedIn = true))
+        runnerEvents.emit(versionNegotiated(ExchangeProtocolVersion.V2_1))
+
+        runnerEvents.emit(messageSent(RecoveryCodeDone.create(RecoveryCodeDone.Reason.Success)))
+
+        verify(syncPixels).fireSyncSetupJoinerSuccess(
+            hostHasAccount = true,
+            hostKind = PeerKind.THIRD_PARTY,
+            joinerHasAccount = false,
+            joinerKind = PeerKind.DDG,
+            negotiatedVersion = ExchangeProtocolVersion.V2_1,
+        )
+    }
+
+    @Test
+    fun `recovery_code_done with LoginFailed sent - fires failure pixel`() = runTest {
+        runnerEvents.emit(roleElected(ownSignedIn = true, peerKind = "ddg", peerSignedIn = false))
+        runnerEvents.emit(versionNegotiated(ExchangeProtocolVersion.V2_1))
+
+        runnerEvents.emit(messageSent(RecoveryCodeDone.create(RecoveryCodeDone.Reason.LoginFailed)))
+
+        verify(syncPixels).fireSyncSetupJoinerFailure(
+            hostHasAccount = false,
+            hostKind = PeerKind.DDG,
+            joinerHasAccount = true,
+            joinerKind = PeerKind.DDG,
+            negotiatedVersion = ExchangeProtocolVersion.V2_1,
+        )
+    }
+
+    @Test
+    fun `recovery_code_done with ScopeRejected sent - fires failure pixel`() = runTest {
+        runnerEvents.emit(roleElected(ownSignedIn = false, peerKind = "ddg", peerSignedIn = true))
+        runnerEvents.emit(versionNegotiated(ExchangeProtocolVersion.V2_1))
+
+        runnerEvents.emit(messageSent(RecoveryCodeDone.create(RecoveryCodeDone.Reason.ScopeRejected)))
+
+        verify(syncPixels).fireSyncSetupJoinerFailure(
+            hostHasAccount = true,
+            hostKind = PeerKind.DDG,
+            joinerHasAccount = false,
+            joinerKind = PeerKind.DDG,
+            negotiatedVersion = ExchangeProtocolVersion.V2_1,
+        )
+    }
+
+    @Test
+    fun `recovery_code_done with Unknown reason sent - fires failure pixel`() = runTest {
+        runnerEvents.emit(roleElected(ownSignedIn = false, peerKind = "ddg", peerSignedIn = true))
+        runnerEvents.emit(versionNegotiated(ExchangeProtocolVersion.V2_1))
+
+        runnerEvents.emit(messageSent(RecoveryCodeDone.create(RecoveryCodeDone.Reason.Unknown("weird"))))
+
+        verify(syncPixels).fireSyncSetupJoinerFailure(
+            hostHasAccount = true,
+            hostKind = PeerKind.DDG,
+            joinerHasAccount = false,
+            joinerKind = PeerKind.DDG,
+            negotiatedVersion = ExchangeProtocolVersion.V2_1,
+        )
+    }
+
+    @Test
+    fun `recovery_code_done sent without role election - no pixel fired`() = runTest {
+        runnerEvents.emit(versionNegotiated(ExchangeProtocolVersion.V2_1))
+
+        runnerEvents.emit(messageSent(RecoveryCodeDone.create(RecoveryCodeDone.Reason.Success)))
+
+        verifyNoInteractions(syncPixels)
+    }
+
+    @Test
+    fun `recovery_code_done sent without version negotiation - no pixel fired`() = runTest {
+        runnerEvents.emit(roleElected(ownSignedIn = false, peerKind = "ddg", peerSignedIn = true))
+
+        runnerEvents.emit(messageSent(RecoveryCodeDone.create(RecoveryCodeDone.Reason.Success)))
+
+        verifyNoInteractions(syncPixels)
+    }
+
+    @Test
+    fun `other message types sent - no pixel fired`() = runTest {
+        runnerEvents.emit(roleElected(ownSignedIn = false, peerKind = "ddg", peerSignedIn = true))
+        runnerEvents.emit(versionNegotiated(ExchangeProtocolVersion.V2_1))
+
+        runnerEvents.emit(messageSent(ExchangeV2Message.Bye.create(ExchangeV2Message.Bye.Reason.Done)))
+
+        verifyNoInteractions(syncPixels)
+    }
+
+    @Test
+    fun `recovery_code_done received rather than sent - no pixel fired`() = runTest {
+        runnerEvents.emit(roleElected(ownSignedIn = true, peerKind = "ddg", peerSignedIn = false))
+        runnerEvents.emit(versionNegotiated(ExchangeProtocolVersion.V2_1))
+
+        runnerEvents.emit(
+            ExchangeV2Event.MessageReceived(
+                timestampMs = TIMESTAMP_MS,
+                message = RecoveryCodeDone.create(RecoveryCodeDone.Reason.Success),
+            ),
+        )
+
+        verifyNoInteractions(syncPixels)
+    }
+
+    private fun roleElected(
+        ownSignedIn: Boolean,
+        peerKind: String?,
+        peerSignedIn: Boolean,
+    ): ExchangeV2Event.RoleElected {
+        return ExchangeV2Event.RoleElected(
+            timestampMs = TIMESTAMP_MS,
+            role = Role.Joiner,
+            ownPairingRole = PairingRole.Scanner,
+            ownSignedIn = ownSignedIn,
+            ownKind = "ddg",
+            peerKind = peerKind,
+            peerSignedIn = peerSignedIn,
+        )
+    }
+
+    private fun versionNegotiated(negotiatedVersion: ExchangeProtocolVersion): ExchangeV2Event.VersionNegotiated {
+        return ExchangeV2Event.VersionNegotiated(
+            timestampMs = TIMESTAMP_MS,
+            peerSource = PeerVersionSource.LinkingCode,
+            peerVersion = negotiatedVersion,
+            ourVersion = ExchangeProtocolVersion.V2_1,
+            negotiatedVersion = negotiatedVersion,
+        )
+    }
+
+    private fun messageSent(message: ExchangeV2Message): ExchangeV2Event.MessageSent {
+        return ExchangeV2Event.MessageSent(timestampMs = TIMESTAMP_MS, message = message)
+    }
+
+    companion object {
+        private const val TIMESTAMP_MS = 1_000L
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
@@ -1144,14 +1144,14 @@ class RealSyncPixelsTest {
     ) {
         ProtocolV1("v1"),
         ProtocolV2("v2"),
+        ProtocolV2Point1("v2.1"),
         ;
 
         fun configure(syncFeature: SyncFeature) {
-            val isEnabled = when (this) {
-                ProtocolV1 -> false
-                ProtocolV2 -> true
-            }
-            syncFeature.canUseV2ConnectFlow().setRawStoredState(State(isEnabled))
+            val v2Enabled = this != ProtocolV1
+            val v2Point1Enabled = this == ProtocolV2Point1
+            syncFeature.canUseV2ConnectFlow().setRawStoredState(State(v2Enabled))
+            syncFeature.canUseExchangeV2Point1().setRawStoredState(State(v2Point1Enabled))
         }
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/wideevents/SyncSetupWideEventImplTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/wideevents/SyncSetupWideEventImplTest.kt
@@ -24,10 +24,13 @@ import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.auth.DeviceAuthenticator
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -35,6 +38,7 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 
+@RunWith(TestParameterInjector::class)
 class SyncSetupWideEventImplTest {
 
     @get:Rule
@@ -60,7 +64,10 @@ class SyncSetupWideEventImplTest {
     }
 
     @Test
-    fun `onFlowStarted starts a new flow with correct ui parameters`() = runTest {
+    fun `onFlowStarted starts a new flow with correct ui and flow parameters`(
+        @TestParameter protocol: ProtocolVersion,
+    ) = runTest {
+        protocol.configure(syncFeature)
         whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(1L))
 
@@ -68,13 +75,16 @@ class SyncSetupWideEventImplTest {
 
         verify(wideEventClient).flowStart(
             name = "sync-setup",
-            metadata = mapOf("user_auth_required" to "true", "ui_version" to "v2"),
+            metadata = mapOf("user_auth_required" to "true", "ui_version" to "v2", "flow_version" to protocol.value),
             cleanupPolicy = CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
         )
     }
 
     @Test
-    fun `onFlowStarted passes source as flowEntryPoint`() = runTest {
+    fun `onFlowStarted passes source as flowEntryPoint`(
+        @TestParameter protocol: ProtocolVersion,
+    ) = runTest {
+        protocol.configure(syncFeature)
         whenever(wideEventClient.flowStart(any(), any(), any(), any(), any(), any()))
             .thenReturn(Result.success(1L))
 
@@ -83,7 +93,7 @@ class SyncSetupWideEventImplTest {
         verify(wideEventClient).flowStart(
             name = "sync-setup",
             flowEntryPoint = "settings",
-            metadata = mapOf("user_auth_required" to "true", "ui_version" to "v2"),
+            metadata = mapOf("user_auth_required" to "true", "ui_version" to "v2", "flow_version" to protocol.value),
             cleanupPolicy = CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
         )
     }
@@ -333,5 +343,21 @@ class SyncSetupWideEventImplTest {
 
         verify(wideEventClient, org.mockito.kotlin.times(2)).getFlowIds("sync-setup")
         verifyNoMoreInteractions(wideEventClient)
+    }
+
+    enum class ProtocolVersion(
+        val value: String,
+    ) {
+        ProtocolV1("v1"),
+        ProtocolV2("v2"),
+        ProtocolV2Point1("v2.1"),
+        ;
+
+        fun configure(syncFeature: SyncFeature) {
+            val v2Enabled = this != ProtocolV1
+            val v2Point1Enabled = this == ProtocolV2Point1
+            syncFeature.canUseV2ConnectFlow().setRawStoredState(State(v2Enabled))
+            syncFeature.canUseExchangeV2Point1().setRawStoredState(State(v2Point1Enabled))
+        }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1217367677188801
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Adds the Exchange v2.1 setup telemetry: a new `v2.1` value for the existing `flow_version` parameter, and a new pair of joiner outcome pixels fired when this device sends its `recovery_code_done` join report.

Flow version:
- `flow_version` now reports `v2.1` when both `canUseV2ConnectFlow` and `canUseExchangeV2Point1` are enabled, `v2` when only `canUseV2ConnectFlow` is enabled, and `v1` otherwise.
- The value is applied to every existing sync setup pixel that already carried `flow_version`.
- The `sync-setup` wide event now also carries `flow_version` in its metadata, alongside the existing `ui_version`.

Joiner outcome pixels:
- `ExchangeV2RecoverCodeDonePixelObserver` listens to the exchange runner's events for the lifetime of the main process.
- It tracks the elected roles and the negotiated protocol version for the current session, and fires when a `RecoveryCodeDone` message is successfully sent.
- A `success` reason fires `sync_setup_joiner_recovery_code_done_success`, any other reason fires `sync_setup_joiner_recovery_code_done_failed`. Each is sent as both a count and a daily pixel.

### Steps to test this PR

_Joiner success report_
- [ ] Install an internal build on two devices.
- [ ] Enable `canUseV2ConnectFlow` in Sync Dev Settings on both devices.
- [ ] Enable `canUseExchangeV2Point1` in Sync Dev Settings on both devices.
- [ ] Pair the two devices through the sync setup flow.
- [ ] Verify `sync_setup_joiner_recovery_code_done_success_count` is fired from the joining device.
- [ ] Verify the pixel carries `host_has_account`, `host_kind`, `joiner_has_account`, `joiner_kind`, and `protocol_version` of `2.1`.
- [x] Verify `sync_setup_joiner_recovery_code_done_success_daily` is fired once on the same day.

_Joiner failure report_
- [ ] Apply [this patch](https://github.com/user-attachments/files/31791456/failure.patch).
```sh
curl -fL https://github.com/user-attachments/files/31791456/failure.patch | git apply
```
```diff
diff --git a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
index d4d19773d9..615bd17348 100644
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -437,37 +437,7 @@ class RealSyncCodeDispatcher @Inject constructor(
      * [SyncAccountRepository.joinAccountFromThirdPartyRecoveryCode].
      */
     private suspend fun loginWithV2RecoveryCode(b64: String, peerKind: PeerKind?): DispatchOutcome {
-        val parsed = decodeV2Recovery(b64) ?: return DispatchOutcome.Failed("Couldn't parse received recovery code as v2.0")
-        return when (parsed.cid) {
-            CID_DDG -> {
-                val primaryKey = v2SecretToV1PrimaryKey(parsed.secret)
-                    ?: return DispatchOutcome.Failed("Received recovery code has a malformed secret")
-                val recovery = SyncAuthCode.Recovery(RecoveryCode(primaryKey = primaryKey, userId = parsed.userId))
-                logcat { "$TAG: v2 LinkingV2 received ddg code → $recovery" }
-                syncAccountRepository.processCode(recovery, existingDeviceId = null)
-                    .toOutcome(
-                        label = "v2 LinkingV2 login (ddg)",
-                        path = SetupPath.PAIRING,
-                        myRole = SetupRole.JOINER,
-                        peerKind = peerKind,
-                        codeForAccountSwitch = encodeV1RecoveryCodeAsB64(userId = parsed.userId, secret = primaryKey),
-                    )
-            }
-            CID_3PARTY -> {
-                logcat { "$TAG: v2 LinkingV2 received 3party code → joinAccountFromThirdPartyRecoveryCode" }
-                syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(b64)
-                    .toOutcome(
-                        label = "v2 LinkingV2 login (3party upgrade)",
-                        path = SetupPath.PAIRING,
-                        myRole = SetupRole.JOINER,
-                        peerKind = peerKind,
-                    )
-            }
-            else -> DispatchOutcome.Failed(
-                "Received unknown credential type '${parsed.cid}' over v2 linking",
-                UNSUPPORTED_CREDENTIAL_TYPE.code,
-            )
-        }
+        return DispatchOutcome.Failed("test")
     }
 
     private data class ParsedV2Recovery(val userId: String, val secret: String, val cid: String, val v: String)
```
- [ ] Try to pair the two devices through the sync setup flow.
- [ ] Verify `sync_setup_joiner_recovery_code_done_failed_count` is fired from the joining device.
- [ ] Verify the pixel carries `host_has_account`, `host_kind`, `joiner_has_account`, `joiner_kind`, and `protocol_version` of `2.1`.
- [x] Verify `sync_setup_joiner_recovery_code_done_failed_daily` is fired once on the same day.

_Flow version on v2.1_
- [ ] With both flags enabled, run a sync setup flow.
- [x] Verify the setup pixels carry `flow_version` of `v2.1`.

_Flow version on v2_
- [ ] Disable `canUseExchangeV2Point1` while leaving `canUseV2ConnectFlow` enabled.
- [ ] Run a sync setup flow.
- [ ] Verify the setup pixels carry `flow_version` of `v2`.

### UI changes
N/A

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to analytics definitions and pixel firing; no pairing, auth, or account logic is modified.
> 
> **Overview**
> Adds telemetry for **Exchange v2.1** sync setup: existing setup pixels and the `sync-setup` wide event now allow **`flow_version` = `v2.1`**, set when both `canUseV2ConnectFlow` and `canUseExchangeV2Point1` are on (otherwise `v2` or `v1` as before).
> 
> Introduces **joiner join-report pixels** for when this device **sends** `recovery_code_done` after v2.1 pairing: success vs non-success reasons map to new count + daily pixels with host/joiner account flags, peer kinds, and negotiated `protocol_version`. **`ExchangeV2RecoverCodeDonePixelObserver`** subscribes to `ExchangeV2Runner` for the main process, caches role/version context from exchange events, and skips firing if context is incomplete or the message was only received.
> 
> Pixel schema/definitions, ATB stripping for the new events, and unit tests for the observer and wide-event `flow_version` behavior are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 233b57dd6e6927ffba40959acaaaa26b6c6ca39e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->