### PR TITLE
Fix: Auto-granted site permission after the OS permission is revoked

### DIFF
--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerImpl.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerImpl.kt
@@ -27,7 +27,6 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extractDomain
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.site.permissions.api.SitePermissionsManager
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.LocationPermissionRequest
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissionQueryResponse
@@ -38,7 +37,7 @@ import com.duckduckgo.site.permissions.impl.drm.DrmPolicyManager
 import com.duckduckgo.site.permissions.impl.drm.DrmPolicyReason
 import com.duckduckgo.site.permissions.impl.drm.DrmSessionStore
 import com.duckduckgo.site.permissions.impl.feature.DrmPolicyFeature
-import com.duckduckgo.site.permissions.impl.feature.MicrophoneSitePermissionsDomainRecoveryFeature
+import com.duckduckgo.site.permissions.impl.feature.SitePermissionsSystemRecoveryFeature
 import com.duckduckgo.site.permissions.impl.feature.isCentralPolicyEnabled
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.withContext
@@ -53,12 +52,11 @@ class SitePermissionsManagerImpl @Inject constructor(
     private val sitePermissionsRepository: SitePermissionsRepository,
     private val dispatcherProvider: DispatcherProvider,
     private val context: Context,
-    private val microphoneSitePermissionsDomainRecoveryFeature: MicrophoneSitePermissionsDomainRecoveryFeature,
+    private val sitePermissionsSystemRecoveryFeature: SitePermissionsSystemRecoveryFeature,
     private val drmPolicyFeature: DrmPolicyFeature,
     private val drmPolicyManager: DrmPolicyManager,
     private val drmSessionStore: DrmSessionStore,
     private val pixel: Pixel,
-    duckAiHostProvider: DuckAiHostProvider,
 ) : SitePermissionsManager {
 
     private suspend fun getSitePermissionsGranted(
@@ -97,17 +95,13 @@ class SitePermissionsManagerImpl @Inject constructor(
 
         logcat { "Permissions: sitePermissionsAllowedToAsk in $url ${sitePermissionsAllowedToAsk.asList()}" }
 
-        val filteredPermissionsGranted = if (microphoneSitePermissionsDomainRecoveryFeature.self().isEnabled()) {
-            getSitePermissionsGranted(url, tabId, sitePermissionsAllowedToAsk).filter { permission ->
-                if (permission == PermissionRequest.RESOURCE_AUDIO_CAPTURE && audioCapturePermissionDomains.contains(url.extractDomain())) {
-                    ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED &&
-                        ContextCompat.checkSelfPermission(context, Manifest.permission.MODIFY_AUDIO_SETTINGS) == PackageManager.PERMISSION_GRANTED
-                } else {
-                    true
-                }
-            }.toTypedArray()
+        val permissionsGranted = getSitePermissionsGranted(url, tabId, sitePermissionsAllowedToAsk)
+
+        // Drop saved grants the app can no longer honor, so the dialog can ask for the OS permission back
+        val filteredPermissionsGranted = if (sitePermissionsSystemRecoveryFeature.self().isEnabled()) {
+            permissionsGranted.filter { hasSystemPermission(it) }.toTypedArray()
         } else {
-            getSitePermissionsGranted(url, tabId, sitePermissionsAllowedToAsk)
+            permissionsGranted
         }
 
         val sitePermissionsGranted = if (drmDecision?.action == DrmPolicyAction.GRANT) {
@@ -202,6 +196,18 @@ class SitePermissionsManagerImpl @Inject constructor(
         )
     }
 
+    private fun hasSystemPermission(sitePermission: String): Boolean = when (sitePermission) {
+        PermissionRequest.RESOURCE_AUDIO_CAPTURE ->
+            isSystemPermissionGranted(Manifest.permission.RECORD_AUDIO) &&
+                isSystemPermissionGranted(Manifest.permission.MODIFY_AUDIO_SETTINGS)
+        PermissionRequest.RESOURCE_VIDEO_CAPTURE -> isSystemPermissionGranted(Manifest.permission.CAMERA)
+        LocationPermissionRequest.RESOURCE_LOCATION_PERMISSION -> isSystemPermissionGranted(Manifest.permission.ACCESS_COARSE_LOCATION)
+        else -> true
+    }
+
+    private fun isSystemPermissionGranted(androidPermission: String): Boolean =
+        ContextCompat.checkSelfPermission(context, androidPermission) == PackageManager.PERMISSION_GRANTED
+
     private fun isPermissionSupported(permission: String): Boolean =
         permission == PermissionRequest.RESOURCE_AUDIO_CAPTURE || permission == PermissionRequest.RESOURCE_VIDEO_CAPTURE ||
             permission == PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID || permission == LocationPermissionRequest.RESOURCE_LOCATION_PERMISSION
@@ -225,6 +231,4 @@ class SitePermissionsManagerImpl @Inject constructor(
             else -> null
         }
     }
-
-    private val audioCapturePermissionDomains: List<String> = listOf(duckAiHostProvider.getHost(), "duckduckgo.com")
 }

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/feature/SitePermissionsSystemRecoveryFeature.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/feature/SitePermissionsSystemRecoveryFeature.kt
@@ -19,12 +19,13 @@ package com.duckduckgo.site.permissions.impl.feature
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
-    featureName = "microphoneSitePermissionsDomainRecovery",
+    featureName = "sitePermissionsSystemRecovery",
 )
-interface MicrophoneSitePermissionsDomainRecoveryFeature {
-    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.TRUE)
+interface SitePermissionsSystemRecoveryFeature {
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerTest.kt
+++ b/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerTest.kt
@@ -25,9 +25,9 @@ import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.site.permissions.api.SitePermissionsManager.LocationPermissionRequest
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissionQueryResponse
 import com.duckduckgo.site.permissions.impl.drm.DrmPolicyAction
 import com.duckduckgo.site.permissions.impl.drm.DrmPolicyDecision
@@ -35,7 +35,7 @@ import com.duckduckgo.site.permissions.impl.drm.DrmPolicyManager
 import com.duckduckgo.site.permissions.impl.drm.DrmPolicyReason
 import com.duckduckgo.site.permissions.impl.drm.DrmSessionStore
 import com.duckduckgo.site.permissions.impl.feature.DrmPolicyFeature
-import com.duckduckgo.site.permissions.impl.feature.MicrophoneSitePermissionsDomainRecoveryFeature
+import com.duckduckgo.site.permissions.impl.feature.SitePermissionsSystemRecoveryFeature
 import com.duckduckgo.site.permissions.store.sitepermissions.SitePermissionsEntity
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
@@ -64,9 +64,8 @@ class SitePermissionsManagerTest {
     private val mockPackageManager = mock<PackageManager>()
     private val mockLocationManager = mock<LocationManager>()
     private val mockContext = mock<Context>()
-    private val mockDuckAiHostProvider = mock<DuckAiHostProvider>()
-    private val fakeMicrophoneSitePermissionsDomainRecoveryFeature = FakeFeatureToggleFactory.create(
-        MicrophoneSitePermissionsDomainRecoveryFeature::class.java,
+    private val fakeSitePermissionsSystemRecoveryFeature = FakeFeatureToggleFactory.create(
+        SitePermissionsSystemRecoveryFeature::class.java,
     )
     private val drmPolicyFeature = FakeFeatureToggleFactory.create(DrmPolicyFeature::class.java)
     private val mockDrmPolicyManager: DrmPolicyManager = mock()
@@ -80,12 +79,11 @@ class SitePermissionsManagerTest {
             mockSitePermissionsRepository,
             coroutineRule.testDispatcherProvider,
             mockContext,
-            fakeMicrophoneSitePermissionsDomainRecoveryFeature,
+            fakeSitePermissionsSystemRecoveryFeature,
             drmPolicyFeature,
             mockDrmPolicyManager,
             drmSessionStore,
             mockPixel,
-            mockDuckAiHostProvider,
         )
     }
 
@@ -94,9 +92,9 @@ class SitePermissionsManagerTest {
 
     @Before
     fun before() {
-        whenever(mockDuckAiHostProvider.getHost()).thenReturn("duck.ai")
         whenever(mockPackageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY)).thenReturn(true)
-        fakeMicrophoneSitePermissionsDomainRecoveryFeature.self().setRawStoredState(Toggle.State(false))
+        fakeSitePermissionsSystemRecoveryFeature.self().setRawStoredState(Toggle.State(true))
+        whenever(mockContext.checkPermission(any(), any(), any())).thenReturn(PackageManager.PERMISSION_GRANTED)
         drmPolicyFeature.self().setRawStoredState(Toggle.State(true))
         drmPolicyFeature.centralPolicy().setRawStoredState(Toggle.State(false))
     }
@@ -419,21 +417,68 @@ class SitePermissionsManagerTest {
     }
 
     @Test
-    fun whenRecoveryEnabledAndDuckAiAudioGrantedAndAndroidPermissionDeniedThenAudioNotAutoAccepted() = runTest {
-        val duckAiUrl = "https://duck.ai/chat"
-        fakeMicrophoneSitePermissionsDomainRecoveryFeature.self().setRawStoredState(Toggle.State(true))
-        val resources = arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE)
-        whenever(mockSitePermissionsRepository.isDomainAllowedToAsk(duckAiUrl, PermissionRequest.RESOURCE_AUDIO_CAPTURE)).thenReturn(true)
-        whenever(mockSitePermissionsRepository.isDomainGranted(duckAiUrl, tabId, PermissionRequest.RESOURCE_AUDIO_CAPTURE)).thenReturn(true)
+    fun whenAudioSiteGrantedAndSystemPermissionDeniedThenAudioUserHandled() = runTest {
+        assertSavedGrantIsUserHandledWhenSystemPermissionDenied(PermissionRequest.RESOURCE_AUDIO_CAPTURE)
+    }
+
+    @Test
+    fun whenCameraSiteGrantedAndSystemPermissionDeniedThenCameraUserHandled() = runTest {
+        assertSavedGrantIsUserHandledWhenSystemPermissionDenied(PermissionRequest.RESOURCE_VIDEO_CAPTURE)
+    }
+
+    @Test
+    fun whenLocationSiteGrantedAndSystemPermissionDeniedThenLocationUserHandled() = runTest {
+        assertSavedGrantIsUserHandledWhenSystemPermissionDenied(LocationPermissionRequest.RESOURCE_LOCATION_PERMISSION)
+    }
+
+    @Test
+    fun whenRecoveryDisabledAndSystemPermissionDeniedThenSavedGrantStillAutoAccepted() = runTest {
+        fakeSitePermissionsSystemRecoveryFeature.self().setRawStoredState(Toggle.State(false))
         whenever(mockContext.checkPermission(any(), any(), any())).thenReturn(PackageManager.PERMISSION_DENIED)
+        val resources = arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE)
+        whenever(mockSitePermissionsRepository.isDomainAllowedToAsk(url, PermissionRequest.RESOURCE_VIDEO_CAPTURE)).thenReturn(true)
+        whenever(mockSitePermissionsRepository.isDomainGranted(url, tabId, PermissionRequest.RESOURCE_VIDEO_CAPTURE)).thenReturn(true)
 
         val permissionRequest: PermissionRequest = mock()
-        whenever(permissionRequest.origin).thenReturn(duckAiUrl.toUri())
+        whenever(permissionRequest.origin).thenReturn(url.toUri())
+        whenever(permissionRequest.resources).thenReturn(resources)
+
+        testee.getSitePermissions(tabId, permissionRequest)
+
+        verify(permissionRequest).grant(arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE))
+    }
+
+    @Test
+    fun whenDrmSiteGrantedThenAutoAcceptedRegardlessOfSystemPermissions() = runTest {
+        whenever(mockContext.checkPermission(any(), any(), any())).thenReturn(PackageManager.PERMISSION_DENIED)
+        val resources = arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
+        whenever(mockSitePermissionsRepository.isDomainAllowedToAsk(url, PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)).thenReturn(true)
+        whenever(mockSitePermissionsRepository.isDomainGranted(url, tabId, PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)).thenReturn(true)
+
+        val permissionRequest: PermissionRequest = mock()
+        whenever(permissionRequest.origin).thenReturn(url.toUri())
+        whenever(permissionRequest.resources).thenReturn(resources)
+
+        testee.getSitePermissions(tabId, permissionRequest)
+
+        verify(permissionRequest).grant(arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID))
+    }
+
+    private suspend fun assertSavedGrantIsUserHandledWhenSystemPermissionDenied(permission: String) {
+        whenever(mockContext.checkPermission(any(), any(), any())).thenReturn(PackageManager.PERMISSION_DENIED)
+        whenever(mockLocationManager.isLocationEnabled).thenReturn(true)
+        val resources = arrayOf(permission)
+        whenever(mockSitePermissionsRepository.isDomainAllowedToAsk(url, permission)).thenReturn(true)
+        whenever(mockSitePermissionsRepository.isDomainGranted(url, tabId, permission)).thenReturn(true)
+
+        val permissionRequest: PermissionRequest = mock()
+        whenever(permissionRequest.origin).thenReturn(url.toUri())
         whenever(permissionRequest.resources).thenReturn(resources)
 
         val permissions = testee.getSitePermissions(tabId, permissionRequest)
-        assertEquals(1, permissions.userHandled.size)
-        assertEquals(PermissionRequest.RESOURCE_AUDIO_CAPTURE, permissions.userHandled.first())
+
+        assertEquals(listOf(permission), permissions.userHandled)
         assertEquals(0, permissions.autoAccept.size)
+        verify(permissionRequest, never()).grant(any())
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1218187438620201?focus=true

### Description

Fixes a dead end flow when a previously auto-approved site permission doesn't do anything after the OS permission is revoked.

### Steps to test this PR
                                                                                                                                                                                                                           
- [ ] Navigate to`https://permission.site`                                                                                                                                                                                                                                           
- [ ] Tap "Camera"                                                                                                                                                                                                                                                                   
- [ ] Verify that the DuckDuckGo permission dialog appears                                                                                                                                                                                                                           
- [ ] Tick "Remember my choice" and tap "Allow"                                                                                                                                                                                                                                      
- [ ] Grant camera when the Android system permission prompt appears                                                                                                                                                                                                                 
- [ ] Verify that the site shows the camera stream                                                                                                                                                                                                                                   
- [ ] Open Android Settings → Apps → DuckDuckGo → Permissions → Camera
- [ ] Select "Don't allow"                                                                                                                                                                                               
- [ ] Return to the app and reload `https://permission.site`                                                                                                                                                                                                                           
- [ ] Tap "Camera"
- [ ] Verify that either the Android system permission prompt appears, or a dialog offering to open app settings appears
- [ ] Grant camera through that path and return to the site
- [ ] Verify that the camera permission worked

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes permission auto-grant behavior behind a renamed remote feature flag; incorrect mapping could block or over-prompt on camera/mic/location until toggled off.
> 
> **Overview**
> Fixes a dead-end where sites with a saved “allow” still appeared granted even after the user revoked the matching Android permission, so nothing useful happened on the next request.
> 
> **`sitePermissionsSystemRecovery`** replaces the Duck AI–only **`microphoneSitePermissionsDomainRecovery`** toggle. When enabled, saved site grants are only auto-honored if the app still holds the required system permissions (mic, camera, coarse location); otherwise the permission is routed to **user-handled** flow so the OS prompt or settings path can run again. **`DuckAiHostProvider`** and domain-specific mic checks are removed.
> 
> DRM saved grants are unchanged and still auto-accept without system permission checks. With recovery **disabled**, behavior stays the old path (saved grants can still auto-accept even if OS permission is denied). Tests cover audio, camera, location, toggle-off, and DRM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5750f13eecd8a6b08bc75c4dec54249ae1712334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->