### PR TITLE
Enable R8 optimization

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -151,7 +151,7 @@ android {
         }
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             manifestPlaceholders = [
                     appIcon     : "@mipmap/ic_launcher_red",
                     appIconRound: "@mipmap/ic_launcher_red_round"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1218149406979969?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

- Removes -dontoptimize by using getDefaultProguardFile('proguard-android-optimize.txt') for release builds.
- Requires https://github.com/duckduckgo/Android/pull/9664

### Steps to test this PR

- [ ] General smoke test
- [ ] Smoke test sync
- [ ] Smoke test PIR
- [ ] Smoke test autofill
- [ ] Smoke test VPN
- [ ] Smoke test Duck.ai
- [ ] Smoke test downloads
- [ ] Smoke test crash reporting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Gradle default-rules swap with release minification still disabled; main risk is unexpected shrink/obfuscation behavior when minify is later enabled without sufficient keep rules.
> 
> **Overview**
> The **release** build type in `app/build.gradle` now points `proguardFiles` at **`proguard-android-optimize.txt`** instead of **`proguard-android.txt`**, matching the pattern already used in `gradle/android-library.gradle`.
> 
> That default ruleset turns on **additional R8 shrinking and optimization** beyond the non-optimize file. **`minifyEnabled` is still `false`** for release in this diff, so the new rules only affect builds once release minification/R8 is actually enabled (or if another flag turns it on elsewhere).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3830ce1514f1da264ce8b70b972c82e62fc1d663. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->