### PR TITLE
Add camera pixel for the sync flow

### DIFF
--- a/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -32,6 +32,25 @@
             }
         ]
     },
+    "sync_scanner_camera_permission_state": {
+        "description": "Reports the camera permission state observed on the sync scanner screen: whether it was already granted before and after asking for it, via the permission dialog or the system settings",
+        "owners": ["MiSikora"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "before_requesting",
+                "type": "boolean",
+                "description": "Whether camera permission was already granted before any request was made"
+            },
+            {
+                "key": "after_requesting",
+                "type": "boolean",
+                "description": "Whether camera permission ended up granted, via the permission dialog or the system settings"
+            }
+        ]
+    },
     "sync_setup_barcode_screen_shown": {
         "description": "The sync setup barcode (QR) screen was shown to the user",
         "owners": ["CDRussell"],

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
@@ -49,6 +49,7 @@ class SyncPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugi
             SyncPixelName.SYNC_SETUP_DEEP_LINK_FLOW_ABANDONED.pixelName to PixelParameter.removeAtb(),
 
             SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_SCANNER_CAMERA_PERMISSION_STATE.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_BARCODE_CODE_COPIED.pixelName to PixelParameter.removeAtb(),

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
@@ -49,7 +49,6 @@ class SyncPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugi
             SyncPixelName.SYNC_SETUP_DEEP_LINK_FLOW_ABANDONED.pixelName to PixelParameter.removeAtb(),
 
             SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN.pixelName to PixelParameter.removeAtb(),
-            SyncPixelName.SYNC_SCANNER_CAMERA_PERMISSION_STATE.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_BARCODE_CODE_COPIED.pixelName to PixelParameter.removeAtb(),

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -36,6 +36,8 @@ import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_DAILY_SUCCESS_RATE_PIX
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_OBJECT_LIMIT_EXCEEDED_DAILY
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.CONNECTED_DEVICES_WHEN_DELETING
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_FEATURE_PROMOTION_SOURCE
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SCANNER_CAMERA_PERMISSION_AFTER_REQUESTING
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SCANNER_CAMERA_PERMISSION_BEFORE_REQUESTING
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_CODE_TYPE
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_CODE_VERSION
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_FLOW_VERSION
@@ -125,6 +127,7 @@ interface SyncPixels {
     fun fireTimeoutOnDeepLinkSetup()
     fun fireScanCodeScreenShown(screenType: ScreenType)
     fun fireSyncBarcodeScreenShown(screenType: ScreenType)
+    fun fireScannerCameraPermissionState(beforeRequesting: Boolean, afterRequesting: Boolean)
     fun fireSyncSetupFinishedSuccessfully(
         screenType: ScreenType,
         path: SetupPath? = null,
@@ -668,6 +671,16 @@ class RealSyncPixels @Inject constructor(
         )
     }
 
+    override fun fireScannerCameraPermissionState(beforeRequesting: Boolean, afterRequesting: Boolean) {
+        pixel.fire(
+            SyncPixelName.SYNC_SCANNER_CAMERA_PERMISSION_STATE,
+            parameters = mapOf(
+                SYNC_SCANNER_CAMERA_PERMISSION_BEFORE_REQUESTING to beforeRequesting.toString(),
+                SYNC_SCANNER_CAMERA_PERMISSION_AFTER_REQUESTING to afterRequesting.toString(),
+            ),
+        )
+    }
+
     override fun fireSyncSetupAbandoned(screenType: ScreenType, reason: CancellationReason?) {
         pixel.fire(
             SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
@@ -1005,6 +1018,7 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_SETTINGS_RECOVER_SYNC_DATA_TAPPED("m_settings_sync_recover_synced_data_tapped"),
     SYNC_SETTINGS_RECOVER_SYNC_DATA_CONFIRMED("m_settings_sync_recovery_confirmed_tapped"),
     SYNC_SETUP_SCAN_QR_SCREEN_SHOWN("sync_setup_scan_qr_screen_shown"),
+    SYNC_SCANNER_CAMERA_PERMISSION_STATE("sync_scanner_camera_permission_state"),
     SYNC_SETUP_BARCODE_SCREEN_SHOWN("sync_setup_barcode_screen_shown"),
     SYNC_SETUP_BARCODE_SCANNER_SUCCESS("sync_setup_barcode_scanner_success"),
     SYNC_SETUP_BARCODE_SCANNER_FAILED("sync_setup_barcode_scanner_failed"),
@@ -1080,6 +1094,8 @@ object SyncPixelParameters {
     const val SYNC_FEATURE_PROMOTION_DISMISS_REASON = "reason"
     const val GET_OTHER_DEVICES_SCREEN_LAUNCH_SOURCE = "source"
     const val SYNC_SETUP_SCREEN_TYPE = "source"
+    const val SYNC_SCANNER_CAMERA_PERMISSION_BEFORE_REQUESTING = "before_requesting"
+    const val SYNC_SCANNER_CAMERA_PERMISSION_AFTER_REQUESTING = "after_requesting"
     const val SYNC_SETUP_FLOW_VERSION = "flow_version"
     const val SYNC_SETUP_UI_VERSION = "ui_version"
     const val SYNC_SETUP_MY_KIND = "my_kind"

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/pairing/read/camera/ReadSyncCodeCameraFragment.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/pairing/read/camera/ReadSyncCodeCameraFragment.kt
@@ -54,6 +54,7 @@ import com.duckduckgo.sync.impl.ui.SyncEntryPoint
 import com.duckduckgo.sync.impl.ui.pairing.read.ReadSyncCodeViewModel
 import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command
 import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command.ExpandScannerCutout
+import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command.OpenPermissionSettings
 import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command.PlayIntroAnimation
 import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command.RequestCameraPermission
 import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command.ResumeCamera
@@ -214,6 +215,14 @@ class ReadSyncCodeCameraFragment : DuckDuckGoFragment() {
                 cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
             }
 
+            OpenPermissionSettings -> {
+                val intent = Intent(
+                    Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                    Uri.fromParts("package", requireContext().packageName, null),
+                )
+                startActivity(intent)
+            }
+
             ResumeCamera -> {
                 if (isResumed) binding.includeCamera.barcodeView.resume()
             }
@@ -259,11 +268,7 @@ class ReadSyncCodeCameraFragment : DuckDuckGoFragment() {
 
     private fun configureGoToSettingsButton() {
         binding.includeNoPermission.goToPermissionsSettingsButton.setOnClickListener {
-            val intent = Intent(
-                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                Uri.fromParts("package", requireContext().packageName, null),
-            )
-            startActivity(intent)
+            animationViewModel.onGoToPermissionSettingsClicked()
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/pairing/read/camera/ReadSyncCodeCameraIntroViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/pairing/read/camera/ReadSyncCodeCameraIntroViewModel.kt
@@ -20,7 +20,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command.ExpandScannerCutout
+import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command.OpenPermissionSettings
 import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command.PlayIntroAnimation
 import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command.RequestCameraPermission
 import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command.ResumeCamera
@@ -35,8 +37,11 @@ import javax.inject.Inject
 @ContributesViewModel(FragmentScope::class)
 class ReadSyncCodeCameraIntroViewModel @Inject constructor(
     private val cameraAccess: CameraAccess,
+    private val syncPixels: SyncPixels,
 ) : ViewModel() {
     private val isCameraHardwareAvailable = cameraAccess.isHardwareAvailable()
+    private val isCameraGrantedOnInit = cameraAccess.isPermissionGranted()
+    private var shouldReportCameraPermission = true
 
     private val _viewState = MutableStateFlow(
         ViewState(
@@ -95,6 +100,7 @@ class ReadSyncCodeCameraIntroViewModel @Inject constructor(
 
     fun onCameraPermissionResult() = withCameraHardware {
         val isGranted = cameraAccess.isPermissionGranted()
+        reportCameraPermissionState(isGranted = isGranted)
         _viewState.update {
             it.copy(viewMode = if (isGranted) ViewMode.Camera else ViewMode.NoCameraPermission)
         }
@@ -103,13 +109,34 @@ class ReadSyncCodeCameraIntroViewModel @Inject constructor(
         }
     }
 
+    fun onGoToPermissionSettingsClicked() = withCameraHardware {
+        // The user may grant the permission in the system settings, so we allow to capture the pixel again.
+        shouldReportCameraPermission = true
+        viewModelScope.launch {
+            _command.send(OpenPermissionSettings)
+        }
+    }
+
     private fun requestCameraActivation() {
         if (viewState.value.viewMode == ViewMode.Camera) {
+            // An active camera means the permission is granted. This is where we report grants
+            // that skip the permission dialog: a permission granted before this screen opened or
+            // one granted from the system settings.
+            reportCameraPermissionState(isGranted = true)
             viewModelScope.launch {
                 _command.send(ResumeCamera)
                 _command.send(ExpandScannerCutout)
             }
         }
+    }
+
+    private fun reportCameraPermissionState(isGranted: Boolean) {
+        if (!shouldReportCameraPermission) return
+        shouldReportCameraPermission = false
+        syncPixels.fireScannerCameraPermissionState(
+            beforeRequesting = isCameraGrantedOnInit,
+            afterRequesting = isGranted,
+        )
     }
 
     private inline fun withCameraHardware(block: () -> Unit) {
@@ -133,6 +160,7 @@ class ReadSyncCodeCameraIntroViewModel @Inject constructor(
     sealed class Command {
         data object PlayIntroAnimation : Command()
         data object RequestCameraPermission : Command()
+        data object OpenPermissionSettings : Command()
         data object ResumeCamera : Command()
         data object ExpandScannerCutout : Command()
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
@@ -218,6 +218,19 @@ class RealSyncPixelsTest {
     }
 
     @Test
+    fun `when scanner camera permission state is reported then the pixel is fired`() {
+        testee.fireScannerCameraPermissionState(beforeRequesting = false, afterRequesting = true)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SCANNER_CAMERA_PERMISSION_STATE,
+            mapOf(
+                SyncPixelParameters.SYNC_SCANNER_CAMERA_PERMISSION_BEFORE_REQUESTING to "false",
+                SyncPixelParameters.SYNC_SCANNER_CAMERA_PERMISSION_AFTER_REQUESTING to "true",
+            ),
+        )
+    }
+
+    @Test
     fun `when manual code entry screen is shown the pixel is fired`(
         @TestParameter protocol: ProtocolVersion,
         @TestParameter screenType: ScreenType,

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/pairing/read/camera/ReadSyncCodeCameraIntroViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/pairing/read/camera/ReadSyncCodeCameraIntroViewModelTest.kt
@@ -18,7 +18,9 @@ package com.duckduckgo.sync.impl.ui.pairing.read.camera
 
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command.ExpandScannerCutout
+import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command.OpenPermissionSettings
 import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command.PlayIntroAnimation
 import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command.RequestCameraPermission
 import com.duckduckgo.sync.impl.ui.pairing.read.camera.ReadSyncCodeCameraIntroViewModel.Command.ResumeCamera
@@ -30,6 +32,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 
 class ReadSyncCodeCameraIntroViewModelTest {
@@ -37,13 +41,16 @@ class ReadSyncCodeCameraIntroViewModelTest {
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private val cameraAccess = mock<CameraAccess>()
+    private val syncPixels = mock<SyncPixels>()
 
-    // Created lazily because the view model reads the camera hardware state at construction
-    private val testee by lazy { ReadSyncCodeCameraIntroViewModel(cameraAccess) }
+    // The view model reads the camera hardware/permission state at construction, so callers
+    // must stub cameraAccess before calling this.
+    private fun createTestee() = ReadSyncCodeCameraIntroViewModel(cameraAccess, syncPixels)
 
     @Test
     fun `when camera hardware is available then the intro is shown`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        val testee = createTestee()
 
         testee.viewState.test {
             val viewState = awaitItem()
@@ -57,6 +64,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     @Test
     fun `when camera hardware is not available then the no camera available screen is shown`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(false)
+        val testee = createTestee()
 
         assertEquals(ViewMode.NoCameraAvailable, testee.viewState.value.viewMode)
     }
@@ -64,6 +72,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     @Test
     fun `when the animation start is requested then the play command is sent`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        val testee = createTestee()
 
         testee.commands.test {
             testee.requestAnimationStart()
@@ -77,6 +86,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when the animation start is requested after the animation finished then no play command is sent`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
 
         testee.onAnimationFinished()
 
@@ -91,6 +101,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     @Test
     fun `when the animation start is requested without camera hardware then no play command is sent`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(false)
+        val testee = createTestee()
 
         testee.commands.test {
             testee.requestAnimationStart()
@@ -104,6 +115,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when the animation finishes without camera permission then the intro remains shown`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
 
         testee.onAnimationFinished()
 
@@ -115,6 +127,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when the animation finishes with camera permission granted then the camera is shown`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        val testee = createTestee()
 
         testee.onAnimationFinished()
 
@@ -125,6 +138,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when the scan button is clicked without camera permission then the permission request command is sent`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
 
         testee.commands.test {
             testee.onScanButtonClicked()
@@ -138,6 +152,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when the scan button is clicked with camera permission granted then the camera is shown`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        val testee = createTestee()
 
         testee.onScanButtonClicked()
 
@@ -149,6 +164,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when the scan button is clicked without camera permission then the animation is treated as finished`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
 
         testee.onScanButtonClicked()
 
@@ -160,6 +176,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when the permission request is granted then the camera is shown`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        val testee = createTestee()
 
         testee.onCameraPermissionResult()
 
@@ -170,6 +187,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when the permission request is denied then the no camera permission screen is shown`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
 
         testee.onCameraPermissionResult()
 
@@ -180,6 +198,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when permission is granted in settings after a denial then refreshing shows the camera`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
         testee.onCameraPermissionResult()
 
         whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
@@ -192,6 +211,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when permission is granted in settings after the animation finished then refreshing shows the camera`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
         testee.onAnimationFinished()
 
         whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
@@ -204,6 +224,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when permission is granted while the animation is still running then refreshing keeps the intro`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        val testee = createTestee()
 
         testee.refreshCameraPermissionState()
 
@@ -214,6 +235,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when permission is not granted then refreshing keeps the current screen`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
 
         testee.refreshCameraPermissionState()
 
@@ -224,11 +246,13 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when there is no camera hardware then no event changes the screen`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(false)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        val testee = createTestee()
 
         testee.onAnimationFinished()
         testee.onScanButtonClicked()
         testee.onCameraPermissionResult()
         testee.refreshCameraPermissionState()
+        testee.onGoToPermissionSettingsClicked()
 
         assertEquals(ViewMode.NoCameraAvailable, testee.viewState.value.viewMode)
         assertFalse(testee.viewState.value.animationFinished)
@@ -238,6 +262,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when the scan button is clicked with camera permission granted then the camera resume and cutout expand commands are sent`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        val testee = createTestee()
 
         testee.commands.test {
             testee.onScanButtonClicked()
@@ -252,6 +277,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when the scan button is clicked without camera permission then only the permission request command is sent`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
 
         testee.commands.test {
             testee.onScanButtonClicked()
@@ -266,6 +292,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when the permission request is granted then the camera resume and cutout expand commands are sent`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        val testee = createTestee()
 
         testee.commands.test {
             testee.onCameraPermissionResult()
@@ -280,6 +307,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when the permission request is denied then no camera commands are sent`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
 
         testee.commands.test {
             testee.onCameraPermissionResult()
@@ -293,6 +321,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when the animation finishes with camera permission granted then the camera resume and cutout expand commands are sent`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        val testee = createTestee()
 
         testee.commands.test {
             testee.onAnimationFinished()
@@ -307,6 +336,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when refreshing shows the camera then the camera resume and cutout expand commands are sent`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
         testee.onCameraPermissionResult()
 
         whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
@@ -324,6 +354,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when refreshing while the camera is already shown then the camera resume and cutout expand commands are sent again`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        val testee = createTestee()
 
         testee.commands.test {
             testee.onScanButtonClicked()
@@ -342,6 +373,7 @@ class ReadSyncCodeCameraIntroViewModelTest {
     fun `when refreshing while the intro is still running then no camera commands are sent`() = runTest {
         whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
         whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        val testee = createTestee()
 
         testee.commands.test {
             testee.refreshCameraPermissionState()
@@ -349,6 +381,198 @@ class ReadSyncCodeCameraIntroViewModelTest {
 
             cancel()
         }
+    }
+
+    @Test
+    fun `when permission result is granted and already granted on init then pixel reports granted before and after`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        val testee = createTestee()
+
+        testee.onCameraPermissionResult()
+
+        verify(syncPixels).fireScannerCameraPermissionState(beforeRequesting = true, afterRequesting = true)
+    }
+
+    @Test
+    fun `when permission result is granted and not granted on init then pixel reports not granted before and granted after`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
+
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        testee.onCameraPermissionResult()
+
+        verify(syncPixels).fireScannerCameraPermissionState(beforeRequesting = false, afterRequesting = true)
+    }
+
+    @Test
+    fun `when permission result is denied and not granted on init then pixel reports not granted before and after`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
+
+        testee.onCameraPermissionResult()
+
+        verify(syncPixels).fireScannerCameraPermissionState(beforeRequesting = false, afterRequesting = false)
+    }
+
+    @Test
+    fun `when the animation finishes with permission granted on init then pixel reports granted before and after`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        val testee = createTestee()
+
+        testee.onAnimationFinished()
+
+        verify(syncPixels).fireScannerCameraPermissionState(beforeRequesting = true, afterRequesting = true)
+    }
+
+    @Test
+    fun `when the scan button is clicked with permission granted on init then pixel reports granted before and after`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        val testee = createTestee()
+
+        testee.onScanButtonClicked()
+
+        verify(syncPixels).fireScannerCameraPermissionState(beforeRequesting = true, afterRequesting = true)
+    }
+
+    @Test
+    fun `when the animation finishes without camera permission then no permission state pixel is fired`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
+
+        testee.onAnimationFinished()
+
+        verifyNoMoreInteractions(syncPixels)
+    }
+
+    @Test
+    fun `when the camera activates again after reporting the permission state then the pixel is not fired again`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        val testee = createTestee()
+
+        testee.onAnimationFinished()
+        testee.refreshCameraPermissionState()
+        testee.onScanButtonClicked()
+
+        verify(syncPixels).fireScannerCameraPermissionState(beforeRequesting = true, afterRequesting = true)
+        verifyNoMoreInteractions(syncPixels)
+    }
+
+    @Test
+    fun `when permission is granted in settings without any request then pixel reports not granted before and granted after`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
+        testee.onAnimationFinished()
+
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        testee.refreshCameraPermissionState()
+
+        assertEquals(ViewMode.Camera, testee.viewState.value.viewMode)
+        verify(syncPixels).fireScannerCameraPermissionState(beforeRequesting = false, afterRequesting = true)
+    }
+
+    @Test
+    fun `when permission is granted in settings after a denial without going to them from this screen then the pixel is not fired again`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
+        testee.onCameraPermissionResult()
+
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        testee.refreshCameraPermissionState()
+
+        verify(syncPixels).fireScannerCameraPermissionState(beforeRequesting = false, afterRequesting = false)
+        verifyNoMoreInteractions(syncPixels)
+    }
+
+    @Test
+    fun `when permission is granted in settings after going to them from a denial then pixel reports the grant`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
+        testee.onCameraPermissionResult()
+        testee.onGoToPermissionSettingsClicked()
+
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        testee.refreshCameraPermissionState()
+
+        verify(syncPixels).fireScannerCameraPermissionState(beforeRequesting = false, afterRequesting = false)
+        verify(syncPixels).fireScannerCameraPermissionState(beforeRequesting = false, afterRequesting = true)
+    }
+
+    @Test
+    fun `when the user returns from settings without granting the permission then no additional pixel is fired`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
+        testee.onCameraPermissionResult()
+        testee.onGoToPermissionSettingsClicked()
+
+        testee.refreshCameraPermissionState()
+
+        verify(syncPixels).fireScannerCameraPermissionState(beforeRequesting = false, afterRequesting = false)
+        verifyNoMoreInteractions(syncPixels)
+    }
+
+    @Test
+    fun `when the go to settings button is clicked then the open permission settings command is sent`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
+
+        testee.commands.test {
+            testee.onGoToPermissionSettingsClicked()
+            assertIs<OpenPermissionSettings>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the go to settings button is clicked without camera hardware then no command is sent`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(false)
+        val testee = createTestee()
+
+        testee.commands.test {
+            testee.onGoToPermissionSettingsClicked()
+            expectNoEvents()
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when refreshing the camera permission state then no permission state pixel is fired`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        val testee = createTestee()
+
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        testee.refreshCameraPermissionState()
+
+        verifyNoMoreInteractions(syncPixels)
+    }
+
+    @Test
+    fun `when there is no camera hardware then no permission state pixel is fired`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(false)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+        val testee = createTestee()
+
+        testee.onAnimationFinished()
+        testee.onScanButtonClicked()
+        testee.onCameraPermissionResult()
+        testee.refreshCameraPermissionState()
+        testee.onGoToPermissionSettingsClicked()
+
+        verifyNoMoreInteractions(syncPixels)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218142887748447?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Moves the "Go to Settings" action on the sync scanner's no camera permission screen from the fragment into the view model, so the view model can measure the camera permission state around it. Tapping "Go to Settings" on the no camera permission screen now routes through the view model's `onGoToPermissionSettingsClicked`, which sends the `OpenPermissionSettings` command.

### Steps to test this PR

_Go to settings from the no camera permission screen_
- [x] Have camera permission not granted.
- [x] Go to Sync & Backup.
- [x] Tap "Sync With Another Device".
- [x] Tap "I'm Ready to Scan".
- [x] Deny the camera permission when prompted.
- [x] Check the logs for the `sync_scanner_camera_permission_state` pixel.
- [x] Verify it fired once with `before_requesting=false` and `after_requesting=false`.
- [x] Tap "Go to Settings" on the no camera permission screen.
- [x] Verify the app's system settings screen opens.
- [x] Grant the camera permission in settings.
- [x] Return to the app.
- [x] Verify the camera scanner is shown.
- [x] Check the logs for the `sync_scanner_camera_permission_state` pixel.
- [x] Verify it fired again with `before_requesting=false` and `after_requesting=true`.

### UI changes
N/A

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics and a small MVVM refactor on the sync scanner permission UI; no changes to sync auth or data handling.
> 
> **Overview**
> Adds analytics for **camera permission on the sync QR scanner**: a new `sync_scanner_camera_permission_state` pixel (with `before_requesting` / `after_requesting` booleans) and `SyncPixels.fireScannerCameraPermissionState`.
> 
> **Go to Settings** on the no-permission screen is routed through `ReadSyncCodeCameraIntroViewModel` (`onGoToPermissionSettingsClicked` → `OpenPermissionSettings` command) so the view model can record permission before/after the dialog or system settings. Reporting fires **once** per “resolution” path, with a second report allowed after the user opens settings from that screen.
> 
> Unit tests cover pixel wiring and the view model’s reporting rules (grant/deny, pre-granted, settings return).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6908df91d0f519133515f0749a3a020662b6449. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->