### PR TITLE
Count a Duck.ai prompt toward the search experiment metric

### DIFF
--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePlugin.kt
@@ -26,27 +26,12 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @ContributesMultibinding(AppScope::class)
-class RetentionMetricsAtbLifecyclePlugin(
+class RetentionMetricsAtbLifecyclePlugin @Inject constructor(
     private val searchMetricPixelsPlugin: SearchMetricPixelsPlugin,
     private val appUseMetricPixelsPlugin: AppUseMetricPixelsPlugin,
     private val duckAiPromptSentMetricPixelsPlugin: DuckAiPromptSentMetricPixelsPlugin,
-    private val appCoroutineScope: CoroutineScope,
-    private val experimentsExcludedFromDuckAiSearchMetric: Set<String>,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : AtbLifecyclePlugin {
-
-    @Inject
-    constructor(
-        searchMetricPixelsPlugin: SearchMetricPixelsPlugin,
-        appUseMetricPixelsPlugin: AppUseMetricPixelsPlugin,
-        duckAiPromptSentMetricPixelsPlugin: DuckAiPromptSentMetricPixelsPlugin,
-        @AppCoroutineScope appCoroutineScope: CoroutineScope,
-    ) : this(
-        searchMetricPixelsPlugin,
-        appUseMetricPixelsPlugin,
-        duckAiPromptSentMetricPixelsPlugin,
-        appCoroutineScope,
-        EXPERIMENTS_EXCLUDED_FROM_DUCK_AI_SEARCH_METRIC,
-    )
 
     override fun onSearchRetentionAtbRefreshed(oldAtb: String, newAtb: String) {
         appCoroutineScope.launch {
@@ -63,7 +48,9 @@ class RetentionMetricsAtbLifecyclePlugin(
     override fun onDuckAiRetentionAtbRefreshed(oldAtb: String, newAtb: String, metadata: Map<String, String?>) {
         appCoroutineScope.launch {
             duckAiPromptSentMetricPixelsPlugin.getMetrics().forEach { it.send() }
-            searchMetricPixelsPlugin.getMetrics(excluding = experimentsExcludedFromDuckAiSearchMetric).forEach { it.send() }
+            searchMetricPixelsPlugin.getMetrics()
+                .filterNot { it.toggle.featureName().name in EXPERIMENTS_EXCLUDED_FROM_DUCK_AI_SEARCH_METRIC }
+                .forEach { it.send() }
         }
     }
 
@@ -73,8 +60,6 @@ class RetentionMetricsAtbLifecyclePlugin(
          * They are excluded from counting prompts to avoid skewing the metrics.
          */
         private val EXPERIMENTS_EXCLUDED_FROM_DUCK_AI_SEARCH_METRIC = setOf(
-            "tdsNextExperiment016",
-            "contentScopeExperiment7",
             "addToDockAndWidgetExperimentJul25",
         )
     }

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePlugin.kt
@@ -26,12 +26,27 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @ContributesMultibinding(AppScope::class)
-class RetentionMetricsAtbLifecyclePlugin @Inject constructor(
+class RetentionMetricsAtbLifecyclePlugin(
     private val searchMetricPixelsPlugin: SearchMetricPixelsPlugin,
     private val appUseMetricPixelsPlugin: AppUseMetricPixelsPlugin,
     private val duckAiPromptSentMetricPixelsPlugin: DuckAiPromptSentMetricPixelsPlugin,
-    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val appCoroutineScope: CoroutineScope,
+    private val experimentsExcludedFromDuckAiSearchMetric: Set<String>,
 ) : AtbLifecyclePlugin {
+
+    @Inject
+    constructor(
+        searchMetricPixelsPlugin: SearchMetricPixelsPlugin,
+        appUseMetricPixelsPlugin: AppUseMetricPixelsPlugin,
+        duckAiPromptSentMetricPixelsPlugin: DuckAiPromptSentMetricPixelsPlugin,
+        @AppCoroutineScope appCoroutineScope: CoroutineScope,
+    ) : this(
+        searchMetricPixelsPlugin,
+        appUseMetricPixelsPlugin,
+        duckAiPromptSentMetricPixelsPlugin,
+        appCoroutineScope,
+        EXPERIMENTS_EXCLUDED_FROM_DUCK_AI_SEARCH_METRIC,
+    )
 
     override fun onSearchRetentionAtbRefreshed(oldAtb: String, newAtb: String) {
         appCoroutineScope.launch {
@@ -48,6 +63,19 @@ class RetentionMetricsAtbLifecyclePlugin @Inject constructor(
     override fun onDuckAiRetentionAtbRefreshed(oldAtb: String, newAtb: String, metadata: Map<String, String?>) {
         appCoroutineScope.launch {
             duckAiPromptSentMetricPixelsPlugin.getMetrics().forEach { it.send() }
+            searchMetricPixelsPlugin.getMetrics(excluding = experimentsExcludedFromDuckAiSearchMetric).forEach { it.send() }
         }
+    }
+
+    companion object {
+        /**
+         * Experiments that were enrolling/running before Duck.ai prompts were added towards search retention metrics.
+         * They are excluded from counting prompts to avoid skewing the metrics.
+         */
+        private val EXPERIMENTS_EXCLUDED_FROM_DUCK_AI_SEARCH_METRIC = setOf(
+            "tdsNextExperiment016",
+            "contentScopeExperiment7",
+            "addToDockAndWidgetExperimentJul25",
+        )
     }
 }

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/SearchMetricPixelsPlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/SearchMetricPixelsPlugin.kt
@@ -28,13 +28,8 @@ import javax.inject.Inject
 @ContributesMultibinding(AppScope::class)
 class SearchMetricPixelsPlugin @Inject constructor(private val inventory: FeatureTogglesInventory) : MetricsPixelPlugin {
 
-    override suspend fun getMetrics(): List<MetricsPixel> = getMetrics(excluding = emptySet())
-
-    /**
-     * @param excluding bare subfeature names, as returned by [com.duckduckgo.feature.toggles.api.Toggle.featureName], to leave out.
-     */
-    suspend fun getMetrics(excluding: Set<String>): List<MetricsPixel> {
-        return inventory.getAllActiveExperimentToggles().filterNot { it.featureName().name in excluding }.flatMap { toggle ->
+    override suspend fun getMetrics(): List<MetricsPixel> {
+        return inventory.getAllActiveExperimentToggles().flatMap { toggle ->
             listOf(
                 MetricsPixel(
                     metric = "search",

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/SearchMetricPixelsPlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/SearchMetricPixelsPlugin.kt
@@ -28,8 +28,13 @@ import javax.inject.Inject
 @ContributesMultibinding(AppScope::class)
 class SearchMetricPixelsPlugin @Inject constructor(private val inventory: FeatureTogglesInventory) : MetricsPixelPlugin {
 
-    override suspend fun getMetrics(): List<MetricsPixel> {
-        return inventory.getAllActiveExperimentToggles().flatMap { toggle ->
+    override suspend fun getMetrics(): List<MetricsPixel> = getMetrics(excluding = emptySet())
+
+    /**
+     * @param excluding bare subfeature names, as returned by [com.duckduckgo.feature.toggles.api.Toggle.featureName], to leave out.
+     */
+    suspend fun getMetrics(excluding: Set<String>): List<MetricsPixel> {
+        return inventory.getAllActiveExperimentToggles().filterNot { it.featureName().name in excluding }.flatMap { toggle ->
             listOf(
                 MetricsPixel(
                     metric = "search",

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt
@@ -80,6 +80,7 @@ class RetentionMetricsAtbLifecyclePluginTest {
             appUseMetricPixelsPlugin = appUseMetricPixelsPlugin,
             duckAiPromptSentMetricPixelsPlugin = duckAiPromptSentMetricPixelsPlugin,
             appCoroutineScope = coroutineRule.testScope,
+            experimentsExcludedFromDuckAiSearchMetric = setOf("experimentFooFeature"),
         )
     }
 
@@ -189,8 +190,7 @@ class RetentionMetricsAtbLifecyclePluginTest {
 
         val expected = duckAiPromptSentMetricPixelsPlugin.getMetrics()
         assertTrue(expected.isNotEmpty())
-        assertEquals(expected.size, fakeMetricsPixelExtension.sentMetrics.size)
-        assertTrue(fakeMetricsPixelExtension.sentMetrics.all { it.metric == "duck_ai_prompt_sent" })
+        assertEquals(expected.size, fakeMetricsPixelExtension.sentMetrics.count { it.metric == "duck_ai_prompt_sent" })
     }
 
     @Test
@@ -258,6 +258,41 @@ class RetentionMetricsAtbLifecyclePluginTest {
                 assignedCohort = cohort,
             ),
         )
+    }
+
+    @Test
+    fun `when duck ai atb refreshed then search metrics are also sent`() = runTest {
+        setCohorts(ZonedDateTime.now(ZoneId.of("America/New_York")).toString())
+
+        atbLifecyclePlugin.onDuckAiRetentionAtbRefreshed("", "", emptyMap())
+
+        assertTrue(fakeMetricsPixelExtension.sentMetrics.any { it.metric == "search" })
+        assertTrue(fakeMetricsPixelExtension.sentMetrics.any { it.metric == "duck_ai_prompt_sent" })
+    }
+
+    @Test
+    fun `when duck ai atb refreshed then excluded experiments get no search metrics`() = runTest {
+        setCohorts(ZonedDateTime.now(ZoneId.of("America/New_York")).toString())
+
+        atbLifecyclePlugin.onDuckAiRetentionAtbRefreshed("", "", emptyMap())
+
+        val searchMetricToggles = fakeMetricsPixelExtension.sentMetrics
+            .filter { it.metric == "search" }
+            .map { it.toggle.featureName().name }
+            .toSet()
+        assertEquals(setOf("fooFeature"), searchMetricToggles)
+    }
+
+    @Test
+    fun `when search atb refreshed then excluded experiments still get search metrics`() = runTest {
+        setCohorts(ZonedDateTime.now(ZoneId.of("America/New_York")).toString())
+
+        atbLifecyclePlugin.onSearchRetentionAtbRefreshed("", "")
+
+        val searchMetricToggles = fakeMetricsPixelExtension.sentMetrics
+            .map { it.toggle.featureName().name }
+            .toSet()
+        assertTrue(searchMetricToggles.containsAll(setOf("experimentFooFeature", "fooFeature")))
     }
 }
 

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt
@@ -23,6 +23,9 @@ import com.duckduckgo.feature.toggles.api.FakeToggleStore
 import com.duckduckgo.feature.toggles.api.FeatureToggles
 import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
+import com.duckduckgo.feature.toggles.api.Toggle.Experiment
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.feature.toggles.codegen.TestTriggerFeature
 import com.duckduckgo.feature.toggles.impl.RealFeatureTogglesInventory
@@ -44,6 +47,7 @@ class RetentionMetricsAtbLifecyclePluginTest {
 
     private val fakeMetricsPixelExtension = FakeMetricsPixelExtension()
     private lateinit var testFeature: TestTriggerFeature
+    private lateinit var excludedExperimentFeature: ExcludedExperimentFeature
     private lateinit var inventory: FeatureTogglesInventory
     private lateinit var searchMetricPixelsPlugin: SearchMetricPixelsPlugin
     private lateinit var appUseMetricPixelsPlugin: AppUseMetricPixelsPlugin
@@ -57,12 +61,18 @@ class RetentionMetricsAtbLifecyclePluginTest {
             featureName = "testFeature",
         ).build().create(TestTriggerFeature::class.java)
 
+        excludedExperimentFeature = FeatureToggles.Builder(
+            FakeToggleStore(),
+            featureName = "testFeature",
+        ).build().create(ExcludedExperimentFeature::class.java)
+
         inventory = RealFeatureTogglesInventory(
             setOf(
                 FakeFeatureTogglesInventory(
                     features = listOf(
                         testFeature.experimentFooFeature(),
                         testFeature.fooFeature(),
+                        excludedExperimentFeature.addToDockAndWidgetExperimentJul25(),
                     ),
                 ),
             ),
@@ -80,7 +90,6 @@ class RetentionMetricsAtbLifecyclePluginTest {
             appUseMetricPixelsPlugin = appUseMetricPixelsPlugin,
             duckAiPromptSentMetricPixelsPlugin = duckAiPromptSentMetricPixelsPlugin,
             appCoroutineScope = coroutineRule.testScope,
-            experimentsExcludedFromDuckAiSearchMetric = setOf("experimentFooFeature"),
         )
     }
 
@@ -258,6 +267,14 @@ class RetentionMetricsAtbLifecyclePluginTest {
                 assignedCohort = cohort,
             ),
         )
+        excludedExperimentFeature.addToDockAndWidgetExperimentJul25().setRawStoredState(
+            State(
+                remoteEnableState = true,
+                enable = true,
+                cohorts = listOf(cohort),
+                assignedCohort = cohort,
+            ),
+        )
     }
 
     @Test
@@ -271,7 +288,7 @@ class RetentionMetricsAtbLifecyclePluginTest {
     }
 
     @Test
-    fun `when duck ai atb refreshed then excluded experiments get no search metrics`() = runTest {
+    fun `when duck ai atb refreshed then addToDockAndWidgetExperimentJul25 gets no search metric`() = runTest {
         setCohorts(ZonedDateTime.now(ZoneId.of("America/New_York")).toString())
 
         atbLifecyclePlugin.onDuckAiRetentionAtbRefreshed("", "", emptyMap())
@@ -280,20 +297,27 @@ class RetentionMetricsAtbLifecyclePluginTest {
             .filter { it.metric == "search" }
             .map { it.toggle.featureName().name }
             .toSet()
-        assertEquals(setOf("fooFeature"), searchMetricToggles)
+        assertEquals(setOf("experimentFooFeature", "fooFeature"), searchMetricToggles)
     }
 
     @Test
-    fun `when search atb refreshed then excluded experiments still get search metrics`() = runTest {
+    fun `when search atb refreshed then addToDockAndWidgetExperimentJul25 still gets a search metric`() = runTest {
         setCohorts(ZonedDateTime.now(ZoneId.of("America/New_York")).toString())
 
         atbLifecyclePlugin.onSearchRetentionAtbRefreshed("", "")
 
         val searchMetricToggles = fakeMetricsPixelExtension.sentMetrics
+            .filter { it.metric == "search" }
             .map { it.toggle.featureName().name }
             .toSet()
-        assertTrue(searchMetricToggles.containsAll(setOf("experimentFooFeature", "fooFeature")))
+        assertEquals(setOf("addToDockAndWidgetExperimentJul25", "experimentFooFeature", "fooFeature"), searchMetricToggles)
     }
+}
+
+interface ExcludedExperimentFeature {
+    @DefaultValue(DefaultFeatureValue.FALSE)
+    @Experiment
+    fun addToDockAndWidgetExperimentJul25(): Toggle
 }
 
 class FakeFeatureTogglesInventory(private val features: List<Toggle>) : FeatureTogglesInventory {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1216793387267215?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Aligns expected retention metrics with other platform by counting Duck.ai prompts towards the search metric.

To avoid impacting in-flight experiments, any active experiment from the current local/remote config is excluded.

### Steps to test this PR

Verify unit tests, and that they pass on CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when search retention pixels fire for experiments; a wrong or incomplete exclusion list could distort in-flight experiment metrics.
> 
> **Overview**
> Duck.ai ATB refresh now **also fires search retention metrics**, alongside existing `duck_ai_prompt_sent` pixels, so Duck.ai prompt activity is counted toward search experiment retention like other platforms.
> 
> Search metrics are **filtered on the Duck.ai path only**: experiments listed in `EXPERIMENTS_EXCLUDED_FROM_DUCK_AI_SEARCH_METRIC` (currently `addToDockAndWidgetExperimentJul25`) are skipped so pre-existing in-flight experiments are not skewed. **Search ATB refresh is unchanged**—those experiments still get search metrics there.
> 
> Unit tests cover dual-metric sends on Duck.ai refresh, the exclusion on Duck.ai, and unchanged behavior on search refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd77be96ddf12e00e3f8769e3d6a39ff7e941889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->