### PR TITLE
[Segmented Onboarding] Experiment setup and metrics

### DIFF
--- a/PixelDefinitions/pixels/definitions/onboarding.json5
+++ b/PixelDefinitions/pixels/definitions/onboarding.json5
@@ -122,7 +122,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             "inputPreviewAction",
             {
                 "key": "value",
@@ -179,7 +179,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             "inputPreviewAction",
             {
                 "key": "value",
@@ -201,7 +201,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             {
                 "key": "value",
                 "type": "string",
@@ -262,7 +262,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             "inputPreviewAction",
             {
                 "key": "value",
@@ -299,7 +299,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
@@ -336,7 +336,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
@@ -353,7 +353,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             "inputPreviewAction",
             {
                 "key": "value",
@@ -375,7 +375,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
@@ -392,7 +392,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
@@ -409,7 +409,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
@@ -446,13 +446,13 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             "inputPreviewAction",
             { "key": "value", "type": "string", "description": "Only set when event=clicked.", "enum": ["engage", "dismiss"] }
         ]
     },
     "onboarding_download-choice": {
-        "description": "Download-reason step of the segmented onboarding flow. shown when the download-reason screen is displayed; clicked when the user confirms a reason, which is also the point the reason starts being reported as variant_segmented. Unique once per user per (event, value).",
+        "description": "Download-reason step of the segmented onboarding flow. shown when the download-reason screen is displayed; clicked when the user confirms a reason, which is also the point the reason starts being reported as variant_download_reason. Unique once per user per (event, value).",
         "owners": ["LukasPaczos"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
@@ -463,7 +463,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             {
                 "key": "value",
                 "type": "string",
@@ -484,7 +484,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             {
                 "key": "recently_visited_sites_enabled",
                 "type": "boolean",
@@ -509,7 +509,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             {
                 "key": "value",
                 "type": "string",
@@ -530,7 +530,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             {
                 "key": "value",
                 "type": "string",
@@ -551,7 +551,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             {
                 "key": "search_assist_enabled",
                 "type": "boolean",
@@ -576,7 +576,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             {
                 "key": "value",
                 "type": "string",
@@ -597,7 +597,7 @@
             "onboardingDaysSinceInstall",
             "onboardingFlow",
             "onboardingPixelSource",
-            "onboardingSegmentedVariant",
+            "onboardingDownloadReasonVariant",
             {
                 "key": "youtube_ad_blocking_enabled",
                 "type": "boolean",

--- a/PixelDefinitions/pixels/native_experiments.json5
+++ b/PixelDefinitions/pixels/native_experiments.json5
@@ -1,5 +1,47 @@
 {
     // This file will define pixels sent by the native experiments framework
     "defaultSuffixes": ["form_factor"],
-    "activeExperiments": {}
+    "activeExperiments": {
+        "onboardingFlowByDownloadReasonExperiment": {
+            "cohorts": ["control", "treatment"],
+            "metrics": {
+                "onboarding_completed": {
+                    "description": "User reached the end-of-journey dialog (onboarding completed)",
+                    "enum": [""]
+                },
+                "download_reason_selected_search": {
+                    "description": "User selected the 'search' download reason",
+                    "enum": [""]
+                },
+                "download_reason_selected_ai-chat": {
+                    "description": "User selected the 'ai-chat' download reason",
+                    "enum": [""]
+                },
+                "download_reason_selected_no-ai": {
+                    "description": "User selected the 'no-ai' download reason",
+                    "enum": [""]
+                },
+                "download_reason_selected_ad-blocking": {
+                    "description": "User selected the 'ad-blocking' download reason",
+                    "enum": [""]
+                },
+                "download_reason_search_retention_search": {
+                    "description": "D5-7 search retention for the 'search' download-reason segment",
+                    "enum": ["1", "4", "6", "11", "21", "30"]
+                },
+                "download_reason_search_retention_ai-chat": {
+                    "description": "D5-7 search retention for the 'ai-chat' download-reason segment",
+                    "enum": ["1", "4", "6", "11", "21", "30"]
+                },
+                "download_reason_search_retention_no-ai": {
+                    "description": "D5-7 search retention for the 'no-ai' download-reason segment",
+                    "enum": ["1", "4", "6", "11", "21", "30"]
+                },
+                "download_reason_search_retention_ad-blocking": {
+                    "description": "D5-7 search retention for the 'ad-blocking' download-reason segment",
+                    "enum": ["1", "4", "6", "11", "21", "30"]
+                }
+            }
+        }
+    }
 }

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -57,8 +57,8 @@
         "description": "Onboarding Duck.ai search/chat branch, chosen at the input-screen preview step. Set on every onboarding pixel fired after the user passes that step; absent for pixels fired before it or for users who never see it.",
         "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
     },
-    "onboardingSegmentedVariant": {
-        "key": "variant_segmented",
+    "onboardingDownloadReasonVariant": {
+        "key": "variant_download_reason",
         "type": "string",
         "description": "Download reason picked on the download-choice screen of the segmented onboarding flow. Set on every onboarding pixel fired after that screen; absent for pixels fired before it and for flows that never show it. Independent of the search/chat branch reported by `variant`, since a run can make both choices.",
         "enum": ["download_reason_search", "download_reason_ai-chat", "download_reason_no-ai", "download_reason_ad-blocking"]

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -296,7 +296,7 @@ import com.duckduckgo.app.location.data.LocationPermissionType
 import com.duckduckgo.app.onboarding.CustomAiOnboardingStore
 import com.duckduckgo.app.onboarding.OnboardingInputScreenLaunchTarget
 import com.duckduckgo.app.onboarding.store.OnboardingStore
-import com.duckduckgo.app.onboarding.store.SegmentedOnboardingPath
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_RESULT_DELETED
@@ -5508,7 +5508,7 @@ class BrowserTabViewModel @Inject constructor(
                     val uri = "https://duckduckgo.com/pro".toUri().buildUpon()
                         .appendQueryParameter("origin", "funnel_onboarding_android")
                         .apply {
-                            val isSegmentedAiPath = onboardingStore.getSegmentedPathWithAiInput() == SegmentedOnboardingPath.AI
+                            val isSegmentedAiPath = onboardingStore.getSegmentedPathWithAiInput() == DownloadReasonSelection.AI_CHAT
                             if (customAiOnboardingStore.isEnabled() || isSegmentedAiPath) {
                                 appendQueryParameter("featurePage", "duckai")
                             }
@@ -5524,7 +5524,7 @@ class BrowserTabViewModel @Inject constructor(
                 refresh()
             }
             is DaxEndBrandDesignUpdateBubbleCta -> {
-                if (cta.segmentedPathWithAiInput == SegmentedOnboardingPath.SEARCH) {
+                if (cta.segmentedPathWithAiInput == DownloadReasonSelection.SEARCH) {
                     viewModelScope.launch {
                         ctaViewState.value = currentCtaViewState().copy(cta = null)
                         command.value = HideOnboardingDaxBubbleCta(cta)

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -36,11 +36,11 @@ import com.duckduckgo.app.onboarding.CustomAiOnboardingStore
 import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingPlanProvider
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.OnboardingStore
-import com.duckduckgo.app.onboarding.store.SegmentedOnboardingPath
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.store.daxOnboardingActive
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPixelAction
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPixelSender
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.pixels.AppPixelName
@@ -172,7 +172,7 @@ class CtaViewModel @Inject constructor(
 
         // Only NTP offers the End dialog with Try Duck.ai / Skip for the segmented onboarding's search path.
         // The contextual End dialog doesn't offer this.
-        is DaxEndBrandDesignUpdateBubbleCta -> if (cta.segmentedPathWithAiInput == SegmentedOnboardingPath.SEARCH) {
+        is DaxEndBrandDesignUpdateBubbleCta -> if (cta.segmentedPathWithAiInput == DownloadReasonSelection.SEARCH) {
             listOf(OnboardingPixelName.ONBOARDING_END, OnboardingPixelName.ONBOARDING_END_TRY_DUCK_AI)
         } else {
             listOf(OnboardingPixelName.ONBOARDING_END)

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxDuckAiEndBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxDuckAiEndBrandDesignUpdateBubbleCta.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.store.OnboardingStore
-import com.duckduckgo.app.onboarding.store.SegmentedOnboardingPath
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.ui.view.appendIconToText
@@ -36,14 +36,14 @@ data class DaxDuckAiEndBrandDesignUpdateBubbleCta(
     override val isLightTheme: Boolean,
     override val deviceInfo: DeviceInfo,
     val isCustomAiOnboardingFlow: Boolean,
-    val segmentedPath: SegmentedOnboardingPath?,
+    val segmentedPath: DownloadReasonSelection?,
     override val onboardingImprovementsV2Enabled: Boolean,
 ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
     ctaId = CtaId.DAX_DUCK_AI_END,
     title = R.string.onboardingDuckAiEndCtaTitle,
     description = when {
         isCustomAiOnboardingFlow -> R.string.onboardingEndCustomAiFlowDaxDialogDescription
-        segmentedPath == SegmentedOnboardingPath.AI -> R.string.aiPathWithToggleEnabledContextualEndDescription
+        segmentedPath == DownloadReasonSelection.AI_CHAT -> R.string.aiPathWithToggleEnabledContextualEndDescription
         else -> R.string.onboardingDuckAiEndCtaDescription
     },
     backgroundRes = CommonR.drawable.bg_onboarding_end,
@@ -75,7 +75,7 @@ data class DaxDuckAiEndBrandDesignUpdateBubbleCta(
     override fun decorateDescription(
         context: Context,
         text: CharSequence,
-    ): CharSequence = if (segmentedPath == SegmentedOnboardingPath.AI) {
+    ): CharSequence = if (segmentedPath == DownloadReasonSelection.AI_CHAT) {
         text
     } else {
         context.appendIconToText(text, CommonR.drawable.ic_ai_chat_16)

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
@@ -25,9 +25,11 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.store.OnboardingStore
-import com.duckduckgo.app.onboarding.store.SegmentedOnboardingPath
-import com.duckduckgo.app.onboarding.store.SegmentedOnboardingPath.AI
-import com.duckduckgo.app.onboarding.store.SegmentedOnboardingPath.SEARCH
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection.AI_CHAT
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection.BLOCK_ADS
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection.NO_AI
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection.SEARCH
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.device.DeviceInfo
@@ -42,16 +44,16 @@ data class DaxEndBrandDesignUpdateBubbleCta constructor(
     override val onboardingImprovementsEnabled: Boolean,
     override val onboardingImprovementsV2Enabled: Boolean,
     val isOmnibarBottom: Boolean,
-    val segmentedPathWithAiInput: SegmentedOnboardingPath?,
+    val segmentedPathWithAiInput: DownloadReasonSelection?,
 ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
     ctaId = CtaId.DAX_END,
     title = when (segmentedPathWithAiInput) {
         SEARCH -> R.string.searchPathWithToggleEnabledContextualEndTitle
-        AI, null -> R.string.onboardingEndDaxDialogTitle
+        AI_CHAT, NO_AI, BLOCK_ADS, null -> R.string.onboardingEndDaxDialogTitle
     },
     description = when (segmentedPathWithAiInput) {
         SEARCH -> R.string.searchPathWithToggleEnabledContextualEndDescription
-        AI, null -> R.string.onboardingEndDaxDialogDescription
+        AI_CHAT, NO_AI, BLOCK_ADS, null -> R.string.onboardingEndDaxDialogDescription
     },
     backgroundRes = CommonR.drawable.bg_onboarding_end,
     shownPixel = AppPixelName.ONBOARDING_DAX_CTA_SHOWN,

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.store.OnboardingStore
-import com.duckduckgo.app.onboarding.store.SegmentedOnboardingPath
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.device.DeviceInfo
@@ -39,13 +39,13 @@ data class DaxSubscriptionBrandDesignUpdateBubbleCta(
     override val deviceInfo: DeviceInfo,
     val isCustomAiOnboardingFlow: Boolean,
     val isFreeTrialCopy: Boolean,
-    val segmentedPath: SegmentedOnboardingPath?,
+    val segmentedPath: DownloadReasonSelection?,
     override val onboardingImprovementsEnabled: Boolean,
     override val onboardingImprovementsV2Enabled: Boolean,
 ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
     ctaId = CtaId.DAX_INTRO_PRIVACY_PRO,
     title = R.string.onboardingPrivacyProDaxDialogTitle,
-    description = if (isCustomAiOnboardingFlow || segmentedPath == SegmentedOnboardingPath.AI) {
+    description = if (isCustomAiOnboardingFlow || segmentedPath == DownloadReasonSelection.AI_CHAT) {
         R.string.onboardingPrivacyProCustomAiFlowDaxDialogDescription
     } else {
         R.string.onboardingPrivacyProDaxDialogDescription

--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingCompletedMetricObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingCompletedMetricObserver.kt
@@ -37,12 +37,16 @@ class OnboardingCompletedMetricObserver @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val userStageStore: UserStageStore,
     private val onboardingPromptsExperimentMetrics: OnboardingPromptsExperimentMetrics,
+    private val segmentedOnboardingExperimentMetrics: SegmentedOnboardingExperimentMetrics,
 ) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         userStageStore.userAppStageFlow()
             .filter { it == AppStage.ESTABLISHED }
-            .onEach { onboardingPromptsExperimentMetrics.fireOnboardingCompletedMetric() }
+            .onEach {
+                onboardingPromptsExperimentMetrics.fireOnboardingCompletedMetric()
+                segmentedOnboardingExperimentMetrics.fireOnboardingCompletedMetric()
+            }
             .launchIn(appCoroutineScope)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/SegmentedOnboardingExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/SegmentedOnboardingExperimentManager.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.onboarding
 
 import com.duckduckgo.app.onboarding.SegmentedOnboardingExperimentManager.SegmentedOnboardingExperimentVariant
+import com.duckduckgo.app.onboarding.SegmentedOnboardingFeatureToggles.Cohorts
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -39,21 +40,32 @@ interface SegmentedOnboardingExperimentManager {
 @SingleInstanceIn(AppScope::class)
 class SegmentedOnboardingExperimentManagerImpl @Inject constructor(
     private val onboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles,
-    private val dispatcherProvider: DispatcherProvider,
+    private val segmentedOnboardingFeatureToggles: SegmentedOnboardingFeatureToggles,
+    private val onboardingPasswordImportToggles: OnboardingPasswordImportToggles,
+    private val onboardingPromptsToggles: OnboardingPromptsToggles,
     private val appBuildConfig: AppBuildConfig,
+    private val dispatcherProvider: DispatcherProvider,
     private val onboardingPrivacyConfigPersistedGate: OnboardingPrivacyConfigPersistedGate,
 ) : SegmentedOnboardingExperimentManager {
 
     override suspend fun enroll(): SegmentedOnboardingExperimentVariant? = withContext(dispatcherProvider.io()) {
-        if (onboardingPrivacyConfigPersistedGate.awaitPersisted() && checkPrerequisites()) {
-            // scaffolding for future experiment enrollment logic
+        if (!onboardingPrivacyConfigPersistedGate.awaitPersisted() || !checkPrerequisites()) {
             return@withContext null
-        } else {
-            null
+        }
+
+        val toggle = segmentedOnboardingFeatureToggles.onboardingFlowByDownloadReasonExperiment()
+        toggle.enroll()
+        when {
+            toggle.isEnrolledAndEnabled(Cohorts.TREATMENT) -> SegmentedOnboardingExperimentVariant.TREATMENT
+            toggle.isEnrolledAndEnabled(Cohorts.CONTROL) -> SegmentedOnboardingExperimentVariant.CONTROL
+            else -> null
         }
     }
 
     private suspend fun checkPrerequisites() =
-        onboardingBrandDesignUpdateToggles.configDrivenDialogs().isEnabled() &&
+        onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled() &&
+            onboardingBrandDesignUpdateToggles.configDrivenDialogs().isEnabled() &&
+            !onboardingPromptsToggles.addToDockAndWidgetExperimentJul25().isEnabled() &&
+            !onboardingPasswordImportToggles.passwordImportExperimentAug25().isEnabled() &&
             !appBuildConfig.isAppReinstall()
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/SegmentedOnboardingExperimentMetrics.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/SegmentedOnboardingExperimentMetrics.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.MetricType
+import com.duckduckgo.feature.toggles.api.MetricsPixel
+import com.duckduckgo.feature.toggles.api.send
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface SegmentedOnboardingExperimentMetrics {
+
+    suspend fun fireOnboardingCompletedMetric()
+
+    suspend fun fireDownloadReasonSelectedMetric(reason: DownloadReasonSelection)
+
+    suspend fun fireDownloadReasonSearchRetentionMetrics(reason: DownloadReasonSelection)
+}
+
+@ContributesBinding(AppScope::class)
+class SegmentedOnboardingExperimentMetricsImpl @Inject constructor(
+    private val toggles: SegmentedOnboardingFeatureToggles,
+) : SegmentedOnboardingExperimentMetrics {
+
+    override suspend fun fireOnboardingCompletedMetric() {
+        MetricsPixel(
+            metric = "onboarding_completed",
+            type = MetricType.NORMAL,
+            value = "",
+            toggle = toggles.onboardingFlowByDownloadReasonExperiment(),
+            conversionWindow = listOf(ConversionWindow(lowerWindow = 0, upperWindow = 0)),
+        ).send()
+    }
+
+    override suspend fun fireDownloadReasonSelectedMetric(reason: DownloadReasonSelection) {
+        MetricsPixel(
+            metric = "download_reason_selected_${reason.pixelToken}",
+            type = MetricType.NORMAL,
+            value = "",
+            toggle = toggles.onboardingFlowByDownloadReasonExperiment(),
+            conversionWindow = listOf(ConversionWindow(lowerWindow = 0, upperWindow = 0)),
+        ).send()
+    }
+
+    override suspend fun fireDownloadReasonSearchRetentionMetrics(reason: DownloadReasonSelection) {
+        val metric = "download_reason_search_retention_${reason.pixelToken}"
+        val toggle = toggles.onboardingFlowByDownloadReasonExperiment()
+        val window = listOf(ConversionWindow(lowerWindow = 5, upperWindow = 7))
+        listOf(
+            MetricsPixel(
+                metric = metric,
+                type = MetricType.COUNT_WHEN_IN_WINDOW,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = window,
+            ),
+            MetricsPixel(
+                metric = metric,
+                type = MetricType.COUNT_WHEN_IN_WINDOW,
+                value = "4",
+                toggle = toggle,
+                conversionWindow = window,
+            ),
+            MetricsPixel(
+                metric = metric,
+                type = MetricType.COUNT_WHEN_IN_WINDOW,
+                value = "6",
+                toggle = toggle,
+                conversionWindow = window,
+            ),
+            MetricsPixel(
+                metric = metric,
+                type = MetricType.COUNT_WHEN_IN_WINDOW,
+                value = "11",
+                toggle = toggle,
+                conversionWindow = window,
+            ),
+            MetricsPixel(
+                metric = metric,
+                type = MetricType.COUNT_WHEN_IN_WINDOW,
+                value = "21",
+                toggle = toggle,
+                conversionWindow = window,
+            ),
+            MetricsPixel(
+                metric = metric,
+                type = MetricType.COUNT_WHEN_IN_WINDOW,
+                value = "30",
+                toggle = toggle,
+                conversionWindow = window,
+            ),
+        ).forEach { it.send() }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/SegmentedOnboardingFeatureToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/SegmentedOnboardingFeatureToggles.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "segmentedOnboarding",
+)
+interface SegmentedOnboardingFeatureToggles {
+
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun self(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun onboardingFlowByDownloadReasonExperiment(): Toggle
+
+    enum class Cohorts(override val cohortName: String) : CohortName {
+        CONTROL("control"),
+        TREATMENT("treatment"),
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/SegmentedOnboardingSearchRetentionAtbPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/SegmentedOnboardingSearchRetentionAtbPlugin.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.onboarding.store.OnboardingStore
+import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class SegmentedOnboardingSearchRetentionAtbPlugin @Inject constructor(
+    private val onboardingStore: OnboardingStore,
+    private val segmentedOnboardingExperimentMetrics: SegmentedOnboardingExperimentMetrics,
+    private val dispatcherProvider: DispatcherProvider,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+) : AtbLifecyclePlugin {
+
+    override fun onSearchRetentionAtbRefreshed(oldAtb: String, newAtb: String) {
+        fireForStoredDownloadReason()
+    }
+
+    // Duck.ai prompts also count towards search retention
+    override fun onDuckAiRetentionAtbRefreshed(oldAtb: String, newAtb: String, metadata: Map<String, String?>) {
+        fireForStoredDownloadReason()
+    }
+
+    private fun fireForStoredDownloadReason() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            val reason = onboardingStore.getDownloadReason() ?: return@launch
+            segmentedOnboardingExperimentMetrics.fireDownloadReasonSearchRetentionMetrics(reason)
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
@@ -37,8 +37,8 @@ import com.duckduckgo.app.onboarding.OnboardingPreferenceCatalog
 import com.duckduckgo.app.onboarding.OnboardingPromptsExperimentManager
 import com.duckduckgo.app.onboarding.SegmentedOnboardingExperimentManager
 import com.duckduckgo.app.onboarding.SegmentedOnboardingExperimentManager.SegmentedOnboardingExperimentVariant
+import com.duckduckgo.app.onboarding.SegmentedOnboardingExperimentMetrics
 import com.duckduckgo.app.onboarding.store.OnboardingStore
-import com.duckduckgo.app.onboarding.store.SegmentedOnboardingPath
 import com.duckduckgo.app.onboarding.ui.page.ComparisonChartConfig
 import com.duckduckgo.app.onboarding.ui.page.OnboardingBackground
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPixelAction
@@ -116,6 +116,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
     private val duckAiOnboardingDemo: DuckAiOnboardingDemo,
     private val onboardingPromptsExperimentManager: OnboardingPromptsExperimentManager,
     private val segmentedOnboardingExperimentManager: SegmentedOnboardingExperimentManager,
+    private val segmentedOnboardingExperimentMetrics: SegmentedOnboardingExperimentMetrics,
     private val onboardingPasswordImportExperimentManager: OnboardingPasswordImportExperimentManager,
     private val onboardingPreferenceCatalog: OnboardingPreferenceCatalog,
     private val singleChoiceDataPlugins: ActivePluginPoint<OnboardingSingleChoiceDataPlugin>,
@@ -131,8 +132,10 @@ class NewUserOnboardingPlanProvider @Inject constructor(
         ctx.isReinstall = appBuildConfig.isAppReinstall()
 
         // A restarted run replays from before the branching step, so a branch persisted by a previous
-        // run must not label this run's pre-branch pixels as branched.
+        // run must not label this run's pre-branch pixels as branched, nor keep driving the contextual
+        // CTAs and the segment retention metrics of a branch this run may never reach.
         onboardingPixelSender.clearFlowAttribution()
+        onboardingStore.setDownloadReason(null)
 
         return if (customAiOnboardingResolver.resolve()) {
             // in custom AI onboarding path, the input toggle is enabled by default
@@ -552,8 +555,11 @@ class NewUserOnboardingPlanProvider @Inject constructor(
                             DownloadReasonSelection.SEARCH
                         }
 
+                        // Persisted before the pixel is fired, so this step's own clicked pixel already
+                        // carries the reason as its `variant_download_reason` param.
+                        onboardingStore.setDownloadReason(selection)
                         onboardingPixelSender.fire(pixelName, OnboardingPixelAction.DownloadReasonClicked(selection))
-                        onboardingPixelSender.downloadReasonSelected(selection)
+                        segmentedOnboardingExperimentMetrics.fireDownloadReasonSelectedMetric(selection)
 
                         when (selection) {
                             DownloadReasonSelection.SEARCH -> SwitchTo(segmentedSearchPlan(ctx))
@@ -570,7 +576,6 @@ class NewUserOnboardingPlanProvider @Inject constructor(
 
     private fun segmentedSearchPlan(ctx: NewUserOnboardingPlanContext): LinearOnboardingPlan {
         val duckAiEnabled = SuspendMemo { duckAiOnboardingAvailability.isDuckAiOnboardingEnabled() }
-        onboardingStore.setSegmentedOnboardingPath(SegmentedOnboardingPath.SEARCH)
         return sidePlan(
             id = SEGMENTED_SEARCH_PLAN_ID,
             steps = listOf(
@@ -605,7 +610,6 @@ class NewUserOnboardingPlanProvider @Inject constructor(
         modelProviderChoice: OnboardingSingleChoiceDataPlugin?,
         togglePositionChoice: OnboardingSingleChoiceDataPlugin?,
     ): LinearOnboardingPlan {
-        onboardingStore.setSegmentedOnboardingPath(SegmentedOnboardingPath.AI)
         applyInputModeSelection(ctx, withAi = true, fireTelemetry = false)
         ctx.onFinish { onboardingInputScreenLaunchTarget.setOpenOnDuckAi() }
         return sidePlan(
@@ -625,7 +629,6 @@ class NewUserOnboardingPlanProvider @Inject constructor(
         ctx: NewUserOnboardingPlanContext,
         duckAiStateChoice: OnboardingSingleChoiceDataPlugin?,
     ): LinearOnboardingPlan {
-        onboardingStore.setSegmentedOnboardingPath(null)
         applyInputModeSelection(ctx, withAi = false, fireTelemetry = false)
         return sidePlan(
             id = SEGMENTED_NO_AI_PLAN_ID,
@@ -650,7 +653,6 @@ class NewUserOnboardingPlanProvider @Inject constructor(
 
     private fun segmentedBlockAdsPlan(ctx: NewUserOnboardingPlanContext): LinearOnboardingPlan {
         val duckAiEnabled = SuspendMemo { duckAiOnboardingAvailability.isDuckAiOnboardingEnabled() }
-        onboardingStore.setSegmentedOnboardingPath(null)
         return sidePlan(
             id = SEGMENTED_BLOCK_ADS_PLAN_ID,
             steps = listOf(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStore.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.onboarding.store
 
 import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
 
 interface OnboardingStore {
     var onboardingDialogJourney: String?
@@ -31,20 +32,14 @@ interface OnboardingStore {
     fun setInputScreenSelectionOverriddenByUser()
     fun setDuckAiOnboardingFlow()
     fun isDuckAiOnboardingFlow(): Boolean
-    fun setSegmentedOnboardingPath(path: SegmentedOnboardingPath?)
+    fun setDownloadReason(reason: DownloadReasonSelection?)
+    fun getDownloadReason(): DownloadReasonSelection?
 
     /**
      * The segmented path the user is on, but only once that path has opted into the input screen. The
      * search path only does so if the user enabled the toggle; the AI path always does. Null everywhere
-     * else, including a search path left without the toggle.
+     * else, including a search path left without the toggle and the paths that never touch the input
+     * screen.
      */
-    fun getSegmentedPathWithAiInput(): SegmentedOnboardingPath?
-}
-
-/**
- * The branch the user picked on the download reason step. Only enumerates a subset of paths that can have side effects on contextual CTAs.
- */
-enum class SegmentedOnboardingPath {
-    SEARCH,
-    AI,
+    fun getSegmentedPathWithAiInput(): DownloadReasonSelection?
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
@@ -21,6 +21,7 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -230,14 +231,18 @@ class OnboardingStoreImpl @Inject constructor(
         return preferences.getBoolean(KEY_DUCK_AI_ONBOARDING_FLOW, false)
     }
 
-    override fun setSegmentedOnboardingPath(path: SegmentedOnboardingPath?) {
-        preferences.edit { putString(KEY_SEGMENTED_ONBOARDING_PATH, path?.name) }
+    override fun setDownloadReason(reason: DownloadReasonSelection?) {
+        preferences.edit { putString(KEY_DOWNLOAD_REASON, reason?.name) }
     }
 
-    override fun getSegmentedPathWithAiInput(): SegmentedOnboardingPath? {
+    override fun getDownloadReason(): DownloadReasonSelection? {
+        val stored = preferences.getString(KEY_DOWNLOAD_REASON, null) ?: return null
+        return DownloadReasonSelection.entries.firstOrNull { it.name == stored }
+    }
+
+    override fun getSegmentedPathWithAiInput(): DownloadReasonSelection? {
         if (getInputScreenSelection() != true) return null
-        val stored = preferences.getString(KEY_SEGMENTED_ONBOARDING_PATH, null) ?: return null
-        return SegmentedOnboardingPath.entries.firstOrNull { it.name == stored }
+        return getDownloadReason()?.takeIf { it == DownloadReasonSelection.SEARCH || it == DownloadReasonSelection.AI_CHAT }
     }
 
     companion object {
@@ -247,6 +252,6 @@ class OnboardingStoreImpl @Inject constructor(
         private const val KEY_INPUT_SCREEN_SELECTION_OVERRIDDEN_BY_USER = "inputScreenSelectionOverriddenByUser"
         private const val KEY_DUCK_AI_ONBOARDING_FLOW = "duckAiOnboardingFlow"
         private const val KEY_LINEAR_PLAN_WIDGET_PROMPT_SHOWN = "linearPlanWidgetPromptShown"
-        private const val KEY_SEGMENTED_ONBOARDING_PATH = "segmentedOnboardingPath"
+        private const val KEY_DOWNLOAD_REASON = "downloadReason"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingPixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingPixelSender.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.global.install.daysInstalled
 import com.duckduckgo.app.onboarding.CustomAiOnboardingStore
 import com.duckduckgo.app.onboarding.OnboardingPreference
 import com.duckduckgo.app.onboarding.orchestrator.PasswordImportOutcome
+import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
 import com.duckduckgo.app.pixels.OnboardingPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -109,12 +110,6 @@ interface OnboardingPixelSender {
     fun segmentedFlowStarted()
 
     /**
-     * Records the download reason the user picked. Persisted so it can be attached as the
-     * `variant_segmented` param to every subsequent onboarding pixel.
-     */
-    fun downloadReasonSelected(reason: DownloadReasonSelection)
-
-    /**
      * Clears the persisted flow and variant attribution. Called when a new linear onboarding run
      * starts: a run restarted after an app kill replays from before the branching step, so
      * attribution persisted by a previous run must not label this run's pre-branch pixels.
@@ -135,6 +130,7 @@ class RealOnboardingPixelSender @Inject constructor(
     private val widgetCapabilities: WidgetCapabilities,
     private val deviceInfo: DeviceInfo,
     private val appBuildConfig: AppBuildConfig,
+    private val onboardingStore: OnboardingStore,
 ) : OnboardingPixelSender {
 
     private val variantPrefs by lazy { sharedPreferencesProvider.getSharedPreferences(PREFS_VARIANT_FILENAME) }
@@ -155,14 +151,9 @@ class RealOnboardingPixelSender @Inject constructor(
         variantPrefs.edit().putBoolean(PREFS_KEY_SEGMENTED_FLOW, true).apply()
     }
 
-    override fun downloadReasonSelected(reason: DownloadReasonSelection) {
-        variantPrefs.edit().putString(PREFS_KEY_DOWNLOAD_REASON, downloadReasonToken(reason)).apply()
-    }
-
     override fun clearFlowAttribution() {
         variantPrefs.edit()
             .remove(PREFS_KEY_VARIANT)
-            .remove(PREFS_KEY_DOWNLOAD_REASON)
             .remove(PREFS_KEY_SEGMENTED_FLOW)
             .apply()
     }
@@ -203,7 +194,7 @@ class RealOnboardingPixelSender @Inject constructor(
                 fireStep(pixelName, PIXEL_EVENT_CONFIRMED, action.outcome.value)
 
             is OnboardingPixelAction.DownloadReasonClicked ->
-                fireStep(pixelName, PIXEL_EVENT_CLICKED, downloadReasonToken(action.reason))
+                fireStep(pixelName, PIXEL_EVENT_CLICKED, action.reason.pixelToken)
 
             is OnboardingPixelAction.PreferencesClicked ->
                 fireStep(pixelName, PIXEL_EVENT_CLICKED, extraParams = preferenceParams(action.selections))
@@ -297,7 +288,7 @@ class RealOnboardingPixelSender @Inject constructor(
             PIXEL_PARAM_PIXEL_SOURCE to deviceInfo.formFactor().description,
         )
         attribution.branchVariant?.let { params[PIXEL_PARAM_VARIANT] = it }
-        attribution.segmentedVariant?.let { params[PIXEL_PARAM_VARIANT_SEGMENTED] = it }
+        attribution.downloadReasonVariant?.let { params[PIXEL_PARAM_VARIANT_DOWNLOAD_REASON] = it }
         params[PIXEL_PARAM_DAYS_SINCE_INSTALL] = daysSinceInstallBucket(days)
         return params
     }
@@ -317,8 +308,8 @@ class RealOnboardingPixelSender @Inject constructor(
             PREFS_VARIANT_CHAT -> VARIANT_CHAT
             else -> null
         },
-        segmentedVariant = variantPrefs.getString(PREFS_KEY_DOWNLOAD_REASON, null)
-            ?.let { "$VARIANT_DOWNLOAD_REASON_PREFIX$it" },
+        downloadReasonVariant = onboardingStore.getDownloadReason()
+            ?.let { "$VARIANT_DOWNLOAD_REASON_PREFIX${it.pixelToken}" },
     )
 
     /**
@@ -329,15 +320,8 @@ class RealOnboardingPixelSender @Inject constructor(
     private data class FlowAttribution(
         val isSegmentedFlow: Boolean,
         val branchVariant: String?,
-        val segmentedVariant: String?,
+        val downloadReasonVariant: String?,
     )
-
-    private fun downloadReasonToken(reason: DownloadReasonSelection): String = when (reason) {
-        DownloadReasonSelection.SEARCH -> DOWNLOAD_REASON_SEARCH
-        DownloadReasonSelection.AI_CHAT -> DOWNLOAD_REASON_AI_CHAT
-        DownloadReasonSelection.NO_AI -> DOWNLOAD_REASON_NO_AI
-        DownloadReasonSelection.BLOCK_ADS -> DOWNLOAD_REASON_AD_BLOCKING
-    }
 
     private fun preferenceParams(selections: Map<OnboardingPreference, Boolean>): Map<String, String> =
         selections.entries.associate { (preference, enabled) ->
@@ -380,7 +364,7 @@ class RealOnboardingPixelSender @Inject constructor(
         private const val PIXEL_PARAM_DAYS_SINCE_INSTALL = "daysSinceInstall"
         private const val PIXEL_PARAM_FLOW = "flow"
         private const val PIXEL_PARAM_VARIANT = "variant"
-        private const val PIXEL_PARAM_VARIANT_SEGMENTED = "variant_segmented"
+        private const val PIXEL_PARAM_VARIANT_DOWNLOAD_REASON = "variant_download_reason"
         private const val PIXEL_PARAM_PIXEL_SOURCE = "pixelSource"
 
         private const val PIXEL_EVENT_SHOWN = "shown"
@@ -400,15 +384,9 @@ class RealOnboardingPixelSender @Inject constructor(
 
         private const val PREFS_VARIANT_FILENAME = "com.duckduckgo.app.onboarding.variant"
         private const val PREFS_KEY_VARIANT = "variant"
-        private const val PREFS_KEY_DOWNLOAD_REASON = "downloadReason"
         private const val PREFS_KEY_SEGMENTED_FLOW = "segmentedFlow"
         private const val PREFS_VARIANT_SEARCH = "search"
         private const val PREFS_VARIANT_CHAT = "chat"
-
-        private const val DOWNLOAD_REASON_SEARCH = "search"
-        private const val DOWNLOAD_REASON_AI_CHAT = "ai-chat"
-        private const val DOWNLOAD_REASON_NO_AI = "no-ai"
-        private const val DOWNLOAD_REASON_AD_BLOCKING = "ad-blocking"
 
         private const val PARAM_RECENTLY_VISITED_SITES_ENABLED = "recently_visited_sites_enabled"
         private const val PARAM_SAFE_SEARCH_ENABLED = "safe_search_enabled"

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ContentConfig.kt
@@ -210,10 +210,3 @@ data class DownloadReasonContentState(val selection: DownloadReasonSelection?)
 data class PreferenceSelectorContentState(val enabled: Map<OnboardingPreference, Boolean>)
 
 data class SingleChoiceContentState(val selected: Option)
-
-enum class DownloadReasonSelection {
-    SEARCH,
-    AI_CHAT,
-    NO_AI,
-    BLOCK_ADS,
-}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DownloadReasonSelection.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DownloadReasonSelection.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.page.configdriven
+
+enum class DownloadReasonSelection(val pixelToken: String) {
+    SEARCH("search"),
+    AI_CHAT("ai-chat"),
+    NO_AI("no-ai"),
+    BLOCK_ADS("ad-blocking"),
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -221,10 +221,10 @@ import com.duckduckgo.app.onboarding.OnboardingInputScreenLaunchTarget
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.AppStage.ESTABLISHED
 import com.duckduckgo.app.onboarding.store.OnboardingStore
-import com.duckduckgo.app.onboarding.store.SegmentedOnboardingPath
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPixelAction
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPixelSender
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.pixels.AppPixelName
@@ -4129,7 +4129,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenUserClickedSegmentedSearchEndCtaOkButtonThenBubbleHiddenAndInputOpensOnDuckAiTab() = runTest {
-        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = SegmentedOnboardingPath.SEARCH)
+        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = DownloadReasonSelection.SEARCH)
         setCta(cta)
 
         testee.onUserClickCtaOkButton(cta)
@@ -4155,7 +4155,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenUserClickedSegmentedSearchEndCtaSecondaryButtonThenCtaIsRefreshedAway() = runTest {
-        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = SegmentedOnboardingPath.SEARCH)
+        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = DownloadReasonSelection.SEARCH)
         setCta(cta)
 
         testee.onUserClickCtaSecondaryButton(cta)
@@ -4165,7 +4165,7 @@ class BrowserTabViewModelTest {
         verify(mockOnboardingInputScreenLaunchTarget, never()).setOpenOnDuckAi()
     }
 
-    private fun daxEndBrandDesignUpdateBubbleCta(segmentedPath: SegmentedOnboardingPath?) = DaxEndBrandDesignUpdateBubbleCta(
+    private fun daxEndBrandDesignUpdateBubbleCta(segmentedPath: DownloadReasonSelection?) = DaxEndBrandDesignUpdateBubbleCta(
         onboardingStore = mockOnboardingStore,
         appInstallStore = mockAppInstallStore,
         isLightTheme = true,
@@ -4238,7 +4238,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenUserClickedDaxSubscriptionCtaOnSegmentedAiPathThenLaunchSubscriptionWithFeaturePageDuckAi() = runTest {
-        whenever(mockOnboardingStore.getSegmentedPathWithAiInput()).thenReturn(SegmentedOnboardingPath.AI)
+        whenever(mockOnboardingStore.getSegmentedPathWithAiInput()).thenReturn(DownloadReasonSelection.AI_CHAT)
         val cta = DaxBubbleCta.DaxSubscriptionCta(
             mockOnboardingStore,
             mockAppInstallStore,
@@ -4254,7 +4254,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenUserClickedSegmentedAiEndCtaOkButtonThenCtaIsRefreshedAway() = runTest {
-        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = SegmentedOnboardingPath.AI)
+        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = DownloadReasonSelection.AI_CHAT)
         setCta(cta)
 
         testee.onUserClickCtaOkButton(cta)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignUpdateBubbleCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignUpdateBubbleCtaTest.kt
@@ -28,7 +28,7 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.store.OnboardingStore
-import com.duckduckgo.app.onboarding.store.SegmentedOnboardingPath
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleBrandDesignUpdateCardView
@@ -363,7 +363,7 @@ class BrandDesignUpdateBubbleCtaTest {
             deviceInfo = mockDeviceInfo,
             isCustomAiOnboardingFlow = false,
             isFreeTrialCopy = false,
-            segmentedPath = SegmentedOnboardingPath.AI,
+            segmentedPath = DownloadReasonSelection.AI_CHAT,
             onboardingImprovementsEnabled = true,
             onboardingImprovementsV2Enabled = true,
         )
@@ -379,7 +379,7 @@ class BrandDesignUpdateBubbleCtaTest {
             deviceInfo = mockDeviceInfo,
             isCustomAiOnboardingFlow = false,
             isFreeTrialCopy = false,
-            segmentedPath = SegmentedOnboardingPath.SEARCH,
+            segmentedPath = DownloadReasonSelection.SEARCH,
             onboardingImprovementsEnabled = true,
             onboardingImprovementsV2Enabled = true,
         )

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -41,10 +41,10 @@ import com.duckduckgo.app.onboarding.CustomAiOnboardingStore
 import com.duckduckgo.app.onboarding.RealDuckAiOnboardingDemo
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.OnboardingStore
-import com.duckduckgo.app.onboarding.store.SegmentedOnboardingPath
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPixelAction
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPixelSender
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.pixels.AppPixelName.*
@@ -1457,7 +1457,7 @@ class CtaViewModelTest {
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)
         givenAtLeastOneDaxDialogCtaShown()
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
-        whenever(mockOnboardingStore.getSegmentedPathWithAiInput()).thenReturn(SegmentedOnboardingPath.SEARCH)
+        whenever(mockOnboardingStore.getSegmentedPathWithAiInput()).thenReturn(DownloadReasonSelection.SEARCH)
 
         val value = testee.refreshCta(
             coroutineRule.testDispatcher,
@@ -1466,7 +1466,7 @@ class CtaViewModelTest {
             brokenSitePromptUrl = null,
         )
 
-        assertEquals(SegmentedOnboardingPath.SEARCH, (value as DaxEndBrandDesignUpdateBubbleCta).segmentedPathWithAiInput)
+        assertEquals(DownloadReasonSelection.SEARCH, (value as DaxEndBrandDesignUpdateBubbleCta).segmentedPathWithAiInput)
         verify(mockDuckChat).setInputScreenUserSetting(true)
     }
 
@@ -1477,7 +1477,7 @@ class CtaViewModelTest {
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)
         givenAtLeastOneDaxDialogCtaShown()
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
-        whenever(mockOnboardingStore.getSegmentedPathWithAiInput()).thenReturn(SegmentedOnboardingPath.AI)
+        whenever(mockOnboardingStore.getSegmentedPathWithAiInput()).thenReturn(DownloadReasonSelection.AI_CHAT)
 
         val value = testee.refreshCta(
             coroutineRule.testDispatcher,
@@ -1487,7 +1487,7 @@ class CtaViewModelTest {
         )
 
         value as DaxEndBrandDesignUpdateBubbleCta
-        assertEquals(SegmentedOnboardingPath.AI, value.segmentedPathWithAiInput)
+        assertEquals(DownloadReasonSelection.AI_CHAT, value.segmentedPathWithAiInput)
         // The AI path's own copy lives on the Duck.ai End CTA, which it reaches by submitting a chat.
         assertEquals(R.string.onboardingEndDaxDialogDescription, value.description)
         verify(mockDuckChat).setInputScreenUserSetting(true)
@@ -1564,7 +1564,7 @@ class CtaViewModelTest {
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_END)).thenReturn(true)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
-        whenever(mockOnboardingStore.getSegmentedPathWithAiInput()).thenReturn(SegmentedOnboardingPath.AI)
+        whenever(mockOnboardingStore.getSegmentedPathWithAiInput()).thenReturn(DownloadReasonSelection.AI_CHAT)
 
         val value = testee.refreshCta(
             coroutineRule.testDispatcher,
@@ -1862,7 +1862,7 @@ class CtaViewModelTest {
         givenCanShowDuckAiEndCta()
         showInputScreenFlow.value = false
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
-        whenever(mockOnboardingStore.getSegmentedPathWithAiInput()).thenReturn(SegmentedOnboardingPath.AI)
+        whenever(mockOnboardingStore.getSegmentedPathWithAiInput()).thenReturn(DownloadReasonSelection.AI_CHAT)
 
         val cta = testee.refreshCta(
             coroutineRule.testDispatcher,
@@ -1980,7 +1980,7 @@ class CtaViewModelTest {
             isLightTheme = true,
             deviceInfo = mockDeviceInfo,
             isCustomAiOnboardingFlow = false,
-            segmentedPath = SegmentedOnboardingPath.AI,
+            segmentedPath = DownloadReasonSelection.AI_CHAT,
             onboardingImprovementsV2Enabled = true,
         )
         assertEquals(R.string.aiPathWithToggleEnabledContextualEndDescription, cta.description)
@@ -1994,7 +1994,7 @@ class CtaViewModelTest {
             isLightTheme = true,
             deviceInfo = mockDeviceInfo,
             isCustomAiOnboardingFlow = false,
-            segmentedPath = SegmentedOnboardingPath.SEARCH,
+            segmentedPath = DownloadReasonSelection.SEARCH,
             onboardingImprovementsV2Enabled = true,
         )
         assertEquals(R.string.onboardingDuckAiEndCtaDescription, cta.description)
@@ -2402,7 +2402,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenSegmentedSearchPathEndBubbleShownThenBothEndAndTryDuckAiShownPixelsFired() = runTest {
-        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = SegmentedOnboardingPath.SEARCH)
+        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = DownloadReasonSelection.SEARCH)
 
         testee.onCtaShown(cta)
 
@@ -2412,7 +2412,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenSegmentedSearchPathEndBubbleOkClickedThenBothEndAndTryDuckAiClickedEngageFired() = runTest {
-        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = SegmentedOnboardingPath.SEARCH)
+        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = DownloadReasonSelection.SEARCH)
 
         testee.onUserClickCtaOkButton(cta)
 
@@ -2422,7 +2422,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenSegmentedSearchPathEndBubbleSkippedThenBothEndAndTryDuckAiClickedDismissFired() = runTest {
-        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = SegmentedOnboardingPath.SEARCH)
+        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = DownloadReasonSelection.SEARCH)
 
         testee.onUserDismissedCta(cta, viaSkipBtn = true)
 
@@ -2432,7 +2432,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenSegmentedAiPathEndBubbleShownThenTryDuckAiPixelNotFired() = runTest {
-        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = SegmentedOnboardingPath.AI)
+        val cta = daxEndBrandDesignUpdateBubbleCta(segmentedPath = DownloadReasonSelection.AI_CHAT)
 
         testee.onCtaShown(cta)
 
@@ -2543,7 +2543,7 @@ class CtaViewModelTest {
         onboardingImprovementsV2Enabled = true,
     )
 
-    private fun daxEndBrandDesignUpdateBubbleCta(segmentedPath: SegmentedOnboardingPath? = null) = DaxEndBrandDesignUpdateBubbleCta(
+    private fun daxEndBrandDesignUpdateBubbleCta(segmentedPath: DownloadReasonSelection? = null) = DaxEndBrandDesignUpdateBubbleCta(
         mockOnboardingStore,
         mockAppInstallStore,
         isLightTheme = true,

--- a/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingCompletedMetricObserverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingCompletedMetricObserverTest.kt
@@ -37,12 +37,14 @@ class OnboardingCompletedMetricObserverTest {
     private val appStageFlow = MutableSharedFlow<AppStage>(replay = 1)
     private val userStageStore: UserStageStore = mock { on { userAppStageFlow() } doReturn appStageFlow }
     private val metrics: OnboardingPromptsExperimentMetrics = mock()
+    private val segmentedMetrics: SegmentedOnboardingExperimentMetrics = mock()
     private val lifecycleOwner: LifecycleOwner = mock()
 
     private val testee = OnboardingCompletedMetricObserver(
         appCoroutineScope = coroutineRule.testScope,
         userStageStore = userStageStore,
         onboardingPromptsExperimentMetrics = metrics,
+        segmentedOnboardingExperimentMetrics = segmentedMetrics,
     )
 
     @Test
@@ -62,5 +64,24 @@ class OnboardingCompletedMetricObserverTest {
         appStageFlow.emit(AppStage.DAX_ONBOARDING)
 
         verify(metrics, never()).fireOnboardingCompletedMetric()
+    }
+
+    @Test
+    fun `when user app stage becomes established then segmented onboarding completed metric is fired`() = runTest {
+        testee.onCreate(lifecycleOwner)
+
+        appStageFlow.emit(AppStage.ESTABLISHED)
+
+        verify(segmentedMetrics).fireOnboardingCompletedMetric()
+    }
+
+    @Test
+    fun `when user app stage is not established then segmented onboarding completed metric is not fired`() = runTest {
+        testee.onCreate(lifecycleOwner)
+
+        appStageFlow.emit(AppStage.NEW)
+        appStageFlow.emit(AppStage.DAX_ONBOARDING)
+
+        verify(segmentedMetrics, never()).fireOnboardingCompletedMetric()
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingInputScreenSelectionObserverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingInputScreenSelectionObserverTest.kt
@@ -18,8 +18,8 @@ package com.duckduckgo.app.onboarding
 
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.OnboardingStore
-import com.duckduckgo.app.onboarding.store.SegmentedOnboardingPath
 import com.duckduckgo.app.onboarding.store.UserStageStore
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.duckchat.api.DuckChat
@@ -249,7 +249,7 @@ class OnboardingInputScreenSelectionObserverTest {
     @Test
     fun whenOnSegmentedPathWithAiInputAndSettingEnabledBeforeEstablishedThenDoNotMarkAsOverriddenByUser() =
         runTest {
-            whenever(mockOnboardingStore.getSegmentedPathWithAiInput()).thenReturn(SegmentedOnboardingPath.SEARCH)
+            whenever(mockOnboardingStore.getSegmentedPathWithAiInput()).thenReturn(DownloadReasonSelection.SEARCH)
             whenever(mockUserStageStore.userAppStageFlow()).thenReturn(userAppStageFlow)
             whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
             whenever(mockOnboardingStore.getInputScreenSelection()).thenReturn(true)
@@ -277,7 +277,7 @@ class OnboardingInputScreenSelectionObserverTest {
     @Test
     fun whenOnSegmentedPathWithAiInputAndUserStageIsEstablishedThenStillApplySelection() =
         runTest {
-            whenever(mockOnboardingStore.getSegmentedPathWithAiInput()).thenReturn(SegmentedOnboardingPath.SEARCH)
+            whenever(mockOnboardingStore.getSegmentedPathWithAiInput()).thenReturn(DownloadReasonSelection.SEARCH)
             whenever(mockUserStageStore.userAppStageFlow()).thenReturn(userAppStageFlow)
             whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
             whenever(mockOnboardingStore.getInputScreenSelection()).thenReturn(true)

--- a/app/src/test/java/com/duckduckgo/app/onboarding/SegmentedOnboardingExperimentManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/SegmentedOnboardingExperimentManagerTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import android.annotation.SuppressLint
+import com.duckduckgo.app.onboarding.SegmentedOnboardingExperimentManager.SegmentedOnboardingExperimentVariant
+import com.duckduckgo.app.onboarding.SegmentedOnboardingFeatureToggles.Cohorts
+import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@SuppressLint("DenyListedApi")
+class SegmentedOnboardingExperimentManagerTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val segmentedToggles: SegmentedOnboardingFeatureToggles =
+        FakeFeatureToggleFactory.create(SegmentedOnboardingFeatureToggles::class.java)
+    private val brandDesignToggles: OnboardingBrandDesignUpdateToggles =
+        FakeFeatureToggleFactory.create(OnboardingBrandDesignUpdateToggles::class.java)
+    private val passwordImportToggles: OnboardingPasswordImportToggles =
+        FakeFeatureToggleFactory.create(OnboardingPasswordImportToggles::class.java)
+    private val promptsToggles: OnboardingPromptsToggles =
+        FakeFeatureToggleFactory.create(OnboardingPromptsToggles::class.java)
+    private val privacyConfigPersistedGate = OnboardingPrivacyConfigPersistedGateImpl()
+    private val appBuildConfig: AppBuildConfig = mock()
+
+    private val testee = SegmentedOnboardingExperimentManagerImpl(
+        onboardingBrandDesignUpdateToggles = brandDesignToggles,
+        segmentedOnboardingFeatureToggles = segmentedToggles,
+        onboardingPasswordImportToggles = passwordImportToggles,
+        onboardingPromptsToggles = promptsToggles,
+        appBuildConfig = appBuildConfig,
+        dispatcherProvider = coroutineRule.testDispatcherProvider,
+        onboardingPrivacyConfigPersistedGate = privacyConfigPersistedGate,
+    )
+
+    @Test
+    fun `when privacy config never persisted then enroll returns null`() = runTest {
+        givenPrerequisitesMet()
+        givenCohortEnabled(Cohorts.TREATMENT)
+
+        assertNull(testee.enroll())
+    }
+
+    @Test
+    fun `when config driven dialogs disabled then enroll returns null`() = runTest {
+        givenPrerequisitesMet()
+        brandDesignToggles.configDrivenDialogs().setRawStoredState(Toggle.State(enable = false))
+        givenCohortEnabled(Cohorts.TREATMENT)
+
+        privacyConfigPersistedGate.onPrivacyConfigPersisted()
+
+        assertNull(testee.enroll())
+    }
+
+    @Test
+    fun `when brand design update disabled then enroll returns null`() = runTest {
+        givenPrerequisitesMet()
+        brandDesignToggles.brandDesignUpdate().setRawStoredState(Toggle.State(enable = false))
+        givenCohortEnabled(Cohorts.TREATMENT)
+
+        privacyConfigPersistedGate.onPrivacyConfigPersisted()
+
+        assertNull(testee.enroll())
+    }
+
+    @Test
+    fun `when experiment disabled then enroll returns null`() = runTest {
+        givenPrerequisitesMet()
+        givenCohortEnabled(winner = null)
+
+        privacyConfigPersistedGate.onPrivacyConfigPersisted()
+
+        assertNull(testee.enroll())
+    }
+
+    @Test
+    fun `when enrolled in control then enroll returns control`() = runTest {
+        givenPrerequisitesMet()
+        givenCohortEnabled(Cohorts.CONTROL)
+
+        privacyConfigPersistedGate.onPrivacyConfigPersisted()
+
+        assertEquals(SegmentedOnboardingExperimentVariant.CONTROL, testee.enroll())
+    }
+
+    @Test
+    fun `when enrolled in treatment then enroll returns treatment`() = runTest {
+        givenPrerequisitesMet()
+        givenCohortEnabled(Cohorts.TREATMENT)
+
+        privacyConfigPersistedGate.onPrivacyConfigPersisted()
+
+        assertEquals(SegmentedOnboardingExperimentVariant.TREATMENT, testee.enroll())
+    }
+
+    @Test
+    fun `when returning user then enroll returns null`() = runTest {
+        givenPrerequisitesMet()
+        whenever(appBuildConfig.isAppReinstall()).thenReturn(true)
+        givenCohortEnabled(Cohorts.TREATMENT)
+
+        privacyConfigPersistedGate.onPrivacyConfigPersisted()
+
+        assertNull(testee.enroll())
+    }
+
+    @Test
+    fun `when enroll called twice then same variant is returned both times`() = runTest {
+        givenPrerequisitesMet()
+        givenCohortEnabled(Cohorts.TREATMENT)
+
+        privacyConfigPersistedGate.onPrivacyConfigPersisted()
+
+        assertEquals(testee.enroll(), testee.enroll())
+    }
+
+    @Test
+    fun `when add to dock and widget experiment enabled then enroll returns null`() = runTest {
+        givenPrerequisitesMet()
+        promptsToggles.addToDockAndWidgetExperimentJul25().setRawStoredState(Toggle.State(enable = true))
+        givenCohortEnabled(Cohorts.TREATMENT)
+
+        privacyConfigPersistedGate.onPrivacyConfigPersisted()
+
+        assertNull(testee.enroll())
+    }
+
+    @Test
+    fun `when password import experiment enabled then enroll returns null`() = runTest {
+        givenPrerequisitesMet()
+        passwordImportToggles.passwordImportExperimentAug25().setRawStoredState(Toggle.State(enable = true))
+        givenCohortEnabled(Cohorts.TREATMENT)
+
+        privacyConfigPersistedGate.onPrivacyConfigPersisted()
+
+        assertNull(testee.enroll())
+    }
+
+    private suspend fun givenPrerequisitesMet() {
+        brandDesignToggles.brandDesignUpdate().setRawStoredState(Toggle.State(enable = true))
+        brandDesignToggles.configDrivenDialogs().setRawStoredState(Toggle.State(enable = true))
+        whenever(appBuildConfig.isAppReinstall()).thenReturn(false)
+        promptsToggles.addToDockAndWidgetExperimentJul25().setRawStoredState(Toggle.State(enable = false))
+        passwordImportToggles.passwordImportExperimentAug25().setRawStoredState(Toggle.State(enable = false))
+    }
+
+    private fun givenCohortEnabled(winner: Cohorts?) {
+        segmentedToggles.onboardingFlowByDownloadReasonExperiment().setRawStoredState(
+            Toggle.State(
+                remoteEnableState = true,
+                enable = winner != null,
+                cohorts = Cohorts.entries.map {
+                    Toggle.State.Cohort(name = it.cohortName, weight = if (it == winner) 1 else 0)
+                },
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/onboarding/SegmentedOnboardingExperimentMetricsTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/SegmentedOnboardingExperimentMetricsTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import android.annotation.SuppressLint
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.FakeMetricsPixelExtension
+import com.duckduckgo.feature.toggles.api.MetricType
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@SuppressLint("DenyListedApi")
+class SegmentedOnboardingExperimentMetricsTest {
+
+    private val fakeMetricsPixelExtension = FakeMetricsPixelExtension()
+    private val toggles = FakeFeatureToggleFactory.create(SegmentedOnboardingFeatureToggles::class.java)
+    private lateinit var metrics: SegmentedOnboardingExperimentMetrics
+
+    @Before
+    fun setup() {
+        fakeMetricsPixelExtension.register()
+        metrics = SegmentedOnboardingExperimentMetricsImpl(toggles = toggles)
+    }
+
+    @Test
+    fun `when fireOnboardingCompletedMetric then sends onboarding_completed d0 NORMAL metric with an empty value`() = runTest {
+        metrics.fireOnboardingCompletedMetric()
+
+        val sent = fakeMetricsPixelExtension.sentMetrics.single()
+        assertEquals("onboarding_completed", sent.metric)
+        assertEquals("", sent.value)
+        assertEquals(MetricType.NORMAL, sent.type)
+        assertEquals(listOf(ConversionWindow(lowerWindow = 0, upperWindow = 0)), sent.conversionWindow)
+        assertEquals(
+            toggles.onboardingFlowByDownloadReasonExperiment().featureName().name,
+            sent.toggle.featureName().name,
+        )
+    }
+
+    @Test
+    fun `when fireDownloadReasonSelectedMetric then the reason token is part of the metric name`() = runTest {
+        val expected = mapOf(
+            DownloadReasonSelection.SEARCH to "download_reason_selected_search",
+            DownloadReasonSelection.AI_CHAT to "download_reason_selected_ai-chat",
+            DownloadReasonSelection.NO_AI to "download_reason_selected_no-ai",
+            DownloadReasonSelection.BLOCK_ADS to "download_reason_selected_ad-blocking",
+        )
+
+        assertEquals(DownloadReasonSelection.entries.toSet(), expected.keys)
+
+        expected.forEach { (reason, metricName) ->
+            fakeMetricsPixelExtension.sentMetrics.clear()
+
+            metrics.fireDownloadReasonSelectedMetric(reason)
+
+            val sent = fakeMetricsPixelExtension.sentMetrics.single()
+            assertEquals(metricName, sent.metric)
+            assertEquals("", sent.value)
+            assertEquals(MetricType.NORMAL, sent.type)
+            assertEquals(listOf(ConversionWindow(lowerWindow = 0, upperWindow = 0)), sent.conversionWindow)
+        }
+    }
+
+    @Test
+    fun `when fireDownloadReasonSearchRetentionMetrics then sends the six d5-7 thresholds for that reason`() = runTest {
+        metrics.fireDownloadReasonSearchRetentionMetrics(DownloadReasonSelection.AI_CHAT)
+
+        val sent = fakeMetricsPixelExtension.sentMetrics
+        assertEquals(6, sent.size)
+        assertEquals(listOf("1", "4", "6", "11", "21", "30"), sent.map { it.value })
+        sent.forEach {
+            assertEquals("download_reason_search_retention_ai-chat", it.metric)
+            assertEquals(MetricType.COUNT_WHEN_IN_WINDOW, it.type)
+            assertEquals(listOf(ConversionWindow(lowerWindow = 5, upperWindow = 7)), it.conversionWindow)
+        }
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/onboarding/SegmentedOnboardingSearchRetentionAtbPluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/SegmentedOnboardingSearchRetentionAtbPluginTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import com.duckduckgo.app.onboarding.store.OnboardingStore
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+class SegmentedOnboardingSearchRetentionAtbPluginTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val metrics: SegmentedOnboardingExperimentMetrics = mock()
+
+    @Test
+    fun `when no download reason stored then no retention metrics are fired`() = runTest {
+        val testee = testee(reason = null)
+
+        testee.onSearchRetentionAtbRefreshed("v1-1", "v1-2")
+
+        verify(metrics, never()).fireDownloadReasonSearchRetentionMetrics(any())
+    }
+
+    @Test
+    fun `when a download reason is stored then retention metrics are fired for it`() = runTest {
+        val testee = testee(reason = DownloadReasonSelection.BLOCK_ADS)
+
+        testee.onSearchRetentionAtbRefreshed("v1-1", "v1-2")
+
+        verify(metrics).fireDownloadReasonSearchRetentionMetrics(DownloadReasonSelection.BLOCK_ADS)
+    }
+
+    @Test
+    fun `when a duck ai prompt refreshes retention then retention metrics are fired for the stored reason`() = runTest {
+        val testee = testee(reason = DownloadReasonSelection.AI_CHAT)
+
+        testee.onDuckAiRetentionAtbRefreshed("v1-1", "v1-2", emptyMap())
+
+        verify(metrics).fireDownloadReasonSearchRetentionMetrics(DownloadReasonSelection.AI_CHAT)
+    }
+
+    private fun testee(reason: DownloadReasonSelection?) = SegmentedOnboardingSearchRetentionAtbPlugin(
+        onboardingStore = mock<OnboardingStore> { on { getDownloadReason() } doReturn reason },
+        segmentedOnboardingExperimentMetrics = metrics,
+        dispatcherProvider = coroutineRule.testDispatcherProvider,
+        appCoroutineScope = coroutineRule.testScope,
+    )
+}

--- a/app/src/test/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProviderTest.kt
@@ -36,9 +36,9 @@ import com.duckduckgo.app.onboarding.OnboardingPreferenceCatalog
 import com.duckduckgo.app.onboarding.OnboardingPromptsExperimentManager
 import com.duckduckgo.app.onboarding.SegmentedOnboardingExperimentManager
 import com.duckduckgo.app.onboarding.SegmentedOnboardingExperimentManager.SegmentedOnboardingExperimentVariant
+import com.duckduckgo.app.onboarding.SegmentedOnboardingExperimentMetrics
 import com.duckduckgo.app.onboarding.TestOption
 import com.duckduckgo.app.onboarding.store.OnboardingStore
-import com.duckduckgo.app.onboarding.store.SegmentedOnboardingPath
 import com.duckduckgo.app.onboarding.ui.page.ComparisonChartConfig
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPixelAction
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPixelSender
@@ -96,6 +96,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -128,6 +129,7 @@ class NewUserOnboardingPlanProviderTest {
     private val duckAiOnboardingDemo: DuckAiOnboardingDemo = mock()
     private val homeScreenPromptsExperiment: OnboardingPromptsExperimentManager = mock()
     private val segmentedOnboardingExperiment: SegmentedOnboardingExperimentManager = mock()
+    private val segmentedOnboardingMetrics: SegmentedOnboardingExperimentMetrics = mock()
     private val onboardingPreferenceCatalog: OnboardingPreferenceCatalog = mock {
         onBlocking { offer(any()) } doReturn emptyList()
     }
@@ -194,6 +196,7 @@ class NewUserOnboardingPlanProviderTest {
             duckAiOnboardingDemo = duckAiOnboardingDemo,
             onboardingPromptsExperimentManager = homeScreenPromptsExperiment,
             segmentedOnboardingExperimentManager = segmentedOnboardingExperiment,
+            segmentedOnboardingExperimentMetrics = segmentedOnboardingMetrics,
             onboardingPasswordImportExperimentManager = passwordImportExperiment,
             onboardingPreferenceCatalog = onboardingPreferenceCatalog,
             singleChoiceDataPlugins = singleChoiceDataPlugins,
@@ -262,7 +265,32 @@ class NewUserOnboardingPlanProviderTest {
 
         orchestrator.onEvent(NewUserOnboardingEvent.DownloadReasonConfirmed(DownloadReasonSelection.AI_CHAT))
 
-        verify(onboardingStore).setSegmentedOnboardingPath(SegmentedOnboardingPath.AI)
+        verify(onboardingStore).setDownloadReason(DownloadReasonSelection.AI_CHAT)
+    }
+
+    @Test
+    fun `when a run starts then a download reason left by an abandoned run is cleared`() = runTest {
+        startSegmentedAtDownloadReason()
+
+        verify(onboardingStore).setDownloadReason(null)
+    }
+
+    @Test
+    fun `when a download reason is picked then the selection metric is fired for it`() = runTest {
+        startSegmentedAtDownloadReason()
+
+        orchestrator.onEvent(NewUserOnboardingEvent.DownloadReasonConfirmed(DownloadReasonSelection.AI_CHAT))
+
+        verify(segmentedOnboardingMetrics).fireDownloadReasonSelectedMetric(DownloadReasonSelection.AI_CHAT)
+    }
+
+    @Test
+    fun `when the download reason is missing then the fallback selection metric is fired`() = runTest {
+        startSegmentedAtDownloadReason()
+
+        orchestrator.onEvent(NewUserOnboardingEvent.DownloadReasonConfirmed(selection = null))
+
+        verify(segmentedOnboardingMetrics).fireDownloadReasonSelectedMetric(DownloadReasonSelection.SEARCH)
     }
 
     private suspend fun startSegmentedAtAiProviderChoice() {
@@ -499,23 +527,23 @@ class NewUserOnboardingPlanProviderTest {
     }
 
     @Test
-    fun `when the no ai download reason is confirmed then it clears an input screen selection left by an abandoned run`() = runTest {
+    fun `when the no ai download reason is confirmed then it is persisted and clears an input screen selection left by an abandoned run`() = runTest {
         startSegmentedAtDownloadReason()
 
         orchestrator.onEvent(NewUserOnboardingEvent.DownloadReasonConfirmed(DownloadReasonSelection.NO_AI))
 
-        verify(onboardingStore).setSegmentedOnboardingPath(null)
+        verify(onboardingStore).setDownloadReason(DownloadReasonSelection.NO_AI)
         verify(duckChat).setCosmeticInputScreenUserSetting(false)
         verify(onboardingStore).storeInputScreenSelection(false)
     }
 
     @Test
-    fun `when the block ads download reason is confirmed then it clears a segmented path left by an abandoned run`() = runTest {
+    fun `when the block ads download reason is confirmed then it is persisted`() = runTest {
         startSegmentedAtDownloadReason()
 
         orchestrator.onEvent(NewUserOnboardingEvent.DownloadReasonConfirmed(DownloadReasonSelection.BLOCK_ADS))
 
-        verify(onboardingStore).setSegmentedOnboardingPath(null)
+        verify(onboardingStore).setDownloadReason(DownloadReasonSelection.BLOCK_ADS)
     }
 
     @Test
@@ -721,7 +749,7 @@ class NewUserOnboardingPlanProviderTest {
         verify(onboardingPreferenceCatalog, never()).apply(any())
         assertStep(NewUserOnboardingStepIds.INPUT_SCREEN)
         orchestrator.onEvent(NewUserOnboardingEvent.InputModeConfirmed(withAi = false))
-        verify(onboardingStore).setSegmentedOnboardingPath(SegmentedOnboardingPath.SEARCH)
+        verify(onboardingStore).setDownloadReason(DownloadReasonSelection.SEARCH)
         assertStep(NewUserOnboardingStepIds.ADDRESS_BAR_POSITION)
         orchestrator.onEvent(NewUserOnboardingEvent.AddressBarConfirmed(OmnibarType.SINGLE_TOP))
         assertStep(NewUserOnboardingStepIds.INPUT_SCREEN_PREVIEW)
@@ -757,7 +785,7 @@ class NewUserOnboardingPlanProviderTest {
         assertStep(NewUserOnboardingStepIds.INPUT_SCREEN)
         orchestrator.onEvent(NewUserOnboardingEvent.InputModeConfirmed(withAi = true))
 
-        verify(onboardingStore).setSegmentedOnboardingPath(SegmentedOnboardingPath.SEARCH)
+        verify(onboardingStore).setDownloadReason(DownloadReasonSelection.SEARCH)
         assertStep(NewUserOnboardingStepIds.ADDRESS_BAR_POSITION)
     }
 
@@ -1870,16 +1898,20 @@ class NewUserOnboardingPlanProviderTest {
     }
 
     @Test
-    fun `when a download reason is confirmed then the clicked pixel fires and the variant is established`() = runTest {
+    fun `when a download reason is confirmed then it is persisted before the clicked pixel fires`() = runTest {
         startSegmentedAtDownloadReason()
 
         orchestrator.onEvent(NewUserOnboardingEvent.DownloadReasonConfirmed(DownloadReasonSelection.BLOCK_ADS))
 
-        verify(onboardingPixelSender).fire(
-            ONBOARDING_DOWNLOAD_CHOICE,
-            OnboardingPixelAction.DownloadReasonClicked(DownloadReasonSelection.BLOCK_ADS),
-        )
-        verify(onboardingPixelSender).downloadReasonSelected(DownloadReasonSelection.BLOCK_ADS)
+        // The pixel sender reads the reason back off the store, so the step's own clicked pixel only
+        // carries the variant param if the write happens first.
+        inOrder(onboardingStore, onboardingPixelSender) {
+            verify(onboardingStore).setDownloadReason(DownloadReasonSelection.BLOCK_ADS)
+            verify(onboardingPixelSender).fire(
+                ONBOARDING_DOWNLOAD_CHOICE,
+                OnboardingPixelAction.DownloadReasonClicked(DownloadReasonSelection.BLOCK_ADS),
+            )
+        }
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImplTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.store
+
+import android.content.Context
+import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
+import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
+import com.duckduckgo.common.test.api.InMemorySharedPreferences
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class OnboardingStoreImplTest {
+
+    private val fakePreferences = InMemorySharedPreferences()
+    private val sharedPreferencesProvider: SharedPreferencesProvider = mock {
+        on { getSharedPreferences(any(), any(), any()) } doReturn fakePreferences
+    }
+
+    private val testee = OnboardingStoreImpl(
+        context = mock<Context>(),
+        onboardingBrandDesignUpdateToggles = mock<OnboardingBrandDesignUpdateToggles>(),
+        sharedPreferencesProvider = sharedPreferencesProvider,
+    )
+
+    @Test
+    fun `when no download reason stored then getDownloadReason returns null`() {
+        assertNull(testee.getDownloadReason())
+    }
+
+    @Test
+    fun `when download reason stored then getDownloadReason round-trips every value`() {
+        DownloadReasonSelection.entries.forEach { reason ->
+            testee.setDownloadReason(reason)
+
+            assertEquals(reason, testee.getDownloadReason())
+        }
+    }
+
+    @Test
+    fun `when download reason cleared then getDownloadReason returns null`() {
+        testee.setDownloadReason(DownloadReasonSelection.AI_CHAT)
+
+        testee.setDownloadReason(null)
+
+        assertNull(testee.getDownloadReason())
+    }
+
+    @Test
+    fun `when input screen not selected then getSegmentedPathWithAiInput returns null`() {
+        testee.setDownloadReason(DownloadReasonSelection.AI_CHAT)
+        testee.storeInputScreenSelection(selected = false)
+
+        assertNull(testee.getSegmentedPathWithAiInput())
+    }
+
+    @Test
+    fun `when input screen selected then getSegmentedPathWithAiInput exposes only the search and ai paths`() {
+        testee.storeInputScreenSelection(selected = true)
+
+        testee.setDownloadReason(DownloadReasonSelection.SEARCH)
+        assertEquals(DownloadReasonSelection.SEARCH, testee.getSegmentedPathWithAiInput())
+
+        testee.setDownloadReason(DownloadReasonSelection.AI_CHAT)
+        assertEquals(DownloadReasonSelection.AI_CHAT, testee.getSegmentedPathWithAiInput())
+
+        testee.setDownloadReason(DownloadReasonSelection.NO_AI)
+        assertNull(testee.getSegmentedPathWithAiInput())
+
+        testee.setDownloadReason(DownloadReasonSelection.BLOCK_ADS)
+        assertNull(testee.getSegmentedPathWithAiInput())
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/RealOnboardingPixelSenderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/RealOnboardingPixelSenderTest.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.CustomAiOnboardingStore
 import com.duckduckgo.app.onboarding.OnboardingPreference
 import com.duckduckgo.app.onboarding.orchestrator.PasswordImportOutcome
+import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.ui.page.configdriven.DownloadReasonSelection
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_ADDRESS_BAR_POSITION
 import com.duckduckgo.app.pixels.OnboardingPixelName.ONBOARDING_AI_INTRO
@@ -80,6 +81,7 @@ class RealOnboardingPixelSenderTest {
         on { formFactor() } doReturn DeviceInfo.FormFactor.PHONE
     }
     private val mockAppBuildConfig: AppBuildConfig = mock { onBlocking { isAppReinstall() } doReturn false }
+    private val mockOnboardingStore: OnboardingStore = mock()
 
     private val testee = RealOnboardingPixelSender(
         appCoroutineScope = coroutineRule.testScope,
@@ -92,6 +94,7 @@ class RealOnboardingPixelSenderTest {
         widgetCapabilities = mockWidgetCapabilities,
         deviceInfo = mockDeviceInfo,
         appBuildConfig = mockAppBuildConfig,
+        onboardingStore = mockOnboardingStore,
     )
 
     @Test
@@ -123,6 +126,7 @@ class RealOnboardingPixelSenderTest {
             widgetCapabilities = mockWidgetCapabilities,
             deviceInfo = mockDeviceInfo,
             appBuildConfig = mockReinstallBuildConfig,
+            onboardingStore = mockOnboardingStore,
         )
         reinstallTestee.fire(ONBOARDING_WELCOME, OnboardingPixelAction.Clicked(engaged = true))
 
@@ -317,6 +321,7 @@ class RealOnboardingPixelSenderTest {
             widgetCapabilities = mockWidgetCapabilities,
             deviceInfo = mockDeviceInfo,
             appBuildConfig = mockReinstallBuildConfig,
+            onboardingStore = mockOnboardingStore,
         )
         reinstallTestee.fire(ONBOARDING_QUICK_SETUP, OnboardingPixelAction.Shown)
 
@@ -345,6 +350,7 @@ class RealOnboardingPixelSenderTest {
             widgetCapabilities = mockWidgetCapabilities,
             deviceInfo = mockDeviceInfo,
             appBuildConfig = mockReinstallBuildConfig,
+            onboardingStore = mockOnboardingStore,
         )
         reinstallTestee.fire(
             ONBOARDING_QUICK_SETUP,
@@ -389,6 +395,7 @@ class RealOnboardingPixelSenderTest {
             widgetCapabilities = mockWidgetCapabilities,
             deviceInfo = mockDeviceInfo,
             appBuildConfig = mockReinstallBuildConfig,
+            onboardingStore = mockOnboardingStore,
         )
         reinstallTestee.fire(
             ONBOARDING_QUICK_SETUP,
@@ -433,6 +440,7 @@ class RealOnboardingPixelSenderTest {
             widgetCapabilities = mockWidgetCapabilities,
             deviceInfo = mockDeviceInfo,
             appBuildConfig = mockReinstallBuildConfig,
+            onboardingStore = mockOnboardingStore,
         )
         reinstallTestee.fire(
             ONBOARDING_QUICK_SETUP,
@@ -489,6 +497,7 @@ class RealOnboardingPixelSenderTest {
             widgetCapabilities = mockWidgetCapabilities,
             deviceInfo = mockDeviceInfo,
             appBuildConfig = mockAppBuildConfig,
+            onboardingStore = mockOnboardingStore,
         )
         variantTestee.chatBranchSelected()
 
@@ -523,6 +532,7 @@ class RealOnboardingPixelSenderTest {
             widgetCapabilities = mockWidgetCapabilities,
             deviceInfo = mockDeviceInfo,
             appBuildConfig = mockAppBuildConfig,
+            onboardingStore = mockOnboardingStore,
         )
         variantTestee.searchBranchSelected()
 
@@ -558,6 +568,7 @@ class RealOnboardingPixelSenderTest {
             widgetCapabilities = mockWidgetCapabilities,
             deviceInfo = mockDeviceInfo,
             appBuildConfig = mockAppBuildConfig,
+            onboardingStore = mockOnboardingStore,
         )
         variantTestee.chatBranchSelected()
 
@@ -986,10 +997,10 @@ class RealOnboardingPixelSenderTest {
     }
 
     @Test
-    fun whenDownloadReasonSelectedThenSegmentedVariantParamIsThatReason() = runTest {
+    fun whenDownloadReasonSelectedThenDownloadReasonVariantParamIsThatReason() = runTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
 
-        testee.downloadReasonSelected(DownloadReasonSelection.AI_CHAT)
+        whenever(mockOnboardingStore.getDownloadReason()).thenReturn(DownloadReasonSelection.AI_CHAT)
         testee.fire(ONBOARDING_SET_DEFAULT, OnboardingPixelAction.Shown)
 
         verify(mockPixel).fire(
@@ -997,7 +1008,7 @@ class RealOnboardingPixelSenderTest {
             mapOf(
                 "installType" to "new",
                 "flow" to "default",
-                "variant_segmented" to "download_reason_ai-chat",
+                "variant_download_reason" to "download_reason_ai-chat",
                 "pixelSource" to "phone",
                 "daysSinceInstall" to "0",
                 "event" to "shown",
@@ -1010,7 +1021,7 @@ class RealOnboardingPixelSenderTest {
     fun whenBothDownloadReasonAndBranchSelectedThenEachGetsItsOwnParam() = runTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
 
-        testee.downloadReasonSelected(DownloadReasonSelection.BLOCK_ADS)
+        whenever(mockOnboardingStore.getDownloadReason()).thenReturn(DownloadReasonSelection.BLOCK_ADS)
         testee.chatBranchSelected()
         testee.fire(ONBOARDING_END, OnboardingPixelAction.Shown)
 
@@ -1020,7 +1031,7 @@ class RealOnboardingPixelSenderTest {
                 "installType" to "new",
                 "flow" to "default",
                 "variant" to "search_plus_duckai-chat",
-                "variant_segmented" to "download_reason_ad-blocking",
+                "variant_download_reason" to "download_reason_ad-blocking",
                 "pixelSource" to "phone",
                 "daysSinceInstall" to "0",
                 "event" to "shown",
@@ -1030,7 +1041,7 @@ class RealOnboardingPixelSenderTest {
     }
 
     @Test
-    fun whenOnlyTheBranchIsSelectedThenSegmentedVariantIsAbsent() = runTest {
+    fun whenOnlyTheBranchIsSelectedThenDownloadReasonVariantIsAbsent() = runTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
 
         testee.searchBranchSelected()
@@ -1051,11 +1062,11 @@ class RealOnboardingPixelSenderTest {
     }
 
     @Test
-    fun whenFlowAttributionClearedThenSegmentedFlowAndReasonAreBothDropped() = runTest {
+    fun whenFlowAttributionClearedThenSegmentedFlowAndBranchAreBothDropped() = runTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
 
         testee.segmentedFlowStarted()
-        testee.downloadReasonSelected(DownloadReasonSelection.SEARCH)
+        testee.chatBranchSelected()
         testee.clearFlowAttribution()
         testee.fire(ONBOARDING_WELCOME, OnboardingPixelAction.Shown)
 
@@ -1088,10 +1099,10 @@ class RealOnboardingPixelSenderTest {
 
     /** The reason is persisted as the choice is confirmed, so the step's own clicked pixel already carries it. */
     @Test
-    fun whenFireDownloadReasonClickedAfterTheReasonIsPersistedThenTheSegmentedVariantIsAlsoSent() = runTest {
+    fun whenFireDownloadReasonClickedAfterTheReasonIsPersistedThenTheDownloadReasonVariantIsAlsoSent() = runTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
 
-        testee.downloadReasonSelected(DownloadReasonSelection.NO_AI)
+        whenever(mockOnboardingStore.getDownloadReason()).thenReturn(DownloadReasonSelection.NO_AI)
         testee.fire(ONBOARDING_DOWNLOAD_CHOICE, OnboardingPixelAction.DownloadReasonClicked(DownloadReasonSelection.NO_AI))
 
         verify(mockPixel).fire(
@@ -1099,7 +1110,7 @@ class RealOnboardingPixelSenderTest {
             mapOf(
                 "installType" to "new",
                 "flow" to "default",
-                "variant_segmented" to "download_reason_no-ai",
+                "variant_download_reason" to "download_reason_no-ai",
                 "pixelSource" to "phone",
                 "daysSinceInstall" to "0",
                 "event" to "clicked",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1218095440012407?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

### Steps to test this PR
_logs_
- [x] Filter logcat by `message~:"onboardingFlowByDownloadReasonExperiment"`.

_regression_
- [x] Clear downloads dir:
```bash
adb shell rm -rf /sdcard/Download/DuckDuckGo
```
- [x] Clean install.
- [x] Verify onboarding launches and **no** `onboardingFlowByDownloadReasonExperiment` pixels fire.

_control_
- [x] Create `privacy-config/privacy-config-internal/local-config-patches/review_patch.json`:
```json
[
  {
    "op": "add",
    "path": "/features/segmentedOnboarding",
    "value": {
      "state": "enabled",
      "features": {
        "onboardingFlowByDownloadReasonExperiment": {
          "state": "enabled",
          "cohorts": [
            {
              "name": "control",
              "weight": 1
            },
            {
              "name": "treatment",
              "weight": 0
            }
          ]
        }
      }
    }
  },
  {
    "op": "replace",
    "path": "/features/onboardingPrompts/features/addToDockAndWidgetExperimentJul25/state",
    "value": "disabled"
  },
  {
    "op": "add",
    "path": "/features/onboardingPrompts/hash",
    "value": "patched"
  },
  {
    "op": "replace",
    "path": "/version",
    "value": "90000000000001"
  }
]
```
- [x] Create `privacy-config/privacy-config-internal/local.properties`:
```
config_patches=privacy-config/privacy-config-internal/local-config-patches/review_patch.json
```
- [x] Apply below diff:
```diff
diff --git a/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json b/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
index b75a2db48f..e2514ade54 100644
--- a/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
+++ b/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
@@ -954,3 +954,3 @@
                 "addToDockAndWidgetExperimentJul25": {
-                    "state": "enabled",
+                    "state": "disabled",
                     "cohorts": [
@@ -975,2 +975,20 @@
             }
+        },
+        "segmentedOnboarding": {
+            "state": "enabled",
+            "features": {
+                "onboardingFlowByDownloadReasonExperiment": {
+                    "state": "enabled",
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 0
+                        }
+                    ]
+                }
+            }
         }
```
- [x] Clear downloads dir:
```bash
adb shell rm -rf /sdcard/Download/DuckDuckGo
```
- [x] Clean install.
- [x] Verify the default onboarding flow runs, no download-choice screen.
- [x] Verify `experiment_enroll_onboardingFlowByDownloadReasonExperiment_control` pixel was sent.
- [x] Walk the onboarding till the end.
- [x] Verify pixel with `metric=onboarding_completed` was sent.

_treatment_
- [x] Update `privacy_config.json` and `review_patch.json`:
  - [x]  `control` to `0`
  - [x]  `treatment` to `1`
- [x] Clear downloads dir:
```bash
adb shell rm -rf /sdcard/Download/DuckDuckGo
```
- [x] Clean install.
- [x] Verify `experiment_enroll_onboardingFlowByDownloadReasonExperiment_treatment` pixel was sent.
- [x] Pick a download reason.
- [x] Verify pixel with `metric=download_reason_selected_<reason>` was sent
- [x] Walk the onboarding till the end.
- [x] Verify pixel with `metric=onboarding_completed` was sent.
- [x] Increment the date on the device by 5-6 days.
- [x] Go back to the app and send a new chat prompt.
- [x] Verify metric pixels were sent:
  - [x] `metric=duck_ai_new_chat`
  - [x] `metric=duck_ai_prompt_sent`
  - [x] `metric=search`
  - [x] `metric=download_reason_search_retention_<reason>`

_returning user_
- [x] Do not change the config, do not clear the downloads folder.
- [x] Clean install the app.
- [x] Verify onboarding launches and **no** `onboardingFlowByDownloadReasonExperiment` pixels fire.

_clean up_
- [x] Delete `privacy-config/privacy-config-internal/local-config-patches/review_patch.json` and revert changes in `privacy-config/privacy-config-internal/local.properties`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches new-user onboarding branching, experiment enrollment gates, and a breaking analytics param rename (`variant_download_reason`); incorrect persistence or enrollment could skew experiment data or CTA behavior on segmented paths.
> 
> **Overview**
> Adds **native experiment** support for `onboardingFlowByDownloadReasonExperiment` (control/treatment) with metrics for completion, per-reason selection, and D5–7 search retention by download-reason segment.
> 
> **Telemetry rename:** onboarding pixels now use shared param `onboardingDownloadReasonVariant` (`variant_download_reason`) instead of `onboardingSegmentedVariant` (`variant_segmented`).
> 
> **State model:** replaces `SegmentedOnboardingPath` with `DownloadReasonSelection` persisted in `OnboardingStore`; download reason is written before the download-choice clicked pixel and cleared when a new linear onboarding run starts so attribution and retention metrics don’t leak from abandoned runs.
> 
> **Enrollment:** `SegmentedOnboardingExperimentManager` actually enrolls via `SegmentedOnboardingFeatureToggles`, with prerequisites (brand design update, config-driven dialogs, no conflicting experiments, non-reinstall). Metrics fire on established stage, reason confirmation, and ATB search/Duck.ai retention refreshes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58a7ef03e807f42fcf16aa60b662d1e0a36cbd1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->