### PR TITLE
Keep bookmark search results when a folder deletion is committed

### DIFF
--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModel.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModel.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.autofill.api.ImportFromGoogle
+import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.di.scopes.ActivityScope
@@ -32,6 +33,7 @@ import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
+import com.duckduckgo.savedsites.api.models.SavedSites
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.api.service.ExportSavedSitesResult
 import com.duckduckgo.savedsites.api.service.ImportSavedSitesResult
@@ -67,9 +69,12 @@ import com.duckduckgo.sync.api.engine.SyncEngine
 import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.FEATURE_READ
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import logcat.logcat
@@ -132,6 +137,7 @@ class BookmarksViewModel @Inject constructor(
 
     private val _itemsToDisplay = MutableStateFlow<List<BookmarksItemTypes>>(emptyList())
     val itemsToDisplay = _itemsToDisplay.asStateFlow()
+    private val displayedItemsJob = ConflatedJob()
 
     init {
         viewState.value = ViewState()
@@ -255,40 +261,57 @@ class BookmarksViewModel @Inject constructor(
     }
 
     fun fetchBookmarksAndFolders(parentId: String) {
-        viewModelScope.launch(dispatcherProvider.io()) {
-            if (faviconsFetchingPrompt.shouldShow()) {
-                withContext(dispatcherProvider.main()) {
-                    command.value = ShowFaviconsPrompt
-                }
-            }
-
+        displayItemsFrom(
             savedSitesRepository.getSavedSites(parentId)
-                .combine(hiddenIds) { savedSites, hiddenIds ->
-                    val filteredBookmarks = savedSites.bookmarks.filter {
-                        when (it) {
-                            is Bookmark -> it.id !in hiddenIds.items
-                            is BookmarkFolder -> it.id !in hiddenIds.items
-                            else -> false
-                        }
-                    }
-                    savedSites.copy(
-                        bookmarks = filteredBookmarks,
-                        favorites = savedSites.favorites.filter { it.id !in hiddenIds.items },
-                    )
-                }.collect {
-                    onSavedSitesItemsChanged(it.favorites, it.bookmarks)
-                }
-        }
+                .onStart { showFaviconsPromptIfNeeded() },
+        )
     }
 
     fun fetchAllBookmarksAndFolders() {
-        viewModelScope.launch(dispatcherProvider.io()) {
-            val favorites = savedSitesRepository.getFavoritesSync()
-            val folders = savedSitesRepository.getFolderTree(SavedSitesNames.BOOKMARKS_ROOT, null)
-                .map { it.bookmarkFolder }
-                .filter { it.id != SavedSitesNames.BOOKMARKS_ROOT }
-            val bookmarks = savedSitesRepository.getBookmarksTree()
-            onSavedSitesItemsChanged(favorites, bookmarks + folders)
+        displayItemsFrom(
+            flow {
+                val folders = savedSitesRepository.getFolderTree(SavedSitesNames.BOOKMARKS_ROOT, null)
+                    .map { it.bookmarkFolder }
+                    .filter { it.id != SavedSitesNames.BOOKMARKS_ROOT }
+                emit(
+                    SavedSites(
+                        favorites = savedSitesRepository.getFavoritesSync(),
+                        bookmarks = savedSitesRepository.getBookmarksTree() + folders,
+                    ),
+                )
+            },
+        )
+    }
+
+    /**
+     * Only one source may own the displayed list at a time. The folder scoped Flow keeps emitting on
+     * every database change, so leaving it collecting would overwrite the whole tree the user searches through.
+     */
+    private fun displayItemsFrom(source: Flow<SavedSites>) {
+        displayedItemsJob += viewModelScope.launch(dispatcherProvider.io()) {
+            source.combine(hiddenIds) { savedSites, hiddenIds ->
+                val filteredBookmarks = savedSites.bookmarks.filter {
+                    when (it) {
+                        is Bookmark -> it.id !in hiddenIds.items
+                        is BookmarkFolder -> it.id !in hiddenIds.items
+                        else -> false
+                    }
+                }
+                savedSites.copy(
+                    bookmarks = filteredBookmarks,
+                    favorites = savedSites.favorites.filter { it.id !in hiddenIds.items },
+                )
+            }.collect {
+                onSavedSitesItemsChanged(it.favorites, it.bookmarks)
+            }
+        }
+    }
+
+    private suspend fun showFaviconsPromptIfNeeded() {
+        if (faviconsFetchingPrompt.shouldShow()) {
+            withContext(dispatcherProvider.main()) {
+                command.value = ShowFaviconsPrompt
+            }
         }
     }
 

--- a/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModelTest.kt
+++ b/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModelTest.kt
@@ -653,4 +653,35 @@ class BookmarksViewModelTest {
         verify(commandObserver).onChanged(commandCaptor.capture())
         assertEquals(BookmarksViewModel.Command.LaunchAddFolder, commandCaptor.lastValue)
     }
+
+    @Test
+    fun whenFolderDeletedWhileSearchingThenRemainingItemsStayInTheSearchableList() = runTest {
+        savedSitesFlow.value = SavedSites(favorites = emptyList(), bookmarks = listOf(bookmarkFolder))
+        whenever(savedSitesRepository.getFavoritesSync()).thenReturn(listOf(favorite))
+        whenever(savedSitesRepository.getBookmarksTree()).thenReturn(listOf(bookmark))
+        whenever(savedSitesRepository.getFolderTree(BOOKMARKS_ROOT, null)).thenReturn(listOf(bookmarkFolderItem))
+
+        testee.fetchAllBookmarksAndFolders()
+        assertTrue(testee.itemsToDisplay.value.isNotEmpty())
+
+        testee.onDeleteBookmarkFolderRequested(bookmarkFolder)
+
+        val remainingItems = testee.itemsToDisplay.value
+        assertTrue(remainingItems.any { it is BookmarkItem && it.bookmark.id == bookmark.id })
+        assertFalse(remainingItems.any { it is BookmarksAdapter.BookmarkFolderItem })
+    }
+
+    @Test
+    fun whenSearchingThenFoldersPendingDeletionAreNotDisplayed() = runTest {
+        whenever(savedSitesRepository.getFavoritesSync()).thenReturn(listOf(favorite))
+        whenever(savedSitesRepository.getBookmarksTree()).thenReturn(listOf(bookmark))
+        whenever(savedSitesRepository.getFolderTree(BOOKMARKS_ROOT, null)).thenReturn(listOf(bookmarkFolderItem))
+
+        testee.onDeleteBookmarkFolderRequested(bookmarkFolder)
+        testee.fetchAllBookmarksAndFolders()
+
+        val searchableItems = testee.itemsToDisplay.value
+        assertTrue(searchableItems.any { it is BookmarkItem && it.bookmark.id == bookmark.id })
+        assertFalse(searchableItems.any { it is BookmarksAdapter.BookmarkFolderItem })
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/Android/issues/6062
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

`BookmarksViewModel` had two producers writing to the same `_itemsToDisplay`:

- `fetchBookmarksAndFolders(parentId)` collects `getSavedSites(parentId)` in a coroutine that is never cancelled, and a new collector is added every time the search bar is closed.
- `fetchAllBookmarksAndFolders()`, called when the search bar opens, overwrites that same state with the whole tree.

Deleting a folder is only committed to the database when the undo snackbar is dismissed. That write makes the still active folder scoped collector re-emit and overwrite the search list with the current folder contents, which are now empty, so the search shows no results at all. It is also why the failure only reproduces when the search bar is opened while the snackbar is still on screen.

Both sources now go through a single `displayItemsFrom(source: Flow<SavedSites>)` that owns the displayed list and holds its collection in a `ConflatedJob`, so switching source cancels the previous one. The hidden ids filtering that already existed for the folder listing now applies to both sources, which also keeps folders pending deletion out of the search results (the stale folder half of #5671).

Two unit tests were added to `BookmarksViewModelTest`; both fail on `develop` and pass with this change. The 45 existing tests are untouched and still pass. No public API is touched.

While investigating I found an adjacent issue that I deliberately left out of this PR: `BookmarksActivity.observeItemsToDisplay()` pushes list updates straight to the adapter without re-applying the current query, so any update that lands while the search bar is open repaints the unfiltered list. That behaviour predates this change and lives in a different layer. Happy to follow up separately if you would like it addressed.

### Steps to test this PR

_Search results survive a folder deletion being committed_
- [ ] Open Bookmarks and save a few pages first, so there is something to search for
- [ ] Create folder A at the root, open it, and create folder B inside it
- [ ] Delete folder B and, while the undo snackbar is still on screen, tap the search icon and type a letter
- [ ] Confirm results are listed
- [ ] Let the snackbar time out on its own, without tapping Undo
- [ ] Results stay on screen. Before this change the list was cleared the moment the snackbar disappeared

### UI changes

<table>
  <tr>
    <th width="50%">Before</th>
    <th width="50%">After</th>
  </tr>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/c2aaf4ee-da47-4cd0-92a6-4eb65eca66a4"></video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/218c55a8-a287-4141-8731-ac8a54cb0d01"></video>
    </td>
  </tr>
  <tr>
    <td>The list is cleared the moment the undo snackbar disappears, even though the query is still typed in the search bar.</td>
    <td>The results stay on screen when the deletion is committed, and filtering keeps working.</td>
  </tr>
</table>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Scoped to bookmarks UI state and coroutine lifecycle; behavior changes when toggling search and during deferred deletes, but no API or persistence changes.
> 
> **Overview**
> Fixes bookmark search clearing when an undo snackbar times out during search. **Folder-scoped** and **whole-tree** bookmark loading both wrote to `itemsToDisplay`; the folder `Flow` kept collecting after search opened, so a committed folder delete re-emitted and replaced the search list with empty folder contents.
> 
> Both `fetchBookmarksAndFolders` and `fetchAllBookmarksAndFolders` now feed a shared **`displayItemsFrom`** path backed by **`ConflatedJob`**, so switching modes cancels the prior collector and only one source owns the list. The existing **`hiddenIds`** filter is applied in that path for both sources, so folders pending deletion stay out of search results. Favicon prompt logic moves to **`onStart`** on the folder flow.
> 
> Two **`BookmarksViewModelTest`** cases cover search surviving folder delete and hiding pending-delete folders while searching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 952f3b0a2c938f44a34b3c8f356390176d817eeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->