### PR TITLE
Add translations for the passwords import step in linear onboarding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
@@ -372,7 +372,7 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
             .setTitle(R.string.preOnboardingImportErrorTitle)
             .setMessage(R.string.preOnboardingImportErrorBody)
             .setPositiveButton(R.string.preOnboardingImportErrorRetry)
-            .setNegativeButton(R.string.preOnboardingImportErrorCancel)
+            .setNegativeButton(CommonR.string.cancel)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/DialogConfigResolver.kt
@@ -256,7 +256,7 @@ class DialogConfigResolver @Inject constructor(
                 action = CtaAction.Emit(NewUserOnboardingEvent.PasswordImportRequested),
             ),
             secondaryCta = CtaConfig(
-                text = TextConfig.Resource(R.string.preOnboardingImportPasswordsSecondaryCta),
+                text = TextConfig.Resource(R.string.preOnboardingWidgetPromptSecondaryCta),
                 action = CtaAction.Emit(NewUserOnboardingEvent.PasswordImportSkipped),
             ),
         )

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -966,6 +966,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Добавяне на приспособлението</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Пропускане</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Импортиране на пароли от Google</string>
+    <string name="preOnboardingImportPasswordsBody">Google може да Ви помоли да влезете или да въведете паролата си, за да потвърдите.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Импортиране от Google</string>
+    <string name="preOnboardingImportCompleteTitle">Импортирането е завършено</string>
+    <string name="preOnboardingImportCompleteCta">Продължаване</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Импортиране на пароли</string>
+    <string name="preOnboardingImportCompleteParsingBody">Това ще отнеме само няколко секунди.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Импортирането е неуспешно</string>
+    <string name="preOnboardingImportCompleteFailed">Импортирането на паролата е неуспешно</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Импортирани пароли: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Пропуснати (дублирани или невалидни): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Възникна някаква грешка</string>
+    <string name="preOnboardingImportErrorBody">Моля, опитайте отново.</string>
+    <string name="preOnboardingImportErrorRetry">Нов опит</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Добавете ме към реда с любими.</string>
     <string name="preOnboardingAddToDockBody">Намерете иконата на DuckDuckGo на началния екран. След това натиснете и плъзнете на място. Това е всичко!</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1002,6 +1002,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Přidat widget</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Přeskočit</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Import hesel z Googlu</string>
+    <string name="preOnboardingImportPasswordsBody">Google tě může požádat o přihlášení nebo potvrzení zadáním hesla.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Importovat z Googlu</string>
+    <string name="preOnboardingImportCompleteTitle">Import je hotový</string>
+    <string name="preOnboardingImportCompleteCta">Pokračovat</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Importování hesel</string>
+    <string name="preOnboardingImportCompleteParsingBody">Bude to trvat jen chvilku.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Import se nezdařil</string>
+    <string name="preOnboardingImportCompleteFailed">Import hesel se nezdařil</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Importovaných hesel: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Přeskočeno (duplicitní nebo neplatné): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Něco se pokazilo</string>
+    <string name="preOnboardingImportErrorBody">Zkus to znovu.</string>
+    <string name="preOnboardingImportErrorRetry">Zkus to znovu</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Přidej si mě do řádku oblíbených.</string>
     <string name="preOnboardingAddToDockBody">Najdi ikonu DuckDuckGo na ploše. Pak ji podrž a přetáhni na místo. A je to!</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -966,6 +966,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Tilføj widget</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Spring over</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Importer adgangskoder fra Google</string>
+    <string name="preOnboardingImportPasswordsBody">Google kan bede dig om at logge ind eller indtaste din adgangskode for at bekræfte.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Importer fra Google</string>
+    <string name="preOnboardingImportCompleteTitle">Import er fuldført</string>
+    <string name="preOnboardingImportCompleteCta">Forsæt</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Importerer adgangskoder</string>
+    <string name="preOnboardingImportCompleteParsingBody">Det tager kun et øjeblik.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Import mislykkedes</string>
+    <string name="preOnboardingImportCompleteFailed">Import af adgangskode mislykkedes</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Adgangskoder importeret: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Sprunget over (duplikerede eller ugyldige): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Noget gik galt</string>
+    <string name="preOnboardingImportErrorBody">Prøv igen.</string>
+    <string name="preOnboardingImportErrorRetry">Prøv igen</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Tilføj mig til din favoritrække.</string>
     <string name="preOnboardingAddToDockBody">Find DuckDuckGo-ikonet på din startskærm. Tryk og træk den derefter på plads. Det er det!</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -966,6 +966,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Widget hinzufügen</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Überspringen</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Passwörter von Google importieren</string>
+    <string name="preOnboardingImportPasswordsBody">Google fordert dich eventuell auf, dich anzumelden oder dein Passwort zur Bestätigung einzugeben.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Von Google importieren</string>
+    <string name="preOnboardingImportCompleteTitle">Import abgeschlossen</string>
+    <string name="preOnboardingImportCompleteCta">Fortsetzen</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Importieren von Passwörtern</string>
+    <string name="preOnboardingImportCompleteParsingBody">Das wird nur einen Moment dauern.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Fehlgeschlagene Importe</string>
+    <string name="preOnboardingImportCompleteFailed">Passwortimport fehlgeschlagen</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Passwörter importiert: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Übersprungen (doppelt oder ungültig): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Etwas ist schiefgelaufen</string>
+    <string name="preOnboardingImportErrorBody">Bitte versuche es noch einmal.</string>
+    <string name="preOnboardingImportErrorRetry">Erneut versuchen</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Füge mich zu deiner Favoritenzeile hinzu.</string>
     <string name="preOnboardingAddToDockBody">Suche auf deinem Startbildschirm das DuckDuckGo-Symbol. Ziehe es an die richtige Stelle. Das war es schon!</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -966,6 +966,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Προσθήκη μικροεφαρμογής</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Παράλειψη</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Εισαγωγή κωδικών πρόσβασης από το Google</string>
+    <string name="preOnboardingImportPasswordsBody">Η Google μπορεί να σου ζητήσει να συνδεθείς ή να εισαγάγεις τον κωδικό πρόσβασής σου για επιβεβαίωση.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Εισαγωγή από το Google</string>
+    <string name="preOnboardingImportCompleteTitle">Η εισαγωγή ολοκληρώθηκε</string>
+    <string name="preOnboardingImportCompleteCta">Συνέχεια</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Γίνεται εισαγωγή κωδικών πρόσβασης</string>
+    <string name="preOnboardingImportCompleteParsingBody">Αυτό θα διαρκέσει ελάχιστο χρόνο.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Η εισαγωγή απέτυχε</string>
+    <string name="preOnboardingImportCompleteFailed">Η εισαγωγή κωδικού πρόσβασης απέτυχε</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Κωδικοί πρόσβασης που εισήχθησαν: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Παραλείφθηκε (διπλότυπο ή μη έγκυρο): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Κάτι πήγε στραβά</string>
+    <string name="preOnboardingImportErrorBody">Προσπάθησε ξανά.</string>
+    <string name="preOnboardingImportErrorRetry">Προσπάθησε ξανά</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Πρόσθεσέ με στη σειρά των αγαπημένων σου.</string>
     <string name="preOnboardingAddToDockBody">Βρείτε το εικονίδιο DuckDuckGo στην Αρχική οθόνη σας. Στη συνέχεια, πατήστε και μεταφέρετέ το στη θέση του. Αυτό ήταν!</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -966,6 +966,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Añadir widget</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Omitir</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Importar contraseñas de Google</string>
+    <string name="preOnboardingImportPasswordsBody">Google puede pedirte que inicies sesión o introduzcas tu contraseña para confirmar.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Importar desde Google</string>
+    <string name="preOnboardingImportCompleteTitle">Importación completada</string>
+    <string name="preOnboardingImportCompleteCta">Continuar</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Importar contraseñas</string>
+    <string name="preOnboardingImportCompleteParsingBody">Esto solo tardará un momento.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Error en la importación</string>
+    <string name="preOnboardingImportCompleteFailed">Se ha producido un error al importar tu contraseña</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Contraseñas importadas: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Omitido (duplicado o no válido): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Se ha producido un error</string>
+    <string name="preOnboardingImportErrorBody">Inténtalo de nuevo.</string>
+    <string name="preOnboardingImportErrorRetry">Intentar de nuevo</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">¡Añádeme a tu fila de favoritos!</string>
     <string name="preOnboardingAddToDockBody">Busca el icono de DuckDuckGo en tu pantalla de inicio. A continuación, selecciónalo y arrástralo a su ubicación. ¡Eso es todo!</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -966,6 +966,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Lisa vidin</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Jäta vahele</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Impordi paroolid Google\'ist</string>
+    <string name="preOnboardingImportPasswordsBody">Google võib paluda sul sisse logida või sisestada kinnitamiseks parooli.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Impordi Google\'ist</string>
+    <string name="preOnboardingImportCompleteTitle">Import on lõpetatud</string>
+    <string name="preOnboardingImportCompleteCta">Jätka</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Paroolide importimine</string>
+    <string name="preOnboardingImportCompleteParsingBody">See võtab vaid hetke.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Import ebaõnnestus</string>
+    <string name="preOnboardingImportCompleteFailed">Parooli import ebaõnnestus</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Imporditud paroolid: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Vahele jäetud (duplikaat või kehtetu): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Midagi läks valesti</string>
+    <string name="preOnboardingImportErrorBody">Proovi uuesti.</string>
+    <string name="preOnboardingImportErrorRetry">Proovi uuesti</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Lisa mind oma lemmikute reale.</string>
     <string name="preOnboardingAddToDockBody">Leia oma avakuvalt DuckDuckGo ikoon. Seejärel vajuta ja lohista see oma kohale. See ongi kõik!</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -966,6 +966,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Lisää widget</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Ohita</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Tuo salasanat Googlesta</string>
+    <string name="preOnboardingImportPasswordsBody">Google saattaa pyytää sinua kirjautumaan sisään tai antamaan salasanasi vahvistusta varten.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Tuo Googlesta</string>
+    <string name="preOnboardingImportCompleteTitle">Tuonti on valmis</string>
+    <string name="preOnboardingImportCompleteCta">Jatka</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Tuodaan salasanoja</string>
+    <string name="preOnboardingImportCompleteParsingBody">Tämä kestää vain hetken.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Tuonti epäonnistui</string>
+    <string name="preOnboardingImportCompleteFailed">Salasanojen tuonti epäonnistui</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Tuodut salasanat: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Ohitettu (kaksoiskappale tai virheellinen): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Jokin meni pieleen</string>
+    <string name="preOnboardingImportErrorBody">Yritä uudelleen.</string>
+    <string name="preOnboardingImportErrorRetry">Yritä uudelleen</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Lisää minut suosikkirivillesi.</string>
     <string name="preOnboardingAddToDockBody">Etsi DuckDuckGo-kuvake aloitusnäytöltäsi. Paina ja vedä se sitten paikalleen. Siinä kaikki!</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -966,6 +966,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Ajouter un widget</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Ignorer</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Importer des mots de passe depuis Google</string>
+    <string name="preOnboardingImportPasswordsBody">Google peut vous demander de vous connecter ou de saisir votre mot de passe pour confirmer.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Importer depuis Google</string>
+    <string name="preOnboardingImportCompleteTitle">Importation terminée</string>
+    <string name="preOnboardingImportCompleteCta">Continuer</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Importation des mots de passe</string>
+    <string name="preOnboardingImportCompleteParsingBody">Cela ne prendra qu\'un instant.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Échec de l\'importation</string>
+    <string name="preOnboardingImportCompleteFailed">Échec de l\'importation des mots de passe</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Mots de passe importés : %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Ignorés (doublons ou non valides) : %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Une erreur s\'est produite</string>
+    <string name="preOnboardingImportErrorBody">Veuillez réessayer.</string>
+    <string name="preOnboardingImportErrorRetry">Réessayer</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Ajoutez-moi à votre ligne de favoris.</string>
     <string name="preOnboardingAddToDockBody">Trouvez l\'icône DuckDuckGo sur votre écran d\'accueil. Appuyez ensuite dessus pour la faire glisser au bon endroit. Voilà !</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1002,6 +1002,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Dodaj widget</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Preskoči</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Uvezi lozinke s Googlea</string>
+    <string name="preOnboardingImportPasswordsBody">Google te može tražiti da se prijaviš ili uneseš svoju lozinku za potvrdu.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Uvezi s Googlea</string>
+    <string name="preOnboardingImportCompleteTitle">Uvoz je završen</string>
+    <string name="preOnboardingImportCompleteCta">Nastavi</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Uvoz lozinki</string>
+    <string name="preOnboardingImportCompleteParsingBody">Ovo će potrajati samo trenutak.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Uvoz nije uspio</string>
+    <string name="preOnboardingImportCompleteFailed">Uvoz lozinke nije uspio</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Uvezene lozinke: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Preskočeno (duplicirano ili nevažeće): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Nešto nije bilo kako treba</string>
+    <string name="preOnboardingImportErrorBody">Pokušaj ponovno.</string>
+    <string name="preOnboardingImportErrorRetry">Pokušaj ponovno</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Dodaj me u red omiljenih.</string>
     <string name="preOnboardingAddToDockBody">Pronađi ikonu DuckDuckGo na početnom zaslonu. Zatim pritisni i povuci na mjesto. To je to!</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -966,6 +966,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Minialkalmazás hozzáadása</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Kihagyás</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Jelszavak importálása a Google-ból</string>
+    <string name="preOnboardingImportPasswordsBody">A Google megkérhet, hogy jelentkezz be, vagy a megerősítéshez add meg a jelszavad.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Importálás a Google-ból</string>
+    <string name="preOnboardingImportCompleteTitle">Importálás kész</string>
+    <string name="preOnboardingImportCompleteCta">Folytatás</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Jelszavak importálása</string>
+    <string name="preOnboardingImportCompleteParsingBody">Ez csak egy pillanatig tart.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Az importálás nem sikerült</string>
+    <string name="preOnboardingImportCompleteFailed">A jelszó importálása nem sikerült</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Importált jelszó: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Kihagyott (ismétlődő vagy érvénytelen): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Hiba történt</string>
+    <string name="preOnboardingImportErrorBody">Próbálkozz újra.</string>
+    <string name="preOnboardingImportErrorRetry">Próbálkozz újra</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Adj hozzá a kedvencek sorához.</string>
     <string name="preOnboardingAddToDockBody">Keresd meg a DuckDuckGo ikont a kezdőképernyőn. Ezután az ikont nyomva tartva húzd a helyére. Ennyi az egész!</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -966,6 +966,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Aggiungi widget</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Salta</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Importa le password da Google</string>
+    <string name="preOnboardingImportPasswordsBody">Google potrebbe chiederti di effettuare l\'accesso o di inserire la password per confermare.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Importa da Google</string>
+    <string name="preOnboardingImportCompleteTitle">Importazione completata</string>
+    <string name="preOnboardingImportCompleteCta">Continua</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Importazione password in corso</string>
+    <string name="preOnboardingImportCompleteParsingBody">L\'operazione richiederà solo pochi istanti.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Importazione non riuscita</string>
+    <string name="preOnboardingImportCompleteFailed">Importazione password non riuscita</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Password importate: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Ignorato (duplicato o non valido): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Si è verificato un errore</string>
+    <string name="preOnboardingImportErrorBody">Riprova.</string>
+    <string name="preOnboardingImportErrorRetry">Riprova</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Aggiungimi alla riga dei preferiti.</string>
     <string name="preOnboardingAddToDockBody">Trova l\'icona di DuckDuckGo sulla tua schermata principale. Quindi premi e trascina nella posizione desiderata. Ecco fatto.</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1002,6 +1002,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Pridėti valdiklį</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Praleisti</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Importuokite slaptažodžius iš „Google“</string>
+    <string name="preOnboardingImportPasswordsBody">„Google“ gali paprašyti prisijungti arba įvesti slaptažodį patvirtinimui.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Importuokite iš „Google“</string>
+    <string name="preOnboardingImportCompleteTitle">Importavimas baigtas</string>
+    <string name="preOnboardingImportCompleteCta">Tęsti</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Importuojami slaptažodžiai</string>
+    <string name="preOnboardingImportCompleteParsingBody">Tai užtruks tik akimirką.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Nepavyko importuoti</string>
+    <string name="preOnboardingImportCompleteFailed">Nepavyko importuoti slaptažodžių</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Importuoti slaptažodžiai: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Praleista (dublikatas arba netinkamas): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Įvyko klaida</string>
+    <string name="preOnboardingImportErrorBody">Bandykite dar kartą.</string>
+    <string name="preOnboardingImportErrorRetry">Bandykite dar kartą</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Įtraukite mane į mėgstamiausiųjų eilutę.</string>
     <string name="preOnboardingAddToDockBody">Pagrindiniame ekrane raskite „DuckDuckGo“ piktogramą. Tada paspauskite ir vilkite į vietą. Štai ir viskas!</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -984,6 +984,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Pievienot logrīku</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Izlaist</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Importēt paroles no Google</string>
+    <string name="preOnboardingImportPasswordsBody">Lai apstiprinātu, Google var lūgt tevi pierakstīties vai ievadīt paroli.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Importēt no Google</string>
+    <string name="preOnboardingImportCompleteTitle">Importēšana pabeigta</string>
+    <string name="preOnboardingImportCompleteCta">Turpināt</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Paroļu importēšana</string>
+    <string name="preOnboardingImportCompleteParsingBody">Tas aizņems tikai mirkli.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Importēšana neizdevās</string>
+    <string name="preOnboardingImportCompleteFailed">Neizdevās importēt paroles</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Importētās paroles: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Izlaists (dublikāts vai nederīgs): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Radās kāda problēma</string>
+    <string name="preOnboardingImportErrorBody">Lūdzu, mēģini vēlreiz.</string>
+    <string name="preOnboardingImportErrorRetry">Mēģināt vēlreiz</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Pievieno mani izlases joslai.</string>
     <string name="preOnboardingAddToDockBody">Atrodi DuckDuckGo ikonu sākuma ekrānā. Pēc tam piespied un ievelc vietā. Tik vienkārši!</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -966,6 +966,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Legg til widget</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Hopp over</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Importer passord fra Google</string>
+    <string name="preOnboardingImportPasswordsBody">Google kan be deg om å logge inn eller skrive inn passordet ditt for å bekrefte.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Importer fra Google</string>
+    <string name="preOnboardingImportCompleteTitle">Importen er fullført</string>
+    <string name="preOnboardingImportCompleteCta">Fortsett</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Importerer passord</string>
+    <string name="preOnboardingImportCompleteParsingBody">Dette tar bare et øyeblikk.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Import mislyktes</string>
+    <string name="preOnboardingImportCompleteFailed">Import av passord mislyktes</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Passord importert: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Hoppet over (duplikat eller ugyldig): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Noe gikk galt</string>
+    <string name="preOnboardingImportErrorBody">Prøv igjen.</string>
+    <string name="preOnboardingImportErrorRetry">Prøv igjen</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Legg meg til i favorittraden din.</string>
     <string name="preOnboardingAddToDockBody">Finn DuckDuckGo-ikonet på startskjermen. Trykk på det og dra det dit du vil ha det. Det er det hele!</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -966,6 +966,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Widget toevoegen</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Overslaan</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Wachtwoorden importeren van Google</string>
+    <string name="preOnboardingImportPasswordsBody">Google kan je vragen om in te loggen of je wachtwoord in te voeren ter bevestiging.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Importeren van Google</string>
+    <string name="preOnboardingImportCompleteTitle">Importeren voltooid</string>
+    <string name="preOnboardingImportCompleteCta">Doorgaan</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Wachtwoorden importeren...</string>
+    <string name="preOnboardingImportCompleteParsingBody">Dit duurt maar even.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Importeren mislukt</string>
+    <string name="preOnboardingImportCompleteFailed">Wachtwoord importeren mislukt</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Wachtwoorden geïmporteerd: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Overgeslagen (duplicaat of ongeldig): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Er is iets misgegaan</string>
+    <string name="preOnboardingImportErrorBody">Probeer het opnieuw.</string>
+    <string name="preOnboardingImportErrorRetry">Probeer het opnieuw</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Voeg me toe aan je favorietenrij.</string>
     <string name="preOnboardingAddToDockBody">Zoek het DuckDuckGo-pictogram op je beginscherm. Houd het vervolgens ingedrukt en sleep het naar zijn plaats. Dat is alles!</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1002,6 +1002,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Dodaj widżet</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Pomiń</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Importuj hasła z Google</string>
+    <string name="preOnboardingImportPasswordsBody">Google może poprosić o zalogowanie lub podanie hasła, aby potwierdzić.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Importuj z Google</string>
+    <string name="preOnboardingImportCompleteTitle">Import zakończony</string>
+    <string name="preOnboardingImportCompleteCta">Kontynuuj</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Importowanie haseł</string>
+    <string name="preOnboardingImportCompleteParsingBody">To zajmie tylko chwilę.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Nie udało się zaimportować</string>
+    <string name="preOnboardingImportCompleteFailed">Importowanie haseł nie powiodło się</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Zaimportowane hasła: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Pominięto (duplikat lub nieprawidłowy): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Wystąpił błąd</string>
+    <string name="preOnboardingImportErrorBody">Spróbuj ponownie.</string>
+    <string name="preOnboardingImportErrorRetry">Spróbuj ponownie</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Dodaj mnie do wiersza ulubionych.</string>
     <string name="preOnboardingAddToDockBody">Znajdź ikonę DuckDuckGo na ekranie głównym. Następnie naciśnij i przeciągnij w odpowiednie miejsce. Gotowe!</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -966,6 +966,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Adicionar widget</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Ignorar</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Importar palavras-passe do Google</string>
+    <string name="preOnboardingImportPasswordsBody">O Google pode pedir-te para iniciares sessão ou introduzires a tua palavra-passe para confirmação.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Importar do Google</string>
+    <string name="preOnboardingImportCompleteTitle">Importação concluída</string>
+    <string name="preOnboardingImportCompleteCta">Continuar</string>
+    <string name="preOnboardingImportCompleteParsingTitle">A importar palavras-passe</string>
+    <string name="preOnboardingImportCompleteParsingBody">Só vai demorar um momento.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Falha na importação</string>
+    <string name="preOnboardingImportCompleteFailed">Falha na importação da palavra-passe</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Palavras-passe importadas: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Ignorada (duplicada ou inválida): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Ocorreu um erro</string>
+    <string name="preOnboardingImportErrorBody">Tenta novamente.</string>
+    <string name="preOnboardingImportErrorRetry">Tentar novamente</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Adiciona-me à tua linha de favoritos.</string>
     <string name="preOnboardingAddToDockBody">Encontra o ícone do DuckDuckGo no ecrã inicial. Em seguida, prime e arrasta para o lugar certo. Está feito!</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -984,6 +984,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Adaugă widget</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Omite</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Importă parole din Google</string>
+    <string name="preOnboardingImportPasswordsBody">Google îți poate solicita să te conectezi sau să completezi parola pentru a confirma.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Importă din Google</string>
+    <string name="preOnboardingImportCompleteTitle">Import finalizat</string>
+    <string name="preOnboardingImportCompleteCta">Continuă</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Se importă parolele</string>
+    <string name="preOnboardingImportCompleteParsingBody">Acest lucru va dura doar un moment.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Importul nu a reușit</string>
+    <string name="preOnboardingImportCompleteFailed">Importarea parolelor nu a reușit</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Parole importate: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Omise (duplicate sau nevalide): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Ceva nu a funcționat corect</string>
+    <string name="preOnboardingImportErrorBody">Încearcă din nou.</string>
+    <string name="preOnboardingImportErrorRetry">Încearcă din nou</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Adaugă-mă în șirul tău de preferințe.</string>
     <string name="preOnboardingAddToDockBody">Găsește pictograma DuckDuckGo pe ecranul de pornire. Apoi apasă și trage în poziție. Gata!</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1002,6 +1002,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Добавить виджет</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Пропустить</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Импортировать пароли из Google</string>
+    <string name="preOnboardingImportPasswordsBody">Google может попросить вас войти в систему или ввести пароль для подтверждения.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Импортировать из Google</string>
+    <string name="preOnboardingImportCompleteTitle">Импортирование завершено</string>
+    <string name="preOnboardingImportCompleteCta">Продолжить</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Импорт паролей</string>
+    <string name="preOnboardingImportCompleteParsingBody">Это займет совсем немного времени.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Не удалось импортировать</string>
+    <string name="preOnboardingImportCompleteFailed">Не удалось импортировать пароли</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Импортировано паролей: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Пропущено (дубликаты и недействительные): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Что-то пошло не так</string>
+    <string name="preOnboardingImportErrorBody">Повторите попытку.</string>
+    <string name="preOnboardingImportErrorRetry">Повторить попытку</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Добавьте меня в строку избранного.</string>
     <string name="preOnboardingAddToDockBody">Найдите значок DuckDuckGo на главном экране. Затем нажмите и перетащите виджет на нужное место. Готово!</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1002,6 +1002,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Pridať miniaplikáciu</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Preskočiť</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Importovanie hesiel z Google</string>
+    <string name="preOnboardingImportPasswordsBody">Google ťa môže požiadať, aby si sa prihlásil/-a alebo zadal/-a svoje heslo na potvrdenie.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Importovať z Google</string>
+    <string name="preOnboardingImportCompleteTitle">Import bol dokončený</string>
+    <string name="preOnboardingImportCompleteCta">Pokračovať</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Importovanie hesiel</string>
+    <string name="preOnboardingImportCompleteParsingBody">Bude to trvať len chvíľu.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Import zlyhal</string>
+    <string name="preOnboardingImportCompleteFailed">Importovanie hesiel zlyhalo</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Počet importovaných hesiel: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Preskočené (duplicitné alebo neplatné): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Vyskytla sa chyba</string>
+    <string name="preOnboardingImportErrorBody">Skús to znova.</string>
+    <string name="preOnboardingImportErrorRetry">Skús to znova</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Pridaj ma do svojho riadku s obľúbenými položkami.</string>
     <string name="preOnboardingAddToDockBody">Nájdi ikonu DuckDuckGo na svojej úvodnej obrazovke. Potom stlač a potiahni na miesto. To je všetko!</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1002,6 +1002,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Dodaj pripomoček</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Preskoči</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Uvozi gesla iz Googla</string>
+    <string name="preOnboardingImportPasswordsBody">Google vas bo morda prosil, da se prijavite ali vnesete geslo za potrditev.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Uvozi iz Googla</string>
+    <string name="preOnboardingImportCompleteTitle">Uvoz je dokončan</string>
+    <string name="preOnboardingImportCompleteCta">Nadaljuj</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Uvažanje gesel</string>
+    <string name="preOnboardingImportCompleteParsingBody">To bo trajalo le trenutek.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Uvoz ni uspel</string>
+    <string name="preOnboardingImportCompleteFailed">Uvoz gesel ni uspel</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Uvožena gesla: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Preskočeno (podvojeno ali neveljavno): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Nekaj je šlo narobe</string>
+    <string name="preOnboardingImportErrorBody">Poskusite znova.</string>
+    <string name="preOnboardingImportErrorRetry">Poskusi znova</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Dodajte me v vrstico priljubljenih.</string>
     <string name="preOnboardingAddToDockBody">Poiščite ikono DuckDuckGo na domačem zaslonu. Nato jo pritisnite in povlecite na želeno mesto. To je to!</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -966,6 +966,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Lägg till widget</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Hoppa över</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Importera lösenord från Google</string>
+    <string name="preOnboardingImportPasswordsBody">Google kan be dig att logga in eller ange ditt lösenord för att bekräfta åtgärden.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Importera från Google</string>
+    <string name="preOnboardingImportCompleteTitle">Importen är klar</string>
+    <string name="preOnboardingImportCompleteCta">Fortsätt</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Importerar lösenord</string>
+    <string name="preOnboardingImportCompleteParsingBody">Detta tar bara ett ögonblick.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Importen misslyckades</string>
+    <string name="preOnboardingImportCompleteFailed">Lösenordsimporten misslyckades</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Importerade lösenord: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Hoppade över (dubblett eller ogiltig): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Något gick fel</string>
+    <string name="preOnboardingImportErrorBody">Försök igen.</string>
+    <string name="preOnboardingImportErrorRetry">Försök igen</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Lägg till mig i din favoritrad.</string>
     <string name="preOnboardingAddToDockBody">Leta upp DuckDuckGo-ikonen på startskärmen. Tryck och dra den därefter på plats. Sedan är det klart!</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -966,6 +966,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Widget Ekle</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Atla</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Google\'dan şifreleri içe aktar</string>
+    <string name="preOnboardingImportPasswordsBody">Google, onaylamak için oturum açmanızı veya şifre girmenizi isteyebilir.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Google\'dan İçe Aktar</string>
+    <string name="preOnboardingImportCompleteTitle">İçe aktarma tamamlandı</string>
+    <string name="preOnboardingImportCompleteCta">Devam et</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Şifreler içe aktarılıyor</string>
+    <string name="preOnboardingImportCompleteParsingBody">Bu sadece bir an sürecek.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">İçe aktarma başarısız</string>
+    <string name="preOnboardingImportCompleteFailed">Şifre içe aktarma başarısız</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">İçe aktarılan şifreler: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Atlandı (yinelenen veya geçersiz): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Bir hata oluştu</string>
+    <string name="preOnboardingImportErrorBody">Lütfen tekrar deneyin.</string>
+    <string name="preOnboardingImportErrorRetry">Tekrar dene</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Beni favoriler satırına ekle.</string>
     <string name="preOnboardingAddToDockBody">Ana Ekranınızda DuckDuckGo simgesini bulun. Daha sonra simgeye basıp sürükleyerek yerine sabitleyin. Hepsi bu kadar!</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -136,21 +136,4 @@
         <item quantity="other" instruction="%1$d is the number of chats the user is about to delete.">Delete %1$d chats?</item>
     </plurals>
 
-    <!-- Pre-onboarding: import passwords -->
-    <string name="preOnboardingImportPasswordsTitle">Import passwords from Google</string>
-    <string name="preOnboardingImportPasswordsBody">Google may ask you to sign in or enter your password to confirm.</string>
-    <string name="preOnboardingImportPasswordsPrimaryCta">Import From Google</string>
-    <string name="preOnboardingImportPasswordsSecondaryCta">Skip</string>
-    <string name="preOnboardingImportCompleteTitle">Import complete</string>
-    <string name="preOnboardingImportCompleteCta">Continue</string>
-    <string name="preOnboardingImportCompleteParsingTitle">Importing passwords</string>
-    <string name="preOnboardingImportCompleteParsingBody">This will only take a moment.</string>
-    <string name="preOnboardingImportCompleteFailedTitle">Import failed</string>
-    <string name="preOnboardingImportCompleteFailed">Password import failed</string>
-    <string name="preOnboardingImportCompleteImported" instruction="%1$s is the number of passwords that were imported.">Passwords imported: %1$s</string>
-    <string name="preOnboardingImportCompleteSkipped" instruction="%1$s is the number of passwords that were not imported.">Skipped (duplicate or invalid): %1$s</string>
-    <string name="preOnboardingImportErrorTitle">Something went wrong</string>
-    <string name="preOnboardingImportErrorBody">Please try again.</string>
-    <string name="preOnboardingImportErrorRetry">Try again</string>
-    <string name="preOnboardingImportErrorCancel">Cancel</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -965,6 +965,22 @@
     <string name="preOnboardingWidgetPromptPrimaryCta">Add Widget</string>
     <string name="preOnboardingWidgetPromptSecondaryCta">Skip</string>
 
+    <!-- Pre-onboarding: import passwords -->
+    <string name="preOnboardingImportPasswordsTitle">Import passwords from Google</string>
+    <string name="preOnboardingImportPasswordsBody">Google may ask you to sign in or enter your password to confirm.</string>
+    <string name="preOnboardingImportPasswordsPrimaryCta">Import From Google</string>
+    <string name="preOnboardingImportCompleteTitle">Import complete</string>
+    <string name="preOnboardingImportCompleteCta">Continue</string>
+    <string name="preOnboardingImportCompleteParsingTitle">Importing passwords</string>
+    <string name="preOnboardingImportCompleteParsingBody">This will only take a moment.</string>
+    <string name="preOnboardingImportCompleteFailedTitle">Import failed</string>
+    <string name="preOnboardingImportCompleteFailed">Password import failed</string>
+    <string name="preOnboardingImportCompleteImported" instruction="Placeholder is the number of passwords that were imported.">Passwords imported: %1$s</string>
+    <string name="preOnboardingImportCompleteSkipped" instruction="Placeholder is the number of passwords that were not imported.">Skipped (duplicate or invalid): %1$s</string>
+    <string name="preOnboardingImportErrorTitle">Something went wrong</string>
+    <string name="preOnboardingImportErrorBody">Please try again.</string>
+    <string name="preOnboardingImportErrorRetry">Try again</string>
+
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingDockStepTitle">Add me to your favorites row.</string>
     <string name="preOnboardingAddToDockBody">Find the DuckDuckGo icon on your Home Screen. Then press and drag into place. That’s it!</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-it/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-it/strings-subscriptions.xml
@@ -100,7 +100,7 @@
     <string name="itrSettingTitle" translatable="false">Identity Theft Restoration</string>
 
     <!-- Change Plan -->
-    <string name="changePlanTitle">Aggiorna o o annulla il piano</string>
+    <string name="changePlanTitle">Aggiorna o annulla il piano</string>
     <string name="changePlanDescription">L\'abbonamento è stato acquistato tramite l\'App Store di Apple. Per modificare il tuo piano o le impostazioni di fatturazione, vai su Impostazioni &gt; Account Apple &gt; Abbonamenti su un dispositivo che ha effettuato l\'accesso con lo stesso account Apple utilizzato per acquistare l\'abbonamento.</string>
 
     <!-- PIR Activity-->


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1218089882447998?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

Add translations for the passwords import step in the linear onboarding.

### Steps to test this PR

QA-Optional

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localization and string-resource wiring only; no changes to import logic or security behavior.
> 
> **Overview**
> Adds **localized copy** for the linear onboarding **Google password import** step (prompt, progress, success/failure counts, and error/retry) across default `strings.xml` and many locale files, and **removes** those entries from `donottranslate.xml` so they go through normal translation.
> 
> **String consolidation:** the import step’s secondary action now uses the existing **widget prompt “Skip”** string (`preOnboardingWidgetPromptSecondaryCta`), and the import error dialog’s dismiss button uses the shared **`CommonR.string.cancel`** instead of a dedicated `preOnboardingImportErrorCancel` key (dropped from resources).
> 
> Unrelated: fixes an Italian subscriptions string typo (“Aggiorna o o” → “Aggiorna o”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c151275637780d82353ac1652b60a5fc020b645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->