### PR TITLE
Update content scope scripts to version 17.2.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -551,7 +551,8 @@
     "trackerProtection",
     // only enabled on apple platforms
     "textSelection",
-    "uaChBrands"
+    "uaChBrands",
+    "chromeWebstorePatching"
   ];
   var selfGatingFeatures = ["trackerProtection", "uaChBrands"];
   function isPlatformSpecificFeature(featureName) {
@@ -626,7 +627,8 @@
       "trackerProtection",
       "tabSuspension",
       "autofillPasskeys",
-      "textSelection"
+      "textSelection",
+      "chromeWebstorePatching"
     ]
   );
   var platformSupport = {
@@ -699,7 +701,8 @@
       "duckAiDataClearing",
       "performanceMetrics",
       "duckAiChatHistory",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "chromeWebstorePatching"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -2066,7 +2066,8 @@
     "trackerProtection",
     // only enabled on apple platforms
     "textSelection",
-    "uaChBrands"
+    "uaChBrands",
+    "chromeWebstorePatching"
   ];
   var selfGatingFeatures = ["trackerProtection", "uaChBrands"];
   function isPlatformSpecificFeature(featureName) {
@@ -2170,7 +2171,8 @@
       "trackerProtection",
       "tabSuspension",
       "autofillPasskeys",
-      "textSelection"
+      "textSelection",
+      "chromeWebstorePatching"
     ]
   );
   var platformSupport = {
@@ -2243,7 +2245,8 @@
       "duckAiDataClearing",
       "performanceMetrics",
       "duckAiChatHistory",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "chromeWebstorePatching"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2066,7 +2066,8 @@
     "trackerProtection",
     // only enabled on apple platforms
     "textSelection",
-    "uaChBrands"
+    "uaChBrands",
+    "chromeWebstorePatching"
   ];
   var selfGatingFeatures = ["trackerProtection", "uaChBrands"];
   function isPlatformSpecificFeature(featureName) {
@@ -2142,7 +2143,8 @@
       "trackerProtection",
       "tabSuspension",
       "autofillPasskeys",
-      "textSelection"
+      "textSelection",
+      "chromeWebstorePatching"
     ]
   );
   var platformSupport = {
@@ -2215,7 +2217,8 @@
       "duckAiDataClearing",
       "performanceMetrics",
       "duckAiChatHistory",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "chromeWebstorePatching"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1422,7 +1422,8 @@
     "trackerProtection",
     // only enabled on apple platforms
     "textSelection",
-    "uaChBrands"
+    "uaChBrands",
+    "chromeWebstorePatching"
   ];
   var selfGatingFeatures = ["trackerProtection", "uaChBrands"];
   function isPlatformSpecificFeature(featureName) {
@@ -1507,7 +1508,8 @@
       "trackerProtection",
       "tabSuspension",
       "autofillPasskeys",
-      "textSelection"
+      "textSelection",
+      "chromeWebstorePatching"
     ]
   );
   var platformSupport = {
@@ -1580,7 +1582,8 @@
       "duckAiDataClearing",
       "performanceMetrics",
       "duckAiChatHistory",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "chromeWebstorePatching"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -533,7 +533,8 @@
     "trackerProtection",
     // only enabled on apple platforms
     "textSelection",
-    "uaChBrands"
+    "uaChBrands",
+    "chromeWebstorePatching"
   ];
   var selfGatingFeatures = ["trackerProtection", "uaChBrands"];
   function isPlatformSpecificFeature(featureName) {
@@ -608,7 +609,8 @@
       "trackerProtection",
       "tabSuspension",
       "autofillPasskeys",
-      "textSelection"
+      "textSelection",
+      "chromeWebstorePatching"
     ]
   );
   var platformSupport = {
@@ -681,7 +683,8 @@
       "duckAiDataClearing",
       "performanceMetrics",
       "duckAiChatHistory",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "chromeWebstorePatching"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
@@ -533,7 +533,8 @@
     "trackerProtection",
     // only enabled on apple platforms
     "textSelection",
-    "uaChBrands"
+    "uaChBrands",
+    "chromeWebstorePatching"
   ];
   var selfGatingFeatures = ["trackerProtection", "uaChBrands"];
   function isPlatformSpecificFeature(featureName) {
@@ -608,7 +609,8 @@
       "trackerProtection",
       "tabSuspension",
       "autofillPasskeys",
-      "textSelection"
+      "textSelection",
+      "chromeWebstorePatching"
     ]
   );
   var platformSupport = {
@@ -681,7 +683,8 @@
       "duckAiDataClearing",
       "performanceMetrics",
       "duckAiChatHistory",
-      "autofillPasskeys"
+      "autofillPasskeys",
+      "chromeWebstorePatching"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^16.34.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#17.0.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#17.2.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "16.36.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.36.0.tgz",
-      "integrity": "sha512-a5W0QGkRJgOQdFko4LRtRpdxnFzTBwTAaMcgrJG6cEsj+WvFB7C9hB3P+gc/Oyke3dNgIsdqEqUx3vl9hQurgQ==",
+      "version": "16.38.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.38.0.tgz",
+      "integrity": "sha512-DNMsSOX9P5btSXc1Y8aWmdm0/P1eHWtKomaa97rL/XrCdq+LXPa8/38TOcLYsU5mdprHzYnqPwxWJm6V/xVS/w==",
       "license": "MPL-2.0",
       "dependencies": {
         "tldts-experimental": "^7.4.3"
@@ -61,7 +61,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#e27d61495b3e8793e507a483d885b758e75c0732",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9287f33ab29e2a00e71a9741bce5107ef7604d00",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^16.34.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#17.0.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#17.2.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1218207265376188

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run