### PR TITLE
Subscription Onboarding: IDTR step

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -20,7 +20,7 @@
     <string name="duck_chat_remove_chat_suggestion_content_description">Delete chat</string>
 
     <!-- Subscription onboarding - Duck.ai step (placeholder copy) -->
-    <string name="subscriptionOnboardingDuckAiTitle">Duck.ai step</string>
+    <string name="subscriptionOnboardingDuckAiTitle">Step 3 of 3</string>
     <string name="subscriptionOnboardingDuckAiText">Duck.ai onboarding step</string>
     <string name="subscriptionOnboardingDuckAiNext">Next</string>
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/features/SubscriptionOnboardingFeatureInfoActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/features/SubscriptionOnboardingFeatureInfoActivity.kt
@@ -17,47 +17,25 @@
 package com.duckduckgo.subscriptions.impl.onboarding.features
 
 import android.Manifest
-import android.annotation.SuppressLint
-import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Bundle
-import android.os.Environment
+import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.annotation.DrawableRes
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
-import androidx.core.content.ContextCompat
-import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
-import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.ui.DuckDuckGoActivity
-import com.duckduckgo.common.ui.view.addClickableLink
 import com.duckduckgo.common.ui.view.getColorFromAttr
-import com.duckduckgo.common.ui.view.makeSnackbarWithNoBottomInset
-import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.ui.viewbinding.viewBinding
-import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
-import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_DELAY
-import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_LENGTH
-import com.duckduckgo.downloads.api.DownloadCommand
-import com.duckduckgo.downloads.api.DownloadStateListener
-import com.duckduckgo.downloads.api.DownloadsFileActions
-import com.duckduckgo.downloads.api.FileDownloader
-import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.navigation.api.getActivityParams
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingFeature
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionOnboardingFeatureInfoScreen
 import com.duckduckgo.subscriptions.impl.R
-import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ITR_SUMMARY_OF_BENEFITS_URL
 import com.duckduckgo.subscriptions.impl.databinding.ActivitySubscriptionOnboardingFeatureInfoBinding
-import com.google.android.material.snackbar.Snackbar
-import kotlinx.coroutines.flow.cancellable
-import kotlinx.coroutines.launch
-import java.io.File
 import javax.inject.Inject
 
 /**
@@ -75,21 +53,16 @@ class SubscriptionOnboardingFeatureInfoActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
-    @Inject
-    lateinit var appBuildConfig: AppBuildConfig
-
-    @Inject
-    lateinit var fileDownloader: FileDownloader
-
-    @Inject
-    lateinit var downloadCallback: DownloadStateListener
-
-    @Inject
-    lateinit var downloadsFileActions: DownloadsFileActions
-
     private val binding: ActivitySubscriptionOnboardingFeatureInfoBinding by viewBinding()
 
-    private val downloadMessagesJob = ConflatedJob()
+    private val summaryOfBenefitsFooter: SummaryOfBenefitsFooterView
+        get() = binding.subscriptionOnboardingFeatureInfoContent.findViewById(R.id.subscriptionOnboardingFeatureInfoLegalFooter)
+
+    private val writeStoragePermission = registerForActivityResult(RequestPermission()) { granted ->
+        if (granted) {
+            summaryOfBenefitsFooter.onWriteStoragePermissionGranted()
+        }
+    }
 
     private val feature: OnboardingFeature by lazy {
         val screenFeature = intent.getActivityParams(SubscriptionOnboardingFeatureInfoScreen::class.java)?.feature
@@ -124,7 +97,9 @@ class SubscriptionOnboardingFeatureInfoActivity : DuckDuckGoActivity() {
         layoutInflater.inflate(feature.contentRes, binding.subscriptionOnboardingFeatureInfoContent, true)
 
         if (feature == OnboardingFeature.ITR) {
-            setupSummaryOfBenefitsLink()
+            summaryOfBenefitsFooter.onWriteStoragePermissionRequired = {
+                writeStoragePermission.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            }
         }
 
         if (edgeToEdgeEnabled) {
@@ -132,115 +107,6 @@ class SubscriptionOnboardingFeatureInfoActivity : DuckDuckGoActivity() {
             edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout, installScrim = false)
             edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.subscriptionOnboardingFeatureInfoScrollView)
         }
-    }
-
-    override fun onResume() {
-        if (feature == OnboardingFeature.ITR) {
-            launchDownloadMessagesJob()
-        }
-        super.onResume()
-    }
-
-    override fun onPause() {
-        downloadMessagesJob.cancel()
-        super.onPause()
-    }
-
-    private fun setupSummaryOfBenefitsLink() {
-        binding.subscriptionOnboardingFeatureInfoContent
-            .findViewById<DaxTextView>(R.id.subscriptionOnboardingFeatureInfoLegalFooter)
-            .addClickableLink(
-                annotation = "summary_of_benefits_link",
-                textSequence = getText(R.string.subscriptionOnboardingFeatureInfoItrLegalFooter),
-            ) {
-                if (hasWriteStoragePermission()) {
-                    downloadSummaryOfBenefits()
-                } else {
-                    requestWriteStoragePermission()
-                }
-            }
-    }
-
-    private fun downloadSummaryOfBenefits() {
-        fileDownloader.enqueueDownload(
-            PendingFileDownload(
-                url = ITR_SUMMARY_OF_BENEFITS_URL,
-                mimeType = PDF_MIME_TYPE,
-                subfolder = Environment.DIRECTORY_DOWNLOADS,
-                browserMode = BrowserMode.REGULAR,
-            ),
-        )
-    }
-
-    @Suppress("NewApi")
-    private fun hasWriteStoragePermission(): Boolean {
-        return appBuildConfig.sdkInt >= 30 ||
-            ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PERMISSION_GRANTED
-    }
-
-    private fun requestWriteStoragePermission() {
-        requestPermissions(arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE), PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE)
-    }
-
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<out String>,
-        grantResults: IntArray,
-    ) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE &&
-            grantResults.isNotEmpty() &&
-            grantResults[0] == PERMISSION_GRANTED
-        ) {
-            downloadSummaryOfBenefits()
-        }
-    }
-
-    private fun launchDownloadMessagesJob() {
-        downloadMessagesJob += lifecycleScope.launch {
-            downloadCallback.commands().cancellable().collect {
-                processFileDownloadedCommand(it)
-            }
-        }
-    }
-
-    private fun processFileDownloadedCommand(command: DownloadCommand) {
-        when (command) {
-            is DownloadCommand.ShowDownloadStartedMessage -> downloadStarted(command)
-            is DownloadCommand.ShowDownloadFailedMessage -> downloadFailed(command)
-            is DownloadCommand.ShowDownloadSuccessMessage -> downloadSucceeded(command)
-        }
-    }
-
-    @SuppressLint("WrongConstant")
-    private fun downloadStarted(command: DownloadCommand.ShowDownloadStartedMessage) {
-        binding.root.makeSnackbarWithNoBottomInset(getString(command.messageId, command.fileName), DOWNLOAD_SNACKBAR_LENGTH).show()
-    }
-
-    private fun downloadFailed(command: DownloadCommand.ShowDownloadFailedMessage) {
-        val downloadFailedSnackbar = binding.root.makeSnackbarWithNoBottomInset(getString(command.messageId), Snackbar.LENGTH_LONG)
-        binding.root.postDelayed({ downloadFailedSnackbar.show() }, DOWNLOAD_SNACKBAR_DELAY)
-    }
-
-    private fun downloadSucceeded(command: DownloadCommand.ShowDownloadSuccessMessage) {
-        val downloadSucceededSnackbar = binding.root.makeSnackbarWithNoBottomInset(
-            getString(command.messageId, command.fileName),
-            Snackbar.LENGTH_LONG,
-        )
-            .apply {
-                this.setAction(R.string.downloadsDownloadFinishedActionName) {
-                    val result = downloadsFileActions.openFile(context, File(command.filePath))
-                    if (!result) {
-                        view.makeSnackbarWithNoBottomInset(getString(R.string.downloadsCannotOpenFileErrorMessage), Snackbar.LENGTH_LONG).show()
-                    }
-                }
-            }
-        binding.root.postDelayed({ downloadSucceededSnackbar.show() }, DOWNLOAD_SNACKBAR_DELAY)
-    }
-
-    companion object {
-        private const val PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE = 200
-        private const val PDF_MIME_TYPE = "application/pdf"
     }
 }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/features/SummaryOfBenefitsFooterView.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/features/SummaryOfBenefitsFooterView.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding.features
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import android.os.Environment
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.common.ui.view.addClickableLink
+import com.duckduckgo.common.ui.view.makeSnackbarWithNoBottomInset
+import com.duckduckgo.common.utils.ConflatedJob
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_DELAY
+import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_LENGTH
+import com.duckduckgo.downloads.api.DownloadCommand
+import com.duckduckgo.downloads.api.DownloadStateListener
+import com.duckduckgo.downloads.api.DownloadsFileActions
+import com.duckduckgo.downloads.api.FileDownloader
+import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
+import com.duckduckgo.subscriptions.impl.R
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ITR_SUMMARY_OF_BENEFITS_URL
+import com.duckduckgo.subscriptions.impl.databinding.ViewSummaryOfBenefitsFooterBinding
+import com.google.android.material.snackbar.Snackbar
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import java.io.File
+import javax.inject.Inject
+
+@InjectWith(ViewScope::class)
+class SummaryOfBenefitsFooterView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    @Inject
+    lateinit var appBuildConfig: AppBuildConfig
+
+    @Inject
+    lateinit var fileDownloader: FileDownloader
+
+    @Inject
+    lateinit var downloadCallback: DownloadStateListener
+
+    @Inject
+    lateinit var downloadsFileActions: DownloadsFileActions
+
+    private val binding = ViewSummaryOfBenefitsFooterBinding.inflate(LayoutInflater.from(context), this)
+
+    private val downloadMessagesJob = ConflatedJob()
+    var onWriteStoragePermissionRequired: (() -> Unit)? = null
+
+    fun onWriteStoragePermissionGranted() {
+        downloadSummaryOfBenefits()
+    }
+
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+
+        binding.summaryOfBenefitsFooterText.addClickableLink(
+            annotation = "summary_of_benefits_link",
+            textSequence = context.getText(R.string.subscriptionOnboardingFeatureInfoItrLegalFooter),
+        ) {
+            if (hasWriteStoragePermission()) {
+                downloadSummaryOfBenefits()
+            } else {
+                onWriteStoragePermissionRequired?.invoke()
+            }
+        }
+
+        val lifecycleOwner = findViewTreeLifecycleOwner() ?: return
+        downloadMessagesJob += downloadCallback.commands()
+            .flowWithLifecycle(lifecycleOwner.lifecycle, Lifecycle.State.RESUMED)
+            .onEach { processFileDownloadedCommand(it) }
+            .launchIn(lifecycleOwner.lifecycleScope)
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        downloadMessagesJob.cancel()
+    }
+
+    private fun downloadSummaryOfBenefits() {
+        fileDownloader.enqueueDownload(
+            PendingFileDownload(
+                url = ITR_SUMMARY_OF_BENEFITS_URL,
+                mimeType = PDF_MIME_TYPE,
+                subfolder = Environment.DIRECTORY_DOWNLOADS,
+                browserMode = BrowserMode.REGULAR,
+            ),
+        )
+    }
+
+    @Suppress("NewApi")
+    private fun hasWriteStoragePermission(): Boolean {
+        return appBuildConfig.sdkInt >= 30 ||
+            ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PERMISSION_GRANTED
+    }
+
+    private fun processFileDownloadedCommand(command: DownloadCommand) {
+        when (command) {
+            is DownloadCommand.ShowDownloadStartedMessage -> downloadStarted(command)
+            is DownloadCommand.ShowDownloadFailedMessage -> downloadFailed(command)
+            is DownloadCommand.ShowDownloadSuccessMessage -> downloadSucceeded(command)
+        }
+    }
+
+    @SuppressLint("WrongConstant")
+    private fun downloadStarted(command: DownloadCommand.ShowDownloadStartedMessage) {
+        makeSnackbarWithNoBottomInset(context.getString(command.messageId, command.fileName), DOWNLOAD_SNACKBAR_LENGTH).show()
+    }
+
+    private fun downloadFailed(command: DownloadCommand.ShowDownloadFailedMessage) {
+        val downloadFailedSnackbar = makeSnackbarWithNoBottomInset(context.getString(command.messageId), Snackbar.LENGTH_LONG)
+        postDelayed({ downloadFailedSnackbar.show() }, DOWNLOAD_SNACKBAR_DELAY)
+    }
+
+    private fun downloadSucceeded(command: DownloadCommand.ShowDownloadSuccessMessage) {
+        val downloadSucceededSnackbar = makeSnackbarWithNoBottomInset(
+            context.getString(command.messageId, command.fileName),
+            Snackbar.LENGTH_LONG,
+        )
+            .apply {
+                this.setAction(R.string.downloadsDownloadFinishedActionName) {
+                    val result = downloadsFileActions.openFile(context, File(command.filePath))
+                    if (!result) {
+                        view.makeSnackbarWithNoBottomInset(
+                            context.getString(R.string.downloadsCannotOpenFileErrorMessage),
+                            Snackbar.LENGTH_LONG,
+                        ).show()
+                    }
+                }
+            }
+        postDelayed({ downloadSucceededSnackbar.show() }, DOWNLOAD_SNACKBAR_DELAY)
+    }
+
+    companion object {
+        private const val PDF_MIME_TYPE = "application/pdf"
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrFragment.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrFragment.kt
@@ -17,48 +17,26 @@
 package com.duckduckgo.subscriptions.impl.onboarding.itr
 
 import android.Manifest
-import android.annotation.SuppressLint
-import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
-import android.os.Environment
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
-import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
 import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.core.widget.NestedScrollView
-import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
-import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.ui.DuckDuckGoFragment
-import com.duckduckgo.common.ui.view.addClickableLink
 import com.duckduckgo.common.ui.view.getColorFromAttr
-import com.duckduckgo.common.ui.view.makeSnackbarWithNoBottomInset
-import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.ui.viewbinding.viewBinding
-import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.di.scopes.FragmentScope
-import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_DELAY
-import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_LENGTH
-import com.duckduckgo.downloads.api.DownloadCommand
-import com.duckduckgo.downloads.api.DownloadStateListener
-import com.duckduckgo.downloads.api.DownloadsFileActions
-import com.duckduckgo.downloads.api.FileDownloader
-import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
 import com.duckduckgo.subscriptions.impl.R
-import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ITR_SUMMARY_OF_BENEFITS_URL
 import com.duckduckgo.subscriptions.impl.databinding.FragmentSubscriptionOnboardingItrBinding
 import com.duckduckgo.subscriptions.impl.onboarding.features.OnboardingFeature
+import com.duckduckgo.subscriptions.impl.onboarding.features.SummaryOfBenefitsFooterView
 import com.duckduckgo.subscriptions.impl.onboarding.itr.SubscriptionOnboardingItrStepPlugin.Companion.ITR_STEP_ID
-import com.google.android.material.snackbar.Snackbar
-import kotlinx.coroutines.flow.cancellable
-import kotlinx.coroutines.launch
-import java.io.File
 import javax.inject.Inject
 
 /**
@@ -72,25 +50,14 @@ class SubscriptionOnboardingItrFragment : DuckDuckGoFragment(R.layout.fragment_s
     @Inject
     lateinit var controller: SubscriptionOnboardingController
 
-    @Inject
-    lateinit var appBuildConfig: AppBuildConfig
-
-    @Inject
-    lateinit var fileDownloader: FileDownloader
-
-    @Inject
-    lateinit var downloadCallback: DownloadStateListener
-
-    @Inject
-    lateinit var downloadsFileActions: DownloadsFileActions
-
     private val binding: FragmentSubscriptionOnboardingItrBinding by viewBinding()
 
-    private val downloadMessagesJob = ConflatedJob()
+    private val summaryOfBenefitsFooter: SummaryOfBenefitsFooterView
+        get() = binding.subscriptionOnboardingItrContent.findViewById(R.id.subscriptionOnboardingFeatureInfoLegalFooter)
 
     private val writeStoragePermission = registerForActivityResult(RequestPermission()) { granted ->
         if (granted) {
-            downloadSummaryOfBenefits()
+            summaryOfBenefitsFooter.onWriteStoragePermissionGranted()
         }
     }
 
@@ -103,23 +70,15 @@ class SubscriptionOnboardingItrFragment : DuckDuckGoFragment(R.layout.fragment_s
         binding.subscriptionOnboardingItrDescription.setText(feature.descriptionRes)
         layoutInflater.inflate(feature.contentRes, binding.subscriptionOnboardingItrContent, true)
 
-        setupSummaryOfBenefitsLink()
+        summaryOfBenefitsFooter.onWriteStoragePermissionRequired = {
+            writeStoragePermission.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        }
 
         binding.subscriptionOnboardingItrActivateButton.setOnClickListener {
             controller.onStepFinished(ITR_STEP_ID, COMPLETED)
         }
 
         setupScrollFade()
-    }
-
-    override fun onResume() {
-        launchDownloadMessagesJob()
-        super.onResume()
-    }
-
-    override fun onPause() {
-        downloadMessagesJob.cancel()
-        super.onPause()
     }
 
     private fun setupScrollFade() {
@@ -141,83 +100,5 @@ class SubscriptionOnboardingItrFragment : DuckDuckGoFragment(R.layout.fragment_s
     private fun updateScrollFade() {
         binding.subscriptionOnboardingItrScrollFade.isVisible =
             binding.subscriptionOnboardingItrScrollView.canScrollVertically(1)
-    }
-
-    private fun setupSummaryOfBenefitsLink() {
-        binding.subscriptionOnboardingItrContent
-            .findViewById<DaxTextView>(R.id.subscriptionOnboardingFeatureInfoLegalFooter)
-            .addClickableLink(
-                annotation = "summary_of_benefits_link",
-                textSequence = getText(R.string.subscriptionOnboardingFeatureInfoItrLegalFooter),
-            ) {
-                if (hasWriteStoragePermission()) {
-                    downloadSummaryOfBenefits()
-                } else {
-                    writeStoragePermission.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                }
-            }
-    }
-
-    private fun downloadSummaryOfBenefits() {
-        fileDownloader.enqueueDownload(
-            PendingFileDownload(
-                url = ITR_SUMMARY_OF_BENEFITS_URL,
-                mimeType = PDF_MIME_TYPE,
-                subfolder = Environment.DIRECTORY_DOWNLOADS,
-                browserMode = BrowserMode.REGULAR,
-            ),
-        )
-    }
-
-    @Suppress("NewApi")
-    private fun hasWriteStoragePermission(): Boolean {
-        return appBuildConfig.sdkInt >= 30 ||
-            ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.WRITE_EXTERNAL_STORAGE) == PERMISSION_GRANTED
-    }
-
-    private fun launchDownloadMessagesJob() {
-        downloadMessagesJob += viewLifecycleOwner.lifecycleScope.launch {
-            downloadCallback.commands().cancellable().collect {
-                processFileDownloadedCommand(it)
-            }
-        }
-    }
-
-    private fun processFileDownloadedCommand(command: DownloadCommand) {
-        when (command) {
-            is DownloadCommand.ShowDownloadStartedMessage -> downloadStarted(command)
-            is DownloadCommand.ShowDownloadFailedMessage -> downloadFailed(command)
-            is DownloadCommand.ShowDownloadSuccessMessage -> downloadSucceeded(command)
-        }
-    }
-
-    @SuppressLint("WrongConstant")
-    private fun downloadStarted(command: DownloadCommand.ShowDownloadStartedMessage) {
-        binding.root.makeSnackbarWithNoBottomInset(getString(command.messageId, command.fileName), DOWNLOAD_SNACKBAR_LENGTH).show()
-    }
-
-    private fun downloadFailed(command: DownloadCommand.ShowDownloadFailedMessage) {
-        val downloadFailedSnackbar = binding.root.makeSnackbarWithNoBottomInset(getString(command.messageId), Snackbar.LENGTH_LONG)
-        binding.root.postDelayed({ downloadFailedSnackbar.show() }, DOWNLOAD_SNACKBAR_DELAY)
-    }
-
-    private fun downloadSucceeded(command: DownloadCommand.ShowDownloadSuccessMessage) {
-        val downloadSucceededSnackbar = binding.root.makeSnackbarWithNoBottomInset(
-            getString(command.messageId, command.fileName),
-            Snackbar.LENGTH_LONG,
-        )
-            .apply {
-                this.setAction(R.string.downloadsDownloadFinishedActionName) {
-                    val result = downloadsFileActions.openFile(context, File(command.filePath))
-                    if (!result) {
-                        view.makeSnackbarWithNoBottomInset(getString(R.string.downloadsCannotOpenFileErrorMessage), Snackbar.LENGTH_LONG).show()
-                    }
-                }
-            }
-        binding.root.postDelayed({ downloadSucceededSnackbar.show() }, DOWNLOAD_SNACKBAR_DELAY)
-    }
-
-    companion object {
-        private const val PDF_MIME_TYPE = "application/pdf"
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrFragment.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrFragment.kt
@@ -16,24 +16,49 @@
 
 package com.duckduckgo.subscriptions.impl.onboarding.itr
 
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
+import android.os.Environment
 import android.view.View
+import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
+import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
 import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.core.widget.NestedScrollView
+import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.ui.DuckDuckGoFragment
+import com.duckduckgo.common.ui.view.addClickableLink
 import com.duckduckgo.common.ui.view.getColorFromAttr
+import com.duckduckgo.common.ui.view.makeSnackbarWithNoBottomInset
+import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_DELAY
+import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_LENGTH
+import com.duckduckgo.downloads.api.DownloadCommand
+import com.duckduckgo.downloads.api.DownloadStateListener
+import com.duckduckgo.downloads.api.DownloadsFileActions
+import com.duckduckgo.downloads.api.FileDownloader
+import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
 import com.duckduckgo.subscriptions.impl.R
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ITR_SUMMARY_OF_BENEFITS_URL
 import com.duckduckgo.subscriptions.impl.databinding.FragmentSubscriptionOnboardingItrBinding
 import com.duckduckgo.subscriptions.impl.onboarding.features.OnboardingFeature
 import com.duckduckgo.subscriptions.impl.onboarding.itr.SubscriptionOnboardingItrStepPlugin.Companion.ITR_STEP_ID
+import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.flow.cancellable
+import kotlinx.coroutines.launch
+import java.io.File
 import javax.inject.Inject
 
 /**
@@ -47,7 +72,27 @@ class SubscriptionOnboardingItrFragment : DuckDuckGoFragment(R.layout.fragment_s
     @Inject
     lateinit var controller: SubscriptionOnboardingController
 
+    @Inject
+    lateinit var appBuildConfig: AppBuildConfig
+
+    @Inject
+    lateinit var fileDownloader: FileDownloader
+
+    @Inject
+    lateinit var downloadCallback: DownloadStateListener
+
+    @Inject
+    lateinit var downloadsFileActions: DownloadsFileActions
+
     private val binding: FragmentSubscriptionOnboardingItrBinding by viewBinding()
+
+    private val downloadMessagesJob = ConflatedJob()
+
+    private val writeStoragePermission = registerForActivityResult(RequestPermission()) { granted ->
+        if (granted) {
+            downloadSummaryOfBenefits()
+        }
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -58,11 +103,23 @@ class SubscriptionOnboardingItrFragment : DuckDuckGoFragment(R.layout.fragment_s
         binding.subscriptionOnboardingItrDescription.setText(feature.descriptionRes)
         layoutInflater.inflate(feature.contentRes, binding.subscriptionOnboardingItrContent, true)
 
+        setupSummaryOfBenefitsLink()
+
         binding.subscriptionOnboardingItrActivateButton.setOnClickListener {
             controller.onStepFinished(ITR_STEP_ID, COMPLETED)
         }
 
         setupScrollFade()
+    }
+
+    override fun onResume() {
+        launchDownloadMessagesJob()
+        super.onResume()
+    }
+
+    override fun onPause() {
+        downloadMessagesJob.cancel()
+        super.onPause()
     }
 
     private fun setupScrollFade() {
@@ -84,5 +141,83 @@ class SubscriptionOnboardingItrFragment : DuckDuckGoFragment(R.layout.fragment_s
     private fun updateScrollFade() {
         binding.subscriptionOnboardingItrScrollFade.isVisible =
             binding.subscriptionOnboardingItrScrollView.canScrollVertically(1)
+    }
+
+    private fun setupSummaryOfBenefitsLink() {
+        binding.subscriptionOnboardingItrContent
+            .findViewById<DaxTextView>(R.id.subscriptionOnboardingFeatureInfoLegalFooter)
+            .addClickableLink(
+                annotation = "summary_of_benefits_link",
+                textSequence = getText(R.string.subscriptionOnboardingFeatureInfoItrLegalFooter),
+            ) {
+                if (hasWriteStoragePermission()) {
+                    downloadSummaryOfBenefits()
+                } else {
+                    writeStoragePermission.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                }
+            }
+    }
+
+    private fun downloadSummaryOfBenefits() {
+        fileDownloader.enqueueDownload(
+            PendingFileDownload(
+                url = ITR_SUMMARY_OF_BENEFITS_URL,
+                mimeType = PDF_MIME_TYPE,
+                subfolder = Environment.DIRECTORY_DOWNLOADS,
+                browserMode = BrowserMode.REGULAR,
+            ),
+        )
+    }
+
+    @Suppress("NewApi")
+    private fun hasWriteStoragePermission(): Boolean {
+        return appBuildConfig.sdkInt >= 30 ||
+            ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.WRITE_EXTERNAL_STORAGE) == PERMISSION_GRANTED
+    }
+
+    private fun launchDownloadMessagesJob() {
+        downloadMessagesJob += viewLifecycleOwner.lifecycleScope.launch {
+            downloadCallback.commands().cancellable().collect {
+                processFileDownloadedCommand(it)
+            }
+        }
+    }
+
+    private fun processFileDownloadedCommand(command: DownloadCommand) {
+        when (command) {
+            is DownloadCommand.ShowDownloadStartedMessage -> downloadStarted(command)
+            is DownloadCommand.ShowDownloadFailedMessage -> downloadFailed(command)
+            is DownloadCommand.ShowDownloadSuccessMessage -> downloadSucceeded(command)
+        }
+    }
+
+    @SuppressLint("WrongConstant")
+    private fun downloadStarted(command: DownloadCommand.ShowDownloadStartedMessage) {
+        binding.root.makeSnackbarWithNoBottomInset(getString(command.messageId, command.fileName), DOWNLOAD_SNACKBAR_LENGTH).show()
+    }
+
+    private fun downloadFailed(command: DownloadCommand.ShowDownloadFailedMessage) {
+        val downloadFailedSnackbar = binding.root.makeSnackbarWithNoBottomInset(getString(command.messageId), Snackbar.LENGTH_LONG)
+        binding.root.postDelayed({ downloadFailedSnackbar.show() }, DOWNLOAD_SNACKBAR_DELAY)
+    }
+
+    private fun downloadSucceeded(command: DownloadCommand.ShowDownloadSuccessMessage) {
+        val downloadSucceededSnackbar = binding.root.makeSnackbarWithNoBottomInset(
+            getString(command.messageId, command.fileName),
+            Snackbar.LENGTH_LONG,
+        )
+            .apply {
+                this.setAction(R.string.downloadsDownloadFinishedActionName) {
+                    val result = downloadsFileActions.openFile(context, File(command.filePath))
+                    if (!result) {
+                        view.makeSnackbarWithNoBottomInset(getString(R.string.downloadsCannotOpenFileErrorMessage), Snackbar.LENGTH_LONG).show()
+                    }
+                }
+            }
+        binding.root.postDelayed({ downloadSucceededSnackbar.show() }, DOWNLOAD_SNACKBAR_DELAY)
+    }
+
+    companion object {
+        private const val PDF_MIME_TYPE = "application/pdf"
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrFragment.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrFragment.kt
@@ -25,32 +25,30 @@ import androidx.core.graphics.ColorUtils
 import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.core.widget.NestedScrollView
+import androidx.lifecycle.ViewModelProvider
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoFragment
 import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.di.scopes.FragmentScope
-import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController
-import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
 import com.duckduckgo.subscriptions.impl.R
 import com.duckduckgo.subscriptions.impl.databinding.FragmentSubscriptionOnboardingItrBinding
 import com.duckduckgo.subscriptions.impl.onboarding.features.OnboardingFeature
 import com.duckduckgo.subscriptions.impl.onboarding.features.SummaryOfBenefitsFooterView
-import com.duckduckgo.subscriptions.impl.onboarding.itr.SubscriptionOnboardingItrStepPlugin.Companion.ITR_STEP_ID
 import javax.inject.Inject
 
-/**
- * Identity Theft Restoration step of the native subscription onboarding. Shows the same content as the ITR
- * feature-detail screen, but with an always-visible Activate button and the content scrolling behind it.
- * Reports back through [SubscriptionOnboardingController] so it stays decoupled from the host activity.
- */
 @InjectWith(FragmentScope::class)
 class SubscriptionOnboardingItrFragment : DuckDuckGoFragment(R.layout.fragment_subscription_onboarding_itr) {
 
     @Inject
-    lateinit var controller: SubscriptionOnboardingController
+    lateinit var viewModelFactory: FragmentViewModelFactory
 
     private val binding: FragmentSubscriptionOnboardingItrBinding by viewBinding()
+
+    private val viewModel by lazy {
+        ViewModelProvider(this, viewModelFactory)[SubscriptionOnboardingItrViewModel::class.java]
+    }
 
     private val summaryOfBenefitsFooter: SummaryOfBenefitsFooterView
         get() = binding.subscriptionOnboardingItrContent.findViewById(R.id.subscriptionOnboardingFeatureInfoLegalFooter)
@@ -75,15 +73,13 @@ class SubscriptionOnboardingItrFragment : DuckDuckGoFragment(R.layout.fragment_s
         }
 
         binding.subscriptionOnboardingItrActivateButton.setOnClickListener {
-            controller.onStepFinished(ITR_STEP_ID, COMPLETED)
+            viewModel.onPrimaryCtaClicked()
         }
 
         setupScrollFade()
     }
 
     private fun setupScrollFade() {
-        // A gradient can't reference ?attr colors, so derive it from the surface the content sits on. Starting
-        // from a zero-alpha surface rather than Color.TRANSPARENT keeps the hue constant across the ramp.
         val surfaceColor = requireContext().getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorSurface)
         binding.subscriptionOnboardingItrScrollFade.background = GradientDrawable(
             GradientDrawable.Orientation.TOP_BOTTOM,
@@ -93,7 +89,7 @@ class SubscriptionOnboardingItrFragment : DuckDuckGoFragment(R.layout.fragment_s
         binding.subscriptionOnboardingItrScrollView.setOnScrollChangeListener(
             NestedScrollView.OnScrollChangeListener { _, _, _, _, _ -> updateScrollFade() },
         )
-        // The per-feature content is inflated above, so the first reliable measurement is the next layout pass.
+
         binding.subscriptionOnboardingItrScrollView.doOnLayout { updateScrollFade() }
     }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrFragment.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrFragment.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding.itr
+
+import android.graphics.drawable.GradientDrawable
+import android.os.Bundle
+import android.view.View
+import androidx.core.graphics.ColorUtils
+import androidx.core.view.doOnLayout
+import androidx.core.view.isVisible
+import androidx.core.widget.NestedScrollView
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.DuckDuckGoFragment
+import com.duckduckgo.common.ui.view.getColorFromAttr
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
+import com.duckduckgo.subscriptions.impl.R
+import com.duckduckgo.subscriptions.impl.databinding.FragmentSubscriptionOnboardingItrBinding
+import com.duckduckgo.subscriptions.impl.onboarding.features.OnboardingFeature
+import com.duckduckgo.subscriptions.impl.onboarding.itr.SubscriptionOnboardingItrStepPlugin.Companion.ITR_STEP_ID
+import javax.inject.Inject
+
+/**
+ * Identity Theft Restoration step of the native subscription onboarding. Shows the same content as the ITR
+ * feature-detail screen, but with an always-visible Activate button and the content scrolling behind it.
+ * Reports back through [SubscriptionOnboardingController] so it stays decoupled from the host activity.
+ */
+@InjectWith(FragmentScope::class)
+class SubscriptionOnboardingItrFragment : DuckDuckGoFragment(R.layout.fragment_subscription_onboarding_itr) {
+
+    @Inject
+    lateinit var controller: SubscriptionOnboardingController
+
+    private val binding: FragmentSubscriptionOnboardingItrBinding by viewBinding()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val feature = OnboardingFeature.ITR
+        binding.subscriptionOnboardingItrIcon.setImageResource(feature.iconRes)
+        binding.subscriptionOnboardingItrTitle.setText(feature.titleRes)
+        binding.subscriptionOnboardingItrDescription.setText(feature.descriptionRes)
+        layoutInflater.inflate(feature.contentRes, binding.subscriptionOnboardingItrContent, true)
+
+        binding.subscriptionOnboardingItrActivateButton.setOnClickListener {
+            controller.onStepFinished(ITR_STEP_ID, COMPLETED)
+        }
+
+        setupScrollFade()
+    }
+
+    private fun setupScrollFade() {
+        // A gradient can't reference ?attr colors, so derive it from the surface the content sits on. Starting
+        // from a zero-alpha surface rather than Color.TRANSPARENT keeps the hue constant across the ramp.
+        val surfaceColor = requireContext().getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorSurface)
+        binding.subscriptionOnboardingItrScrollFade.background = GradientDrawable(
+            GradientDrawable.Orientation.TOP_BOTTOM,
+            intArrayOf(ColorUtils.setAlphaComponent(surfaceColor, 0), surfaceColor),
+        )
+
+        binding.subscriptionOnboardingItrScrollView.setOnScrollChangeListener(
+            NestedScrollView.OnScrollChangeListener { _, _, _, _, _ -> updateScrollFade() },
+        )
+        // The per-feature content is inflated above, so the first reliable measurement is the next layout pass.
+        binding.subscriptionOnboardingItrScrollView.doOnLayout { updateScrollFade() }
+    }
+
+    private fun updateScrollFade() {
+        binding.subscriptionOnboardingItrScrollFade.isVisible =
+            binding.subscriptionOnboardingItrScrollView.canScrollVertically(1)
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrStepPlugin.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrStepPlugin.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.subscriptions.impl.R
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 
-/** Identity Theft Restoration step of the subscription onboarding, between the VPN and Duck.ai steps. */
 @ContributesMultibinding(AppScope::class)
 @PriorityKey(250)
 class SubscriptionOnboardingItrStepPlugin @Inject constructor() : SubscriptionOnboardingStepPlugin {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrStepPlugin.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrStepPlugin.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding.itr
+
+import androidx.fragment.app.Fragment
+import com.duckduckgo.anvil.annotations.PriorityKey
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
+import com.duckduckgo.subscriptions.impl.R
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+/** Identity Theft Restoration step of the subscription onboarding, between the VPN and Duck.ai steps. */
+@ContributesMultibinding(AppScope::class)
+@PriorityKey(250)
+class SubscriptionOnboardingItrStepPlugin @Inject constructor() : SubscriptionOnboardingStepPlugin {
+
+    override val stepId: String = ITR_STEP_ID
+
+    override val titleResId: Int = R.string.subscriptionOnboardingItrTitle
+
+    override suspend fun shouldShow(): Boolean = true
+
+    override fun createFragment(): Fragment = SubscriptionOnboardingItrFragment()
+
+    companion object {
+        const val ITR_STEP_ID = "itr"
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrViewModel.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding.itr
+
+import androidx.lifecycle.ViewModel
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
+import com.duckduckgo.subscriptions.impl.onboarding.itr.SubscriptionOnboardingItrStepPlugin.Companion.ITR_STEP_ID
+import javax.inject.Inject
+
+@ContributesViewModel(FragmentScope::class)
+class SubscriptionOnboardingItrViewModel @Inject constructor(
+    private val controller: SubscriptionOnboardingController,
+) : ViewModel() {
+
+    fun onPrimaryCtaClicked() {
+        controller.onStepFinished(ITR_STEP_ID, COMPLETED)
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/res/layout/content_subscription_onboarding_feature_info_idtr.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/content_subscription_onboarding_feature_info_idtr.xml
@@ -85,13 +85,10 @@
         app:featureInfoIcon="@drawable/profile_16"
         app:featureInfoTitle="@string/subscriptionOnboardingFeatureInfoItrItem8Title" />
 
-    <com.duckduckgo.common.ui.view.text.DaxTextView
+    <com.duckduckgo.subscriptions.impl.onboarding.features.SummaryOfBenefitsFooterView
         android:id="@+id/subscriptionOnboardingFeatureInfoLegalFooter"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_4"
-        android:text="@string/subscriptionOnboardingFeatureInfoItrLegalFooter"
-        app:textType="secondary"
-        app:typography="caption" />
+        android:layout_marginTop="@dimen/keyline_4" />
 
 </merge>

--- a/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_itr.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_itr.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/daxColorSurface">
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/subscriptionOnboardingItrScrollView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        app:layout_constraintBottom_toTopOf="@id/subscriptionOnboardingItrActivateButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingHorizontal="@dimen/keyline_5"
+            android:paddingBottom="@dimen/keyline_5">
+
+            <ImageView
+                android:id="@+id/subscriptionOnboardingItrIcon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="@dimen/keyline_5"
+                android:src="@drawable/identity_theft_restoration_feature_128"
+                tools:ignore="ContentDescription" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/subscriptionOnboardingItrTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_4"
+                android:gravity="center"
+                app:typography="h1"
+                tools:text="@string/subscriptionOnboardingFeatureInfoItrTitle" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/subscriptionOnboardingItrDescription"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                app:textType="secondary"
+                app:typography="body1"
+                tools:text="@string/subscriptionOnboardingFeatureInfoItrDescription" />
+
+            <LinearLayout
+                android:id="@+id/subscriptionOnboardingItrContent"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+    <View
+        android:id="@+id/subscriptionOnboardingItrScrollFade"
+        android:layout_width="0dp"
+        android:layout_height="48dp"
+        android:importantForAccessibility="no"
+        app:layout_constraintBottom_toBottomOf="@id/subscriptionOnboardingItrScrollView"
+        app:layout_constraintEnd_toEndOf="@id/subscriptionOnboardingItrScrollView"
+        app:layout_constraintStart_toStartOf="@id/subscriptionOnboardingItrScrollView" />
+
+    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+        android:id="@+id/subscriptionOnboardingItrActivateButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/keyline_5"
+        android:layout_marginBottom="@dimen/keyline_4"
+        android:text="@string/subscriptionOnboardingItrActivate"
+        app:daxButtonSize="large"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/subscriptions/subscriptions-impl/src/main/res/layout/view_summary_of_benefits_footer.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/view_summary_of_benefits_footer.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:parentTag="android.widget.FrameLayout">
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/summaryOfBenefitsFooterText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:textType="secondary"
+        app:typography="caption"
+        tools:text="@string/subscriptionOnboardingFeatureInfoItrLegalFooter" />
+
+</merge>

--- a/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
@@ -61,6 +61,10 @@
     <string name="subscriptionOnboardingFeature4Title">Personal Information Removal</string>
     <string name="subscriptionOnboardingFeature4Description">Find and remove your personal info from sites that store and sell it, reducing spam. </string>
     <string name="subscriptionOnboardingFeaturesPrimaryButton">Next</string>
+
+    <!-- ITR step -->
+    <string name="subscriptionOnboardingItrTitle">Step 2 of 3</string>
+    <string name="subscriptionOnboardingItrActivate">Activate</string>
     <!-- Feature detail screens -->
 
     <!-- Platform labels -->

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/onboarding/itr/SubscriptionOnboardingItrViewModelTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding.itr
+
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
+import com.duckduckgo.subscriptions.impl.onboarding.itr.SubscriptionOnboardingItrStepPlugin.Companion.ITR_STEP_ID
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class SubscriptionOnboardingItrViewModelTest {
+
+    private val controller: SubscriptionOnboardingController = mock()
+
+    private val testee = SubscriptionOnboardingItrViewModel(controller)
+
+    @Test
+    fun whenPrimaryCtaClickedThenStepCompleted() {
+        testee.onPrimaryCtaClicked()
+
+        verify(controller).onStepFinished(ITR_STEP_ID, COMPLETED)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216636588501793?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

- Add Identity Thief Restoration step to Subscription Onboarding
- Also, moved pdf download to a custom footer view to be reused

### Steps to test this PR

_Pre steps_
- [x] Apply patch on https://app.asana.com/1/137249556945/project/72649045549333/task/1218112192755682
- [x] Fresh install

_IDTR step_
- [x] Purchase a test subscription
- [x] New onboarding is launched
- [x] Once you finish VPN step, verify IDTR step is shown

_Summary of Benefits Footer_
- [x] Scroll all the way down
- [x] Tap on 'Review the Summary of Benefits
- [x] Check pdf is downloaded

### UI changes
| IDTR step |
| ------ |
<img width="377" height="839" alt="Screenshot 2026-09-04 at 13 03 48" src="https://github.com/user-attachments/assets/34d2b014-b7ef-4e3a-810a-55602a06400a" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UI and a localized refactor of ITR PDF download behavior; no changes to subscription purchase or auth flows.
> 
> **Overview**
> Adds **Step 2 of 3** Identity Theft Restoration (ITR) to the post-purchase subscription onboarding flow, registered via `SubscriptionOnboardingItrStepPlugin` with an **Activate** CTA that marks the step completed through the shared onboarding controller.
> 
> The ITR screen reuses existing `OnboardingFeature.ITR` copy and detail content, adds a bottom scroll fade, and wires the same legal footer behavior as the feature-info screen.
> 
> **Summary of Benefits** PDF download, storage permission handling, and download snackbars are moved out of `SubscriptionOnboardingFeatureInfoActivity` into a reusable `SummaryOfBenefitsFooterView`; hosts now request `WRITE_EXTERNAL_STORAGE` through the Activity Result API and delegate permission grants to the footer. The ITR detail layout swaps the plain legal `DaxTextView` for this custom view.
> 
> Copy updates label the Duck.ai onboarding title as **Step 3 of 3** (duckchat strings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbb649f7f8ef29ea69baf44eeadeb34ffe668828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->