### PR TITLE
Remove duckAiSettings toggle

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -253,13 +253,6 @@ interface DuckChatFeature {
     fun aiFeaturesNativeControls(): Toggle
 
     /**
-     * @return `true` when the "Duck.ai Settings" link is visible in AI Features.
-     * If the remote feature is not present defaults to `internal`
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
-    fun duckAiSettings(): Toggle
-
-    /**
      * @return Toggle iseÉnabled `true` when the remove chat history feature is enabled.
      * If the remote feature is not present defaults to `true`
      */

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
@@ -157,7 +157,7 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
                 searchAssistVisibility = searchAssistVisibility,
                 hideAiGeneratedImages = hideAiGeneratedImages,
                 isUseWithoutAiActionEnabled = !isAlreadyWithoutAi,
-                isDuckAiWebSettingsVisible = isDuckChatUserEnabled && duckChatFeature.duckAiSettings().isEnabled(),
+                isDuckAiWebSettingsVisible = isDuckChatUserEnabled,
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), ViewState())
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
@@ -1045,10 +1045,8 @@ class DuckChatSettingsViewModelTest {
         }
 
     @Test
-    fun `when duckAiSettings toggle enabled and duck chat enabled then isDuckAiWebSettingsVisible is true`() =
+    fun `when duck chat enabled then isDuckAiWebSettingsVisible is true`() =
         runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.duckAiSettings().setRawStoredState(State(enable = true))
             whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(true))
             testee = DuckChatSettingsViewModel(
                 duckChatActivityParams = DuckChatSettingsNoParams,
@@ -1068,33 +1066,8 @@ class DuckChatSettingsViewModelTest {
         }
 
     @Test
-    fun `when duckAiSettings toggle disabled then isDuckAiWebSettingsVisible is false`() =
+    fun `when duck chat disabled then isDuckAiWebSettingsVisible is false`() =
         runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.duckAiSettings().setRawStoredState(State(enable = false))
-            whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(true))
-            testee = DuckChatSettingsViewModel(
-                duckChatActivityParams = DuckChatSettingsNoParams,
-                duckChat = duckChat,
-                pixel = mockPixel,
-                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
-                settingsPageFeature = settingsPageFeature,
-                duckChatPixels = mockDuckChatPixels,
-                dispatcherProvider = coroutineRule.testDispatcherProvider,
-                duckChatFeature = duckChatFeature,
-                serpSettingsDataProvider = serpSettingsDataProvider,
-            )
-
-            testee.viewState.test {
-                assertFalse(awaitItem().isDuckAiWebSettingsVisible)
-            }
-        }
-
-    @Test
-    fun `when duckAiSettings toggle enabled and duck chat disabled then isDuckAiWebSettingsVisible is false`() =
-        runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.duckAiSettings().setRawStoredState(State(enable = true))
             whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(false))
             testee = DuckChatSettingsViewModel(
                 duckChatActivityParams = DuckChatSettingsNoParams,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1216310295964780?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

- Removes the `duckAiSettings` feature toggle

### Steps to test this PR

- [ ] Verify "Duck.ai Settings" is visible in "AI Features"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small feature-flag cleanup that broadens when the web settings link appears (only when Duck Chat is user-enabled); no auth or data-path changes.
> 
> **Overview**
> Removes the **`duckAiSettings`** remote feature flag from `DuckChatFeature` and stops using it to gate the Duck.ai web settings entry in AI Features settings.
> 
> **`isDuckAiWebSettingsVisible`** in `DuckChatSettingsViewModel` now tracks only whether the user has Duck Chat enabled (`isDuckChatUserEnabled`), so the "Duck.ai Settings" link shows whenever Duck.ai is on for the user, without a separate remote kill switch.
> 
> View model tests are updated to match: toggle setup is dropped, and coverage is reduced to enabled vs disabled Duck Chat user setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c1461a76fb0d3f6a2b5b56aefd9615a91a00f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->