### PR TITLE
Do not show Got It dialog when syncing on v2.1+

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -308,10 +308,18 @@ class RealSyncCodeDispatcher @Inject constructor(
         peerKind: PeerKind?,
     ): DispatchOutcome? = when (transition.to) {
         ExchangeV2State.Joiner.Confirming ->
-            DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+            DispatchOutcome.JoinerConfirmationRequested(
+                peerName = runner.peerName,
+                protocolVersion = runner.protocolVersion,
+                peerKind = peerKind,
+            )
 
         ExchangeV2State.Host.Confirming ->
-            DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+            DispatchOutcome.HostConfirmationRequested(
+                peerName = runner.peerName,
+                protocolVersion = runner.protocolVersion,
+                peerKind = peerKind,
+            )
 
         ExchangeV2State.Host.Done -> hostDoneToOutcome(transition.trigger, peerKind)
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.sync.impl
 
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
@@ -118,14 +119,26 @@ sealed interface DispatchOutcome {
     /**
      * SM reached Joiner.Confirming. Caller must prompt the user ("Sync your data with [peerName]?")
      * then call [SyncCodeDispatcher.confirmJoiner] or [SyncCodeDispatcher.denyJoiner] to resume.
+     * [protocolVersion] is the session's negotiated exchange version, letting the caller pick the
+     * post-confirmation UX (v2.1+ skips the acknowledgment dialog).
      */
-    data class JoinerConfirmationRequested(val peerName: String?, val peerKind: PeerKind? = null) : DispatchOutcome
+    data class JoinerConfirmationRequested(
+        val peerName: String?,
+        val protocolVersion: ExchangeProtocolVersion.V2,
+        val peerKind: PeerKind? = null,
+    ) : DispatchOutcome
 
     /**
      * SM reached Host.Confirming. Caller must prompt the user ("Allow [peerName] to join your
      * sync & backup?") then call [SyncCodeDispatcher.confirmHost] or [SyncCodeDispatcher.denyHost].
+     * [protocolVersion] is the session's negotiated exchange version, letting the caller pick the
+     * post-confirmation UX (v2.1+ skips the acknowledgment dialog).
      */
-    data class HostConfirmationRequested(val peerName: String?, val peerKind: PeerKind? = null) : DispatchOutcome
+    data class HostConfirmationRequested(
+        val peerName: String?,
+        val protocolVersion: ExchangeProtocolVersion.V2,
+        val peerKind: PeerKind? = null,
+    ) : DispatchOutcome
 
     /**
      * Emitted once per [SyncCodeDispatcher.presentV2] session, before any confirmation or

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -111,6 +111,12 @@ interface ExchangeV2Runner {
     val peerKind: String?
 
     /**
+     * Protocol version negotiated with the peer: the lower of the two sides' versions. Baseline
+     * v2.0 until the peer's version is learned (from the scanned linking code or the hello message).
+     */
+    val protocolVersion: ExchangeProtocolVersion.V2
+
+    /**
      * Join the session behind a linking code this device scanned or pasted. Returns immediately;
      * the session is only usable once [ExchangeV2Event.SessionStarted] has been emitted, and a code
      * that doesn't parse surfaces as a [ExchangeV2Event.SessionError] rather than a thrown exception.
@@ -207,6 +213,7 @@ class RealExchangeV2Runner @Inject constructor(
     override val canStartAsPresenter: Boolean get() = true
     override val peerName: String? get() = peerData?.name
     override val peerKind: String? get() = peerData?.kind
+    override val protocolVersion: ExchangeProtocolVersion.V2 get() = negotiatedVersion
 
     // -----------------------------------------------------------------------
     // Entry points

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/pairing/process/ProcessSyncCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/pairing/process/ProcessSyncCodeViewModel.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.sync.impl.SyncAuthCode.Unknown
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters
@@ -128,15 +129,11 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
     }
 
     fun onAcknowledgmentConfirmed() {
-        _viewState.update { it.copy(dialog = null) }
-        if (viewState.value.isWaitingForOtherDevice) return
-        viewModelScope.launch {
-            _commands.send(Command.RunAcknowledgmentAnimation)
-        }
+        dismissDialogAndRunAnimation()
     }
 
     fun onHostConfirmed() {
-        _viewState.update { it.copy(dialog = DialogType.PairingAcknowledgment) }
+        handleRoleConfirmation()
         codeDispatcher.confirmHost()
     }
 
@@ -146,7 +143,7 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
     }
 
     fun onJoinerConfirmed() {
-        _viewState.update { it.copy(dialog = DialogType.PairingAcknowledgment) }
+        handleRoleConfirmation()
         codeDispatcher.confirmJoiner()
     }
 
@@ -273,19 +270,31 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
             is DispatchOutcome.LinkingCodeReady -> Unit
 
             is DispatchOutcome.HostConfirmationRequested -> {
-                _viewState.update { it.copy(dialog = DialogType.HostConfirmation(outcome.peerName, outcome.peerKind)) }
+                _viewState.update {
+                    it.copy(
+                        protocolVersion = outcome.protocolVersion,
+                        dialog = DialogType.HostConfirmation(outcome.peerName, outcome.peerKind),
+                    )
+                }
             }
 
             is DispatchOutcome.JoinerConfirmationRequested -> {
-                _viewState.update { it.copy(dialog = DialogType.JoinerConfirmation(outcome.peerName, outcome.peerKind)) }
+                _viewState.update {
+                    it.copy(
+                        protocolVersion = outcome.protocolVersion,
+                        dialog = DialogType.JoinerConfirmation(outcome.peerName, outcome.peerKind),
+                    )
+                }
             }
 
             is DispatchOutcome.LoggedIn -> {
                 val stateBeforeLogin = viewState.value
                 _viewState.update { it.copy(isLoggedIn = true, isWaitingForOtherDevice = false, dialog = null) }
-                // The animation normally starts when the user confirms the acknowledgment dialog; if the
-                // login lands while that dialog is still open, it has to be started here or the wait for
-                // the animation below would never finish.
+                // The animation normally starts on role confirmation (v2.1+) or on confirming the
+                // acknowledgment dialog (v2.0); if the login lands while that dialog is still open, or
+                // while we were waiting for the other device (where confirming skips the animation), it
+                // has to be started here or the wait below would never finish. A duplicate command is
+                // harmless: the Activity plays the animation at most once.
                 val startAnimation = outcome.path == SetupPath.RECOVERY ||
                     stateBeforeLogin.isWaitingForOtherDevice ||
                     stateBeforeLogin.dialog == DialogType.PairingAcknowledgment
@@ -340,6 +349,23 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
         fireLoginSuccessPixels(path, myRole, peerKind)
         _commands.send(Command.SetPairingResult(pairingResult()))
         _commands.send(Command.Close)
+    }
+
+    private fun handleRoleConfirmation() {
+        val protocol = _viewState.value.protocolVersion
+        if (protocol == null || protocol < ExchangeProtocolVersion.V2_1) {
+            _viewState.update { it.copy(dialog = DialogType.PairingAcknowledgment) }
+        } else {
+            dismissDialogAndRunAnimation()
+        }
+    }
+
+    private fun dismissDialogAndRunAnimation() {
+        _viewState.update { it.copy(dialog = null) }
+        if (viewState.value.isWaitingForOtherDevice) return
+        viewModelScope.launch {
+            _commands.send(Command.RunAcknowledgmentAnimation)
+        }
     }
 
     private fun fireCodeParsedPixel(decision: RouteDecision) {
@@ -411,6 +437,7 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
     internal data class ViewState(
         val isLoggedIn: Boolean = false,
         val isWaitingForOtherDevice: Boolean = false,
+        val protocolVersion: ExchangeProtocolVersion.V2? = null,
         val dialog: DialogType? = null,
     )
 

--- a/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup е криптирано от край до край на всички устройства.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Проверете другото устройство</string>
     <string name="sync_simplified_pairing_headline_recovery">Възстановяване на данни</string>
     <string name="sync_simplified_pairing_body">Свързване…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Отмяна</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Потвърдете на другото устройство…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Разбрах</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Проверете другото устройство</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">В процес на синхронизиране</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Свързване…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s е добавено към Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Funkce Sync &amp; Backup používá end-to-end šifrování na všech tvých zařízeních.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Podívej se na své druhé zařízení</string>
     <string name="sync_simplified_pairing_headline_recovery">Obnovují se data</string>
     <string name="sync_simplified_pairing_body">Připojování…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Zrušit</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Potvrď na druhém zařízení…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Rozumím</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Podívej se na své druhé zařízení</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Probíhá synchronizace</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Připojování…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Zařízení %1$s bylo přidáno do Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-da/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-da/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup er end-to-end-krypteret på alle dine enheder.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Tjek din anden enhed</string>
     <string name="sync_simplified_pairing_headline_recovery">Gendanner data</string>
     <string name="sync_simplified_pairing_body">Forbinder ...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Annuller</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Bekræft på din anden enhed…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Forstået</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Tjek din anden enhed</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Synkronisering i gang</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Forbinder ...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s er føjet til Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-de/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-de/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup ist auf all deinen Geräten Ende-zu-Ende-verschlüsselt.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Überprüfe dein anderes Gerät</string>
     <string name="sync_simplified_pairing_headline_recovery">Datenwiederherstellung</string>
     <string name="sync_simplified_pairing_body">Verbinden …</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Abbrechen</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Bestätige auf deinem anderen Gerät …</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Verstanden</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Überprüfe dein anderes Gerät</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Synchronisierung läuft</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Verbinden …</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s wurde zu Sync &amp; Backup hinzugefügt.</string>

--- a/sync/sync-impl/src/main/res/values-el/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-el/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Το Sync &amp; Backup είναι κρυπτογραφημένο από άκρο σε άκρο σε όλες τις συσκευές σας.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Έλεγξε την άλλη συσκευή σου</string>
     <string name="sync_simplified_pairing_headline_recovery">Γίνεται ανάκτηση δεδομένων</string>
     <string name="sync_simplified_pairing_body">Σύνδεση...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Ακύρωση</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Επιβεβαιώστε στην άλλη συσκευή σας...</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Το κατάλαβα</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Έλεγξε την άλλη συσκευή σου</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Συγχρονισμός σε εξέλιξη</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Σύνδεση...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Η συσκευή %1$s προστέθηκε στο Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-es/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-es/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup está cifrado de extremo a extremo en todos tus dispositivos.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Comprueba tu otro dispositivo</string>
     <string name="sync_simplified_pairing_headline_recovery">Recuperación de datos</string>
     <string name="sync_simplified_pairing_body">Conectando...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Cancelar</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Confirma en tu otro dispositivo…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Entendido</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Comprueba tu otro dispositivo</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sincronización en curso</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Conectando...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Se ha añadido %1$s a Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-et/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-et/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup on kõigis sinu seadmetes otspunktkrüpeeritud.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Kontrolli oma teist seadet</string>
     <string name="sync_simplified_pairing_headline_recovery">Andmete taastamine</string>
     <string name="sync_simplified_pairing_body">Ühendamine...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Tühista</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Kinnita oma teises seadmes…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Sain aru</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Kontrolli oma teist seadet</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sünkroonimine pooleli</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Ühendamine...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s on lisatud Sync &amp; Backupi.</string>

--- a/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup on päästä päähän salattu kaikilla laitteillasi.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Tarkista toinen laitteesi</string>
     <string name="sync_simplified_pairing_headline_recovery">Palautetaan tietoja</string>
     <string name="sync_simplified_pairing_body">Yhdistetään…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Peruuta</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Vahvista toisella laitteellasi…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Selvä</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Tarkista toinen laitteesi</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Synkronointi käynnissä</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Yhdistetään…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s on lisätty Sync &amp; Backup-toimintoon.</string>

--- a/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup est crypté de bout en bout sur tous vos appareils.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Vérifie ton autre appareil</string>
     <string name="sync_simplified_pairing_headline_recovery">Récupération des données</string>
     <string name="sync_simplified_pairing_body">Connexion…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Annuler</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Confirme sur ton autre appareil…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">J\'ai compris</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Vérifie ton autre appareil</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Synchronisation en cours</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Connexion…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s a été ajouté à Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Opcija Sync &amp; Backup šifrirana je metodom \"od kraja do kraja\" (end-to-end) na svim tvojim uređajima.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Provjeri svoj drugi uređaj</string>
     <string name="sync_simplified_pairing_headline_recovery">Obnavljanje podataka</string>
     <string name="sync_simplified_pairing_body">Povezivanje u tijeku...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Otkaži</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Potvrdi na drugom uređaju…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Shvaćam</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Provjeri svoj drugi uređaj</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sinkronizacija u tijeku</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Povezivanje u tijeku...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s je dodan u Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">A Sync &amp; Backup végpontok közötti titkosítással működik minden eszközödön.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Ellenőrizd a másik eszközödet</string>
     <string name="sync_simplified_pairing_headline_recovery">Adatok helyreállítása</string>
     <string name="sync_simplified_pairing_body">Csatlakozás…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Mégsem</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Erősítsd meg a másik eszközödön…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Értem</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Ellenőrizd a másik eszközödet</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Szinkronizálás folyamatban</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Csatlakozás…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">A(z) %1$s hozzáadva a Sync &amp; Backup szolgáltatáshoz.</string>

--- a/sync/sync-impl/src/main/res/values-it/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-it/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup è crittografato end-to-end su tutti i tuoi dispositivi.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Controlla l\'altro dispositivo</string>
     <string name="sync_simplified_pairing_headline_recovery">Recupero dei dati</string>
     <string name="sync_simplified_pairing_body">Connessione…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Annulla</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Conferma sull\'altro dispositivo…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Ho capito</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Controlla l\'altro dispositivo</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sincronizzazione in corso</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Connessione in corso…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s è stato aggiunto a Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Funkcijai „Sync &amp; Backup“ visuose jūsų įrenginiuose naudojamas ištisinis šifravimas.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Patikrink kitą savo įrenginį</string>
     <string name="sync_simplified_pairing_headline_recovery">Duomenų atkūrimas</string>
     <string name="sync_simplified_pairing_body">Jungiamasi...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Atšaukti</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Patvirtinkite kitame įrenginyje…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Supratau</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Patikrink kitą savo įrenginį</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Vyksta sinchronizavimas</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Jungiamasi...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s buvo pridėtas prie „Sync &amp; Backup“.</string>

--- a/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup ir pilnībā šifrēta visās tavās ierīcēs.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Pārbaudi otru ierīci</string>
     <string name="sync_simplified_pairing_headline_recovery">Datu atgūšana</string>
     <string name="sync_simplified_pairing_body">Notiek savienojuma izveide…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Atcelt</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Apstiprini to savā otrā ierīcē...</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Sapratu</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Pārbaudi otru ierīci</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Notiek sinhronizācija</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Notiek savienojuma izveide…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Ierīce %1$s ir pievienota pakalpojumam Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup er ende-til-ende-kryptert på alle enhetene dine.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Sjekk den andre enheten din</string>
     <string name="sync_simplified_pairing_headline_recovery">Gjenoppretter data</string>
     <string name="sync_simplified_pairing_body">Kobler til…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Avbryt</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Bekreft på den andre enheten …</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Den er grei</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Sjekk den andre enheten din</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Synkronisering pågår</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Kobler til…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s er lagt til i Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup is end-to-end versleuteld op al je apparaten.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Controleer je andere apparaat</string>
     <string name="sync_simplified_pairing_headline_recovery">Gegevens herstellen</string>
     <string name="sync_simplified_pairing_body">Er wordt verbinding gemaakt ...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Annuleren</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Bevestig op je andere apparaat …</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Ik snap het</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Controleer je andere apparaat</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Synchronisatie wordt uitgevoerd</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Er wordt verbinding gemaakt...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s is toegevoegd aan Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Funkcja Sync &amp; Backup jest kompleksowo szyfrowana na wszystkich Twoich urządzeniach.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Sprawdź drugie urządzenie</string>
     <string name="sync_simplified_pairing_headline_recovery">Odzyskiwanie danych</string>
     <string name="sync_simplified_pairing_body">Łączenie...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Anuluj</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Potwierdź na drugim urządzeniu…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Rozumiem</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Sprawdź drugie urządzenie</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Trwa synchronizacja</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Łączenie...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Dodano %1$s do Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">O Sync &amp; Backup é encriptado ponto a ponto em todos os teus dispositivos.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Verifica o teu outro dispositivo</string>
     <string name="sync_simplified_pairing_headline_recovery">Recuperar dados</string>
     <string name="sync_simplified_pairing_body">A ligar…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Cancelar</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Confirma no teu outro dispositivo…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Entendido</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Verifica o teu outro dispositivo</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sincronização em curso</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">A ligar…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">O %1$s foi adicionado ao Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup este criptat de la un capăt la altul pe toate dispozitivele tale.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Verifică-ți celălalt dispozitiv</string>
     <string name="sync_simplified_pairing_headline_recovery">Se recuperează datele</string>
     <string name="sync_simplified_pairing_body">Se conectează…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Anulează</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Confirmă pe celălalt dispozitiv…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Am înțeles</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Verifică-ți celălalt dispozitiv</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sincronizare în curs</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Se conectează…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s a fost adăugat la Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Функция Sync &amp; Backup защищена сквозным шифрованием на всех ваших устройствах.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Проверьте другое устройство</string>
     <string name="sync_simplified_pairing_headline_recovery">Восстановление данных</string>
     <string name="sync_simplified_pairing_body">Выполняется подключение…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Отменить</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Подтвердите на другом устройстве…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Понятно</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Проверьте другое устройство</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Выполняется синхронизация</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Выполняется подключение…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Устройство %1$s подключено к Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Služba Sync &amp; Backup je na všetkých tvojich zariadeniach šifrovaná spôsobom end-to-end.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Skontroluj svoje druhé zariadenie</string>
     <string name="sync_simplified_pairing_headline_recovery">Obnovenie údajov</string>
     <string name="sync_simplified_pairing_body">Pripája sa...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Zrušiť</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Potvrď na inom zariadení…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Rozumiem</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Skontroluj svoje druhé zariadenie</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Prebieha synchronizácia</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Pripája sa…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Zariadenie %1$s bolo pridané do služby Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup je šifriran v celoti v vseh vaših napravah.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Preveri drugo napravo</string>
     <string name="sync_simplified_pairing_headline_recovery">Obnovitev podatkov</string>
     <string name="sync_simplified_pairing_body">Povezovanje ...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Prekliči</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Potrdite v drugi napravi …</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Razumem</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Preveri drugo napravo</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sinhronizacija poteka</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Povezovanje ...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">Naprava %1$s je bila dodana v Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup är krypterad på alla dina enheter.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Kontrollera din andra enhet</string>
     <string name="sync_simplified_pairing_headline_recovery">Återställer data</string>
     <string name="sync_simplified_pairing_body">Ansluter …</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Avbryt</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Bekräfta på din andra enhet ...</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Jag förstår</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Kontrollera din andra enhet</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Synkronisering pågår</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Ansluter…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s har lagts till i Sync &amp; Backup.</string>

--- a/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync &amp; Backup tüm cihazlarınızda uçtan uca şifrelenmiştir.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Diğer cihazı kontrol edin</string>
     <string name="sync_simplified_pairing_headline_recovery">Veriler kurtarılıyor</string>
     <string name="sync_simplified_pairing_body">Bağlantı kuruluyor...</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">İptal</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Diğer cihazınızdan onaylayın…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Anladım</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Diğer cihazı kontrol edin</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Senkronizasyon devam ediyor</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Bağlantı kuruluyor...</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s, Sync &amp; Backup\'a eklendi.</string>

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -15,11 +15,6 @@
   -->
 
 <resources>
-    <string name="sync_simplified_pairing_headline_check_other_device">Check your other device</string>
-    <string name="sync_simplified_pairing_dialog_check_other_device_title">Check your other device</string>
-    <string name="sync_simplified_pairing_dialog_connecting_title">Sync in progress</string>
-    <string name="sync_simplified_pairing_dialog_connecting_body">Connecting…</string>
-
     <!-- Scanner screen: manual entry tab -->
     <string name="sync_simplified_scanner_manual_entry_example_code">eyJyZWNvdmVyeSI6eyJ1c2VyX2lkIjoiNjgwRDQ1QjUtNUU2RS00MzQ3LTlDNDQtQjZGQkU4MEZDNEE3IiwicHJpbWFyelkasd92V9rZXkiOiJBUUVCQVFFQkFRRUJBUUVCQVFFQkFRRUJBUUVCQVFFQkFRRUJBUUVCQVFFPSJ9fQ==</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values/strings-sync.xml
@@ -377,6 +377,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync&#160;&amp;&#160;Backup is end-to-end encrypted on all your devices.</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Check your other device</string>
     <string name="sync_simplified_pairing_headline_recovery">Recovering data</string>
     <string name="sync_simplified_pairing_body">Connecting…</string>
 
@@ -389,6 +390,9 @@
     <string name="sync_simplified_pairing_dialog_joiner_secondary_button">Cancel</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_title">Confirm on your other device…</string>
     <string name="sync_simplified_pairing_dialog_acknowledgment_primary_button">Got It</string>
+    <string name="sync_simplified_pairing_dialog_check_other_device_title">Check your other device</string>
+    <string name="sync_simplified_pairing_dialog_connecting_title">Sync in progress</string>
+    <string name="sync_simplified_pairing_dialog_connecting_body">Connecting…</string>
 
     <!-- Recovery Code screen -->
     <string name="sync_simplified_recovery_code_headline" instruction="Placeholder is a device name. e.g., Samsung S23">%1$s has been added to Sync&#160;&amp;&#160;Backup.</string>

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -86,6 +86,7 @@ class RealSyncCodeDispatcherTest {
             runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
         }
         whenever(it.localTrigger(any())).thenAnswer { Job().apply { complete() } }
+        whenever(it.protocolVersion).thenReturn(ExchangeProtocolVersion.V2_0)
     }
 
     private val dispatcher = RealSyncCodeDispatcher(
@@ -643,7 +644,10 @@ class RealSyncCodeDispatcherTest {
         whenever(runner.peerName).thenReturn("Peer Phone")
         dispatcher.presentV2().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
-            assertEquals(DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone"), awaitItem())
+            assertEquals(
+                DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone", protocolVersion = ExchangeProtocolVersion.V2_0),
+                awaitItem(),
+            )
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -654,7 +658,11 @@ class RealSyncCodeDispatcherTest {
         dispatcher.presentV2().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
             assertEquals(
-                DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.THIRD_PARTY),
+                DispatchOutcome.HostConfirmationRequested(
+                    peerName = "Peer Phone",
+                    protocolVersion = ExchangeProtocolVersion.V2_0,
+                    peerKind = PeerKind.THIRD_PARTY,
+                ),
                 awaitItem(),
             )
             cancelAndIgnoreRemainingEvents()
@@ -667,7 +675,37 @@ class RealSyncCodeDispatcherTest {
         dispatcher.presentV2().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Joiner.Confirming))
             assertEquals(
-                DispatchOutcome.JoinerConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.DDG),
+                DispatchOutcome.JoinerConfirmationRequested(
+                    peerName = "Peer Phone",
+                    protocolVersion = ExchangeProtocolVersion.V2_0,
+                    peerKind = PeerKind.DDG,
+                ),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `Presenter carries the negotiated protocol version on HostConfirmationRequested`() = runTest {
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.protocolVersion).thenReturn(ExchangeProtocolVersion.V2_1)
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
+            assertEquals(
+                DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone", protocolVersion = ExchangeProtocolVersion.V2_1),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `Presenter carries the negotiated protocol version on JoinerConfirmationRequested`() = runTest {
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.protocolVersion).thenReturn(ExchangeProtocolVersion.V2_1)
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Joiner.Confirming))
+            assertEquals(
+                DispatchOutcome.JoinerConfirmationRequested(peerName = "Peer Phone", protocolVersion = ExchangeProtocolVersion.V2_1),
                 awaitItem(),
             )
             cancelAndIgnoreRemainingEvents()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -350,6 +350,7 @@ class RealExchangeV2RunnerTest {
 
         val negotiation = runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().single()
         assertEquals(negotiated.toProtocolVersion(), negotiation.negotiatedVersion)
+        assertEquals(negotiated.toProtocolVersion(), runner.protocolVersion)
     }
 
     @Test
@@ -376,6 +377,7 @@ class RealExchangeV2RunnerTest {
 
         val negotiation = runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().single()
         assertEquals(negotiated.toProtocolVersion(), negotiation.negotiatedVersion)
+        assertEquals(negotiated.toProtocolVersion(), runner.protocolVersion)
     }
 
     @Test fun `Scanner reports the scanned code as the source of the peer version`() = runTest {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/pairing/process/ProcessSyncCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/pairing/process/ProcessSyncCodeViewModelTest.kt
@@ -40,6 +40,7 @@ import com.duckduckgo.sync.impl.SyncCodeType
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.autorestore.RestorePayload
 import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
@@ -437,7 +438,7 @@ class ProcessSyncCodeViewModelTest {
 
     @Test
     fun `when the host confirmation is requested then the host confirmation dialog is shown`() = runTest {
-        givenV2Outcomes(DispatchOutcome.HostConfirmationRequested(peerName = "Other Device"))
+        givenV2Outcomes(DispatchOutcome.HostConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0))
 
         val testee = createTestee()
         advanceUntilIdle()
@@ -447,7 +448,7 @@ class ProcessSyncCodeViewModelTest {
 
     @Test
     fun `when the joiner confirmation is requested then the joiner confirmation dialog is shown`() = runTest {
-        givenV2Outcomes(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device"))
+        givenV2Outcomes(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0))
 
         val testee = createTestee()
         advanceUntilIdle()
@@ -612,13 +613,31 @@ class ProcessSyncCodeViewModelTest {
     }
 
     @Test
-    fun `when the host is confirmed then the dispatcher is notified and the acknowledgment dialog is shown`() = runTest {
-        givenV2Outcomes()
+    fun `when the host is confirmed on a v2_0 session then the dispatcher is notified and the acknowledgment dialog is shown`() = runTest {
+        givenV2Outcomes(DispatchOutcome.HostConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0))
 
         val testee = createTestee()
+        advanceUntilIdle()
         testee.onHostConfirmed()
 
         assertEquals(DialogType.PairingAcknowledgment, testee.viewState.value.dialog)
+        verify(codeDispatcher).confirmHost()
+    }
+
+    @Test
+    fun `when the host is confirmed on a v2_1 session then the animation runs instead of the acknowledgment dialog`() = runTest {
+        givenV2Outcomes(DispatchOutcome.HostConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_1))
+
+        val testee = createTestee()
+        advanceUntilIdle()
+
+        testee.commands.test {
+            testee.onHostConfirmed()
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+
+            cancel()
+        }
+        assertEquals(null, testee.viewState.value.dialog)
         verify(codeDispatcher).confirmHost()
     }
 
@@ -634,13 +653,31 @@ class ProcessSyncCodeViewModelTest {
     }
 
     @Test
-    fun `when the joiner is confirmed then the dispatcher is notified and the acknowledgment dialog is shown`() = runTest {
-        givenV2Outcomes()
+    fun `when the joiner is confirmed on a v2_0 session then the dispatcher is notified and the acknowledgment dialog is shown`() = runTest {
+        givenV2Outcomes(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0))
 
         val testee = createTestee()
+        advanceUntilIdle()
         testee.onJoinerConfirmed()
 
         assertEquals(DialogType.PairingAcknowledgment, testee.viewState.value.dialog)
+        verify(codeDispatcher).confirmJoiner()
+    }
+
+    @Test
+    fun `when the joiner is confirmed on a v2_1 session then the animation runs instead of the acknowledgment dialog`() = runTest {
+        givenV2Outcomes(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_1))
+
+        val testee = createTestee()
+        advanceUntilIdle()
+
+        testee.commands.test {
+            testee.onJoinerConfirmed()
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+
+            cancel()
+        }
+        assertEquals(null, testee.viewState.value.dialog)
         verify(codeDispatcher).confirmJoiner()
     }
 
@@ -680,7 +717,7 @@ class ProcessSyncCodeViewModelTest {
         val testee = createTestee()
         advanceUntilIdle()
 
-        outcomes.emit(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device"))
+        outcomes.emit(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0))
         advanceUntilIdle()
         testee.onJoinerConfirmed()
         outcomes.emit(DispatchOutcome.LoggedIn(path = SetupPath.PAIRING))
@@ -698,6 +735,32 @@ class ProcessSyncCodeViewModelTest {
     }
 
     @Test
+    fun `when the login completes after a v2_1 confirmation then the success result is set after the animation completes`() = runTest {
+        val outcomes = MutableSharedFlow<DispatchOutcome>(extraBufferCapacity = 8)
+        whenever(codeDispatcher.route(any())).thenReturn(RouteDecision.V2InProgress(SyncCodeType.LINKING, outcomes))
+        givenThisConnectedDevice()
+
+        val testee = createTestee()
+        advanceUntilIdle()
+
+        outcomes.emit(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_1))
+        advanceUntilIdle()
+
+        testee.commands.test {
+            testee.onJoinerConfirmed()
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            assertEquals(null, testee.viewState.value.dialog)
+
+            outcomes.emit(DispatchOutcome.LoggedIn(path = SetupPath.PAIRING))
+            testee.onAnimationComplete()
+            assertIs<SetPairingResult>(awaitItem())
+            assertIs<Close>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
     fun `when the join outcome is unknown then the waiting screen replaces the acknowledgment dialog`() = runTest {
         val outcomes = MutableSharedFlow<DispatchOutcome>(extraBufferCapacity = 8)
         whenever(codeDispatcher.route(any())).thenReturn(RouteDecision.V2InProgress(SyncCodeType.LINKING, outcomes))
@@ -705,7 +768,7 @@ class ProcessSyncCodeViewModelTest {
         val testee = createTestee()
         advanceUntilIdle()
 
-        outcomes.emit(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device"))
+        outcomes.emit(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0))
         advanceUntilIdle()
         testee.onJoinerConfirmed()
         outcomes.emit(DispatchOutcome.JoinOutcomeUnknown())

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/pairing/show/DisplayQrCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/pairing/show/DisplayQrCodeViewModelTest.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAccountRepository.AuthCode
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
@@ -358,7 +359,9 @@ class DisplayQrCodeViewModelTest {
     @Test
     fun `when the host confirmation is requested then the host confirmation dialog is shown`() = runTest {
         givenV2Enabled()
-        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.HostConfirmationRequested(peerName = "Other Device")))
+        whenever(codeDispatcher.presentV2()).thenReturn(
+            flowOf(DispatchOutcome.HostConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0)),
+        )
 
         val testee = createTestee()
 
@@ -372,7 +375,9 @@ class DisplayQrCodeViewModelTest {
     @Test
     fun `when the joiner confirmation is requested then the joiner confirmation dialog is shown`() = runTest {
         givenV2Enabled()
-        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device")))
+        whenever(codeDispatcher.presentV2()).thenReturn(
+            flowOf(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0)),
+        )
 
         val testee = createTestee()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218258811849715?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Skips the Got It acknowledgment dialog during Sync Exchange pairing when both devices have negotiated protocol v2.1 or higher.

- The negotiated protocol version is now carried on `HostConfirmationRequested` and `JoinerConfirmationRequested`, so `ProcessSyncCodeViewModel` knows which version is in use when the user confirms their role.
- On a v2.0 session, confirming the host or joiner role still shows the acknowledgment dialog as before.
- On a v2.1+ session, confirming the host or joiner role dismisses any dialog and starts the pairing animation directly, skipping the acknowledgment dialog.
- If login completes while still waiting for the other device on a v2.1+ session, the success result is set once the animation finishes, same as the existing v2.0 behavior.

### Steps to test this PR

_Pairing on v2.0_
- [ ] On one of the devices disable the `canUseExchangeV2Point1` feature flag.
- [ ] Sync two devices.
- [ ] Confirm syncing on the Scanner device.
- [ ] Verify the "Confirm on your other device…" dialog with the "Got It" button is shown.
- [ ] Finish syncing.

_Pairing on v2.1+_
- [ ] On both devices enable the `canUseExchangeV2Point1` feature flag.
- [ ] Sync two devices.
- [ ] Confirm syncing on the Scanner device.
- [x] Verify the "Confirm on your other device…" dialog with the "Got It" button is not shown.
- [ ] Finish syncing.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized pairing UX branching on negotiated protocol version; v2.0 behavior is preserved and coverage is added in unit tests.
> 
> **Overview**
> **Skips the post-confirmation “Got It” pairing acknowledgment on Sync Exchange v2.1+**, while keeping the extra step for negotiated **v2.0** sessions.
> 
> The negotiated version is exposed from **`ExchangeV2Runner.protocolVersion`** and forwarded on **`HostConfirmationRequested`** / **`JoinerConfirmationRequested`** via **`RealSyncCodeDispatcher`**. **`ProcessSyncCodeViewModel`** stores that version in view state; after the user confirms host or joiner, **v2.0** still opens **`PairingAcknowledgment`**, but **v2.1+** dismisses the dialog and runs the acknowledgment animation immediately. **`LoggedIn`** handling is updated so the animation still starts if login completes while the v2.0 acknowledgment dialog is open.
> 
> Tests are updated for the new outcome fields and for v2.0 vs v2.1 confirmation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72bf9c721ff275317935287ae930587f9d1f2428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->