### PR TITLE
Add Exchange v2.1 translations

### DIFF
--- a/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup е криптирано от край до край на всички устройства.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Проверете другото устройство</string>
     <string name="sync_simplified_pairing_headline_recovery">Възстановяване на данни</string>
     <string name="sync_simplified_pairing_body">Свързване…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Отмяна</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Потвърдете на другото устройство…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Разбрах</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Проверете другото устройство</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">В процес на синхронизиране</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Свързване…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s е добавено към Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Funkce Sync &amp; Backup používá end-to-end šifrování na všech tvých zařízeních.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Podívej se na své druhé zařízení</string>
     <string name="sync_simplified_pairing_headline_recovery">Obnovují se data</string>
     <string name="sync_simplified_pairing_body">Připojování…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Zrušit</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Potvrď na druhém zařízení…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Rozumím</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Podívej se na své druhé zařízení</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Probíhá synchronizace</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Připojování…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Zařízení %1$s bylo přidáno do Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-da/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-da/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup er end-to-end-krypteret på alle dine enheder.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Tjek din anden enhed</string>
     <string name="sync_simplified_pairing_headline_recovery">Gendanner data</string>
     <string name="sync_simplified_pairing_body">Forbinder ...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Annuller</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Bekræft på din anden enhed…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Forstået</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Tjek din anden enhed</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Synkronisering i gang</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Forbinder ...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s er føjet til Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-de/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-de/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup ist auf all deinen Geräten Ende-zu-Ende-verschlüsselt.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Überprüfe dein anderes Gerät</string>
     <string name="sync_simplified_pairing_headline_recovery">Datenwiederherstellung</string>
     <string name="sync_simplified_pairing_body">Verbinden …</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Abbrechen</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Bestätige auf deinem anderen Gerät …</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Verstanden</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Überprüfe dein anderes Gerät</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Synchronisierung läuft</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Verbinden …</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s wurde zu Sync &amp; Backup hinzugefügt.</string>

--- a/sync/sync-impl/src/main/res/values-el/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-el/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Το Sync &amp; Backup είναι κρυπτογραφημένο από άκρο σε άκρο σε όλες τις συσκευές σας.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Έλεγξε την άλλη συσκευή σου</string>
     <string name="sync_simplified_pairing_headline_recovery">Γίνεται ανάκτηση δεδομένων</string>
     <string name="sync_simplified_pairing_body">Σύνδεση...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Ακύρωση</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Επιβεβαιώστε στην άλλη συσκευή σας...</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Το κατάλαβα</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Έλεγξε την άλλη συσκευή σου</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Συγχρονισμός σε εξέλιξη</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Σύνδεση...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Η συσκευή %1$s προστέθηκε στο Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-es/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-es/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup está cifrado de extremo a extremo en todos tus dispositivos.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Comprueba tu otro dispositivo</string>
     <string name="sync_simplified_pairing_headline_recovery">Recuperación de datos</string>
     <string name="sync_simplified_pairing_body">Conectando...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Cancelar</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Confirma en tu otro dispositivo…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Entendido</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Comprueba tu otro dispositivo</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sincronización en curso</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Conectando...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Se ha añadido %1$s a Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-et/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-et/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup on kõigis sinu seadmetes otspunktkrüpeeritud.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Kontrolli oma teist seadet</string>
     <string name="sync_simplified_pairing_headline_recovery">Andmete taastamine</string>
     <string name="sync_simplified_pairing_body">Ühendamine...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Tühista</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Kinnita oma teises seadmes…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Sain aru</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Kontrolli oma teist seadet</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sünkroonimine pooleli</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Ühendamine...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s on lisatud Sync &amp; Backupi.</string>

--- a/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup on päästä päähän salattu kaikilla laitteillasi.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Tarkista toinen laitteesi</string>
     <string name="sync_simplified_pairing_headline_recovery">Palautetaan tietoja</string>
     <string name="sync_simplified_pairing_body">Yhdistetään…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Peruuta</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Vahvista toisella laitteellasi…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Selvä</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Tarkista toinen laitteesi</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Synkronointi käynnissä</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Yhdistetään…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s on lisätty Sync &amp; Backup-toimintoon.</string>

--- a/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup est crypté de bout en bout sur tous vos appareils.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Vérifie ton autre appareil</string>
     <string name="sync_simplified_pairing_headline_recovery">Récupération des données</string>
     <string name="sync_simplified_pairing_body">Connexion…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Annuler</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Confirme sur ton autre appareil…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">J\'ai compris</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Vérifie ton autre appareil</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Synchronisation en cours</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Connexion…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s a été ajouté à Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Opcija Sync &amp; Backup šifrirana je metodom \"od kraja do kraja\" (end-to-end) na svim tvojim uređajima.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Provjeri svoj drugi uređaj</string>
     <string name="sync_simplified_pairing_headline_recovery">Obnavljanje podataka</string>
     <string name="sync_simplified_pairing_body">Povezivanje u tijeku...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Otkaži</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Potvrdi na drugom uređaju…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Shvaćam</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Provjeri svoj drugi uređaj</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sinkronizacija u tijeku</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Povezivanje u tijeku...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s je dodan u Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">A Sync &amp; Backup végpontok közötti titkosítással működik minden eszközödön.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Ellenőrizd a másik eszközödet</string>
     <string name="sync_simplified_pairing_headline_recovery">Adatok helyreállítása</string>
     <string name="sync_simplified_pairing_body">Csatlakozás…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Mégsem</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Erősítsd meg a másik eszközödön…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Értem</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Ellenőrizd a másik eszközödet</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Szinkronizálás folyamatban</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Csatlakozás…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">A(z) %1$s hozzáadva a Sync &amp; Backup szolgáltatáshoz.</string>

--- a/sync/sync-impl/src/main/res/values-it/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-it/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup è crittografato end-to-end su tutti i tuoi dispositivi.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Controlla l\'altro dispositivo</string>
     <string name="sync_simplified_pairing_headline_recovery">Recupero dei dati</string>
     <string name="sync_simplified_pairing_body">Connessione…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Annulla</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Conferma sull\'altro dispositivo…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Ho capito</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Controlla l\'altro dispositivo</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sincronizzazione in corso</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Connessione in corso…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s è stato aggiunto a Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Funkcijai „Sync &amp; Backup“ visuose jūsų įrenginiuose naudojamas ištisinis šifravimas.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Patikrink kitą savo įrenginį</string>
     <string name="sync_simplified_pairing_headline_recovery">Duomenų atkūrimas</string>
     <string name="sync_simplified_pairing_body">Jungiamasi...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Atšaukti</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Patvirtinkite kitame įrenginyje…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Supratau</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Patikrink kitą savo įrenginį</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Vyksta sinchronizavimas</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Jungiamasi...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s buvo pridėtas prie „Sync &amp; Backup“.</string>

--- a/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup ir pilnībā šifrēta visās tavās ierīcēs.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Pārbaudi otru ierīci</string>
     <string name="sync_simplified_pairing_headline_recovery">Datu atgūšana</string>
     <string name="sync_simplified_pairing_body">Notiek savienojuma izveide…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Atcelt</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Apstiprini to savā otrā ierīcē...</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Sapratu</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Pārbaudi otru ierīci</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Notiek sinhronizācija</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Notiek savienojuma izveide…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Ierīce %1$s ir pievienota pakalpojumam Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup er ende-til-ende-kryptert på alle enhetene dine.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Sjekk den andre enheten din</string>
     <string name="sync_simplified_pairing_headline_recovery">Gjenoppretter data</string>
     <string name="sync_simplified_pairing_body">Kobler til…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Avbryt</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Bekreft på den andre enheten …</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Den er grei</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Sjekk den andre enheten din</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Synkronisering pågår</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Kobler til…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s er lagt til i Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup is end-to-end versleuteld op al je apparaten.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Controleer je andere apparaat</string>
     <string name="sync_simplified_pairing_headline_recovery">Gegevens herstellen</string>
     <string name="sync_simplified_pairing_body">Er wordt verbinding gemaakt ...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Annuleren</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Bevestig op je andere apparaat …</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Ik snap het</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Controleer je andere apparaat</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Synchronisatie wordt uitgevoerd</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Er wordt verbinding gemaakt...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s is toegevoegd aan Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Funkcja Sync &amp; Backup jest kompleksowo szyfrowana na wszystkich Twoich urządzeniach.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Sprawdź drugie urządzenie</string>
     <string name="sync_simplified_pairing_headline_recovery">Odzyskiwanie danych</string>
     <string name="sync_simplified_pairing_body">Łączenie...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Anuluj</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Potwierdź na drugim urządzeniu…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Rozumiem</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Sprawdź drugie urządzenie</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Trwa synchronizacja</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Łączenie...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Dodano %1$s do Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">O Sync &amp; Backup é encriptado ponto a ponto em todos os teus dispositivos.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Verifica o teu outro dispositivo</string>
     <string name="sync_simplified_pairing_headline_recovery">Recuperar dados</string>
     <string name="sync_simplified_pairing_body">A ligar…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Cancelar</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Confirma no teu outro dispositivo…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Entendido</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Verifica o teu outro dispositivo</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sincronização em curso</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">A ligar…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">O %1$s foi adicionado ao Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup este criptat de la un capăt la altul pe toate dispozitivele tale.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Verifică-ți celălalt dispozitiv</string>
     <string name="sync_simplified_pairing_headline_recovery">Se recuperează datele</string>
     <string name="sync_simplified_pairing_body">Se conectează…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Anulează</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Confirmă pe celălalt dispozitiv…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Am înțeles</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Verifică-ți celălalt dispozitiv</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sincronizare în curs</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Se conectează…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s a fost adăugat la Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Функция Sync &amp; Backup защищена сквозным шифрованием на всех ваших устройствах.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Проверьте другое устройство</string>
     <string name="sync_simplified_pairing_headline_recovery">Восстановление данных</string>
     <string name="sync_simplified_pairing_body">Выполняется подключение…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Отменить</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Подтвердите на другом устройстве…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Понятно</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Проверьте другое устройство</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Выполняется синхронизация</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Выполняется подключение…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Устройство %1$s подключено к Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Služba Sync &amp; Backup je na všetkých tvojich zariadeniach šifrovaná spôsobom end-to-end.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Skontroluj svoje druhé zariadenie</string>
     <string name="sync_simplified_pairing_headline_recovery">Obnovenie údajov</string>
     <string name="sync_simplified_pairing_body">Pripája sa...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Zrušiť</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Potvrď na inom zariadení…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Rozumiem</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Skontroluj svoje druhé zariadenie</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Prebieha synchronizácia</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Pripája sa…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Zariadenie %1$s bolo pridané do služby Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup je šifriran v celoti v vseh vaših napravah.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Preveri drugo napravo</string>
     <string name="sync_simplified_pairing_headline_recovery">Obnovitev podatkov</string>
     <string name="sync_simplified_pairing_body">Povezovanje ...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Prekliči</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Potrdite v drugi napravi …</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Razumem</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Preveri drugo napravo</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sinhronizacija poteka</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Povezovanje ...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Naprava %1$s je bila dodana v Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup är krypterad på alla dina enheter.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Kontrollera din andra enhet</string>
     <string name="sync_simplified_pairing_headline_recovery">Återställer data</string>
     <string name="sync_simplified_pairing_body">Ansluter …</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Avbryt</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Bekräfta på din andra enhet ...</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Jag förstår</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Kontrollera din andra enhet</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Synkronisering pågår</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Ansluter…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s har lagts till i Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup tüm cihazlarınızda uçtan uca şifrelenmiştir.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Diğer cihazı kontrol edin</string>
     <string name="sync_simplified_pairing_headline_recovery">Veriler kurtarılıyor</string>
     <string name="sync_simplified_pairing_body">Bağlantı kuruluyor...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">İptal</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Diğer cihazınızdan onaylayın…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Anladım</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Diğer cihazı kontrol edin</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Senkronizasyon devam ediyor</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Bağlantı kuruluyor...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s, Sync &amp; Backup\'a eklendi.</string>

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -15,11 +15,6 @@
   -->
 
 <resources>
-    <string name="sync_simplified_pairing_headline_check_other_device">Check your other device</string>
-    <string name="sync_simplified_pairing_dialog_check_other_device_title">Check your other device</string>
-    <string name="sync_simplified_pairing_dialog_connecting_title">Sync in progress</string>
-    <string name="sync_simplified_pairing_dialog_connecting_body">Connecting…</string>
-
     <!-- Scanner screen: manual entry tab -->
     <string name="sync_simplified_scanner_manual_entry_example_code">eyJyZWNvdmVyeSI6eyJ1c2VyX2lkIjoiNjgwRDQ1QjUtNUU2RS00MzQ3LTlDNDQtQjZGQkU4MEZDNEE3IiwicHJpbWFyelkasd92V9rZXkiOiJBUUVCQVFFQkFRRUJBUUVCQVFFQkFRRUJBUUVCQVFFQkFRRUJBUUVCQVFFPSJ9fQ==</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync&#160;&amp;&#160;Backup is end-to-end encrypted on all your devices.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Check your other device</string>
     <string name="sync_simplified_pairing_headline_recovery">Recovering data</string>
     <string name="sync_simplified_pairing_body">Connecting…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Cancel</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Confirm on your other device…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Got It</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Check your other device</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sync in progress</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Connecting…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s has been added to Sync&#160;&amp;&#160;Backup.</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/2/137249556945/project/72649045549333/task/1218138429945358?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Translations for the Exchange v2.1 changes.

### Steps to test this PR
N/A

### UI changes
N/A

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-resource and translation updates only; no sync logic or security behavior changes in this diff.
> 
> **Overview**
> Adds **localized copy** for Exchange v2.1 simplified sync pairing: a “check your other device” pairing headline and dialog title, plus “sync in progress” / “connecting…” dialog strings used on the QR and pairing flows.
> 
> The four keys move from English-only `donottranslate.xml` into the default `strings-sync.xml` and are translated across all existing `values-*` locale files so non-English users see the updated pairing states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c99ea093f7806a41ba710440f4c25f823e2bc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->