### PR TITLE
PIR: Remove auth requirement from DBP config endpoints

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/service/DbpService.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/service/DbpService.kt
@@ -30,13 +30,11 @@ import retrofit2.http.Streaming
 
 @ContributesServiceApi(AppScope::class)
 interface DbpService {
-    @PirAuthRequired
     @GET("$BASE_URL/remote/v0/main_config.json")
     suspend fun getMainConfig(
         @Header("If-None-Match") etag: String?,
     ): Response<PirMainConfig>
 
-    @PirAuthRequired
     @GET("$BASE_URL/remote/v0?name=all.zip&type=spec")
     @Streaming
     suspend fun getBrokerJsonFiles(): ResponseBody


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1215453182904602?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1215419939170798?focus=true
API Proposals URL(s) (if applicable): N/A

### Description
Removes the auth token requirements from two DBP endpoints.

### Steps to test this PR

_Dev settings_
- [x] Open PIR Dev settings
- [x] Go to Broker Config and press Reset All Configs
- [x] Filter logcat for `PIR-update`
- [x] Verify you see `PIR-update: Main config result Response{protocol=http/1.1, code=200`
- [x] Verify that all configs were downloaded

_(optional) Reset PIR_
- [ ] Clean install
- [ ] Add subscription
- [ ] Filter logcat for `PIR-update: Main config result Response{protocol=http/1.1, code=200`

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows auth to fewer DBP routes; sensitive PIR operations remain protected, but mis-scoping could expose config fetches if callers assumed token-gated access.
> 
> **Overview**
> **Removes `@PirAuthRequired` from two DBP Retrofit calls** so broker configuration can be fetched without a PIR auth token.
> 
> `getMainConfig` (`main_config.json`) and `getBrokerJsonFiles` (`all.zip` spec bundle) no longer go through the `PirAuthInterceptor` auth header path. **Email generation, captcha, and email-data endpoints stay `@PirAuthRequired`.**
> 
> This matches the backend making public config/spec assets available without subscription auth, which should unblock config refresh flows (e.g. dev “Reset All Configs”) that only need broker metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fc230e84e13194be17e7803a67d27a6dba45720. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->