### PR TITLE
Add performanceOptimizedPaywalls feature flag and paths config

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -261,6 +261,12 @@ interface SubscriptionsFeature {
     fun allowProTierPurchase(): Toggle
 
     /**
+     * When enabled, the paywall opens a faster-rendering page
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun performanceOptimizedPaywalls(): Toggle
+
+    /**
      * When enabled, pending plan hint is displayed to users.
      * When disabled, pending plans hint is not shown (kill switch for pending plans UI).
      */

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PaywallPathProvider.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PaywallPathProvider.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.internal
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import javax.inject.Inject
+
+interface PaywallPathProvider {
+    fun getPath(featurePage: String): String?
+}
+
+@ContributesBinding(AppScope::class)
+class RealPaywallPathProvider @Inject constructor(
+    private val subscriptionsFeature: SubscriptionsFeature,
+    moshi: Moshi,
+) : PaywallPathProvider {
+
+    private val jsonAdapter: JsonAdapter<PaywallsSettings> by lazy {
+        moshi.newBuilder().add(KotlinJsonAdapterFactory()).build().adapter(PaywallsSettings::class.java)
+    }
+
+    override fun getPath(featurePage: String): String? {
+        val entryPoints = parseSettings()?.entryPoints ?: return null
+        val path = entryPoints[featurePage]?.path ?: return null
+        return path.takeIf { it.isNotBlank() }
+    }
+
+    private fun parseSettings(): PaywallsSettings? =
+        subscriptionsFeature.performanceOptimizedPaywalls().getSettings()?.let {
+            runCatching { jsonAdapter.fromJson(it) }.getOrNull()
+        }
+
+    private class PaywallsSettings(
+        val entryPoints: Map<String, EntryPoint>?,
+    )
+
+    private class EntryPoint(
+        val path: String?,
+    )
+}

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/internal/RealPaywallPathProviderTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/internal/RealPaywallPathProviderTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.internal
+
+import android.annotation.SuppressLint
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
+import com.squareup.moshi.Moshi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@SuppressLint("DenyListedApi")
+class RealPaywallPathProviderTest {
+
+    private val subscriptionsFeature: SubscriptionsFeature = FakeFeatureToggleFactory.create(SubscriptionsFeature::class.java)
+
+    private val moshi = Moshi.Builder().build()
+
+    private val testee = RealPaywallPathProvider(
+        subscriptionsFeature = subscriptionsFeature,
+        moshi = moshi,
+    )
+
+    @Test
+    fun whenSettingsCarryEntryPointsThenPathsAreReturned() {
+        givenSettings(ENTRY_POINTS_SETTINGS)
+
+        assertEquals("/subscriptions/new/mobile/vpn", testee.getPath("vpn"))
+        assertEquals("/subscriptions/new/mobile/duckai", testee.getPath("duckai"))
+        assertEquals("/subscriptions/new/mobile/pir", testee.getPath("pir"))
+    }
+
+    @Test
+    fun whenFeatureDisabledThenPathIsStillReturned() {
+        subscriptionsFeature.performanceOptimizedPaywalls().setRawStoredState(
+            State(remoteEnableState = false, settings = ENTRY_POINTS_SETTINGS),
+        )
+
+        assertEquals("/subscriptions/new/mobile/vpn", testee.getPath("vpn"))
+    }
+
+    @Test
+    fun whenNoSettingsThenNoPath() {
+        subscriptionsFeature.performanceOptimizedPaywalls().setRawStoredState(State(remoteEnableState = true))
+
+        assertNull(testee.getPath("vpn"))
+    }
+
+    @Test
+    fun whenSettingsMalformedThenNoPath() {
+        givenSettings("not json")
+
+        assertNull(testee.getPath("vpn"))
+    }
+
+    @Test
+    fun whenSettingsMissingEntryPointsKeyThenNoPath() {
+        givenSettings("""{"someOtherKey":"value"}""")
+
+        assertNull(testee.getPath("vpn"))
+    }
+
+    @Test
+    fun whenFeaturePageHasNoEntryPointThenNoPath() {
+        givenSettings("""{"entryPoints":{"vpn":{"path":"/subscriptions/new/mobile/vpn"}}}""")
+
+        assertNull(testee.getPath("duckai"))
+        assertNull(testee.getPath("itr"))
+    }
+
+    @Test
+    fun whenPathBlankThenNoPath() {
+        givenSettings("""{"entryPoints":{"vpn":{"path":"  "}}}""")
+
+        assertNull(testee.getPath("vpn"))
+    }
+
+    @Test
+    fun whenEntryPointHasNoPathThenNoPath() {
+        givenSettings("""{"entryPoints":{"vpn":{}}}""")
+
+        assertNull(testee.getPath("vpn"))
+    }
+
+    private fun givenSettings(settings: String) {
+        subscriptionsFeature.performanceOptimizedPaywalls().setRawStoredState(
+            State(remoteEnableState = true, settings = settings),
+        )
+    }
+
+    private companion object {
+        val ENTRY_POINTS_SETTINGS = """
+            {
+                "entryPoints": {
+                    "vpn": {
+                        "path": "/subscriptions/new/mobile/vpn"
+                    },
+                    "duckai": {
+                        "path": "/subscriptions/new/mobile/duckai"
+                    },
+                    "pir": {
+                        "path": "/subscriptions/new/mobile/pir"
+                    }
+                }
+            }
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218238886830992
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Adds the `performanceOptimizedPaywalls` sub-feature of `privacyPro`, off by default, and the provider that reads the paywall paths from its remote `settings`. The paths are already in production config, merged in duckduckgo/privacy-configuration#5809. 

Nothing is wired to it yet, opening the new URLs comes in the next PR of the stack.

### Steps to test this PR

  _Feature flag_                                                                                                                                                                                                                                                                                                                                                                                                                            
  - [ ] Tap on Settings > Internal Features > Feature Flag Inventory.                                                                                                                                                                                                                                                                                                                                                                       
  - [ ] Search for "performance".                                                                                                                                                                                                                                                                                                                                                                                                           
  - [ ] Verify the `performanceOptimizedPaywalls` toggle is present and off.                                                                                                                                                                                                                                                                                                                                                                
  - [ ] Open the subscription paywall from Settings and verify it loads exactly as it does today.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Off-by-default feature flag and unused path resolver; no subscription launch or purchase flow changes in this diff.
> 
> **Overview**
> Introduces a **`performanceOptimizedPaywalls`** remote sub-feature on `privacyPro` (default **off**) to support faster-rendering paywall URLs in a follow-up change.
> 
> Adds **`PaywallPathProvider`** / **`RealPaywallPathProvider`**, which reads the toggle’s remote **`settings`** JSON (`entryPoints` → per-feature-page `path`) and returns a path for a given feature page, with safe handling for missing/malformed/blank config. Tests document that paths come from **settings**, not from whether the toggle is enabled.
> 
> **No paywall navigation is hooked up in this PR**—existing paywall behavior should be unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05f31c5d4643de761c8bfa30077d7fa2be4748e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->