### PR TITLE
Add ddg_homepage as entry point to duck.ai pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_return_session.json5
+++ b/PixelDefinitions/pixels/definitions/wide_return_session.json5
@@ -116,6 +116,7 @@
                     "onboarding",
                     "direct_url",
                     "serp",
+                    "ddg_homepage",
                     "icon_shortcut",
                     "contextual_chat",
                     "widget_quick_actions",

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -116,6 +116,7 @@
             "onboarding",
             "direct_url",
             "serp",
+            "ddg_homepage",
             "icon_shortcut",
             "contextual_chat",
             "widget_quick_actions",

--- a/PixelDefinitions/wide_events/definitions/return_session.json5
+++ b/PixelDefinitions/wide_events/definitions/return_session.json5
@@ -99,6 +99,7 @@
                             "onboarding",
                             "direct_url",
                             "serp",
+                            "ddg_homepage",
                             "icon_shortcut",
                             "contextual_chat",
                             "widget_quick_actions",

--- a/PixelDefinitions/wide_events/generated_schemas/android-return-session-1.0.0.json
+++ b/PixelDefinitions/wide_events/generated_schemas/android-return-session-1.0.0.json
@@ -158,6 +158,7 @@
                                         "onboarding",
                                         "direct_url",
                                         "serp",
+                                        "ddg_homepage",
                                         "icon_shortcut",
                                         "contextual_chat",
                                         "widget_quick_actions",

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -78,6 +78,7 @@ import com.duckduckgo.autofill.api.InternalTestUserChecker
 import com.duckduckgo.browser.api.JsInjectorPlugin
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.AppUrl.ParamKey.QUERY
+import com.duckduckgo.common.utils.AppUrl.Url.HOST
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
@@ -149,6 +150,7 @@ class BrowserWebViewClient @Inject constructor(
 
     // WebView clears hasGesture() on redirect hops, but the App Link rules assume Chromium's per-navigation gesture flag.
     private var mainFrameGestureOriginUrl: String? = null
+    private var duckChatEntryReportedForCurrentNavigation = false
     private var start: Long? = null
 
     // Needed for PageLoadWideEvent: it identifies the page load the wide event is currently measuring,
@@ -255,6 +257,7 @@ class BrowserWebViewClient @Inject constructor(
                 // Anchored to originalUrl, not the request's own URL, so both comparison sides share one source,
                 // stable across a chain's redirects, changes once an unrelated navigation commits.
                 mainFrameGestureOriginUrl = webView.originalUrl.takeIf { hasGesture }
+                duckChatEntryReportedForCurrentNavigation = false
             }
             val hasGestureInNavigation = hasGesture ||
                 (isForMainFrame && isRedirect && mainFrameGestureOriginUrl != null && mainFrameGestureOriginUrl == webView.originalUrl)
@@ -364,6 +367,7 @@ class BrowserWebViewClient @Inject constructor(
                     if (
                         isForMainFrame &&
                         hasGestureInNavigation &&
+                        !duckChatEntryReportedForCurrentNavigation &&
                         duckChat.isDuckChatUrl(url) &&
                         webView.originalUrl?.toUri()?.let(duckChat::isDuckChatUrl) != true
                     ) {
@@ -372,6 +376,7 @@ class BrowserWebViewClient @Inject constructor(
                             opensNewTab = false,
                             hasPrompt = url.getQueryParameter("prompt") == "1" && !url.getQueryParameter(QUERY).isNullOrBlank(),
                         )
+                        duckChatEntryReportedForCurrentNavigation = true
                     }
                     shouldOverrideWebRequest(url, webView, isForMainFrame)
                 }
@@ -452,12 +457,19 @@ class BrowserWebViewClient @Inject constructor(
         }
     }
 
-    private fun duckChatEntryPointFor(initiatingUrl: String?): DuckChatEntryPoint =
-        if (initiatingUrl?.let(duckDuckGoUrlDetector::isDuckDuckGoQueryUrl) == true) {
-            DuckChatEntryPoint.SERP
-        } else {
-            DuckChatEntryPoint.DIRECT_URL
+    private fun duckChatEntryPointFor(initiatingUrl: String?): DuckChatEntryPoint {
+        val isSerp = initiatingUrl?.let(duckDuckGoUrlDetector::isDuckDuckGoQueryUrl) == true
+        val initiatingUri = initiatingUrl?.toUri()
+        val isDdgRoot = initiatingUri?.run { host == HOST && (path.isNullOrEmpty() || path == "/") } == true
+        val isDuckAiPage = isDdgRoot && initiatingUri?.let(duckChat::isDuckChatUrl) == true
+        val isDdgHomepage = isDdgRoot && !isDuckAiPage
+        val entryPoint = when {
+            isSerp -> DuckChatEntryPoint.SERP
+            isDdgHomepage -> DuckChatEntryPoint.DDG_HOMEPAGE
+            else -> DuckChatEntryPoint.DIRECT_URL
         }
+        return entryPoint
+    }
 
     private fun shouldOverrideWebRequest(
         url: Uri,

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -605,6 +605,34 @@ class BrowserWebViewClientTest {
     }
 
     @Test
+    fun whenDuckChatLinkIsLaunchedFromDuckDuckGoHomepageThenSourceIsDdgHomepage() {
+        val homepageWebView: WebView = mock()
+        whenever(homepageWebView.originalUrl).thenReturn("https://duckduckgo.com/")
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.ShouldLaunchDuckChatLink)
+        whenever(webResourceRequest.url).thenReturn("https://duck.ai/".toUri())
+
+        testee.shouldOverrideUrlLoading(homepageWebView, webResourceRequest)
+
+        verify(mockDuckChat).openDuckChat(DuckChatEntryPoint.DDG_HOMEPAGE)
+    }
+
+    @Test
+    fun whenDuckChatLinkIsLaunchedFromDuckDuckGoChatPageThenSourceIsDirectUrl() {
+        val chatPage = "https://duckduckgo.com/?ia=chat"
+        val chatWebView: WebView = mock()
+        whenever(chatWebView.originalUrl).thenReturn(chatPage)
+        whenever(mockDuckChat.isDuckChatUrl(chatPage.toUri())).thenReturn(true)
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.ShouldLaunchDuckChatLink)
+        whenever(webResourceRequest.url).thenReturn("https://duck.ai/".toUri())
+
+        testee.shouldOverrideUrlLoading(chatWebView, webResourceRequest)
+
+        verify(mockDuckChat).openDuckChat(DuckChatEntryPoint.DIRECT_URL)
+    }
+
+    @Test
     fun whenInPageDuckChatLinkNavigatesInPlaceThenDirectUrlEntryIsReported() {
         val pageWebView: WebView = mock()
         whenever(pageWebView.originalUrl).thenReturn("https://example.com/page")
@@ -619,6 +647,57 @@ class BrowserWebViewClientTest {
         testee.shouldOverrideUrlLoading(pageWebView, webResourceRequest)
 
         verify(mockDuckChat).reportDuckChatEntry(DuckChatEntryPoint.DIRECT_URL, opensNewTab = false, hasPrompt = false)
+    }
+
+    @Test
+    fun whenDuckChatNavigationRedirectsThenEntryIsReportedOnceForTheNavigation() {
+        val homepageUrl = "https://duckduckgo.com/"
+        val duckChatUrl = "https://duck.ai/?q=prompt&prompt=1"
+        val homepageWebView: WebView = mock()
+        whenever(homepageWebView.originalUrl).thenReturn(homepageUrl)
+        whenever(homepageWebView.url).thenReturn(homepageUrl)
+        whenever(webResourceRequest.url).thenReturn(duckChatUrl.toUri())
+        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+        whenever(webResourceRequest.isRedirect).thenReturn(false, true)
+        whenever(webResourceRequest.hasGesture()).thenReturn(true, false)
+        whenever(mockDuckChat.isDuckChatUrl(duckChatUrl.toUri())).thenReturn(true)
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.Web(duckChatUrl))
+
+        testee.shouldOverrideUrlLoading(homepageWebView, webResourceRequest)
+        testee.shouldOverrideUrlLoading(homepageWebView, webResourceRequest)
+
+        verify(mockDuckChat, times(1)).reportDuckChatEntry(
+            DuckChatEntryPoint.DDG_HOMEPAGE,
+            opensNewTab = false,
+            hasPrompt = true,
+        )
+    }
+
+    @Test
+    fun whenDuckChatIsEnteredAgainAfterRedirectThenEntryIsReportedForTheNewNavigation() {
+        val homepageUrl = "https://duckduckgo.com/"
+        val duckChatUrl = "https://duck.ai/?q=prompt&prompt=1"
+        val homepageWebView: WebView = mock()
+        whenever(homepageWebView.originalUrl).thenReturn(homepageUrl)
+        whenever(homepageWebView.url).thenReturn(homepageUrl)
+        whenever(webResourceRequest.url).thenReturn(duckChatUrl.toUri())
+        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+        whenever(webResourceRequest.isRedirect).thenReturn(false, true, false)
+        whenever(webResourceRequest.hasGesture()).thenReturn(true, false, true)
+        whenever(mockDuckChat.isDuckChatUrl(duckChatUrl.toUri())).thenReturn(true)
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.Web(duckChatUrl))
+
+        testee.shouldOverrideUrlLoading(homepageWebView, webResourceRequest)
+        testee.shouldOverrideUrlLoading(homepageWebView, webResourceRequest)
+        testee.shouldOverrideUrlLoading(homepageWebView, webResourceRequest)
+
+        verify(mockDuckChat, times(2)).reportDuckChatEntry(
+            DuckChatEntryPoint.DDG_HOMEPAGE,
+            opensNewTab = false,
+            hasPrompt = true,
+        )
     }
 
     @Test

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatEntryPoint.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatEntryPoint.kt
@@ -33,6 +33,7 @@ enum class DuckChatEntryPoint {
     ONBOARDING,
     DIRECT_URL,
     SERP,
+    DDG_HOMEPAGE,
     ICON_SHORTCUT,
     CONTEXTUAL_CHAT,
     WIDGET_QUICK_ACTIONS,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218201061912183?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): https://app.asana.com/1/137249556945/project/1212087397361015/task/1218201061912189?focus=true

### Description
Adds `ddg_homepage` as a Duck.ai entry source when duck.ai accessed from the home page (duckduckgo.com)

### Steps to test this PR
_Prerequisites_
- [x] Install the internal build.
- [x] Filter Logcat for `m_aichat_entry_point`.

_DuckDuckGo homepage_
- [x] Open `https://duckduckgo.com/`.
- [x] Enter a prompt in the Duck.ai field and submit it.
- [x] Verify one `m_aichat_entry_point_count` pixel is sent.
- [x] Verify `source=ddg_homepage`, `has_prompt=true`, and `opens_new_tab=false`.
- [x] Go back to the home page
- [x] Click on duck.ai on top of the page to go to duck.ai (do not submit a prompt)
- [x] Verify `has_prompt=false` this time

_Return-session wide event_
- [x] Enable the `wideEvents`, `enqueueWideEventPixels`, `sendWideEventsViaPixels`, and `returnSessionWideEvent` flags, then restart the app.
- [x] Enter Duck.ai from the DuckDuckGo homepage (submit a query or tap on top link)
- [x] Background the app, wait few seconds, then reopen the app with that Duck.ai tab selected.
- [x] Submit a follow-up prompt.
- [x] Verify `wide_return_session_c` contains `status_reason=ai_prompt_submitted` and `source=ddg_homepage`.

### UI changes
 NO UI Changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics and WebView navigation classification only; no auth, payments, or user data handling changes.
> 
> **Overview**
> Introduces **`ddg_homepage`** as a Duck.ai entry **`source`** when users open Duck.ai from the bare **`duckduckgo.com`** homepage (distinct from SERP and generic **`direct_url`**).
> 
> **`BrowserWebViewClient`** now classifies the initiating URL in **`duckChatEntryPointFor`**: SERP queries stay **`serp`**, root DDG host without an in-page Duck Chat URL maps to **`DDG_HOMEPAGE`**, and **`duckduckgo.com/?ia=chat`** still counts as **`direct_url`**. In-page navigations to Duck.ai use the same logic for **`reportDuckChatEntry`**, with a per-navigation latch so redirect hops only fire **one** entry pixel per user gesture.
> 
> Pixel and wide-event schemas (**`duckAiEntrySource`**, **`wide_return_session`**, generated Android return-session schema) and **`DuckChatEntryPoint.DDG_HOMEPAGE`** are updated accordingly; unit tests cover homepage vs chat-page vs redirect deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d28057f980ecebf768041b05e848772bac6380af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->