### PR TITLE
Stop a first device_info write triggering a redundant repair PATCH

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoMigrator.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoMigrator.kt
@@ -54,6 +54,7 @@ class RealDeviceInfoMigrator @Inject constructor(
     private val syncFeature: SyncFeature,
     private val syncDeviceIds: SyncDeviceIds,
     private val deviceInfoUpdater: DeviceInfoUpdater,
+    private val deviceInfoPublishWatcher: DeviceInfoPublishWatcher,
     private val dispatchers: DispatcherProvider,
 ) : DeviceInfoMigrator {
 
@@ -133,6 +134,8 @@ class RealDeviceInfoMigrator @Inject constructor(
             )
         ) {
             is Success -> {
+                // record before the migration marker so a concurrent read seeing the marker also sees this publish
+                deviceInfoPublishWatcher.markPublished()
                 markMigrated(userId)
                 logcat { "Sync-UnifiedDevices: migration complete for this device (${updateResult.data.size} devices_v2 returned)" }
                 Success(Unit)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoPublishWatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceInfoPublishWatcher.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import com.duckduckgo.di.scopes.AppScope
+import dagger.SingleInstanceIn
+import java.util.concurrent.atomic.AtomicInteger
+import javax.inject.Inject
+
+/**
+ * Tracks first publishes of this device's `device_info` so a `getDevices` read can tell whether it was in flight before we published.
+ * Without this, a response that raced our first write sees its own blob missing and mistakes a stale read for a server-side gap.
+ */
+@SingleInstanceIn(AppScope::class)
+class DeviceInfoPublishWatcher @Inject constructor() {
+
+    // a counter, not a boolean: a snapshot compares the count before and after a fetch, so publishes that happen and are consumed
+    // between two reads still register as "something changed" rather than being lost to a flag that was already true
+    private val publishes = AtomicInteger(0)
+
+    fun snapshot(): Int = publishes.get()
+
+    fun markPublished() {
+        publishes.incrementAndGet()
+    }
+
+    fun publishedSince(snapshot: Int): Boolean = publishes.get() != snapshot
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -179,6 +179,7 @@ class AppSyncAccountRepository @Inject constructor(
     private val loginDeviceInfoWriter: LoginDeviceInfoWriter,
     private val signupAccountInfoBuilder: SignupAccountInfoBuilder,
     private val deviceInfoUpdater: DeviceInfoUpdater,
+    private val deviceInfoPublishWatcher: DeviceInfoPublishWatcher,
 ) : SyncAccountRepository {
 
     // Bounded backoff for the 3party→ddg upgrade network calls.
@@ -981,24 +982,27 @@ class AppSyncAccountRepository @Inject constructor(
     private fun getConnectedDevicesV2(
         token: String,
         primaryKey: String,
-    ): Result<List<ConnectedDevice>> = when (val result = syncApi.getDevices(token)) {
-        is Error -> {
-            connectedDevicesCached.clear()
-            result.alsoFireAccountErrorPixel().copy(code = GENERIC_ERROR.code)
-        }
-        is Success -> {
-            val entriesV2 = result.data.entriesV2
-            val devices = if (entriesV2 != null) {
-                val decryptResult = thirdPartyDeviceListDecryptor.decryptAll(entriesV2, syncStore.deviceId)
-                logoutFailedV2Devices(decryptResult.undecryptable)
-                fireUnifiedDeviceListReadPixels(decryptResult)
-                if (decryptResult.thisDeviceInfoNeedsRepair) republishThisDeviceInfo()
-                decryptResult.decrypted.map { it.toConnectedDevice() }
-            } else {
-                // entries_v2 missing
-                decryptLegacyEntries(result.data.entries, primaryKey)
+    ): Result<List<ConnectedDevice>> {
+        val publishSnapshot = deviceInfoPublishWatcher.snapshot()
+        return when (val result = syncApi.getDevices(token)) {
+            is Error -> {
+                connectedDevicesCached.clear()
+                result.alsoFireAccountErrorPixel().copy(code = GENERIC_ERROR.code)
             }
-            finishWith(devices)
+            is Success -> {
+                val entriesV2 = result.data.entriesV2
+                val devices = if (entriesV2 != null) {
+                    val decryptResult = thirdPartyDeviceListDecryptor.decryptAll(entriesV2, syncStore.deviceId, publishSnapshot)
+                    logoutFailedV2Devices(decryptResult.undecryptable)
+                    fireUnifiedDeviceListReadPixels(decryptResult)
+                    if (decryptResult.thisDeviceInfoNeedsRepair) republishThisDeviceInfo()
+                    decryptResult.decrypted.map { it.toConnectedDevice() }
+                } else {
+                    // entries_v2 missing
+                    decryptLegacyEntries(result.data.entries, primaryKey)
+                }
+                finishWith(devices)
+            }
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptor.kt
@@ -39,8 +39,9 @@ import javax.inject.Inject
 interface ThirdPartyDeviceListDecryptor {
     /**
      * @param thisDeviceId this device's sync id, used to report back whether our own `device_info` resolved
+     * @param publishSnapshot [DeviceInfoPublishWatcher.snapshot] taken before [entries] were fetched, so a read that raced our first write isn't reported as a missing blob
      */
-    fun decryptAll(entries: List<DeviceV2>, thisDeviceId: String?): DecryptAllResult
+    fun decryptAll(entries: List<DeviceV2>, thisDeviceId: String?, publishSnapshot: Int): DecryptAllResult
 
     companion object {
         const val FALLBACK_TYPE_3PARTY = "Browser"
@@ -83,9 +84,10 @@ class RealThirdPartyDeviceListDecryptor @Inject constructor(
     private val deviceInfoDecryptor: DeviceInfoDecryptor,
     private val syncFeature: SyncFeature,
     private val syncStore: SyncStore,
+    private val deviceInfoPublishWatcher: DeviceInfoPublishWatcher,
 ) : ThirdPartyDeviceListDecryptor {
 
-    override fun decryptAll(entries: List<DeviceV2>, thisDeviceId: String?): DecryptAllResult {
+    override fun decryptAll(entries: List<DeviceV2>, thisDeviceId: String?, publishSnapshot: Int): DecryptAllResult {
         if (entries.isEmpty()) return DecryptAllResult(emptyList(), emptyList())
 
         val readEnabled = syncFeature.canReadUnifiedDeviceList().isEnabled()
@@ -102,7 +104,7 @@ class RealThirdPartyDeviceListDecryptor @Inject constructor(
         }
 
         val ownDeviceReadOutcome = session?.let {
-            ownDeviceReadOutcome(entries, thisDeviceId, viaDeviceInfo.resolved, legacy, viaDeviceInfo.failedDecryptIds)
+            ownDeviceReadOutcome(entries, thisDeviceId, viaDeviceInfo.resolved, legacy, viaDeviceInfo.failedDecryptIds, publishSnapshot)
         }
         val credentialsById = otherRowCredentialsById(entries, excludingDeviceId = thisDeviceId)
 
@@ -168,14 +170,17 @@ class RealThirdPartyDeviceListDecryptor @Inject constructor(
         viaDeviceInfo: List<DecryptedDevice>,
         legacy: LegacyDecryptResult,
         failedDeviceInfoIds: Set<String>,
+        publishSnapshot: Int,
     ): OwnDeviceReadOutcome? {
         val ownDeviceId = thisDeviceId ?: return null
         val ownEntry = entries.firstOrNull { it.deviceId == ownDeviceId } ?: return null
         if (viaDeviceInfo.any { it.deviceId == ownDeviceId }) return OwnDeviceReadOutcome.ResolvedDeviceInfo
 
+        val publishedDuringFetch = deviceInfoPublishWatcher.publishedSince(publishSnapshot)
         val reason = when {
             ownEntry.deviceId in failedDeviceInfoIds -> DeviceInfoReadFailureReason.BLOB_DECRYPT_FAILED
-            syncStore.unifiedDeviceListMigratedForUserId == syncStore.userId -> DeviceInfoReadFailureReason.BLOB_ABSENT
+            syncStore.unifiedDeviceListMigratedForUserId == syncStore.userId && !publishedDuringFetch ->
+                DeviceInfoReadFailureReason.BLOB_ABSENT
             else -> DeviceInfoReadFailureReason.NOT_PUBLISHED_YET
         }
         return if (legacy.viaLegacy.any { it.deviceId == ownDeviceId }) {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -138,6 +138,7 @@ class AppSyncAccountRepositoryTest {
     private val loginDeviceInfoWriter: LoginDeviceInfoWriter = mock()
     private val signupAccountInfoBuilder: SignupAccountInfoBuilder = mock()
     private val deviceInfoUpdater: DeviceInfoUpdater = mock()
+    private val publishTracker = DeviceInfoPublishWatcher()
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
@@ -164,6 +165,7 @@ class AppSyncAccountRepositoryTest {
             loginDeviceInfoWriter = loginDeviceInfoWriter,
             signupAccountInfoBuilder = signupAccountInfoBuilder,
             deviceInfoUpdater = deviceInfoUpdater,
+            deviceInfoPublishWatcher = publishTracker,
         )
         (syncRepo as AppSyncAccountRepository).upgradeRetryDelayMillis = 0L // keep retry-path tests instant
 
@@ -692,7 +694,7 @@ class AppSyncAccountRepositoryTest {
         whenever(syncApi.getDevices(anyString())).thenReturn(
             Success(DeviceEntries(entries = emptyList(), entriesV2 = listOf(v2Entry))),
         )
-        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(v2Entry), deviceId)).thenReturn(
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(v2Entry), deviceId, 0)).thenReturn(
             DecryptAllResult(
                 decrypted = listOf(DecryptedDevice(deviceId = "d1", name = "Chrome/148", type = "Browser")),
                 undecryptable = emptyList(),
@@ -704,9 +706,31 @@ class AppSyncAccountRepositoryTest {
 
         assertEquals(1, result.data.size)
         assertEquals("Chrome/148", result.data[0].deviceName)
-        verify(thirdPartyDeviceListDecryptor).decryptAll(listOf(v2Entry), deviceId)
+        verify(thirdPartyDeviceListDecryptor).decryptAll(listOf(v2Entry), deviceId, 0)
         verify(syncPixels).fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.OwnRowResolvedDeviceInfo)
         verify(syncApi, never()).logout(anyString(), anyString())
+    }
+
+    @Test
+    fun whenDeviceInfoPublishedDuringTheDevicesRequestThenDecryptorGetsThePrePublishSnapshot() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.deviceId).thenReturn(deviceId)
+        val v2Entry = DeviceV2(deviceId = "d1", deviceName = "ENC", deviceType = "ENC_T", credentialId = "ddg")
+        val snapshotBefore = publishTracker.snapshot()
+        whenever(syncApi.getDevices(anyString())).thenAnswer {
+            publishTracker.markPublished()
+            Success(DeviceEntries(entries = emptyList(), entriesV2 = listOf(v2Entry)))
+        }
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(any(), anyOrNull(), any())).thenReturn(
+            DecryptAllResult(decrypted = emptyList(), undecryptable = emptyList()),
+        )
+
+        syncRepo.getConnectedDevices()
+
+        verify(thirdPartyDeviceListDecryptor).decryptAll(listOf(v2Entry), deviceId, snapshotBefore)
     }
 
     @Test
@@ -719,7 +743,7 @@ class AppSyncAccountRepositoryTest {
         whenever(syncStore.deviceId).thenReturn(deviceId)
         val own = DeviceV2(deviceId = deviceId, credentialId = "ddg")
         whenever(syncApi.getDevices(anyString())).thenReturn(Success(DeviceEntries(emptyList(), listOf(own))))
-        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(own), deviceId)).thenReturn(
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(own), deviceId, 0)).thenReturn(
             DecryptAllResult(
                 decrypted = listOf(DecryptedDevice(deviceId, deviceName, "phone")),
                 undecryptable = emptyList(),
@@ -744,7 +768,7 @@ class AppSyncAccountRepositoryTest {
         whenever(syncStore.deviceId).thenReturn(deviceId)
         val own = DeviceV2(deviceId = deviceId, credentialId = "ddg")
         whenever(syncApi.getDevices(anyString())).thenReturn(Success(DeviceEntries(emptyList(), listOf(own))))
-        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(own), deviceId)).thenReturn(
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(own), deviceId, 0)).thenReturn(
             DecryptAllResult(
                 decrypted = listOf(DecryptedDevice(deviceId, deviceName, "phone")),
                 undecryptable = emptyList(),
@@ -769,7 +793,7 @@ class AppSyncAccountRepositoryTest {
         whenever(syncStore.deviceId).thenReturn(deviceId)
         val own = DeviceV2(deviceId = deviceId, credentialId = "ddg")
         whenever(syncApi.getDevices(anyString())).thenReturn(Success(DeviceEntries(emptyList(), listOf(own))))
-        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(own), deviceId)).thenReturn(
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(own), deviceId, 0)).thenReturn(
             DecryptAllResult(
                 decrypted = listOf(DecryptedDevice(deviceId, deviceName, "phone")),
                 undecryptable = emptyList(),
@@ -793,7 +817,7 @@ class AppSyncAccountRepositoryTest {
         whenever(syncStore.deviceId).thenReturn(deviceId)
         val other = DeviceV2(deviceId = "other", credentialId = "3party")
         whenever(syncApi.getDevices(anyString())).thenReturn(Success(DeviceEntries(emptyList(), listOf(other))))
-        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(other), deviceId)).thenReturn(
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(other), deviceId, 0)).thenReturn(
             DecryptAllResult(
                 decrypted = listOf(DecryptedDevice("other", "Unknown device", "Browser")),
                 undecryptable = emptyList(),
@@ -826,7 +850,7 @@ class AppSyncAccountRepositoryTest {
 
         // Fell back to legacy decrypt — same library path as the legacy `entries`-only response.
         assertEquals(1, result.data.size)
-        verify(thirdPartyDeviceListDecryptor, never()).decryptAll(any(), anyOrNull())
+        verify(thirdPartyDeviceListDecryptor, never()).decryptAll(any(), anyOrNull(), any())
     }
 
     @Test
@@ -851,7 +875,7 @@ class AppSyncAccountRepositoryTest {
         whenever(syncApi.getDevices(anyString())).thenReturn(
             Success(DeviceEntries(entries = emptyList(), entriesV2 = listOf(v2Entry))),
         )
-        whenever(thirdPartyDeviceListDecryptor.decryptAll(any(), anyOrNull())).thenReturn(
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(any(), anyOrNull(), any())).thenReturn(
             DecryptAllResult(decrypted = emptyList(), undecryptable = listOf("d-other")),
         )
         whenever(syncApi.logout(eq(token), eq("d-other"))).thenReturn(Success(Logout("d-other")))
@@ -873,7 +897,7 @@ class AppSyncAccountRepositoryTest {
         whenever(syncApi.getDevices(anyString())).thenReturn(
             Success(DeviceEntries(entries = emptyList(), entriesV2 = listOf(v2Entry))),
         )
-        whenever(thirdPartyDeviceListDecryptor.decryptAll(any(), anyOrNull())).thenReturn(
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(any(), anyOrNull(), any())).thenReturn(
             DecryptAllResult(decrypted = emptyList(), undecryptable = listOf(deviceId)),
         )
 
@@ -893,7 +917,7 @@ class AppSyncAccountRepositoryTest {
 
         syncRepo.getConnectedDevices()
 
-        verify(thirdPartyDeviceListDecryptor, never()).decryptAll(any(), anyOrNull())
+        verify(thirdPartyDeviceListDecryptor, never()).decryptAll(any(), anyOrNull(), any())
     }
 
     @Test
@@ -989,7 +1013,7 @@ class AppSyncAccountRepositoryTest {
         whenever(syncApi.getDevices(anyString())).thenReturn(
             Success(DeviceEntries(entries = emptyList(), entriesV2 = listOf(ownEntry))),
         )
-        whenever(thirdPartyDeviceListDecryptor.decryptAll(any(), anyOrNull())).thenReturn(
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(any(), anyOrNull(), any())).thenReturn(
             DecryptAllResult(
                 decrypted = listOf(DecryptedDevice(deviceId = deviceId, name = deviceName, type = "phone")),
                 undecryptable = emptyList(),

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoMigratorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceInfoMigratorTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.sync.TestSyncFixtures.token
 import com.duckduckgo.sync.TestSyncFixtures.userId
 import com.duckduckgo.sync.store.SyncStore
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -42,6 +43,7 @@ class DeviceInfoMigratorTest {
     private val syncApi: SyncApi = mock()
     private val syncDeviceIds: SyncDeviceIds = mock()
     private val deviceInfoUpdater: DeviceInfoUpdater = mock()
+    private val publishTracker = DeviceInfoPublishWatcher()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
 
     @get:Rule
@@ -57,6 +59,7 @@ class DeviceInfoMigratorTest {
             syncFeature = syncFeature,
             syncDeviceIds = syncDeviceIds,
             deviceInfoUpdater = deviceInfoUpdater,
+            deviceInfoPublishWatcher = publishTracker,
             dispatchers = coroutineTestRule.testDispatcherProvider,
         )
         syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
@@ -130,6 +133,30 @@ class DeviceInfoMigratorTest {
         assertTrue(result is Result.Success)
         verify(deviceInfoUpdater).setThisDeviceName(name = "deviceName", source = DeviceInfoUpdateSource.FIRST_WRITE)
         verify(syncStore).unifiedDeviceListMigratedForUserId = userId
+    }
+
+    @Test
+    fun whenDeviceInfoWrittenThenPublishRecorded() = runTest {
+        val snapshot = publishTracker.snapshot()
+        whenever(syncApi.getDevices(token)).thenReturn(Result.Success(deviceEntries(deviceInfo = null)))
+        whenever(deviceInfoUpdater.setThisDeviceName(name = "deviceName", source = DeviceInfoUpdateSource.FIRST_WRITE))
+            .thenReturn(Result.Success(emptyList()))
+
+        migrator.ensureMigrated()
+
+        assertTrue(publishTracker.publishedSince(snapshot))
+    }
+
+    @Test
+    fun whenServerAlreadyHasDeviceInfoThenNoPublishRecorded() = runTest {
+        val snapshot = publishTracker.snapshot()
+        whenever(syncApi.getDevices(token)).thenReturn(
+            Result.Success(deviceEntries(deviceInfo = "existing.device.info.jwe")),
+        )
+
+        migrator.ensureMigrated()
+
+        assertFalse(publishTracker.publishedSince(snapshot))
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptorTest.kt
@@ -48,13 +48,21 @@ class ThirdPartyDeviceListDecryptorTest {
     private val session: Session = mock()
     private val syncStore: SyncStore = mock()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val publishTracker = DeviceInfoPublishWatcher()
 
     private lateinit var decryptor: ThirdPartyDeviceListDecryptor
 
     @Before
     fun before() {
         syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(enable = false))
-        decryptor = RealThirdPartyDeviceListDecryptor(fieldDecryptor, thirdPartyCredentialManager, deviceInfoDecryptor, syncFeature, syncStore)
+        decryptor = RealThirdPartyDeviceListDecryptor(
+            fieldDecryptor,
+            thirdPartyCredentialManager,
+            deviceInfoDecryptor,
+            syncFeature,
+            syncStore,
+            publishTracker,
+        )
     }
 
     private fun enableReadFlag() {
@@ -64,7 +72,7 @@ class ThirdPartyDeviceListDecryptorTest {
 
     @Test
     fun whenInputIsEmptyThenReturnsEmptyAndNoRefreshCall() {
-        val result = decryptor.decryptAll(emptyList(), thisDeviceId = null)
+        val result = decryptor.decryptAll(emptyList(), thisDeviceId = null, publishSnapshot = 0)
 
         assertTrue(result.decrypted.isEmpty())
         assertTrue(result.undecryptable.isEmpty())
@@ -78,7 +86,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Pixel 7", "phone")))
         whenever(fieldDecryptor.decrypt(tp)).thenReturn(Success(DecryptedDevice("d2", "Chrome", "Browser")))
 
-        val result = decryptor.decryptAll(listOf(ddg, tp), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(ddg, tp), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(2, result.decrypted.size)
         assertTrue(result.undecryptable.isEmpty())
@@ -93,7 +101,7 @@ class ThirdPartyDeviceListDecryptorTest {
             .thenReturn(Success(DecryptedDevice("d1", "Chrome", "Browser")))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(true))
 
-        val result = decryptor.decryptAll(listOf(tp), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(tp), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(listOf(DecryptedDevice("d1", "Chrome", "Browser")), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())
@@ -107,7 +115,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(tp)).thenReturn(Error(reason = "still bad"))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(true))
 
-        val result = decryptor.decryptAll(listOf(tp), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(tp), thisDeviceId = null, publishSnapshot = 0)
 
         assertTrue(result.decrypted.isEmpty())
         assertEquals(listOf("d1"), result.undecryptable)
@@ -120,7 +128,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(tp)).thenReturn(Error(reason = "still bad"))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Error(reason = "server down"))
 
-        val result = decryptor.decryptAll(listOf(tp), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(tp), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(listOf(DecryptedDevice("d1", FALLBACK_NAME, FALLBACK_TYPE_3PARTY)), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())
@@ -133,7 +141,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(tp)).thenReturn(Error(reason = "still bad"))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(false))
 
-        val result = decryptor.decryptAll(listOf(tp), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(tp), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(listOf(DecryptedDevice("d1", FALLBACK_NAME, FALLBACK_TYPE_3PARTY)), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())
@@ -148,7 +156,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(tp2)).thenReturn(Error(reason = "bad"))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(true))
 
-        val result = decryptor.decryptAll(listOf(tp1, tp2), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(tp1, tp2), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(listOf("d1", "d2"), result.undecryptable)
         verify(thirdPartyCredentialManager, times(1)).refresh()
@@ -159,7 +167,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC")
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Error(reason = "primaryKey rotated?"))
 
-        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null, publishSnapshot = 0)
 
         assertTrue(result.decrypted.isEmpty())
         assertEquals(listOf("d1"), result.undecryptable)
@@ -174,7 +182,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(tp)).thenReturn(Error(reason = "3p bad"))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Error(reason = "network"))
 
-        val result = decryptor.decryptAll(listOf(ddg, tp), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(ddg, tp), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(listOf(DecryptedDevice("d2", FALLBACK_NAME, FALLBACK_TYPE_3PARTY)), result.decrypted)
         assertEquals(listOf("d1"), result.undecryptable)
@@ -186,7 +194,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val orphan = DeviceV2(deviceId = null, credentialId = "ddg", deviceName = "ENC")
         whenever(fieldDecryptor.decrypt(orphan)).thenReturn(Error(reason = "no id"))
 
-        val result = decryptor.decryptAll(listOf(orphan), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(orphan), thisDeviceId = null, publishSnapshot = 0)
 
         assertTrue(result.decrypted.isEmpty())
         assertTrue(result.undecryptable.isEmpty())
@@ -204,7 +212,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(tpOk)).thenReturn(Success(DecryptedDevice("d3", "Edge", "Browser")))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(true))
 
-        val result = decryptor.decryptAll(listOf(ddgOk, tpFail, tpOk), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(ddgOk, tpFail, tpOk), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(3, result.decrypted.size)
         assertTrue(result.undecryptable.isEmpty())
@@ -220,7 +228,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val ddg2 = DeviceV2(deviceId = "d2", credentialId = null, deviceName = "n")
         whenever(fieldDecryptor.decrypt(any())).thenReturn(Error(reason = "bad"))
 
-        val result = decryptor.decryptAll(listOf(ddg1, ddg2), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(ddg1, ddg2), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(listOf("d1", "d2"), result.undecryptable)
         verify(thirdPartyCredentialManager, never()).refresh()
@@ -231,7 +239,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
 
-        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(listOf(DecryptedDevice("d1", "Legacy Pixel", "phone")), result.decrypted)
         verify(deviceInfoDecryptor, never()).openSession()
@@ -245,7 +253,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Pixel", "phone")))
         whenever(fieldDecryptor.decrypt(tp)).thenReturn(Success(DecryptedDevice("d2", "Chrome", "Browser")))
 
-        val result = decryptor.decryptAll(listOf(ddg, tp), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(ddg, tp), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(2, result.decrypted.size)
         verify(deviceInfoDecryptor).openSession()
@@ -257,7 +265,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
         whenever(session.decrypt("info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Unified Pixel", type = "phone")))
 
-        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(listOf(DecryptedDevice("d1", "Unified Pixel", "phone")), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())
@@ -273,7 +281,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(session.decrypt("ddg.info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Pixel", type = "phone")))
         whenever(session.decrypt("3p.info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Chrome", type = "Browser")))
 
-        val result = decryptor.decryptAll(listOf(ddg, tp), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(ddg, tp), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(
             listOf(DecryptedDevice("d1", "Pixel", "phone"), DecryptedDevice("d2", "Chrome", "Browser")),
@@ -290,7 +298,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
 
-        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(listOf(DecryptedDevice("d1", "Legacy Pixel", "phone")), result.decrypted)
         verify(session, never()).decrypt(any())
@@ -303,7 +311,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(session.decrypt("corrupt.jwe")).thenReturn(Error(reason = "bad device_info"))
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
 
-        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(listOf(DecryptedDevice("d1", "Legacy Pixel", "phone")), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())
@@ -318,7 +326,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
 
-        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(listOf(DecryptedDevice("d1", "Legacy Pixel", "phone")), result.decrypted)
         verify(session, never()).decrypt(any())
@@ -332,7 +340,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(session.decrypt("info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Pixel", type = "phone")))
         whenever(fieldDecryptor.decrypt(viaLegacy)).thenReturn(Success(DecryptedDevice("d2", "Chrome", "Browser")))
 
-        val result = decryptor.decryptAll(listOf(viaInfo, viaLegacy), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(viaInfo, viaLegacy), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(2, result.decrypted.size)
         assertTrue(result.decrypted.contains(DecryptedDevice("d1", "Pixel", "phone")))
@@ -347,7 +355,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Error(reason = "primaryKey rotated?"))
 
-        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(listOf(DecryptedDevice("d1", FALLBACK_NAME, null)), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())
@@ -361,7 +369,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(fieldDecryptor.decrypt(tp)).thenReturn(Error(reason = "still bad"))
         whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(true))
 
-        val result = decryptor.decryptAll(listOf(tp), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(tp), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(listOf(DecryptedDevice("d1", FALLBACK_NAME, FALLBACK_TYPE_3PARTY)), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())
@@ -373,7 +381,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val own = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
         whenever(session.decrypt("info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Pixel", type = "phone")))
 
-        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1")
+        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1", publishSnapshot = 0)
 
         assertFalse(result.thisDeviceInfoNeedsRepair)
         assertEquals(OwnDeviceReadOutcome.ResolvedDeviceInfo, result.ownDeviceReadOutcome)
@@ -389,7 +397,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(session.decrypt("info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Chrome", type = "Browser")))
         whenever(fieldDecryptor.decrypt(own)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
 
-        val result = decryptor.decryptAll(listOf(own, other), thisDeviceId = "d1")
+        val result = decryptor.decryptAll(listOf(own, other), thisDeviceId = "d1", publishSnapshot = 0)
 
         assertFalse(result.thisDeviceInfoNeedsRepair)
         assertEquals(
@@ -406,7 +414,45 @@ class ThirdPartyDeviceListDecryptorTest {
         val own = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
         whenever(fieldDecryptor.decrypt(own)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
 
-        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1")
+        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1", publishSnapshot = 0)
+
+        assertEquals(
+            OwnDeviceReadOutcome.ResolvedLegacy(DeviceInfoReadFailureReason.BLOB_ABSENT),
+            result.ownDeviceReadOutcome,
+        )
+        assertTrue(result.thisDeviceInfoNeedsRepair)
+    }
+
+    @Test
+    fun whenOwnDeviceInfoPublishedWhileTheListWasBeingFetchedThenNotReportedAsBlobAbsent() {
+        enableReadFlag()
+        whenever(syncStore.userId).thenReturn("user")
+        whenever(syncStore.unifiedDeviceListMigratedForUserId).thenReturn("user")
+        val own = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
+        whenever(fieldDecryptor.decrypt(own)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
+        val snapshot = publishTracker.snapshot()
+        publishTracker.markPublished()
+
+        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1", publishSnapshot = snapshot)
+
+        assertEquals(
+            OwnDeviceReadOutcome.ResolvedLegacy(DeviceInfoReadFailureReason.NOT_PUBLISHED_YET),
+            result.ownDeviceReadOutcome,
+        )
+        assertFalse(result.thisDeviceInfoNeedsRepair)
+    }
+
+    @Test
+    fun whenOwnDeviceInfoWasPublishedBeforeTheListWasFetchedThenStillReportedAsBlobAbsent() {
+        enableReadFlag()
+        whenever(syncStore.userId).thenReturn("user")
+        whenever(syncStore.unifiedDeviceListMigratedForUserId).thenReturn("user")
+        val own = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
+        whenever(fieldDecryptor.decrypt(own)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
+        publishTracker.markPublished()
+        val snapshot = publishTracker.snapshot()
+
+        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1", publishSnapshot = snapshot)
 
         assertEquals(
             OwnDeviceReadOutcome.ResolvedLegacy(DeviceInfoReadFailureReason.BLOB_ABSENT),
@@ -422,7 +468,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(session.decrypt("corrupt.jwe")).thenReturn(Error(reason = "bad device_info"))
         whenever(fieldDecryptor.decrypt(own)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
 
-        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1")
+        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1", publishSnapshot = 0)
 
         assertTrue(result.thisDeviceInfoNeedsRepair)
         assertEquals(
@@ -440,7 +486,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val own = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
         whenever(fieldDecryptor.decrypt(own)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
 
-        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1")
+        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1", publishSnapshot = 0)
 
         assertEquals(AccountInfoKeyUnavailableReason.NO_WRAP_FOR_OUR_CREDENTIAL, result.keyUnavailableReason)
         assertEquals(null, result.ownDeviceReadOutcome)
@@ -453,7 +499,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(session.decrypt("corrupt.jwe")).thenReturn(Error(reason = "bad device_info"))
         whenever(fieldDecryptor.decrypt(other)).thenReturn(Error(reason = "bad legacy"))
 
-        val result = decryptor.decryptAll(listOf(other), thisDeviceId = "d1")
+        val result = decryptor.decryptAll(listOf(other), thisDeviceId = "d1", publishSnapshot = 0)
 
         assertEquals(setOf(DeviceCredential.THIRD_PARTY), result.otherRowFailedDecryptionCredentials)
         assertEquals(setOf(DeviceCredential.THIRD_PARTY), result.otherRowPlaceholderCredentials)
@@ -466,7 +512,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(session.decrypt("corrupt.jwe")).thenReturn(Error(reason = "bad device_info"))
         whenever(fieldDecryptor.decrypt(other)).thenReturn(Error(reason = "bad legacy"))
 
-        val result = decryptor.decryptAll(listOf(other), thisDeviceId = "d1")
+        val result = decryptor.decryptAll(listOf(other), thisDeviceId = "d1", publishSnapshot = 0)
 
         assertEquals(setOf(DeviceCredential.NONE), result.otherRowFailedDecryptionCredentials)
         assertEquals(setOf(DeviceCredential.NONE), result.otherRowPlaceholderCredentials)
@@ -480,7 +526,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(session.decrypt("info.jwe")).thenReturn(Success(DeviceInfoPayload(name = "Pixel", type = "phone")))
         whenever(fieldDecryptor.decrypt(other)).thenReturn(Success(DecryptedDevice("d2", "Chrome", "Browser")))
 
-        val result = decryptor.decryptAll(listOf(own, other), thisDeviceId = "d1")
+        val result = decryptor.decryptAll(listOf(own, other), thisDeviceId = "d1", publishSnapshot = 0)
 
         assertFalse(result.thisDeviceInfoNeedsRepair)
     }
@@ -491,7 +537,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val other = DeviceV2(deviceId = "d2", credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
         whenever(fieldDecryptor.decrypt(other)).thenReturn(Success(DecryptedDevice("d2", "Chrome", "Browser")))
 
-        val result = decryptor.decryptAll(listOf(other), thisDeviceId = "d1")
+        val result = decryptor.decryptAll(listOf(other), thisDeviceId = "d1", publishSnapshot = 0)
 
         assertFalse(result.thisDeviceInfoNeedsRepair)
     }
@@ -502,7 +548,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val orphan = DeviceV2(deviceId = null, credentialId = "ddg", deviceName = "ENC", deviceInfo = null)
         whenever(fieldDecryptor.decrypt(orphan)).thenReturn(Error(reason = "missing device id"))
 
-        val result = decryptor.decryptAll(listOf(orphan), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(orphan), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(null, result.ownDeviceReadOutcome)
     }
@@ -513,7 +559,7 @@ class ThirdPartyDeviceListDecryptorTest {
         val own = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC", deviceInfo = "info.jwe")
         whenever(fieldDecryptor.decrypt(own)).thenReturn(Success(DecryptedDevice("d1", "Legacy Pixel", "phone")))
 
-        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1")
+        val result = decryptor.decryptAll(listOf(own), thisDeviceId = "d1", publishSnapshot = 0)
 
         assertFalse(result.thisDeviceInfoNeedsRepair)
     }
@@ -525,7 +571,7 @@ class ThirdPartyDeviceListDecryptorTest {
         whenever(session.decrypt("corrupt.jwe")).thenReturn(Error(reason = "bad device_info"))
         whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Error(reason = "bad legacy"))
 
-        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null)
+        val result = decryptor.decryptAll(listOf(ddg), thisDeviceId = null, publishSnapshot = 0)
 
         assertEquals(listOf(DecryptedDevice("d1", FALLBACK_NAME, null)), result.decrypted)
         assertTrue(result.undecryptable.isEmpty())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1218149406867552?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
There is a narrow window where we might think a repair to re-publish `device_info` is needed and do one where it isn't necessary. Even without this  PR the state would end up ok, but the repair is redundant. 

**Cause**
Essentially, it happens when the request to get devices was issued before the PATCH publishing `device_info` landed and the get devices response is handled after the published marker is set. i.e., the get devices request fires and before it comes back we've patched `device_info`.

Repair is not triggered just by “device_info being missing”. It is triggered by device_info missing and we already marked this account as published. 
- If not marked as published  + no blob → reason NOT_PUBLISHED_YET → no repair.
- If marked as published + no blob → reason BLOB_ABSENT → repair PATCH.

The published marker is set immediately after the first-write PATCH succeeds. So any list read whose payload predates the PATCH (but which is decrypted after the latch is set) will classify as BLOB_ABSENT and fire a redundant repair.

This PR removes that redundant repair, by having a count of `device_info` publishes in memory and snapshotting the count before issuing the get-devices request.

### Steps to test this PR

_The genuine repair still fires when the blob really is missing_

Needs an `internal` build; no second device required.

- [ ] Open Sync Dev Settings and enable sync
- [ ] Turn `canWriteUnifiedDeviceList` OFF
- [ ] Confirm the Unified Devices Migration section still reads `migrated: true` — the repair only applies once this device has published
- [ ] Tap **Rename device (PATCH device_info)** and give it any new name. With write off this PATCH omits `device_info`, so the server clears the blob
- [ ] Tap **Fetch & decrypt devices**. This device's entry must read `device_info: (no device_info)`. If it still shows a blob the rename did not take effect — stop here
- [ ] Turn `canWriteUnifiedDeviceList` back ON
- [ ] Force-stop the app. The repair runs at most once per account per process, so an earlier attempt in the same session would mask the result
- [ ] Launch the app and open Settings → Sync (the signed-in devices screen)
- [ ] Expect in logcat: `this device's device_info did not resolve on read; re-publishing it` followed by `device_info re-published`
- [ ] Back in Dev Settings → Sync, tap **Fetch & decrypt devices** again. This device's entry now shows `device_info: name=…`, and the devices screen shows the correct name

Logcat filter: `message~:"Sync-UnifiedDevices"`


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b38269be08a0e8a931edabccb31e7a3a3fa9a462. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
