### PR TITLE
Add "new" pill to the Subscriber Offers settings row

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/res/layout/view_partner_benefit_settings.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/view_partner_benefit_settings.xml
@@ -24,4 +24,6 @@
     android:visibility="gone"
     app:leadingIcon="@drawable/ic_subscription_gift_color_24"
     app:primaryText="@string/partnerBenefitSettingTitle"
+    app:pillIcon="true"
+    app:pillText="@string/partnerBenefitSettingNewPill"
     tools:visibility="visible" />

--- a/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
@@ -25,6 +25,7 @@
 
     <!-- Partnerships Hub -->
     <string name="partnerBenefitSettingTitle">Subscriber Offers</string>
+    <string name="partnerBenefitSettingNewPill">New</string>
 
     <!-- Black Friday offer-->
     <string name="subscriptionSettingBlackFridayOffer">Save 40% on First Year</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218176572503011?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description
The Subscriber Offers row in Settings now shows a "new" pill, following the feedback from the Ship Review https://app.asana.com/1/137249556945/task/1217730323487522/comment/1218078631540932?focus=true.

### Steps to test this PR
_Pre steps_
- [x] Install the build on a device with an active subscription or free trial.
- [x] Settings → Internal Features → Feature Flag Inventory, enable `partnershipsHub`, then leave Settings and reopen it.

_Subscriber Offers row_
- [x] Scroll to DuckDuckGo Subscription.
- [x] The Subscriber Offers row shows a yellow “_new_” pill next to the title, in the same style as BETA on Personal Information Removal.
- [x] Check both light and dark themes.

_Flag off_
- [x] Disable `partnershipsHub`, leave Settings and reopen it.
- [x] The row is gone, so no pill either.

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1080" height="2400" alt="subscriber-offers-android-settings-dark" src="https://github.com/user-attachments/assets/0ffcf272-7e0e-4c8b-bf89-3ee425a1669f" />|<img width="1080" height="2400" alt="staging-subscriber-offers-new-pill-dark" src="https://github.com/user-attachments/assets/bab459b1-a912-4a2f-ac04-f65a39e373f9" />|
<img width="1080" height="2400" alt="subscriber-offers-android-settings-light" src="https://github.com/user-attachments/assets/db5d450f-f17f-4e3e-8982-1843b4a3b218" />|<img width="1080" height="2400" alt="staging-subscriber-offers-new-pill-light" src="https://github.com/user-attachments/assets/b9beb4a6-9c28-489f-95f8-d50f974579c1" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout and string-only change with no logic, networking, or data handling impact.
> 
> **Overview**
> The **Subscriber Offers** settings row (`view_partner_benefit_settings.xml`) now shows a **New** pill beside the title by enabling `OneLineListItem` pill attributes (`pillIcon` + `pillText`), matching the existing BETA-style treatment used elsewhere in Settings.
> 
> Copy for the pill is added as `partnerBenefitSettingNewPill` in `donottranslate.xml`. Visibility is unchanged—the row still only appears when `partnershipsHub` is on and the user has an active subscription or trial.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c12c4eed1afe80234511b5a815ae88319b0190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->