### PR TITLE
Permissions: Redesigned reminder dialog and snackbar copy

### DIFF
--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -875,6 +875,7 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
     ) {
         StackedAlertDialogBuilder(activity)
             .setRebrandUpdate(true)
+            .setCancellable(true)
             .setHeaderImageResource(iconRes)
             .setTitle(titleRes)
             .setMessage(contentRes)

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -696,11 +696,12 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
     private fun systemPermissionDenied() {
         when (systemPermissionsHelper.isPermissionsRejectedForever(activity)) {
             true -> showSystemPermissionsDeniedDialog()
-            false -> showPermissionsDeniedSnackBar()
+            false -> showPermissionsDeniedSnackBar(permissionPermanent)
         }
     }
 
     private fun showPermissionsDeniedSnackBar(rememberChoice: Boolean = false) {
+        val redesigned = sitePermissionsDialogRedesignFeature.self().isEnabled()
         val onPermissionAllowed: () -> Unit
         val message =
             when (permissionRequested) {
@@ -708,17 +709,21 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                     onPermissionAllowed = {
                         askForCameraPermissions(rememberChoice)
                     }
-                    R.string.sitePermissionsCameraDeniedSnackBarMessage
+                    if (redesigned) {
+                        R.string.sitePermissionsTieredCameraDeniedSnackBarMessage
+                    } else {
+                        R.string.sitePermissionsCameraDeniedSnackBarMessage
+                    }
                 }
 
                 SitePermissionsRequestedType.AUDIO -> {
                     onPermissionAllowed = {
                         askForMicPermissions(rememberChoice)
                     }
-                    if (isDuckAiAudioCapture) {
-                        R.string.duckAiMicPermissionDeniedSnackBarMessage
-                    } else {
-                        R.string.sitePermissionsMicDeniedSnackBarMessage
+                    when {
+                        isDuckAiAudioCapture -> R.string.duckAiMicPermissionDeniedSnackBarMessage
+                        redesigned -> R.string.sitePermissionsTieredMicDeniedSnackBarMessage
+                        else -> R.string.sitePermissionsMicDeniedSnackBarMessage
                     }
                 }
 
@@ -726,14 +731,22 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                     onPermissionAllowed = {
                         askForMicAndCameraPermissions(rememberChoice)
                     }
-                    R.string.sitePermissionsCameraAndMicDeniedSnackBarMessage
+                    if (redesigned) {
+                        R.string.sitePermissionsTieredCameraAndMicDeniedSnackBarMessage
+                    } else {
+                        R.string.sitePermissionsCameraAndMicDeniedSnackBarMessage
+                    }
                 }
 
                 SitePermissionsRequestedType.LOCATION -> {
                     onPermissionAllowed = {
                         askForLocationPermissions(rememberChoice)
                     }
-                    R.string.sitePermissionsLocationDeniedSnackBarMessage
+                    if (redesigned) {
+                        R.string.sitePermissionsTieredLocationDeniedSnackBarMessage
+                    } else {
+                        R.string.sitePermissionsLocationDeniedSnackBarMessage
+                    }
                 }
             }
 
@@ -792,30 +805,38 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
         // OS-level denial is not a site-level Never Allow, so no site choice is persisted here
         denyPermissions()
 
-        val openAppSettings = { activity.launchApplicationInfoSettings() }
+        val openAppSettings: () -> Unit = { activity.launchApplicationInfoSettings() }
 
         if (isDuckAiAudioCapture) {
-            StackedAlertDialogBuilder(activity)
-                .setRebrandUpdate(true)
-                .setHeaderImageResource(CommonR.drawable.ic_microphone_24)
-                .setTitle(R.string.duckAiMicPermissionDeniedDialogTitle)
-                .setMessage(R.string.duckAiMicPermissionDeniedDialogContent)
-                .setStackedButtons(
-                    listOf(
-                        StackedButton(R.string.duckAiMicPermissionDeniedDialogPositiveButton, PRIMARY, CommonR.drawable.ic_open_in_16),
-                        StackedButton(R.string.systemPermissionsDeniedDialogNegativeButton, SECONDARY),
-                    ),
-                )
-                .addEventListener(
-                    object : StackedAlertDialogBuilder.EventListener() {
-                        override fun onButtonClicked(position: Int) {
-                            if (position == CHANGE_PERMISSIONS_BUTTON) {
-                                openAppSettings()
-                            }
-                        }
-                    },
-                )
-                .show()
+            showChangePermissionsDialog(
+                iconRes = CommonR.drawable.ic_microphone_24,
+                titleRes = R.string.duckAiMicPermissionDeniedDialogTitle,
+                contentRes = R.string.duckAiMicPermissionDeniedDialogContent,
+                buttonRes = R.string.duckAiMicPermissionDeniedDialogPositiveButton,
+                openAppSettings = openAppSettings,
+            )
+        } else if (sitePermissionsDialogRedesignFeature.self().isEnabled()) {
+            showChangePermissionsDialog(
+                iconRes = when (permissionRequested) {
+                    SitePermissionsRequestedType.CAMERA, SitePermissionsRequestedType.CAMERA_AND_AUDIO -> CommonR.drawable.ic_video_24
+                    SitePermissionsRequestedType.AUDIO -> CommonR.drawable.ic_microphone_24
+                    SitePermissionsRequestedType.LOCATION -> CommonR.drawable.ic_location_24
+                },
+                titleRes = when (permissionRequested) {
+                    SitePermissionsRequestedType.CAMERA -> R.string.sitePermissionsTieredSystemDeniedCameraTitle
+                    SitePermissionsRequestedType.AUDIO -> R.string.sitePermissionsTieredSystemDeniedMicTitle
+                    SitePermissionsRequestedType.CAMERA_AND_AUDIO -> R.string.sitePermissionsTieredSystemDeniedCameraAndMicTitle
+                    SitePermissionsRequestedType.LOCATION -> R.string.sitePermissionsTieredSystemDeniedLocationTitle
+                },
+                contentRes = when (permissionRequested) {
+                    SitePermissionsRequestedType.CAMERA -> R.string.sitePermissionsTieredSystemDeniedCameraContent
+                    SitePermissionsRequestedType.AUDIO -> R.string.sitePermissionsTieredSystemDeniedMicContent
+                    SitePermissionsRequestedType.CAMERA_AND_AUDIO -> R.string.sitePermissionsTieredSystemDeniedCameraAndMicContent
+                    SitePermissionsRequestedType.LOCATION -> R.string.sitePermissionsTieredSystemDeniedLocationContent
+                },
+                buttonRes = R.string.sitePermissionsDialogChangePermissionsButton,
+                openAppSettings = openAppSettings,
+            )
         } else {
             val titleRes = when (permissionRequested) {
                 SitePermissionsRequestedType.CAMERA -> R.string.systemPermissionDialogCameraDeniedTitle
@@ -843,6 +864,36 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                 )
                 .show()
         }
+    }
+
+    private fun showChangePermissionsDialog(
+        @DrawableRes iconRes: Int,
+        @StringRes titleRes: Int,
+        @StringRes contentRes: Int,
+        @StringRes buttonRes: Int,
+        openAppSettings: () -> Unit,
+    ) {
+        StackedAlertDialogBuilder(activity)
+            .setRebrandUpdate(true)
+            .setHeaderImageResource(iconRes)
+            .setTitle(titleRes)
+            .setMessage(contentRes)
+            .setStackedButtons(
+                listOf(
+                    StackedButton(buttonRes, PRIMARY, CommonR.drawable.ic_open_in_16),
+                    StackedButton(R.string.systemPermissionsDeniedDialogNegativeButton, SECONDARY),
+                ),
+            )
+            .addEventListener(
+                object : StackedAlertDialogBuilder.EventListener() {
+                    override fun onButtonClicked(position: Int) {
+                        if (position == CHANGE_PERMISSIONS_BUTTON) {
+                            openAppSettings()
+                        }
+                    }
+                },
+            )
+            .show()
     }
 
     private fun storeFavicon(url: String) {

--- a/site-permissions/site-permissions-impl/src/main/res/values/donottranslate.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values/donottranslate.xml
@@ -29,4 +29,21 @@
     <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your microphone</string>
     <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your camera and microphone</string>
     <string name="sitePermissionsTieredDrmDialogSubtitle">If you don\'t allow, videos on the site may become unplayable, but this site will not have access to device identifiers provided by DRM software.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton">Change Permissions</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo needs to access your location</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Location permissions are needed if you want to use location features on this site.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo needs to access your camera</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Camera permissions are needed if you want to use camera features on this site.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo needs to access your microphone</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Microphone permissions are needed if you want to use microphone features on this site.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo needs to access your camera and microphone</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Camera and microphone permissions are needed if you want to use camera and microphone features on this site.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo couldn\'t share location with this site</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo couldn\'t give camera access to this site</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo couldn\'t give microphone access to this site</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo couldn\'t give camera and microphone access to this site</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncherTest.kt
+++ b/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncherTest.kt
@@ -63,6 +63,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -920,6 +921,18 @@ class SitePermissionsDialogActivityLauncherTest {
             dialog.context.getString(R.string.sitePermissionsTieredSystemDeniedCameraTitle),
             dialog.findViewById<TextView>(CommonR.id.stackedAlertDialogTitle)!!.text,
         )
+    }
+
+    @Test
+    fun whenReminderDialogIsDismissedThenRequestStaysDeniedWithoutPersisting() {
+        val dialog = denyOsPermissionAfter(tier = 1, rejectedForever = true)!!
+
+        dialog.cancel()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertTrue(shadowOf(dialog).isCancelable)
+        verify(request).deny()
+        verify(sitePermissionsRepository, never()).sitePermissionPermanentlySaved(any(), any(), any())
     }
 
     @Test

--- a/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncherTest.kt
+++ b/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncherTest.kt
@@ -70,6 +70,7 @@ import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowDialog
 import com.duckduckgo.mobile.android.R as CommonR
+import com.google.android.material.R as MaterialR
 
 @RunWith(AndroidJUnit4::class)
 class SitePermissionsDialogActivityLauncherTest {
@@ -347,7 +348,8 @@ class SitePermissionsDialogActivityLauncherTest {
         sitePermissionsDialogRedesignFeature.self().setRawStoredState(Toggle.State(redesignEnabled))
         whenever(systemPermissionsHelper.hasCameraPermissionsGranted()).thenReturn(true)
 
-        val activity = Robolectric.buildActivity(ThemedActivity::class.java).setup().get()
+        activity = Robolectric.buildActivity(ThemedActivity::class.java).setup().get()
+        testee.registerPermissionLauncher(activity)
         val request: PermissionRequest = mock()
         whenever(request.resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE))
         whenever(request.origin).thenReturn(Uri.parse(requestUrl))
@@ -368,6 +370,7 @@ class SitePermissionsDialogActivityLauncherTest {
     }
 
     private lateinit var request: PermissionRequest
+    private lateinit var activity: ThemedActivity
 
     private fun AlertDialog.tieredButtons() =
         findViewById<LinearLayout>(CommonR.id.stackedAlertDialogButtonLayout)!!
@@ -881,6 +884,60 @@ class SitePermissionsDialogActivityLauncherTest {
         val dialog = showCameraDialog(pageUrl = THIRD_PARTY_PAGE, redesignEnabled = false)
 
         assertNotNull(dialog.findViewById<TextView>(CommonR.id.textAlertDialogMessage))
+    }
+
+    private fun denyOsPermissionAfter(
+        tier: Int,
+        rejectedForever: Boolean,
+    ): AlertDialog? {
+        val dialog = showCameraDialog()
+
+        // showCameraDialog leaves the OS permission granted, so revoke it only once the prompt is up.
+        whenever(systemPermissionsHelper.hasCameraPermissionsGranted()).thenReturn(false)
+        whenever(systemPermissionsHelper.isPermissionsRejectedForever(any())).thenReturn(rejectedForever)
+        dialog.tieredButtons().getChildAt(tier).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        val captor = argumentCaptor<(Boolean) -> Unit>()
+        verify(systemPermissionsHelper).registerPermissionLaunchers(any(), captor.capture(), any())
+        captor.firstValue.invoke(false)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        return ShadowDialog.getLatestDialog() as? AlertDialog
+    }
+
+    @Test
+    fun whenSystemPermissionRejectedForeverThenReminderDialogUsesTheStackedComponent() {
+        val dialog = denyOsPermissionAfter(tier = 0, rejectedForever = true)!!
+
+        val buttons = dialog.findViewById<LinearLayout>(CommonR.id.stackedAlertDialogButtonLayout)!!
+        assertEquals(2, buttons.childCount)
+        assertEquals(
+            dialog.context.getString(R.string.sitePermissionsDialogChangePermissionsButton),
+            (buttons.getChildAt(0) as Button).text,
+        )
+        assertEquals(
+            dialog.context.getString(R.string.sitePermissionsTieredSystemDeniedCameraTitle),
+            dialog.findViewById<TextView>(CommonR.id.stackedAlertDialogTitle)!!.text,
+        )
+    }
+
+    @Test
+    fun whenSystemPermissionDeniedOnceThenAllowingFromSnackbarKeepsTheStandingGrant() {
+        denyOsPermissionAfter(tier = 0, rejectedForever = false)
+
+        whenever(systemPermissionsHelper.hasCameraPermissionsGranted()).thenReturn(true)
+        val action = activity.window.decorView.findViewById<Button>(MaterialR.id.snackbar_action)
+        assertNotNull(action)
+        action.performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify(sitePermissionsRepository).sitePermissionPermanentlySaved(
+            "https://example.com",
+            PermissionRequest.RESOURCE_VIDEO_CAPTURE,
+            ALLOW_ALWAYS,
+        )
+        verify(sitePermissionsRepository, never()).sitePermissionGranted(any(), any(), any())
     }
 
     companion object {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -261,6 +261,12 @@ interface SubscriptionsFeature {
     fun allowProTierPurchase(): Toggle
 
     /**
+     * When enabled, the paywall opens a faster-rendering page
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun performanceOptimizedPaywalls(): Toggle
+
+    /**
      * When enabled, pending plan hint is displayed to users.
      * When disabled, pending plans hint is not shown (kill switch for pending plans UI).
      */

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PaywallPathProvider.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PaywallPathProvider.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.internal
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import javax.inject.Inject
+
+interface PaywallPathProvider {
+    fun getPath(featurePage: String): String?
+}
+
+@ContributesBinding(AppScope::class)
+class RealPaywallPathProvider @Inject constructor(
+    private val subscriptionsFeature: SubscriptionsFeature,
+    moshi: Moshi,
+) : PaywallPathProvider {
+
+    private val jsonAdapter: JsonAdapter<PaywallsSettings> by lazy {
+        moshi.newBuilder().add(KotlinJsonAdapterFactory()).build().adapter(PaywallsSettings::class.java)
+    }
+
+    override fun getPath(featurePage: String): String? {
+        val entryPoints = parseSettings()?.entryPoints ?: return null
+        val path = entryPoints[featurePage]?.path ?: return null
+        return path.takeIf { it.isNotBlank() }
+    }
+
+    private fun parseSettings(): PaywallsSettings? =
+        subscriptionsFeature.performanceOptimizedPaywalls().getSettings()?.let {
+            runCatching { jsonAdapter.fromJson(it) }.getOrNull()
+        }
+
+    private class PaywallsSettings(
+        val entryPoints: Map<String, EntryPoint>?,
+    )
+
+    private class EntryPoint(
+        val path: String?,
+    )
+}

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/internal/RealPaywallPathProviderTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/internal/RealPaywallPathProviderTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.internal
+
+import android.annotation.SuppressLint
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
+import com.squareup.moshi.Moshi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@SuppressLint("DenyListedApi")
+class RealPaywallPathProviderTest {
+
+    private val subscriptionsFeature: SubscriptionsFeature = FakeFeatureToggleFactory.create(SubscriptionsFeature::class.java)
+
+    private val moshi = Moshi.Builder().build()
+
+    private val testee = RealPaywallPathProvider(
+        subscriptionsFeature = subscriptionsFeature,
+        moshi = moshi,
+    )
+
+    @Test
+    fun whenSettingsCarryEntryPointsThenPathsAreReturned() {
+        givenSettings(ENTRY_POINTS_SETTINGS)
+
+        assertEquals("/subscriptions/new/mobile/vpn", testee.getPath("vpn"))
+        assertEquals("/subscriptions/new/mobile/duckai", testee.getPath("duckai"))
+        assertEquals("/subscriptions/new/mobile/pir", testee.getPath("pir"))
+    }
+
+    @Test
+    fun whenFeatureDisabledThenPathIsStillReturned() {
+        subscriptionsFeature.performanceOptimizedPaywalls().setRawStoredState(
+            State(remoteEnableState = false, settings = ENTRY_POINTS_SETTINGS),
+        )
+
+        assertEquals("/subscriptions/new/mobile/vpn", testee.getPath("vpn"))
+    }
+
+    @Test
+    fun whenNoSettingsThenNoPath() {
+        subscriptionsFeature.performanceOptimizedPaywalls().setRawStoredState(State(remoteEnableState = true))
+
+        assertNull(testee.getPath("vpn"))
+    }
+
+    @Test
+    fun whenSettingsMalformedThenNoPath() {
+        givenSettings("not json")
+
+        assertNull(testee.getPath("vpn"))
+    }
+
+    @Test
+    fun whenSettingsMissingEntryPointsKeyThenNoPath() {
+        givenSettings("""{"someOtherKey":"value"}""")
+
+        assertNull(testee.getPath("vpn"))
+    }
+
+    @Test
+    fun whenFeaturePageHasNoEntryPointThenNoPath() {
+        givenSettings("""{"entryPoints":{"vpn":{"path":"/subscriptions/new/mobile/vpn"}}}""")
+
+        assertNull(testee.getPath("duckai"))
+        assertNull(testee.getPath("itr"))
+    }
+
+    @Test
+    fun whenPathBlankThenNoPath() {
+        givenSettings("""{"entryPoints":{"vpn":{"path":"  "}}}""")
+
+        assertNull(testee.getPath("vpn"))
+    }
+
+    @Test
+    fun whenEntryPointHasNoPathThenNoPath() {
+        givenSettings("""{"entryPoints":{"vpn":{}}}""")
+
+        assertNull(testee.getPath("vpn"))
+    }
+
+    private fun givenSettings(settings: String) {
+        subscriptionsFeature.performanceOptimizedPaywalls().setRawStoredState(
+            State(remoteEnableState = true, settings = settings),
+        )
+    }
+
+    private companion object {
+        val ENTRY_POINTS_SETTINGS = """
+            {
+                "entryPoints": {
+                    "vpn": {
+                        "path": "/subscriptions/new/mobile/vpn"
+                    },
+                    "duckai": {
+                        "path": "/subscriptions/new/mobile/duckai"
+                    },
+                    "pir": {
+                        "path": "/subscriptions/new/mobile/pir"
+                    }
+                }
+            }
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1218239480235739?focus=true

### Description

This PR updates the design of the permission reminder dialog and the permissions snackbar copy.

Figma: https://www.figma.com/design/aMaDTBcE9Fsfu40NbjzcrH/Permission--iOS-Android-?node-id=6-1734&t=h7xRDCTTiQYiYhcv-4

<img width="2160" height="937" alt="image" src="https://github.com/user-attachments/assets/a9ed55fa-2ad7-4158-9aff-217387590eeb" />

<img width="904" height="964" alt="image" src="https://github.com/user-attachments/assets/8d7f7493-3994-4ffd-92ac-e8061eb864b8" />

### Steps to test this PR

_Snackbar copy, and the tier surviving a retry_
- [x] Clear the app's data so camera has never been asked for
- [x] Open `https://permission.site`
- [x] Verify the HTTP/HTTPS toggle at the top of the page is set to HTTPS
- [x] Tap "Camera"
- [x] Tap "Allow While Using Site"
- [x] On the Android system prompt tap "Don't allow"
- [x] Verify the snackbar reads "DuckDuckGo couldn't give camera access to this site" with an "Allow" action
- [x] Tap "Allow" on the snackbar
- [x] On the Android system prompt tap "Allow"
- [x] Verify the site shows the camera stream
- [x] Open Settings → Permissions → Manage Sites and select `permission.site`
- [x] Verify Camera is set to "Allow"

_Reminder dialog_
- [x] Clear the app's data again
- [x] Open `https://permission.site` and verify the HTTP/HTTPS toggle is set to HTTPS
- [x] Tap "Camera"
- [x] Tap "Allow This Time"
- [x] On the Android system prompt tap "Don't allow"
- [x] Tap "Allow" on the snackbar
- [x] On the Android system prompt tap "Don't allow" again
- [x] Verify a dialog appears with a camera icon in a circle, titled "DuckDuckGo needs to access your camera"
- [x] Verify the body reads "Camera permissions are needed if you want to use camera features on this site."
- [x] Verify the buttons are "Change Permissions" and "Cancel"
- [x] Tap "Change Permissions"
- [x] Verify the DuckDuckGo app settings screen opens

_Location snackbar wording_
- [x] Clear the app's data again
- [x] Open `https://permission.site` and verify the HTTP/HTTPS toggle is set to HTTPS
- [x] Tap "Location"
- [x] Tap "Allow This Time"
- [x] On the Android system prompt tap "Don't allow"
- [x] Verify the snackbar reads "DuckDuckGo couldn't share location with this site"


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes permission denial/reminder flows and how site grants are persisted on snackbar retry; incorrect behavior could block camera/mic/location or save the wrong tier.
> 
> **Overview**
> **Site permissions (redesign flag on):** When Android denies camera/mic/location after a tiered site choice, denial snackbars use new tiered copy, and “don’t ask again” flows show a stacked **Change Permissions** reminder (shared via `showChangePermissionsDialog`) instead of the legacy text dialog—Duck AI mic denial is refactored onto the same stacked UI. OS denial snackbars now pass through the user’s **remember** choice so retrying **Allow** can still apply the standing site grant (e.g. Allow While Using Site).
> 
> **Subscriptions (bundled):** Adds `performanceOptimizedPaywalls` remote toggle and `PaywallPathProvider`, which maps feature entry keys (e.g. `vpn`) to paywall paths from toggle settings JSON; unit tests cover parsing and edge cases. No call-site wiring in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e0c1b32513eb16b860f976560db3eeac08a923f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->