### PR TITLE
Skip redundant tab-row writes during page load

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -304,12 +304,14 @@ class TabDataRepository(
         tabId: String,
         site: Site?,
     ) {
+        val url = site?.url
+        val title = site?.title
         databaseExecutor().scheduleDirect {
-            val state = TabUpdateState(site?.url, site?.title)
+            val state = TabUpdateState(url, title)
             if (lastUpdatedTabState.put(tabId, state) == state) return@scheduleDirect
 
-            tabsDao.updateUrlAndTitle(tabId, site?.url, site?.title, viewed = true)
-            duckAiTabSessionRepository.tryClaimEntryPointSource(tabId, site?.url)
+            tabsDao.updateUrlAndTitle(tabId, url, title, viewed = true)
+            duckAiTabSessionRepository.tryClaimEntryPointSource(tabId, url)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -54,6 +54,7 @@ import logcat.LogPriority.INFO
 import logcat.LogPriority.WARN
 import logcat.logcat
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 class TabDataRepository(
     private val tabsDao: TabsDao,
@@ -94,6 +95,10 @@ class TabDataRepository(
     override val tabSwitcherData: Flow<TabSwitcherData> = tabSwitcherDataStore.data
 
     private val siteData: LinkedHashMap<String, MutableLiveData<Site>> = LinkedHashMap()
+
+    // Seeded only by update(), never by insertion, or a background tab's first update could match its
+    // inserted title and never get viewed=true.
+    private val lastUpdatedTabState = ConcurrentHashMap<String, TabUpdateState>()
 
     private var purgeDeletableTabsJob = ConflatedJob()
 
@@ -300,6 +305,9 @@ class TabDataRepository(
         site: Site?,
     ) {
         databaseExecutor().scheduleDirect {
+            val state = TabUpdateState(site?.url, site?.title)
+            if (lastUpdatedTabState.put(tabId, state) == state) return@scheduleDirect
+
             tabsDao.updateUrlAndTitle(tabId, site?.url, site?.title, viewed = true)
             duckAiTabSessionRepository.tryClaimEntryPointSource(tabId, site?.url)
         }
@@ -336,6 +344,7 @@ class TabDataRepository(
             deleteOldPreviewImages(tab.tabId)
             deleteOldFavicon(tab.tabId)
             tabsDao.deleteTabAndUpdateSelection(tab)
+            lastUpdatedTabState.remove(tab.tabId)
         }
         siteData.remove(tab.tabId)
         tabVisitedSitesRepository.clearTab(tab.tabId)
@@ -370,6 +379,7 @@ class TabDataRepository(
             deleteOldPreviewImages(tabId)
             deleteOldFavicon(tabId)
             siteData.remove(tabId)
+            lastUpdatedTabState.remove(tabId)
             duckChatContextualDataStore.clearTabChatUrl(tabId)
         }
     }
@@ -431,6 +441,7 @@ class TabDataRepository(
                 }
             tabsDao.deleteTabAndUpdateSelection(tabToDelete, tabToSelect)
             siteData.remove(tabToDelete.tabId)
+            lastUpdatedTabState.remove(tabToDelete.tabId)
 
             tabToSelect?.let {
                 appCoroutineScope.launch(dispatchers.io()) {
@@ -450,6 +461,7 @@ class TabDataRepository(
         adClickManager.clearAll()
         webViewSessionStorage.deleteAllSessions()
         siteData.clear()
+        lastUpdatedTabState.clear()
         duckChatContextualDataStore.clearAll()
         tabVisitedSitesRepository.clearAll()
         nativeInputStatePublisher.clearAll()
@@ -535,3 +547,8 @@ class TabDataRepository(
         return Schedulers.single()
     }
 }
+
+private data class TabUpdateState(
+    val url: String?,
+    val title: String?,
+)

--- a/app/src/test/java/com/duckduckgo/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/tabs/model/TabDataRepositoryTest.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
 import com.duckduckgo.app.fire.store.TabVisitedSitesRepository
 import com.duckduckgo.app.global.db.AppDatabase
+import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.model.SiteFactoryImpl
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.tabs.TabManagerFeatureFlags
@@ -69,7 +70,9 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Instant
@@ -165,6 +168,160 @@ class TabDataRepositoryTest {
         val captor = argumentCaptor<Boolean>()
         verify(mockDao).updateUrlAndTitle(any(), anyOrNull(), anyOrNull(), captor.capture())
         assertTrue(captor.firstValue)
+    }
+
+    @Test
+    fun whenUpdateCalledRepeatedlyWithUnchangedSiteThenDaoWrittenOnce() = runTest {
+        val testee = tabDataRepository()
+        val site = site("http://example.com", "Example")
+
+        repeat(50) { testee.update("tabid", site) }
+
+        verify(mockDao, times(1)).updateUrlAndTitle(eq("tabid"), eq("http://example.com"), eq("Example"), eq(true))
+    }
+
+    @Test
+    fun whenUpdateCalledRepeatedlyWithNullSiteThenDaoWrittenOnce() = runTest {
+        val testee = tabDataRepository()
+
+        repeat(50) { testee.update("tabid", null) }
+
+        verify(mockDao, times(1)).updateUrlAndTitle(eq("tabid"), anyOrNull(), anyOrNull(), eq(true))
+    }
+
+    @Test
+    fun whenUpdateCalledWithChangedUrlThenDaoWrittenAgain() = runTest {
+        val testee = tabDataRepository()
+
+        testee.update("tabid", site("http://example.com", "Example"))
+        testee.update("tabid", site("http://example.com/other", "Example"))
+
+        verify(mockDao).updateUrlAndTitle(eq("tabid"), eq("http://example.com"), eq("Example"), eq(true))
+        verify(mockDao).updateUrlAndTitle(eq("tabid"), eq("http://example.com/other"), eq("Example"), eq(true))
+    }
+
+    @Test
+    fun whenUpdateCalledWithChangedTitleThenDaoWrittenAgain() = runTest {
+        val testee = tabDataRepository()
+
+        testee.update("tabid", site("http://example.com", null))
+        testee.update("tabid", site("http://example.com", "Example"))
+
+        verify(mockDao).updateUrlAndTitle(eq("tabid"), eq("http://example.com"), isNull(), eq(true))
+        verify(mockDao).updateUrlAndTitle(eq("tabid"), eq("http://example.com"), eq("Example"), eq(true))
+    }
+
+    @Test
+    fun whenUpdateCalledForDifferentTabsThenEachTabIsWritten() = runTest {
+        val testee = tabDataRepository()
+        val site = site("http://example.com", "Example")
+
+        testee.update("tabid1", site)
+        testee.update("tabid2", site)
+
+        verify(mockDao).updateUrlAndTitle(eq("tabid1"), eq("http://example.com"), eq("Example"), eq(true))
+        verify(mockDao).updateUrlAndTitle(eq("tabid2"), eq("http://example.com"), eq("Example"), eq(true))
+    }
+
+    @Test
+    fun whenTabDeletedThenSubsequentUpdateWritesAgain() = runTest {
+        val testee = tabDataRepository()
+        val site = site("http://example.com", "Example")
+
+        testee.update("tabid", site)
+        testee.delete(TabEntity("tabid", position = 0))
+        testee.update("tabid", site)
+
+        verify(mockDao, times(2)).updateUrlAndTitle(eq("tabid"), eq("http://example.com"), eq("Example"), eq(true))
+    }
+
+    @Test
+    fun whenTabsDeletedThenSubsequentUpdateWritesAgain() = runTest {
+        val testee = tabDataRepository()
+        val site = site("http://example.com", "Example")
+
+        testee.update("tabid", site)
+        testee.deleteTabs(listOf("tabid"))
+        testee.update("tabid", site)
+
+        verify(mockDao, times(2)).updateUrlAndTitle(eq("tabid"), eq("http://example.com"), eq("Example"), eq(true))
+    }
+
+    @Test
+    fun whenTabReplacedWithNewTabThenSubsequentUpdateWritesAgain() = runTest {
+        val testee = tabDataRepository()
+        val site = site("http://example.com", "Example")
+
+        testee.update("tabid", site)
+        testee.replaceTabWithNewTab("tabid", "http://example.com")
+        testee.update("tabid", site)
+
+        verify(mockDao, times(2)).updateUrlAndTitle(eq("tabid"), eq("http://example.com"), eq("Example"), eq(true))
+    }
+
+    @Test
+    fun whenAllTabsDeletedThenSubsequentUpdateWritesAgain() = runTest {
+        val testee = tabDataRepository()
+        val site = site("http://example.com", "Example")
+
+        testee.update("tabid", site)
+        testee.deleteAll()
+        testee.update("tabid", site)
+
+        verify(mockDao, times(2)).updateUrlAndTitle(eq("tabid"), eq("http://example.com"), eq("Example"), eq(true))
+    }
+
+    @Test
+    fun whenTabMarkedDeletableThenUndoneSubsequentUnchangedUpdateStillSkipsDao() = runTest {
+        val testee = tabDataRepository()
+        val site = site("http://example.com", "Example")
+        val tab = TabEntity("tabid", position = 0)
+
+        testee.update("tabid", site)
+        // markDeletable/undoDeletable only flip the deletable flag and never write url/title,
+        // so they deliberately leave the update() dedup cache untouched.
+        testee.markDeletable(tab)
+        testee.undoDeletable(tab)
+        testee.update("tabid", site)
+
+        verify(mockDao, times(1)).updateUrlAndTitle(eq("tabid"), eq("http://example.com"), eq("Example"), eq(true))
+    }
+
+    /**
+     * A background tab is inserted with title defaulted to its host, so the first update() can carry values
+     * identical to the inserted row. That update still has to reach the DAO or the tab stays unread forever.
+     */
+    @Test
+    fun whenBackgroundTabUpdatedWithValuesMatchingInsertedRowThenViewedIsStillWritten() = runTest {
+        val testee = tabDataRepository()
+        testee.addNewTabAfterExistingTab("http://www.example.com", "tabid")
+
+        val inserted = argumentCaptor<TabEntity>()
+        verify(mockDao).insertTabAtPosition(inserted.capture())
+        val newTabId = inserted.firstValue.tabId
+
+        testee.update(newTabId, site(inserted.firstValue.url!!, inserted.firstValue.title))
+
+        verify(mockDao).updateUrlAndTitle(eq(newTabId), eq("http://www.example.com"), eq("example.com"), eq(true))
+    }
+
+    @Test
+    fun whenUpdateCalledRepeatedlyWithUnchangedSiteThenEntryPointSourceClaimedOnce() = runTest {
+        val duckAiTabSessionRepository: DuckAiTabSessionRepository = mock()
+        val testee = tabDataRepository(duckAiTabSessionRepository = duckAiTabSessionRepository)
+        val site = site("http://example.com", "Example")
+
+        repeat(50) { testee.update("tabid", site) }
+
+        verify(duckAiTabSessionRepository, times(1)).tryClaimEntryPointSource("tabid", "http://example.com")
+    }
+
+    private fun site(
+        url: String,
+        title: String?,
+    ): Site = mock<Site>().apply {
+        whenever(this.url).thenReturn(url)
+        whenever(this.title).thenReturn(title)
     }
 
     @Test
@@ -386,6 +543,29 @@ class TabDataRepositoryTest {
         currentSelectedTabId = testee.liveSelectedTab.blockingObserve()?.tabId
         assertEquals(currentSelectedTabId, sourceTab.tabId)
         verify(mockTabVisitedSitesRepository).clearTab("tabToDeleteId")
+    }
+
+    @Test
+    fun whenTabDeletedAndSelectSourceThenSubsequentUpdateWritesAgain() = runTest {
+        val db = createDatabase()
+        val dao = db.tabsDao()
+        val sourceTab = TabEntity(tabId = "sourceId", url = "http://www.example.com", position = 0)
+        val tabToDelete = TabEntity(tabId = "tabToDeleteId", url = "http://www.example.com", position = 1, sourceTabId = "sourceId")
+        dao.addAndSelectTab(sourceTab)
+        dao.addAndSelectTab(tabToDelete)
+        val testee = tabDataRepository(dao)
+        val site = site("http://example.com", "Example")
+
+        testee.update(tabToDelete.tabId, site)
+        testee.deleteTabAndSelectSource(tabToDelete.tabId)
+        dao.addAndSelectTab(TabEntity(tabId = tabToDelete.tabId, position = 2))
+
+        testee.update(tabToDelete.tabId, site)
+
+        val reinsertedTab = dao.tab(tabToDelete.tabId)
+        assertEquals("http://example.com", reinsertedTab?.url)
+        assertEquals("Example", reinsertedTab?.title)
+        db.close()
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/tabs/model/TabDataRepositoryTest.kt
@@ -325,6 +325,27 @@ class TabDataRepositoryTest {
     }
 
     @Test
+    fun whenSiteUrlMutatesBetweenCacheGuardAndDaoWriteThenLaterUpdateWithOriginalUrlIsPersisted() = runTest {
+        val db = createDatabase()
+        val dao = db.tabsDao()
+        dao.insertTab(TabEntity(tabId = "tabid", position = 0))
+        val testee = tabDataRepository(dao)
+
+        // Site.url/title are unsynchronized vars mutated on the main thread; this fake reproduces a
+        // mutation landing between update()'s cache-guard read and its DAO-write read of the same call.
+        val divergingSite = mock<Site>().apply {
+            whenever(this.url).thenReturn("http://first.example.com", "http://second.example.com")
+            whenever(this.title).thenReturn("Example")
+        }
+        val stableSite = site("http://first.example.com", "Example")
+
+        testee.update("tabid", divergingSite)
+        testee.update("tabid", stableSite)
+
+        assertEquals("http://first.example.com", dao.tab("tabid")?.url)
+    }
+
+    @Test
     fun whenNewTabAddedAfterNonExistingTabThenTitleUrlPositionOfNewTabAreCorrectAndTabIsNotViewed() = runTest {
         val testee = tabDataRepository()
         testee.addNewTabAfterExistingTab("http://www.example.com", "tabid")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211850753229323/task/1218089979456219?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Skips redundant tab-row writes during page load: `TabDataRepository.update()` runs ~144 times per
page load, driven by repeated tracker-detected/privacy-shield refreshes, but only the first call
per navigation actually carries new `(url, title)` data, the rest were rewriting an identical row.

### Steps to test this PR

> [!NOTE]
> Prerequisites:
> - [x] Install Internal Debug.

_Happy path_
- [x] Load a tracker-heavy page (e.g. theguardian.com) → confirm the omnibar title and URL update normally as the page loads, and the tab switcher shows the final title/URL.
- [x] Navigate within a single-page app (in-page URL changes) → confirm the tab switcher picks up the updated URL.

_Guards_
- [x] Long-press a link → "Open in background tab" → confirm the new tab shows as **unread** in
      the tab switcher, then open it and confirm it becomes read and shows the real page title.
- [x] Open a site whose page title matches its bare host in a background tab → confirm it still
      becomes read once opened. This is the case a naive dedup would strand as permanently unread.
- [x] Close a tab, then open a new tab that reuses behaviour on the same site → confirm its title
      and URL still land correctly (tab removal must invalidate the dedup cache).
- [x] Load a page, then kill the app from the recents screen and relaunch → confirm tabs restore
      with correct titles and URLs.

### UI changes

No user-facing UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core tab persistence and read/unread semantics; edge cases are heavily tested but incorrect dedup could leave stale tab metadata or tabs stuck unread.
> 
> **Overview**
> **Reduces tab DB churn during page load** by skipping `TabsDao.updateUrlAndTitle` and `tryClaimEntryPointSource` when `TabDataRepository.update()` sees the same `(url, title)` as the last write for that tab—addressing hundreds of identical updates driven by tracker/privacy refreshes per navigation.
> 
> The dedup state lives in a per-tab `ConcurrentHashMap` seeded **only** on `update()`, not when tabs are inserted, so a background tab’s first update can still set `viewed=true` even when url/title match the row created at insert. Url/title are read once before the single-threaded DB executor runs to align the guard with what gets persisted. Cache entries are cleared when tabs are removed or all site data is cleared.
> 
> **Tests** cover repeat updates, url/title changes, per-tab isolation, invalidation after delete/replace/deleteAll, background-tab viewed behavior, Duck AI entry-point claiming, and a `Site` mutation race between guard and DAO write.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec66105cc040e01fcb63b25db43370bb2652ba6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->