### PR TITLE
Permissions: Add new location, camera and mic permission dialogs

### DIFF
--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -23,6 +23,7 @@ import android.content.res.Configuration
 import android.view.ViewGroup
 import android.webkit.PermissionRequest
 import androidx.activity.result.ActivityResultCaller
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.favicon.FaviconManager
@@ -48,6 +49,7 @@ import com.duckduckgo.site.permissions.api.SitePermissionsGrantedListener
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.LocationPermissionRequest
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 import com.duckduckgo.site.permissions.impl.feature.DrmPolicyFeature
+import com.duckduckgo.site.permissions.impl.feature.SitePermissionsDialogRedesignFeature
 import com.duckduckgo.site.permissions.impl.feature.isCentralPolicyEnabled
 import com.duckduckgo.site.permissions.store.sitepermissions.SitePermissionAskSettingType
 import com.duckduckgo.site.permissions.store.sitepermissions.SitePermissionAskSettingType.ALLOW_ALWAYS
@@ -75,6 +77,7 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
     private val duckAiHostProvider: DuckAiHostProvider,
     private val browserMode: BrowserMode,
     private val drmPolicyFeature: DrmPolicyFeature,
+    private val sitePermissionsDialogRedesignFeature: SitePermissionsDialogRedesignFeature,
 ) : SitePermissionsDialogLauncher {
 
     private lateinit var sitePermissionRequest: PermissionRequest
@@ -121,6 +124,8 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                 showSitePermissionsRationaleDialog(
                     R.string.sitePermissionsMicAndCameraDialogTitle,
                     R.string.sitePermissionsMicAndCameraDialogSubtitle,
+                    R.string.sitePermissionsTieredMicAndCameraDialogTitle,
+                    CommonR.drawable.ic_video_24,
                     url,
                     SitePermissionsPixelValues.CAMERA_AND_MICROPHONE,
                     { rememberChoice ->
@@ -136,6 +141,8 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                     showSitePermissionsRationaleDialog(
                         R.string.sitePermissionsMicDialogTitle,
                         R.string.sitePermissionsMicDialogSubtitle,
+                        R.string.sitePermissionsTieredMicDialogTitle,
+                        CommonR.drawable.ic_microphone_24,
                         url,
                         SitePermissionsPixelValues.MICROPHONE,
                         { rememberChoice ->
@@ -149,6 +156,8 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                 showSitePermissionsRationaleDialog(
                     R.string.sitePermissionsCameraDialogTitle,
                     R.string.sitePermissionsCameraDialogSubtitle,
+                    R.string.sitePermissionsTieredCameraDialogTitle,
+                    CommonR.drawable.ic_video_24,
                     url,
                     SitePermissionsPixelValues.CAMERA,
                     { rememberChoice ->
@@ -177,8 +186,26 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
         this.activity = activity
 
         val domain = locationPermissionRequest.origin.websiteFromGeoLocationsApiOrigin()
+        val isDdgSite = domain == "duckduckgo.com"
 
-        val subtitle = if (domain == "duckduckgo.com") {
+        if (sitePermissionsDialogRedesignFeature.self().isEnabled()) {
+            val titleRes = if (isDdgSite) {
+                R.string.sitePermissionsTieredDdgLocationDialogTitle
+            } else {
+                R.string.sitePermissionsTieredLocationDialogTitle
+            }
+            showTieredSitePermissionsDialog(
+                iconRes = CommonR.drawable.ic_location_24,
+                title = String.format(activity.getString(titleRes), domain),
+                messageRes = R.string.sitePermissionsTieredDdgLocationDialogSubtitle.takeIf { isDdgSite },
+                pixelType = SitePermissionsPixelValues.LOCATION,
+                faviconUrl = locationPermissionRequest.origin,
+                onPermissionAllowed = ::askForLocationPermissions,
+            )
+            return
+        }
+
+        val subtitle = if (isDdgSite) {
             R.string.preciseLocationDDGDialogSubtitle
         } else {
             R.string.preciseLocationSiteDialogSubtitle
@@ -222,11 +249,26 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
     private fun showSitePermissionsRationaleDialog(
         @StringRes titleRes: Int,
         @StringRes messageRes: Int,
+        @StringRes tieredTitleRes: Int,
+        @DrawableRes tieredIconRes: Int,
         url: String,
         pixelType: String,
         onPermissionAllowed: (Boolean) -> Unit,
     ) {
         sendDialogImpressionPixel(pixelType)
+
+        if (sitePermissionsDialogRedesignFeature.self().isEnabled()) {
+            showTieredSitePermissionsDialog(
+                iconRes = tieredIconRes,
+                title = String.format(activity.getString(tieredTitleRes), url.websiteFromGeoLocationsApiOrigin()),
+                messageRes = null,
+                pixelType = pixelType,
+                faviconUrl = null,
+                onPermissionAllowed = onPermissionAllowed,
+            )
+            return
+        }
+
         TextAlertDialogBuilder(activity)
             .setTitle(String.format(activity.getString(titleRes), url.websiteFromGeoLocationsApiOrigin()))
             .setMessage(messageRes)
@@ -249,6 +291,60 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
 
                     override fun onCheckedChanged(checked: Boolean) {
                         rememberChoice = checked
+                    }
+                },
+            )
+            .show()
+    }
+
+    private fun showTieredSitePermissionsDialog(
+        @DrawableRes iconRes: Int,
+        title: CharSequence,
+        @StringRes messageRes: Int?,
+        pixelType: String,
+        faviconUrl: String?,
+        onPermissionAllowed: (Boolean) -> Unit,
+    ) {
+        StackedAlertDialogBuilder(activity)
+            .setRebrandUpdate(true)
+            .setCancellable(true)
+            .setHeaderImageResource(iconRes)
+            .setTitle(title)
+            .setMessage(messageRes?.let { activity.getText(it) } ?: "")
+            .setStackedButtons(
+                listOf(
+                    StackedButton(R.string.sitePermissionsDialogAllowWhileUsingSiteButton, SECONDARY),
+                    StackedButton(R.string.sitePermissionsDialogAllowThisTimeButton, SECONDARY),
+                    StackedButton(R.string.sitePermissionsDialogNeverAllowButton, SECONDARY),
+                ),
+            )
+            .addEventListener(
+                object : StackedAlertDialogBuilder.EventListener() {
+                    override fun onButtonClicked(position: Int) {
+                        when (position) {
+                            ALLOW_WHILE_USING_SITE_BUTTON -> {
+                                faviconUrl?.let { storeFavicon(it) }
+                                sendPositiveDialogClickPixel(pixelType, rememberChoice = true)
+                                onPermissionAllowed(true)
+                            }
+
+                            ALLOW_THIS_TIME_BUTTON -> {
+                                sendPositiveDialogClickPixel(pixelType, rememberChoice = false)
+                                onPermissionAllowed(false)
+                            }
+
+                            NEVER_ALLOW_BUTTON -> {
+                                faviconUrl?.let { storeFavicon(it) }
+                                sendNegativeDialogClickPixel(pixelType, rememberChoice = true)
+                                denyPermissions(rememberChoice = true)
+                            }
+                        }
+                    }
+
+                    // The tiered dialog has no explicit deny-once button; dismissing it is that choice.
+                    override fun onDialogCancelled() {
+                        sendNegativeDialogClickPixel(pixelType, rememberChoice = false)
+                        denyPermissions(rememberChoice = false)
                     }
                 },
             )
@@ -613,16 +709,17 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                 sitePermissionRequest.grant(permissionsHandledAutomatically.toTypedArray())
             } else {
                 sitePermissionRequest.deny()
+            }
 
-                // Fire mode denies the in-session permission above but must not persist the choice.
-                if (rememberChoice && browserMode != BrowserMode.FIRE) {
-                    sitePermissionRequest.resources.forEach { permission ->
-                        sitePermissionsRepository.sitePermissionPermanentlySaved(
-                            siteURL,
-                            permission,
-                            DENY_ALWAYS,
-                        )
-                    }
+            // Only the permissions the dialog offered: a request can also carry auto-accepted ones.
+            // Fire mode answers the request in-session but must not persist the choice.
+            if (rememberChoice && browserMode != BrowserMode.FIRE) {
+                permissionsHandledByUser.forEach { permission ->
+                    sitePermissionsRepository.sitePermissionPermanentlySaved(
+                        siteURL,
+                        permission,
+                        DENY_ALWAYS,
+                    )
                 }
             }
         } catch (e: IllegalStateException) {
@@ -632,7 +729,9 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
     }
 
     private fun showSystemPermissionsDeniedDialog() {
-        denyPermissions(permissionPermanent)
+        // OS-level denial is not a site-level Never Allow, so no site choice is persisted here
+        denyPermissions()
+
         val openAppSettings = { activity.launchApplicationInfoSettings() }
 
         if (isDuckAiAudioCapture) {
@@ -700,6 +799,9 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
     companion object {
         private const val DRM_LEARN_MORE_ANNOTATION = "drm_learn_more_link"
         private const val CHANGE_PERMISSIONS_BUTTON = 0
+        private const val ALLOW_WHILE_USING_SITE_BUTTON = 0
+        private const val ALLOW_THIS_TIME_BUTTON = 1
+        private const val NEVER_ALLOW_BUTTON = 2
         val DRM_LEARN_MORE_URL = "https://duckduckgo.com/duckduckgo-help-pages/privacy/drm-permission/".toUri()
     }
 }

--- a/site-permissions/site-permissions-impl/src/main/res/values/donottranslate.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values/donottranslate.xml
@@ -22,10 +22,10 @@
     <string name="sitePermissionsDialogAllowWhileUsingSiteButton">Allow While Using Site</string>
     <string name="sitePermissionsDialogAllowThisTimeButton">Allow This Time</string>
     <string name="sitePermissionsDialogNeverAllowButton">Never Allow</string>
-    <string name="sitePermissionsTieredLocationDialogTitle">\"%1$s\" website wants to access your location</string>
-    <string name="sitePermissionsTieredDdgLocationDialogTitle">\"%1$s\" wants to access your location</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your location</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" wants to access your location</string>
     <string name="sitePermissionsTieredDdgLocationDialogSubtitle">We\'ll anonymize your location and use it to deliver better results, closer to you.</string>
-    <string name="sitePermissionsTieredCameraDialogTitle">\"%1$s\" website wants to access the camera</string>
-    <string name="sitePermissionsTieredMicDialogTitle">\"%1$s\" website wants to access the microphone</string>
-    <string name="sitePermissionsTieredMicAndCameraDialogTitle">\"%1$s\" website wants to access the camera and microphone</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access the camera</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access the microphone</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access the camera and microphone</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values/donottranslate.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values/donottranslate.xml
@@ -25,7 +25,7 @@
     <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your location</string>
     <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" wants to access your location</string>
     <string name="sitePermissionsTieredDdgLocationDialogSubtitle">We\'ll anonymize your location and use it to deliver better results, closer to you.</string>
-    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access the camera</string>
-    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access the microphone</string>
-    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access the camera and microphone</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your camera</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your microphone</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your camera and microphone</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values/donottranslate.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values/donottranslate.xml
@@ -17,4 +17,15 @@
 <resources>
     <!-- DRM -->
     <string name="sitePermissionsSettingsDRM">DRM</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton">Allow While Using Site</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton">Allow This Time</string>
+    <string name="sitePermissionsDialogNeverAllowButton">Never Allow</string>
+    <string name="sitePermissionsTieredLocationDialogTitle">\"%1$s\" website wants to access your location</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle">\"%1$s\" wants to access your location</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">We\'ll anonymize your location and use it to deliver better results, closer to you.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle">\"%1$s\" website wants to access the camera</string>
+    <string name="sitePermissionsTieredMicDialogTitle">\"%1$s\" website wants to access the microphone</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle">\"%1$s\" website wants to access the camera and microphone</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncherTest.kt
+++ b/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncherTest.kt
@@ -19,9 +19,13 @@ package com.duckduckgo.site.permissions.impl
 import android.app.Activity
 import android.net.Uri
 import android.os.Bundle
+import android.os.Looper
 import android.text.Spanned
 import android.text.style.ClickableSpan
+import android.view.View
 import android.webkit.PermissionRequest
+import android.widget.CheckBox
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -34,20 +38,31 @@ import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.site.permissions.api.SitePermissionsGrantedListener
+import com.duckduckgo.site.permissions.api.SitePermissionsManager.LocationPermissionRequest
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 import com.duckduckgo.site.permissions.impl.feature.DrmPolicyFeature
+import com.duckduckgo.site.permissions.impl.feature.SitePermissionsDialogRedesignFeature
+import com.duckduckgo.site.permissions.store.sitepermissions.SitePermissionAskSettingType.ALLOW_ALWAYS
+import com.duckduckgo.site.permissions.store.sitepermissions.SitePermissionAskSettingType.DENY_ALWAYS
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowDialog
 import com.duckduckgo.mobile.android.R as CommonR
 
@@ -67,6 +82,7 @@ class SitePermissionsDialogActivityLauncherTest {
     }
 
     private val drmPolicyFeature = FakeFeatureToggleFactory.create(DrmPolicyFeature::class.java)
+    private val sitePermissionsDialogRedesignFeature = FakeFeatureToggleFactory.create(SitePermissionsDialogRedesignFeature::class.java)
 
     private val testee = createLauncher(BrowserMode.REGULAR)
 
@@ -80,6 +96,7 @@ class SitePermissionsDialogActivityLauncherTest {
         duckAiHostProvider = duckAiHostProvider,
         browserMode = browserMode,
         drmPolicyFeature = drmPolicyFeature,
+        sitePermissionsDialogRedesignFeature = sitePermissionsDialogRedesignFeature,
     )
 
     @Test
@@ -302,6 +319,315 @@ class SitePermissionsDialogActivityLauncherTest {
 
         assertFalse(dialog.isShowing)
         verify(request).deny()
+    }
+
+    private fun showTieredCameraDialog(): AlertDialog {
+        sitePermissionsDialogRedesignFeature.self().setRawStoredState(Toggle.State(true))
+        whenever(systemPermissionsHelper.hasCameraPermissionsGranted()).thenReturn(true)
+
+        val activity = Robolectric.buildActivity(ThemedActivity::class.java).setup().get()
+        val request: PermissionRequest = mock()
+        whenever(request.resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE))
+        whenever(request.origin).thenReturn(Uri.parse("https://example.com"))
+
+        testee.askForSitePermission(
+            activity = activity,
+            url = "https://example.com",
+            tabId = "tabId",
+            permissionsRequested = SitePermissions(
+                autoAccept = emptyList(),
+                userHandled = listOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE),
+            ),
+            request = request,
+            permissionsGrantedListener = permissionsGrantedListener,
+        )
+        this.request = request
+        return ShadowDialog.getLatestDialog() as AlertDialog
+    }
+
+    private lateinit var request: PermissionRequest
+
+    private fun AlertDialog.tieredButtons() =
+        findViewById<LinearLayout>(CommonR.id.stackedAlertDialogButtonLayout)!!
+
+    @Test
+    fun whenRedesignEnabledThenDialogOffersThreeTiersAndNoRememberChoiceCheckbox() {
+        val dialog = showTieredCameraDialog()
+
+        assertEquals(3, dialog.tieredButtons().childCount)
+        assertNull(dialog.findViewById<CheckBox>(CommonR.id.textAlertDialogCheckBox))
+    }
+
+    @Test
+    fun whenRedesignDisabledThenLegacyDialogShown() {
+        sitePermissionsDialogRedesignFeature.self().setRawStoredState(Toggle.State(false))
+        val activity = Robolectric.buildActivity(ThemedActivity::class.java).setup().get()
+        val request: PermissionRequest = mock()
+        whenever(request.resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE))
+        whenever(request.origin).thenReturn(Uri.parse("https://example.com"))
+
+        testee.askForSitePermission(
+            activity = activity,
+            url = "https://example.com",
+            tabId = "tabId",
+            permissionsRequested = SitePermissions(
+                autoAccept = emptyList(),
+                userHandled = listOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE),
+            ),
+            request = request,
+            permissionsGrantedListener = permissionsGrantedListener,
+        )
+
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        assertNotNull(dialog.findViewById<TextView>(CommonR.id.textAlertDialogMessage))
+        assertNull(dialog.findViewById<LinearLayout>(CommonR.id.stackedAlertDialogButtonLayout))
+    }
+
+    @Test
+    fun whenAllowWhileUsingSiteClickedThenPermissionPersistedAsAlwaysAllow() {
+        val dialog = showTieredCameraDialog()
+
+        dialog.tieredButtons().getChildAt(0).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify(request).grant(any())
+        verify(request, never()).deny()
+        verify(sitePermissionsRepository).sitePermissionPermanentlySaved(
+            "https://example.com",
+            PermissionRequest.RESOURCE_VIDEO_CAPTURE,
+            ALLOW_ALWAYS,
+        )
+    }
+
+    @Test
+    fun whenAllowThisTimeClickedThenGrantIsSessionOnly() {
+        val dialog = showTieredCameraDialog()
+
+        dialog.tieredButtons().getChildAt(1).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify(request).grant(any())
+        verify(request, never()).deny()
+        verify(sitePermissionsRepository).sitePermissionGranted(
+            "https://example.com",
+            "tabId",
+            PermissionRequest.RESOURCE_VIDEO_CAPTURE,
+        )
+        verify(sitePermissionsRepository, never()).sitePermissionPermanentlySaved(any(), any(), any())
+    }
+
+    @Test
+    fun whenNeverAllowClickedThenDeniedAndPersistedAsDenyAlways() {
+        val dialog = showTieredCameraDialog()
+
+        dialog.tieredButtons().getChildAt(2).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify(request, times(1)).deny()
+        verify(request, never()).grant(any())
+        verify(sitePermissionsRepository).sitePermissionPermanentlySaved(
+            "https://example.com",
+            PermissionRequest.RESOURCE_VIDEO_CAPTURE,
+            DENY_ALWAYS,
+        )
+    }
+
+    @Test
+    fun whenDialogDismissedThenDeniedForThisRequestOnlyAndReportedAsDenyOnce() {
+        val dialog = showTieredCameraDialog()
+
+        dialog.cancel()
+        // Dialog.cancel() dispatches onCancel through a Handler message, which Robolectric's
+        // paused looper will not run on its own.
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify(request).deny()
+        verify(sitePermissionsRepository, never()).sitePermissionPermanentlySaved(any(), any(), any())
+        verify(sitePermissionsRepository, never()).sitePermissionGranted(any(), any(), any())
+        verify(pixel).fire(
+            SitePermissionsPixelName.PERMISSION_DIALOG_CLICK,
+            mapOf(
+                SitePermissionsPixelParameters.PERMISSION_TYPE to SitePermissionsPixelValues.CAMERA,
+                SitePermissionsPixelParameters.PERMISSION_SELECTION to SitePermissionsPixelValues.DENY_ONCE,
+            ),
+        )
+    }
+
+    @Test
+    fun whenNeverAllowClickedAndOtherPermissionAutoAcceptedThenOnlyTheOfferedPermissionIsDenied() {
+        sitePermissionsDialogRedesignFeature.self().setRawStoredState(Toggle.State(true))
+
+        val activity = Robolectric.buildActivity(ThemedActivity::class.java).setup().get()
+        val request: PermissionRequest = mock()
+        whenever(request.resources).thenReturn(
+            arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE, PermissionRequest.RESOURCE_AUDIO_CAPTURE),
+        )
+        whenever(request.origin).thenReturn(Uri.parse("https://example.com"))
+
+        testee.askForSitePermission(
+            activity = activity,
+            url = "https://example.com",
+            tabId = "tabId",
+            permissionsRequested = SitePermissions(
+                autoAccept = listOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE),
+                userHandled = listOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE),
+            ),
+            request = request,
+            permissionsGrantedListener = permissionsGrantedListener,
+        )
+
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        dialog.findViewById<LinearLayout>(CommonR.id.stackedAlertDialogButtonLayout)!!.getChildAt(2).performClick()
+
+        verify(request).grant(arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE))
+        verify(sitePermissionsRepository).sitePermissionPermanentlySaved(
+            "https://example.com",
+            PermissionRequest.RESOURCE_AUDIO_CAPTURE,
+            DENY_ALWAYS,
+        )
+        verify(sitePermissionsRepository, never()).sitePermissionPermanentlySaved(
+            any(),
+            eq(PermissionRequest.RESOURCE_VIDEO_CAPTURE),
+            any(),
+        )
+    }
+
+    @Test
+    fun whenSystemPermissionPermanentlyDeniedThenAllowChoiceIsNotSavedAsNeverAllow() {
+        sitePermissionsDialogRedesignFeature.self().setRawStoredState(Toggle.State(true))
+        whenever(systemPermissionsHelper.hasCameraPermissionsGranted()).thenReturn(false)
+        whenever(systemPermissionsHelper.isPermissionsRejectedForever(any())).thenReturn(true)
+
+        val onSystemResult = argumentCaptor<(Boolean) -> Unit>()
+        testee.registerPermissionLauncher(mock())
+        verify(systemPermissionsHelper).registerPermissionLaunchers(any(), onSystemResult.capture(), any())
+
+        val activity = Robolectric.buildActivity(ThemedActivity::class.java).setup().get()
+        val request: PermissionRequest = mock()
+        whenever(request.resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE))
+        whenever(request.origin).thenReturn(Uri.parse("https://example.com"))
+
+        testee.askForSitePermission(
+            activity = activity,
+            url = "https://example.com",
+            tabId = "tabId",
+            permissionsRequested = SitePermissions(
+                autoAccept = emptyList(),
+                userHandled = listOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE),
+            ),
+            request = request,
+            permissionsGrantedListener = permissionsGrantedListener,
+        )
+
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        dialog.findViewById<LinearLayout>(CommonR.id.stackedAlertDialogButtonLayout)!!.getChildAt(0).performClick()
+
+        onSystemResult.firstValue.invoke(false)
+
+        verify(request).deny()
+        verify(sitePermissionsRepository, never()).sitePermissionPermanentlySaved(any(), any(), eq(DENY_ALWAYS))
+    }
+
+    private fun showTieredLocationDialog(origin: String): AlertDialog {
+        sitePermissionsDialogRedesignFeature.self().setRawStoredState(Toggle.State(true))
+
+        val activity = Robolectric.buildActivity(ThemedActivity::class.java).setup().get()
+        val request = LocationPermissionRequest(origin, mock())
+
+        testee.askForSitePermission(
+            activity = activity,
+            url = origin,
+            tabId = "tabId",
+            permissionsRequested = SitePermissions(
+                autoAccept = emptyList(),
+                userHandled = listOf(LocationPermissionRequest.RESOURCE_LOCATION_PERMISSION),
+            ),
+            request = request,
+            permissionsGrantedListener = permissionsGrantedListener,
+        )
+        return ShadowDialog.getLatestDialog() as AlertDialog
+    }
+
+    @Test
+    fun whenLocationRequestedBySiteThenTieredDialogShownWithoutSubtitle() {
+        val dialog = showTieredLocationDialog("https://example.com/")
+
+        assertEquals(3, dialog.findViewById<LinearLayout>(CommonR.id.stackedAlertDialogButtonLayout)!!.childCount)
+        assertEquals(View.GONE, dialog.findViewById<TextView>(CommonR.id.stackedlertDialogMessage)!!.visibility)
+    }
+
+    @Test
+    fun whenLocationRequestedByDuckDuckGoThenTieredDialogKeepsAnonymisationSubtitle() {
+        val dialog = showTieredLocationDialog("https://duckduckgo.com/")
+
+        val message = dialog.findViewById<TextView>(CommonR.id.stackedlertDialogMessage)!!
+        assertEquals(View.VISIBLE, message.visibility)
+        assertEquals(
+            dialog.context.getString(R.string.sitePermissionsTieredDdgLocationDialogSubtitle),
+            message.text.toString(),
+        )
+    }
+
+    @Test
+    fun whenFireModeAndNeverAllowClickedThenDeniedButNothingPersisted() {
+        val fireLauncher = createLauncher(BrowserMode.FIRE)
+        sitePermissionsDialogRedesignFeature.self().setRawStoredState(Toggle.State(true))
+
+        val activity = Robolectric.buildActivity(ThemedActivity::class.java).setup().get()
+        val request: PermissionRequest = mock()
+        whenever(request.resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE))
+        whenever(request.origin).thenReturn(Uri.parse("https://example.com"))
+
+        fireLauncher.askForSitePermission(
+            activity = activity,
+            url = "https://example.com",
+            tabId = "tabId",
+            permissionsRequested = SitePermissions(
+                autoAccept = emptyList(),
+                userHandled = listOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE),
+            ),
+            request = request,
+            permissionsGrantedListener = permissionsGrantedListener,
+        )
+
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        dialog.findViewById<LinearLayout>(CommonR.id.stackedAlertDialogButtonLayout)!!.getChildAt(2).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify(request).deny()
+        verify(sitePermissionsRepository, never()).sitePermissionPermanentlySaved(any(), any(), any())
+    }
+
+    @Test
+    fun whenFireModeAndAllowWhileUsingSiteClickedThenGrantedButNothingPersisted() {
+        val fireLauncher = createLauncher(BrowserMode.FIRE)
+        sitePermissionsDialogRedesignFeature.self().setRawStoredState(Toggle.State(true))
+        whenever(systemPermissionsHelper.hasCameraPermissionsGranted()).thenReturn(true)
+
+        val activity = Robolectric.buildActivity(ThemedActivity::class.java).setup().get()
+        val request: PermissionRequest = mock()
+        whenever(request.resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE))
+        whenever(request.origin).thenReturn(Uri.parse("https://example.com"))
+
+        fireLauncher.askForSitePermission(
+            activity = activity,
+            url = "https://example.com",
+            tabId = "tabId",
+            permissionsRequested = SitePermissions(
+                autoAccept = emptyList(),
+                userHandled = listOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE),
+            ),
+            request = request,
+            permissionsGrantedListener = permissionsGrantedListener,
+        )
+
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        dialog.findViewById<LinearLayout>(CommonR.id.stackedAlertDialogButtonLayout)!!.getChildAt(0).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify(request).grant(any())
+        verify(sitePermissionsRepository, never()).sitePermissionPermanentlySaved(any(), any(), any())
+        verify(sitePermissionsRepository, never()).sitePermissionGranted(any(), any(), any())
     }
 
     class ThemedActivity : AppCompatActivity() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1218158103366423?focus=true 

### Description

Replaces the binary Allow/Deny prompt and its "Remember my choice" checkbox with three tiers (Allow While Using Site, Allow This Time, Never Allow) for location, camera, microphone and the combined camera+microphone request. Dismissing the dialog denies that request without saving anything.

Behind `sitePermissionsDialogRedesign`, default off. The tiers map onto existing storage, so there is no schema change.

Also fixes two pre-existing cases where the saved choice was wrong:
- [Never Allow saved nothing when the request also carried an already-granted permission](https://github.com/duckduckgo/Android/pull/9719/changes#diff-152c120bf3a319f7882f5b8da4d60b869f32899434b7d6c5b0b1c32dcfe34d63L617-R722)
- [An OS-level permanent denial saved a per-site Never Allow. This fix applies with the flag off](https://github.com/duckduckgo/Android/pull/9719/changes#diff-152c120bf3a319f7882f5b8da4d60b869f32899434b7d6c5b0b1c32dcfe34d63R733)

DRM keeps the old dialog and moves in a follow-up.

### Steps to test this PR

_Tiered prompt_
- [x] Open `https://permission.site/` and tap Location
- [x] Verify that the dialog shows a location icon and the options "Allow While Using Site", "Allow This Time" and "Never Allow"
- [x] Tap "Allow This Time" and grant the system permission
- [x] Open the same site in a new tab and tap Location
- [x] Verify that the dialog appears again
- [x] Tap "Allow While Using Site"
- [x] Reload the page and tap Location
- [x] Verify that no dialog appears

_Dismissing the prompt_
- [x] Open `https://permission.site/`
- [x] Tap Microphone and tap outside the dialog
- [x] Verify that the site reports the permission was denied
- [x] Tap Microphone again
- [x] Verify that the dialog appears again

_Never Allow_
- [x] Open `https://permission.site/`
- [x] Tap Camera and tap "Never Allow"
- [x] Tap Camera again
- [x] Verify that no dialog appears and the site reports the permission was denied

_Never Allow when another permission is already granted_
- [x] Remove the site's permissions in Settings > Permissions > Site Permissions
- [x] Open `https://permission.site/`
- [x] Tap Camera and tap "Allow While Using Site"
- [x] Tap Camera and microphone
- [x] Verify that the dialog asks for the microphone only
- [x] Tap "Never Allow"
- [x] Open the site in Settings > Permissions > Site Permissions
- [x] Verify that Microphone is "Deny" and Camera is "Allow"

_System permission denied_
- [ ] Revoke the camera permission with `adb shell pm revoke com.duckduckgo.mobile.android.debug android.permission.CAMERA`
- [ ] Open `https://permission.site/`
- [ ] Tap Camera and tap "Allow While Using Site"
- [ ] Tap "Don't allow" on the Android system permission dialog
- [ ] Verify that the "Allow DuckDuckGo to ask for camera access on this device" dialog appears
- [ ] Open Settings > Permissions > Site Permissions
- [ ] Verify that the site has no saved camera permission

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/c2a20524-046b-4223-9256-15e123b6eaad" />|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/0c993956-8464-48ac-8d73-494bb68bfe7c" />|

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes permission UX and persistence for sensitive site capabilities; fixes alter deny/save behavior but are covered by new tests and sit behind a feature flag.
> 
> **Overview**
> When **`sitePermissionsDialogRedesign`** is on (default off), site prompts for **location**, **camera**, **microphone**, and **camera+mic** switch from Allow/Deny plus “Remember my choice” to a **`StackedAlertDialog`** with **Allow While Using Site**, **Allow This Time**, and **Never Allow**. Dismissal denies the current request only (no persistence). Tiers map to existing `ALLOW_ALWAYS`, session grant, and `DENY_ALWAYS` storage—no schema change. DuckDuckGo location keeps the anonymization subtitle; DRM still uses the legacy dialog.
> 
> **Bug fixes** (including when the flag is off): **Never Allow** now persists only for **`permissionsHandledByUser`** so auto-granted resources on the same request are not mishandled; after an **OS-level** permanent denial, the app no longer writes a per-site **Never Allow**.
> 
> Adds copy in `donottranslate.xml` and broad Robolectric coverage for tiers, Fire mode, mixed auto-accept, and system denial.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acc7dab53439f4ad70d3540fdd9394999430995b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->