### PR TITLE
Contextual/DuckAi: Fix backpress bug coming from contextual

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewFragment.kt
@@ -228,7 +228,8 @@ class DuckChatContextualWebViewFragment :
                 if (newState == BottomSheetBehavior.STATE_HIDDEN) {
                     viewModel.onSheetClosed()
                 }
-                backPressedCallback.isEnabled = newState != BottomSheetBehavior.STATE_HIDDEN
+                backPressedCallback.isEnabled =
+                    newState == BottomSheetBehavior.STATE_EXPANDED || newState == BottomSheetBehavior.STATE_HALF_EXPANDED
             }
 
             override fun onSlide(
@@ -512,7 +513,10 @@ class DuckChatContextualWebViewFragment :
 
     private fun setupBackPressHandling() {
         backPressedCallback =
-            object : OnBackPressedCallback(bottomSheetBehavior.state != BottomSheetBehavior.STATE_HIDDEN) {
+            object : OnBackPressedCallback(
+                bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED ||
+                    bottomSheetBehavior.state == BottomSheetBehavior.STATE_HALF_EXPANDED,
+            ) {
                 override fun handleOnBackPressed() {
                     viewModel.onContextualClose()
                 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213881875984009/task/1218145363965411?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
**Root cause:** 
Closing the sheet routes through the transient STATE_SETTLING, which re-armed the callback; when the source tab is backgrounded the sheet freezes mid-settle before reaching HIDDEN, leaving the callback active to intercept the next tab's first back press. Ignoring the transient states lets it disarm correctly.
**Fix:**
- Fix the contextual chat sheet swallowing the first back/close press on a newly opened tab.
- Arm the sheet's OnBackPressedCallback only in the stable open states (STATE_EXPANDED / STATE_HALF_EXPANDED) instead of "any state that isn't HIDDEN".

### Steps to test this PR
Fix only applied on contextualRedesign ON
- [x] Ensure you have chat history
- [x] Open a website on a tab and start chat 
- [x] Select the chats menu and open any recent chat
- [x] On the new chat tab press X
- [x] Verify you return to previous tab


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized navigation/back-press gating for the contextual redesign sheet; no auth, data, or API changes.
> 
> **Overview**
> Fixes the contextual Duck.ai sheet **intercepting the first back/close on a newly opened tab** after opening a chat from history.
> 
> **Back handling** in `DuckChatContextualWebViewFragment` now arms `OnBackPressedCallback` only when the bottom sheet is in **`STATE_EXPANDED` or `STATE_HALF_EXPANDED`**, instead of whenever state is not `STATE_HIDDEN`. Closing the sheet passes through **`STATE_SETTLING`**, which previously re-enabled the callback; if the source tab is backgrounded and the sheet never reaches `HIDDEN`, the callback stayed active and swallowed the next tab’s first back press.
> 
> Initial callback registration uses the same expanded/half-expanded check so behavior matches the sheet callback updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3602ec8cb01aae81764ce09f22e95c06f0067a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->