### PR TITLE
Subscription Onboarding: VPN product review updates

### DIFF
--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/onboarding/SubscriptionOnboardingVpnFragment.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/onboarding/SubscriptionOnboardingVpnFragment.kt
@@ -208,7 +208,9 @@ class SubscriptionOnboardingVpnFragment : DuckDuckGoFragment(R.layout.fragment_s
     private fun showInfoPage() = with(binding) {
         showingInfo = true
         transition?.cancel()
-        renderHeaderImage(connected = true, error = false, animate = false)
+        subscriptionOnboardingVpnHeaderAnimation.pauseAnimation()
+        subscriptionOnboardingVpnHeaderAnimation.gone()
+        subscriptionOnboardingVpnHeaderErrorIcon.gone()
         subscriptionOnboardingVpnHeaderTitle.setText(R.string.subscriptionOnboardingVpnInfoTitle)
         subscriptionOnboardingVpnStatusContent.gone()
         subscriptionOnboardingVpnInfoContent.show()
@@ -316,11 +318,11 @@ class SubscriptionOnboardingVpnFragment : DuckDuckGoFragment(R.layout.fragment_s
         if (vpnOn) {
             subscriptionOnboardingVpnIpAddressTitle.setText(R.string.subscriptionOnboardingVpnIpAddressTitleOn)
             subscriptionOnboardingVpnNewIpAddressContainer.show()
-            subscriptionOnboardingVpnIpAddressInfo.gone()
+            subscriptionOnboardingVpnIpAddressInfo.setText(R.string.subscriptionOnboardingVpnOnIpAddressInfo)
         } else {
             subscriptionOnboardingVpnIpAddressTitle.setText(R.string.subscriptionOnboardingVpnIpAddressTitle)
             subscriptionOnboardingVpnNewIpAddressContainer.gone()
-            subscriptionOnboardingVpnIpAddressInfo.show()
+            subscriptionOnboardingVpnIpAddressInfo.setText(R.string.subscriptionOnboardingVpnOffIpAddressInfo)
         }
 
         val benefitIcon = if (vpnOn) R.drawable.check_circle_color_24 else R.drawable.alert_recolorable_24

--- a/network-protection/network-protection-impl/src/main/res/layout/fragment_subscription_onboarding_vpn.xml
+++ b/network-protection/network-protection-impl/src/main/res/layout/fragment_subscription_onboarding_vpn.xml
@@ -279,7 +279,7 @@
                 android:id="@+id/subscriptionOnboardingVpnInfoContent"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/keyline_5"
+                android:layout_marginTop="@dimen/keyline_7"
                 android:clipToPadding="false"
                 android:paddingHorizontal="@dimen/keyline_4"
                 android:scrollbars="none"

--- a/network-protection/network-protection-impl/src/main/res/layout/fragment_subscription_onboarding_vpn.xml
+++ b/network-protection/network-protection-impl/src/main/res/layout/fragment_subscription_onboarding_vpn.xml
@@ -35,7 +35,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:paddingTop="@dimen/keyline_5"
+            android:paddingTop="@dimen/keyline_3"
             android:paddingBottom="@dimen/keyline_4">
 
             <com.airbnb.lottie.LottieAnimationView

--- a/network-protection/network-protection-impl/src/main/res/layout/fragment_subscription_onboarding_vpn.xml
+++ b/network-protection/network-protection-impl/src/main/res/layout/fragment_subscription_onboarding_vpn.xml
@@ -35,7 +35,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:paddingTop="@dimen/keyline_6"
+            android:paddingTop="@dimen/keyline_5"
             android:paddingBottom="@dimen/keyline_4">
 
             <com.airbnb.lottie.LottieAnimationView
@@ -59,7 +59,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="@dimen/keyline_4"
-                android:layout_marginTop="@dimen/keyline_5"
+                android:layout_marginTop="@dimen/keyline_4"
                 android:gravity="center"
                 android:text="@string/subscriptionOnboardingVpnHeaderTitle"
                 app:typography="h1" />
@@ -188,7 +188,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/keyline_4"
-                    android:text="@string/subscriptionOnboardingVpnIpAddressInfo"
+                    android:text="@string/subscriptionOnboardingVpnOffIpAddressInfo"
                     app:textType="secondary"
                     app:typography="body2" />
 
@@ -292,7 +292,8 @@
 
                     <LinearLayout
                         android:layout_width="240dp"
-                        android:layout_height="346dp"
+                        android:layout_height="match_parent"
+                        android:minHeight="312dp"
                         android:background="@drawable/subscription_onboarding_vpn_item_background"
                         android:orientation="vertical"
                         android:padding="@dimen/keyline_5">
@@ -322,7 +323,8 @@
 
                     <LinearLayout
                         android:layout_width="240dp"
-                        android:layout_height="346dp"
+                        android:layout_height="match_parent"
+                        android:minHeight="312dp"
                         android:layout_marginStart="@dimen/keyline_3"
                         android:background="@drawable/subscription_onboarding_vpn_item_background"
                         android:orientation="vertical"
@@ -353,7 +355,8 @@
 
                     <LinearLayout
                         android:layout_width="240dp"
-                        android:layout_height="346dp"
+                        android:layout_height="match_parent"
+                        android:minHeight="312dp"
                         android:layout_marginStart="@dimen/keyline_3"
                         android:background="@drawable/subscription_onboarding_vpn_item_background"
                         android:orientation="vertical"

--- a/network-protection/network-protection-impl/src/main/res/values/donottranslate.xml
+++ b/network-protection/network-protection-impl/src/main/res/values/donottranslate.xml
@@ -21,7 +21,7 @@
     <string name="subscriptionOnboardingVpnHeaderTitle">DuckDuckGo VPN is Off</string>
     <string name="subscriptionOnboardingVpnHeaderText">Connect to secure all of your device\'s internet traffic. <annotation type="learn_more_link">Learn More</annotation></string>
     <string name="subscriptionOnboardingVpnIpAddressTitle">Your IP Address is Visible</string>
-    <string name="subscriptionOnboardingVpnIpAddressInfo">When the VPN is off, sites and apps can see this info and use it to connect your activity across sessions.</string>
+    <string name="subscriptionOnboardingVpnOffIpAddressInfo">When the VPN is off, sites and apps can see this info and use it to connect your activity across sessions.</string>
     <string name="subscriptionOnboardingVpnBenefitShielding">Shielding your online activity</string>
     <string name="subscriptionOnboardingVpnBenefitLocation">Hiding your location &amp; IP address</string>
     <string name="subscriptionOnboardingVpnBenefitHarmful">Blocking harmful sites</string>
@@ -34,6 +34,7 @@
     <string name="subscriptionOnboardingVpnHeaderTextOn">All device internet traffic is being secured through the VPN. <annotation type="learn_more_link">Learn More</annotation></string>
     <string name="subscriptionOnboardingVpnIpAddressTitleOn">Your IP Address is Hidden</string>
     <string name="subscriptionOnboardingVpnNewIpAddressTitle">Your New IP Address</string>
+    <string name="subscriptionOnboardingVpnOnIpAddressInfo">When the VPN is on, sites and apps see your new IP instead, helping keep your activity anonymous.</string>
 
     <!-- Subscription onboarding - VPN step, activation error state -->
     <string name="subscriptionOnboardingVpnErrorTitle">Unable to Activate DuckDuckGo VPN</string>

--- a/network-protection/network-protection-impl/src/main/res/values/donottranslate.xml
+++ b/network-protection/network-protection-impl/src/main/res/values/donottranslate.xml
@@ -43,7 +43,7 @@
 
     <!-- Subscription onboarding - VPN step, "what to know" info page -->
     <string name="subscriptionOnboardingVpnInfoTitle">What to know about using your VPN</string>
-    <string name="subscriptionOnboardingVpnInfoGotIt">Got it</string>
+    <string name="subscriptionOnboardingVpnInfoGotIt">Got It</string>
     <string name="subscriptionOnboardingVpnInfoNoCapsTitle">No data or speed caps</string>
     <string name="subscriptionOnboardingVpnInfoNoCapsText">Stream, download, game, use as much data as you want. Unlike other VPNs, we only throttle connections to prevent abuse or network errors.</string>
     <string name="subscriptionOnboardingVpnInfoSpeedsTitle">All VPNs affect internet speeds</string>

--- a/subscriptions/subscriptions-impl/src/main/res/layout/activity_subscription_onboarding_feature_info.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/activity_subscription_onboarding_feature_info.xml
@@ -43,7 +43,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:layout_marginTop="@dimen/keyline_5"
+                android:layout_marginTop="@dimen/keyline_3"
                 android:src="@drawable/vpn_feature_128"
                 tools:ignore="ContentDescription" />
 

--- a/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_features_summary.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_features_summary.xml
@@ -44,7 +44,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="@dimen/keyline_5"
-                android:layout_marginTop="@dimen/keyline_5"
+                android:layout_marginTop="@dimen/keyline_4"
                 android:gravity="center"
                 android:text="@string/subscriptionOnboardingFeaturesTitle"
                 app:typography="h1" />

--- a/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_features_summary.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_features_summary.xml
@@ -36,7 +36,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:layout_marginTop="@dimen/keyline_5"
+                android:layout_marginTop="@dimen/keyline_3"
                 android:src="@drawable/subscription_ddg_feature_128" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextView

--- a/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_welcome.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_welcome.xml
@@ -60,7 +60,7 @@
                 android:id="@+id/subscriptionOnboardingWelcomeTitle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/keyline_5"
+                android:layout_marginTop="@dimen/keyline_4"
                 android:gravity="center"
                 android:text="@string/subscriptionOnboardingWelcomeTitle"
                 app:typography="h1" />

--- a/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_welcome.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_welcome.xml
@@ -53,7 +53,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:layout_marginTop="@dimen/keyline_5"
+                android:layout_marginTop="@dimen/keyline_3"
                 android:src="@drawable/subscription_check_feature_128" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextView


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218194577180955?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Applied changes requested in product/copy review

### Steps to test this PR _(Optional)_

_Text VPN On above benefit items_
- [ ] Verify that there is text about the VPN ON information above the benefit items.
<img width="250" alt="Screenshot 2026-09-04 at 11 12 30" src="https://github.com/user-attachments/assets/6a18bed2-ee0a-4068-afaf-7652ee78789a" />


_Placeholder margin_
- [ ] Verify that the top placeholders’ margins are minimised


_VPN info items screen_
- [ ] Verify there is not placeholder in VPN info screen
<img width="250" alt="Screenshot 2026-09-04 at 11 34 45" src="https://github.com/user-attachments/assets/c61a417e-2a13-40a8-9571-b419208e7521" />

### UI changes
See https://app.asana.com/1/137249556945/inbox/1201807753392396/item/1217488882853479/story/1218114073655091

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only onboarding layout, strings, and visibility changes with no auth, networking, or data-handling impact.
> 
> **Overview**
> Applies product-review tweaks across subscription onboarding, centered on the VPN step.
> 
> **VPN status screen:** The IP blurb above the benefit rows now stays visible in both off and on states, with state-specific copy (`subscriptionOnboardingVpnOffIpAddressInfo` / `subscriptionOnboardingVpnOnIpAddressInfo`) set from `applyState` instead of hiding the view when VPN is on. Opening the “what to know” info page **pauses and hides** the header Lottie (and error icon) rather than rendering a connected header placeholder.
> 
> **Layout/spacing:** Tighter top spacing on the VPN fragment and on welcome, features summary, and feature-info screens (smaller icon/title margins). Info carousel cards use flexible height (`match_parent` + `minHeight`) instead of fixed 346dp, with adjusted info-section top margin.
> 
> Minor copy: **“Got It”** capitalization on the info dismiss button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a91d22a80127defc7c52fa92bafddf78c8f14b64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->