### PR TITLE
Permissions: Translations

### DIFF
--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -812,7 +812,7 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                 iconRes = CommonR.drawable.ic_microphone_24,
                 titleRes = R.string.duckAiMicPermissionDeniedDialogTitle,
                 contentRes = R.string.duckAiMicPermissionDeniedDialogContent,
-                buttonRes = R.string.duckAiMicPermissionDeniedDialogPositiveButton,
+                buttonRes = R.string.sitePermissionsDialogChangePermissionsButton,
                 openAppSettings = openAppSettings,
             )
         } else if (sitePermissionsDialogRedesignFeature.self().isEnabled()) {

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -875,6 +875,7 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
     ) {
         StackedAlertDialogBuilder(activity)
             .setRebrandUpdate(true)
+            .setCancellable(true)
             .setHeaderImageResource(iconRes)
             .setTitle(titleRes)
             .setMessage(contentRes)

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -696,11 +696,12 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
     private fun systemPermissionDenied() {
         when (systemPermissionsHelper.isPermissionsRejectedForever(activity)) {
             true -> showSystemPermissionsDeniedDialog()
-            false -> showPermissionsDeniedSnackBar()
+            false -> showPermissionsDeniedSnackBar(permissionPermanent)
         }
     }
 
     private fun showPermissionsDeniedSnackBar(rememberChoice: Boolean = false) {
+        val redesigned = sitePermissionsDialogRedesignFeature.self().isEnabled()
         val onPermissionAllowed: () -> Unit
         val message =
             when (permissionRequested) {
@@ -708,17 +709,21 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                     onPermissionAllowed = {
                         askForCameraPermissions(rememberChoice)
                     }
-                    R.string.sitePermissionsCameraDeniedSnackBarMessage
+                    if (redesigned) {
+                        R.string.sitePermissionsTieredCameraDeniedSnackBarMessage
+                    } else {
+                        R.string.sitePermissionsCameraDeniedSnackBarMessage
+                    }
                 }
 
                 SitePermissionsRequestedType.AUDIO -> {
                     onPermissionAllowed = {
                         askForMicPermissions(rememberChoice)
                     }
-                    if (isDuckAiAudioCapture) {
-                        R.string.duckAiMicPermissionDeniedSnackBarMessage
-                    } else {
-                        R.string.sitePermissionsMicDeniedSnackBarMessage
+                    when {
+                        isDuckAiAudioCapture -> R.string.duckAiMicPermissionDeniedSnackBarMessage
+                        redesigned -> R.string.sitePermissionsTieredMicDeniedSnackBarMessage
+                        else -> R.string.sitePermissionsMicDeniedSnackBarMessage
                     }
                 }
 
@@ -726,14 +731,22 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                     onPermissionAllowed = {
                         askForMicAndCameraPermissions(rememberChoice)
                     }
-                    R.string.sitePermissionsCameraAndMicDeniedSnackBarMessage
+                    if (redesigned) {
+                        R.string.sitePermissionsTieredCameraAndMicDeniedSnackBarMessage
+                    } else {
+                        R.string.sitePermissionsCameraAndMicDeniedSnackBarMessage
+                    }
                 }
 
                 SitePermissionsRequestedType.LOCATION -> {
                     onPermissionAllowed = {
                         askForLocationPermissions(rememberChoice)
                     }
-                    R.string.sitePermissionsLocationDeniedSnackBarMessage
+                    if (redesigned) {
+                        R.string.sitePermissionsTieredLocationDeniedSnackBarMessage
+                    } else {
+                        R.string.sitePermissionsLocationDeniedSnackBarMessage
+                    }
                 }
             }
 
@@ -792,30 +805,38 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
         // OS-level denial is not a site-level Never Allow, so no site choice is persisted here
         denyPermissions()
 
-        val openAppSettings = { activity.launchApplicationInfoSettings() }
+        val openAppSettings: () -> Unit = { activity.launchApplicationInfoSettings() }
 
         if (isDuckAiAudioCapture) {
-            StackedAlertDialogBuilder(activity)
-                .setRebrandUpdate(true)
-                .setHeaderImageResource(CommonR.drawable.ic_microphone_24)
-                .setTitle(R.string.duckAiMicPermissionDeniedDialogTitle)
-                .setMessage(R.string.duckAiMicPermissionDeniedDialogContent)
-                .setStackedButtons(
-                    listOf(
-                        StackedButton(R.string.duckAiMicPermissionDeniedDialogPositiveButton, PRIMARY, CommonR.drawable.ic_open_in_16),
-                        StackedButton(R.string.systemPermissionsDeniedDialogNegativeButton, SECONDARY),
-                    ),
-                )
-                .addEventListener(
-                    object : StackedAlertDialogBuilder.EventListener() {
-                        override fun onButtonClicked(position: Int) {
-                            if (position == CHANGE_PERMISSIONS_BUTTON) {
-                                openAppSettings()
-                            }
-                        }
-                    },
-                )
-                .show()
+            showChangePermissionsDialog(
+                iconRes = CommonR.drawable.ic_microphone_24,
+                titleRes = R.string.duckAiMicPermissionDeniedDialogTitle,
+                contentRes = R.string.duckAiMicPermissionDeniedDialogContent,
+                buttonRes = R.string.duckAiMicPermissionDeniedDialogPositiveButton,
+                openAppSettings = openAppSettings,
+            )
+        } else if (sitePermissionsDialogRedesignFeature.self().isEnabled()) {
+            showChangePermissionsDialog(
+                iconRes = when (permissionRequested) {
+                    SitePermissionsRequestedType.CAMERA, SitePermissionsRequestedType.CAMERA_AND_AUDIO -> CommonR.drawable.ic_video_24
+                    SitePermissionsRequestedType.AUDIO -> CommonR.drawable.ic_microphone_24
+                    SitePermissionsRequestedType.LOCATION -> CommonR.drawable.ic_location_24
+                },
+                titleRes = when (permissionRequested) {
+                    SitePermissionsRequestedType.CAMERA -> R.string.sitePermissionsTieredSystemDeniedCameraTitle
+                    SitePermissionsRequestedType.AUDIO -> R.string.sitePermissionsTieredSystemDeniedMicTitle
+                    SitePermissionsRequestedType.CAMERA_AND_AUDIO -> R.string.sitePermissionsTieredSystemDeniedCameraAndMicTitle
+                    SitePermissionsRequestedType.LOCATION -> R.string.sitePermissionsTieredSystemDeniedLocationTitle
+                },
+                contentRes = when (permissionRequested) {
+                    SitePermissionsRequestedType.CAMERA -> R.string.sitePermissionsTieredSystemDeniedCameraContent
+                    SitePermissionsRequestedType.AUDIO -> R.string.sitePermissionsTieredSystemDeniedMicContent
+                    SitePermissionsRequestedType.CAMERA_AND_AUDIO -> R.string.sitePermissionsTieredSystemDeniedCameraAndMicContent
+                    SitePermissionsRequestedType.LOCATION -> R.string.sitePermissionsTieredSystemDeniedLocationContent
+                },
+                buttonRes = R.string.sitePermissionsDialogChangePermissionsButton,
+                openAppSettings = openAppSettings,
+            )
         } else {
             val titleRes = when (permissionRequested) {
                 SitePermissionsRequestedType.CAMERA -> R.string.systemPermissionDialogCameraDeniedTitle
@@ -843,6 +864,36 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                 )
                 .show()
         }
+    }
+
+    private fun showChangePermissionsDialog(
+        @DrawableRes iconRes: Int,
+        @StringRes titleRes: Int,
+        @StringRes contentRes: Int,
+        @StringRes buttonRes: Int,
+        openAppSettings: () -> Unit,
+    ) {
+        StackedAlertDialogBuilder(activity)
+            .setRebrandUpdate(true)
+            .setHeaderImageResource(iconRes)
+            .setTitle(titleRes)
+            .setMessage(contentRes)
+            .setStackedButtons(
+                listOf(
+                    StackedButton(buttonRes, PRIMARY, CommonR.drawable.ic_open_in_16),
+                    StackedButton(R.string.systemPermissionsDeniedDialogNegativeButton, SECONDARY),
+                ),
+            )
+            .addEventListener(
+                object : StackedAlertDialogBuilder.EventListener() {
+                    override fun onButtonClicked(position: Int) {
+                        if (position == CHANGE_PERMISSIONS_BUTTON) {
+                            openAppSettings()
+                        }
+                    }
+                },
+            )
+            .show()
     }
 
     private fun storeFavicon(url: String) {

--- a/site-permissions/site-permissions-impl/src/main/res/values-bg/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-bg/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">За гласовите функции е необходимо разрешение за достъп до микрофона</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo има нужда от достъп до микрофона</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Ако искате да използвате гласов чат в Duck.ai, трябва да разрешите достъп до микрофона.</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Промяна на разрешенията</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Промяна на разрешенията</string>
 
     <string name="sitePermissionsSettingsDescription">Сайтовете, които посещавате, може да поискат достъп до местоположението, камерата, микрофона или софтуера за управление на цифровите права (DRM) на устройството. Те няма да имат достъп до тях, освен ако не им дадете изрично разрешение.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Разрешаване на всички сайтове да искат:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-bg/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-bg/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">За гласовите функции е необходимо разрешение за достъп до микрофона</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo има нужда от достъп до микрофона</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Ако искате да използвате гласов чат в Duck.ai, трябва да разрешите достъп до микрофона.</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Промяна на разрешенията</string>
 
     <string name="sitePermissionsSettingsDescription">Сайтовете, които посещавате, може да поискат достъп до местоположението, камерата, микрофона или софтуера за управление на цифровите права (DRM) на устройството. Те няма да имат достъп до тях, освен ако не им дадете изрично разрешение.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Разрешаване на всички сайтове да искат:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Разрешавам</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Деактивирано за всички сайтове</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s разрешение за %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Разрешаване при използване на сайта</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Разрешаване само този път</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Никога не разрешавай</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Уебсайтът „%1$s“ иска достъп до местоположението</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">„%1$s“ иска достъп до местоположението</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Ще анонимизираме местоположението и ще го използваме, за да осигурим по-добри резултати близо до мястото, на което се намирате.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Уебсайтът „%1$s“ иска достъп до камерата</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Уебсайтът „%1$s“ иска достъп до микрофона</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Уебсайтът „%1$s“ иска достъп до камерата и микрофона</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Ако не разрешите достъп, има вероятност видеоклиповете на сайта да не могат да бъдат възпроизвеждани, но този сайт няма да има достъп до идентификатори на устройства, предоставени от софтуера за DRM.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Промяна на разрешенията</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo има нужда от достъп до местоположението ти</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Необходими са разрешения за местоположение, ако искаш да използваш функциите за местоположение на този сайт.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo има нужда от достъп до камерата</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Ако искаш да използваш функциите за камерата на този сайт, са необходими разрешения за камерата.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo има нужда от достъп до микрофона</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Ако искаш да използваш функциите за микрофон на този сайт, трябва да разрешиш достъп до микрофона.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo има нужда от достъп до камерата и микрофона</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Ако искаш да използваш функциите за камера и микрофон на този сайт, трябва да разрешиш достъп до камерата и микрофона.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo не успя да сподели местоположението с този сайт</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo не можа да предостави достъп до камерата на този сайт</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo не можа да даде достъп до микрофона на този сайт</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo не можа да предостави достъп до камерата и микрофона на този сайт</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-cs/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-cs/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Pro hlasové funkce je potřeba povolit přístup k mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potřebuje přístup k mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Pokud chceš v Duck.ai používat hlasový chat, je potřeba povolit přístup k mikrofonu.</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Změnit oprávnění</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Změnit oprávnění</string>
 
     <string name="sitePermissionsSettingsDescription">Stránky, které navštívíš, můžou žádat o přístup k fotoaparátu, mikrofonu, softwaru DRM (Digital Rights Management) nebo k poloze tvého zařízení. Přístup mít nebudou, pokud jim ho výslovně nepovolíš.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Povolit všem webům, aby žádaly o:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-cs/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-cs/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Pro hlasové funkce je potřeba povolit přístup k mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potřebuje přístup k mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Pokud chceš v Duck.ai používat hlasový chat, je potřeba povolit přístup k mikrofonu.</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Změnit oprávnění</string>
 
     <string name="sitePermissionsSettingsDescription">Stránky, které navštívíš, můžou žádat o přístup k fotoaparátu, mikrofonu, softwaru DRM (Digital Rights Management) nebo k poloze tvého zařízení. Přístup mít nebudou, pokud jim ho výslovně nepovolíš.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Povolit všem webům, aby žádaly o:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Povolit</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Zakázáno pro všechny weby</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s – povolení pro web %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Povolit při používání webu</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Povolit tentokrát</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Nikdy nepovolit</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Webová stránka \"%1$s\" chce získat přístup ke tvé poloze</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">„%1$s“ chce získat přístup ke tvé poloze</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Tvoji polohu anonymizujeme a použijeme ji k tomu, abychom ti poskytovali lepší výsledky ve tvé blízkosti.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Webová stránka \"%1$s\" chce získat přístup k tvému fotoaparátu</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Webová stránka \"%1$s\" chce získat přístup k tvému mikrofonu</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Webová stránka \"%1$s\" chce získat přístup k tvému fotoaparátu a mikrofonu</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Pokud to nepovolíš, může se stát, že nepůjdou přehrát videa na stránce, ale tento web nebude mít přístup k identifikátorům zařízení poskytovaným softwarem DRM.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Změnit oprávnění</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo potřebuje přístup k poloze</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Pokud chceš na tomto webu používat funkce polohy, je potřeba povolit přístup k poloze.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo potřebuje přístup k fotoaparátu</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Pokud chceš na tomto webu používat funkce fotoaparátu, je potřeba povolit přístup k fotoaparátu.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo potřebuje přístup k mikrofonu</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Pokud chceš na tomto webu používat funkce mikrofonu, je potřeba povolit přístup k mikrofonu.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo potřebuje přístup k fotoaparátu a mikrofonu</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Pokud chceš na tomto webu používat funkce fotoaparátu a mikrofonu, je potřeba povolit přístup k fotoaparátu a mikrofonu.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo nemohl sdílet polohu s tímto webem</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo nemohl tomuto webu udělit přístup k fotoaparátu</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo nemohl tomuto webu udělit přístup k mikrofonu</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo nemohlo tomuto webu udělit přístup k fotoaparátu a mikrofonu</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-da/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-da/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Mikrofontilladelse er nødvendig for stemmefunktioner</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo skal have adgang til din mikrofon</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofontilladelser er nødvendige, hvis du vil bruge stemmechat i Duck.ai</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Skift tilladelser</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Skift tilladelser</string>
 
     <string name="sitePermissionsSettingsDescription">Websteder, du besøger, kan bede om adgang til din enheds placering, kamera, mikrofon eller DRM-software (Digital Rights Management). De vil ikke kunne få adgang til disse, medmindre du udtrykkeligt giver dem tilladelse.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Tillad, at alle websteder beder om:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-da/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-da/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Mikrofontilladelse er nødvendig for stemmefunktioner</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo skal have adgang til din mikrofon</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofontilladelser er nødvendige, hvis du vil bruge stemmechat i Duck.ai</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Skift tilladelser</string>
 
     <string name="sitePermissionsSettingsDescription">Websteder, du besøger, kan bede om adgang til din enheds placering, kamera, mikrofon eller DRM-software (Digital Rights Management). De vil ikke kunne få adgang til disse, medmindre du udtrykkeligt giver dem tilladelse.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Tillad, at alle websteder beder om:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Tillad</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Deaktiveret for alle websteder</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s tilladelse til %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Tillad, mens webstedet bruges</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Tillad denne gang</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Tillad aldrig</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Webstedet \"%1$s\" ønsker at få adgang til din placering</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" ønsker at få adgang til din placering</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Vi anonymiserer din placering og bruger den til at levere bedre resultater tættere på dig.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Webstedet \"%1$s\" ønsker at få adgang til dit kamera</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Webstedet \"%1$s\" ønsker at få adgang til din mikrofon</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Websitet \"%1$s\" ønsker at få adgang til dit kamera og din mikrofon</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Hvis du ikke tillader det, kan videoer på webstedet muligvis ikke afspilles, men dette websted vil ikke have adgang til enhedens identifikatorer leveret af DRM-software.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Skift tilladelser</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo skal have adgang til din placering</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Placeringstilladelser er nødvendige, hvis du vil bruge placeringsfunktioner på dette websted.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo skal have adgang til dit kamera</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Kameratilladelser er nødvendige, hvis du vil bruge kamerafunktioner på dette websted.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo skal have adgang til din mikrofon</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Mikrofontilladelser er nødvendige, hvis du vil bruge mikrofonfunktioner på dette websted.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo skal have adgang til dit kamera og din mikrofon</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Kamera- og mikrofontilladelser er nødvendige, hvis du vil bruge kamera- og mikrofonfunktioner på dette websted.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo kunne ikke dele placering med dette websted</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo kunne ikke give dette websted adgang til kamera</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo kunne ikke give dette websted adgang til mikrofonen</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo kunne ikke give dette websted adgang til kamera og mikrofon</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-de/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-de/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Mikrofonberechtigung für Sprachfunktionen erforderlich</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo benötigt Zugriff auf dein Mikrofon.</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofonberechtigungen werden benötigt, wenn du den Sprachchat in Duck.ai nutzen möchtest.</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Berechtigungen ändern</string>
 
     <string name="sitePermissionsSettingsDescription">Von dir besuchte Websites bitten möglicherweise um Zugriff auf den Standort, die Kamera, das Mikrofon oder die DRM-Software (Digital Rights Management) deines Geräts. Sie können darauf nicht zugreifen, es sei denn, du erteilst ihnen ausdrücklich die Erlaubnis.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Allen Websites erlauben, um Folgendes zu bitten:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Zulassen</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Für alle Websites deaktiviert</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s-Berechtigung für %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Beim Verwenden der Website zulassen</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Dieses Mal zulassen</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Nie zulassen</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Die Website „%1$s“ möchte auf deinen Standort zugreifen</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">„%1$s“ möchte auf deinen Standort zugreifen</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Wir anonymisieren deinen Standort und verwenden ihn, um dir bessere Ergebnisse in deiner Nähe zu liefern.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Die Website „%1$s“ möchte auf deine Kamera zugreifen</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Die Website „%1$s“ möchte auf dein Mikrofon zugreifen</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Die Website „%1$s“ möchte auf deine Kamera und dein Mikrofon zugreifen</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Wenn du dies nicht erlaubst, können Videos auf der Website möglicherweise nicht mehr abgespielt werden, aber diese Website hat keinen Zugriff auf die von der DRM-Software bereitgestellten Gerätekennungen.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Berechtigungen ändern</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo muss auf deinen Standort zugreifen</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Standortberechtigungen werden benötigt, wenn du Standortfunktionen auf dieser Website nutzen möchtest.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo muss auf deine Kamera zugreifen</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Kameraberechtigungen werden benötigt, wenn du Kamerafunktionen auf dieser Website nutzen möchtest.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo muss auf dein Mikrofon zugreifen</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Mikrofonberechtigungen werden benötigt, wenn du Mikrofonfunktionen auf dieser Website nutzen möchtest.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo muss auf deine Kamera und dein Mikrofon zugreifen</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Kamera- und Mikrofonberechtigungen werden benötigt, wenn du Kamera- und Mikrofonfunktionen auf dieser Website nutzen möchtest.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo konnte den Standort nicht mit dieser Website teilen</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo konnte dieser Website keinen Zugriff auf die Kamera gewähren</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo konnte dieser Website keinen Zugriff auf das Mikrofon gewähren</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo konnte dieser Website keinen Zugriff auf Kamera und Mikrofon gewähren</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-de/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-de/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Mikrofonberechtigung für Sprachfunktionen erforderlich</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo benötigt Zugriff auf dein Mikrofon.</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofonberechtigungen werden benötigt, wenn du den Sprachchat in Duck.ai nutzen möchtest.</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Berechtigungen ändern</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Berechtigungen ändern</string>
 
     <string name="sitePermissionsSettingsDescription">Von dir besuchte Websites bitten möglicherweise um Zugriff auf den Standort, die Kamera, das Mikrofon oder die DRM-Software (Digital Rights Management) deines Geräts. Sie können darauf nicht zugreifen, es sei denn, du erteilst ihnen ausdrücklich die Erlaubnis.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Allen Websites erlauben, um Folgendes zu bitten:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-el/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-el/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Απαιτείται δικαίωμα πρόσβασης στο μικρόφωνο για τις φωνητικές λειτουργίες</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">Το DuckDuckGo χρειάζεται πρόσβαση στο μικρόφωνό σου</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Απαιτούνται δικαιώματα πρόσβασης στο μικρόφωνο αν θέλεις να χρησιμοποιήσεις τη φωνητική συνομιλία στο Duck.ai</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Αλλαγή δικαιωμάτων</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Αλλαγή δικαιωμάτων</string>
 
     <string name="sitePermissionsSettingsDescription">Οι ιστότοποι που επισκέπτεστε ενδέχεται να ζητήσουν πρόσβαση στην τοποθεσία, την κάμερα, το μικρόφωνο ή το λογισμικό DRM (Διαχείριση ψηφιακών δικαιωμάτων) της συσκευής σας. Δεν θα μπορούν να έχουν πρόσβαση σε αυτά εάν δεν τους παρέχετε ρητά την άδειά σας.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Να επιτρέπεται σε όλους τους ιστότοπους να αιτούνται:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-el/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-el/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Απαιτείται δικαίωμα πρόσβασης στο μικρόφωνο για τις φωνητικές λειτουργίες</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">Το DuckDuckGo χρειάζεται πρόσβαση στο μικρόφωνό σου</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Απαιτούνται δικαιώματα πρόσβασης στο μικρόφωνο αν θέλεις να χρησιμοποιήσεις τη φωνητική συνομιλία στο Duck.ai</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Αλλαγή δικαιωμάτων</string>
 
     <string name="sitePermissionsSettingsDescription">Οι ιστότοποι που επισκέπτεστε ενδέχεται να ζητήσουν πρόσβαση στην τοποθεσία, την κάμερα, το μικρόφωνο ή το λογισμικό DRM (Διαχείριση ψηφιακών δικαιωμάτων) της συσκευής σας. Δεν θα μπορούν να έχουν πρόσβαση σε αυτά εάν δεν τους παρέχετε ρητά την άδειά σας.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Να επιτρέπεται σε όλους τους ιστότοπους να αιτούνται:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Αποδοχή</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Απενεργοποιήθηκε για όλους τους ιστότοπους</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s άδεια για %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Να επιτρέπεται κατά τη χρήση του ιστότοπου</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Αποδοχή αυτή τη φορά</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Να μην επιτρέπεται ποτέ</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Ο ιστότοπος «%1$s» θέλει να αποκτήσει πρόσβαση στην τοποθεσία σου</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">Η εφαρμογή «%1$s» θέλει να αποκτήσει πρόσβαση στην τοποθεσία σου</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Θα ανωνυμοποιήσουμε την τοποθεσία σου και θα τη χρησιμοποιήσουμε για να προσφέρουμε καλύτερα αποτελέσματα, πιο κοντά σε σένα.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Ο ιστότοπος «%1$s» θέλει να αποκτήσει πρόσβαση στην κάμερά σου</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Ο ιστότοπος «%1$s» επιθυμεί να αποκτήσει πρόσβαση στο μικρόφωνό σου</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Ο ιστότοπος «%1$s» θέλει να αποκτήσει πρόσβαση στην κάμερα και στο μικρόφωνό σου</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Αν δεν το επιτρέψεις, η αναπαραγωγή των βίντεο στον ιστότοπο ενδέχεται να μην είναι δυνατή, αλλά αυτός ο ιστότοπος δεν θα έχει πρόσβαση στα αναγνωριστικά συσκευών που παρέχονται από το λογισμικό DRM.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Αλλαγή δικαιωμάτων</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">Το DuckDuckGo χρειάζεται πρόσβαση στην τοποθεσία σου</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Απαιτούνται δικαιώματα πρόσβασης στην τοποθεσία αν θέλεις να χρησιμοποιήσεις λειτουργίες τοποθεσίας σε αυτόν τον ιστότοπο.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">Το DuckDuckGo χρειάζεται πρόσβαση στην κάμερά σου</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Απαιτούνται δικαιώματα πρόσβασης στην κάμερα αν θέλεις να χρησιμοποιήσεις λειτουργίες κάμερας σε αυτόν τον ιστότοπο.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">Το DuckDuckGo χρειάζεται πρόσβαση στο μικρόφωνό σου</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Απαιτούνται δικαιώματα πρόσβασης στο μικρόφωνο αν θέλεις να χρησιμοποιήσεις λειτουργίες μικροφώνου σε αυτόν τον ιστότοπο.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">Το DuckDuckGo χρειάζεται πρόσβαση στην κάμερα και στο μικρόφωνό σου</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Απαιτούνται δικαιώματα πρόσβασης στην κάμερα και στο μικρόφωνο αν θέλεις να χρησιμοποιήσεις τις λειτουργίες κάμερας και μικροφώνου σε αυτόν τον ιστότοπο.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">Το DuckDuckGo δεν μπόρεσε να κοινοποιήσει την τοποθεσία σε αυτόν τον ιστότοπο</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">Το DuckDuckGo δεν μπόρεσε να δώσει πρόσβαση στην κάμερα σε αυτόν τον ιστότοπο</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">Το DuckDuckGo δεν μπόρεσε να δώσει πρόσβαση στο μικρόφωνο σε αυτόν τον ιστότοπο</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">Το DuckDuckGo δεν μπόρεσε να δώσει πρόσβαση στην κάμερα και στο μικρόφωνο σε αυτόν τον ιστότοπο</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-es/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-es/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Se necesita permiso de micrófono para las funciones de voz</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo necesita acceder a tu micrófono</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Se necesitan permisos de micrófono si quieres usar el chat de voz en Duck.ai</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Cambiar permisos</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Cambiar permisos</string>
 
     <string name="sitePermissionsSettingsDescription">Los sitios que visites pueden pedirte acceso a la ubicación de tu dispositivo, a la cámara, al micrófono o al software DRM (Gestión de Derechos Digitales). No podrán acceder a ellos a menos que les des permiso explícitamente.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Permitir que todos los sitios soliciten:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-es/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-es/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Se necesita permiso de micrófono para las funciones de voz</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo necesita acceder a tu micrófono</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Se necesitan permisos de micrófono si quieres usar el chat de voz en Duck.ai</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Cambiar permisos</string>
 
     <string name="sitePermissionsSettingsDescription">Los sitios que visites pueden pedirte acceso a la ubicación de tu dispositivo, a la cámara, al micrófono o al software DRM (Gestión de Derechos Digitales). No podrán acceder a ellos a menos que les des permiso explícitamente.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Permitir que todos los sitios soliciten:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Permitir</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Desactivado para todos los sitios</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s permiso para %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Permitir mientras se usa el sitio</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Permitir esta vez</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">No permitir nunca</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">El sitio web «%1$s» quiere acceder a tu ubicación</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">«%1$s» quiere acceder a tu ubicación</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Anonimizaremos tu ubicación y la utilizaremos para ofrecer mejores resultados, más cerca de ti.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">El sitio web «%1$s» quiere acceder a tu cámara</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">El sitio web \"%1$s\" quiere acceder a tu micrófono</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">El sitio web «%1$s» quiere acceder a tu cámara y micrófono</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Si no lo permites, los vídeos en el sitio pueden volverse irreproducibles, pero este sitio no tendrá acceso a los identificadores de dispositivo proporcionados por el software DRM.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Cambiar permisos</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo necesita acceder a tu ubicación</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Se necesitan permisos de ubicación si quieres usar las funciones de ubicación en este sitio.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo necesita acceder a tu cámara</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Se necesitan permisos de cámara si quieres usar las funciones de cámara en este sitio.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo necesita acceder a tu micrófono</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Se necesitan permisos de micrófono si quieres usar las funciones de micrófono en este sitio.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo necesita acceder a tu cámara y micrófono</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Se necesitan permisos de cámara y micrófono si quieres usar las funciones de cámara y micrófono en este sitio.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo no pudo compartir la ubicación con este sitio</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo no pudo dar acceso a la cámara a este sitio</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo no pudo dar acceso al micrófono a este sitio</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo no pudo dar acceso a la cámara y al micrófono a este sitio</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-et/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-et/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Häälfunktsioonide jaoks on tarvis mikrofoni luba</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo vajab juurdepääsu teie mikrofonile</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofoni juurdepääsu on tarvis, kui soovite Duck.ai-s häälvestlust kasutada.</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Muuda load</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Muuda load</string>
 
     <string name="sitePermissionsSettingsDescription">Külastatavad veebisaidid võivad küsida juurdepääsu sinu seadme asukohale, kaamerale, mikrofonile või DRM-i (Digital Rights Management) tarkvarale. Need ei saa juurdepääsu enne, kui oled selleks andnud selgesõnalise loa.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Luba kõigil saitidel küsida järgmist.</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-et/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-et/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Häälfunktsioonide jaoks on tarvis mikrofoni luba</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo vajab juurdepääsu teie mikrofonile</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofoni juurdepääsu on tarvis, kui soovite Duck.ai-s häälvestlust kasutada.</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Muuda load</string>
 
     <string name="sitePermissionsSettingsDescription">Külastatavad veebisaidid võivad küsida juurdepääsu sinu seadme asukohale, kaamerale, mikrofonile või DRM-i (Digital Rights Management) tarkvarale. Need ei saa juurdepääsu enne, kui oled selleks andnud selgesõnalise loa.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Luba kõigil saitidel küsida järgmist.</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Luba</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Kõigi saitide jaoks keelatud</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Luba %1$s saidile %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Luba saidi kasutamise ajal</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Luba seekord</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Ära kunagi luba</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Veebisait „%1$s“ soovib juurdepääsu sinu asukohale</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">„%1$s“ soovib juurdepääsu sinu asukohale</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Anonümiseerime sinu asukoha ja kasutame seda selleks, et pakkuda paremaid tulemusi, mis on sulle lähemal.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Veebisait „%1$s“ soovib juurdepääsu sinu kaamerale</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Veebisait „%1$s“ soovib juurdepääsu sinu mikrofonile</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Veebisait „%1$s“ soovib juurdepääsu kaamerale ja mikrofonile</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Kui keeldud, võivad saidil videod muutuda mängitamatuks, kuid sellel saidil puudub juurdepääs DRM-tarkvara pakutavatele seadme identifikaatoritele.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Muuda load</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo vajab juurdepääsu sinu asukohale</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Asukoha load on vajalikud, kui soovid sellel saidil asukohafunktsioone kasutada.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo vajab juurdepääsu kaamerale</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Kaamera load on vajalikud, kui soovid sellel saidil kaamerafunktsioone kasutada.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo vajab juurdepääsu sinu mikrofonile</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Mikrofoni load on vajalikud, kui soovid sellel saidil kasutada mikrofoni funktsioone.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo vajab juurdepääsu sinu kaamerale ja mikrofonile</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Kaamera ja mikrofoni load on vajalikud, kui soovid sellel saidil kaamera ja mikrofoni funktsioone kasutada.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo ei saanud selle saidiga asukohta jagada</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo ei saanud sellele saidile kaamerale juurdepääsu anda</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo ei saanud sellele saidile mikrofoni ligipääsu anda</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo ei saanud sellele saidile kaamerale ja mikrofonile juurdepääsu anda</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-fi/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-fi/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Mikrofonin käyttöoikeus tarvitaan äänitoimintoja varten</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo tarvitsee mikrofonisi käyttöoikeuden</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofonin käyttöoikeudet tarvitaan, jos haluat käyttää äänikeskustelua Duck.ai:ssa</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Muuta käyttöoikeuksia</string>
 
     <string name="sitePermissionsSettingsDescription">Käyttämäsi sivustot saattavat pyytää pääsyä laitteesi sijaintiin, kameraan, mikrofoniin tai DRM-ohjelmistoon (Digital Rights Management). Ne eivät voi käyttää tietoja, ellet myönnä niille erillistä käyttöoikeutta.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Salli kaikkien sivustojen pyytää:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Salli</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Poistettu käytöstä kaikilla sivustoilla</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s: käyttöoikeus – lupa %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Salli sivustoa käytettäessä</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Salli tällä kertaa</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Älä koskaan salli</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\"-verkkosivusto haluaa käyttää sijaintiasi</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" haluaa käyttää sijaintiasi</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Anonymisoimme sijaintisi ja käytämme sitä tarjotaksemme parempia tuloksia lähempää sinua.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\"-verkkosivusto haluaa käyttää kameraasi</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Sivusto \"%1$s\" haluaa käyttää mikrofonia</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\"-verkkosivusto haluaa käyttää kameraasi ja mikrofoniasi</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Jos et salli, sivustolla olevia videoita ei ehkä voida toistaa, mutta tämä sivusto ei voi käyttää DRM-ohjelmiston tarjoamia laitetunnisteita.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Muuta käyttöoikeuksia</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo tarvitsee sijaintisi käyttöoikeuden</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Sijainnin käyttöoikeudet tarvitaan, jos haluat käyttää sijaintiominaisuuksia tällä sivustolla.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo tarvitsee kamerasi käyttöoikeuden</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Kameran käyttöoikeudet tarvitaan, jos haluat käyttää kameratoimintoja tällä sivustolla.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo tarvitsee mikrofonisi käyttöoikeuden</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Mikrofonin käyttöoikeudet tarvitaan, jos haluat käyttää mikrofonitoimintoja tällä sivustolla.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo tarvitsee kamerasi ja mikrofonisi käyttöoikeuden</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Kameran ja mikrofonin käyttöoikeudet tarvitaan, jos haluat käyttää kamera- ja mikrofonitoimintoja tällä sivustolla.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo ei voinut jakaa sijaintia tämän sivuston kanssa</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo ei voinut antaa kameran käyttöoikeutta tälle sivustolle</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo ei voinut antaa mikrofonin käyttöoikeutta tälle sivustolle</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo ei voinut antaa kameran ja mikrofonin käyttöoikeutta tälle sivustolle</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-fi/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-fi/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Mikrofonin käyttöoikeus tarvitaan äänitoimintoja varten</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo tarvitsee mikrofonisi käyttöoikeuden</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofonin käyttöoikeudet tarvitaan, jos haluat käyttää äänikeskustelua Duck.ai:ssa</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Muuta käyttöoikeuksia</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Muuta käyttöoikeuksia</string>
 
     <string name="sitePermissionsSettingsDescription">Käyttämäsi sivustot saattavat pyytää pääsyä laitteesi sijaintiin, kameraan, mikrofoniin tai DRM-ohjelmistoon (Digital Rights Management). Ne eivät voi käyttää tietoja, ellet myönnä niille erillistä käyttöoikeutta.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Salli kaikkien sivustojen pyytää:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-fr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-fr/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Autorisation d’accès au micro requise pour les fonctionnalités vocales</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo a besoin d’accéder à votre micro</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Les autorisations d’accès au micro sont nécessaires si vous souhaitez utiliser le chat vocal dans Duck.ai</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Modifier les autorisations</string>
 
     <string name="sitePermissionsSettingsDescription">Les sites que vous visitez sont susceptibles de demander l\'accès à la localisation, à l\'appareil photo, au micro ou au logiciel DRM (gestion des droits numériques) de votre appareil. Ils ne pourront y accéder que si vous leur en donnez explicitement la permission.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Autoriser tous les sites à demander :</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Autoriser</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Désactivé pour tous les sites</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Autorisation de %1$s pour %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Autoriser pendant l\'utilisation du site</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Autoriser cette fois</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Ne jamais autoriser</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Le site Web « %1$s » souhaite accéder à votre position</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">« %1$s » souhaite accéder à votre position</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Nous anonymiserons ta localisation et l’utiliserons pour te fournir de meilleurs résultats, plus proches de toi.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Le site Web \"%1$s\" souhaite accéder à ton appareil photo</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Le site Web « %1$s » souhaite accéder à votre micro</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Le site Web « %1$s » souhaite accéder à votre appareil photo et à votre micro</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Si tu n’autorises pas, les vidéos sur le site pourraient ne pas être lues, mais ce site n’aura pas accès aux identifiants d’appareil fournis par le logiciel DRM.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Modifier les autorisations</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo a besoin d’accéder à votre position</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Les autorisations de localisation sont nécessaires si tu souhaites utiliser les fonctionnalités de localisation sur ce site.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo a besoin d\'accéder à votre appareil photo</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Les autorisations d\'accès à l\'appareil photo sont nécessaires si tu souhaites utiliser les fonctionnalités de l\'appareil photo sur ce site.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo a besoin d\'accéder à votre micro</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Les autorisations d’accès au micro sont nécessaires si tu souhaites utiliser les fonctionnalités du micro sur ce site.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo a besoin d’accéder à votre appareil photo et à votre micro</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Les autorisations d’accès à l’appareil photo et au micro sont nécessaires si tu souhaites utiliser les fonctionnalités de l’appareil photo et du micro sur ce site.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">Impossible pour DuckDuckGo de partager ta position avec ce site</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo n’a pas pu donner l’accès à l’appareil photo à ce site</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo n’a pas pu donner l’accès au micro à ce site</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo n’a pas pu donner l’accès à l’appareil photo et au micro à ce site</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-fr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-fr/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Autorisation d’accès au micro requise pour les fonctionnalités vocales</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo a besoin d’accéder à votre micro</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Les autorisations d’accès au micro sont nécessaires si vous souhaitez utiliser le chat vocal dans Duck.ai</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Modifier les autorisations</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Modifier les autorisations</string>
 
     <string name="sitePermissionsSettingsDescription">Les sites que vous visitez sont susceptibles de demander l\'accès à la localisation, à l\'appareil photo, au micro ou au logiciel DRM (gestion des droits numériques) de votre appareil. Ils ne pourront y accéder que si vous leur en donnez explicitement la permission.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Autoriser tous les sites à demander :</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-hr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-hr/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Za glasovne funkcije potrebno je dopuštenje za mikrofon</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo treba pristupiti tvom mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Dozvole za mikrofon potrebne su ako želiš koristiti Glasovno čavrljanje u Duck.ai</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Promijeni dozvole</string>
 
     <string name="sitePermissionsSettingsDescription">Stranice koje posjećuješ mogu tražiti pristup lokaciji tvog uređaja, fotoaparatu, mikrofonu ili DRM (Digital Rights Management) softveru. Neće im moći pristupiti osim ako im za to izričito ne daš dopuštenje.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Dopusti svim web-lokacijama da zatraže:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Dopusti</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Onemogućeno za sva web-mjesta</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s dopuštenje za %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Dopusti tijekom upotrebe web-mjesta</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Dopusti ovaj put</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Nikada ne dopusti</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Web-mjesto \"%1$s\" želi pristupiti tvojoj lokaciji</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" želi pristupiti tvojoj lokaciji</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Anonimizirat ćemo tvoju lokaciju i upotrijebiti je da bismo ti pružili bolje rezultate, bliže tebi.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Web-mjesto \"%1$s\" želi pristupiti tvojoj kameri</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Web-mjesto \"%1$s\" želi pristupiti tvojem mikrofonu</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Web-stranica \"%1$s\" želi pristupiti tvojoj kameri i mikrofonu</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Ako ne dopustiš, videozapise na web-mjestu možda neće biti moguće reproducirati, ali ovo web-mjesto neće imati pristup identifikatorima uređaja koje pruža DRM softver.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Promijeni dozvole</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo treba pristupiti tvojoj lokaciji</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Dopuštenja za lokaciju potrebna su ako želiš koristiti značajke lokacije na ovom web-mjestu.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo treba pristupiti tvojoj kameri</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Dopuštenja za kameru potrebna su ako želiš koristiti značajke kamere na ovom web-mjestu.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo treba pristupiti tvom mikrofonu</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Dozvole za mikrofon potrebne su ako želiš koristiti značajke mikrofona na ovom web-mjestu.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo treba pristupiti tvojoj kameri i mikrofonu</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Dopuštenja za kameru i mikrofon potrebna su ako želiš koristiti značajke kamere i mikrofona na ovom web-mjestu.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo nije mogao podijeliti lokaciju s ovom stranicom</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo nije mogao dati pristup kameri ovoj stranici</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo nije mogao dati pristup mikrofonu ovoj stranici</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo nije mogao dati pristup kameri i mikrofonu ovoj stranici</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-hr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-hr/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Za glasovne funkcije potrebno je dopuštenje za mikrofon</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo treba pristupiti tvom mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Dozvole za mikrofon potrebne su ako želiš koristiti Glasovno čavrljanje u Duck.ai</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Promijeni dozvole</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Promijeni dozvole</string>
 
     <string name="sitePermissionsSettingsDescription">Stranice koje posjećuješ mogu tražiti pristup lokaciji tvog uređaja, fotoaparatu, mikrofonu ili DRM (Digital Rights Management) softveru. Neće im moći pristupiti osim ako im za to izričito ne daš dopuštenje.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Dopusti svim web-lokacijama da zatraže:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-hu/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-hu/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">A beszédhangfunkciókhoz mikrofonengedély szükséges</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">A DuckDuckGónak hozzá kell férnie a mikrofonhoz</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofonengedélyre van szükség, ha a Duck.ai-ban szeretnél hangcsevegést használni</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Engedélyek módosítása</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Engedélyek módosítása</string>
 
     <string name="sitePermissionsSettingsDescription">A meglátogatott webhelyek hozzáférést kérhetnek az eszköz helyéhez, kamerájához, mikrofonjához vagy a digitális jogosultságokat kezelő (DRM) szoftveréhez. Ezekhez nem férhetnek hozzá, hacsak nem adsz rá kifejezett engedélyt.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Minden webhely kérheti a következőket:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-hu/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-hu/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">A beszédhangfunkciókhoz mikrofonengedély szükséges</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">A DuckDuckGónak hozzá kell férnie a mikrofonhoz</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofonengedélyre van szükség, ha a Duck.ai-ban szeretnél hangcsevegést használni</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Engedélyek módosítása</string>
 
     <string name="sitePermissionsSettingsDescription">A meglátogatott webhelyek hozzáférést kérhetnek az eszköz helyéhez, kamerájához, mikrofonjához vagy a digitális jogosultságokat kezelő (DRM) szoftveréhez. Ezekhez nem férhetnek hozzá, hacsak nem adsz rá kifejezett engedélyt.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Minden webhely kérheti a következőket:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Engedélyezés</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Letiltva minden webhely számára</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s engedély a(z) %2$s számára</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Engedélyezés a webhely használata közben</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Engedélyezés csak most</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Soha ne engedélyezd</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">A(z) „%1$s” webhely hozzá akar férni a tartózkodási helyedhez</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">A(z) „%1$s” hozzá akar férni a tartózkodási helyedhez</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Anonimizáljuk a tartózkodási helyedet, és arra használjuk, hogy jobb, hozzád közelebbi találatokat nyújtsunk.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">A(z) „%1$s” webhely hozzá akar férni a kamerádhoz</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">A(z) „%1$s” webhely hozzá akar férni a mikrofonodhoz</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">A(z) „%1$s” webhely hozzá akar férni a kamerádhoz és a mikrofonodhoz</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Ha nem engedélyezed, előfordulhat, hogy a webhelyen lévő videók nem lesznek lejátszhatók, de ez a webhely nem fog hozzáférni a DRM-szoftver által biztosított eszközazonosítókhoz.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Engedélyek módosítása</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">A DuckDuckGónak hozzá kell férnie a tartózkodási helyedhez</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Helyhozzáférési engedélyre van szükség, ha helyfunkciókat szeretnél használni ezen a webhelyen.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">A DuckDuckGónak hozzá kell férnie a kamerádhoz</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Kameraengedélyre van szükség, ha kamerafunkciókat szeretnél használni ezen a webhelyen.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">A DuckDuckGónak hozzá kell férnie a mikrofonodhoz</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Mikrofonengedélyre van szükség, ha mikrofonfunkciókat szeretnél használni ezen a webhelyen.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">A DuckDuckGónak hozzá kell férnie a kamerádhoz és a mikrofonodhoz</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Kamera- és mikrofonengedélyre van szükség, ha kamera- és mikrofonfunkciókat szeretnél használni ezen a webhelyen.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">A DuckDuckGo nem tudta megosztani a tartózkodási helyet ezzel a webhellyel</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">A DuckDuckGo nem tudott kamera-hozzáférést adni a webhelynek</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">A DuckDuckGo nem tudott mikrofon-hozzáférést adni a webhelynek</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">A DuckDuckGo nem tudott kamera- és mikrofon-hozzáférést adni a webhelynek</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-it/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-it/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Autorizzazione del microfono necessaria per le funzioni vocali</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo deve accedere al microfono</string>
     <string name="duckAiMicPermissionDeniedDialogContent">I permessi del microfono sono necessari se vuoi usare la chat vocale su Duck.ai</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Modifica autorizzazioni</string>
 
     <string name="sitePermissionsSettingsDescription">I siti che visiti potrebbero richiedere l\'accesso al software di localizzazione, videocamera, microfono o DRM (Digital Rights Management) del tuo dispositivo. Non potranno accedervi finché non darai il consenso esplicito.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Consenti a tutti i siti di richiedere:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Consenti</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Disattivato per tutti i siti</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Autorizzazione %1$s per %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Consenti durante l\'uso del sito</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Consenti questa volta</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Non consentire mai</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Il sito web \"%1$s\" vuole accedere alla tua posizione</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" vuole accedere alla tua posizione</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Anonimizzeremo la tua posizione e la useremo per offrirti risultati migliori, più vicini a te.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Il sito web \"%1$s\" vuole accedere alla tua fotocamera</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Il sito web \"%1$s\" vuole accedere al tuo microfono</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Il sito web \"%1$s\" vuole accedere alla fotocamera e al microfono</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Se non consenti, i video sul sito potrebbero diventare non riproducibili, ma questo sito non avrà accesso agli identificatori del dispositivo forniti dal software DRM.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Modifica autorizzazioni</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo deve accedere alla posizione</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">I permessi per la posizione sono necessari se vuoi usare le funzionalità per la posizione su questo sito.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo deve accedere alla fotocamera</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Le autorizzazioni della fotocamera sono necessarie se vuoi usare le funzionalità della fotocamera su questo sito.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo deve accedere al microfono</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">I permessi per il microfono sono necessari se vuoi usare le funzionalità del microfono su questo sito.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo deve accedere alla fotocamera e al microfono</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Le autorizzazioni della fotocamera e del microfono sono necessarie se vuoi usare le funzionalità della fotocamera e del microfono su questo sito.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo non è riuscito a condividere la posizione con questo sito</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo non ha potuto concedere l’accesso alla fotocamera a questo sito</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo non ha potuto concedere l’accesso al microfono a questo sito</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo non ha potuto concedere l’accesso alla fotocamera e al microfono a questo sito</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-it/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-it/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Autorizzazione del microfono necessaria per le funzioni vocali</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo deve accedere al microfono</string>
     <string name="duckAiMicPermissionDeniedDialogContent">I permessi del microfono sono necessari se vuoi usare la chat vocale su Duck.ai</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Modifica autorizzazioni</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Modifica autorizzazioni</string>
 
     <string name="sitePermissionsSettingsDescription">I siti che visiti potrebbero richiedere l\'accesso al software di localizzazione, videocamera, microfono o DRM (Digital Rights Management) del tuo dispositivo. Non potranno accedervi finché non darai il consenso esplicito.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Consenti a tutti i siti di richiedere:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-lt/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-lt/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Balso funkcijoms reikia leidimo naudoti mikrofoną</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">„DuckDuckGo“ reikia prieigos prie tavo mikrofono</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Jei nori naudotis „Duck.ai“ pokalbiais balsu, reikia leidimo naudoti mikrofoną</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Keisti leidimus</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Keisti leidimus</string>
 
     <string name="sitePermissionsSettingsDescription">Svetainėse, kuriose lankotės, gali būti prašoma prieigos prie jūsų įrenginio buvimo vietos, kameros, mikrofono arba DRM (skaitmeninių teisių valdymo) programinės įrangos. Jos negalės prie jų prisijungti, nebent aiškiai suteiksite joms leidimą.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Leisti visoms svetainėms prašyti:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-lt/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-lt/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Balso funkcijoms reikia leidimo naudoti mikrofoną</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">„DuckDuckGo“ reikia prieigos prie tavo mikrofono</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Jei nori naudotis „Duck.ai“ pokalbiais balsu, reikia leidimo naudoti mikrofoną</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Keisti leidimus</string>
 
     <string name="sitePermissionsSettingsDescription">Svetainėse, kuriose lankotės, gali būti prašoma prieigos prie jūsų įrenginio buvimo vietos, kameros, mikrofono arba DRM (skaitmeninių teisių valdymo) programinės įrangos. Jos negalės prie jų prisijungti, nebent aiškiai suteiksite joms leidimą.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Leisti visoms svetainėms prašyti:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Leisti</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Išjungta visose svetainėse</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s leidimas %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Leisti naudojant svetainę</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Leisti šį kartą</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Niekada neleisti</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Interneto svetainė „%1$s“ nori pasiekti tavo vietovę</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">„%1$s“ nori pasiekti tavo vietovę</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Anonimizuosime tavo vietą ir naudosime ją, kad pateiktume geresnius rezultatus, esančius arčiau tavęs.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Interneto svetainė „%1$s“ nori pasiekti tavo kamerą</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Interneto svetainė „%1$s“ nori pasiekti tavo mikrofoną</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Interneto svetainė „%1$s“ nori pasiekti tavo kamerą ir mikrofoną</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Jei neleisi, vaizdo įrašai svetainėje gali nebeveikti, tačiau ši svetainė neturės prieigos prie įrenginio identifikatorių, kuriuos teikia DRM programinė įranga.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Keisti leidimus</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">„DuckDuckGo“ reikia pasiekti tavo vietovę</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Norint šioje svetainėje naudotis vietos funkcijomis, reikia vietos leidimų.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">„DuckDuckGo“ reikia pasiekti tavo kamerą</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Norint šioje svetainėje naudotis kameros funkcijomis, reikia kameros leidimų.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">„DuckDuckGo“ reikia pasiekti tavo mikrofoną</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Jei šioje svetainėje nori naudotis mikrofono funkcijomis, reikia mikrofono leidimų.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">„DuckDuckGo“ reikia pasiekti tavo kamerą ir mikrofoną</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Jei nori šioje svetainėje naudotis kameros ir mikrofono funkcijomis, reikia leidimo naudoti kamerą ir mikrofoną.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">„DuckDuckGo“ nepavyko bendrinti vietovės su šia svetaine</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">„DuckDuckGo“ nepavyko suteikti šiai svetainei prieigos prie kameros</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">„DuckDuckGo“ nepavyko suteikti šiai svetainei prieigos prie mikrofono</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">„DuckDuckGo“ nepavyko suteikti šiai svetainei prieigos prie kameros ir mikrofono</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-lv/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-lv/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Balss funkcijām nepieciešama mikrofona atļauja</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo ir nepieciešama piekļuve tavam mikrofonam</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Ja vēlies izmantot balss tērzēšanu vietnē Duck.ai, ir nepieciešamas mikrofona atļaujas</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Mainīt atļaujas</string>
 
     <string name="sitePermissionsSettingsDescription">Apmeklētās vietnes var pieprasīt piekļuvi tavas ierīces atrašanās vietai, kamerai, mikrofonam vai DRM (digitālā satura tiesību pārvaldības) programmatūrai. Tās nevarēs tiem piekļūt, ja vien īpaši nedosi attiecīgo atļauju.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Ļaut visām vietnēm prasīt:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Atļaut</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Atspējots visām vietnēm</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s – atļauja vietnei %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Atļaut vietnes lietošanas laikā</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Atļaut šoreiz</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Nekad neatļaut</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Vietne \"%1$s\" vēlas piekļūt tavai atrašanās vietai</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" grib piekļūt tavai atrašanās vietai</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Mēs anonimizēsim tavu atrašanās vietu un izmantosim to, lai sniegtu labākus rezultātus tuvāk tev.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Vietne \"%1$s\" vēlas piekļūt tavai kamerai</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Vietne \"%1$s\" vēlas piekļūt tavam mikrofonam</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Vietne \"%1$s\" vēlas piekļūt tavai kamerai un mikrofonam</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Ja neatļausi, vietnē esošos videoklipus, iespējams, nevarēs atskaņot, taču šai vietnei nebūs piekļuves DRM programmatūras nodrošinātajiem ierīču identifikatoriem.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Mainīt atļaujas</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo ir nepieciešama piekļuve tavai atrašanās vietai</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Ja vēlies izmantot atrašanās vietas funkcijas šajā vietnē, ir nepieciešamas atrašanās vietas atļaujas.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo ir nepieciešama piekļuve tavai kamerai</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Ja vēlies izmantot kameras funkcijas šajā vietnē, ir nepieciešamas kameras atļaujas.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo ir nepieciešama piekļuve mikrofonam</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Ja vēlies izmantot mikrofona funkcijas šajā vietnē, ir nepieciešamas mikrofona atļaujas.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo ir nepieciešama piekļuve tavai kamerai un mikrofonam</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Ja šajā vietnē vēlies izmantot kameras un mikrofona funkcijas, ir nepieciešamas kameras un mikrofona atļaujas.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo nevarēja kopīgot atrašanās vietu ar šo vietni</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo nevarēja piešķirt šai vietnei piekļuvi kamerai</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo nevarēja piešķirt šai vietnei piekļuvi mikrofonam</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo nevarēja piešķirt šai vietnei piekļuvi kamerai un mikrofonam</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-lv/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-lv/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Balss funkcijām nepieciešama mikrofona atļauja</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo ir nepieciešama piekļuve tavam mikrofonam</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Ja vēlies izmantot balss tērzēšanu vietnē Duck.ai, ir nepieciešamas mikrofona atļaujas</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Mainīt atļaujas</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Mainīt atļaujas</string>
 
     <string name="sitePermissionsSettingsDescription">Apmeklētās vietnes var pieprasīt piekļuvi tavas ierīces atrašanās vietai, kamerai, mikrofonam vai DRM (digitālā satura tiesību pārvaldības) programmatūrai. Tās nevarēs tiem piekļūt, ja vien īpaši nedosi attiecīgo atļauju.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Ļaut visām vietnēm prasīt:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-nb/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-nb/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Mikrofontillatelse er nødvendig for talefunksjoner</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo trenger tilgang til mikrofonen</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofontillatelser er nødvendig hvis du vil bruke talefunksjoner i Duck.ai</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Endre tillatelser</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Endre tillatelser</string>
 
     <string name="sitePermissionsSettingsDescription">Nettsteder du besøker, kan be om tilgang til enhetens posisjon, kamera, mikrofon eller DRA-programvare (digital rettighetsadministrasjon). De får ikke tilgang til disse med mindre du uttrykkelig gir dem tillatelse.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Tillat alle nettsteder å be om:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-nb/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-nb/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Mikrofontillatelse er nødvendig for talefunksjoner</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo trenger tilgang til mikrofonen</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofontillatelser er nødvendig hvis du vil bruke talefunksjoner i Duck.ai</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Endre tillatelser</string>
 
     <string name="sitePermissionsSettingsDescription">Nettsteder du besøker, kan be om tilgang til enhetens posisjon, kamera, mikrofon eller DRA-programvare (digital rettighetsadministrasjon). De får ikke tilgang til disse med mindre du uttrykkelig gir dem tillatelse.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Tillat alle nettsteder å be om:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Tillat</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Deaktivert for alle nettsteder</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$stillatelse for %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Tillat mens nettstedet er i bruk</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Tillat denne gangen</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Tillat aldri</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Nettstedet «%1$s» ønsker tilgang til posisjonen din</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">«%1$s» ønsker tilgang til posisjonen din</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Vi anonymiserer posisjonen din og bruker den til å levere bedre resultater, i nærheten av deg.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Nettstedet «%1$s» ønsker tilgang til kameraet ditt</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Nettstedet «%1$s» ønsker tilgang til mikrofonen din</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Nettstedet «%1$s» ønsker tilgang til kameraet og mikrofonen din</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Hvis du ikke tillater det, kan det hende at videoer på nettstedet ikke kan spilles av, men dette nettstedet får ikke tilgang til enhetsidentifikatorer oppgitt av DRM-programvare.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Endre tillatelser</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo trenger tilgang til posisjonen din</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Posisjonstillatelser er nødvendige hvis du vil bruke stedsfunksjoner på dette nettstedet.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo trenger tilgang til kameraet</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Kameratillatelser er nødvendige hvis du vil bruke kamerafunksjoner på dette nettstedet.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo trenger tilgang til mikrofonen din</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Mikrofontillatelser er nødvendige hvis du vil bruke mikrofonfunksjoner på dette nettstedet.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo trenger tilgang til kameraet og mikrofonen din</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Kamera- og mikrofontillatelser er nødvendige hvis du vil bruke kamera- og mikrofonfunksjoner på dette nettstedet.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo kunne ikke dele posisjonen med dette nettstedet</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo kunne ikke gi kameratilgang til dette nettstedet</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo kunne ikke gi mikrofontilgang til dette nettstedet</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo kunne ikke gi kamera- og mikrofontilgang til dette nettstedet</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-nl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-nl/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Microfoonmachtiging nodig voor spraakfuncties</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo heeft toegang tot je microfoon nodig</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Microfoonmachtigingen zijn vereist als je spraakchat wilt gebruiken in Duck.ai</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Toestemmingen wijzigen</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Toestemmingen wijzigen</string>
 
     <string name="sitePermissionsSettingsDescription">Sites die je bezoekt, kunnen toegang vragen tot de software, je camera, je microfoon of DRM (Digital Rights Management) op je apparaat. Ze krijgen die toegang alleen als je daar expliciet toestemming voor geeft.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Sta alle sites toe om het volgende vragen:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-nl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-nl/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Microfoonmachtiging nodig voor spraakfuncties</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo heeft toegang tot je microfoon nodig</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Microfoonmachtigingen zijn vereist als je spraakchat wilt gebruiken in Duck.ai</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Toestemmingen wijzigen</string>
 
     <string name="sitePermissionsSettingsDescription">Sites die je bezoekt, kunnen toegang vragen tot de software, je camera, je microfoon of DRM (Digital Rights Management) op je apparaat. Ze krijgen die toegang alleen als je daar expliciet toestemming voor geeft.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Sta alle sites toe om het volgende vragen:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Toestaan</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Uitgeschakeld voor alle sites</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Toestemming voor %1$s voor %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Toestaan tijdens gebruik van site</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Deze keer toestaan</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Nooit toestaan</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Website \"%1$s\" wil toegang tot je locatie</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">\'%1$s\' wil toegang tot je locatie</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">We anonimiseren je locatie en gebruiken deze om betere resultaten dichter bij je in de buurt aan te bieden.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Website \"%1$s\" wil toegang tot je camera</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">De website \"%1$s\" wil toegang tot je microfoon</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Website \'%1$s\' wil toegang tot je camera en microfoon</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Als je dit niet toestaat, kunnen video\'s op de site mogelijk niet worden afgespeeld, maar deze site heeft geen toegang tot apparaat-ID\'s die door DRM-software worden verstrekt.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Toestemmingen wijzigen</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo heeft toegang tot je locatie nodig</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Locatiemachtigingen zijn nodig als je locatiefuncties op deze site wilt gebruiken.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo heeft toegang tot je camera nodig</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Cameramachtigingen zijn nodig als je camerafuncties op deze site wilt gebruiken.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo heeft toegang tot je microfoon nodig</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Microfoontoegang is nodig als je microfoonfuncties op deze site wilt gebruiken.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo heeft toegang tot je camera en microfoon nodig</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Camera- en microfoontoegang is nodig als je camera- en microfoonfuncties op deze site wilt gebruiken.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo kon je locatie niet delen met deze site</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo kon deze site geen toegang tot de camera geven</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo kon deze site geen toegang tot de microfoon geven</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo kon deze site geen toegang tot de camera en microfoon geven</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-pl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-pl/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Do obsługi funkcji głosowych wymagane jest uprawnienie do korzystania z mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potrzebuje dostępu do Twojego mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Uprawnienia do mikrofonu są potrzebne, jeśli chcesz korzystać z czatu głosowego w Duck.ai</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Zmień uprawnienia</string>
 
     <string name="sitePermissionsSettingsDescription">Strony, które odwiedzasz, mogą prosić o dostęp do lokalizacji urządzenia, kamery, mikrofonu lub oprogramowania DRM (Digital Rights Management). Nie będą miały do nich dostępu, jeśli nie udzielisz im zgody.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Pozwól wszystkim stronom prosić o:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Zezwól</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Wyłączono dla wszystkich witryn</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Pozwolenie dla witryny %2$s na dostęp do urządzenia: %1$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Zezwalaj podczas korzystania z witryny</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Zezwól tym razem</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Nigdy nie zezwalaj</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Strona „%1$s” chce uzyskać dostęp do Twojej lokalizacji</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">„%1$s” chce uzyskać dostęp do lokalizacji</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Zanonimizujemy Twoją lokalizację i użyjemy jej, aby zapewnić lepsze wyniki, bliżej Ciebie.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Witryna „%1$s” chce uzyskać dostęp do Twojego aparatu</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Witryna „%1$s” chce uzyskać dostęp do Twojego mikrofonu</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Witryna „%1$s” chce uzyskać dostęp do Twojego aparatu i mikrofonu</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Jeśli nie zezwolisz, filmy na stronie mogą stać się niedostępne, ale ta strona nie będzie miała dostępu do identyfikatorów urządzeń dostarczanych przez oprogramowanie DRM.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Zmień uprawnienia</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo potrzebuje dostępu do Twojej lokalizacji</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Uprawnienia do lokalizacji są potrzebne, jeśli chcesz korzystać z funkcji lokalizacji na tej stronie.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo potrzebuje dostępu do Twojej kamery</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Uprawnienia do aparatu są potrzebne, jeśli chcesz korzystać z funkcji aparatu na tej stronie.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo potrzebuje dostępu do Twojego mikrofonu</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Uprawnienia do mikrofonu są potrzebne, jeśli chcesz korzystać z funkcji mikrofonu na tej stronie.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo potrzebuje dostępu do Twojej kamery i mikrofonu</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Uprawnienia do kamery i mikrofonu są potrzebne, jeśli chcesz korzystać z funkcji kamery i mikrofonu na tej stronie.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo nie mogło udostępnić lokalizacji tej witrynie</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo nie może przyznać tej witrynie dostępu do kamery</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo nie mogło przyznać tej witrynie dostępu do mikrofonu</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo nie mogło przyznać tej witrynie dostępu do kamery i mikrofonu</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-pl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-pl/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Do obsługi funkcji głosowych wymagane jest uprawnienie do korzystania z mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potrzebuje dostępu do Twojego mikrofonu</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Uprawnienia do mikrofonu są potrzebne, jeśli chcesz korzystać z czatu głosowego w Duck.ai</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Zmień uprawnienia</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Zmień uprawnienia</string>
 
     <string name="sitePermissionsSettingsDescription">Strony, które odwiedzasz, mogą prosić o dostęp do lokalizacji urządzenia, kamery, mikrofonu lub oprogramowania DRM (Digital Rights Management). Nie będą miały do nich dostępu, jeśli nie udzielisz im zgody.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Pozwól wszystkim stronom prosić o:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-pt/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-pt/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">É necessária permissão de microfone para as funcionalidades de voz</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">O DuckDuckGo precisa de aceder ao teu microfone</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Precisas de permissões de microfone se quiseres utilizar o chat de voz no Duck.ai</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Alterar permissões</string>
 
     <string name="sitePermissionsSettingsDescription">Os sites que visitas podem pedir acesso à localização, câmara, microfone ou DRM (Digital Rights Management) do teu dispositivo. Não poderão aceder a estas funcionalidades sem que concedas permissão explicitamente.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Permitir que todos os sites peçam:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Permitir</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Desativado para todos os sites</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Permissão para %2$s utilizar %1$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Permitir durante a utilização do site</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Permitir desta vez</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Nunca permitir</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">O website \"%1$s\" quer aceder à tua localização</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" quer aceder à tua localização</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Vamos anonimizar a tua localização e utilizá-la para apresentar resultados melhores, mais perto de ti.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">O website \"%1$s\" quer aceder à tua câmara</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">O website \"%1$s\" quer aceder ao teu microfone</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">O site \"%1$s\" quer aceder à tua câmara e ao teu microfone</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Se não permitires, os vídeos no site podem tornar-se inutilizáveis, mas este site não terá acesso aos identificadores de dispositivo fornecidos pelo software de DRM.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Alterar permissões</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">O DuckDuckGo precisa de aceder à tua localização</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Precisas de permissões de localização se quiseres usar funcionalidades de localização neste site.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">O DuckDuckGo precisa de aceder à tua câmara</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Precisas de permissões da câmara se quiseres usar funcionalidades da câmara neste site.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">O DuckDuckGo precisa de aceder ao teu microfone</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Precisas de permissões de microfone se quiseres usar as funcionalidades de microfone neste site.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">O DuckDuckGo precisa de aceder à tua câmara e ao teu microfone</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Precisas de permissões de câmara e microfone se quiseres usar as funcionalidades de câmara e microfone neste site.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">O DuckDuckGo não conseguiu partilhar a localização com este site</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">O DuckDuckGo não conseguiu dar acesso à câmara a este site</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">O DuckDuckGo não conseguiu dar acesso ao microfone a este site</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">O DuckDuckGo não conseguiu dar acesso à câmara e ao microfone a este site</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-pt/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-pt/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">É necessária permissão de microfone para as funcionalidades de voz</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">O DuckDuckGo precisa de aceder ao teu microfone</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Precisas de permissões de microfone se quiseres utilizar o chat de voz no Duck.ai</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Alterar permissões</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Alterar permissões</string>
 
     <string name="sitePermissionsSettingsDescription">Os sites que visitas podem pedir acesso à localização, câmara, microfone ou DRM (Digital Rights Management) do teu dispositivo. Não poderão aceder a estas funcionalidades sem que concedas permissão explicitamente.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Permitir que todos os sites peçam:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-ro/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-ro/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Este necesară permisiunea pentru microfon în scopul de a utiliza funcțiile vocale</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo are nevoie de acces la microfon</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Sunt necesare permisiunile pentru microfon dacă vrei să folosești chatul vocal în Duck.ai</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Modifică permisiunile</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Modifică permisiunile</string>
 
     <string name="sitePermissionsSettingsDescription">Site-urile pe care le accesezi îți pot solicita accesul la locația dispozitivului, la camera foto, la microfon sau la software-ul DRM (Digital Rights Management). Acestea nu vor putea accesa aceste date decât dacă le oferi în mod explicit permisiunea.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Permite tuturor site-urilor să solicite:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-ro/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-ro/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Este necesară permisiunea pentru microfon în scopul de a utiliza funcțiile vocale</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo are nevoie de acces la microfon</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Sunt necesare permisiunile pentru microfon dacă vrei să folosești chatul vocal în Duck.ai</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Modifică permisiunile</string>
 
     <string name="sitePermissionsSettingsDescription">Site-urile pe care le accesezi îți pot solicita accesul la locația dispozitivului, la camera foto, la microfon sau la software-ul DRM (Digital Rights Management). Acestea nu vor putea accesa aceste date decât dacă le oferi în mod explicit permisiunea.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Permite tuturor site-urilor să solicite:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Permite</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Dezactivat pentru toate site-urile</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Permisiune %1$s pentru %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Permite în timpul utilizării site-ului</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Permite de data aceasta</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Nu permite niciodată</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Site-ul „%1$s” dorește să-ți acceseze locația</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">„%1$s” dorește să-ți acceseze locația</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Îți vom anonimiza locația și o vom folosi pentru a oferi rezultate mai bune, mai aproape de tine.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Site-ul „%1$s” dorește să-ți acceseze camera</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Site-ul „%1$s” dorește să-ți acceseze microfonul</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Site-ul „%1$s” dorește să-ți acceseze camera și microfonul</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Dacă nu permiți, videoclipurile de pe site ar putea deveni de neredat, dar acest site nu va avea acces la identificatorii de dispozitiv oferiți de software-ul DRM.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Modifică permisiunile</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo are nevoie de acces la locație</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Sunt necesare permisiunile pentru locație dacă vrei să folosești funcțiile de localizare de pe acest site.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo are nevoie de acces la cameră</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Sunt necesare permisiunile pentru cameră dacă vrei să folosești funcțiile de cameră de pe acest site.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo are nevoie de acces la microfon</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Sunt necesare permisiunile pentru microfon dacă vrei să folosești funcțiile de microfon de pe acest site.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo are nevoie de acces la cameră și microfon</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Sunt necesare permisiunile pentru cameră și microfon dacă vrei să folosești funcțiile de cameră și microfon de pe acest site.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo nu a putut partaja locația cu acest site</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo nu a putut oferi accesul la cameră acestui site</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo nu a putut acorda accesul la microfon acestui site</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo nu a putut acorda accesul la cameră și microfon acestui site</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-ru/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-ru/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Для работы голосовых функций требуется разрешение на доступ к микрофону</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo требуется доступ к вашему микрофону</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Для использования голосового чата в Duck.ai требуется доступ к микрофону</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Изменить разрешения</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Изменить разрешения</string>
 
     <string name="sitePermissionsSettingsDescription">Посещаемые вами сайты могут запрашивать доступ к геопозиции, камере, микрофону или программам DRM (защиты авторских прав) вашего устройства. Доступ предоставляется только с вашего разрешения.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Разрешить всем сайтам запрашивать:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-ru/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-ru/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Для работы голосовых функций требуется разрешение на доступ к микрофону</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo требуется доступ к вашему микрофону</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Для использования голосового чата в Duck.ai требуется доступ к микрофону</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Изменить разрешения</string>
 
     <string name="sitePermissionsSettingsDescription">Посещаемые вами сайты могут запрашивать доступ к геопозиции, камере, микрофону или программам DRM (защиты авторских прав) вашего устройства. Доступ предоставляется только с вашего разрешения.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Разрешить всем сайтам запрашивать:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Разрешить</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Отключено в отношении всех сайтов</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">Разрешение на доступ %2$s к %1$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Разрешать при использовании сайта</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Разрешить в этот раз</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Никогда не разрешать</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Сайт «%1$s» запрашивает доступ к вашему местоположению</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">Сайт «%1$s» запрашивает доступ к вашему местоположению</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Мы обезличиваем данные о вашем местоположении и используем их, чтобы показывать более релевантные результаты поблизости.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Сайт «%1$s» запрашивает доступ к вашей камере</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Сайт «%1$s» запрашивает доступ к вашему микрофону</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Сайт «%1$s» запрашивает доступ к вашей камере и микрофону</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Если ты не разрешишь, видео на сайте могут перестать воспроизводиться, но этот сайт не получит доступа к идентификаторам устройств, которые предоставляет DRM.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Изменить разрешения</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo требуется доступ к твоему местоположению</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Для использования функций геопозиции на этом сайте требуется доступ к геопозиции.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo требуется доступ к твоей камере</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Для использования функций камеры на этом сайте требуется доступ к камере.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo требуется доступ к вашему микрофону</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Для использования функций микрофона на этом сайте требуется доступ к микрофону.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo требуется доступ к твоей камере и микрофону</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Для использования функций камеры и микрофона на этом сайте требуется доступ к камере и микрофону.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo не удалось передать данные о местоположении этому сайту</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo не удалось предоставить этому сайту доступ к камере</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo не удалось предоставить этому сайту доступ к микрофону</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo не удалось предоставить этому сайту доступ к камере и микрофону</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-sk/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-sk/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Na používanie hlasových funkcií potrebuješ povolenie pre mikrofón</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potrebuje prístup k tvojmu mikrofónu</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Ak chceš v Duck.ai používať hlasový čet, je potrebné povolenie pre mikrofón.</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Zmeniť oprávnenia</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Zmeniť oprávnenia</string>
 
     <string name="sitePermissionsSettingsDescription">Stránky, ktoré navštívite, môžu požiadať o prístup k polohe vášho zariadenia, fotoaparátu, mikrofónu alebo softvéru DRM (Digital Rights Management). Nebudú mať k nim prístup, pokiaľ im to výslovne nepovolíte.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Povoliť všetkým lokalitám žiadať o:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-sk/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-sk/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Na používanie hlasových funkcií potrebuješ povolenie pre mikrofón</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potrebuje prístup k tvojmu mikrofónu</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Ak chceš v Duck.ai používať hlasový čet, je potrebné povolenie pre mikrofón.</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Zmeniť oprávnenia</string>
 
     <string name="sitePermissionsSettingsDescription">Stránky, ktoré navštívite, môžu požiadať o prístup k polohe vášho zariadenia, fotoaparátu, mikrofónu alebo softvéru DRM (Digital Rights Management). Nebudú mať k nim prístup, pokiaľ im to výslovne nepovolíte.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Povoliť všetkým lokalitám žiadať o:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Povoliť</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Zakázané pre všetky lokality</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s povolenie pre %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Povoliť pri používaní lokality</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Povoliť tentoraz</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Nikdy nepovoliť</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Webová stránka \"%1$s\" chce získať prístup k tvojej polohe</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">„%1$s“ chce získať prístup k tvojej polohe</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Anonymizujeme tvoju polohu a použijeme ju na poskytovanie lepších výsledkov z tvojho okolia.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Webová stránka \"%1$s\" chce získať prístup k tvojmu fotoaparátu</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Webová stránka \"%1$s\" chce získať prístup k tvojmu mikrofónu</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Webová stránka \"%1$s\" chce získať prístup k tvojmu fotoaparátu a mikrofónu</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Ak to nepovolíš, videá na stránke sa nemusia dať prehrať, ale táto stránka nebude mať prístup k identifikátorom zariadení poskytovaným softvérom DRM.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Zmeniť oprávnenia</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo potrebuje prístup k tvojej polohe</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Ak chceš na tejto stránke používať funkcie polohy, sú potrebné povolenia pre polohu.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo potrebuje prístup k tvojmu fotoaparátu</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Ak chceš na tejto stránke používať funkcie fotoaparátu, sú potrebné povolenia pre fotoaparát.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo potrebuje prístup k tvojmu mikrofónu</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Ak chceš na tejto stránke používať funkcie mikrofónu, je potrebné povolenie pre mikrofón.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo potrebuje prístup k tvojmu fotoaparátu a mikrofónu</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Ak chceš na tejto stránke používať funkcie fotoaparátu a mikrofónu, sú potrebné povolenia pre fotoaparát a mikrofón.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo nemohol zdieľať polohu s touto lokalitou</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo nemohol tejto lokalite udeliť prístup k fotoaparátu</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo nemohol udeliť prístup k mikrofónu tejto lokalite</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo nemohol udeliť prístup k fotoaparátu a mikrofónu tejto stránke</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-sl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-sl/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Za glasovne funkcije je potrebno dovoljenje za mikrofon</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potrebuje dostop do mikrofona</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Dovoljenja za mikrofon so potrebna, če želite uporabljati glasovni klepet v Duck.ai</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Sprememba dovoljenj</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Sprememba dovoljenj</string>
 
     <string name="sitePermissionsSettingsDescription">Spletna mesta, ki jih obiščete, lahko zahtevajo dostop do lokacije, kamere, mikrofona ali programske opreme DRM (Digital Rights Management) vaše naprave. Do njih ne bodo mogla dostopati, razen če jim to izrecno dovolite.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Dovoli vsem mestom, da zahtevajo:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-sl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-sl/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Za glasovne funkcije je potrebno dovoljenje za mikrofon</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo potrebuje dostop do mikrofona</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Dovoljenja za mikrofon so potrebna, če želite uporabljati glasovni klepet v Duck.ai</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Sprememba dovoljenj</string>
 
     <string name="sitePermissionsSettingsDescription">Spletna mesta, ki jih obiščete, lahko zahtevajo dostop do lokacije, kamere, mikrofona ali programske opreme DRM (Digital Rights Management) vaše naprave. Do njih ne bodo mogla dostopati, razen če jim to izrecno dovolite.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Dovoli vsem mestom, da zahtevajo:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Dovoli</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Onemogočeno za vsa spletna mesta</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s dovoljenje za %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Dovoli med uporabo spletnega mesta</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Dovoli tokrat</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Nikoli ne dovoli</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Spletno mesto »%1$s« želi dostopati do vaše lokacije</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">»%1$s« želi dostopati do vaše lokacije</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Vašo lokacijo bomo anonimizirali in jo uporabili za zagotavljanje boljših rezultatov v vaši bližini.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Spletno mesto »%1$s« želi dostopati do vašega fotoaparata</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Spletno mesto »%1$s« želi dostopati do vašega mikrofona</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Spletno mesto »%1$s« želi dostopati do vašega fotoaparata in mikrofona</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Če ne dovolite, videoposnetkov na spletnem mestu morda ne bo mogoče predvajati, vendar to spletno mesto ne bo imelo dostopa do identifikatorjev naprav, ki jih zagotavlja programska oprema DRM.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Sprememba dovoljenj</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo potrebuje dostop do lokacije</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Če želite uporabljati lokacijske funkcije na tem spletnem mestu, so potrebna dovoljenja za lokacijo.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo potrebuje dostop do fotoaparata</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Če želite uporabljati funkcije fotoaparata na tem spletnem mestu, so potrebna dovoljenja za fotoaparat.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo potrebuje dostop do mikrofona</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Dovoljenja za mikrofon so potrebna, če želite uporabljati funkcije mikrofona na tem spletnem mestu.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo potrebuje dostop do kamere in mikrofona</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Dovoljenja za fotoaparat in mikrofon so potrebna, če želite uporabljati funkcije fotoaparata in mikrofona na tem spletnem mestu.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo ni mogel deliti lokacije s tem spletnim mestom</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo temu spletnemu mestu ni mogel omogočiti dostopa do fotoaparata</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo temu spletnemu mestu ni mogel omogočiti dostopa do mikrofona</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo temu spletnemu mestu ni mogel omogočiti dostopa do kamere in mikrofona</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-sv/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-sv/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Mikrofonbehörighet krävs för röstfunktioner</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo behöver komma åt din mikrofon</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofonbehörighet behövs om du vill använda röstchatt i Duck.ai</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Ändra behörigheter</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">Ändra behörigheter</string>
 
     <string name="sitePermissionsSettingsDescription">Webbplatser som du besöker kan begära åtkomst till din enhets plats, kamera, mikrofon eller DRM-programvara (Digital Rights Management). De kan inte komma åt dessa om du inte uttryckligen tillåter det.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Tillåt alla webbplatser att be om:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-sv/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-sv/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Mikrofonbehörighet krävs för röstfunktioner</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo behöver komma åt din mikrofon</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Mikrofonbehörighet behövs om du vill använda röstchatt i Duck.ai</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">Ändra behörigheter</string>
 
     <string name="sitePermissionsSettingsDescription">Webbplatser som du besöker kan begära åtkomst till din enhets plats, kamera, mikrofon eller DRM-programvara (Digital Rights Management). De kan inte komma åt dessa om du inte uttryckligen tillåter det.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Tillåt alla webbplatser att be om:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Tillåt</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Inaktiverat för alla webbplatser</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s-behörighet för %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Tillåt medan webbplatsen används</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Tillåt den här gången</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Tillåt aldrig</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">Webbplatsen ”%1$s” vill få åtkomst till din plats</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">”%1$s” vill få åtkomst till din plats</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Vi anonymiserar din plats och använder den för att ge dig bättre resultat, närmare dig.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">Webbplatsen ”%1$s” vill få åtkomst till din kamera</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">Webbplatsen ”%1$s” vill få åtkomst till din mikrofon</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">Webbplatsen ”%1$s” vill få åtkomst till din kamera och mikrofon</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">Om du inte tillåter kan videor på webbplatsen bli ospelbara, men denna webbplats kommer inte att ha åtkomst till enhetsidentifierare som tillhandahålls av DRM-programvara.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Ändra behörigheter</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo behöver komma åt din plats</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Platsbehörighet behövs om du vill använda platsfunktioner på den här webbplatsen.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo behöver komma åt din kamera</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Kamerabehörighet behövs om du vill använda kamerafunktioner på den här webbplatsen.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo behöver få åtkomst till din mikrofon</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Mikrofonbehörighet behövs om du vill använda mikrofonfunktioner på den här webbplatsen.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo behöver komma åt din kamera och mikrofon</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Kamera- och mikrofonbehörighet behövs om du vill använda kamera- och mikrofonfunktioner på den här webbplatsen.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo kunde inte dela plats med den här webbplatsen</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo kunde inte ge den här webbplatsen kameraåtkomst</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo kunde inte ge mikrofonåtkomst till den här webbplatsen</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo kunde inte ge den här webbplatsen kamera- och mikrofonåtkomst</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values-tr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-tr/strings-site-permissions.xml
@@ -60,7 +60,7 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Ses özellikleri için mikrofon izni gerekiyor</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo\'nun mikrofonunuza erişmesi gerekiyor</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Duck.ai\'da Sesli Sohbet özelliğini kullanmak istiyorsanız mikrofon izinleri gereklidir</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">İzinleri Değiştir</string>
+    <string name="sitePermissionsDialogChangePermissionsButton">İzinleri Değiştir</string>
 
     <string name="sitePermissionsSettingsDescription">Ziyaret ettiğiniz siteler cihazınızın konumuna, kamerasına, mikrofonuna veya DRM (Dijital Haklar Yönetimi) yazılımına erişim isteyebilir. Siz açıkça izin vermediğiniz sürece bunlara erişemezler.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Tüm sitelerin şunları istemesine izin ver:</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-tr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-tr/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Ses özellikleri için mikrofon izni gerekiyor</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo\'nun mikrofonunuza erişmesi gerekiyor</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Duck.ai\'da Sesli Sohbet özelliğini kullanmak istiyorsanız mikrofon izinleri gereklidir</string>
-    <string name="sitePermissionsDialogChangePermissionsButton">İzinleri Değiştir</string>
 
     <string name="sitePermissionsSettingsDescription">Ziyaret ettiğiniz siteler cihazınızın konumuna, kamerasına, mikrofonuna veya DRM (Dijital Haklar Yönetimi) yazılımına erişim isteyebilir. Siz açıkça izin vermediğiniz sürece bunlara erişemezler.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Tüm sitelerin şunları istemesine izin ver:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">İzin ver</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Tüm siteler için devre dışı</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%2$s için %1$s izni</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Siteyi kullanırken izin ver</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Bu seferlik izin ver</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Hiçbir Zaman İzin Verme</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" web sitesi konumunuza erişmek istiyor</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" konumunuza erişmek istiyor</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">Konumunu anonimleştirip sana daha yakın, daha iyi sonuçlar sunmak için kullanacağız.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" web sitesi kamerana erişmek istiyor</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">\"%1$s\" web sitesi mikrofonuna erişmek istiyor</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" web sitesi kamerana ve mikrofonuna erişmek istiyor</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">İzin vermezsen sitedeki videolar oynatılamaz duruma gelebilir ancak bu site, DRM yazılımı tarafından sağlanan cihaz tanımlayıcılarına erişemez.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">İzinleri Değiştir</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo\'nun konumunuza erişmesi gerekiyor</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Bu sitedeki konum özelliklerini kullanmak istiyorsan konum izinleri gereklidir.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo\'nun kameranıza erişmesi gerekiyor</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Bu sitedeki kamera özelliklerini kullanmak istiyorsan kamera izinleri gereklidir.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo\'nun mikrofonunuza erişmesi gerekiyor</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Bu sitedeki mikrofon özelliklerini kullanmak istiyorsan mikrofon izinleri gereklidir.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo\'nun kamera ve mikrofonunuza erişmesi gerekiyor</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Bu sitede kamera ve mikrofon özelliklerini kullanmak istiyorsan kamera ve mikrofon izinleri gereklidir.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo bu siteyle konum paylaşamadı</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo bu siteye kamera erişimi veremedi</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo bu siteye mikrofon erişimi veremedi</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo bu siteye kamera ve mikrofon erişimi veremedi</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values/donottranslate.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values/donottranslate.xml
@@ -29,4 +29,21 @@
     <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your microphone</string>
     <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your camera and microphone</string>
     <string name="sitePermissionsTieredDrmDialogSubtitle">If you don\'t allow, videos on the site may become unplayable, but this site will not have access to device identifiers provided by DRM software.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton">Change Permissions</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo needs to access your location</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Location permissions are needed if you want to use location features on this site.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo needs to access your camera</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Camera permissions are needed if you want to use camera features on this site.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo needs to access your microphone</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Microphone permissions are needed if you want to use microphone features on this site.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo needs to access your camera and microphone</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Camera and microphone permissions are needed if you want to use camera and microphone features on this site.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo couldn\'t share location with this site</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo couldn\'t give camera access to this site</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo couldn\'t give microphone access to this site</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo couldn\'t give camera and microphone access to this site</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values/donottranslate.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values/donottranslate.xml
@@ -18,32 +18,4 @@
     <!-- DRM -->
     <string name="sitePermissionsSettingsDRM">DRM</string>
 
-    <!-- Tiered permission dialog -->
-    <string name="sitePermissionsDialogAllowWhileUsingSiteButton">Allow While Using Site</string>
-    <string name="sitePermissionsDialogAllowThisTimeButton">Allow This Time</string>
-    <string name="sitePermissionsDialogNeverAllowButton">Never Allow</string>
-    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your location</string>
-    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" wants to access your location</string>
-    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">We\'ll anonymize your location and use it to deliver better results, closer to you.</string>
-    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your camera</string>
-    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your microphone</string>
-    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your camera and microphone</string>
-    <string name="sitePermissionsTieredDrmDialogSubtitle">If you don\'t allow, videos on the site may become unplayable, but this site will not have access to device identifiers provided by DRM software.</string>
-
-    <!-- Reminder dialog -->
-    <string name="sitePermissionsDialogChangePermissionsButton">Change Permissions</string>
-    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo needs to access your location</string>
-    <string name="sitePermissionsTieredSystemDeniedLocationContent">Location permissions are needed if you want to use location features on this site.</string>
-    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo needs to access your camera</string>
-    <string name="sitePermissionsTieredSystemDeniedCameraContent">Camera permissions are needed if you want to use camera features on this site.</string>
-    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo needs to access your microphone</string>
-    <string name="sitePermissionsTieredSystemDeniedMicContent">Microphone permissions are needed if you want to use microphone features on this site.</string>
-    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo needs to access your camera and microphone</string>
-    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Camera and microphone permissions are needed if you want to use camera and microphone features on this site.</string>
-
-    <!-- Denial snackbar -->
-    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo couldn\'t share location with this site</string>
-    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo couldn\'t give camera access to this site</string>
-    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo couldn\'t give microphone access to this site</string>
-    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo couldn\'t give camera and microphone access to this site</string>
 </resources>

--- a/site-permissions/site-permissions-impl/src/main/res/values/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values/strings-site-permissions.xml
@@ -60,7 +60,6 @@
     <string name="duckAiMicPermissionDeniedSnackBarMessage">Microphone permission needed for voice features</string>
     <string name="duckAiMicPermissionDeniedDialogTitle">DuckDuckGo needs to access your microphone</string>
     <string name="duckAiMicPermissionDeniedDialogContent">Microphone permissions are needed if you want to use Voice Chat in Duck.ai</string>
-    <string name="duckAiMicPermissionDeniedDialogPositiveButton">Change Permissions</string>
 
     <string name="sitePermissionsSettingsDescription">Sites you visit may ask for access to your device’s location, camera, microphone, or DRM (Digital Rights Management) software. They won’t be able to access these unless you explicitly give them permission.</string>
     <string name="sitePermissionsSettingsEnablePermissionTitle">Allow all sites to ask for:</string>
@@ -76,5 +75,34 @@
     <string name="permissionsPerWebsiteAllowSetting">Allow</string>
     <string name="permissionsPerWebsiteAskDisabledSetting">Disabled for all sites</string>
     <string name="permissionsPerWebsiteSelectorDialogTitle" instruction="%1$s is the name of a permissions and %2$s is the name of a website, i.e. Camera permission for example.com">%1$s permission for %2$s</string>
+
+    <!-- Tiered permission dialog -->
+    <string name="sitePermissionsDialogAllowWhileUsingSiteButton" instruction="Button granting a website a permission for every visit, until the user changes it">Allow While Using Site</string>
+    <string name="sitePermissionsDialogAllowThisTimeButton" instruction="Button granting a website a permission for the current visit only">Allow This Time</string>
+    <string name="sitePermissionsDialogNeverAllowButton" instruction="Button refusing a website a permission for every visit, until the user changes it">Never Allow</string>
+    <string name="sitePermissionsTieredLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your location</string>
+    <string name="sitePermissionsTieredDdgLocationDialogTitle" instruction="Placeholder is a website">\"%1$s\" wants to access your location</string>
+    <string name="sitePermissionsTieredDdgLocationDialogSubtitle">We\'ll anonymize your location and use it to deliver better results, closer to you.</string>
+    <string name="sitePermissionsTieredCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your camera</string>
+    <string name="sitePermissionsTieredMicDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your microphone</string>
+    <string name="sitePermissionsTieredMicAndCameraDialogTitle" instruction="Placeholder is a website">\"%1$s\" website wants to access your camera and microphone</string>
+    <string name="sitePermissionsTieredDrmDialogSubtitle">If you don\'t allow, videos on the site may become unplayable, but this site will not have access to device identifiers provided by DRM software.</string>
+
+    <!-- Reminder dialog -->
+    <string name="sitePermissionsDialogChangePermissionsButton" instruction="Button opening the DuckDuckGo permission settings in the Android system settings app">Change Permissions</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationTitle">DuckDuckGo needs to access your location</string>
+    <string name="sitePermissionsTieredSystemDeniedLocationContent">Location permissions are needed if you want to use location features on this site.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraTitle">DuckDuckGo needs to access your camera</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraContent">Camera permissions are needed if you want to use camera features on this site.</string>
+    <string name="sitePermissionsTieredSystemDeniedMicTitle">DuckDuckGo needs to access your microphone</string>
+    <string name="sitePermissionsTieredSystemDeniedMicContent">Microphone permissions are needed if you want to use microphone features on this site.</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicTitle">DuckDuckGo needs to access your camera and microphone</string>
+    <string name="sitePermissionsTieredSystemDeniedCameraAndMicContent">Camera and microphone permissions are needed if you want to use camera and microphone features on this site.</string>
+
+    <!-- Denial snackbar -->
+    <string name="sitePermissionsTieredLocationDeniedSnackBarMessage">DuckDuckGo couldn\'t share location with this site</string>
+    <string name="sitePermissionsTieredCameraDeniedSnackBarMessage">DuckDuckGo couldn\'t give camera access to this site</string>
+    <string name="sitePermissionsTieredMicDeniedSnackBarMessage">DuckDuckGo couldn\'t give microphone access to this site</string>
+    <string name="sitePermissionsTieredCameraAndMicDeniedSnackBarMessage">DuckDuckGo couldn\'t give camera and microphone access to this site</string>
 
 </resources>

--- a/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncherTest.kt
+++ b/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncherTest.kt
@@ -63,6 +63,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -920,6 +921,18 @@ class SitePermissionsDialogActivityLauncherTest {
             dialog.context.getString(R.string.sitePermissionsTieredSystemDeniedCameraTitle),
             dialog.findViewById<TextView>(CommonR.id.stackedAlertDialogTitle)!!.text,
         )
+    }
+
+    @Test
+    fun whenReminderDialogIsDismissedThenRequestStaysDeniedWithoutPersisting() {
+        val dialog = denyOsPermissionAfter(tier = 1, rejectedForever = true)!!
+
+        dialog.cancel()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertTrue(shadowOf(dialog).isCancelable)
+        verify(request).deny()
+        verify(sitePermissionsRepository, never()).sitePermissionPermanentlySaved(any(), any(), any())
     }
 
     @Test

--- a/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncherTest.kt
+++ b/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncherTest.kt
@@ -70,6 +70,7 @@ import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowDialog
 import com.duckduckgo.mobile.android.R as CommonR
+import com.google.android.material.R as MaterialR
 
 @RunWith(AndroidJUnit4::class)
 class SitePermissionsDialogActivityLauncherTest {
@@ -347,7 +348,8 @@ class SitePermissionsDialogActivityLauncherTest {
         sitePermissionsDialogRedesignFeature.self().setRawStoredState(Toggle.State(redesignEnabled))
         whenever(systemPermissionsHelper.hasCameraPermissionsGranted()).thenReturn(true)
 
-        val activity = Robolectric.buildActivity(ThemedActivity::class.java).setup().get()
+        activity = Robolectric.buildActivity(ThemedActivity::class.java).setup().get()
+        testee.registerPermissionLauncher(activity)
         val request: PermissionRequest = mock()
         whenever(request.resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE))
         whenever(request.origin).thenReturn(Uri.parse(requestUrl))
@@ -368,6 +370,7 @@ class SitePermissionsDialogActivityLauncherTest {
     }
 
     private lateinit var request: PermissionRequest
+    private lateinit var activity: ThemedActivity
 
     private fun AlertDialog.tieredButtons() =
         findViewById<LinearLayout>(CommonR.id.stackedAlertDialogButtonLayout)!!
@@ -881,6 +884,60 @@ class SitePermissionsDialogActivityLauncherTest {
         val dialog = showCameraDialog(pageUrl = THIRD_PARTY_PAGE, redesignEnabled = false)
 
         assertNotNull(dialog.findViewById<TextView>(CommonR.id.textAlertDialogMessage))
+    }
+
+    private fun denyOsPermissionAfter(
+        tier: Int,
+        rejectedForever: Boolean,
+    ): AlertDialog? {
+        val dialog = showCameraDialog()
+
+        // showCameraDialog leaves the OS permission granted, so revoke it only once the prompt is up.
+        whenever(systemPermissionsHelper.hasCameraPermissionsGranted()).thenReturn(false)
+        whenever(systemPermissionsHelper.isPermissionsRejectedForever(any())).thenReturn(rejectedForever)
+        dialog.tieredButtons().getChildAt(tier).performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        val captor = argumentCaptor<(Boolean) -> Unit>()
+        verify(systemPermissionsHelper).registerPermissionLaunchers(any(), captor.capture(), any())
+        captor.firstValue.invoke(false)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        return ShadowDialog.getLatestDialog() as? AlertDialog
+    }
+
+    @Test
+    fun whenSystemPermissionRejectedForeverThenReminderDialogUsesTheStackedComponent() {
+        val dialog = denyOsPermissionAfter(tier = 0, rejectedForever = true)!!
+
+        val buttons = dialog.findViewById<LinearLayout>(CommonR.id.stackedAlertDialogButtonLayout)!!
+        assertEquals(2, buttons.childCount)
+        assertEquals(
+            dialog.context.getString(R.string.sitePermissionsDialogChangePermissionsButton),
+            (buttons.getChildAt(0) as Button).text,
+        )
+        assertEquals(
+            dialog.context.getString(R.string.sitePermissionsTieredSystemDeniedCameraTitle),
+            dialog.findViewById<TextView>(CommonR.id.stackedAlertDialogTitle)!!.text,
+        )
+    }
+
+    @Test
+    fun whenSystemPermissionDeniedOnceThenAllowingFromSnackbarKeepsTheStandingGrant() {
+        denyOsPermissionAfter(tier = 0, rejectedForever = false)
+
+        whenever(systemPermissionsHelper.hasCameraPermissionsGranted()).thenReturn(true)
+        val action = activity.window.decorView.findViewById<Button>(MaterialR.id.snackbar_action)
+        assertNotNull(action)
+        action.performClick()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify(sitePermissionsRepository).sitePermissionPermanentlySaved(
+            "https://example.com",
+            PermissionRequest.RESOURCE_VIDEO_CAPTURE,
+            ALLOW_ALWAYS,
+        )
+        verify(sitePermissionsRepository, never()).sitePermissionGranted(any(), any(), any())
     }
 
     companion object {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1218056908982088?focus=true

### Description

New string translations and a key renaming of one of the existing strings.

### Steps to test this PR

QA-optional

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-resource and localization changes with a single Kotlin resource ID swap; no permission logic changes.
> 
> **Overview**
> Adds **localized copy** for the tiered site-permissions redesign (dialog actions, titles/subtitles, system-denied reminder dialogs, and denial snackbars) by moving those keys out of `donottranslate.xml` into `strings-site-permissions.xml` and supplying translations across the updated locale files.
> 
> **Unifies** the Duck.ai microphone “open settings” dialog so it uses the shared `sitePermissionsDialogChangePermissionsButton` string in `SitePermissionsDialogActivityLauncher` instead of the removed `duckAiMicPermissionDeniedDialogPositiveButton` key (same label intent, one resource).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffbbbb1910571200a5ace3bd0eb8e8851a852054. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->