### PR TITLE
Permissions: Feature flag and pixel definitions

### DIFF
--- a/PixelDefinitions/pixels/definitions/site_permissions.json5
+++ b/PixelDefinitions/pixels/definitions/site_permissions.json5
@@ -23,7 +23,7 @@
         ]
     },
     "m_site_permissions_dialog_click": {
-        "description": "Fires when the user resolves the site permission dialog. Paired with m_site_permissions_dialog_impresssion to give the decision rate per permission type; a prompt abandoned without a decision fires no click pixel and so appears only in the impression count. The pixel name retains the historic misspelling of its impression counterpart",
+        "description": "Fires when the user resolves the site permission dialog. Paired with m_site_permissions_dialog_impresssion to give the decision rate per permission type. A prompt the user never resolves, because the tab or activity went away, fires no click pixel and so appears only in the impression count. The pixel name retains the historic misspelling of its impression counterpart",
         "owners": ["0nko"],
         "triggers": ["page_load"],
         "suffixes": ["form_factor"],

--- a/PixelDefinitions/pixels/definitions/site_permissions.json5
+++ b/PixelDefinitions/pixels/definitions/site_permissions.json5
@@ -21,5 +21,41 @@
             },
             "petal"
         ]
+    },
+    "m_site_permissions_dialog_click": {
+        "description": "Fires when the user resolves the site permission dialog. Paired with m_site_permissions_dialog_impresssion to give the decision rate per permission type; a prompt abandoned without a decision fires no click pixel and so appears only in the impression count. The pixel name retains the historic misspelling of its impression counterpart",
+        "owners": ["0nko"],
+        "triggers": ["page_load"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "type",
+                "type": "string",
+                "description": "Permission type the dialog was shown for",
+                "enum": ["location", "camera", "microphone", "camera_and_microphone", "drm"]
+            },
+            {
+                "key": "selection",
+                "type": "string",
+                "description": "The decision made, and whether it persists for the site. The _always variants are remembered for future visits; the _once variants apply to the current visit only. Under the binary dialog the split comes from the remember-my-choice checkbox; under the tiered dialog it comes from the explicit option chosen, and deny_once additionally covers dismissing the prompt. Figures either side of the tiered-dialog rollout are therefore not directly comparable",
+                "enum": ["allow_always", "allow_once", "deny_always", "deny_once"]
+            }
+        ]
+    },
+    "m_site_permissions_dialog_impresssion": {
+        "description": "Fires when a site permission dialog is shown to the user. Acts as the denominator for m_site_permissions_dialog_click. Note the triple-s misspelling is the live wire name and is kept deliberately",
+        "owners": ["0nko"],
+        "triggers": ["page_load"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "type",
+                "type": "string",
+                "description": "Permission type the dialog was shown for",
+                "enum": ["location", "camera", "microphone", "camera_and_microphone", "drm"]
+            }
+        ]
     }
 }

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/feature/SitePermissionsDialogRedesignFeature.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/feature/SitePermissionsDialogRedesignFeature.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.site.permissions.impl.feature
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "sitePermissionsDialogRedesign",
+)
+interface SitePermissionsDialogRedesignFeature {
+    @InternalAlwaysEnabled
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun self(): Toggle
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1218155238924636?focus=true

### Description

This PR just adds a FF and pixel definitions for the existing pixels that will be used.

### Steps to test this PR

QA-optional


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds metadata and a disabled-by-default remote feature flag with no behavior changes to permission flows.
> 
> **Overview**
> Registers **site permission dialog** analytics in `site_permissions.json5` and introduces a remote feature toggle for the upcoming dialog redesign.
> 
> Adds pixel definitions for **`m_site_permissions_dialog_impresssion`** and **`m_site_permissions_dialog_click`** (including `type` and `selection` enums) so existing wire events are documented and validated. The impression name keeps the intentional triple-**s** spelling to match production.
> 
> Adds **`SitePermissionsDialogRedesignFeature`** (`sitePermissionsDialogRedesign`), default **off**, with `@InternalAlwaysEnabled` on `self()`—scaffolding only; no UI or firing logic changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98bccf7cac3f89ad9fed2504fdab900f92ad771b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->