### PR TITLE
Make onboarding widget bottom sheet assertion optional

### DIFF
--- a/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
+++ b/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
@@ -52,12 +52,22 @@ tags:
           text: ".*Remember: every time you browse with me a creepy ad loses its.wings..*"
       - runFlow: ../shared/browser_screen/click_on_tabs_button.yaml
       - tapOn: "New Tab"
-      # In the widget cohorts of addToDockAndWidgetExperimentJul25 the linear plan already showed
-      # the widget page, so AddWidgetModalEvaluator suppresses this sheet (unit-tested). Assert it
-      # appears only in the cohorts that didn't get that page.
       - runFlow:
           when:
             true: ${!output.linearWidgetPromptShown}
           commands:
             - assertVisible:
+                text: ".*Try our Home screen widget!.*"
+      - runFlow:
+          when:
+            true: ${output.linearWidgetPromptShown}
+          commands:
+            # Optional so the wait itself can't fail: it exists to give the sheet the ~450ms
+            # window it would have had, so the assertion below can't pass by running too early.
+            - extendedWaitUntil:
+                visible:
+                  text: ".*Try our Home screen widget!.*"
+                timeout: 3000
+                optional: true
+            - assertNotVisible:
                 text: ".*Try our Home screen widget!.*"

--- a/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
+++ b/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
@@ -52,5 +52,11 @@ tags:
           text: ".*Remember: every time you browse with me a creepy ad loses its.wings..*"
       - runFlow: ../shared/browser_screen/click_on_tabs_button.yaml
       - tapOn: "New Tab"
-      - assertVisible:
-          text: ".*Try our Home screen widget!.*"
+      # Suppressed when the linear plan already showed the widget page (see
+      # AddWidgetModalEvaluator), which happens in the widget cohorts of
+      # addToDockAndWidgetExperimentJul25 — so this stays optional.
+      - extendedWaitUntil:
+          visible:
+            text: ".*Try our Home screen widget!.*"
+          timeout: 3000
+          optional: true

--- a/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
+++ b/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
@@ -62,8 +62,6 @@ tags:
           when:
             true: ${output.linearWidgetPromptShown}
           commands:
-            # Optional so the wait itself can't fail: it exists to give the sheet the ~450ms
-            # window it would have had, so the assertion below can't pass by running too early.
             - extendedWaitUntil:
                 visible:
                   text: ".*Try our Home screen widget!.*"

--- a/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
+++ b/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
@@ -52,11 +52,21 @@ tags:
           text: ".*Remember: every time you browse with me a creepy ad loses its.wings..*"
       - runFlow: ../shared/browser_screen/click_on_tabs_button.yaml
       - tapOn: "New Tab"
-      # Suppressed when the linear plan already showed the widget page (see
-      # AddWidgetModalEvaluator), which happens in the widget cohorts of
-      # addToDockAndWidgetExperimentJul25 — so this stays optional.
+      # The widget bottom sheet is suppressed when the linear plan already showed the widget page
       - extendedWaitUntil:
           visible:
             text: ".*Try our Home screen widget!.*"
           timeout: 3000
           optional: true
+      - runFlow:
+          when:
+            true: ${!output.linearWidgetPromptShown}
+          commands:
+            - assertVisible:
+                text: ".*Try our Home screen widget!.*"
+      - runFlow:
+          when:
+            true: ${output.linearWidgetPromptShown}
+          commands:
+            - assertNotVisible:
+                text: ".*Try our Home screen widget!.*"

--- a/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
+++ b/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
@@ -52,21 +52,12 @@ tags:
           text: ".*Remember: every time you browse with me a creepy ad loses its.wings..*"
       - runFlow: ../shared/browser_screen/click_on_tabs_button.yaml
       - tapOn: "New Tab"
-      # The widget bottom sheet is suppressed when the linear plan already showed the widget page
-      - extendedWaitUntil:
-          visible:
-            text: ".*Try our Home screen widget!.*"
-          timeout: 3000
-          optional: true
+      # In the widget cohorts of addToDockAndWidgetExperimentJul25 the linear plan already showed
+      # the widget page, so AddWidgetModalEvaluator suppresses this sheet (unit-tested). Assert it
+      # appears only in the cohorts that didn't get that page.
       - runFlow:
           when:
             true: ${!output.linearWidgetPromptShown}
           commands:
             - assertVisible:
-                text: ".*Try our Home screen widget!.*"
-      - runFlow:
-          when:
-            true: ${output.linearWidgetPromptShown}
-          commands:
-            - assertNotVisible:
                 text: ".*Try our Home screen widget!.*"

--- a/.maestro/shared/pre_onboarding.yaml
+++ b/.maestro/shared/pre_onboarding.yaml
@@ -1,5 +1,9 @@
 appId: com.duckduckgo.mobile.android
 ---
+# Consumers need to know whether the linear widget page ran: it and the end-of-onboarding widget
+# bottom sheet are mutually exclusive (see AddWidgetModalEvaluator). Initialised here rather than in
+# onboarding_scripts/setup.js because this flow is also called directly, without that script.
+- evalScript: ${output.linearWidgetPromptShown = false}
 - assertVisible:
     text: ".*(Ready for a faster browser that protects you and lets you decide when and how to use.AI|Ready for a faster browser that puts you in.control).*"
 - tapOn:
@@ -51,6 +55,7 @@ appId: com.duckduckgo.mobile.android
         id: "widgetPromptTitle"
     commands:
       - tapOn: "Not Now"
+      - evalScript: ${output.linearWidgetPromptShown = true}
 - assertVisible:
     text: ".*where should I put your address.bar?.*"
 - tapOn: "next"

--- a/.maestro/shared/pre_onboarding.yaml
+++ b/.maestro/shared/pre_onboarding.yaml
@@ -1,8 +1,7 @@
 appId: com.duckduckgo.mobile.android
 ---
-# Consumers need to know whether the linear widget page ran: it and the end-of-onboarding widget
-# bottom sheet are mutually exclusive (see AddWidgetModalEvaluator). Initialised here rather than in
-# onboarding_scripts/setup.js because this flow is also called directly, without that script.
+# Consumers need to know whether the linear widget step was shown: it and the end-of-onboarding widget
+# bottom sheet are mutually exclusive (see AddWidgetModalEvaluator).
 - evalScript: ${output.linearWidgetPromptShown = false}
 - assertVisible:
     text: ".*(Ready for a faster browser that protects you and lets you decide when and how to use.AI|Ready for a faster browser that puts you in.control).*"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1218223868976953?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

The `onboarding_dismiss_all_dialogs` flow asserted the end-of-onboarding "Try our Home screen widget!" bottom sheet unconditionally, but that sheet is suppressed in the widget cohorts of `addToDockAndWidgetExperimentJul25` — the linear onboarding plan has already shown the widget page, so `AddWidgetModalEvaluator` skips it. Cohort is re-rolled on every `clearState`, so the flow failed in a fraction of runs.

`pre_onboarding` now records whether the linear widget page ran, and the flow asserts the sheet is visible when it didn't and not visible when it did.

### Steps to test this PR

_Onboarding widget prompt_
- [ ] Run `.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml` locally and confirm it passes

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes|No UI changes|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Maestro onboarding test flow changes only; no production app or runtime behavior is modified.
> 
> **Overview**
> Fixes flaky `onboarding_dismiss_all_dialogs` runs where the end-of-onboarding **"Try our Home screen widget!"** bottom sheet is not shown because widget experiment cohorts already surfaced the linear widget step during pre-onboarding (`AddWidgetModalEvaluator` skips the NTP promo when that happened).
> 
> **`pre_onboarding.yaml`** initializes `output.linearWidgetPromptShown` to `false` and sets it to `true` when the optional linear widget prompt (`widgetPromptTitle`) is dismissed, so downstream flows know which UI path ran.
> 
> **`onboarding_dismiss_all_dialogs.yaml`** replaces the unconditional widget bottom-sheet visibility assert with two conditional branches: assert the sheet is visible when the linear prompt did not run, and when it did, optionally wait then assert the sheet is **not** visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d7079ed07804c55ddf56a0dde785c8d1077e75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->