### PR TITLE
Guard bookmark folder traversal against cyclic folder relations

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/bookmarks/model/SavedSitesRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/model/SavedSitesRepositoryTest.kt
@@ -770,6 +770,42 @@ class SavedSitesRepositoryTest {
     }
 
     @Test
+    fun whenFolderRelationsContainCycleThenGetFolderBranchTerminates() = runTest {
+        val parentFolder =
+            BookmarkFolder("folder1", "Parent Folder", SavedSitesNames.BOOKMARKS_ROOT, numBookmarks = 0, numFolders = 1, lastModified = "timestamp")
+        val childFolder = BookmarkFolder("folder2", "Child Folder", "folder1", numBookmarks = 1, numFolders = 0, lastModified = "timestamp")
+        val childBookmark = Bookmark("bookmark1", "title", "www.example.com", "folder2", "timestamp")
+        repository.insertFolderBranch(FolderBranch(listOf(childBookmark), listOf(parentFolder, childFolder)))
+
+        // folder2 is already a child of folder1; making folder1 a child of folder2 closes the loop
+        savedSitesRelationsDao.insert(Relation(folderId = childFolder.id, entityId = parentFolder.id))
+
+        val branch = repository.getFolderBranch(parentFolder)
+
+        assertTrue(branch.folders.any { it.id == parentFolder.id })
+        assertTrue(branch.folders.any { it.id == childFolder.id })
+        assertEquals(branch.folders.distinctBy { it.id }.size, branch.folders.size)
+        assertEquals(listOf(childBookmark), branch.bookmarks)
+    }
+
+    @Test
+    fun whenFolderRelationsContainCycleThenDeleteFolderBranchTerminates() = runTest {
+        val parentFolder =
+            BookmarkFolder("folder1", "Parent Folder", SavedSitesNames.BOOKMARKS_ROOT, numBookmarks = 0, numFolders = 1, lastModified = "timestamp")
+        val childFolder = BookmarkFolder("folder2", "Child Folder", "folder1", numBookmarks = 1, numFolders = 0, lastModified = "timestamp")
+        val childBookmark = Bookmark("bookmark1", "title", "www.example.com", "folder2", "timestamp")
+        repository.insertFolderBranch(FolderBranch(listOf(childBookmark), listOf(parentFolder, childFolder)))
+
+        savedSitesRelationsDao.insert(Relation(folderId = childFolder.id, entityId = parentFolder.id))
+
+        repository.deleteFolderBranch(parentFolder)
+
+        assertNull(repository.getFolder(parentFolder.id))
+        assertNull(repository.getFolder(childFolder.id))
+        assertNull(repository.getBookmark(childBookmark.url))
+    }
+
+    @Test
     fun whenBuildFlatStructureThenReturnFolderListWithDepth() = runTest {
         val rootFolder = BookmarkFolder(id = SavedSitesNames.BOOKMARKS_ROOT, name = "root", lastModified = "timestamp", parentId = "")
         val parentFolder = BookmarkFolder(
@@ -797,6 +833,36 @@ class SavedSitesRepositoryTest {
         )
 
         assertEquals(items, flatStructure)
+    }
+
+    @Test
+    fun whenFolderRelationsContainCycleThenGetFolderTreeTerminates() = runTest {
+        val rootFolder = BookmarkFolder(id = SavedSitesNames.BOOKMARKS_ROOT, name = "root", lastModified = "timestamp", parentId = "")
+        val parentFolder = BookmarkFolder(id = "folder1", name = "name", lastModified = "timestamp", parentId = SavedSitesNames.BOOKMARKS_ROOT)
+        val childFolder = BookmarkFolder(id = "folder2", name = "another name", lastModified = "timestamp", parentId = "folder1")
+
+        repository.insert(rootFolder)
+        repository.insert(parentFolder)
+        repository.insert(childFolder)
+
+        // close the loop: folder1 becomes a child of folder2, which is already a child of folder1
+        savedSitesRelationsDao.insert(Relation(folderId = childFolder.id, entityId = parentFolder.id))
+
+        val flatStructure = repository.getFolderTree(childFolder.id, null)
+
+        assertEquals(flatStructure.distinctBy { it.bookmarkFolder.id }.size, flatStructure.size)
+    }
+
+    @Test
+    fun whenSameFolderInsertedTwiceThenRelationIsNotDuplicated() = runTest {
+        val rootFolder = BookmarkFolder(id = SavedSitesNames.BOOKMARKS_ROOT, name = "root", lastModified = "timestamp", parentId = "")
+        val folder = BookmarkFolder(id = "folder1", name = "name", lastModified = "timestamp", parentId = SavedSitesNames.BOOKMARKS_ROOT)
+
+        repository.insert(rootFolder)
+        repository.insert(folder)
+        repository.insert(folder)
+
+        assertEquals(1, savedSitesRelationsDao.relationsByEntityId(folder.id).size)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/model/SyncSavedSitesRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/model/SyncSavedSitesRepositoryTest.kt
@@ -648,6 +648,23 @@ class SyncSavedSitesRepositoryTest {
     }
 
     @Test
+    fun whenFolderRelationsContainCycleThenSetLocalEntitiesForNextSyncTerminates() {
+        val twoHoursAgo = DatabaseDateFormatter.iso8601(OffsetDateTime.now(ZoneOffset.UTC).minusHours(2))
+        val folderA = BookmarkFolder(id = "folderA", name = "Folder A", parentId = bookmarksRootFolder.id, lastModified = twoHoursAgo)
+        val folderB = BookmarkFolder(id = "folderB", name = "Folder B", parentId = folderA.id, lastModified = twoHoursAgo)
+        savedSitesRepository.insert(folderA)
+        savedSitesRepository.insert(folderB)
+        // folderB now also contains folderA, forming a loop in the relations table
+        savedSitesRelationsDao.insert(Relation(folderId = folderB.id, entityId = folderA.id))
+
+        val oneHourAhead = DatabaseDateFormatter.iso8601(OffsetDateTime.now(ZoneOffset.UTC).plusHours(1))
+        repository.setLocalEntitiesForNextSync(oneHourAhead)
+
+        assertTrue(savedSitesEntitiesDao.entityById(folderA.id) != null)
+        assertTrue(savedSitesEntitiesDao.entityById(folderB.id) != null)
+    }
+
+    @Test
     fun whenDeduplicatingBookmarkThenRemoteBookmarkReplacesLocal() {
         // given a local bookmark
         repository.insert(bookmark1, favouritesRoot.entityId)

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/service/SavedSitesExporterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/service/SavedSitesExporterTest.kt
@@ -38,10 +38,12 @@ import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
 import com.duckduckgo.savedsites.impl.service.RealSavedSitesExporter
 import com.duckduckgo.savedsites.impl.service.RealSavedSitesParser
+import com.duckduckgo.savedsites.store.Relation
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
 import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
 import kotlinx.coroutines.test.runTest
 import org.junit.*
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.runner.RunWith
 import java.io.File
@@ -187,6 +189,29 @@ class SavedSitesExporterTest {
                 preOrderCount++
             },
         )
+    }
+
+    @Test
+    fun whenFolderRelationsContainCycleThenGetTreeStructureTerminates() = runTest {
+        val root = BookmarkFolder(SavedSitesNames.BOOKMARKS_ROOT, "DuckDuckGo Bookmarks", "", 0, 0, "timestamp")
+        val parentFolder = BookmarkFolder("folder1", "Folder One", SavedSitesNames.BOOKMARKS_ROOT, 0, 0, "timestamp")
+        val childFolder = BookmarkFolder("folder2", "Folder Two", "folder1", 0, 0, "timestamp")
+        val childBookmark = Bookmark("bookmark1", "title", "www.example.com", "folder2", "timestamp")
+        savedSitesRepository.insertFolderBranch(FolderBranch(listOf(childBookmark), listOf(root, parentFolder, childFolder)))
+
+        // folder2 is already a child of folder1; making folder1 a child of folder2 closes the loop
+        savedSitesRelationsDao.insert(Relation(folderId = childFolder.id, entityId = parentFolder.id))
+
+        val treeStructure = exporter.getTreeFolderStructure()
+
+        val visitedFolderIds = mutableListOf<String>()
+        treeStructure.forEachVisit(
+            { node -> if (node.value.url == null) visitedFolderIds.add(node.value.id) },
+            { },
+        )
+
+        assertTrue(visitedFolderIds.containsAll(listOf(parentFolder.id, childFolder.id)))
+        assertEquals(visitedFolderIds.distinct().size, visitedFolderIds.size)
     }
 
     private fun testNode(

--- a/app/src/test/java/com/duckduckgo/app/sync/SavedSitesSyncDataProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/SavedSitesSyncDataProviderTest.kt
@@ -51,6 +51,7 @@ import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRequestEntry
 import com.duckduckgo.savedsites.impl.sync.store.RealSavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
+import com.duckduckgo.savedsites.store.Relation
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
 import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
 import com.duckduckgo.sync.api.SyncCrypto
@@ -218,6 +219,25 @@ class SavedSitesSyncDataProviderTest {
         assertTrue(changes.bookmarks.updates[3].id == "bookmark3")
         assertTrue(changes.bookmarks.updates[4].id == "bookmark4")
         assertTrue(changes.bookmarks.updates[5].id == "bookmarks_root")
+    }
+
+    @Test
+    fun whenFolderRelationsContainCycleThenGetChangesTerminatesAndListsEachFolderOnce() {
+        val folderA = aFolder("folderA", "Folder A", SavedSitesNames.BOOKMARKS_ROOT)
+        val folderB = aFolder("folderB", "Folder B", folderA.id)
+        repository.insert(folderA)
+        repository.insert(folderB)
+        repository.insert(bookmark3.copy(parentId = folderB.id))
+        // folderB now also contains folderA, forming a loop in the relations table
+        savedSitesRelationsDao.insert(Relation(folderId = folderB.id, entityId = folderA.id))
+
+        val syncChanges = parser.getChanges()
+
+        val changes = Adapters.adapter.fromJson(syncChanges.jsonString)!!
+        val updatedIds = changes.bookmarks.updates.map { it.id }
+        assertEquals(1, updatedIds.count { it == folderA.id })
+        assertEquals(1, updatedIds.count { it == folderB.id })
+        assertTrue(updatedIds.contains(bookmark3.id))
     }
 
     @Test

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesRepository.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesRepository.kt
@@ -116,7 +116,15 @@ class RealSavedSitesRepository(
         return if (rootFolder != null) {
             val rootFolderItem = BookmarkFolderItem(0, rootFolder, rootFolder.id == selectedFolderId)
             val folders = mutableListOf(rootFolderItem)
-            val folderDepth = traverseFolderWithDepth(1, folders, SavedSitesNames.BOOKMARKS_ROOT, selectedFolderId = selectedFolderId, currentFolder)
+            val folderDepth =
+                traverseFolderWithDepth(
+                    1,
+                    folders,
+                    SavedSitesNames.BOOKMARKS_ROOT,
+                    selectedFolderId = selectedFolderId,
+                    currentFolder,
+                    mutableSetOf(SavedSitesNames.BOOKMARKS_ROOT),
+                )
             if (currentFolder != null) {
                 folderDepth.filterNot { it.bookmarkFolder == currentFolder }
             } else {
@@ -145,11 +153,13 @@ class RealSavedSitesRepository(
         folderId: String,
         selectedFolderId: String,
         currentFolder: BookmarkFolder?,
+        visitedFolderIds: MutableSet<String>,
     ): List<BookmarkFolderItem> {
         getFolders(folderId).map {
-            if (it.id != currentFolder?.id) {
+            // folder relations can form a loop, so a folder already on this branch is never descended into again
+            if (it.id != currentFolder?.id && visitedFolderIds.add(it.id)) {
                 folders.add(BookmarkFolderItem(depth, it, it.id == selectedFolderId))
-                traverseFolderWithDepth(depth + 1, folders, it.id, selectedFolderId = selectedFolderId, currentFolder)
+                traverseFolderWithDepth(depth + 1, folders, it.id, selectedFolderId = selectedFolderId, currentFolder, visitedFolderIds)
             }
         }
         return folders
@@ -169,7 +179,7 @@ class RealSavedSitesRepository(
     override fun getFolderBranch(folder: BookmarkFolder): FolderBranch {
         val bookmarks = mutableListOf<Bookmark>()
         val folders = mutableListOf(folder)
-        val folderContent = traverseBranch(bookmarks, folders, folder.id)
+        val folderContent = traverseBranch(bookmarks, folders, folder.id, mutableSetOf(folder.id))
         return FolderBranch(folderContent.first, folderContent.second)
     }
 
@@ -177,12 +187,15 @@ class RealSavedSitesRepository(
         bookmarks: MutableList<Bookmark>,
         folders: MutableList<BookmarkFolder>,
         folderId: String,
+        visitedFolderIds: MutableSet<String>,
     ): Pair<List<Bookmark>, List<BookmarkFolder>> {
         val folderContent = folderContent(folderId)
         bookmarks.addAll(folderContent.first)
-        folders.addAll(folderContent.second)
-        folderContent.second.forEach {
-            traverseBranch(bookmarks, folders, it.id)
+        // folder relations can form a loop, so a folder already on this branch is never descended into again
+        val unvisitedFolders = folderContent.second.filter { visitedFolderIds.add(it.id) }
+        folders.addAll(unvisitedFolders)
+        unvisitedFolders.forEach {
+            traverseBranch(bookmarks, folders, it.id, visitedFolderIds)
         }
         return Pair(bookmarks, folders)
     }
@@ -434,6 +447,8 @@ class RealSavedSitesRepository(
             type = FOLDER,
         )
         savedSitesEntitiesDao.insert(entity)
+        // a folder has a single parent, so re-inserting one has to replace its relation instead of adding a second
+        savedSitesRelationsDao.deleteRelationByEntity(folder.id)
         savedSitesRelationsDao.insert(Relation(folderId = folder.parentId, entityId = folder.id))
         savedSitesEntitiesDao.updateModified(folder.parentId, folder.lastModified ?: DatabaseDateFormatter.iso8601())
         return folder

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/service/SavedSitesExporter.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/service/SavedSitesExporter.kt
@@ -79,7 +79,7 @@ class RealSavedSitesExporter(
     @VisibleForTesting
     fun getTreeFolderStructure(): TreeNode<FolderTreeItem> {
         val node = TreeNode(FolderTreeItem(SavedSitesNames.BOOKMARKS_ROOT, RealSavedSitesParser.BOOKMARKS_FOLDER, "", null))
-        populateNode(node, SavedSitesNames.BOOKMARKS_ROOT, 1)
+        populateNode(node, SavedSitesNames.BOOKMARKS_ROOT, 1, mutableSetOf(SavedSitesNames.BOOKMARKS_ROOT))
         return node
     }
 
@@ -87,13 +87,17 @@ class RealSavedSitesExporter(
         parentNode: TreeNode<FolderTreeItem>,
         parentId: String,
         currentDepth: Int,
+        visitedFolderIds: MutableSet<String>,
     ) {
         val combinedContent = savedSitesRepository.getFolderTreeItems(parentId)
         combinedContent.forEach { item ->
             if (item.url == null) {
-                val childNode = TreeNode(item.copy(depth = currentDepth))
-                parentNode.add(childNode)
-                populateNode(childNode, item.id, currentDepth + 1)
+                // folder relations can form a loop, so a folder already on this branch is never descended into again
+                if (visitedFolderIds.add(item.id)) {
+                    val childNode = TreeNode(item.copy(depth = currentDepth))
+                    parentNode.add(childNode)
+                    populateNode(childNode, item.id, currentDepth + 1, visitedFolderIds)
+                }
             } else {
                 val childNode = TreeNode(item.copy(depth = currentDepth))
                 parentNode.add(childNode)

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/RealSyncSavedSitesRepository.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/RealSyncSavedSitesRepository.kt
@@ -417,6 +417,8 @@ class RealSyncSavedSitesRepository(
     }
 
     private fun traverseParents(entity: String, entitiesToUpdate: MutableList<String>) {
+        // folder relations can form a loop, so an entity already collected is never walked up from again
+        if (entitiesToUpdate.contains(entity)) return
         // find parent of each entity
         entitiesToUpdate.add(entity)
         val parents = savedSitesRelationsDao.relationsByEntityId(entity)

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncDataProvider.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncDataProvider.kt
@@ -133,7 +133,10 @@ class SavedSitesSyncDataProvider @Inject constructor(
     private fun getRequestEntriesFor(
         folderId: String,
         requestEntries: MutableList<SyncSavedSitesRequestEntry>,
+        visitedFolderIds: MutableSet<String> = mutableSetOf(),
     ): List<SyncSavedSitesRequestEntry> {
+        // folder relations can form a loop, so a folder already on this branch is never descended into again
+        if (!visitedFolderIds.add(folderId)) return requestEntries
         val invalidItems = mutableListOf<String>()
         syncSavedSitesRepository.getAllFolderContentSync(folderId).apply {
             val folder = repository.getFolder(folderId)
@@ -156,7 +159,7 @@ class SavedSitesSyncDataProvider @Inject constructor(
                     if (eachFolder.deleted != null) {
                         requestEntries.add(deletedEntry(eachFolder.id))
                     } else {
-                        getRequestEntriesFor(eachFolder.id, requestEntries)
+                        getRequestEntriesFor(eachFolder.id, requestEntries, visitedFolderIds)
                     }
                 }
                 requestEntries.add(encryptedFolder(fixFolderIfNecessary(folder)))


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/Android/issues/5928
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

A bookmark folder that ends up inside one of its own descendants (for example FolderA contains FolderB and FolderB contains FolderA) makes every recursive walk over the `relations` table loop until the stack overflows, and the app is killed with a `StackOverflowError`. Three walks were affected:

- `traverseFolderWithDepth`, used by the folder picker (`getFolderTree`)
- `traverseBranch`, used when fetching or deleting a folder branch (`getFolderBranch` / `deleteFolderBranch`)
- `populateNode` in `RealSavedSitesExporter`, used by the bookmarks HTML export
- `getRequestEntriesFor` in `SavedSitesSyncDataProvider`, which walks folder contents to build the sync upload
- `traverseParents` in `RealSyncSavedSitesRepository`, which walks up to the root after sync deduplication

Each walk now carries the set of folder ids already on its path and skips any folder it has seen, so a cycle is visited once and the walk terminates. Output for normal, acyclic trees is unchanged.

`insert(folder)` also now replaces the folder's existing parent relation instead of adding a second one. `Relation`'s primary key is autogenerated, so `OnConflictStrategy.REPLACE` never deduplicated it, and re-inserting a folder could create the multi-parent state that leads to cycles.

Sync is also the most likely way such a loop appears in the first place, since folder moves made on two devices can merge into a state where each folder contains the other, so the two sync walks are guarded too and covered by unit tests.

Reproduced on a physical device by inserting one cyclic row into `relations`: the folder picker, the export and the folder delete each crashed with several thousand frames of the corresponding traversal. All three complete with this change on the same data.

Related: #9704 guards `traverseBranch` only. This change covers all five recursions plus the insert path.

### Steps to test this PR

_Cyclic folder relations no longer crash_
- [x] On a debug build, bookmark a site, create FolderA and FolderB inside it, then add a row to `relations` with `folderId = FolderB.id` and `entityId = FolderA.id` (e.g. pull `app.db`, edit with `sqlite3`, push back while the app is force-stopped)
- [x] Open Bookmarks → overflow on a bookmark → Edit → Location: the picker lists Bookmarks / FolderA / FolderB instead of the app being killed
- [x] Bookmarks → overflow → Export: an HTML file is written with each folder listed once
- [x] Bookmarks → overflow on FolderA → Delete → confirm, wait for the snackbar to expire: the folder branch is removed, the app stays alive, and no dangling relations remain

_Normal folder operations are unchanged_
- [x] Create a folder, move a bookmark into it via the picker, export and re-import the file, delete a folder and tap Undo: all behave as before

### UI changes
| Before | After |
| ------ | ----- |
| Folder picker never renders, app is killed | Folder picker lists the cyclic folders and the app stays alive |

![Folder picker before/after](https://raw.githubusercontent.com/theabhishekchandra/Android/pr-folder-cycle-assets/folder-cycle-before-after.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core bookmark tree, export, and sync traversal; behavior for valid trees should be unchanged, but incorrect visit logic could omit folders or leave bad relations after insert.
> 
> **Overview**
> **Prevents `StackOverflowError` when bookmark folder relations form a cycle** (e.g. Folder A contains B and B contains A). Recursive walks over the `relations` table now keep a **visited-folder set** and skip folders already on the current path, so each folder is handled once and traversal stops.
> 
> The same cycle guard is applied across **folder picker** (`getFolderTree` / `traverseFolderWithDepth`), **branch fetch/delete** (`traverseBranch`), **HTML export** (`populateNode`), **sync payload building** (`getRequestEntriesFor`), and **parent walks for dedup sync** (`traverseParents` in `RealSyncSavedSitesRepository`).
> 
> **`insert(BookmarkFolder)`** now **deletes the folder’s existing parent relation** before inserting the new one, so re-inserting a folder cannot accumulate multiple parents (a path that could create cycles, since `Relation` uses an autogenerated PK and `REPLACE` did not dedupe).
> 
> Tests cover cyclic data for those flows plus **no duplicate relation** when the same folder is inserted twice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f34a04976a54002573b8cac9e4c93816317cffd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

