### PR TITLE
Enable the Suggest Redirect feature on internal builds

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/suggestredirect/SuggestRedirectOnUnresolvedErrorFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/suggestredirect/SuggestRedirectOnUnresolvedErrorFeature.kt
@@ -30,9 +30,9 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
     featureName = "suggestRedirectOnUnresolvedError",
 )
 interface SuggestRedirectOnUnresolvedErrorFeature {
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun suggestRedirect(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216807998862658/task/1218170363449830?focus=true

### Description
Enables by default the Suggest Redirect feature on internal builds

### UI changes
See https://github.com/duckduckgo/Android/pull/9580

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects default toggle values for an existing browser error-page feature; scope is limited to internal builds.
> 
> **Overview**
> Changes the default for **`SuggestRedirectOnUnresolvedErrorFeature`** toggles (`self()` and `suggestRedirect()`) from **off** (`FALSE`) to **internal builds only** (`INTERNAL`).
> 
> On internal builds, unresolved bare-domain error pages can now show the suggested **www** redirect link by default, without waiting for remote config. Release builds stay unchanged unless the feature is turned on remotely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 398458686636ae139934a866ec59f106d4c5482b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->