### PR TITLE
Add Duck Ai Session Wide Event

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_duckai_session.json5
+++ b/PixelDefinitions/pixels/definitions/wide_duckai_session.json5
@@ -1,0 +1,54 @@
+{
+    "wide_duckai_session": {
+        "description": "Captures every visit to a full Duck.ai tab, from becoming visible to a confirmed exit, app background, or app termination.",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": [
+            "widePixelPlatform",
+            "widePixelType",
+            "widePixelSampleRate",
+            "widePixelFeatureStatus",
+            "widePixelAppVersion",
+            "widePixelAppName",
+            "widePixelFormFactor",
+            "widePixelDevMode",
+            "widePixelMetaType",
+            "widePixelMetaVersion",
+            "widePixelIsFirstDailyOccurrence",
+            {
+                "key": "feature.name",
+                "type": "string",
+                "description": "Feature identifier for this wide event",
+                "enum": ["duckai_session"]
+            },
+            {
+                "key": "feature.data.ext.status_reason",
+                "type": "string",
+                "description": "Reason the session ended",
+                "enum": ["left_duckai", "app_backgrounded", "app_terminated"]
+            },
+            {
+                "key": "feature.data.ext.exit_trigger",
+                "type": "string",
+                "description": "Action that caused the transition away from Duck.ai. Present only when status_reason is left_duckai",
+                "enum": ["back_or_close", "tab_switched", "new_tab_opened", "fire_tab_opened", "other_navigation"]
+            },
+            {
+                "key": "feature.data.ext.step.prompt_submitted",
+                "type": "boolean",
+                "description": "Parameter present when a Duck.ai prompt was submitted at least once during the session"
+            },
+            {
+                "key": "feature.data.ext.step.new_chat_created",
+                "type": "boolean",
+                "description": "Parameter present when a new chat was created from the active Duck.ai session at least once"
+            },
+            {
+                "key": "feature.data.ext.step.chat_id_changed",
+                "type": "boolean",
+                "description": "Parameter present when the active Duck.ai URL's chatID changed at least once, including a change between missing and present. The identifier itself is never sent"
+            }
+        ]
+    }
+}

--- a/PixelDefinitions/wide_events/definitions/duckai_session.json5
+++ b/PixelDefinitions/wide_events/definitions/duckai_session.json5
@@ -1,0 +1,43 @@
+{
+    "android-duckai-session": {
+        "description": "Captures every visit to a full Duck.ai tab, from becoming visible to a confirmed exit, app background, or app termination.",
+        "owners": ["YoussefKeyrouz"],
+        "meta": {
+            "type": "android-duckai-session",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "duckai_session",
+            "status": ["SUCCESS", "CANCELLED", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "status_reason": {
+                        "type": "string",
+                        "description": "Reason the session ended",
+                        "enum": ["left_duckai", "app_backgrounded", "app_terminated"]
+                    },
+                    "exit_trigger": {
+                        "type": "string",
+                        "description": "Action that caused the transition away from Duck.ai. Present only when status_reason is left_duckai",
+                        "enum": ["back_or_close", "tab_switched", "new_tab_opened", "fire_tab_opened", "other_navigation"]
+                    },
+                    "step.prompt_submitted": {
+                        "type": "string",
+                        "description": "Parameter present when a Duck.ai prompt was submitted at least once during the session",
+                        "enum": ["true"]
+                    },
+                    "step.new_chat_created": {
+                        "type": "string",
+                        "description": "Parameter present when a new chat was created from the active Duck.ai session at least once",
+                        "enum": ["true"]
+                    },
+                    "step.chat_id_changed": {
+                        "type": "string",
+                        "description": "Parameter present when the active Duck.ai URL's chatID changed at least once, including a change between missing and present. The identifier itself is never sent",
+                        "enum": ["true"]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PixelDefinitions/wide_events/generated_schemas/android-duckai-session-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-duckai-session-1.0.0.json
@@ -1,0 +1,105 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Captures every visit to a full Duck.ai tab, from becoming visible to a confirmed exit, app background, or app termination.",
+    "$comment": "{\"owners\":[\"YoussefKeyrouz\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "android-duckai-session" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application sending the event",
+                    "enum": ["DuckDuckGo Android"]
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The version of the app sending the event. Release builds are X.Y.Z; internal and nightly builds append the build number and channel suffix.",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+(-[a-z]+)?)?$"
+                },
+                "form_factor": { "type": "string", "description": "The form factor of the current device", "enum": ["phone", "tablet"] },
+                "dev_mode": { "type": "boolean", "description": "Whether the app is a debug build" }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["Android"] },
+                "type": { "type": "string", "description": "The type of software sending the event", "enum": ["app"] },
+                "sample_rate": {
+                    "type": "number",
+                    "description": "Sample rate for this event, between 0 and 1",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first event completed with this feature name and status in the current UTC calendar day"
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["duckai_session"] },
+                "status": {
+                    "type": "string",
+                    "description": "The terminal status of the flow",
+                    "enum": ["SUCCESS", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "status_reason": {
+                                    "type": "string",
+                                    "description": "Reason the session ended",
+                                    "enum": ["left_duckai", "app_backgrounded", "app_terminated"]
+                                },
+                                "exit_trigger": {
+                                    "type": "string",
+                                    "description": "Action that caused the transition away from Duck.ai. Present only when status_reason is left_duckai",
+                                    "enum": ["back_or_close", "tab_switched", "new_tab_opened", "fire_tab_opened", "other_navigation"]
+                                },
+                                "step.prompt_submitted": {
+                                    "type": "string",
+                                    "description": "Parameter present when a Duck.ai prompt was submitted at least once during the session",
+                                    "enum": ["true"]
+                                },
+                                "step.new_chat_created": {
+                                    "type": "string",
+                                    "description": "Parameter present when a new chat was created from the active Duck.ai session at least once",
+                                    "enum": ["true"]
+                                },
+                                "step.chat_id_changed": {
+                                    "type": "string",
+                                    "description": "Parameter present when the active Duck.ai URL's chatID changed at least once, including a change between missing and present. The identifier itself is never sent",
+                                    "enum": ["true"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -836,9 +836,11 @@ class BrowserTabFragment :
                 duckChat.openVoiceDuckChat(DuckChatEntryPoint.VOICE)
             }
             onMenuItemClicked(contentView.findViewById(com.duckduckgo.duckchat.impl.R.id.chatMenuPopupNewTab)) {
+                viewModel.recordPendingNewTabOpenedExit()
                 browserActivity?.launchNewTab(browserMode = BrowserMode.REGULAR)
             }
             onMenuItemClicked(contentView.findViewById(com.duckduckgo.duckchat.impl.R.id.chatMenuPopupNewFireTab)) {
+                viewModel.recordPendingFireTabOpenedExit()
                 browserActivity?.launchNewTab(browserMode = BrowserMode.FIRE)
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -384,9 +384,11 @@ import com.duckduckgo.downloads.api.model.DownloadItem
 import com.duckduckgo.downloads.store.DownloadStatus
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
+import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.contextual.PageContextJSHelper
 import com.duckduckgo.duckchat.impl.contextual.RealPageContextJSHelper.Companion.PAGE_CONTEXT_FEATURE_NAME
@@ -613,6 +615,7 @@ class BrowserTabViewModel @Inject constructor(
     private val suggestRedirectOnUnresolvedErrorFeature: SuggestRedirectOnUnresolvedErrorFeature,
     private val suggestRedirectEvaluator: SuggestRedirectEvaluator,
     private val badUrlErrorPageWideEvent: BadUrlErrorPageWideEvent,
+    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
 ) : ViewModel(),
     WebViewClientListener,
     EditSavedSiteListener,
@@ -1976,13 +1979,17 @@ class BrowserTabViewModel @Inject constructor(
         val hasSourceTab = tabRepository.liveSelectedTab.value?.sourceTabId != null
 
         if (isNavigationToEmptyUrlFromParent(hasSourceTab, isCustomTab)) {
+            recordPendingDuckAiBackExit()
             viewModelScope.launch {
                 removeCurrentTabFromRepository()
             }
             return true
         }
 
-        val navigation = webNavigationState ?: return false
+        val navigation = webNavigationState ?: run {
+            recordPendingDuckAiBackExit()
+            return false
+        }
 
         if (currentFindInPageViewState().visible) {
             dismissFindInView()
@@ -2000,19 +2007,23 @@ class BrowserTabViewModel @Inject constructor(
         }
 
         if (!currentBrowserViewState().browserShowing) {
+            recordPendingDuckAiBackExit()
             return false
         }
 
         if (navigation.canGoBack) {
             badUrlErrorPageWideEvent.onBadUrlErrorPageExited(tabId)
+            recordPendingDuckAiBackExit()
             command.value = NavigationCommand.NavigateBack(navigation.stepsToPreviousPage)
             return true
         } else if (hasSourceTab && !isCustomTab) {
+            recordPendingDuckAiBackExit()
             viewModelScope.launch {
                 removeCurrentTabFromRepository()
             }
             return true
         } else if (!skipHome && !isCustomTab) {
+            recordPendingDuckAiBackExit()
             navigateHome()
             return true
         }
@@ -2021,7 +2032,20 @@ class BrowserTabViewModel @Inject constructor(
             logcat { "User pressed back and tab is set to skip home; need to generate WebView preview now" }
             command.value = GenerateWebViewPreviewImage
         }
+        recordPendingDuckAiBackExit()
         return false
+    }
+
+    private fun recordPendingDuckAiBackExit() {
+        duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.BACK_OR_CLOSE)
+    }
+
+    fun recordPendingNewTabOpenedExit() {
+        duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.NEW_TAB_OPENED)
+    }
+
+    fun recordPendingFireTabOpenedExit() {
+        duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.FIRE_TAB_OPENED)
     }
 
     private fun isNavigationToEmptyUrlFromParent(
@@ -2698,6 +2722,9 @@ class BrowserTabViewModel @Inject constructor(
         url?.let {
             if (duckChat.isDuckChatUrl(Uri.parse(it))) {
                 command.value = Command.EnableDuckAIFullScreen(currentBrowserViewState())
+                if (isActiveTab()) {
+                    duckAiSessionWideEvent.onDuckAiPageVisible(tabId, it)
+                }
             } else {
                 command.value = Command.DuckAIFullScreenDisabled(url)
             }
@@ -3452,6 +3479,7 @@ class BrowserTabViewModel @Inject constructor(
                     command.value = LaunchSubscription(requiredAction.url.toUri())
                     return true
                 }
+                duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.NEW_TAB_OPENED)
                 command.value = GenerateWebViewPreviewImage
                 command.value = OpenInNewTab(query = requiredAction.url, sourceTabId = tabId)
                 true
@@ -3462,6 +3490,7 @@ class BrowserTabViewModel @Inject constructor(
                     command.value = LaunchSubscription(requiredAction.url.toUri())
                     return true
                 }
+                duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.FIRE_TAB_OPENED)
                 command.value = GenerateWebViewPreviewImage
                 command.value = OpenInFireTab(
                     query = requiredAction.url,
@@ -5764,6 +5793,7 @@ class BrowserTabViewModel @Inject constructor(
         // onInputSubmitted() too: an in-chat follow-up is still "the bar was used" for the old
         // post-idle-session event, which only listens for that generic signal.
         browserInteractionsPlugins.getPlugins().forEach { it.onInputSubmitted() }
+        duckAiSessionWideEvent.onPromptSubmitted(tabId)
         viewModelScope.launch(dispatchers.io()) {
             // The chat was already open, so its entry point was recorded when it was first navigated to.
             val source = duckAiTabSessionRepository.getEntryPointSource(tabId)
@@ -5788,6 +5818,7 @@ class BrowserTabViewModel @Inject constructor(
     fun openNewDuckChat(viewMode: ViewMode) {
         if (viewMode == ViewMode.DuckAI) {
             pixel.fire(DuckChatPixelName.DUCK_CHAT_OMNIBAR_NEW_CHAT_TAPPED)
+            duckAiSessionWideEvent.onNewChatCreated(tabId)
             viewModelScope.launch {
                 val subscriptionEvent = duckChatJSHelper.onNativeAction(NativeAction.NEW_CHAT)
                 _subscriptionEventDataChannel.send(subscriptionEvent)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -384,11 +384,11 @@ import com.duckduckgo.downloads.api.model.DownloadItem
 import com.duckduckgo.downloads.store.DownloadStatus
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
+import com.duckduckgo.duckchat.api.DuckAiSessionExitTrigger
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
-import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.contextual.PageContextJSHelper
 import com.duckduckgo.duckchat.impl.contextual.RealPageContextJSHelper.Companion.PAGE_CONTEXT_FEATURE_NAME
@@ -615,7 +615,7 @@ class BrowserTabViewModel @Inject constructor(
     private val suggestRedirectOnUnresolvedErrorFeature: SuggestRedirectOnUnresolvedErrorFeature,
     private val suggestRedirectEvaluator: SuggestRedirectEvaluator,
     private val badUrlErrorPageWideEvent: BadUrlErrorPageWideEvent,
-    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
+    private val duckAiSessionCallback: DuckAiSessionCallback,
 ) : ViewModel(),
     WebViewClientListener,
     EditSavedSiteListener,
@@ -2037,15 +2037,15 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun recordPendingDuckAiBackExit() {
-        duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.BACK_OR_CLOSE)
+        duckAiSessionCallback.onExitIntent(tabId, DuckAiSessionExitTrigger.BACK_OR_CLOSE)
     }
 
     fun recordPendingNewTabOpenedExit() {
-        duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.NEW_TAB_OPENED)
+        duckAiSessionCallback.onExitIntent(tabId, DuckAiSessionExitTrigger.NEW_TAB_OPENED)
     }
 
     fun recordPendingFireTabOpenedExit() {
-        duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.FIRE_TAB_OPENED)
+        duckAiSessionCallback.onExitIntent(tabId, DuckAiSessionExitTrigger.FIRE_TAB_OPENED)
     }
 
     private fun isNavigationToEmptyUrlFromParent(
@@ -2723,7 +2723,7 @@ class BrowserTabViewModel @Inject constructor(
             if (duckChat.isDuckChatUrl(Uri.parse(it))) {
                 command.value = Command.EnableDuckAIFullScreen(currentBrowserViewState())
                 if (isActiveTab()) {
-                    duckAiSessionWideEvent.onDuckAiPageVisible(tabId, it)
+                    duckAiSessionCallback.onDuckAiPageVisible(tabId, it)
                 }
             } else {
                 command.value = Command.DuckAIFullScreenDisabled(url)
@@ -3479,7 +3479,7 @@ class BrowserTabViewModel @Inject constructor(
                     command.value = LaunchSubscription(requiredAction.url.toUri())
                     return true
                 }
-                duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.NEW_TAB_OPENED)
+                duckAiSessionCallback.onExitIntent(tabId, DuckAiSessionExitTrigger.NEW_TAB_OPENED)
                 command.value = GenerateWebViewPreviewImage
                 command.value = OpenInNewTab(query = requiredAction.url, sourceTabId = tabId)
                 true
@@ -3490,7 +3490,7 @@ class BrowserTabViewModel @Inject constructor(
                     command.value = LaunchSubscription(requiredAction.url.toUri())
                     return true
                 }
-                duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.FIRE_TAB_OPENED)
+                duckAiSessionCallback.onExitIntent(tabId, DuckAiSessionExitTrigger.FIRE_TAB_OPENED)
                 command.value = GenerateWebViewPreviewImage
                 command.value = OpenInFireTab(
                     query = requiredAction.url,
@@ -5793,7 +5793,7 @@ class BrowserTabViewModel @Inject constructor(
         // onInputSubmitted() too: an in-chat follow-up is still "the bar was used" for the old
         // post-idle-session event, which only listens for that generic signal.
         browserInteractionsPlugins.getPlugins().forEach { it.onInputSubmitted() }
-        duckAiSessionWideEvent.onPromptSubmitted(tabId)
+        duckAiSessionCallback.onPromptSubmitted(tabId)
         viewModelScope.launch(dispatchers.io()) {
             // The chat was already open, so its entry point was recorded when it was first navigated to.
             val source = duckAiTabSessionRepository.getEntryPointSource(tabId)
@@ -5818,7 +5818,7 @@ class BrowserTabViewModel @Inject constructor(
     fun openNewDuckChat(viewMode: ViewMode) {
         if (viewMode == ViewMode.DuckAI) {
             pixel.fire(DuckChatPixelName.DUCK_CHAT_OMNIBAR_NEW_CHAT_TAPPED)
-            duckAiSessionWideEvent.onNewChatCreated(tabId)
+            duckAiSessionCallback.onNewChatCreated(tabId)
             viewModelScope.launch {
                 val subscriptionEvent = duckChatJSHelper.onNativeAction(NativeAction.NEW_CHAT)
                 _subscriptionEventDataChannel.send(subscriptionEvent)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -68,6 +68,8 @@ import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
@@ -115,6 +117,7 @@ class BrowserViewModel @Inject constructor(
     private val browserModeStateHolder: BrowserModeStateHolder,
     private val fireModeAvailability: FireModeAvailability,
     private val browserMode: BrowserMode,
+    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
 ) : ViewModel(), CoroutineScope {
 
     // Mode-switch orchestrator: observes the mode it also writes via switchTo().
@@ -264,6 +267,7 @@ class BrowserViewModel @Inject constructor(
     }
 
     suspend fun onNewTabRequested(sourceTabId: String? = null): String {
+        recordPendingNewTabOpenedExit()
         return if (sourceTabId != null) {
             tabRepository.addFromSourceTab(sourceTabId = sourceTabId)
         } else {
@@ -282,6 +286,7 @@ class BrowserViewModel @Inject constructor(
         sourceTabId: String? = null,
         skipHome: Boolean = false,
     ): String {
+        recordPendingNewTabOpenedExit()
         val url = if (skipUrlConversionOnNewTabFeature.self().isEnabled()) {
             query
         } else {
@@ -299,6 +304,12 @@ class BrowserViewModel @Inject constructor(
                 url = url,
                 skipHome = skipHome,
             )
+        }
+    }
+
+    private suspend fun recordPendingNewTabOpenedExit() {
+        tabRepository.getSelectedTab()?.tabId?.let { tabId ->
+            duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.NEW_TAB_OPENED)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -68,8 +68,8 @@ import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
-import com.duckduckgo.duckchat.api.ExitTrigger
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
+import com.duckduckgo.duckchat.api.DuckAiSessionExitTrigger
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
@@ -117,7 +117,7 @@ class BrowserViewModel @Inject constructor(
     private val browserModeStateHolder: BrowserModeStateHolder,
     private val fireModeAvailability: FireModeAvailability,
     private val browserMode: BrowserMode,
-    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
+    private val duckAiSessionCallback: DuckAiSessionCallback,
 ) : ViewModel(), CoroutineScope {
 
     // Mode-switch orchestrator: observes the mode it also writes via switchTo().
@@ -309,7 +309,7 @@ class BrowserViewModel @Inject constructor(
 
     private suspend fun recordPendingNewTabOpenedExit() {
         tabRepository.getSelectedTab()?.tabId?.let { tabId ->
-            duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.NEW_TAB_OPENED)
+            duckAiSessionCallback.onExitIntent(tabId, DuckAiSessionExitTrigger.NEW_TAB_OPENED)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/session/BrowserSessionTabObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/session/BrowserSessionTabObserver.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
@@ -33,7 +33,7 @@ import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 /**
- * Watches the active browser mode's selected tab and reports every raw emission [DuckAiSessionWideEvent].
+ * Watches the active browser mode's selected tab and reports every raw emission [DuckAiSessionCallback].
  * All interpretation lives in the coordinator; this class is just an adapter from the tab repository's Flow to that API.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -42,7 +42,7 @@ import javax.inject.Inject
 class BrowserSessionTabObserver @Inject constructor(
     private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
     private val browserModeStateHolder: BrowserModeStateHolder,
-    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
+    private val duckAiSessionCallback: DuckAiSessionCallback,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : BrowserLifecycleObserver {
 
@@ -53,7 +53,7 @@ class BrowserSessionTabObserver @Inject constructor(
     init {
         currentMode
             .flatMapLatest { mode -> tabRepositoryProvider.forMode(mode).flowSelectedTab }
-            .onEach { tab -> duckAiSessionWideEvent.onSelectedTabChanged(tab?.tabId, tab?.url) }
+            .onEach { tab -> duckAiSessionCallback.onSelectedTabChanged(tab?.tabId, tab?.url) }
             .launchIn(appCoroutineScope)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/session/BrowserSessionTabObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/session/BrowserSessionTabObserver.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.session
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browser.api.BrowserLifecycleObserver
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+/**
+ * Watches the active browser mode's selected tab and reports every raw emission [DuckAiSessionWideEvent].
+ * All interpretation lives in the coordinator; this class is just an adapter from the tab repository's Flow to that API.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@SingleInstanceIn(AppScope::class)
+@ContributesMultibinding(AppScope::class, boundType = BrowserLifecycleObserver::class)
+class BrowserSessionTabObserver @Inject constructor(
+    private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
+    private val browserModeStateHolder: BrowserModeStateHolder,
+    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+) : BrowserLifecycleObserver {
+
+    // This is a genuine mode-transition observer: a Duck.ai session can be active in either mode, so this must follow the active mode's selected tab.
+    @Suppress("DenyListedApi")
+    private val currentMode = browserModeStateHolder.currentMode
+
+    init {
+        currentMode
+            .flatMapLatest { mode -> tabRepositoryProvider.forMode(mode).flowSelectedTab }
+            .onEach { tab -> duckAiSessionWideEvent.onSelectedTabChanged(tab?.tabId, tab?.url) }
+            .launchIn(appCoroutineScope)
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/DefaultTabManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/DefaultTabManager.kt
@@ -24,6 +24,8 @@ import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.ExitTrigger
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.withContext
@@ -61,6 +63,7 @@ class DefaultTabManager @Inject constructor(
     private val queryUrlConverter: OmnibarEntryConverter,
     private val skipUrlConversionOnNewTabFeature: SkipUrlConversionOnNewTabFeature,
     private val browserMode: BrowserMode,
+    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
 ) : TabManager {
     private lateinit var onTabsUpdated: (List<TabModel>) -> Unit
     private var selectedTabId: String? = null
@@ -104,6 +107,9 @@ class DefaultTabManager @Inject constructor(
         sourceTabId: String?,
         skipHome: Boolean,
     ): String = withContext(dispatchers.io()) {
+        selectedTabId?.let { tabId ->
+            duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.NEW_TAB_OPENED)
+        }
         val url = query?.let {
             if (skipUrlConversionOnNewTabFeature.self().isEnabled()) {
                 query

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/DefaultTabManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/DefaultTabManager.kt
@@ -24,8 +24,8 @@ import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
-import com.duckduckgo.duckchat.api.ExitTrigger
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
+import com.duckduckgo.duckchat.api.DuckAiSessionExitTrigger
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.withContext
@@ -63,7 +63,7 @@ class DefaultTabManager @Inject constructor(
     private val queryUrlConverter: OmnibarEntryConverter,
     private val skipUrlConversionOnNewTabFeature: SkipUrlConversionOnNewTabFeature,
     private val browserMode: BrowserMode,
-    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
+    private val duckAiSessionCallback: DuckAiSessionCallback,
 ) : TabManager {
     private lateinit var onTabsUpdated: (List<TabModel>) -> Unit
     private var selectedTabId: String? = null
@@ -108,7 +108,7 @@ class DefaultTabManager @Inject constructor(
         skipHome: Boolean,
     ): String = withContext(dispatchers.io()) {
         selectedTabId?.let { tabId ->
-            duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.NEW_TAB_OPENED)
+            duckAiSessionCallback.onExitIntent(tabId, DuckAiSessionExitTrigger.NEW_TAB_OPENED)
         }
         val url = query?.let {
             if (skipUrlConversionOnNewTabFeature.self().isEnabled()) {

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -37,7 +37,7 @@ import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.customtabs.api.CustomTabDetector
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -72,7 +72,7 @@ class FirstScreenHandlerImpl @Inject constructor(
     private val returnSessionLandingListener: ReturnSessionLandingListener,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val idleThresholdResolver: IdleThresholdResolver,
-    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
+    private val duckAiSessionCallback: DuckAiSessionCallback,
 ) : BrowserLifecycleObserver {
 
     // Launch boundary: process-lifecycle callback, no activity graph exists to provide a frozen mode.
@@ -116,7 +116,7 @@ class FirstScreenHandlerImpl @Inject constructor(
             returnSessionLandingListener.onReturnLandingResolved(resolvedLanding)
             // Report a duck.ai tab launch to the Ai session wide event.
             val duckAiTab = tabRepository.getSelectedTab().takeIf { resolvedLanding.landing == ReturnSessionLanding.DUCK_AI }
-            duckAiSessionWideEvent.onLaunchLandingResolved(duckAiTab?.tabId, duckAiTab?.url)
+            duckAiSessionCallback.onLaunchLandingResolved(duckAiTab?.tabId, duckAiTab?.url)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.customtabs.api.CustomTabDetector
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -71,6 +72,7 @@ class FirstScreenHandlerImpl @Inject constructor(
     private val returnSessionLandingListener: ReturnSessionLandingListener,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val idleThresholdResolver: IdleThresholdResolver,
+    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
 ) : BrowserLifecycleObserver {
 
     // Launch boundary: process-lifecycle callback, no activity graph exists to provide a frozen mode.
@@ -112,6 +114,9 @@ class FirstScreenHandlerImpl @Inject constructor(
             ensureNewUserDefault()
             val resolvedLanding = handleFirstScreen(isFreshLaunch, preAppliedFreshNtpTreatment)
             returnSessionLandingListener.onReturnLandingResolved(resolvedLanding)
+            // Report a duck.ai tab launch to the Ai session wide event.
+            val duckAiTab = tabRepository.getSelectedTab().takeIf { resolvedLanding.landing == ReturnSessionLanding.DUCK_AI }
+            duckAiSessionWideEvent.onLaunchLandingResolved(duckAiTab?.tabId, duckAiTab?.url)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -66,10 +66,10 @@ import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.common.utils.extensions.combine
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
+import com.duckduckgo.duckchat.api.DuckAiSessionExitTrigger
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
-import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.remote.messaging.api.RemoteMessageModel
 import com.duckduckgo.savedsites.api.SavedSitesRepository
@@ -115,7 +115,7 @@ class TabSwitcherViewModel @Inject constructor(
     private val trackersAnimationInfoPanelPixels: TrackersAnimationInfoPanelPixels,
     private val omnibarRepository: OmnibarRepository,
     private val tabTitleResolver: TabTitleResolver,
-    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
+    private val duckAiSessionCallback: DuckAiSessionCallback,
     @param:AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val fireTabsPromos: FireTabsPromos,
     private val remoteMessageModel: RemoteMessageModel,
@@ -252,7 +252,7 @@ class TabSwitcherViewModel @Inject constructor(
 
     fun onNewTabRequested(fromOverflowMenu: Boolean = false) = viewModelScope.launch {
         tabRepository.getSelectedTab()?.tabId?.let { tabId ->
-            duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.NEW_TAB_OPENED)
+            duckAiSessionCallback.onExitIntent(tabId, DuckAiSessionExitTrigger.NEW_TAB_OPENED)
         }
         if (swipingTabsFeature.isEnabled) {
             val newTab = tabs.firstOrNull { tabItem ->

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -66,8 +66,10 @@ import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.common.utils.extensions.combine
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
+import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.remote.messaging.api.RemoteMessageModel
 import com.duckduckgo.savedsites.api.SavedSitesRepository
@@ -113,6 +115,7 @@ class TabSwitcherViewModel @Inject constructor(
     private val trackersAnimationInfoPanelPixels: TrackersAnimationInfoPanelPixels,
     private val omnibarRepository: OmnibarRepository,
     private val tabTitleResolver: TabTitleResolver,
+    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
     @param:AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val fireTabsPromos: FireTabsPromos,
     private val remoteMessageModel: RemoteMessageModel,
@@ -248,6 +251,9 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onNewTabRequested(fromOverflowMenu: Boolean = false) = viewModelScope.launch {
+        tabRepository.getSelectedTab()?.tabId?.let { tabId ->
+            duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.NEW_TAB_OPENED)
+        }
         if (swipingTabsFeature.isEnabled) {
             val newTab = tabs.firstOrNull { tabItem ->
                 tabItem.isNewTabPage && !tabItem.hasSourceTab

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -316,11 +316,11 @@ import com.duckduckgo.downloads.api.model.DownloadItem
 import com.duckduckgo.downloads.store.DownloadStatus
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
+import com.duckduckgo.duckchat.api.DuckAiSessionExitTrigger
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
-import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.contextual.PageContextJSHelper
 import com.duckduckgo.duckchat.impl.contextual.RealPageContextJSHelper.Companion.PAGE_CONTEXT_FEATURE_NAME
@@ -749,7 +749,7 @@ class BrowserTabViewModelTest {
     private val fakeSuggestRedirectFeature = FakeFeatureToggleFactory.create(SuggestRedirectOnUnresolvedErrorFeature::class.java)
     private val mockSuggestRedirectEvaluator: SuggestRedirectEvaluator = mock()
     private val mockBadUrlErrorPageWideEvent: BadUrlErrorPageWideEvent = mock()
-    private val mockDuckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
+    private val mockDuckAiSessionCallback: DuckAiSessionCallback = mock()
     private val mockInlinePdfHandler: InlinePdfHandler = mock()
     private val mockPdfDownloadTooltipDataStore: PdfDownloadTooltipDataStore = mock()
     private val mockCachedFileDownloader: CachedFileDownloader = mock()
@@ -1100,7 +1100,7 @@ class BrowserTabViewModelTest {
                 suggestRedirectOnUnresolvedErrorFeature = fakeSuggestRedirectFeature,
                 suggestRedirectEvaluator = mockSuggestRedirectEvaluator,
                 badUrlErrorPageWideEvent = mockBadUrlErrorPageWideEvent,
-                duckAiSessionWideEvent = mockDuckAiSessionWideEvent,
+                duckAiSessionCallback = mockDuckAiSessionCallback,
             )
 
         testee.loadData("abc", null, false, false)
@@ -3068,7 +3068,7 @@ class BrowserTabViewModelTest {
 
         testee.onLongPressRequiredAction(target, RequiredAction.OpenInNewTab("https://example.com"))
 
-        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.NEW_TAB_OPENED)
+        verify(mockDuckAiSessionCallback).onExitIntent("abc", DuckAiSessionExitTrigger.NEW_TAB_OPENED)
     }
 
     @Test
@@ -3077,7 +3077,7 @@ class BrowserTabViewModelTest {
 
         testee.onLongPressRequiredAction(target, RequiredAction.OpenInFireTab("https://example.com"))
 
-        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.FIRE_TAB_OPENED)
+        verify(mockDuckAiSessionCallback).onExitIntent("abc", DuckAiSessionExitTrigger.FIRE_TAB_OPENED)
     }
 
     @Test
@@ -3087,7 +3087,7 @@ class BrowserTabViewModelTest {
 
         testee.onLongPressRequiredAction(target, RequiredAction.OpenInFireTab("https://example.com"))
 
-        verify(mockDuckAiSessionWideEvent, never()).onExitIntent(any(), any())
+        verify(mockDuckAiSessionCallback, never()).onExitIntent(any(), any())
     }
 
     @Test
@@ -9377,7 +9377,7 @@ class BrowserTabViewModelTest {
 
         testee.onUserPressedBack()
 
-        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.BACK_OR_CLOSE)
+        verify(mockDuckAiSessionCallback).onExitIntent("abc", DuckAiSessionExitTrigger.BACK_OR_CLOSE)
     }
 
     @Test
@@ -9387,7 +9387,7 @@ class BrowserTabViewModelTest {
 
         testee.onUserPressedBack()
 
-        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.BACK_OR_CLOSE)
+        verify(mockDuckAiSessionCallback).onExitIntent("abc", DuckAiSessionExitTrigger.BACK_OR_CLOSE)
     }
 
     @Test
@@ -9396,7 +9396,7 @@ class BrowserTabViewModelTest {
 
         testee.onUserPressedBack()
 
-        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.BACK_OR_CLOSE)
+        verify(mockDuckAiSessionCallback).onExitIntent("abc", DuckAiSessionExitTrigger.BACK_OR_CLOSE)
     }
 
     @Test
@@ -9405,21 +9405,21 @@ class BrowserTabViewModelTest {
 
         testee.onUserPressedBack()
 
-        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.BACK_OR_CLOSE)
+        verify(mockDuckAiSessionCallback).onExitIntent("abc", DuckAiSessionExitTrigger.BACK_OR_CLOSE)
     }
 
     @Test
     fun whenRecordPendingNewTabOpenedExitCalledThenPendingNewTabOpenedExitRecorded() = runTest {
         testee.recordPendingNewTabOpenedExit()
 
-        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.NEW_TAB_OPENED)
+        verify(mockDuckAiSessionCallback).onExitIntent("abc", DuckAiSessionExitTrigger.NEW_TAB_OPENED)
     }
 
     @Test
     fun whenRecordPendingFireTabOpenedExitCalledThenPendingFireTabOpenedExitRecorded() = runTest {
         testee.recordPendingFireTabOpenedExit()
 
-        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.FIRE_TAB_OPENED)
+        verify(mockDuckAiSessionCallback).onExitIntent("abc", DuckAiSessionExitTrigger.FIRE_TAB_OPENED)
     }
 
     @Test
@@ -11870,7 +11870,7 @@ class BrowserTabViewModelTest {
 
         testee.pageFinished(mockWebView, webViewNavState, url)
 
-        verify(mockDuckAiSessionWideEvent).onDuckAiPageVisible("TAB_ID", url)
+        verify(mockDuckAiSessionCallback).onDuckAiPageVisible("TAB_ID", url)
     }
 
     @Test
@@ -11883,7 +11883,7 @@ class BrowserTabViewModelTest {
 
         testee.pageFinished(mockWebView, webViewNavState, "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5")
 
-        verify(mockDuckAiSessionWideEvent, never()).onDuckAiPageVisible(any(), any())
+        verify(mockDuckAiSessionCallback, never()).onDuckAiPageVisible(any(), any())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -316,9 +316,11 @@ import com.duckduckgo.downloads.api.model.DownloadItem
 import com.duckduckgo.downloads.store.DownloadStatus
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
+import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.contextual.PageContextJSHelper
 import com.duckduckgo.duckchat.impl.contextual.RealPageContextJSHelper.Companion.PAGE_CONTEXT_FEATURE_NAME
@@ -747,6 +749,7 @@ class BrowserTabViewModelTest {
     private val fakeSuggestRedirectFeature = FakeFeatureToggleFactory.create(SuggestRedirectOnUnresolvedErrorFeature::class.java)
     private val mockSuggestRedirectEvaluator: SuggestRedirectEvaluator = mock()
     private val mockBadUrlErrorPageWideEvent: BadUrlErrorPageWideEvent = mock()
+    private val mockDuckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
     private val mockInlinePdfHandler: InlinePdfHandler = mock()
     private val mockPdfDownloadTooltipDataStore: PdfDownloadTooltipDataStore = mock()
     private val mockCachedFileDownloader: CachedFileDownloader = mock()
@@ -1097,6 +1100,7 @@ class BrowserTabViewModelTest {
                 suggestRedirectOnUnresolvedErrorFeature = fakeSuggestRedirectFeature,
                 suggestRedirectEvaluator = mockSuggestRedirectEvaluator,
                 badUrlErrorPageWideEvent = mockBadUrlErrorPageWideEvent,
+                duckAiSessionWideEvent = mockDuckAiSessionWideEvent,
             )
 
         testee.loadData("abc", null, false, false)
@@ -3056,6 +3060,34 @@ class BrowserTabViewModelTest {
             assertEquals("https://example.com", query)
             assertNotNull(sourceTabId)
         }
+    }
+
+    @Test
+    fun whenOnLongPressRequiredActionWithOpenInNewTabThenPendingNewTabOpenedExitRecorded() = runTest {
+        val target = LongPressTarget(url = "https://example.com", type = WebView.HitTestResult.SRC_ANCHOR_TYPE)
+
+        testee.onLongPressRequiredAction(target, RequiredAction.OpenInNewTab("https://example.com"))
+
+        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.NEW_TAB_OPENED)
+    }
+
+    @Test
+    fun whenOnLongPressRequiredActionWithOpenInFireTabThenPendingFireTabOpenedExitRecorded() = runTest {
+        val target = LongPressTarget(url = "https://example.com", type = WebView.HitTestResult.SRC_ANCHOR_TYPE)
+
+        testee.onLongPressRequiredAction(target, RequiredAction.OpenInFireTab("https://example.com"))
+
+        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.FIRE_TAB_OPENED)
+    }
+
+    @Test
+    fun whenOnLongPressRequiredActionWithOpenInFireTabAndSubscriptionUrlThenNoPendingExitRecorded() = runTest {
+        whenever(subscriptions.shouldLaunchSubscriptionForUrl(any())).thenReturn(true)
+        val target = LongPressTarget(url = "https://example.com", type = WebView.HitTestResult.SRC_ANCHOR_TYPE)
+
+        testee.onLongPressRequiredAction(target, RequiredAction.OpenInFireTab("https://example.com"))
+
+        verify(mockDuckAiSessionWideEvent, never()).onExitIntent(any(), any())
     }
 
     @Test
@@ -9340,6 +9372,57 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenUserPressedBackAndCanGoBackThenPendingBackOrCloseExitRecorded() = runTest {
+        setupNavigation(isBrowsing = true, canGoBack = true)
+
+        testee.onUserPressedBack()
+
+        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.BACK_OR_CLOSE)
+    }
+
+    @Test
+    fun whenUserPressedBackWithSourceTabThenPendingBackOrCloseExitRecorded() = runTest {
+        selectedTabLiveData.value = TabEntity(tabId = "abc", sourceTabId = "source-tab")
+        setupNavigation(isBrowsing = true, canGoBack = false)
+
+        testee.onUserPressedBack()
+
+        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.BACK_OR_CLOSE)
+    }
+
+    @Test
+    fun whenUserPressedBackNavigatesHomeThenPendingBackOrCloseExitRecorded() = runTest {
+        setupNavigation(isBrowsing = true, canGoBack = false, skipHome = false)
+
+        testee.onUserPressedBack()
+
+        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.BACK_OR_CLOSE)
+    }
+
+    @Test
+    fun whenUserPressedBackWithNothingLeftToHandleThenPendingBackOrCloseExitRecorded() = runTest {
+        setupNavigation(isBrowsing = true, canGoBack = false, skipHome = true)
+
+        testee.onUserPressedBack()
+
+        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.BACK_OR_CLOSE)
+    }
+
+    @Test
+    fun whenRecordPendingNewTabOpenedExitCalledThenPendingNewTabOpenedExitRecorded() = runTest {
+        testee.recordPendingNewTabOpenedExit()
+
+        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.NEW_TAB_OPENED)
+    }
+
+    @Test
+    fun whenRecordPendingFireTabOpenedExitCalledThenPendingFireTabOpenedExitRecorded() = runTest {
+        testee.recordPendingFireTabOpenedExit()
+
+        verify(mockDuckAiSessionWideEvent).onExitIntent("abc", ExitTrigger.FIRE_TAB_OPENED)
+    }
+
+    @Test
     fun whenUserPressedForwardThenWideEventBadUrlErrorPageExited() = runTest {
         setBrowserShowing(true)
 
@@ -11773,6 +11856,34 @@ class BrowserTabViewModelTest {
         val commands = commandCaptor.allValues
         assertFalse(commands.any { it is Command.DuckAIFullScreenDisabled })
         assertTrue(commands.any { it is Command.EnableDuckAIFullScreen })
+    }
+
+    @Test
+    fun whenDuckAiPageFinishedOnTheActiveTabThenFullTabVisibleReported() = runTest {
+        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
+        // givenCurrentSite reloads the ViewModel for tabId "TAB_ID"; matching it here is what makes
+        // isActiveTab() true.
+        val url = "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5&chatID=chat-a"
+        givenCurrentSite(url)
+        selectedTabLiveData.value = TabEntity(tabId = "TAB_ID", url = url)
+        val webViewNavState = WebViewNavigationState(mockStack, 100)
+
+        testee.pageFinished(mockWebView, webViewNavState, url)
+
+        verify(mockDuckAiSessionWideEvent).onDuckAiPageVisible("TAB_ID", url)
+    }
+
+    @Test
+    fun whenDuckAiPageFinishedOnABackgroundTabThenFullTabVisibleNotReported() = runTest {
+        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
+        givenCurrentSite("https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5")
+        // A different tab is selected: this ViewModel's tab ("TAB_ID") is not the one on screen.
+        selectedTabLiveData.value = TabEntity(tabId = "some-other-tab", url = "https://example.com")
+        val webViewNavState = WebViewNavigationState(mockStack, 100)
+
+        testee.pageFinished(mockWebView, webViewNavState, "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5")
+
+        verify(mockDuckAiSessionWideEvent, never()).onDuckAiPageVisible(any(), any())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -45,8 +45,8 @@ import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeature
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
-import com.duckduckgo.duckchat.api.ExitTrigger
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
+import com.duckduckgo.duckchat.api.DuckAiSessionExitTrigger
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.State
@@ -111,7 +111,7 @@ class BrowserViewModelTest {
         on { currentMode } doReturn browserModeFlow
     }
     private val mockFireModeAvailability: FireModeAvailability = mock()
-    private val mockDuckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
+    private val mockDuckAiSessionCallback: DuckAiSessionCallback = mock()
 
     // The activity's frozen BrowserMode value injected into BrowserViewModel; defaults to REGULAR.
     private var browserMode = BrowserMode.REGULAR
@@ -163,7 +163,7 @@ class BrowserViewModelTest {
 
         testee.onNewTabRequested()
 
-        verify(mockDuckAiSessionWideEvent).onExitIntent("current-tab", ExitTrigger.NEW_TAB_OPENED)
+        verify(mockDuckAiSessionCallback).onExitIntent("current-tab", DuckAiSessionExitTrigger.NEW_TAB_OPENED)
     }
 
     @Test
@@ -172,7 +172,7 @@ class BrowserViewModelTest {
 
         testee.onOpenInNewTabRequested(query = "https://example.com")
 
-        verify(mockDuckAiSessionWideEvent).onExitIntent("current-tab", ExitTrigger.NEW_TAB_OPENED)
+        verify(mockDuckAiSessionCallback).onExitIntent("current-tab", DuckAiSessionExitTrigger.NEW_TAB_OPENED)
     }
 
     @Test
@@ -181,7 +181,7 @@ class BrowserViewModelTest {
 
         testee.onOpenInNewTabRequested(query = "https://example.com")
 
-        verify(mockDuckAiSessionWideEvent, never()).onExitIntent(any(), any())
+        verify(mockDuckAiSessionCallback, never()).onExitIntent(any(), any())
     }
 
     // --- selectedTab flow → NtpAfterIdleManager.onNtpShown ---
@@ -770,7 +770,7 @@ class BrowserViewModelTest {
             browserModeStateHolder = mockBrowserModeStateHolder,
             fireModeAvailability = mockFireModeAvailability,
             browserMode = browserMode,
-            duckAiSessionWideEvent = mockDuckAiSessionWideEvent,
+            duckAiSessionCallback = mockDuckAiSessionCallback,
         )
     }
 
@@ -795,7 +795,7 @@ class BrowserViewModelTest {
             browserModeStateHolder = mockBrowserModeStateHolder,
             fireModeAvailability = mockFireModeAvailability,
             browserMode = browserMode,
-            duckAiSessionWideEvent = mockDuckAiSessionWideEvent,
+            duckAiSessionCallback = mockDuckAiSessionCallback,
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -45,6 +45,8 @@ import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeature
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.State
@@ -109,6 +111,7 @@ class BrowserViewModelTest {
         on { currentMode } doReturn browserModeFlow
     }
     private val mockFireModeAvailability: FireModeAvailability = mock()
+    private val mockDuckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
 
     // The activity's frozen BrowserMode value injected into BrowserViewModel; defaults to REGULAR.
     private var browserMode = BrowserMode.REGULAR
@@ -152,6 +155,33 @@ class BrowserViewModelTest {
         whenever(mockTabRepository.liveSelectedTab).doReturn(MutableLiveData())
         testee.onNewTabRequested()
         verify(mockTabRepository).add()
+    }
+
+    @Test
+    fun whenNewTabRequestedThenPendingNewTabOpenedExitRecordedForCurrentlySelectedTab() = runTest {
+        whenever(mockTabRepository.getSelectedTab()).thenReturn(TabEntity(tabId = "current-tab", url = "https://duck.ai/"))
+
+        testee.onNewTabRequested()
+
+        verify(mockDuckAiSessionWideEvent).onExitIntent("current-tab", ExitTrigger.NEW_TAB_OPENED)
+    }
+
+    @Test
+    fun whenOpenInNewTabRequestedThenPendingNewTabOpenedExitRecordedForCurrentlySelectedTab() = runTest {
+        whenever(mockTabRepository.getSelectedTab()).thenReturn(TabEntity(tabId = "current-tab", url = "https://duck.ai/"))
+
+        testee.onOpenInNewTabRequested(query = "https://example.com")
+
+        verify(mockDuckAiSessionWideEvent).onExitIntent("current-tab", ExitTrigger.NEW_TAB_OPENED)
+    }
+
+    @Test
+    fun whenOpenInNewTabRequestedWithNoSelectedTabThenNoPendingExitRecorded() = runTest {
+        whenever(mockTabRepository.getSelectedTab()).thenReturn(null)
+
+        testee.onOpenInNewTabRequested(query = "https://example.com")
+
+        verify(mockDuckAiSessionWideEvent, never()).onExitIntent(any(), any())
     }
 
     // --- selectedTab flow → NtpAfterIdleManager.onNtpShown ---
@@ -740,6 +770,7 @@ class BrowserViewModelTest {
             browserModeStateHolder = mockBrowserModeStateHolder,
             fireModeAvailability = mockFireModeAvailability,
             browserMode = browserMode,
+            duckAiSessionWideEvent = mockDuckAiSessionWideEvent,
         )
     }
 
@@ -764,6 +795,7 @@ class BrowserViewModelTest {
             browserModeStateHolder = mockBrowserModeStateHolder,
             fireModeAvailability = mockFireModeAvailability,
             browserMode = browserMode,
+            duckAiSessionWideEvent = mockDuckAiSessionWideEvent,
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/session/BrowserSessionTabObserverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/session/BrowserSessionTabObserverTest.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -63,7 +63,7 @@ class BrowserSessionTabObserverTest {
     private val browserModeStateHolder: BrowserModeStateHolder = mock<BrowserModeStateHolder>().also {
         whenever(it.currentMode).thenReturn(currentModeFlow)
     }
-    private val duckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
+    private val duckAiSessionCallback: DuckAiSessionCallback = mock()
 
     private lateinit var testee: BrowserSessionTabObserver
 
@@ -72,7 +72,7 @@ class BrowserSessionTabObserverTest {
         testee = BrowserSessionTabObserver(
             tabRepositoryProvider = tabRepositoryProvider,
             browserModeStateHolder = browserModeStateHolder,
-            duckAiSessionWideEvent = duckAiSessionWideEvent,
+            duckAiSessionCallback = duckAiSessionCallback,
             appCoroutineScope = coroutineRule.testScope,
         )
     }
@@ -83,7 +83,7 @@ class BrowserSessionTabObserverTest {
     fun `when no tab is selected at start then it is reported as null tab and null url`() = runTest {
         idle()
 
-        verify(duckAiSessionWideEvent).onSelectedTabChanged(null, null)
+        verify(duckAiSessionCallback).onSelectedTabChanged(null, null)
     }
 
     @Test
@@ -91,7 +91,7 @@ class BrowserSessionTabObserverTest {
         regularSelectedTabFlow.value = TabEntity(tabId = "tab-1", url = "https://duck.ai/?chatID=chat-a")
         idle()
 
-        verify(duckAiSessionWideEvent).onSelectedTabChanged("tab-1", "https://duck.ai/?chatID=chat-a")
+        verify(duckAiSessionCallback).onSelectedTabChanged("tab-1", "https://duck.ai/?chatID=chat-a")
     }
 
     @Test
@@ -101,18 +101,18 @@ class BrowserSessionTabObserverTest {
         regularSelectedTabFlow.value = TabEntity(tabId = "tab-1", url = "https://duck.ai/", title = "Duck.ai 2")
         idle()
 
-        verify(duckAiSessionWideEvent, times(2)).onSelectedTabChanged("tab-1", "https://duck.ai/")
+        verify(duckAiSessionCallback, times(2)).onSelectedTabChanged("tab-1", "https://duck.ai/")
     }
 
     @Test
     fun `opening the tab switcher without changing the selection reports nothing new`() = runTest {
         regularSelectedTabFlow.value = TabEntity(tabId = "tab-1", url = "https://duck.ai/")
         idle()
-        verify(duckAiSessionWideEvent).onSelectedTabChanged("tab-1", "https://duck.ai/")
+        verify(duckAiSessionCallback).onSelectedTabChanged("tab-1", "https://duck.ai/")
 
         // Opening/dismissing the tab switcher doesn't touch the selected-tab flow at all, so nothing
         // further is emitted — there's nothing to verify beyond the single call above.
-        verifyNoMoreInteractions(duckAiSessionWideEvent)
+        verifyNoMoreInteractions(duckAiSessionCallback)
     }
 
     @Test
@@ -124,7 +124,7 @@ class BrowserSessionTabObserverTest {
         fireSelectedTabFlow.value = TabEntity(tabId = "fire-tab", url = "https://example.com")
         idle()
 
-        verify(duckAiSessionWideEvent).onSelectedTabChanged("regular-tab", "https://duck.ai/")
-        verify(duckAiSessionWideEvent).onSelectedTabChanged("fire-tab", "https://example.com")
+        verify(duckAiSessionCallback).onSelectedTabChanged("regular-tab", "https://duck.ai/")
+        verify(duckAiSessionCallback).onSelectedTabChanged("fire-tab", "https://example.com")
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/session/BrowserSessionTabObserverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/session/BrowserSessionTabObserverTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.session
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.tabs.model.TabEntity
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class BrowserSessionTabObserverTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule(StandardTestDispatcher())
+
+    private val regularSelectedTabFlow = MutableStateFlow<TabEntity?>(null)
+    private val fireSelectedTabFlow = MutableStateFlow<TabEntity?>(null)
+    private val regularTabRepository: TabRepository = mock<TabRepository>().also {
+        whenever(it.flowSelectedTab).thenReturn(regularSelectedTabFlow)
+    }
+    private val fireTabRepository: TabRepository = mock<TabRepository>().also {
+        whenever(it.flowSelectedTab).thenReturn(fireSelectedTabFlow)
+    }
+    private val tabRepositoryProvider = object : BrowserModeDataProvider<TabRepository> {
+        override fun forMode(mode: BrowserMode): TabRepository = when (mode) {
+            BrowserMode.REGULAR -> regularTabRepository
+            BrowserMode.FIRE -> fireTabRepository
+        }
+    }
+    private val currentModeFlow = MutableStateFlow(BrowserMode.REGULAR)
+    private val browserModeStateHolder: BrowserModeStateHolder = mock<BrowserModeStateHolder>().also {
+        whenever(it.currentMode).thenReturn(currentModeFlow)
+    }
+    private val duckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
+
+    private lateinit var testee: BrowserSessionTabObserver
+
+    @Before
+    fun setup() {
+        testee = BrowserSessionTabObserver(
+            tabRepositoryProvider = tabRepositoryProvider,
+            browserModeStateHolder = browserModeStateHolder,
+            duckAiSessionWideEvent = duckAiSessionWideEvent,
+            appCoroutineScope = coroutineRule.testScope,
+        )
+    }
+
+    private fun idle() = coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+    @Test
+    fun `when no tab is selected at start then it is reported as null tab and null url`() = runTest {
+        idle()
+
+        verify(duckAiSessionWideEvent).onSelectedTabChanged(null, null)
+    }
+
+    @Test
+    fun `when a tab is selected then its tabId and url are reported as observed`() = runTest {
+        regularSelectedTabFlow.value = TabEntity(tabId = "tab-1", url = "https://duck.ai/?chatID=chat-a")
+        idle()
+
+        verify(duckAiSessionWideEvent).onSelectedTabChanged("tab-1", "https://duck.ai/?chatID=chat-a")
+    }
+
+    @Test
+    fun `every emission is reported, including ones that only change an unrelated field`() = runTest {
+        regularSelectedTabFlow.value = TabEntity(tabId = "tab-1", url = "https://duck.ai/", title = "Duck.ai")
+        idle()
+        regularSelectedTabFlow.value = TabEntity(tabId = "tab-1", url = "https://duck.ai/", title = "Duck.ai 2")
+        idle()
+
+        verify(duckAiSessionWideEvent, times(2)).onSelectedTabChanged("tab-1", "https://duck.ai/")
+    }
+
+    @Test
+    fun `opening the tab switcher without changing the selection reports nothing new`() = runTest {
+        regularSelectedTabFlow.value = TabEntity(tabId = "tab-1", url = "https://duck.ai/")
+        idle()
+        verify(duckAiSessionWideEvent).onSelectedTabChanged("tab-1", "https://duck.ai/")
+
+        // Opening/dismissing the tab switcher doesn't touch the selected-tab flow at all, so nothing
+        // further is emitted — there's nothing to verify beyond the single call above.
+        verifyNoMoreInteractions(duckAiSessionWideEvent)
+    }
+
+    @Test
+    fun `when the browser mode switches then the other mode's selected tab is reported`() = runTest {
+        regularSelectedTabFlow.value = TabEntity(tabId = "regular-tab", url = "https://duck.ai/")
+        idle()
+
+        currentModeFlow.value = BrowserMode.FIRE
+        fireSelectedTabFlow.value = TabEntity(tabId = "fire-tab", url = "https://example.com")
+        idle()
+
+        verify(duckAiSessionWideEvent).onSelectedTabChanged("regular-tab", "https://duck.ai/")
+        verify(duckAiSessionWideEvent).onSelectedTabChanged("fire-tab", "https://example.com")
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/tabs/DefaultTabManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/tabs/DefaultTabManagerTest.kt
@@ -8,6 +8,8 @@ import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import kotlinx.coroutines.test.runTest
@@ -16,6 +18,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -30,6 +33,7 @@ class DefaultTabManagerTest {
     private val tabRepository: TabRepository = mock()
     private val omnibarEntryConverter: OmnibarEntryConverter = mock()
     private val skipUrlConversionOnNewTabFeature = FakeFeatureToggleFactory.create(SkipUrlConversionOnNewTabFeature::class.java)
+    private val duckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
 
     private lateinit var testee: DefaultTabManager
 
@@ -47,6 +51,7 @@ class DefaultTabManagerTest {
         queryUrlConverter = omnibarEntryConverter,
         skipUrlConversionOnNewTabFeature = skipUrlConversionOnNewTabFeature,
         browserMode = browserMode,
+        duckAiSessionWideEvent = duckAiSessionWideEvent,
     )
 
     @Test
@@ -55,6 +60,22 @@ class DefaultTabManagerTest {
         testee.onSelectedTabChanged(tabId)
 
         assertEquals(tabId, testee.getSelectedTabId())
+    }
+
+    @Test
+    fun whenOpenNewTabThenPendingNewTabOpenedExitRecordedForCurrentlySelectedTab() = runTest {
+        testee.onSelectedTabChanged("current-tab")
+
+        testee.openNewTab()
+
+        verify(duckAiSessionWideEvent).onExitIntent("current-tab", ExitTrigger.NEW_TAB_OPENED)
+    }
+
+    @Test
+    fun whenOpenNewTabWithNoSelectedTabThenNoPendingExitRecorded() = runTest {
+        testee.openNewTab()
+
+        verify(duckAiSessionWideEvent, never()).onExitIntent(any(), any())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/tabs/DefaultTabManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/tabs/DefaultTabManagerTest.kt
@@ -8,8 +8,8 @@ import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
-import com.duckduckgo.duckchat.api.ExitTrigger
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
+import com.duckduckgo.duckchat.api.DuckAiSessionExitTrigger
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import kotlinx.coroutines.test.runTest
@@ -33,7 +33,7 @@ class DefaultTabManagerTest {
     private val tabRepository: TabRepository = mock()
     private val omnibarEntryConverter: OmnibarEntryConverter = mock()
     private val skipUrlConversionOnNewTabFeature = FakeFeatureToggleFactory.create(SkipUrlConversionOnNewTabFeature::class.java)
-    private val duckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
+    private val duckAiSessionCallback: DuckAiSessionCallback = mock()
 
     private lateinit var testee: DefaultTabManager
 
@@ -51,7 +51,7 @@ class DefaultTabManagerTest {
         queryUrlConverter = omnibarEntryConverter,
         skipUrlConversionOnNewTabFeature = skipUrlConversionOnNewTabFeature,
         browserMode = browserMode,
-        duckAiSessionWideEvent = duckAiSessionWideEvent,
+        duckAiSessionCallback = duckAiSessionCallback,
     )
 
     @Test
@@ -68,14 +68,14 @@ class DefaultTabManagerTest {
 
         testee.openNewTab()
 
-        verify(duckAiSessionWideEvent).onExitIntent("current-tab", ExitTrigger.NEW_TAB_OPENED)
+        verify(duckAiSessionCallback).onExitIntent("current-tab", DuckAiSessionExitTrigger.NEW_TAB_OPENED)
     }
 
     @Test
     fun whenOpenNewTabWithNoSelectedTabThenNoPendingExitRecorded() = runTest {
         testee.openNewTab()
 
-        verify(duckAiSessionWideEvent, never()).onExitIntent(any(), any())
+        verify(duckAiSessionCallback, never()).onExitIntent(any(), any())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
@@ -37,7 +37,7 @@ import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.customtabs.api.CustomTabDetector
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
@@ -92,7 +92,7 @@ class FirstScreenHandlerImplTest {
     private val ntpAfterIdleManager: NtpAfterIdleManager = mock()
     private val modeSwitchRecreateSignal = ModeSwitchRecreateSignal()
     private val returnSessionLandingListener: ReturnSessionLandingListener = mock()
-    private val duckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
+    private val duckAiSessionCallback: DuckAiSessionCallback = mock()
     private val testScope = coroutineTestRule.testScope
 
     private lateinit var testee: FirstScreenHandlerImpl
@@ -129,7 +129,7 @@ class FirstScreenHandlerImplTest {
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
             appCoroutineScope = testScope,
             idleThresholdResolver = RealIdleThresholdResolver(androidBrowserConfigFeature),
-            duckAiSessionWideEvent = duckAiSessionWideEvent,
+            duckAiSessionCallback = duckAiSessionCallback,
         )
     }
 
@@ -243,7 +243,7 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(duckAiSessionWideEvent).onLaunchLandingResolved(null, null)
+        verify(duckAiSessionCallback).onLaunchLandingResolved(null, null)
     }
 
     @Test
@@ -332,7 +332,7 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(duckAiSessionWideEvent).onLaunchLandingResolved("tab-1", "https://duck.ai/chat?chatID=chat-a")
+        verify(duckAiSessionCallback).onLaunchLandingResolved("tab-1", "https://duck.ai/chat?chatID=chat-a")
     }
 
     @Test
@@ -355,7 +355,7 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(duckAiSessionWideEvent).onLaunchLandingResolved(null, null)
+        verify(duckAiSessionCallback).onLaunchLandingResolved(null, null)
     }
 
     @Test
@@ -370,7 +370,7 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(duckAiSessionWideEvent).onLaunchLandingResolved(null, null)
+        verify(duckAiSessionCallback).onLaunchLandingResolved(null, null)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.customtabs.api.CustomTabDetector
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
@@ -91,6 +92,7 @@ class FirstScreenHandlerImplTest {
     private val ntpAfterIdleManager: NtpAfterIdleManager = mock()
     private val modeSwitchRecreateSignal = ModeSwitchRecreateSignal()
     private val returnSessionLandingListener: ReturnSessionLandingListener = mock()
+    private val duckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
     private val testScope = coroutineTestRule.testScope
 
     private lateinit var testee: FirstScreenHandlerImpl
@@ -127,6 +129,7 @@ class FirstScreenHandlerImplTest {
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
             appCoroutineScope = testScope,
             idleThresholdResolver = RealIdleThresholdResolver(androidBrowserConfigFeature),
+            duckAiSessionWideEvent = duckAiSessionWideEvent,
         )
     }
 
@@ -224,6 +227,26 @@ class FirstScreenHandlerImplTest {
     }
 
     @Test
+    fun whenIdleReturnResolvesToNtpBeforeItsAsyncTabSelectionThenStaleDuckAiTabDoesNotStartSession() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(System.currentTimeMillis() - (6 * 60 * 1000))
+        whenever(showOnAppLaunchOptionHandler.handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR))
+            .thenReturn(
+                ShowOnAppLaunchResult(
+                    destinationUrl = null,
+                    treatment = AfterIdleTreatment.NTP,
+                ),
+            )
+        whenever(tabRepository.getSelectedTab()).thenReturn(TabEntity(tabId = "duckai-tab", url = "https://duck.ai/chat"))
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(duckAiSessionWideEvent).onLaunchLandingResolved(null, null)
+    }
+
+    @Test
     fun whenIdleReturnResolvesWhileAlreadyOnNtpThenReportsOrdinaryNtpLanding() = runTest {
         whenever(idleReturnToggle.isEnabled()).thenReturn(true)
         whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
@@ -289,6 +312,65 @@ class FirstScreenHandlerImplTest {
                 landing = ReturnSessionLanding.DUCK_AI,
             ),
         )
+    }
+
+    @Test
+    fun whenIdleSpecificPageResolvesToDuckAiThenFullTabVisibleReportedWithChatIdBaseline() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(System.currentTimeMillis() - (6 * 60 * 1000))
+        whenever(showOnAppLaunchOptionHandler.handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR))
+            .thenReturn(
+                ShowOnAppLaunchResult(
+                    destinationUrl = "https://duck.ai/chat?chatID=chat-a",
+                    treatment = null,
+                ),
+            )
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
+        whenever(tabRepository.getSelectedTab()).thenReturn(TabEntity(tabId = "tab-1", url = "https://duck.ai/chat?chatID=chat-a"))
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(duckAiSessionWideEvent).onLaunchLandingResolved("tab-1", "https://duck.ai/chat?chatID=chat-a")
+    }
+
+    @Test
+    fun whenResolvedDestinationIsNotDuckAiThenLandingResolvedIsStillReported() = runTest {
+        // Reported regardless of destination: it's what tells the coordinator this app-open's landing
+        // decision is resolved, so a later tab switch can trust it's safe to start a session.
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(System.currentTimeMillis() - (6 * 60 * 1000))
+        whenever(showOnAppLaunchOptionHandler.handleAfterInactivityOption(wasIdle = true, currentMode = BrowserMode.REGULAR))
+            .thenReturn(
+                ShowOnAppLaunchResult(
+                    destinationUrl = "https://example.com",
+                    treatment = null,
+                ),
+            )
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(false)
+        whenever(tabRepository.getSelectedTab()).thenReturn(TabEntity(tabId = "tab-1", url = "https://example.com"))
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(duckAiSessionWideEvent).onLaunchLandingResolved(null, null)
+    }
+
+    @Test
+    fun whenNoTabIsSelectedThenLandingResolvedIsStillReportedWithNullTabData() = runTest {
+        // Reported even with no tab selected: it's what tells the coordinator this app-open's landing
+        // decision is resolved, so a tab added afterward isn't locked out of starting a session.
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(System.currentTimeMillis() - (6 * 60 * 1000))
+        whenever(tabRepository.getSelectedTab()).thenReturn(null)
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(duckAiSessionWideEvent).onLaunchLandingResolved(null, null)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -66,10 +66,10 @@ import com.duckduckgo.common.ui.DuckDuckGoTheme
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeature
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
+import com.duckduckgo.duckchat.api.DuckAiSessionExitTrigger
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
-import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
@@ -176,7 +176,7 @@ class TabSwitcherViewModelTest {
 
     private val mockTabTitleResolver: TabTitleResolver = mock()
 
-    private val mockDuckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
+    private val mockDuckAiSessionCallback: DuckAiSessionCallback = mock()
     private val swipingTabsFeature = FakeFeatureToggleFactory.create(SwipingTabsFeature::class.java)
     private val swipingTabsFeatureProvider = SwipingTabsFeatureProvider(swipingTabsFeature)
 
@@ -251,8 +251,7 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
-            mockDataClearing,
-            mockDataClearingWideEvent,
+            mockDuckAiSessionCallback,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,
@@ -304,8 +303,8 @@ class TabSwitcherViewModelTest {
 
         testee.onNewTabRequested()
 
-        val inOrder = inOrder(mockDuckAiSessionWideEvent, mockTabRepository)
-        inOrder.verify(mockDuckAiSessionWideEvent).onExitIntent("CURRENT_TAB", ExitTrigger.NEW_TAB_OPENED)
+        val inOrder = inOrder(mockDuckAiSessionCallback, mockTabRepository)
+        inOrder.verify(mockDuckAiSessionCallback).onExitIntent("CURRENT_TAB", DuckAiSessionExitTrigger.NEW_TAB_OPENED)
         inOrder.verify(mockTabRepository).add()
     }
 
@@ -328,8 +327,8 @@ class TabSwitcherViewModelTest {
 
         testee.onNewTabRequested()
 
-        val inOrder = inOrder(mockDuckAiSessionWideEvent, mockTabRepository)
-        inOrder.verify(mockDuckAiSessionWideEvent).onExitIntent("1", ExitTrigger.NEW_TAB_OPENED)
+        val inOrder = inOrder(mockDuckAiSessionCallback, mockTabRepository)
+        inOrder.verify(mockDuckAiSessionCallback).onExitIntent("1", DuckAiSessionExitTrigger.NEW_TAB_OPENED)
         inOrder.verify(mockTabRepository).select("EMPTY_TAB")
         verify(mockTabRepository, never()).add()
     }
@@ -2245,8 +2244,7 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
-            mockDataClearing,
-            mockDataClearingWideEvent,
+            mockDuckAiSessionCallback,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,
@@ -2292,8 +2290,7 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
-            mockDataClearing,
-            mockDataClearingWideEvent,
+            mockDuckAiSessionCallback,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,
@@ -2368,8 +2365,7 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
-            mockDataClearing,
-            mockDataClearingWideEvent,
+            mockDuckAiSessionCallback,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -66,8 +66,10 @@ import com.duckduckgo.common.ui.DuckDuckGoTheme
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeature
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
+import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
@@ -106,6 +108,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -173,6 +176,7 @@ class TabSwitcherViewModelTest {
 
     private val mockTabTitleResolver: TabTitleResolver = mock()
 
+    private val mockDuckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
     private val swipingTabsFeature = FakeFeatureToggleFactory.create(SwipingTabsFeature::class.java)
     private val swipingTabsFeatureProvider = SwipingTabsFeatureProvider(swipingTabsFeature)
 
@@ -247,6 +251,8 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
+            mockDataClearing,
+            mockDataClearingWideEvent,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,
@@ -293,6 +299,17 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
+    fun whenNewTabRequestedThenPendingNewTabOpenedExitRecordedForCurrentTabBeforeAdding() = runTest {
+        whenever(mockTabRepository.getSelectedTab()).thenReturn(TabEntity("CURRENT_TAB", url = "https://duck.ai/"))
+
+        testee.onNewTabRequested()
+
+        val inOrder = inOrder(mockDuckAiSessionWideEvent, mockTabRepository)
+        inOrder.verify(mockDuckAiSessionWideEvent).onExitIntent("CURRENT_TAB", ExitTrigger.NEW_TAB_OPENED)
+        inOrder.verify(mockTabRepository).add()
+    }
+
+    @Test
     fun whenNewTabRequestedAndSwipingTabsEnabledAndEmptyTabExistsThenSelectEmptyTab() = runTest {
         swipingTabsFeature.self().setRawStoredState(State(enable = true))
         swipingTabsFeature.enabledForUsers().setRawStoredState(State(enable = true))
@@ -307,9 +324,13 @@ class TabSwitcherViewModelTest {
         initializeViewModel()
         prepareSelectionMode()
 
+        whenever(mockTabRepository.getSelectedTab()).thenReturn(TabEntity("1", url = "https://duck.ai/"))
+
         testee.onNewTabRequested()
 
-        verify(mockTabRepository).select("EMPTY_TAB")
+        val inOrder = inOrder(mockDuckAiSessionWideEvent, mockTabRepository)
+        inOrder.verify(mockDuckAiSessionWideEvent).onExitIntent("1", ExitTrigger.NEW_TAB_OPENED)
+        inOrder.verify(mockTabRepository).select("EMPTY_TAB")
         verify(mockTabRepository, never()).add()
     }
 
@@ -2224,6 +2245,8 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
+            mockDataClearing,
+            mockDataClearingWideEvent,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,
@@ -2269,6 +2292,8 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
+            mockDataClearing,
+            mockDataClearingWideEvent,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,
@@ -2343,6 +2368,8 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
+            mockDataClearing,
+            mockDataClearingWideEvent,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiSessionCallback.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiSessionCallback.kt
@@ -17,29 +17,28 @@
 package com.duckduckgo.duckchat.api
 
 /**
- * Covers every visit to a full Duck.ai tab, from becoming visible to a confirmed exit, as one wide event.
+ * Receives lifecycle and interaction events for visits to a full Duck.ai tab.
  */
-interface DuckAiSessionWideEvent {
+interface DuckAiSessionCallback {
     /**
      * Called once per app-open. [tabId] and [url] are supplied only when the resolved landing is Duck.ai.
-     * A repeated call for a tab that is already active is a no-op.
      */
     fun onLaunchLandingResolved(tabId: String?, url: String?)
 
     /**
-     * Called whenever [tabId] finishes loading [url] and it's a full Duck.ai page, for the currently active tab.
+     * Called whenever [tabId] finishes loading [url] and it is a full Duck.ai page for the currently active tab.
      */
     fun onDuckAiPageVisible(tabId: String, url: String)
 
     /**
-     * Records the selected-tab state for [tabId] and [url]
+     * Records the selected-tab state for [tabId] and [url].
      */
     fun onSelectedTabChanged(tabId: String?, url: String?)
 
     /**
-     * Records that [tabId] left Duck.ai for [trigger].
+     * Records that [tabId] may leave Duck.ai for [trigger].
      */
-    fun onExitIntent(tabId: String, trigger: ExitTrigger)
+    fun onExitIntent(tabId: String, trigger: DuckAiSessionExitTrigger)
 
     /** Records that a prompt was submitted from the active Duck.ai session in [tabId]. */
     fun onPromptSubmitted(tabId: String)
@@ -48,10 +47,10 @@ interface DuckAiSessionWideEvent {
     fun onNewChatCreated(tabId: String)
 }
 
-enum class ExitTrigger(val value: String) {
-    BACK_OR_CLOSE("back_or_close"),
-    TAB_SWITCHED("tab_switched"),
-    NEW_TAB_OPENED("new_tab_opened"),
-    FIRE_TAB_OPENED("fire_tab_opened"),
-    OTHER_NAVIGATION("other_navigation"),
+enum class DuckAiSessionExitTrigger {
+    BACK_OR_CLOSE,
+    TAB_SWITCHED,
+    NEW_TAB_OPENED,
+    FIRE_TAB_OPENED,
+    OTHER_NAVIGATION,
 }

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiSessionWideEvent.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiSessionWideEvent.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.api
+
+/**
+ * Covers every visit to a full Duck.ai tab, from becoming visible to a confirmed exit, as one wide event.
+ */
+interface DuckAiSessionWideEvent {
+    /**
+     * Called once per app-open. [tabId] and [url] are supplied only when the resolved landing is Duck.ai.
+     * A repeated call for a tab that is already active is a no-op.
+     */
+    fun onLaunchLandingResolved(tabId: String?, url: String?)
+
+    /**
+     * Called whenever [tabId] finishes loading [url] and it's a full Duck.ai page, for the currently active tab.
+     */
+    fun onDuckAiPageVisible(tabId: String, url: String)
+
+    /**
+     * Records the selected-tab state for [tabId] and [url]
+     */
+    fun onSelectedTabChanged(tabId: String?, url: String?)
+
+    /**
+     * Records that [tabId] left Duck.ai for [trigger].
+     */
+    fun onExitIntent(tabId: String, trigger: ExitTrigger)
+
+    /** Records that a prompt was submitted from the active Duck.ai session in [tabId]. */
+    fun onPromptSubmitted(tabId: String)
+
+    /** Records that a new chat was created from the active Duck.ai session in [tabId]. */
+    fun onNewChatCreated(tabId: String)
+}
+
+enum class ExitTrigger(val value: String) {
+    BACK_OR_CLOSE("back_or_close"),
+    TAB_SWITCHED("tab_switched"),
+    NEW_TAB_OPENED("new_tab_opened"),
+    FIRE_TAB_OPENED("fire_tab_opened"),
+    OTHER_NAVIGATION("other_navigation"),
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -290,4 +290,11 @@ interface DuckChatFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun contextualSheetRedesign(): Toggle
+
+    /**
+     * @return `true` when the Duck.ai session wide event should be sent
+     * If the remote feature is not present defaults to `internal`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun sendDuckAiSessionWideEvent(): Toggle
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -27,7 +27,9 @@ import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
+import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.ChatState
@@ -128,6 +130,7 @@ class RealDuckChatJSHelper @Inject constructor(
     private val subscriptions: Subscriptions,
     private val editPromptSessionStore: EditPromptSessionStore,
     private val browserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin>,
+    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
 ) : DuckChatJSHelper {
 
     private val registerOpenedJob = ConflatedJob()
@@ -186,6 +189,9 @@ class RealDuckChatJSHelper @Inject constructor(
             }
 
             METHOD_CLOSE_AI_CHAT -> {
+                if (mode == Mode.FULL && tabId.isNotEmpty()) {
+                    duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.BACK_OR_CLOSE)
+                }
                 duckChat.closeDuckChat()
                 null
             }
@@ -264,6 +270,12 @@ class RealDuckChatJSHelper @Inject constructor(
                     duckChatPixels.sendReportMetricPixel(it, modelTier, source)
                     if (it == USER_DID_SUBMIT_PROMPT || it == USER_DID_SUBMIT_FIRST_PROMPT) {
                         browserInteractionsPlugins.getPlugins().forEach { plugin -> plugin.onAiPromptSubmitted() }
+                        if (mode == Mode.FULL && tabId.isNotEmpty()) {
+                            duckAiSessionWideEvent.onPromptSubmitted(tabId)
+                        }
+                    }
+                    if (it == ReportMetric.USER_DID_CREATE_NEW_CHAT && mode == Mode.FULL && tabId.isNotEmpty()) {
+                        duckAiSessionWideEvent.onNewChatCreated(tabId)
                     }
                 }
                 null

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -27,9 +27,9 @@ import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
+import com.duckduckgo.duckchat.api.DuckAiSessionExitTrigger
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
-import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.ChatState
@@ -130,7 +130,7 @@ class RealDuckChatJSHelper @Inject constructor(
     private val subscriptions: Subscriptions,
     private val editPromptSessionStore: EditPromptSessionStore,
     private val browserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin>,
-    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
+    private val duckAiSessionCallback: DuckAiSessionCallback,
 ) : DuckChatJSHelper {
 
     private val registerOpenedJob = ConflatedJob()
@@ -190,7 +190,7 @@ class RealDuckChatJSHelper @Inject constructor(
 
             METHOD_CLOSE_AI_CHAT -> {
                 if (mode == Mode.FULL && tabId.isNotEmpty()) {
-                    duckAiSessionWideEvent.onExitIntent(tabId, ExitTrigger.BACK_OR_CLOSE)
+                    duckAiSessionCallback.onExitIntent(tabId, DuckAiSessionExitTrigger.BACK_OR_CLOSE)
                 }
                 duckChat.closeDuckChat()
                 null
@@ -271,11 +271,11 @@ class RealDuckChatJSHelper @Inject constructor(
                     if (it == USER_DID_SUBMIT_PROMPT || it == USER_DID_SUBMIT_FIRST_PROMPT) {
                         browserInteractionsPlugins.getPlugins().forEach { plugin -> plugin.onAiPromptSubmitted() }
                         if (mode == Mode.FULL && tabId.isNotEmpty()) {
-                            duckAiSessionWideEvent.onPromptSubmitted(tabId)
+                            duckAiSessionCallback.onPromptSubmitted(tabId)
                         }
                     }
                     if (it == ReportMetric.USER_DID_CREATE_NEW_CHAT && mode == Mode.FULL && tabId.isNotEmpty()) {
-                        duckAiSessionWideEvent.onNewChatCreated(tabId)
+                        duckAiSessionCallback.onNewChatCreated(tabId)
                     }
                 }
                 null

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
@@ -302,6 +303,7 @@ class RealDuckChatPixels @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
     private val browserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin>,
     private val duckAiNewChatMetricPixelsPlugin: DuckAiNewChatMetricPixelsPlugin,
+    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
 ) : DuckChatPixels {
 
     /** `first_prompt_new_install` must be attributable to a fresh install, never to an existing user who just updated. */
@@ -909,6 +911,9 @@ class RealDuckChatPixels @Inject constructor(
         ) {
             val source = resolveEntrySource(surface, tabId, addressBarEntryPoint)
             browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted(source = source) }
+            if (surface == DuckChatPixelSurface.DUCK_AI && !tabId.isNullOrEmpty()) {
+                duckAiSessionWideEvent.onPromptSubmitted(tabId)
+            }
             val isFirstPrompt = isFirstPromptForNewInstall()
             buildMap {
                 put(DuckChatPixelParameters.SELECTED_TOOL, selectedTool)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -27,7 +27,7 @@ import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
@@ -303,7 +303,7 @@ class RealDuckChatPixels @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
     private val browserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin>,
     private val duckAiNewChatMetricPixelsPlugin: DuckAiNewChatMetricPixelsPlugin,
-    private val duckAiSessionWideEvent: DuckAiSessionWideEvent,
+    private val duckAiSessionCallback: DuckAiSessionCallback,
 ) : DuckChatPixels {
 
     /** `first_prompt_new_install` must be attributable to a fresh install, never to an existing user who just updated. */
@@ -912,7 +912,7 @@ class RealDuckChatPixels @Inject constructor(
             val source = resolveEntrySource(surface, tabId, addressBarEntryPoint)
             browserInteractionsPlugins.getPlugins().forEach { it.onAiPromptSubmitted(source = source) }
             if (surface == DuckChatPixelSurface.DUCK_AI && !tabId.isNullOrEmpty()) {
-                duckAiSessionWideEvent.onPromptSubmitted(tabId)
+                duckAiSessionCallback.onPromptSubmitted(tabId)
             }
             val isFirstPrompt = isFirstPromptForNewInstall()
             buildMap {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/wideevents/RealDuckAiSessionWideEvent.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/wideevents/RealDuckAiSessionWideEvent.kt
@@ -24,9 +24,9 @@ import com.duckduckgo.app.statistics.wideevents.WideEventClient
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
+import com.duckduckgo.duckchat.api.DuckAiSessionExitTrigger
 import com.duckduckgo.duckchat.api.DuckChat
-import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.duckchat.api.toChatIdOrNull
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.squareup.anvil.annotations.ContributesBinding
@@ -43,7 +43,7 @@ import javax.inject.Inject
 /**
  * All work happens on one sequential consumer reading from one [Channel], so there is never more than
  * one caller's event being processed at a time, and — crucially — events are processed in the order
- * they were sent. That ordering is what makes [DuckAiSessionWideEvent.onExitIntent] safe to call for a
+ * they were sent. That ordering is what makes [DuckAiSessionCallback.onExitIntent] safe to call for a
  * tab whose session is still starting: `onLaunchLandingResolved`/`onDuckAiPageVisible`/
  * `onSelectedTabChanged` for that tab can only have been sent first (the user can't act on a tab before
  * it becomes visible), so the consumer always finishes starting the session before it looks at the exit
@@ -53,7 +53,7 @@ import javax.inject.Inject
  * [WideEventClient.flowFinish].
  */
 @SingleInstanceIn(AppScope::class)
-@ContributesBinding(AppScope::class, boundType = DuckAiSessionWideEvent::class)
+@ContributesBinding(AppScope::class, boundType = DuckAiSessionCallback::class)
 @ContributesMultibinding(AppScope::class, boundType = BrowserLifecycleObserver::class)
 class RealDuckAiSessionWideEvent @Inject constructor(
     private val wideEventClient: WideEventClient,
@@ -61,7 +61,7 @@ class RealDuckAiSessionWideEvent @Inject constructor(
     private val duckChatFeature: Lazy<DuckChatFeature>,
     dispatchers: DispatcherProvider,
     @AppCoroutineScope appCoroutineScope: CoroutineScope,
-) : DuckAiSessionWideEvent, BrowserLifecycleObserver {
+) : DuckAiSessionCallback, BrowserLifecycleObserver {
 
     private val coroutineScope = CoroutineScope(appCoroutineScope.coroutineContext + dispatchers.io())
     private val channel = Channel<Action>(capacity = Channel.UNLIMITED)
@@ -104,7 +104,7 @@ class RealDuckAiSessionWideEvent @Inject constructor(
         channel.trySend(Action.SelectedTabChanged(tabId, url))
     }
 
-    override fun onExitIntent(tabId: String, trigger: ExitTrigger) {
+    override fun onExitIntent(tabId: String, trigger: DuckAiSessionExitTrigger) {
         channel.trySend(Action.ExitIntent(tabId, trigger))
     }
 
@@ -201,7 +201,7 @@ class RealDuckAiSessionWideEvent @Inject constructor(
     private suspend fun applySelectedTabTransition(previous: TabState, current: TabState) {
         when {
             previous.isDuckAi && current.tabId != previous.tabId -> {
-                val trigger = resolvePendingExit(previous.tabId!!) ?: ExitTrigger.TAB_SWITCHED
+                val trigger = resolvePendingExit(previous.tabId!!) ?: DuckAiSessionExitTrigger.TAB_SWITCHED
                 endSessionIfMatches(previous.tabId, trigger)
                 if (current.isDuckAi && current.tabId != null) {
                     startSessionIfNoneActive(current.tabId, current.chatId)
@@ -210,7 +210,7 @@ class RealDuckAiSessionWideEvent @Inject constructor(
             // The two branches below are only reached once the tab identifier is known to be
             // unchanged, since the branch above already handles every case where it differs.
             previous.isDuckAi && !current.isDuckAi -> {
-                val trigger = resolvePendingExit(previous.tabId!!) ?: ExitTrigger.OTHER_NAVIGATION
+                val trigger = resolvePendingExit(previous.tabId!!) ?: DuckAiSessionExitTrigger.OTHER_NAVIGATION
                 endSessionIfMatches(previous.tabId, trigger)
             }
             previous.isDuckAi && current.isDuckAi -> {
@@ -227,7 +227,7 @@ class RealDuckAiSessionWideEvent @Inject constructor(
         }
     }
 
-    private fun processExitIntent(tabId: String, trigger: ExitTrigger) {
+    private fun processExitIntent(tabId: String, trigger: DuckAiSessionExitTrigger) {
         if (activeSession?.tabId != tabId) return
         pendingExit = PendingExit(tabId, trigger)
     }
@@ -242,7 +242,7 @@ class RealDuckAiSessionWideEvent @Inject constructor(
         val pending = pendingExit
         pendingExit = null
         val backOrCloseTrigger = pending
-            ?.takeIf { it.tabId == session.tabId && it.trigger == ExitTrigger.BACK_OR_CLOSE }
+            ?.takeIf { it.tabId == session.tabId && it.trigger == DuckAiSessionExitTrigger.BACK_OR_CLOSE }
             ?.trigger
 
         if (backOrCloseTrigger != null) {
@@ -252,7 +252,7 @@ class RealDuckAiSessionWideEvent @Inject constructor(
         }
     }
 
-    private fun resolvePendingExit(tabId: String): ExitTrigger? {
+    private fun resolvePendingExit(tabId: String): DuckAiSessionExitTrigger? {
         val current = pendingExit ?: return null
         if (current.tabId != tabId) return null
         pendingExit = null
@@ -268,7 +268,7 @@ class RealDuckAiSessionWideEvent @Inject constructor(
         startSession(tabId, chatId)
     }
 
-    private suspend fun endSessionIfMatches(tabId: String, trigger: ExitTrigger) {
+    private suspend fun endSessionIfMatches(tabId: String, trigger: DuckAiSessionExitTrigger) {
         val session = activeSession ?: return
         if (session.tabId != tabId) return
         activeSession = null
@@ -324,14 +324,14 @@ class RealDuckAiSessionWideEvent @Inject constructor(
         session: SessionState,
         status: FlowStatus,
         statusReason: String,
-        exitTrigger: ExitTrigger?,
+        exitTrigger: DuckAiSessionExitTrigger?,
     ) {
         wideEventClient.flowFinish(
             wideEventId = session.flowId,
             status = status,
             metadata = buildMap {
                 put(KEY_STATUS_REASON, statusReason)
-                exitTrigger?.let { put(KEY_EXIT_TRIGGER, it.value) }
+                exitTrigger?.let { put(KEY_EXIT_TRIGGER, it.toPixelValue()) }
             },
         )
         logcat(tag = TAG) { "Duck.ai session finished: status=$status, reason=$statusReason" }
@@ -361,7 +361,7 @@ class RealDuckAiSessionWideEvent @Inject constructor(
         sealed class Dispatchable : Action()
         data class LaunchLandingResolved(val tabId: String?, val url: String?) : Dispatchable()
         data class DuckAiPageVisible(val tabId: String, val url: String) : Dispatchable()
-        data class ExitIntent(val tabId: String, val trigger: ExitTrigger) : Dispatchable()
+        data class ExitIntent(val tabId: String, val trigger: DuckAiSessionExitTrigger) : Dispatchable()
         data class PromptSubmitted(val tabId: String) : Dispatchable()
         data class NewChatCreated(val tabId: String) : Dispatchable()
         data object AppClosed : Dispatchable()
@@ -379,7 +379,7 @@ class RealDuckAiSessionWideEvent @Inject constructor(
 
     private data class PendingExit(
         val tabId: String,
-        val trigger: ExitTrigger,
+        val trigger: DuckAiSessionExitTrigger,
     )
 
     private class SessionState(
@@ -407,3 +407,5 @@ class RealDuckAiSessionWideEvent @Inject constructor(
         const val STEP_CHAT_ID_CHANGED = "chat_id_changed"
     }
 }
+
+private fun DuckAiSessionExitTrigger.toPixelValue(): String = name.lowercase()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/wideevents/RealDuckAiSessionWideEvent.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/wideevents/RealDuckAiSessionWideEvent.kt
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.wideevents
+
+import androidx.core.net.toUri
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.statistics.wideevents.CleanupPolicy
+import com.duckduckgo.app.statistics.wideevents.FlowStatus
+import com.duckduckgo.app.statistics.wideevents.WideEventClient
+import com.duckduckgo.browser.api.BrowserLifecycleObserver
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.ExitTrigger
+import com.duckduckgo.duckchat.api.toChatIdOrNull
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.Lazy
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * All work happens on one sequential consumer reading from one [Channel], so there is never more than
+ * one caller's event being processed at a time, and — crucially — events are processed in the order
+ * they were sent. That ordering is what makes [DuckAiSessionWideEvent.onExitIntent] safe to call for a
+ * tab whose session is still starting: `onLaunchLandingResolved`/`onDuckAiPageVisible`/
+ * `onSelectedTabChanged` for that tab can only have been sent first (the user can't act on a tab before
+ * it becomes visible), so the consumer always finishes starting the session before it looks at the exit
+ * intent, even if starting is slow.
+ *
+ * This class is the sole owner of the session's status/reason mapping and the only caller of
+ * [WideEventClient.flowFinish].
+ */
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class, boundType = DuckAiSessionWideEvent::class)
+@ContributesMultibinding(AppScope::class, boundType = BrowserLifecycleObserver::class)
+class RealDuckAiSessionWideEvent @Inject constructor(
+    private val wideEventClient: WideEventClient,
+    private val duckChat: DuckChat,
+    private val duckChatFeature: Lazy<DuckChatFeature>,
+    dispatchers: DispatcherProvider,
+    @AppCoroutineScope appCoroutineScope: CoroutineScope,
+) : DuckAiSessionWideEvent, BrowserLifecycleObserver {
+
+    private val coroutineScope = CoroutineScope(appCoroutineScope.coroutineContext + dispatchers.io())
+    private val channel = Channel<Action>(capacity = Channel.UNLIMITED)
+
+    // Touched only by the single consumer loop below — no mutex or atomics needed.
+    private var activeSession: SessionState? = null
+    private var lastSelectedTab: TabState? = null
+    private var pendingExit: PendingExit? = null
+
+    // Both default closed so nothing can start a session before the app has genuinely opened once.
+    // AppClosed clears both, so a WebView callback or tab update that was already in flight when the
+    // app closed — and only reaches the channel afterwards — can't start a new session while nothing is
+    // visible; a session can only start again once the next app-open's landing has resolved.
+    private var appOpen = false
+    private var launchResolved = false
+
+    init {
+        coroutineScope.launch {
+            for (action in channel) {
+                try {
+                    processAction(action)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    logcat(tag = TAG) { "Error processing ${action::class.simpleName}: ${e.message}" }
+                }
+            }
+        }
+    }
+
+    override fun onLaunchLandingResolved(tabId: String?, url: String?) {
+        channel.trySend(Action.LaunchLandingResolved(tabId, url))
+    }
+
+    override fun onDuckAiPageVisible(tabId: String, url: String) {
+        channel.trySend(Action.DuckAiPageVisible(tabId, url))
+    }
+
+    override fun onSelectedTabChanged(tabId: String?, url: String?) {
+        channel.trySend(Action.SelectedTabChanged(tabId, url))
+    }
+
+    override fun onExitIntent(tabId: String, trigger: ExitTrigger) {
+        channel.trySend(Action.ExitIntent(tabId, trigger))
+    }
+
+    override fun onPromptSubmitted(tabId: String) {
+        channel.trySend(Action.PromptSubmitted(tabId))
+    }
+
+    override fun onNewChatCreated(tabId: String) {
+        channel.trySend(Action.NewChatCreated(tabId))
+    }
+
+    override fun onOpen(isFreshLaunch: Boolean) {
+        channel.trySend(Action.AppOpened)
+    }
+
+    override fun onClose() {
+        channel.trySend(Action.AppClosed)
+    }
+
+    private suspend fun processAction(action: Action) {
+        // Transition detection and app-open/closed bookkeeping always run, even while the feature is
+        // disabled, so stale state doesn't cause a missed start — or a spurious one — right after the
+        // feature is re-enabled. Only acting on a detected transition (or any other action) is gated on
+        // the feature being enabled.
+        if (action is Action.SelectedTabChanged) {
+            val current = computeTabState(action.tabId, action.url)
+            val previous = lastSelectedTab
+            lastSelectedTab = current
+            if (previous == null || current == previous) return
+            if (isFeatureDisabled()) {
+                abortActiveSession()
+                return
+            }
+            applySelectedTabTransition(previous, current)
+            return
+        }
+
+        if (action is Action.AppOpened) {
+            appOpen = true
+            return
+        }
+
+        // Every other Action subtype is a Dispatchable, so this when below is exhaustive without
+        // needing (unreachable) branches for the two subtypes already handled above.
+        check(action is Action.Dispatchable)
+
+        if (action is Action.AppClosed) {
+            appOpen = false
+            launchResolved = false
+        }
+
+        if (isFeatureDisabled()) {
+            abortActiveSession()
+            return
+        }
+
+        when (action) {
+            is Action.LaunchLandingResolved -> processLaunchLandingResolved(action.tabId, action.url)
+            is Action.DuckAiPageVisible -> processDuckAiPageVisible(action.tabId, action.url)
+            is Action.ExitIntent -> processExitIntent(action.tabId, action.trigger)
+            is Action.PromptSubmitted -> recordActivityOnce(
+                STEP_PROMPT_SUBMITTED,
+                action.tabId,
+                isAlreadyRecorded = { it.promptSubmitted },
+            ) { it.promptSubmitted = true }
+            is Action.NewChatCreated -> recordActivityOnce(
+                STEP_NEW_CHAT_CREATED,
+                action.tabId,
+                isAlreadyRecorded = { it.newChatCreated },
+            ) { it.newChatCreated = true }
+            Action.AppClosed -> processAppClosed()
+        }
+    }
+
+    private suspend fun processLaunchLandingResolved(tabId: String?, url: String?) {
+        if (!appOpen) return
+        launchResolved = true
+        if (tabId == null) return
+        tryStartSession(tabId, url)
+    }
+
+    private suspend fun processDuckAiPageVisible(tabId: String, url: String) {
+        if (!appOpen || !launchResolved) return
+        tryStartSession(tabId, url)
+    }
+
+    private suspend fun tryStartSession(tabId: String, url: String?) {
+        if (activeSession != null) return
+        val state = computeTabState(tabId, url)
+        if (!state.isDuckAi) return
+        startSession(tabId, state.chatId)
+    }
+
+    private suspend fun applySelectedTabTransition(previous: TabState, current: TabState) {
+        when {
+            previous.isDuckAi && current.tabId != previous.tabId -> {
+                val trigger = resolvePendingExit(previous.tabId!!) ?: ExitTrigger.TAB_SWITCHED
+                endSessionIfMatches(previous.tabId, trigger)
+                if (current.isDuckAi && current.tabId != null) {
+                    startSessionIfNoneActive(current.tabId, current.chatId)
+                }
+            }
+            // The two branches below are only reached once the tab identifier is known to be
+            // unchanged, since the branch above already handles every case where it differs.
+            previous.isDuckAi && !current.isDuckAi -> {
+                val trigger = resolvePendingExit(previous.tabId!!) ?: ExitTrigger.OTHER_NAVIGATION
+                endSessionIfMatches(previous.tabId, trigger)
+            }
+            previous.isDuckAi && current.isDuckAi -> {
+                // The URL changed but Duck.ai is still showing in the same tab (a link within the chat,
+                // or Back landing on another Duck.ai page): any pending exit for it no longer applies,
+                // and the active session's chat identity may have changed.
+                resolvePendingExit(previous.tabId!!)
+                updateChatId(previous.tabId, current.chatId)
+            }
+            // previous.isDuckAi is guaranteed false here, since it's covered by the three branches above.
+            current.isDuckAi && current.tabId != null -> {
+                startSessionIfNoneActive(current.tabId, current.chatId)
+            }
+        }
+    }
+
+    private fun processExitIntent(tabId: String, trigger: ExitTrigger) {
+        if (activeSession?.tabId != tabId) return
+        pendingExit = PendingExit(tabId, trigger)
+    }
+
+    private suspend fun processAppClosed() {
+        val session = activeSession ?: run {
+            pendingExit = null
+            return
+        }
+        activeSession = null
+
+        val pending = pendingExit
+        pendingExit = null
+        val backOrCloseTrigger = pending
+            ?.takeIf { it.tabId == session.tabId && it.trigger == ExitTrigger.BACK_OR_CLOSE }
+            ?.trigger
+
+        if (backOrCloseTrigger != null) {
+            finishSession(session, FlowStatus.Success, REASON_LEFT_DUCKAI, backOrCloseTrigger)
+        } else {
+            finishSession(session, FlowStatus.Cancelled, REASON_APP_BACKGROUNDED, exitTrigger = null)
+        }
+    }
+
+    private fun resolvePendingExit(tabId: String): ExitTrigger? {
+        val current = pendingExit ?: return null
+        if (current.tabId != tabId) return null
+        pendingExit = null
+        return current.trigger
+    }
+
+    private suspend fun startSessionIfNoneActive(tabId: String, chatId: String?) {
+        // launchResolved requires a resolved landing (see onLaunchLandingResolved) before a tab switch
+        // alone is trusted to start a session — otherwise stale pre-launch tab state could start one
+        // before the app has actually decided where it's landing.
+        if (!appOpen || !launchResolved) return
+        if (activeSession != null) return
+        startSession(tabId, chatId)
+    }
+
+    private suspend fun endSessionIfMatches(tabId: String, trigger: ExitTrigger) {
+        val session = activeSession ?: return
+        if (session.tabId != tabId) return
+        activeSession = null
+        finishSession(session, FlowStatus.Success, REASON_LEFT_DUCKAI, trigger)
+    }
+
+    private suspend fun updateChatId(tabId: String, chatId: String?) {
+        val session = activeSession ?: return
+        if (session.tabId != tabId) return
+        if (chatId == session.lastObservedChatId) return
+
+        session.lastObservedChatId = chatId
+        if (session.chatIdChangeRecorded) return
+
+        session.chatIdChangeRecorded = true
+        wideEventClient.flowStep(wideEventId = session.flowId, stepName = STEP_CHAT_ID_CHANGED)
+        logcat(tag = TAG) { "Duck.ai session: $STEP_CHAT_ID_CHANGED recorded" }
+    }
+
+    private suspend fun recordActivityOnce(
+        stepName: String,
+        tabId: String,
+        isAlreadyRecorded: (SessionState) -> Boolean,
+        markRecorded: (SessionState) -> Unit,
+    ) {
+        val session = activeSession ?: return
+        if (session.tabId != tabId) return
+        if (isAlreadyRecorded(session)) return
+
+        markRecorded(session)
+        wideEventClient.flowStep(wideEventId = session.flowId, stepName = stepName)
+        logcat(tag = TAG) { "Duck.ai session: $stepName recorded" }
+    }
+
+    private suspend fun startSession(tabId: String, chatId: String?) {
+        val result = wideEventClient.flowStart(
+            name = FEATURE_NAME,
+            cleanupPolicy = CleanupPolicy.OnProcessStart(
+                ignoreIfIntervalTimeoutPresent = false,
+                flowStatus = FlowStatus.Unknown,
+            ),
+            metadata = mapOf(KEY_STATUS_REASON to REASON_APP_TERMINATED),
+        )
+        result.onSuccess { flowId ->
+            activeSession = SessionState(flowId = flowId, tabId = tabId, lastObservedChatId = chatId)
+            logcat(tag = TAG) { "Duck.ai session started" }
+        }.onFailure { error ->
+            logcat(tag = TAG) { "Failed to start Duck.ai session: ${error.message}" }
+        }
+    }
+
+    private suspend fun finishSession(
+        session: SessionState,
+        status: FlowStatus,
+        statusReason: String,
+        exitTrigger: ExitTrigger?,
+    ) {
+        wideEventClient.flowFinish(
+            wideEventId = session.flowId,
+            status = status,
+            metadata = buildMap {
+                put(KEY_STATUS_REASON, statusReason)
+                exitTrigger?.let { put(KEY_EXIT_TRIGGER, it.value) }
+            },
+        )
+        logcat(tag = TAG) { "Duck.ai session finished: status=$status, reason=$statusReason" }
+    }
+
+    private suspend fun abortActiveSession() {
+        pendingExit = null
+        activeSession?.let { session ->
+            wideEventClient.flowAbort(session.flowId)
+            activeSession = null
+        }
+    }
+
+    private fun isFeatureDisabled(): Boolean = !duckChatFeature.get().sendDuckAiSessionWideEvent().isEnabled()
+
+    private fun computeTabState(tabId: String?, url: String?): TabState {
+        val nonBlankUrl = url?.takeIf { it.isNotBlank() }
+        val uri = nonBlankUrl?.toUri()
+        val isDuckAi = uri != null && duckChat.isDuckChatUrl(uri)
+        val chatId = uri?.toChatIdOrNull(duckChat)
+        return TabState(tabId, nonBlankUrl, isDuckAi, chatId)
+    }
+
+    private sealed class Action {
+        // Actions gated by isFeatureDisabled() and dispatched by the second `when` in processAction —
+        // everything except the two that need to run before, and regardless of, that check.
+        sealed class Dispatchable : Action()
+        data class LaunchLandingResolved(val tabId: String?, val url: String?) : Dispatchable()
+        data class DuckAiPageVisible(val tabId: String, val url: String) : Dispatchable()
+        data class ExitIntent(val tabId: String, val trigger: ExitTrigger) : Dispatchable()
+        data class PromptSubmitted(val tabId: String) : Dispatchable()
+        data class NewChatCreated(val tabId: String) : Dispatchable()
+        data object AppClosed : Dispatchable()
+
+        data class SelectedTabChanged(val tabId: String?, val url: String?) : Action()
+        data object AppOpened : Action()
+    }
+
+    private data class TabState(
+        val tabId: String?,
+        val url: String?,
+        val isDuckAi: Boolean,
+        val chatId: String?,
+    )
+
+    private data class PendingExit(
+        val tabId: String,
+        val trigger: ExitTrigger,
+    )
+
+    private class SessionState(
+        val flowId: Long,
+        val tabId: String,
+        var promptSubmitted: Boolean = false,
+        var newChatCreated: Boolean = false,
+        var chatIdChangeRecorded: Boolean = false,
+        var lastObservedChatId: String? = null,
+    )
+
+    private companion object {
+        const val TAG = "RealDuckAiSessionWideEvent"
+        const val FEATURE_NAME = "duckai_session"
+
+        const val REASON_LEFT_DUCKAI = "left_duckai"
+        const val REASON_APP_BACKGROUNDED = "app_backgrounded"
+        const val REASON_APP_TERMINATED = "app_terminated"
+
+        const val KEY_STATUS_REASON = "status_reason"
+        const val KEY_EXIT_TRIGGER = "exit_trigger"
+
+        const val STEP_PROMPT_SUBMITTED = "prompt_submitted"
+        const val STEP_NEW_CHAT_CREATED = "new_chat_created"
+        const val STEP_CHAT_ID_CHANGED = "chat_id_changed"
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/wideevents/RealDuckAiSessionWideEvent.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/wideevents/RealDuckAiSessionWideEvent.kt
@@ -229,6 +229,7 @@ class RealDuckAiSessionWideEvent @Inject constructor(
 
     private fun processExitIntent(tabId: String, trigger: DuckAiSessionExitTrigger) {
         if (activeSession?.tabId != tabId) return
+        if (pendingExit != null) return
         pendingExit = PendingExit(tabId, trigger)
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/wideevents/RealDuckAiSessionWideEvent.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/wideevents/RealDuckAiSessionWideEvent.kt
@@ -199,28 +199,26 @@ class RealDuckAiSessionWideEvent @Inject constructor(
     }
 
     private suspend fun applySelectedTabTransition(previous: TabState, current: TabState) {
+        val previousTabId = previous.tabId
         when {
-            previous.isDuckAi && current.tabId != previous.tabId -> {
-                val trigger = resolvePendingExit(previous.tabId!!) ?: DuckAiSessionExitTrigger.TAB_SWITCHED
-                endSessionIfMatches(previous.tabId, trigger)
+            previous.isDuckAi && previousTabId != null && current.tabId != previousTabId -> {
+                val trigger = resolvePendingExit(previousTabId) ?: DuckAiSessionExitTrigger.TAB_SWITCHED
+                endSessionIfMatches(previousTabId, trigger)
                 if (current.isDuckAi && current.tabId != null) {
                     startSessionIfNoneActive(current.tabId, current.chatId)
                 }
             }
-            // The two branches below are only reached once the tab identifier is known to be
-            // unchanged, since the branch above already handles every case where it differs.
-            previous.isDuckAi && !current.isDuckAi -> {
-                val trigger = resolvePendingExit(previous.tabId!!) ?: DuckAiSessionExitTrigger.OTHER_NAVIGATION
-                endSessionIfMatches(previous.tabId, trigger)
+            previous.isDuckAi && previousTabId != null && !current.isDuckAi -> {
+                val trigger = resolvePendingExit(previousTabId) ?: DuckAiSessionExitTrigger.OTHER_NAVIGATION
+                endSessionIfMatches(previousTabId, trigger)
             }
-            previous.isDuckAi && current.isDuckAi -> {
+            previous.isDuckAi && previousTabId != null && current.isDuckAi -> {
                 // The URL changed but Duck.ai is still showing in the same tab (a link within the chat,
                 // or Back landing on another Duck.ai page): any pending exit for it no longer applies,
                 // and the active session's chat identity may have changed.
-                resolvePendingExit(previous.tabId!!)
-                updateChatId(previous.tabId, current.chatId)
+                resolvePendingExit(previousTabId)
+                updateChatId(previousTabId, current.chatId)
             }
-            // previous.isDuckAi is guaranteed false here, since it's covered by the three branches above.
             current.isDuckAi && current.tabId != null -> {
                 startSessionIfNoneActive(current.tabId, current.chatId)
             }

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
@@ -51,6 +51,7 @@ class RealDuckChatPixelsAttachmentsTest {
         appBuildConfig = mock(),
         browserInteractionsPlugins = mock(),
         duckAiNewChatMetricPixelsPlugin = mock(),
+        duckAiSessionWideEvent = mock(),
     )
 
     @Test

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
@@ -51,7 +51,7 @@ class RealDuckChatPixelsAttachmentsTest {
         appBuildConfig = mock(),
         browserInteractionsPlugins = mock(),
         duckAiNewChatMetricPixelsPlugin = mock(),
-        duckAiSessionWideEvent = mock(),
+        duckAiSessionCallback = mock(),
     )
 
     @Test

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
@@ -51,7 +51,7 @@ class RealDuckChatPixelsPickerTest {
         appBuildConfig = mock(),
         browserInteractionsPlugins = mock(),
         duckAiNewChatMetricPixelsPlugin = mock(),
-        duckAiSessionWideEvent = mock(),
+        duckAiSessionCallback = mock(),
     )
 
     @Test

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
@@ -51,6 +51,7 @@ class RealDuckChatPixelsPickerTest {
         appBuildConfig = mock(),
         browserInteractionsPlugins = mock(),
         duckAiNewChatMetricPixelsPlugin = mock(),
+        duckAiSessionWideEvent = mock(),
     )
 
     @Test

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
@@ -24,7 +24,7 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.plugins.PluginPoint
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
 import com.duckduckgo.duckchat.impl.helper.DuckChatTermsOfServiceHandler
@@ -56,7 +56,7 @@ class RealDuckChatPixelsToolsTest {
     private val appBuildConfig: AppBuildConfig = mock()
     private val browserInteractionsPlugin: BrowserInteractionsPlugin = mock()
     private val browserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin> = mock()
-    private val duckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
+    private val duckAiSessionCallback: DuckAiSessionCallback = mock()
 
     private val testee = RealDuckChatPixels(
         pixel = pixel,
@@ -70,7 +70,7 @@ class RealDuckChatPixelsToolsTest {
         appBuildConfig = appBuildConfig,
         browserInteractionsPlugins = browserInteractionsPlugins,
         duckAiNewChatMetricPixelsPlugin = mock(),
-        duckAiSessionWideEvent = duckAiSessionWideEvent,
+        duckAiSessionCallback = duckAiSessionCallback,
     )
 
     private val surfaceParams = mapOf(DuckChatPixelParameters.SURFACE to "contextual_chat")
@@ -431,7 +431,7 @@ class RealDuckChatPixelsToolsTest {
             addressBarEntryPoint = null,
         )
 
-        verify(duckAiSessionWideEvent).onPromptSubmitted("tab1")
+        verify(duckAiSessionCallback).onPromptSubmitted("tab1")
     }
 
     @Test
@@ -450,7 +450,7 @@ class RealDuckChatPixelsToolsTest {
             addressBarEntryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT,
         )
 
-        verify(duckAiSessionWideEvent, never()).onPromptSubmitted(any())
+        verify(duckAiSessionCallback, never()).onPromptSubmitted(any())
     }
 
     @Test
@@ -469,7 +469,7 @@ class RealDuckChatPixelsToolsTest {
             addressBarEntryPoint = null,
         )
 
-        verify(duckAiSessionWideEvent, never()).onPromptSubmitted(any())
+        verify(duckAiSessionCallback, never()).onPromptSubmitted(any())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
 import com.duckduckgo.duckchat.impl.helper.DuckChatTermsOfServiceHandler
@@ -34,7 +35,9 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -53,6 +56,7 @@ class RealDuckChatPixelsToolsTest {
     private val appBuildConfig: AppBuildConfig = mock()
     private val browserInteractionsPlugin: BrowserInteractionsPlugin = mock()
     private val browserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin> = mock()
+    private val duckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
 
     private val testee = RealDuckChatPixels(
         pixel = pixel,
@@ -66,6 +70,7 @@ class RealDuckChatPixelsToolsTest {
         appBuildConfig = appBuildConfig,
         browserInteractionsPlugins = browserInteractionsPlugins,
         duckAiNewChatMetricPixelsPlugin = mock(),
+        duckAiSessionWideEvent = duckAiSessionWideEvent,
     )
 
     private val surfaceParams = mapOf(DuckChatPixelParameters.SURFACE to "contextual_chat")
@@ -408,6 +413,63 @@ class RealDuckChatPixelsToolsTest {
         )
 
         verify(browserInteractionsPlugin).onAiPromptSubmitted(source = "address_bar_prompt")
+    }
+
+    @Test
+    fun whenPromptSubmittedFromDuckAiSurfaceThenSessionWideEventNotified() = runTest {
+        testee.firePromptSubmitted(
+            selectedTool = "none",
+            modelId = null,
+            reasoningEffort = null,
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.DUCK_AI,
+            defaultMode = null,
+            tabId = "tab1",
+            pageType = DuckChatPixelPageType.DUCK_AI,
+            addressBarEntryPoint = null,
+        )
+
+        verify(duckAiSessionWideEvent).onPromptSubmitted("tab1")
+    }
+
+    @Test
+    fun whenPromptSubmittedFromAddressBarThenSessionWideEventNotNotified() = runTest {
+        testee.firePromptSubmitted(
+            selectedTool = "none",
+            modelId = null,
+            reasoningEffort = null,
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.ADDRESS_BAR,
+            defaultMode = null,
+            tabId = "tab1",
+            pageType = DuckChatPixelPageType.WEBSITE,
+            addressBarEntryPoint = DuckChatEntryPoint.ADDRESS_BAR_PROMPT,
+        )
+
+        verify(duckAiSessionWideEvent, never()).onPromptSubmitted(any())
+    }
+
+    @Test
+    fun whenPromptSubmittedFromContextualChatThenSessionWideEventNotNotified() = runTest {
+        testee.firePromptSubmitted(
+            selectedTool = "none",
+            modelId = null,
+            reasoningEffort = null,
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
+            defaultMode = null,
+            tabId = "tab1",
+            pageType = DuckChatPixelPageType.CONTEXTUAL,
+            addressBarEntryPoint = null,
+        )
+
+        verify(duckAiSessionWideEvent, never()).onPromptSubmitted(any())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -25,7 +25,9 @@ import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
+import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
@@ -74,6 +76,7 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
@@ -117,6 +120,7 @@ class RealDuckChatJSHelperTest {
     private val mockEditPromptSessionStore: EditPromptSessionStore = mock()
     private val mockBrowserInteractionsPlugin: BrowserInteractionsPlugin = mock()
     private val mockBrowserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin> = mock()
+    private val mockDuckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
     private val testee = RealDuckChatJSHelper(
         duckChat = mockDuckChat,
         duckChatPixels = mockDuckChatPixels,
@@ -136,6 +140,7 @@ class RealDuckChatJSHelperTest {
         subscriptions = mockSubscriptions,
         editPromptSessionStore = mockEditPromptSessionStore,
         browserInteractionsPlugins = mockBrowserInteractionsPlugins,
+        duckAiSessionWideEvent = mockDuckAiSessionWideEvent,
     )
 
     init {
@@ -1939,6 +1944,69 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
+    fun whenReportMetricWithSubmittedPromptInFullModeThenPromptSubmittedReported() = runTest {
+        val data = JSONObject(mapOf("metricName" to "userDidSubmitPrompt"))
+
+        testee.processJsCallbackMessage(
+            featureName = "aiChat",
+            method = "reportMetric",
+            id = "123",
+            data = data,
+            mode = Mode.FULL,
+            tabId = "tab-1",
+        )
+
+        verify(mockDuckAiSessionWideEvent).onPromptSubmitted("tab-1")
+    }
+
+    @Test
+    fun whenReportMetricWithSubmittedPromptInContextualModeThenPromptSubmittedNotReported() = runTest {
+        val data = JSONObject(mapOf("metricName" to "userDidSubmitPrompt"))
+
+        testee.processJsCallbackMessage(
+            featureName = "aiChat",
+            method = "reportMetric",
+            id = "123",
+            data = data,
+            mode = Mode.CONTEXTUAL,
+            tabId = "tab-1",
+        )
+
+        verify(mockDuckAiSessionWideEvent, never()).onPromptSubmitted(any())
+    }
+
+    @Test
+    fun whenCloseAiChatInFullModeThenPendingBackOrCloseExitRecordedBeforeClosing() = runTest {
+        testee.processJsCallbackMessage(
+            featureName = "aiChat",
+            method = "closeAIChat",
+            id = "123",
+            data = null,
+            mode = Mode.FULL,
+            tabId = "tab-1",
+        )
+
+        val inOrder = inOrder(mockDuckAiSessionWideEvent, mockDuckChat)
+        inOrder.verify(mockDuckAiSessionWideEvent).onExitIntent("tab-1", ExitTrigger.BACK_OR_CLOSE)
+        inOrder.verify(mockDuckChat).closeDuckChat()
+    }
+
+    @Test
+    fun whenCloseAiChatInContextualModeThenNoPendingExitRecorded() = runTest {
+        testee.processJsCallbackMessage(
+            featureName = "aiChat",
+            method = "closeAIChat",
+            id = "123",
+            data = null,
+            mode = Mode.CONTEXTUAL,
+            tabId = "tab-1",
+        )
+
+        verify(mockDuckAiSessionWideEvent, never()).onExitIntent(any(), any())
+        verify(mockDuckChat).closeDuckChat()
+    }
+
+    @Test
     fun whenReportMetricIsUnrelatedThenDoesNotNotifyBrowserInteractions() = runTest {
         val data = JSONObject(mapOf("metricName" to "userDidOpenHistory"))
 
@@ -2010,6 +2078,38 @@ class RealDuckChatJSHelperTest {
         )
 
         verify(mockDuckChatPixels).sendReportMetricPixel(USER_DID_CREATE_NEW_CHAT)
+    }
+
+    @Test
+    fun whenReportMetricWithCreateNewChatInFullModeThenNewChatCreatedReported() = runTest {
+        val data = JSONObject(mapOf("metricName" to "userDidCreateNewChat"))
+
+        testee.processJsCallbackMessage(
+            featureName = "aiChat",
+            method = "reportMetric",
+            id = "123",
+            data = data,
+            mode = Mode.FULL,
+            tabId = "tab-1",
+        )
+
+        verify(mockDuckAiSessionWideEvent).onNewChatCreated("tab-1")
+    }
+
+    @Test
+    fun whenReportMetricWithCreateNewChatInContextualModeThenNewChatCreatedNotReported() = runTest {
+        val data = JSONObject(mapOf("metricName" to "userDidCreateNewChat"))
+
+        testee.processJsCallbackMessage(
+            featureName = "aiChat",
+            method = "reportMetric",
+            id = "123",
+            data = data,
+            mode = Mode.CONTEXTUAL,
+            tabId = "tab-1",
+        )
+
+        verify(mockDuckAiSessionWideEvent, never()).onNewChatCreated(any())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -25,9 +25,9 @@ import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.plugins.PluginPoint
-import com.duckduckgo.duckchat.api.DuckAiSessionWideEvent
+import com.duckduckgo.duckchat.api.DuckAiSessionCallback
+import com.duckduckgo.duckchat.api.DuckAiSessionExitTrigger
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
-import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
@@ -120,7 +120,7 @@ class RealDuckChatJSHelperTest {
     private val mockEditPromptSessionStore: EditPromptSessionStore = mock()
     private val mockBrowserInteractionsPlugin: BrowserInteractionsPlugin = mock()
     private val mockBrowserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin> = mock()
-    private val mockDuckAiSessionWideEvent: DuckAiSessionWideEvent = mock()
+    private val mockDuckAiSessionCallback: DuckAiSessionCallback = mock()
     private val testee = RealDuckChatJSHelper(
         duckChat = mockDuckChat,
         duckChatPixels = mockDuckChatPixels,
@@ -140,7 +140,7 @@ class RealDuckChatJSHelperTest {
         subscriptions = mockSubscriptions,
         editPromptSessionStore = mockEditPromptSessionStore,
         browserInteractionsPlugins = mockBrowserInteractionsPlugins,
-        duckAiSessionWideEvent = mockDuckAiSessionWideEvent,
+        duckAiSessionCallback = mockDuckAiSessionCallback,
     )
 
     init {
@@ -1956,7 +1956,7 @@ class RealDuckChatJSHelperTest {
             tabId = "tab-1",
         )
 
-        verify(mockDuckAiSessionWideEvent).onPromptSubmitted("tab-1")
+        verify(mockDuckAiSessionCallback).onPromptSubmitted("tab-1")
     }
 
     @Test
@@ -1972,7 +1972,7 @@ class RealDuckChatJSHelperTest {
             tabId = "tab-1",
         )
 
-        verify(mockDuckAiSessionWideEvent, never()).onPromptSubmitted(any())
+        verify(mockDuckAiSessionCallback, never()).onPromptSubmitted(any())
     }
 
     @Test
@@ -1986,8 +1986,8 @@ class RealDuckChatJSHelperTest {
             tabId = "tab-1",
         )
 
-        val inOrder = inOrder(mockDuckAiSessionWideEvent, mockDuckChat)
-        inOrder.verify(mockDuckAiSessionWideEvent).onExitIntent("tab-1", ExitTrigger.BACK_OR_CLOSE)
+        val inOrder = inOrder(mockDuckAiSessionCallback, mockDuckChat)
+        inOrder.verify(mockDuckAiSessionCallback).onExitIntent("tab-1", DuckAiSessionExitTrigger.BACK_OR_CLOSE)
         inOrder.verify(mockDuckChat).closeDuckChat()
     }
 
@@ -2002,7 +2002,7 @@ class RealDuckChatJSHelperTest {
             tabId = "tab-1",
         )
 
-        verify(mockDuckAiSessionWideEvent, never()).onExitIntent(any(), any())
+        verify(mockDuckAiSessionCallback, never()).onExitIntent(any(), any())
         verify(mockDuckChat).closeDuckChat()
     }
 
@@ -2093,7 +2093,7 @@ class RealDuckChatJSHelperTest {
             tabId = "tab-1",
         )
 
-        verify(mockDuckAiSessionWideEvent).onNewChatCreated("tab-1")
+        verify(mockDuckAiSessionCallback).onNewChatCreated("tab-1")
     }
 
     @Test
@@ -2109,7 +2109,7 @@ class RealDuckChatJSHelperTest {
             tabId = "tab-1",
         )
 
-        verify(mockDuckAiSessionWideEvent, never()).onNewChatCreated(any())
+        verify(mockDuckAiSessionCallback, never()).onNewChatCreated(any())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -141,6 +141,7 @@ class RealDuckChatPixelsTest {
             appBuildConfig = mockAppBuildConfig,
             browserInteractionsPlugins = mockBrowserInteractionsPlugins,
             duckAiNewChatMetricPixelsPlugin = mockDuckAiNewChatMetricPixelsPlugin,
+            duckAiSessionWideEvent = mock(),
         )
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -141,7 +141,7 @@ class RealDuckChatPixelsTest {
             appBuildConfig = mockAppBuildConfig,
             browserInteractionsPlugins = mockBrowserInteractionsPlugins,
             duckAiNewChatMetricPixelsPlugin = mockDuckAiNewChatMetricPixelsPlugin,
-            duckAiSessionWideEvent = mock(),
+            duckAiSessionCallback = mock(),
         )
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/wideevents/DuckAiSessionWideEventTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/wideevents/DuckAiSessionWideEventTest.kt
@@ -233,6 +233,24 @@ class DuckAiSessionWideEventTest {
     }
 
     @Test
+    fun `a generic new tab intent does not overwrite an earlier fire tab intent`() = runTest {
+        startFlow(tabId = "tab-1")
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+
+        testee.onExitIntent("tab-1", DuckAiSessionExitTrigger.FIRE_TAB_OPENED)
+        testee.onExitIntent("tab-1", DuckAiSessionExitTrigger.NEW_TAB_OPENED)
+        testee.onSelectedTabChanged("tab-2", null)
+        idle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(1L),
+            status = eq(FlowStatus.Success),
+            metadata = eq(mapOf("status_reason" to "left_duckai", "exit_trigger" to "fire_tab_opened")),
+        )
+    }
+
+    @Test
     fun `when switching between two Duck ai tabs then the old session ends and the new one starts`() = runTest {
         startFlow(tabId = "tab-1")
         testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/wideevents/DuckAiSessionWideEventTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/wideevents/DuckAiSessionWideEventTest.kt
@@ -1,0 +1,613 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.wideevents
+
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.statistics.wideevents.CleanupPolicy
+import com.duckduckgo.app.statistics.wideevents.FlowStatus
+import com.duckduckgo.app.statistics.wideevents.WideEventClient
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.ExitTrigger
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class DuckAiSessionWideEventTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule(StandardTestDispatcher())
+
+    private val wideEventClient: WideEventClient = mock()
+    private val duckChat: DuckChat = mock()
+    private val duckChatFeature = FakeFeatureToggleFactory.create(DuckChatFeature::class.java)
+
+    private lateinit var testee: RealDuckAiSessionWideEvent
+
+    @Before
+    fun setup() = runTest {
+        duckChatFeature.sendDuckAiSessionWideEvent().setRawStoredState(Toggle.State(enable = true))
+        whenever(duckChat.isDuckChatUrl(any())).thenAnswer { invocation ->
+            (invocation.arguments[0] as Uri).toString().startsWith(DUCK_AI_BASE_URL)
+        }
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any())).thenReturn(Result.success(1L))
+        whenever(wideEventClient.flowStep(any(), any(), any(), any())).thenReturn(Result.success(Unit))
+        whenever(wideEventClient.flowFinish(any(), any(), any())).thenReturn(Result.success(Unit))
+        whenever(wideEventClient.flowAbort(any())).thenReturn(Result.success(Unit))
+
+        testee = RealDuckAiSessionWideEvent(
+            wideEventClient = wideEventClient,
+            duckChat = duckChat,
+            duckChatFeature = { duckChatFeature },
+            dispatchers = coroutineRule.testDispatcherProvider,
+            appCoroutineScope = coroutineRule.testScope,
+        )
+        // Most tests are exercising behaviour once the app is already open; the app-closed gate itself
+        // is covered by its own tests below.
+        testee.onOpen(isFreshLaunch = true)
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+    }
+
+    private fun idle() = coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+    private suspend fun startFlow(returnedFlowId: Long = 1L, tabId: String = "tab-1", url: String = DUCKAI_URL_A) {
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any())).thenReturn(Result.success(returnedFlowId))
+        testee.onLaunchLandingResolved(tabId, url)
+        idle()
+    }
+
+    @Test
+    fun `when landing resolved then flow starts with duckai_session name and process-start cleanup`() = runTest {
+        testee.onLaunchLandingResolved("tab-1", DUCKAI_URL_A)
+        idle()
+
+        verify(wideEventClient).flowStart(
+            name = eq("duckai_session"),
+            flowEntryPoint = isNull(),
+            metadata = eq(mapOf("status_reason" to "app_terminated")),
+            cleanupPolicy = eq(CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = false, flowStatus = FlowStatus.Unknown)),
+            samplingProbability = any(),
+            definition = any(),
+        )
+    }
+
+    @Test
+    fun `when landing resolved again for the same tab then no new flow starts`() = runTest {
+        startFlow(tabId = "tab-1")
+
+        testee.onLaunchLandingResolved("tab-1", DUCKAI_URL_A)
+        idle()
+
+        verify(wideEventClient, times(1)).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `when landing resolved for a different tab while another session is active then it is ignored`() = runTest {
+        startFlow(tabId = "tab-1")
+
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any())).thenReturn(Result.success(2L))
+        testee.onLaunchLandingResolved("tab-2", DUCKAI_URL_B)
+        idle()
+
+        verify(wideEventClient, never()).flowFinish(any(), any(), any())
+        verify(wideEventClient, times(1)).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `onLaunchLandingResolved establishes the url's chat id as the baseline`() = runTest {
+        startFlow(tabId = "tab-1", url = DUCKAI_URL_A)
+
+        // Same chat id observed again via a same-tab, still-duckai transition: no change.
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+
+        verify(wideEventClient, never()).flowStep(any(), eq("chat_id_changed"), any(), any())
+    }
+
+    @Test
+    fun `a persisted Duck ai tab reported before any landing is only a baseline`() = runTest {
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+
+        verify(wideEventClient, never()).flowStart(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `when selected tab changes away from Duck ai with no pending exit then other_navigation is used`() = runTest {
+        startFlow(tabId = "tab-1")
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A) // baseline for the observer's own tracking
+        idle()
+
+        testee.onSelectedTabChanged("tab-1", "https://example.com")
+        idle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(1L),
+            status = eq(FlowStatus.Success),
+            metadata = eq(mapOf("status_reason" to "left_duckai", "exit_trigger" to "other_navigation")),
+        )
+    }
+
+    @Test
+    fun `a matching exit intent is used instead of other_navigation for a same-tab exit`() = runTest {
+        startFlow(tabId = "tab-1")
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+
+        testee.onExitIntent("tab-1", ExitTrigger.BACK_OR_CLOSE)
+        testee.onSelectedTabChanged("tab-1", "https://example.com")
+        idle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(1L),
+            status = eq(FlowStatus.Success),
+            metadata = eq(mapOf("status_reason" to "left_duckai", "exit_trigger" to "back_or_close")),
+        )
+    }
+
+    @Test
+    fun `when the selected tab changes to a different tab then tab_switched is used by default`() = runTest {
+        startFlow(tabId = "tab-1")
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+
+        testee.onSelectedTabChanged("tab-2", "https://example.com")
+        idle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(1L),
+            status = eq(FlowStatus.Success),
+            metadata = eq(mapOf("status_reason" to "left_duckai", "exit_trigger" to "tab_switched")),
+        )
+    }
+
+    @Test
+    fun `a matching new_tab_opened exit intent is used instead of tab_switched`() = runTest {
+        startFlow(tabId = "tab-1")
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+
+        testee.onExitIntent("tab-1", ExitTrigger.NEW_TAB_OPENED)
+        testee.onSelectedTabChanged("tab-2", null)
+        idle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(1L),
+            status = eq(FlowStatus.Success),
+            metadata = eq(mapOf("status_reason" to "left_duckai", "exit_trigger" to "new_tab_opened")),
+        )
+    }
+
+    @Test
+    fun `a matching fire_tab_opened exit intent is used instead of tab_switched`() = runTest {
+        startFlow(tabId = "tab-1")
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+
+        testee.onExitIntent("tab-1", ExitTrigger.FIRE_TAB_OPENED)
+        testee.onSelectedTabChanged("tab-2", null)
+        idle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(1L),
+            status = eq(FlowStatus.Success),
+            metadata = eq(mapOf("status_reason" to "left_duckai", "exit_trigger" to "fire_tab_opened")),
+        )
+    }
+
+    @Test
+    fun `when switching between two Duck ai tabs then the old session ends and the new one starts`() = runTest {
+        startFlow(tabId = "tab-1")
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any())).thenReturn(Result.success(2L))
+        testee.onSelectedTabChanged("tab-2", DUCKAI_URL_B)
+        idle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(1L),
+            status = eq(FlowStatus.Success),
+            metadata = eq(mapOf("status_reason" to "left_duckai", "exit_trigger" to "tab_switched")),
+        )
+        verify(wideEventClient, times(2)).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `Back staying on Duck ai in the same tab does not end the session and clears the pending exit`() = runTest {
+        startFlow(tabId = "tab-1")
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+        testee.onExitIntent("tab-1", ExitTrigger.BACK_OR_CLOSE)
+
+        // Back landed on another Duck.ai page in the same tab.
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_B)
+        idle()
+
+        verify(wideEventClient, never()).flowFinish(any(), any(), any())
+
+        // The stale pending exit must not resurface on the next, unrelated real exit.
+        testee.onSelectedTabChanged("tab-1", "https://example.com")
+        idle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(1L),
+            status = eq(FlowStatus.Success),
+            metadata = eq(mapOf("status_reason" to "left_duckai", "exit_trigger" to "other_navigation")),
+        )
+    }
+
+    @Test
+    fun `when app backgrounded with no pending exit then flow finishes cancelled with app_backgrounded`() = runTest {
+        startFlow(tabId = "tab-1")
+
+        testee.onClose()
+        idle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(1L),
+            status = eq(FlowStatus.Cancelled),
+            metadata = eq(mapOf("status_reason" to "app_backgrounded")),
+        )
+    }
+
+    @Test
+    fun `when app backgrounded with a matching pending back_or_close then flow finishes success with left_duckai`() = runTest {
+        startFlow(tabId = "tab-1")
+        testee.onExitIntent("tab-1", ExitTrigger.BACK_OR_CLOSE)
+
+        testee.onClose()
+        idle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(1L),
+            status = eq(FlowStatus.Success),
+            metadata = eq(mapOf("status_reason" to "left_duckai", "exit_trigger" to "back_or_close")),
+        )
+    }
+
+    @Test
+    fun `when app backgrounded with a pending exit for another tab then it is discarded and app_backgrounded is used`() = runTest {
+        startFlow(tabId = "tab-1")
+        // A pending exit can only ever be recorded for the active tab, but guard the discard path too.
+        testee.onExitIntent("tab-1", ExitTrigger.TAB_SWITCHED)
+
+        testee.onClose()
+        idle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(1L),
+            status = eq(FlowStatus.Cancelled),
+            metadata = eq(mapOf("status_reason" to "app_backgrounded")),
+        )
+    }
+
+    @Test
+    fun `when app backgrounded with no active session then nothing is finished`() = runTest {
+        testee.onClose()
+        idle()
+
+        verify(wideEventClient, never()).flowFinish(any(), any(), any())
+    }
+
+    @Test
+    fun `onExitIntent is rejected when there is no active session`() = runTest {
+        testee.onExitIntent("tab-1", ExitTrigger.BACK_OR_CLOSE)
+        idle()
+
+        testee.onClose()
+        idle()
+
+        verify(wideEventClient, never()).flowFinish(any(), any(), any())
+    }
+
+    @Test
+    fun `onExitIntent is rejected for a tab that is not the active session`() = runTest {
+        startFlow(tabId = "tab-1")
+
+        testee.onExitIntent("tab-2", ExitTrigger.BACK_OR_CLOSE)
+        idle()
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+        testee.onSelectedTabChanged("tab-2", "https://example.com")
+        idle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(1L),
+            status = eq(FlowStatus.Success),
+            metadata = eq(mapOf("status_reason" to "left_duckai", "exit_trigger" to "tab_switched")),
+        )
+    }
+
+    @Test
+    fun `a pending exit recorded during ordinary browsing does not leak into a later Duck ai session on the same tab`() = runTest {
+        // Back pressed on tab-1 while it's an ordinary (non-Duck.ai) page: no session is active yet.
+        testee.onExitIntent("tab-1", ExitTrigger.BACK_OR_CLOSE)
+
+        // tab-1 later navigates to Duck.ai.
+        startFlow(tabId = "tab-1")
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+
+        // Leaving Duck.ai through an unrelated link, with no real pending exit for this session.
+        testee.onSelectedTabChanged("tab-1", "https://example.com")
+        idle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(1L),
+            status = eq(FlowStatus.Success),
+            metadata = eq(mapOf("status_reason" to "left_duckai", "exit_trigger" to "other_navigation")),
+        )
+    }
+
+    @Test
+    fun `an exit intent recorded while the session is still starting is not rejected`() = runTest {
+        val flowStartResult = CompletableDeferred<Result<Long>>()
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any(), any(), any()))
+            .doSuspendableAnswer { flowStartResult.await() }
+
+        testee.onLaunchLandingResolved("tab-1", DUCKAI_URL_A)
+        coroutineRule.testScope.testScheduler.runCurrent()
+
+        // Back pressed immediately, before flowStart has resolved.
+        testee.onExitIntent("tab-1", ExitTrigger.BACK_OR_CLOSE)
+
+        flowStartResult.complete(Result.success(1L))
+        idle()
+
+        testee.onClose()
+        idle()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(1L),
+            status = eq(FlowStatus.Success),
+            metadata = eq(mapOf("status_reason" to "left_duckai", "exit_trigger" to "back_or_close")),
+        )
+    }
+
+    @Test
+    fun `when a prompt is submitted for the active tab then prompt_submitted step is recorded once`() = runTest {
+        startFlow(tabId = "tab-1")
+
+        testee.onPromptSubmitted("tab-1")
+        testee.onPromptSubmitted("tab-1")
+        idle()
+
+        verify(wideEventClient, times(1)).flowStep(wideEventId = eq(1L), stepName = eq("prompt_submitted"), success = any(), metadata = any())
+    }
+
+    @Test
+    fun `when a prompt is submitted for a different tab then it is ignored`() = runTest {
+        startFlow(tabId = "tab-1")
+
+        testee.onPromptSubmitted("tab-2")
+        idle()
+
+        verify(wideEventClient, never()).flowStep(any(), eq("prompt_submitted"), any(), any())
+    }
+
+    @Test
+    fun `when a new chat is created for the active tab then new_chat_created step is recorded once`() = runTest {
+        startFlow(tabId = "tab-1")
+
+        testee.onNewChatCreated("tab-1")
+        testee.onNewChatCreated("tab-1")
+        idle()
+
+        verify(wideEventClient, times(1)).flowStep(wideEventId = eq(1L), stepName = eq("new_chat_created"), success = any(), metadata = any())
+    }
+
+    @Test
+    fun `when a new chat is created for a different tab then it is ignored`() = runTest {
+        startFlow(tabId = "tab-1")
+
+        testee.onNewChatCreated("tab-2")
+        idle()
+
+        verify(wideEventClient, never()).flowStep(any(), eq("new_chat_created"), any(), any())
+    }
+
+    @Test
+    fun `a different chat id after the baseline records chat_id_changed once without exposing the id`() = runTest {
+        startFlow(tabId = "tab-1", url = DUCKAI_URL_A)
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_B)
+        idle()
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_C)
+        idle()
+
+        verify(wideEventClient, times(1)).flowStep(
+            wideEventId = eq(1L),
+            stepName = eq("chat_id_changed"),
+            success = any(),
+            metadata = argThat { none { (_, value) -> value.startsWith("chat-") } },
+        )
+    }
+
+    @Test
+    fun `chat id going from present to missing is recorded as a change`() = runTest {
+        startFlow(tabId = "tab-1", url = DUCKAI_URL_A)
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+
+        testee.onSelectedTabChanged("tab-1", DUCK_AI_BASE_URL)
+        idle()
+
+        verify(wideEventClient, times(1)).flowStep(any(), eq("chat_id_changed"), any(), any())
+    }
+
+    @Test
+    fun `no wide event call ever carries the observed chat id`() = runTest {
+        startFlow(tabId = "tab-1", url = "$DUCK_AI_BASE_URL?chatID=super-secret-chat-id")
+        testee.onSelectedTabChanged("tab-1", "$DUCK_AI_BASE_URL?chatID=super-secret-chat-id")
+        idle()
+
+        testee.onSelectedTabChanged("tab-1", "$DUCK_AI_BASE_URL?chatID=another-secret-id")
+        idle()
+        testee.onSelectedTabChanged("tab-1", "https://example.com")
+        idle()
+
+        verify(wideEventClient, never()).flowStep(any(), any(), any(), argThat { values.any { it.contains("secret") } })
+        verify(wideEventClient, never()).flowFinish(any(), any(), argThat { values.any { it.contains("secret") } })
+    }
+
+    @Test
+    fun `when the feature is disabled then the active session is aborted`() = runTest {
+        startFlow(tabId = "tab-1")
+
+        duckChatFeature.sendDuckAiSessionWideEvent().setRawStoredState(Toggle.State(enable = false))
+        testee.onPromptSubmitted("tab-1")
+        idle()
+
+        verify(wideEventClient).flowAbort(1L)
+    }
+
+    @Test
+    fun `when the feature is disabled then landing resolved does not start a flow`() = runTest {
+        duckChatFeature.sendDuckAiSessionWideEvent().setRawStoredState(Toggle.State(enable = false))
+
+        testee.onLaunchLandingResolved("tab-1", DUCKAI_URL_A)
+        idle()
+
+        verify(wideEventClient, never()).flowStart(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `a landing resolved that only reaches the actor after the app closed does not start a session`() = runTest {
+        testee.onClose()
+        idle()
+
+        // A WebView page-load callback that was already in flight when the app closed.
+        testee.onLaunchLandingResolved("tab-1", DUCKAI_URL_A)
+        idle()
+
+        verify(wideEventClient, never()).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+
+        // The next app-open's resolved landing is what re-enables starts.
+        testee.onOpen(isFreshLaunch = false)
+        testee.onLaunchLandingResolved("tab-1", DUCKAI_URL_A)
+        idle()
+
+        verify(wideEventClient).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `a selected-tab transition into Duck ai that only reaches the actor after the app closed does not start a session`() = runTest {
+        testee.onSelectedTabChanged("tab-1", "https://example.com")
+        idle()
+
+        testee.onClose()
+        idle()
+
+        // A background tab update that was already in flight when the app closed.
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+
+        verify(wideEventClient, never()).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `a selected-tab transition into Duck ai before any landing has resolved this app-open does not start a session`() = runTest {
+        // The app is open (per setup's onOpen), but nothing has reported a resolved landing yet.
+        testee.onSelectedTabChanged("tab-1", "https://example.com")
+        idle()
+
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+
+        verify(wideEventClient, never()).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `a Duck ai page becoming visible before the launch has resolved does not start a session or resolve it`() = runTest {
+        // A stale WebView callback racing FirstScreenHandler's still-pending async launch decision.
+        testee.onDuckAiPageVisible("tab-1", DUCKAI_URL_A)
+        idle()
+
+        verify(wideEventClient, never()).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+
+        // Proves the call above didn't itself resolve the launch: only once the real launch landing is
+        // reported (even to an unrelated, non-Duck.ai destination) can a page-visible callback start one.
+        testee.onLaunchLandingResolved("tab-2", "https://example.com")
+        testee.onDuckAiPageVisible("tab-1", DUCKAI_URL_A)
+        idle()
+
+        verify(wideEventClient).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `a Duck ai page becoming visible after the app closed does not start a session even once the launch had already resolved`() = runTest {
+        testee.onLaunchLandingResolved("tab-2", "https://example.com")
+        idle()
+
+        testee.onClose()
+        idle()
+
+        // A WebView page-load callback that was already in flight when the app closed.
+        testee.onDuckAiPageVisible("tab-1", DUCKAI_URL_A)
+        idle()
+
+        verify(wideEventClient, never()).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `a launch landing resolved with no selected tab still resolves the launch without starting a session`() = runTest {
+        testee.onLaunchLandingResolved(null, null)
+        idle()
+
+        verify(wideEventClient, never()).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+
+        // Proves the launch is resolved even with no tab: a Duck.ai tab added afterward this same
+        // app-open can now start a session.
+        testee.onDuckAiPageVisible("tab-1", DUCKAI_URL_A)
+        idle()
+
+        verify(wideEventClient).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+    }
+
+    private companion object {
+        const val DUCK_AI_BASE_URL = "https://duck.ai/"
+        const val DUCKAI_URL_A = "https://duck.ai/?q=hi&chatID=chat-a"
+        const val DUCKAI_URL_B = "https://duck.ai/?q=hi&chatID=chat-b"
+        const val DUCKAI_URL_C = "https://duck.ai/?q=hi&chatID=chat-c"
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/wideevents/DuckAiSessionWideEventTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/wideevents/DuckAiSessionWideEventTest.kt
@@ -22,8 +22,8 @@ import com.duckduckgo.app.statistics.wideevents.CleanupPolicy
 import com.duckduckgo.app.statistics.wideevents.FlowStatus
 import com.duckduckgo.app.statistics.wideevents.WideEventClient
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.DuckAiSessionExitTrigger
 import com.duckduckgo.duckchat.api.DuckChat
-import com.duckduckgo.duckchat.api.ExitTrigger
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
@@ -171,7 +171,7 @@ class DuckAiSessionWideEventTest {
         testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
         idle()
 
-        testee.onExitIntent("tab-1", ExitTrigger.BACK_OR_CLOSE)
+        testee.onExitIntent("tab-1", DuckAiSessionExitTrigger.BACK_OR_CLOSE)
         testee.onSelectedTabChanged("tab-1", "https://example.com")
         idle()
 
@@ -204,7 +204,7 @@ class DuckAiSessionWideEventTest {
         testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
         idle()
 
-        testee.onExitIntent("tab-1", ExitTrigger.NEW_TAB_OPENED)
+        testee.onExitIntent("tab-1", DuckAiSessionExitTrigger.NEW_TAB_OPENED)
         testee.onSelectedTabChanged("tab-2", null)
         idle()
 
@@ -221,7 +221,7 @@ class DuckAiSessionWideEventTest {
         testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
         idle()
 
-        testee.onExitIntent("tab-1", ExitTrigger.FIRE_TAB_OPENED)
+        testee.onExitIntent("tab-1", DuckAiSessionExitTrigger.FIRE_TAB_OPENED)
         testee.onSelectedTabChanged("tab-2", null)
         idle()
 
@@ -255,7 +255,7 @@ class DuckAiSessionWideEventTest {
         startFlow(tabId = "tab-1")
         testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
         idle()
-        testee.onExitIntent("tab-1", ExitTrigger.BACK_OR_CLOSE)
+        testee.onExitIntent("tab-1", DuckAiSessionExitTrigger.BACK_OR_CLOSE)
 
         // Back landed on another Duck.ai page in the same tab.
         testee.onSelectedTabChanged("tab-1", DUCKAI_URL_B)
@@ -291,7 +291,7 @@ class DuckAiSessionWideEventTest {
     @Test
     fun `when app backgrounded with a matching pending back_or_close then flow finishes success with left_duckai`() = runTest {
         startFlow(tabId = "tab-1")
-        testee.onExitIntent("tab-1", ExitTrigger.BACK_OR_CLOSE)
+        testee.onExitIntent("tab-1", DuckAiSessionExitTrigger.BACK_OR_CLOSE)
 
         testee.onClose()
         idle()
@@ -307,7 +307,7 @@ class DuckAiSessionWideEventTest {
     fun `when app backgrounded with a pending exit for another tab then it is discarded and app_backgrounded is used`() = runTest {
         startFlow(tabId = "tab-1")
         // A pending exit can only ever be recorded for the active tab, but guard the discard path too.
-        testee.onExitIntent("tab-1", ExitTrigger.TAB_SWITCHED)
+        testee.onExitIntent("tab-1", DuckAiSessionExitTrigger.TAB_SWITCHED)
 
         testee.onClose()
         idle()
@@ -329,7 +329,7 @@ class DuckAiSessionWideEventTest {
 
     @Test
     fun `onExitIntent is rejected when there is no active session`() = runTest {
-        testee.onExitIntent("tab-1", ExitTrigger.BACK_OR_CLOSE)
+        testee.onExitIntent("tab-1", DuckAiSessionExitTrigger.BACK_OR_CLOSE)
         idle()
 
         testee.onClose()
@@ -342,7 +342,7 @@ class DuckAiSessionWideEventTest {
     fun `onExitIntent is rejected for a tab that is not the active session`() = runTest {
         startFlow(tabId = "tab-1")
 
-        testee.onExitIntent("tab-2", ExitTrigger.BACK_OR_CLOSE)
+        testee.onExitIntent("tab-2", DuckAiSessionExitTrigger.BACK_OR_CLOSE)
         idle()
         testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
         idle()
@@ -359,7 +359,7 @@ class DuckAiSessionWideEventTest {
     @Test
     fun `a pending exit recorded during ordinary browsing does not leak into a later Duck ai session on the same tab`() = runTest {
         // Back pressed on tab-1 while it's an ordinary (non-Duck.ai) page: no session is active yet.
-        testee.onExitIntent("tab-1", ExitTrigger.BACK_OR_CLOSE)
+        testee.onExitIntent("tab-1", DuckAiSessionExitTrigger.BACK_OR_CLOSE)
 
         // tab-1 later navigates to Duck.ai.
         startFlow(tabId = "tab-1")
@@ -387,7 +387,7 @@ class DuckAiSessionWideEventTest {
         coroutineRule.testScope.testScheduler.runCurrent()
 
         // Back pressed immediately, before flowStart has resolved.
-        testee.onExitIntent("tab-1", ExitTrigger.BACK_OR_CLOSE)
+        testee.onExitIntent("tab-1", DuckAiSessionExitTrigger.BACK_OR_CLOSE)
 
         flowStartResult.complete(Result.success(1L))
         idle()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/wideevents/DuckAiSessionWideEventTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/wideevents/DuckAiSessionWideEventTest.kt
@@ -150,6 +150,18 @@ class DuckAiSessionWideEventTest {
     }
 
     @Test
+    fun `when a Duck ai tab id becomes available then the flow starts`() = runTest {
+        testee.onLaunchLandingResolved(null, null)
+        testee.onSelectedTabChanged(null, DUCKAI_URL_A)
+        idle()
+
+        testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A)
+        idle()
+
+        verify(wideEventClient).flowStart(any(), anyOrNull(), any(), any(), any(), any())
+    }
+
+    @Test
     fun `when selected tab changes away from Duck ai with no pending exit then other_navigation is used`() = runTest {
         startFlow(tabId = "tab-1")
         testee.onSelectedTabChanged("tab-1", DUCKAI_URL_A) // baseline for the observer's own tracking


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1218116632504655?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1212087397361015/task/1218080924123047?focus=true
API Proposals URL(s) (if applicable): https://app.asana.com/1/137249556945/project/1212087397361015/task/1218158101808036?focus=true

### Description

Adds `duckai_session`, a wide event covering one full visit to the Duck.ai full-tab experience, from becoming visible to a confirmed exit.

- New `DuckAiSessionWideEvent` contract in `duckchat-api`, implemented by `RealDuckAiSessionWideEvent` in `duckchat-impl`. All state (active flow, pending exit, chat identity, app-open/launch-resolved flags) is owned by a single sequential consumer draining one `Channel<Action>`.
- `BrowserSessionTabObserver` (new, in `app`) forwards the active browser mode's selected-tab flow unfiltered; the coordinator does all Duck.ai/transition interpretation itself.
- Call sites report only domain events: `onLaunchLandingResolved`, `onDuckAiPageVisible`,`onSelectedTabChanged`, `onExitIntent`, `onPromptSubmitted`, `onNewChatCreated` or pending exit: `FirstScreenHandler`, `BrowserTabViewModel`, `BrowserViewModel`,
  `DefaultTabManager`, `TabSwitcherViewModel`, `DuckChatJSHelper`, `DuckChatPixels`.
- Gated behind `aiChat` → `sendDuckAiSessionWideEvent`.

### Steps to test this PR

- Filter logcat on `Pixel sent: wide_duckai_session`
- Make sure `sendDuckAiSessionWideEvent` is enabled

_Session starts and ends on a normal visit_
- [x] Open Duck.ai as a full tab, then leave via Back or the in-chat close button — confirm one
      `wide_duckai_session_c`/`_d` pair with `feature.status=SUCCESS`,
      `feature.data.ext.status_reason=left_duckai`
- [x] Verify first emission of the day (or after install) also includes `wide_duckai_session_d`
- [x] Repeat entry on the same tab without leaving — confirm no pixel fires yet (nothing to finish)

_Exit trigger is recorded per leave path_
- [x] From a Duck.ai tab, switch to a different existing tab via the tab switcher —
      `feature.data.ext.exit_trigger=tab_switched`
- [x] From a Duck.ai tab, open a new tab (toolbar `+` or long-press menu) --> `exit_trigger=new_tab_opened`
- [x] From a Duck.ai tab, reuse an existing blank tab as the "new" tab --> `exit_trigger=new_tab_opened`
- [x] From within the Duck.ai chat's own "+" menu, tap "New Tab" --> `exit_trigger=new_tab_opened`
- [x] From within the Duck.ai chat's own "+" menu, tap "New Fire Tab" --> `exit_trigger=fire_tab_opened`
- [x] Long-press a link inside the Duck.ai chat and choose "Open in New Tab" --> `exit_trigger=new_tab_opened`
- [x] Long-press a link inside the Duck.ai chat and choose "Open in Fire Tab" --> `exit_trigger=fire_tab_opened`
- [x] From a Duck.ai tab, press Back/tap the close button --> `exit_trigger=back_or_close`

_Session stays alive for non-exiting interactions_
- [x] Open the tab switcher and dismiss it (back) without changing tabs --> confirm no pixel fires
- [x] From Duck.ai, open the side menu and select a chat history to load it in the same tab --> confirm no pixel fires

_Params are properly registered_
- [x] Open an existing chat, submit a prompt, then leave Duck.ai --> confirm the finishing pixel carries `feature.data.ext.step.prompt_submitted=true`
- [x] Open an existing chat in Duck.ai, Start a new chat from within Duck.ai, then leave --> confirm `step.new_chat_created=true`
- [x] Switch to a different past chat (changing `chatID`), then leave --> confirm `step.chat_id_changed=true`
- [x] Open an existing chat, go to the menu and Start a new chat from within Duck.ai, submit a promt in this new chat --> Confirm all three params are true: `new_chat_created=true`, `chat_id_changed=true`, `prompt_submitted=true`

_Switching directly between two Duck.ai tabs_
- [x] Setup: Have Duck.ai opened in 2 tabs, tab A and B. 
- [x] Load tab A. Switch to tab B --> Confirm one pixel for tab A (`exit_trigger=tab_switched`) fires immediately.
- [x] Exist tab B (X or switch) --> Confirm a second session's pixel pair fires for tab B's session ends

_Feature 5: App lifecycle_
- [x] Open Duck.ai, background the app (Home button), wait a couple of second then reopen the app --> confirm `feature.status=CANCELLED`,
      `status_reason=app_backgrounded`
- [x] Open Duck.ai in the emulator, force-stop the app by running `adb shell am force-stop com.duckduckgo.mobile.android.debug`, relaunch --> confirm the abandoned session's
      pixel pair fires on the next launch with `feature.status=UNKNOWN`, `status_reason=app_terminated`. Note: swiping the app from the app selector will send `app_backgrounded`

_Feature 6: Feature flag off_
- [x] Disable `sendDuckAiSessionWideEvent` feature flag (internal settings), open Duck.ai and exit it --> confirm no `wide_duckai_session_*` pixel ever fires

### UI changes

N/A. Telemetry only, no user-visible UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Instrumentation is wired across core tab/back/new-tab navigation paths, so ordering bugs could mis-attribute sessions, but behavior is feature-flagged and heavily unit-tested with no user data beyond boolean flags.
> 
> **Overview**
> Introduces **`duckai_session`** telemetry for each visit to a full Duck.ai tab—from visibility through exit, background, or process death—with pixel definitions, wide-event schema, and an internal **`sendDuckAiSessionWideEvent`** feature toggle.
> 
> A new **`DuckAiSessionCallback`** API is implemented by **`RealDuckAiSessionWideEvent`**, which owns session state in a single ordered channel consumer (start/finish via **`WideEventClient`**, exit reasons, optional **`exit_trigger`**, and one-time steps for prompt submit, new chat, and chat ID change without sending the chat ID). **`BrowserSessionTabObserver`** forwards selected-tab updates; browser layers report launch landing, page visible, back/new/fire tab exits, and Duck.ai interactions from **`BrowserTabViewModel`**, tab managers, **`FirstScreenHandler`**, JS bridge, and pixels.
> 
> Extensive unit tests cover exit triggers, lifecycle races, feature-off behavior, and stale launch/tab state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cc87b15820391abfa259ed3e930982a09c76186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->