### PR TITLE
Permissions: Redesigned DRM permission dialog

### DIFF
--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -304,6 +304,7 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
         pixelType: String,
         faviconUrl: String?,
         onPermissionAllowed: (Boolean) -> Unit,
+        onPermissionDenied: (Boolean) -> Unit = ::denyPermissions,
     ) {
         StackedAlertDialogBuilder(activity)
             .setRebrandUpdate(true)
@@ -336,7 +337,7 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                             NEVER_ALLOW_BUTTON -> {
                                 faviconUrl?.let { storeFavicon(it) }
                                 sendNegativeDialogClickPixel(pixelType, rememberChoice = true)
-                                denyPermissions(rememberChoice = true)
+                                onPermissionDenied(true)
                             }
                         }
                     }
@@ -344,7 +345,7 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                     // The tiered dialog has no explicit deny-once button; dismissing it is that choice.
                     override fun onDialogCancelled() {
                         sendNegativeDialogClickPixel(pixelType, rememberChoice = false)
-                        denyPermissions(rememberChoice = false)
+                        onPermissionDenied(false)
                     }
                 },
             )
@@ -381,6 +382,21 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
 
         // No session-based setting and no config --> proceed to show dialog
         val title = url.websiteFromGeoLocationsApiOrigin()
+
+        if (sitePermissionsDialogRedesignFeature.self().isEnabled()) {
+            sendDialogImpressionPixel(SitePermissionsPixelValues.DRM)
+            showTieredSitePermissionsDialog(
+                iconRes = CommonR.drawable.ic_video_player_24,
+                title = String.format(activity.getString(R.string.drmSitePermissionDialogTitle), title),
+                messageRes = R.string.sitePermissionsTieredDrmDialogSubtitle,
+                pixelType = SitePermissionsPixelValues.DRM,
+                faviconUrl = url,
+                onPermissionAllowed = { rememberChoice -> allowDrmPermissions(domain, rememberChoice) },
+                onPermissionDenied = { rememberChoice -> denyDrmPermissions(domain, rememberChoice) },
+            )
+            return
+        }
+
         val dialog = TextAlertDialogBuilder(activity)
         dialog
             .setTitle(
@@ -417,8 +433,6 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                             onSiteDrmPermissionSave(domain, SitePermissionAskSettingType.ALLOW_ALWAYS)
                             storeFavicon(url)
                         } else {
-                            // Fire mode grants the in-session WebView permission below but must not write the
-                            // choice into the shared (app-wide, in-memory) DRM session map that regular tabs read.
                             if (browserMode != BrowserMode.FIRE) {
                                 sitePermissionsRepository.saveDrmForSession(tabId, domain, true)
                             }
@@ -433,8 +447,6 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                             onSiteDrmPermissionSave(domain, SitePermissionAskSettingType.DENY_ALWAYS)
                             storeFavicon(url)
                         } else if (browserMode != BrowserMode.FIRE) {
-                            // Fire mode denied the in-session permission above but must not write the
-                            // choice into the shared (app-wide, in-memory) DRM session map that regular tabs read.
                             sitePermissionsRepository.saveDrmForSession(tabId, domain, false)
                         }
                         sendNegativeDialogClickPixel(SitePermissionsPixelValues.DRM, rememberChoice)
@@ -448,11 +460,34 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
             .show()
     }
 
+    private fun allowDrmPermissions(
+        domain: String,
+        rememberChoice: Boolean,
+    ) {
+        if (browserMode != BrowserMode.FIRE) {
+            if (rememberChoice) {
+                sitePermissionsRepository.sitePermissionPermanentlySaved(siteURL, PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID, ALLOW_ALWAYS)
+            } else {
+                sitePermissionsRepository.saveDrmForSession(tabId, domain, true)
+            }
+        }
+        grantPermissions()
+    }
+
+    private fun denyDrmPermissions(
+        domain: String,
+        rememberChoice: Boolean,
+    ) {
+        if (!rememberChoice && browserMode != BrowserMode.FIRE) {
+            sitePermissionsRepository.saveDrmForSession(tabId, domain, false)
+        }
+        denyPermissions(rememberChoice)
+    }
+
     private fun onSiteDrmPermissionSave(
         domain: String,
         drmPermission: SitePermissionAskSettingType,
     ) {
-        // Fire mode must not persist a per-site DRM choice into the shared store.
         if (browserMode == BrowserMode.FIRE) return
 
         val sitePermissionsEntity = SitePermissionsEntity(

--- a/site-permissions/site-permissions-impl/src/main/res/values/donottranslate.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values/donottranslate.xml
@@ -28,4 +28,5 @@
     <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your camera</string>
     <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your microphone</string>
     <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your camera and microphone</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">If you don\'t allow, videos on the site may become unplayable, but this site will not have access to device identifiers provided by DRM software.</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncherTest.kt
+++ b/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncherTest.kt
@@ -630,6 +630,135 @@ class SitePermissionsDialogActivityLauncherTest {
         verify(sitePermissionsRepository, never()).sitePermissionGranted(any(), any(), any())
     }
 
+    private fun showDrmDialog(
+        launcher: SitePermissionsDialogActivityLauncher = testee,
+        redesignEnabled: Boolean = true,
+    ): AlertDialog {
+        sitePermissionsDialogRedesignFeature.self().setRawStoredState(Toggle.State(redesignEnabled))
+        whenever(sitePermissionsRepository.getDrmForSession("tabId", "example.com")).thenReturn(null)
+        whenever(sitePermissionsRepository.isDrmBlockedForUrlByConfig(any())).thenReturn(false)
+
+        val activity = Robolectric.buildActivity(ThemedActivity::class.java).setup().get()
+        val request: PermissionRequest = mock()
+        whenever(request.resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID))
+        whenever(request.origin).thenReturn(Uri.parse("https://example.com"))
+
+        launcher.askForSitePermission(
+            activity = activity,
+            url = "https://example.com",
+            tabId = "tabId",
+            permissionsRequested = SitePermissions(
+                autoAccept = emptyList(),
+                userHandled = listOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID),
+            ),
+            request = request,
+            permissionsGrantedListener = permissionsGrantedListener,
+        )
+        this.request = request
+        return ShadowDialog.getLatestDialog() as AlertDialog
+    }
+
+    @Test
+    fun whenRedesignEnabledThenDrmDialogOffersThreeTiersWithoutLearnMoreLink() {
+        val dialog = showDrmDialog()
+
+        assertEquals(3, dialog.tieredButtons().childCount)
+        val message = dialog.findViewById<TextView>(CommonR.id.stackedlertDialogMessage)!!
+        assertEquals(
+            dialog.context.getString(R.string.sitePermissionsTieredDrmDialogSubtitle),
+            message.text.toString(),
+        )
+    }
+
+    @Test
+    fun whenRedesignDisabledThenLegacyDrmDialogShown() {
+        val dialog = showDrmDialog(redesignEnabled = false)
+
+        assertNotNull(dialog.findViewById<TextView>(CommonR.id.textAlertDialogMessage))
+        assertNull(dialog.findViewById<LinearLayout>(CommonR.id.stackedAlertDialogButtonLayout))
+    }
+
+    @Test
+    fun whenDrmAllowWhileUsingSiteClickedThenPersistedWithoutReplacingOtherSitePermissions() = runTest {
+        val dialog = showDrmDialog()
+
+        dialog.tieredButtons().getChildAt(0).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify(request).grant(any())
+        verify(sitePermissionsRepository).sitePermissionPermanentlySaved(
+            "https://example.com",
+            PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID,
+            ALLOW_ALWAYS,
+        )
+        verify(sitePermissionsRepository, never()).savePermission(any())
+        verify(sitePermissionsRepository, never()).saveDrmForSession(any(), any(), any())
+    }
+
+    @Test
+    fun whenDrmAllowThisTimeClickedThenGrantIsSessionOnly() {
+        val dialog = showDrmDialog()
+
+        dialog.tieredButtons().getChildAt(1).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify(request).grant(any())
+        verify(sitePermissionsRepository).saveDrmForSession("tabId", "example.com", true)
+        verify(sitePermissionsRepository, never()).sitePermissionPermanentlySaved(any(), any(), any())
+    }
+
+    @Test
+    fun whenDrmNeverAllowClickedThenPersistedWithoutReplacingOtherSitePermissions() = runTest {
+        val dialog = showDrmDialog()
+
+        dialog.tieredButtons().getChildAt(2).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify(request).deny()
+        verify(sitePermissionsRepository).sitePermissionPermanentlySaved(
+            "https://example.com",
+            PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID,
+            DENY_ALWAYS,
+        )
+        verify(sitePermissionsRepository, never()).savePermission(any())
+        verify(sitePermissionsRepository, never()).saveDrmForSession(any(), any(), any())
+    }
+
+    @Test
+    fun whenDrmDialogDismissedThenDeniedForTheTabSession() {
+        val dialog = showDrmDialog()
+
+        dialog.cancel()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify(request).deny()
+        verify(sitePermissionsRepository).saveDrmForSession("tabId", "example.com", false)
+        verify(sitePermissionsRepository, never()).sitePermissionPermanentlySaved(any(), any(), any())
+    }
+
+    @Test
+    fun whenFireModeAndDrmDialogDismissedThenDeniedButNoSessionChoiceStored() {
+        val dialog = showDrmDialog(createLauncher(BrowserMode.FIRE))
+
+        dialog.cancel()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify(request).deny()
+        verify(sitePermissionsRepository, never()).saveDrmForSession(any(), any(), any())
+    }
+
+    @Test
+    fun whenFireModeAndDrmAllowClickedThenGrantedButNothingPersisted() {
+        val dialog = showDrmDialog(createLauncher(BrowserMode.FIRE))
+
+        dialog.tieredButtons().getChildAt(0).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify(request).grant(any())
+        verify(sitePermissionsRepository, never()).sitePermissionPermanentlySaved(any(), any(), any())
+        verify(sitePermissionsRepository, never()).saveDrmForSession(any(), any(), any())
+    }
+
     class ThemedActivity : AppCompatActivity() {
         override fun onCreate(savedInstanceState: Bundle?) {
             setTheme(CommonR.style.Theme_DuckDuckGo_Light)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1218189635146874?focus=true

### Description

This PR brings the redesigned permission dialog to DRM requests.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/74f33cb6-ab51-4f9b-87b8-1f5963420efe" />

### Steps to test this PR

- [x] Open Settings → Permissions → Manage Sites and remove `bitmovin.com` if listed
- [x] Open `https://drmsense.netlify.app/` and start playback of the DRM protected stream
- [x] Verify that the dialog offers "Allow While Using Site", "Allow This Time" and "Never Allow"
- [x] Tap "Allow This Time"
- [x] Verify the "Widevine" card is shown with the encryption information
- [x] Open the same page in a new tab and start playback
- [x] Verify that the dialog appears again
- [x] Dismiss the dialog by tapping outside it
- [x] Reload the page and start playback again
- [x] Verify no dialog appears and only "ClearKey" card is displayed
- [x] Open the same page in a new tab, start playback and tap "Allow While Using Site"
- [x] Verify that the video plays
- [x] Open Settings → Permissions → Manage Sites, select `bitmovin.com` and set DRM to "Ask every time"
- [x] Return to the site, reload, start playback and tap "Never Allow"
- [x] Verify that only "ClearKey" card is displayed
- [x] Open Settings → Permissions → Manage Sites and select `bitmovin.com`
- [x] Verify that DRM is set to "Deny"

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how DRM allow/deny choices are stored and presented; incorrect mapping could break playback or site permission settings, though behavior is covered by new tests and gated behind a feature flag.
> 
> **Overview**
> When the site-permissions dialog redesign is enabled, **DRM (protected media) prompts** use the same stacked **Allow While Using Site / Allow This Time / Never Allow** flow as camera and location, with a new explanatory subtitle and no legacy “learn more” checkbox dialog.
> 
> The shared tiered dialog now accepts an **`onPermissionDenied`** callback so DRM can route **Never Allow** and **dismiss** through **`allowDrmPermissions` / `denyDrmPermissions`**, which grant or deny the WebView request and persist **always** choices via **`sitePermissionPermanentlySaved`** (instead of the legacy **`savePermission`** entity path), **session-only** choices via **`saveDrmForSession`**, and skip all persistence in **Fire** mode. The legacy DRM dialog is unchanged when the redesign flag is off.
> 
> Tests cover the tiered DRM UI, persistence behavior, dismiss-as-deny-once, and Fire mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac93e4ed59fc33ac9d62a8b1a8f6cf7c7df0d149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->