### PR TITLE
Update WorkManger to latest stable (2.11.2) to suppress TooManyRequestsExceptions

### DIFF
--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadWorker.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadWorker.kt
@@ -21,7 +21,7 @@ import android.util.Base64
 import androidx.annotation.VisibleForTesting
 import androidx.work.CoroutineWorker
 import androidx.work.Data
-import androidx.work.Data.MAX_DATA_BYTES
+import androidx.work.Data.Companion.MAX_DATA_BYTES
 import androidx.work.WorkerParameters
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.browsermode.api.BrowserMode

--- a/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFiltersUpdateWorkerTest.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFiltersUpdateWorkerTest.kt
@@ -20,11 +20,10 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
-import org.mockito.kotlin.capture
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.whenever
@@ -135,11 +134,11 @@ class MaliciousSiteProtectionFiltersUpdateWorkerSchedulerTest {
 
         scheduler.onPrivacyConfigDownloaded()
 
-        val workRequestCaptor = ArgumentCaptor.forClass(PeriodicWorkRequest::class.java)
+        val workRequestCaptor = argumentCaptor<PeriodicWorkRequest>()
         verify(workManager).enqueueUniquePeriodicWork(
             eq("MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_TAG"),
             eq(ExistingPeriodicWorkPolicy.UPDATE),
-            capture(workRequestCaptor),
+            workRequestCaptor.capture(),
         )
 
         verify(workManager).cancelUniqueWork(
@@ -151,7 +150,7 @@ class MaliciousSiteProtectionFiltersUpdateWorkerSchedulerTest {
             any(),
         )
 
-        val capturedWorkRequest = workRequestCaptor.value
+        val capturedWorkRequest = workRequestCaptor.firstValue
         val repeatInterval = capturedWorkRequest.workSpec.intervalDuration
         val expectedInterval = TimeUnit.MINUTES.toMillis(updateFrequencyMinutes)
 
@@ -169,13 +168,13 @@ class MaliciousSiteProtectionFiltersUpdateWorkerSchedulerTest {
 
         scheduler.onPrivacyConfigDownloaded()
 
-        val workRequestCaptor = ArgumentCaptor.forClass(PeriodicWorkRequest::class.java)
+        val workRequestCaptor = argumentCaptor<PeriodicWorkRequest>()
         verify(workManager).enqueueUniquePeriodicWork(
             eq("MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_TAG"),
             eq(ExistingPeriodicWorkPolicy.UPDATE),
-            capture(workRequestCaptor),
+            workRequestCaptor.capture(),
         )
-        var capturedWorkRequest = workRequestCaptor.value
+        var capturedWorkRequest = workRequestCaptor.firstValue
         var repeatInterval = capturedWorkRequest.workSpec.intervalDuration
         val expectedInterval = TimeUnit.MINUTES.toMillis(updateFrequencyMinutes)
         var inputData = capturedWorkRequest.workSpec.input
@@ -186,14 +185,14 @@ class MaliciousSiteProtectionFiltersUpdateWorkerSchedulerTest {
             listOf(PHISHING.name, MALWARE.name),
         )
 
-        val scamWorkRequestCaptor = ArgumentCaptor.forClass(PeriodicWorkRequest::class.java)
+        val scamWorkRequestCaptor = argumentCaptor<PeriodicWorkRequest>()
         verify(workManager).enqueueUniquePeriodicWork(
             eq("MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_SCAM_TAG"),
             eq(ExistingPeriodicWorkPolicy.UPDATE),
-            capture(scamWorkRequestCaptor),
+            scamWorkRequestCaptor.capture(),
         )
 
-        capturedWorkRequest = scamWorkRequestCaptor.value
+        capturedWorkRequest = scamWorkRequestCaptor.firstValue
         repeatInterval = capturedWorkRequest.workSpec.intervalDuration
         inputData = capturedWorkRequest.workSpec.input
 

--- a/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorkerTest.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorkerTest.kt
@@ -20,11 +20,10 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
-import org.mockito.kotlin.capture
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.whenever
@@ -135,11 +134,11 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerSchedulerTest {
 
         scheduler.onPrivacyConfigDownloaded()
 
-        val workRequestCaptor = ArgumentCaptor.forClass(PeriodicWorkRequest::class.java)
+        val workRequestCaptor = argumentCaptor<PeriodicWorkRequest>()
         verify(workManager).enqueueUniquePeriodicWork(
             eq("MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG"),
             eq(ExistingPeriodicWorkPolicy.UPDATE),
-            capture(workRequestCaptor),
+            workRequestCaptor.capture(),
         )
 
         verify(workManager).cancelUniqueWork(
@@ -151,7 +150,7 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerSchedulerTest {
             any(),
         )
 
-        val capturedWorkRequest = workRequestCaptor.value
+        val capturedWorkRequest = workRequestCaptor.firstValue
         val repeatInterval = capturedWorkRequest.workSpec.intervalDuration
         val expectedInterval = TimeUnit.MINUTES.toMillis(updateFrequencyMinutes)
 
@@ -169,13 +168,13 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerSchedulerTest {
 
         scheduler.onPrivacyConfigDownloaded()
 
-        val workRequestCaptor = ArgumentCaptor.forClass(PeriodicWorkRequest::class.java)
+        val workRequestCaptor = argumentCaptor<PeriodicWorkRequest>()
         verify(workManager).enqueueUniquePeriodicWork(
             eq("MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG"),
             eq(ExistingPeriodicWorkPolicy.UPDATE),
-            capture(workRequestCaptor),
+            workRequestCaptor.capture(),
         )
-        var capturedWorkRequest = workRequestCaptor.value
+        var capturedWorkRequest = workRequestCaptor.firstValue
         var repeatInterval = capturedWorkRequest.workSpec.intervalDuration
         val expectedInterval = TimeUnit.MINUTES.toMillis(updateFrequencyMinutes)
         var inputData = capturedWorkRequest.workSpec.input
@@ -186,14 +185,14 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerSchedulerTest {
             listOf(PHISHING.name, MALWARE.name),
         )
 
-        val scamWorkRequestCaptor = ArgumentCaptor.forClass(PeriodicWorkRequest::class.java)
+        val scamWorkRequestCaptor = argumentCaptor<PeriodicWorkRequest>()
         verify(workManager).enqueueUniquePeriodicWork(
             eq("MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG"),
             eq(ExistingPeriodicWorkPolicy.UPDATE),
-            capture(scamWorkRequestCaptor),
+            scamWorkRequestCaptor.capture(),
         )
 
-        capturedWorkRequest = scamWorkRequestCaptor.value
+        capturedWorkRequest = scamWorkRequestCaptor.firstValue
         repeatInterval = capturedWorkRequest.workSpec.intervalDuration
         inputData = capturedWorkRequest.workSpec.input
 

--- a/versions.properties
+++ b/versions.properties
@@ -75,7 +75,7 @@ version.androidx.test.runner=1.6.2
 
 version.androidx.webkit=1.14.0
 
-version.androidx.work=2.9.1
+version.androidx.work=2.11.2
 
 version.androidx.security-crypto=1.1.0
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1218182452445002?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
We're using an old version of `WorkManager` and we're seeing an increase in `TooManyRequestsExceptions`, for which a fix is already available in newer versions of `WorkManager`.

### Steps to test this PR
- Smoke testing of anything requiring background workers, downloading config, sync, PIR etc.. 
- I've done as much testing as I can going from `develop` and turning on all the features and then updating to this branch ensuring everything works. 

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency bump with a single import fix; no behavioral logic changes beyond what Work 2.11.2 provides.
> 
> **Overview**
> Bumps **AndroidX Work** from `2.9.1` to **`2.11.2`** in `versions.properties`, aimed at reducing **`TooManyRequestsException`** noise from WorkManager scheduling.
> 
> The only code change is in **`FileDownloadWorker`**: `MAX_DATA_BYTES` is now referenced via **`Data.Companion.MAX_DATA_BYTES`** instead of the top-level `Data` constant, matching the updated Work library API used for URL size limits in download worker input data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36433b48c93644767df2dcc2ce6ca02b9b021ba1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->