### PR TITLE
Permissions: Allow the stacked alert dialog to be cancellable

### DIFF
--- a/PixelDefinitions/pixels/definitions/site_permissions.json5
+++ b/PixelDefinitions/pixels/definitions/site_permissions.json5
@@ -23,7 +23,7 @@
         ]
     },
     "m_site_permissions_dialog_click": {
-        "description": "Fires when the user resolves the site permission dialog. Paired with m_site_permissions_dialog_impresssion to give the decision rate per permission type; a prompt abandoned without a decision fires no click pixel and so appears only in the impression count. The pixel name retains the historic misspelling of its impression counterpart",
+        "description": "Fires when the user resolves the site permission dialog. Paired with m_site_permissions_dialog_impresssion to give the decision rate per permission type. A prompt the user never resolves, because the tab or activity went away, fires no click pixel and so appears only in the impression count. The pixel name retains the historic misspelling of its impression counterpart",
         "owners": ["0nko"],
         "triggers": ["page_load"],
         "suffixes": ["form_factor"],

--- a/PixelDefinitions/pixels/definitions/site_permissions.json5
+++ b/PixelDefinitions/pixels/definitions/site_permissions.json5
@@ -21,5 +21,41 @@
             },
             "petal"
         ]
+    },
+    "m_site_permissions_dialog_click": {
+        "description": "Fires when the user resolves the site permission dialog. Paired with m_site_permissions_dialog_impresssion to give the decision rate per permission type; a prompt abandoned without a decision fires no click pixel and so appears only in the impression count. The pixel name retains the historic misspelling of its impression counterpart",
+        "owners": ["0nko"],
+        "triggers": ["page_load"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "type",
+                "type": "string",
+                "description": "Permission type the dialog was shown for",
+                "enum": ["location", "camera", "microphone", "camera_and_microphone", "drm"]
+            },
+            {
+                "key": "selection",
+                "type": "string",
+                "description": "The decision made, and whether it persists for the site. The _always variants are remembered for future visits; the _once variants apply to the current visit only. Under the binary dialog the split comes from the remember-my-choice checkbox; under the tiered dialog it comes from the explicit option chosen, and deny_once additionally covers dismissing the prompt. Figures either side of the tiered-dialog rollout are therefore not directly comparable",
+                "enum": ["allow_always", "allow_once", "deny_always", "deny_once"]
+            }
+        ]
+    },
+    "m_site_permissions_dialog_impresssion": {
+        "description": "Fires when a site permission dialog is shown to the user. Acts as the denominator for m_site_permissions_dialog_click. Note the triple-s misspelling is the live wire name and is kept deliberately",
+        "owners": ["0nko"],
+        "triggers": ["page_load"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "type",
+                "type": "string",
+                "description": "Permission type the dialog was shown for",
+                "enum": ["location", "camera", "microphone", "camera_and_microphone", "drm"]
+            }
+        ]
     }
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/StackedAlertDialogBuilder.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/StackedAlertDialogBuilder.kt
@@ -81,6 +81,7 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     private var stackedButtonList: MutableList<StackedButtonSpec> = mutableListOf()
     private var isDestructiveVersion: Boolean = false
     private var isRebrandUpdate: Boolean = false
+    private var isCancellable: Boolean = false
     private var componentCallbacks: ComponentCallbacks? = null
 
     fun setHeaderImageResource(@DrawableRes drawableId: Int): StackedAlertDialogBuilder {
@@ -153,6 +154,15 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         return this
     }
 
+    /**
+     * Allows the dialog to be dismissed by tapping outside it or pressing back. Off by default.
+     * [EventListener.onDialogCancelled] only fires when this is enabled.
+     */
+    fun setCancellable(cancellable: Boolean): StackedAlertDialogBuilder {
+        isCancellable = cancellable
+        return this
+    }
+
     fun addEventListener(eventListener: EventListener): StackedAlertDialogBuilder {
         listener = eventListener
         return this
@@ -171,7 +181,7 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         val dialogBuilder = MaterialAlertDialogBuilder(context, dialogTheme)
             .setView(dialogContent(binding))
             .apply {
-                setCancelable(false)
+                setCancelable(isCancellable)
                 setOnDismissListener {
                     unregisterConfigurationCallback()
                     listener.onDialogDismissed()

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/StackedAlertDialogBuilder.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/StackedAlertDialogBuilder.kt
@@ -247,8 +247,9 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     }
 
     /**
-     * Rebuilds the dialog against the new configuration. The dialog is not cancellable, so dropping
-     * it on rotation would strand the caller's flow with no way back to it.
+     * Rebuilds the dialog against the new configuration. Dropping it on rotation would strand the
+     * caller's flow: a non-cancellable dialog leaves no way back to it, and a cancellable one would
+     * report a cancellation the user never made.
      */
     private fun registerConfigurationCallback() {
         if (componentCallbacks != null) return

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/feature/SitePermissionsDialogRedesignFeature.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/feature/SitePermissionsDialogRedesignFeature.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.site.permissions.impl.feature
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "sitePermissionsDialogRedesign",
+)
+interface SitePermissionsDialogRedesignFeature {
+    @InternalAlwaysEnabled
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun self(): Toggle
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1218156296855114?focus=true 

### Description

This PR lets the `StackedAlertDialogBuilder` create cancellable dialogs, which are necessary for the permission dialogs redesign.

### Steps to test this PR

QA-optional.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in API with default false preserves backward compatibility; only callers that enable cancellation change dismiss and callback behavior.
> 
> **Overview**
> **Stacked alert dialogs** can now be dismissed with back or an outside tap via a new **`setCancellable`** flag, matching the pattern already used on `TextAlertDialogBuilder`. The default stays **non-cancellable**, so existing call sites keep today’s behavior unless they opt in.
> 
> When cancellation is enabled, **`EventListener.onDialogCancelled`** runs on those dismissals. The rotation **recreate** comment is updated to note that rebuilding is still required for cancellable dialogs so a config change does not fire a spurious cancellation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41f4d5e9d678bf2b151b9381edbd1324415e2045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->