### PR TITLE
Add metrics for the passwords import onboarding experiment

### DIFF
--- a/PixelDefinitions/pixels/definitions/autofill.json5
+++ b/PixelDefinitions/pixels/definitions/autofill.json5
@@ -515,5 +515,167 @@
         "triggers": ["exception"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion", "error"]
+    },
+    "autofill_import_google_passwords_preimport_prompt_displayed": {
+        "description": "The prompt explaining the Google Password Manager import was displayed to the user.",
+        "owners": ["catalinradoiu"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Where the import was launched from.",
+                "enum": [
+                    "password_management_promo",
+                    "password_management_empty_state",
+                    "password_management_overflow",
+                    "autofill_settings_button",
+                    "in_browser_promo",
+                    "settings",
+                    "onboarding",
+                    "unknown"
+                ]
+            }
+        ]
+    },
+    "autofill_import_google_passwords_preimport_prompt_confirmed": {
+        "description": "The user accepted the pre-import prompt, starting the Google Password Manager import web flow.",
+        "owners": ["catalinradoiu"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Where the import was launched from.",
+                "enum": [
+                    "password_management_promo",
+                    "password_management_empty_state",
+                    "password_management_overflow",
+                    "autofill_settings_button",
+                    "in_browser_promo",
+                    "settings",
+                    "onboarding",
+                    "unknown"
+                ]
+            }
+        ]
+    },
+    "autofill_import_google_passwords_result_user_cancelled": {
+        "description": "The user backed out of the Google Password Manager import. `stage` says where they were when they left: the pre-import prompt, or a stage of the web flow itself.",
+        "owners": ["catalinradoiu"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "stage",
+                "type": "string",
+                "description": "Where the user left the import. `pre-import-dialog` for the prompt before the web flow; otherwise the web flow stage, mapped from the current URL against the URL mappings in the privacy config, or `webflow-unknown` when no mapping matches.",
+                "examples": ["pre-import-dialog", "webflow-unknown"]
+            },
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Where the import was launched from.",
+                "enum": [
+                    "password_management_promo",
+                    "password_management_empty_state",
+                    "password_management_overflow",
+                    "autofill_settings_button",
+                    "in_browser_promo",
+                    "settings",
+                    "onboarding",
+                    "unknown"
+                ]
+            }
+        ]
+    },
+    "autofill_import_google_passwords_result_success": {
+        "description": "The Google Password Manager import completed and the credentials were written to the password store.",
+        "owners": ["catalinradoiu"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "saved_credentials",
+                "type": "string",
+                "description": "Number of credentials saved, bucketed.",
+                "enum": ["none", "few", "some", "many", "lots"]
+            },
+            {
+                "key": "skipped_credentials",
+                "type": "string",
+                "description": "Number of credentials skipped as duplicates, bucketed.",
+                "enum": ["none", "few", "some", "many", "lots"]
+            },
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Where the import was launched from.",
+                "enum": [
+                    "password_management_promo",
+                    "password_management_empty_state",
+                    "password_management_overflow",
+                    "autofill_settings_button",
+                    "in_browser_promo",
+                    "settings",
+                    "onboarding",
+                    "unknown"
+                ]
+            }
+        ]
+    },
+    "autofill_import_google_passwords_result_parsing": {
+        "description": "The Google Password Manager import failed because the exported CSV of credentials could not be parsed.",
+        "owners": ["catalinradoiu"],
+        "triggers": ["exception"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Where the import was launched from.",
+                "enum": [
+                    "password_management_promo",
+                    "password_management_empty_state",
+                    "password_management_overflow",
+                    "autofill_settings_button",
+                    "in_browser_promo",
+                    "settings",
+                    "onboarding",
+                    "unknown"
+                ]
+            }
+        ]
+    },
+    "autofill_import_google_passwords_webview_crash": {
+        "description": "The Google Password Manager import failed because the WebView hosting the import flow crashed.",
+        "owners": ["catalinradoiu"],
+        "triggers": ["exception"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Where the import was launched from.",
+                "enum": [
+                    "password_management_promo",
+                    "password_management_empty_state",
+                    "password_management_overflow",
+                    "autofill_settings_button",
+                    "in_browser_promo",
+                    "settings",
+                    "onboarding",
+                    "unknown"
+                ]
+            }
+        ]
     }
 }

--- a/PixelDefinitions/pixels/native_experiments.json5
+++ b/PixelDefinitions/pixels/native_experiments.json5
@@ -44,29 +44,29 @@
             }
         },
         "passwordImportExperimentAug25": {
-          "cohorts": ["control", "treatment"],
-          "metrics": {
-            "onboarding_completed": {
-              "description": "User saw every onboarding dialog (onboarding completed)",
-              "enum": ["1"]
-            },
-            "password_import_started": {
-              "description": "User entered the Google password import web flow, from the onboarding step or any other entry point",
-              "enum": ["1"]
-            },
-            "password_import_success": {
-              "description": "A Google password import finished, from the onboarding step or any other entry point",
-              "enum": ["1"]
-            },
-            "password_import_failed": {
-              "description": "A Google password import failed with a CSV parsing error or a WebView crash",
-              "enum": ["1"]
-            },
-            "password_import_cancelled": {
-              "description": "User closed or backed out of the Google password import web flow",
-              "enum": ["1"]
+            "cohorts": ["control", "treatment"],
+            "metrics": {
+                "onboarding_completed": {
+                    "description": "User saw every onboarding dialog (onboarding completed)",
+                    "enum": ["1"]
+                },
+                "password_import_started": {
+                    "description": "User entered the Google password import web flow, from the onboarding step or any other entry point",
+                    "enum": ["1"]
+                },
+                "password_import_success": {
+                    "description": "A Google password import finished, from the onboarding step or any other entry point",
+                    "enum": ["1"]
+                },
+                "password_import_failed": {
+                    "description": "A Google password import failed with a CSV parsing error or a WebView crash",
+                    "enum": ["1"]
+                },
+                "password_import_cancelled": {
+                    "description": "User closed or backed out of the Google password import web flow",
+                    "enum": ["1"]
+                }
             }
-          }
         }
     }
 }

--- a/PixelDefinitions/pixels/native_experiments.json5
+++ b/PixelDefinitions/pixels/native_experiments.json5
@@ -42,6 +42,31 @@
                     "enum": ["1", "4", "6", "11", "21", "30"]
                 }
             }
+        },
+        "passwordImportExperimentAug25": {
+          "cohorts": ["control", "treatment"],
+          "metrics": {
+            "onboarding_completed": {
+              "description": "User saw every onboarding dialog (onboarding completed)",
+              "enum": ["1"]
+            },
+            "password_import_started": {
+              "description": "User entered the Google password import web flow, from the onboarding step or any other entry point",
+              "enum": ["1"]
+            },
+            "password_import_success": {
+              "description": "A Google password import finished, from the onboarding step or any other entry point",
+              "enum": ["1"]
+            },
+            "password_import_failed": {
+              "description": "A Google password import failed with a CSV parsing error or a WebView crash",
+              "enum": ["1"]
+            },
+            "password_import_cancelled": {
+              "description": "User closed or backed out of the Google password import web flow",
+              "enum": ["1"]
+            }
+          }
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingCompletedMetricObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingCompletedMetricObserver.kt
@@ -38,6 +38,7 @@ class OnboardingCompletedMetricObserver @Inject constructor(
     private val userStageStore: UserStageStore,
     private val onboardingPromptsExperimentMetrics: OnboardingPromptsExperimentMetrics,
     private val segmentedOnboardingExperimentMetrics: SegmentedOnboardingExperimentMetrics,
+    private val onboardingPasswordImportExperimentMetrics: OnboardingPasswordImportExperimentMetrics,
 ) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
@@ -46,6 +47,7 @@ class OnboardingCompletedMetricObserver @Inject constructor(
             .onEach {
                 onboardingPromptsExperimentMetrics.fireOnboardingCompletedMetric()
                 segmentedOnboardingExperimentMetrics.fireOnboardingCompletedMetric()
+                onboardingPasswordImportExperimentMetrics.fireOnboardingCompletedMetric()
             }
             .launchIn(appCoroutineScope)
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPasswordImportExperimentMetrics.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPasswordImportExperimentMetrics.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.MetricType
+import com.duckduckgo.feature.toggles.api.MetricsPixel
+import com.duckduckgo.feature.toggles.api.send
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface OnboardingPasswordImportExperimentMetrics {
+
+    suspend fun fireOnboardingCompletedMetric()
+}
+
+@ContributesBinding(AppScope::class)
+class OnboardingPasswordImportExperimentMetricsImpl @Inject constructor(
+    private val toggles: OnboardingPasswordImportToggles,
+) : OnboardingPasswordImportExperimentMetrics {
+
+    override suspend fun fireOnboardingCompletedMetric() {
+        MetricsPixel(
+            metric = "onboarding_completed",
+            type = MetricType.NORMAL,
+            value = "1",
+            toggle = toggles.passwordImportExperimentAug25(),
+            conversionWindow = listOf(
+                ConversionWindow(lowerWindow = 0, upperWindow = 0),
+                ConversionWindow(lowerWindow = 0, upperWindow = 14),
+            ),
+        ).send()
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModel.kt
@@ -214,7 +214,7 @@ class ConfigDrivenOnboardingPageViewModel @Inject constructor(
         }
     }
 
-    fun onContentBound(
+    fun onBeforeContentBound(
         stepId: LinearOnboardingStepId,
         content: ContentConfig,
     ) {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenWelcomePageFragment.kt
@@ -189,7 +189,7 @@ class ConfigDrivenWelcomePageFragment : OnboardingPageFragment(R.layout.content_
             content = ContentControllerImpl(
                 binding = binding.daxDialogCta,
                 contentValues = viewModel.contentValues,
-                onContentBound = viewModel::onContentBound,
+                onBeforeContentBound = viewModel::onBeforeContentBound,
                 isLightMode = { appTheme.isLightModeEnabled() },
                 isAddressBarRebrandEnabled = { appBrandDesignUpdateToggles.addressBar().isEnabled() },
             ),

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/configdriven/engine/ContentController.kt
@@ -56,7 +56,7 @@ interface ContentController {
 class ContentControllerImpl(
     private val binding: PreOnboardingDaxDialogCtaBrandDesignUpdateBinding,
     private val contentValues: ContentValueStore,
-    private val onContentBound: (LinearOnboardingStepId, ContentConfig) -> Unit,
+    private val onBeforeContentBound: (LinearOnboardingStepId, ContentConfig) -> Unit,
     isLightMode: () -> Boolean,
     isAddressBarRebrandEnabled: () -> Boolean,
 ) : ContentController {
@@ -95,7 +95,7 @@ class ContentControllerImpl(
         content: ContentConfig,
         scope: BindScope,
     ): ContentHandle {
-        onContentBound(stepId, content)
+        onBeforeContentBound(stepId, content)
         val handle = when (content) {
             is ContentConfig.Welcome -> {
                 boundView = welcome.view

--- a/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingCompletedMetricObserverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingCompletedMetricObserverTest.kt
@@ -38,6 +38,7 @@ class OnboardingCompletedMetricObserverTest {
     private val userStageStore: UserStageStore = mock { on { userAppStageFlow() } doReturn appStageFlow }
     private val metrics: OnboardingPromptsExperimentMetrics = mock()
     private val segmentedMetrics: SegmentedOnboardingExperimentMetrics = mock()
+    private val passwordImportMetrics: OnboardingPasswordImportExperimentMetrics = mock()
     private val lifecycleOwner: LifecycleOwner = mock()
 
     private val testee = OnboardingCompletedMetricObserver(
@@ -45,6 +46,7 @@ class OnboardingCompletedMetricObserverTest {
         userStageStore = userStageStore,
         onboardingPromptsExperimentMetrics = metrics,
         segmentedOnboardingExperimentMetrics = segmentedMetrics,
+        onboardingPasswordImportExperimentMetrics = passwordImportMetrics,
     )
 
     @Test
@@ -54,6 +56,7 @@ class OnboardingCompletedMetricObserverTest {
         appStageFlow.emit(AppStage.ESTABLISHED)
 
         verify(metrics).fireOnboardingCompletedMetric()
+        verify(passwordImportMetrics).fireOnboardingCompletedMetric()
     }
 
     @Test
@@ -64,6 +67,7 @@ class OnboardingCompletedMetricObserverTest {
         appStageFlow.emit(AppStage.DAX_ONBOARDING)
 
         verify(metrics, never()).fireOnboardingCompletedMetric()
+        verify(passwordImportMetrics, never()).fireOnboardingCompletedMetric()
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingPasswordImportExperimentMetricsTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingPasswordImportExperimentMetricsTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import android.annotation.SuppressLint
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.FakeMetricsPixelExtension
+import com.duckduckgo.feature.toggles.api.MetricType
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@SuppressLint("DenyListedApi")
+class OnboardingPasswordImportExperimentMetricsTest {
+
+    private val fakeMetricsPixelExtension = FakeMetricsPixelExtension()
+    private val toggles = FakeFeatureToggleFactory.create(OnboardingPasswordImportToggles::class.java)
+    private lateinit var metrics: OnboardingPasswordImportExperimentMetrics
+
+    @Before
+    fun setup() {
+        fakeMetricsPixelExtension.register()
+        metrics = OnboardingPasswordImportExperimentMetricsImpl(toggles = toggles)
+    }
+
+    @Test
+    fun `when fireOnboardingCompletedMetric then sends onboarding_completed d0 and d0-14 NORMAL metric for the experiment toggle`() = runTest {
+        metrics.fireOnboardingCompletedMetric()
+
+        val sent = fakeMetricsPixelExtension.sentMetrics.single()
+        assertEquals("onboarding_completed", sent.metric)
+        assertEquals("1", sent.value)
+        assertEquals(MetricType.NORMAL, sent.type)
+        assertEquals(
+            listOf(
+                ConversionWindow(lowerWindow = 0, upperWindow = 0),
+                ConversionWindow(lowerWindow = 0, upperWindow = 14),
+            ),
+            sent.conversionWindow,
+        )
+        assertEquals(
+            toggles.passwordImportExperimentAug25().featureName().name,
+            sent.toggle.featureName().name,
+        )
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/configdriven/ConfigDrivenOnboardingPageViewModelTest.kt
@@ -182,7 +182,7 @@ class ConfigDrivenOnboardingPageViewModelTest {
 
     private fun bindContent(testee: ConfigDrivenOnboardingPageViewModel) {
         val dialog = testee.viewState.value.screen as Screen.Dialog
-        testee.onContentBound(dialog.stepId, dialog.config.content)
+        testee.onBeforeContentBound(dialog.stepId, dialog.config.content)
     }
 
     private fun importCompleteState(testee: ConfigDrivenOnboardingPageViewModel): MutableStateFlow<ImportCompleteContentState> {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/CredentialImporter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/CredentialImporter.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autofill.impl.importing
 
 import android.os.Parcelable
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.autofill.api.AutofillImportLaunchSource
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.importing.CredentialImporter.ImportResult
 import com.duckduckgo.autofill.impl.importing.CredentialImporter.ImportResult.Finished
@@ -38,6 +39,7 @@ interface CredentialImporter {
     suspend fun import(
         importList: List<LoginCredentials>,
         originalImportListSize: Int,
+        source: AutofillImportLaunchSource,
     )
 
     fun getImportStatus(): Flow<ImportResult>
@@ -51,6 +53,7 @@ interface CredentialImporter {
         data class Finished(
             val savedCredentials: Int,
             val numberSkipped: Int,
+            val source: AutofillImportLaunchSource,
         ) : ImportResult
     }
 }
@@ -68,15 +71,17 @@ class CredentialImporterImpl @Inject constructor(
     override suspend fun import(
         importList: List<LoginCredentials>,
         originalImportListSize: Int,
+        source: AutofillImportLaunchSource,
     ) {
         appCoroutineScope.launch(dispatchers.io()) {
-            doImportCredentials(importList, originalImportListSize)
+            doImportCredentials(importList, originalImportListSize, source)
         }
     }
 
     private suspend fun doImportCredentials(
         importList: List<LoginCredentials>,
         originalImportListSize: Int,
+        source: AutofillImportLaunchSource,
     ) {
         var skippedCredentials = originalImportListSize - importList.size
 
@@ -89,7 +94,7 @@ class CredentialImporterImpl @Inject constructor(
         // mark that the user has imported passwords at least once, regardless of the number of credentials imported
         autofillStore.hasEverImportedPasswords = true
 
-        _importStatus.emit(Finished(savedCredentials = insertedIds.size, numberSkipped = skippedCredentials))
+        _importStatus.emit(Finished(savedCredentials = insertedIds.size, numberSkipped = skippedCredentials, source = source))
     }
 
     override fun getImportStatus(): Flow<ImportResult> = _importStatus

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/ImportPasswordsResultPixelObserver.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/ImportPasswordsResultPixelObserver.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.importing
+
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.autofill.impl.importing.CredentialImporter.ImportResult.Finished
+import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.ImportPasswordsPixelSender
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Reports the outcome of a successful password import.
+ *
+ * The web flow returns as soon as the credentials are handed over, but they are still being written and
+ * counted after that, so the counts outlive the screen that started the import. Observing app-wide from
+ * process start keeps this independent of whichever caller launched the flow, and means the replay cache
+ * is always empty when collection begins — so every import is reported exactly once.
+ */
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+@SingleInstanceIn(AppScope::class)
+class ImportPasswordsResultPixelObserver @Inject constructor(
+    private val credentialImporter: CredentialImporter,
+    private val importPasswordsPixelSender: ImportPasswordsPixelSender,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+) : MainProcessLifecycleObserver {
+
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
+
+        appCoroutineScope.launch(dispatchers.io()) {
+            credentialImporter.getImportStatus()
+                .filterIsInstance<Finished>()
+                .collect {
+                    importPasswordsPixelSender.onImportSuccessful(
+                        savedCredentials = it.savedCredentials,
+                        numberSkipped = it.numberSkipped,
+                        source = it.source,
+                    )
+                }
+        }
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/ImportPasswordsResultPixelObserver.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/ImportPasswordsResultPixelObserver.kt
@@ -46,6 +46,7 @@ import javax.inject.Inject
 class ImportPasswordsResultPixelObserver @Inject constructor(
     private val credentialImporter: CredentialImporter,
     private val importPasswordsPixelSender: ImportPasswordsPixelSender,
+    private val passwordImportExperimentMetrics: PasswordImportExperimentMetrics,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
 ) : MainProcessLifecycleObserver {
@@ -62,6 +63,7 @@ class ImportPasswordsResultPixelObserver @Inject constructor(
                         numberSkipped = it.numberSkipped,
                         source = it.source,
                     )
+                    passwordImportExperimentMetrics.fireImportSuccessMetric()
                 }
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/PasswordImportExperimentMetrics.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/PasswordImportExperimentMetrics.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.importing
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
+import com.duckduckgo.feature.toggles.api.MetricType
+import com.duckduckgo.feature.toggles.api.MetricsPixel
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.send
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+/**
+ * Experiment metrics for importing passwords from Google, fired for every entry point into the
+ * import web flow so that onboarding and non-onboarding imports are comparable across cohorts.
+ */
+interface PasswordImportExperimentMetrics {
+
+    suspend fun fireImportStartedMetric()
+
+    suspend fun fireImportSuccessMetric()
+
+    suspend fun fireImportFailedMetric()
+
+    suspend fun fireImportCancelledMetric()
+}
+
+@ContributesBinding(AppScope::class)
+class PasswordImportExperimentMetricsImpl @Inject constructor(
+    private val inventory: FeatureTogglesInventory,
+) : PasswordImportExperimentMetrics {
+
+    override suspend fun fireImportStartedMetric() = fire("password_import_started")
+
+    override suspend fun fireImportSuccessMetric() = fire("password_import_success")
+
+    override suspend fun fireImportFailedMetric() = fire("password_import_failed")
+
+    override suspend fun fireImportCancelledMetric() = fire("password_import_cancelled")
+
+    private suspend fun fire(metric: String) {
+        val toggle = experimentToggle() ?: return
+        MetricsPixel(
+            metric = metric,
+            type = MetricType.NORMAL,
+            value = "1",
+            toggle = toggle,
+            conversionWindow = listOf(
+                ConversionWindow(lowerWindow = 0, upperWindow = 0),
+                ConversionWindow(lowerWindow = 0, upperWindow = 14),
+            ),
+        ).send()
+    }
+
+    // The experiment is declared in the onboarding feature, which this module cannot depend on, so it
+    // is resolved through the inventory by name instead.
+    private suspend fun experimentToggle(): Toggle? {
+        return inventory.getAllTogglesForParent(PARENT_FEATURE_NAME).firstOrNull {
+            it.featureName().name == EXPERIMENT_FEATURE_NAME
+        }
+    }
+
+    private companion object {
+        const val PARENT_FEATURE_NAME = "onboardingPasswordImport"
+        const val EXPERIMENT_FEATURE_NAME = "passwordImportExperimentAug25"
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowActivity.kt
@@ -21,6 +21,8 @@ import android.os.Bundle
 import androidx.fragment.app.commit
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.autofill.api.AutofillImportLaunchSource
+import com.duckduckgo.autofill.api.AutofillImportLaunchSource.Unknown
 import com.duckduckgo.autofill.api.AutofillScreens.AutofillImportPasswordsScreen
 import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.databinding.ActivityImportGooglePasswordsWebflowBinding
@@ -33,6 +35,7 @@ import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.navigation.api.getActivityParams
 import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
@@ -46,6 +49,9 @@ class ImportGooglePasswordsWebFlowActivity : DuckDuckGoActivity() {
     lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     val binding: ActivityImportGooglePasswordsWebflowBinding by viewBinding()
+
+    private val launchSource: AutofillImportLaunchSource
+        get() = intent.getActivityParams(AutofillImportPasswordsScreen::class.java)?.source ?: Unknown
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -69,7 +75,7 @@ class ImportGooglePasswordsWebFlowActivity : DuckDuckGoActivity() {
 
     private fun launchImportFragment() {
         supportFragmentManager.commit {
-            replace(R.id.fragment_container, ImportGooglePasswordsWebFlowFragment())
+            replace(R.id.fragment_container, ImportGooglePasswordsWebFlowFragment.newInstance(launchSource))
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowFragment.kt
@@ -25,6 +25,7 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.widget.Toolbar
+import androidx.core.os.BundleCompat
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.Lifecycle
@@ -34,6 +35,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.webkit.WebViewCompat
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.autofill.api.AutofillFragmentResultsPlugin
+import com.duckduckgo.autofill.api.AutofillImportLaunchSource
+import com.duckduckgo.autofill.api.AutofillImportLaunchSource.Unknown
 import com.duckduckgo.autofill.api.BrowserAutofill
 import com.duckduckgo.autofill.api.CredentialAutofillDialogFactory
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
@@ -50,6 +53,7 @@ import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordRe
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.Command.InjectCredentialsFromReauth
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.Command.NoCredentialsAvailable
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.Command.PromptUserToSelectFromStoredCredentials
+import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.Factory
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.UserCannotImportReason
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.ViewState.Initializing
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.ViewState.LoadStartPage
@@ -68,7 +72,6 @@ import com.duckduckgo.autofill.impl.store.ReAuthenticationDetails
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.ui.DuckDuckGoFragment
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.user.agent.api.UserAgentProvider
@@ -96,7 +99,7 @@ class ImportGooglePasswordsWebFlowFragment :
     lateinit var dispatchers: DispatcherProvider
 
     @Inject
-    lateinit var viewModelFactory: FragmentViewModelFactory
+    lateinit var viewModelFactory: Factory
 
     @Inject
     lateinit var credentialAutofillDialogFactory: CredentialAutofillDialogFactory
@@ -121,8 +124,14 @@ class ImportGooglePasswordsWebFlowFragment :
 
     private var binding: FragmentImportGooglePasswordsWebflowBinding? = null
 
+    private val launchSource: AutofillImportLaunchSource
+        get() = BundleCompat.getParcelable(arguments ?: Bundle(), KEY_LAUNCH_SOURCE, AutofillImportLaunchSource::class.java) ?: Unknown
+
     private val viewModel by lazy {
-        ViewModelProvider(requireActivity(), viewModelFactory)[ImportGooglePasswordsWebFlowViewModel::class.java]
+        ViewModelProvider(
+            requireActivity(),
+            Factory.Provider(viewModelFactory, launchSource),
+        )[ImportGooglePasswordsWebFlowViewModel::class.java]
     }
 
     override fun onCreateView(
@@ -462,6 +471,13 @@ class ImportGooglePasswordsWebFlowFragment :
     }
 
     companion object {
+        fun newInstance(source: AutofillImportLaunchSource): ImportGooglePasswordsWebFlowFragment {
+            return ImportGooglePasswordsWebFlowFragment().apply {
+                arguments = Bundle().apply { putParcelable(KEY_LAUNCH_SOURCE, source) }
+            }
+        }
+
+        private const val KEY_LAUNCH_SOURCE = "launchSource"
         private const val CUSTOM_FLOW_TAB_ID = "import-passwords-webflow"
         private const val SELECT_CREDENTIALS_FRAGMENT_TAG = "autofillSelectCredentialsDialog"
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowViewModel.kt
@@ -18,9 +18,10 @@ package com.duckduckgo.autofill.impl.importing.gpm.webflow
 
 import android.os.Parcelable
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.autofill.api.AutofillFeature
+import com.duckduckgo.autofill.api.AutofillImportLaunchSource
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.domain.app.LoginTriggerType
 import com.duckduckgo.autofill.impl.importing.CredentialImporter
@@ -36,8 +37,11 @@ import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsW
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.ViewState.UserCancelledImportFlow
 import com.duckduckgo.autofill.impl.store.ReAuthenticationDetails
 import com.duckduckgo.autofill.impl.store.ReauthenticationHandler
+import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.ImportPasswordsPixelSender
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.di.scopes.FragmentScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -48,10 +52,9 @@ import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import logcat.LogPriority.WARN
 import logcat.logcat
-import javax.inject.Inject
 
-@ContributesViewModel(FragmentScope::class)
-class ImportGooglePasswordsWebFlowViewModel @Inject constructor(
+class ImportGooglePasswordsWebFlowViewModel @AssistedInject constructor(
+    @Assisted private val launchSource: AutofillImportLaunchSource,
     private val dispatchers: DispatcherProvider,
     private val credentialImporter: CredentialImporter,
     private val csvCredentialConverter: CsvCredentialConverter,
@@ -59,6 +62,7 @@ class ImportGooglePasswordsWebFlowViewModel @Inject constructor(
     private val urlToStageMapper: ImportGooglePasswordUrlToStageMapper,
     private val reauthenticationHandler: ReauthenticationHandler,
     private val autofillFeature: AutofillFeature,
+    private val importPasswordsPixelSender: ImportPasswordsPixelSender,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow<ViewState>(Initializing)
@@ -81,17 +85,19 @@ class ImportGooglePasswordsWebFlowViewModel @Inject constructor(
     }
 
     private suspend fun onCsvParsed(parseResult: CsvCredentialImportResult.Success) {
-        credentialImporter.import(parseResult.loginCredentialsToImport, parseResult.numberCredentialsInSource)
+        credentialImporter.import(parseResult.loginCredentialsToImport, parseResult.numberCredentialsInSource, launchSource)
         _viewState.value = ViewState.UserFinishedImportFlow
     }
 
     fun onCsvError() {
         logcat(WARN) { "Error decoding CSV" }
+        importPasswordsPixelSender.onImportFailed(ErrorParsingCsv, launchSource)
         _viewState.value = ViewState.UserFinishedCannotImport(ErrorParsingCsv)
     }
 
     fun onWebViewCrash() {
         logcat(WARN) { "WebView has crashed during password import flow" }
+        importPasswordsPixelSender.onImportFailed(WebViewCrash, launchSource)
         _viewState.value = ViewState.UserFinishedCannotImport(WebViewCrash)
     }
 
@@ -114,7 +120,9 @@ class ImportGooglePasswordsWebFlowViewModel @Inject constructor(
 
     private fun terminateFlowAsCancellation(url: String) {
         viewModelScope.launch {
-            _viewState.value = UserCancelledImportFlow(urlToStageMapper.getStage(url))
+            val stage = urlToStageMapper.getStage(url)
+            importPasswordsPixelSender.onUserCancelledImportWebFlow(stage, launchSource)
+            _viewState.value = UserCancelledImportFlow(stage)
         }
     }
 
@@ -250,5 +258,21 @@ class ImportGooglePasswordsWebFlowViewModel @Inject constructor(
 
     sealed interface BackButtonAction {
         data object NavigateBack : BackButtonAction
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(launchSource: AutofillImportLaunchSource): ImportGooglePasswordsWebFlowViewModel
+
+        class Provider(
+            private val assistedFactory: Factory,
+            private val launchSource: AutofillImportLaunchSource,
+        ) : ViewModelProvider.Factory {
+
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return assistedFactory.create(launchSource) as T
+            }
+        }
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowViewModel.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.autofill.api.domain.app.LoginTriggerType
 import com.duckduckgo.autofill.impl.importing.CredentialImporter
 import com.duckduckgo.autofill.impl.importing.CsvCredentialConverter
 import com.duckduckgo.autofill.impl.importing.CsvCredentialConverter.CsvCredentialImportResult
+import com.duckduckgo.autofill.impl.importing.PasswordImportExperimentMetrics
 import com.duckduckgo.autofill.impl.importing.gpm.feature.AutofillImportPasswordConfigStore
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.Command.InjectCredentialsFromReauth
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.Command.NoCredentialsAvailable
@@ -63,6 +64,7 @@ class ImportGooglePasswordsWebFlowViewModel @AssistedInject constructor(
     private val reauthenticationHandler: ReauthenticationHandler,
     private val autofillFeature: AutofillFeature,
     private val importPasswordsPixelSender: ImportPasswordsPixelSender,
+    private val passwordImportExperimentMetrics: PasswordImportExperimentMetrics,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow<ViewState>(Initializing)
@@ -74,6 +76,7 @@ class ImportGooglePasswordsWebFlowViewModel @AssistedInject constructor(
     fun onViewCreated() {
         viewModelScope.launch(dispatchers.io()) {
             _viewState.value = ViewState.LoadStartPage(autofillImportConfigStore.getConfig().launchUrlGooglePasswords)
+            passwordImportExperimentMetrics.fireImportStartedMetric()
         }
     }
 
@@ -93,12 +96,14 @@ class ImportGooglePasswordsWebFlowViewModel @AssistedInject constructor(
         logcat(WARN) { "Error decoding CSV" }
         importPasswordsPixelSender.onImportFailed(ErrorParsingCsv, launchSource)
         _viewState.value = ViewState.UserFinishedCannotImport(ErrorParsingCsv)
+        viewModelScope.launch { passwordImportExperimentMetrics.fireImportFailedMetric() }
     }
 
     fun onWebViewCrash() {
         logcat(WARN) { "WebView has crashed during password import flow" }
         importPasswordsPixelSender.onImportFailed(WebViewCrash, launchSource)
         _viewState.value = ViewState.UserFinishedCannotImport(WebViewCrash)
+        viewModelScope.launch { passwordImportExperimentMetrics.fireImportFailedMetric() }
     }
 
     fun onCloseButtonPressed(url: String?) {
@@ -123,6 +128,7 @@ class ImportGooglePasswordsWebFlowViewModel @AssistedInject constructor(
             val stage = urlToStageMapper.getStage(url)
             importPasswordsPixelSender.onUserCancelledImportWebFlow(stage, launchSource)
             _viewState.value = UserCancelledImportFlow(stage)
+            passwordImportExperimentMetrics.fireImportCancelledMetric()
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/ImportPasswordsPixelSender.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/ImportPasswordsPixelSender.kt
@@ -32,7 +32,7 @@ import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_GOO
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_SUCCESS
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SYNC_DESKTOP_PASSWORDS_CTA_BUTTON
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SYNC_DESKTOP_PASSWORDS_OVERFLOW_MENU
-import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
@@ -49,7 +49,7 @@ interface ImportPasswordsPixelSender {
     fun onImportPasswordsViaDesktopSyncOverflowMenuTapped()
 }
 
-@ContributesBinding(FragmentScope::class)
+@ContributesBinding(AppScope::class)
 class ImportPasswordsPixelSenderImpl @Inject constructor(
     private val pixel: Pixel,
     private val engagementBucketing: AutofillEngagementBucketing,

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/google/ImportFromGooglePasswordsDialog.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/google/ImportFromGooglePasswordsDialog.kt
@@ -133,8 +133,7 @@ class ImportFromGooglePasswordsDialog : BottomSheetDialogFragment() {
         if (activityResult.resultCode == Activity.RESULT_OK) {
             lifecycleScope.launch {
                 activityResult.data?.let { data ->
-                    val launchSource = getLaunchSource()
-                    processImportFlowResult(data, launchSource)
+                    processImportFlowResult(data)
                 }
             }
         }
@@ -143,16 +142,12 @@ class ImportFromGooglePasswordsDialog : BottomSheetDialogFragment() {
     private fun getLaunchSource() =
         BundleCompat.getParcelable(arguments ?: Bundle(), KEY_LAUNCH_SOURCE, AutofillImportLaunchSource::class.java) ?: Unknown
 
-    private fun ImportFromGooglePasswordsDialog.processImportFlowResult(data: Intent, launchSource: AutofillImportLaunchSource) {
+    private fun ImportFromGooglePasswordsDialog.processImportFlowResult(data: Intent) {
         (IntentCompat.getParcelableExtra(data, ImportGooglePasswordResult.RESULT_KEY_DETAILS, ImportGooglePasswordResult::class.java)).let {
             when (it) {
-                is ImportGooglePasswordResult.Success -> viewModel.onImportFlowFinishedSuccessfully(launchSource)
-                is ImportGooglePasswordResult.Error -> viewModel.onImportFlowFinishedWithError(it.reason, launchSource)
-                is ImportGooglePasswordResult.UserCancelled -> viewModel.onImportFlowCancelledByUser(
-                    it.stage,
-                    canShowPreImportDialog(launchSource),
-                    launchSource,
-                )
+                is ImportGooglePasswordResult.Success -> viewModel.onImportFlowFinishedSuccessfully()
+                is ImportGooglePasswordResult.Error -> viewModel.onImportFlowFinishedWithError()
+                is ImportGooglePasswordResult.UserCancelled -> viewModel.onImportFlowCancelledByUser(canShowPreImportDialog(getLaunchSource()))
                 else -> {}
             }
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/google/ImportFromGooglePasswordsDialogViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/google/ImportFromGooglePasswordsDialogViewModel.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.autofill.api.AutofillImportLaunchSource
 import com.duckduckgo.autofill.api.AutofillImportLaunchSource.InBrowserPromo
 import com.duckduckgo.autofill.impl.importing.CredentialImporter
 import com.duckduckgo.autofill.impl.importing.CredentialImporter.ImportResult
-import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.UserCannotImportReason
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.ImportPasswordsPixelSender
 import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.google.ImportFromGooglePasswordsDialogViewModel.ViewMode.BrowserPromoPreImport
@@ -46,13 +45,13 @@ class ImportFromGooglePasswordsDialogViewModel @Inject constructor(
     private val autofillStore: InternalAutofillStore,
 ) : ViewModel() {
 
-    fun onImportFlowFinishedSuccessfully(importSource: AutofillImportLaunchSource) {
+    fun onImportFlowFinishedSuccessfully() {
         viewModelScope.launch(dispatchers.main()) {
-            observeImportJob(importSource)
+            observeImportJob()
         }
     }
 
-    private suspend fun observeImportJob(importSource: AutofillImportLaunchSource) {
+    private suspend fun observeImportJob() {
         credentialImporter.getImportStatus().collect {
             when (it) {
                 is ImportResult.InProgress -> {
@@ -62,36 +61,20 @@ class ImportFromGooglePasswordsDialogViewModel @Inject constructor(
 
                 is ImportResult.Finished -> {
                     logcat { "Import finished: ${it.savedCredentials} imported. ${it.numberSkipped} skipped." }
-                    fireImportSuccessPixel(savedCredentials = it.savedCredentials, numberSkipped = it.numberSkipped, importSource = importSource)
                     _viewState.value = ViewState(viewMode = ViewMode.ImportSuccess(it))
                 }
             }
         }
     }
 
-    fun onImportFlowFinishedWithError(reason: UserCannotImportReason, importSource: AutofillImportLaunchSource) {
-        fireImportFailedPixel(reason, importSource)
+    fun onImportFlowFinishedWithError() {
         _viewState.value = ViewState(viewMode = ViewMode.ImportError)
     }
 
-    fun onImportFlowCancelledByUser(stage: String, canShowPreImportDialog: Boolean, importSource: AutofillImportLaunchSource) {
-        importPasswordsPixelSender.onUserCancelledImportWebFlow(stage, importSource)
-
+    fun onImportFlowCancelledByUser(canShowPreImportDialog: Boolean) {
         if (!canShowPreImportDialog) {
             _viewState.value = ViewState(viewMode = ViewMode.FlowTerminated)
         }
-    }
-
-    private fun fireImportSuccessPixel(savedCredentials: Int, numberSkipped: Int, importSource: AutofillImportLaunchSource) {
-        importPasswordsPixelSender.onImportSuccessful(
-            savedCredentials = savedCredentials,
-            numberSkipped = numberSkipped,
-            source = importSource,
-        )
-    }
-
-    private fun fireImportFailedPixel(reason: UserCannotImportReason, importSource: AutofillImportLaunchSource) {
-        importPasswordsPixelSender.onImportFailed(reason, importSource)
     }
 
     fun shouldShowInitialInstructionalPrompt(importSource: AutofillImportLaunchSource) {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/CredentialImporterImplTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/CredentialImporterImplTest.kt
@@ -1,6 +1,7 @@
 package com.duckduckgo.autofill.impl.importing
 
 import app.cash.turbine.test
+import com.duckduckgo.autofill.api.AutofillImportLaunchSource.PasswordManagementEmptyState
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.importing.CredentialImporter.ImportResult
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
@@ -132,7 +133,7 @@ class CredentialImporterImplTest {
     }
 
     private suspend fun List<LoginCredentials>.import(originalListSize: Int = this.size) {
-        testee.import(this, originalListSize)
+        testee.import(this, originalListSize, PasswordManagementEmptyState)
     }
 
     private suspend fun assertResult(
@@ -143,6 +144,7 @@ class CredentialImporterImplTest {
             with(awaitItem() as ImportResult.Finished) {
                 assertEquals("Wrong number of duplicates in result", numberSkippedExpected, numberSkipped)
                 assertEquals("Wrong import size in result", importListSizeExpected, savedCredentials)
+                assertEquals("Wrong launch source in result", PasswordManagementEmptyState, source)
             }
         }
     }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/ImportPasswordsResultPixelObserverTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/ImportPasswordsResultPixelObserverTest.kt
@@ -1,0 +1,59 @@
+package com.duckduckgo.autofill.impl.importing
+
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.autofill.api.AutofillImportLaunchSource.Onboarding
+import com.duckduckgo.autofill.impl.importing.CredentialImporter.ImportResult.Finished
+import com.duckduckgo.autofill.impl.importing.CredentialImporter.ImportResult.InProgress
+import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.ImportPasswordsPixelSender
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+class ImportPasswordsResultPixelObserverTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val credentialImporter: CredentialImporter = mock()
+    private val importPasswordsPixelSender: ImportPasswordsPixelSender = mock()
+    private val lifecycleOwner: LifecycleOwner = mock()
+
+    private val testee = ImportPasswordsResultPixelObserver(
+        credentialImporter = credentialImporter,
+        importPasswordsPixelSender = importPasswordsPixelSender,
+        appCoroutineScope = coroutineTestRule.testScope,
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+    )
+
+    @Test
+    fun whenNoImportStatusThenNoPixelSent() = runTest {
+        whenever(credentialImporter.getImportStatus()).thenReturn(emptyFlow())
+        testee.onCreate(lifecycleOwner)
+        verifyNoInteractions(importPasswordsPixelSender)
+    }
+
+    @Test
+    fun whenImportStillInProgressThenNoPixelSent() = runTest {
+        whenever(credentialImporter.getImportStatus()).thenReturn(listOf(InProgress).asFlow())
+        testee.onCreate(lifecycleOwner)
+        verifyNoInteractions(importPasswordsPixelSender)
+    }
+
+    @Test
+    fun whenImportFinishedThenSuccessPixelSentWithCountsAndLaunchSource() = runTest {
+        whenever(credentialImporter.getImportStatus()).thenReturn(
+            listOf(InProgress, Finished(savedCredentials = 10, numberSkipped = 2, source = Onboarding)).asFlow(),
+        )
+
+        testee.onCreate(lifecycleOwner)
+
+        verify(importPasswordsPixelSender).onImportSuccessful(savedCredentials = 10, numberSkipped = 2, source = Onboarding)
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/ImportPasswordsResultPixelObserverTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/ImportPasswordsResultPixelObserverTest.kt
@@ -23,11 +23,13 @@ class ImportPasswordsResultPixelObserverTest {
 
     private val credentialImporter: CredentialImporter = mock()
     private val importPasswordsPixelSender: ImportPasswordsPixelSender = mock()
+    private val passwordImportExperimentMetrics: PasswordImportExperimentMetrics = mock()
     private val lifecycleOwner: LifecycleOwner = mock()
 
     private val testee = ImportPasswordsResultPixelObserver(
         credentialImporter = credentialImporter,
         importPasswordsPixelSender = importPasswordsPixelSender,
+        passwordImportExperimentMetrics = passwordImportExperimentMetrics,
         appCoroutineScope = coroutineTestRule.testScope,
         dispatchers = coroutineTestRule.testDispatcherProvider,
     )
@@ -44,6 +46,35 @@ class ImportPasswordsResultPixelObserverTest {
         whenever(credentialImporter.getImportStatus()).thenReturn(listOf(InProgress).asFlow())
         testee.onCreate(lifecycleOwner)
         verifyNoInteractions(importPasswordsPixelSender)
+    }
+
+    @Test
+    fun whenImportStillInProgressThenNoExperimentMetricFired() = runTest {
+        whenever(credentialImporter.getImportStatus()).thenReturn(listOf(InProgress).asFlow())
+        testee.onCreate(lifecycleOwner)
+        verifyNoInteractions(passwordImportExperimentMetrics)
+    }
+
+    @Test
+    fun whenImportFinishedThenImportSuccessMetricFired() = runTest {
+        whenever(credentialImporter.getImportStatus()).thenReturn(
+            listOf(InProgress, Finished(savedCredentials = 10, numberSkipped = 2, source = Onboarding)).asFlow(),
+        )
+
+        testee.onCreate(lifecycleOwner)
+
+        verify(passwordImportExperimentMetrics).fireImportSuccessMetric()
+    }
+
+    @Test
+    fun whenImportFinishedWithNoCredentialsSavedThenImportSuccessMetricStillFired() = runTest {
+        whenever(credentialImporter.getImportStatus()).thenReturn(
+            listOf(Finished(savedCredentials = 0, numberSkipped = 3, source = Onboarding)).asFlow(),
+        )
+
+        testee.onCreate(lifecycleOwner)
+
+        verify(passwordImportExperimentMetrics).fireImportSuccessMetric()
     }
 
     @Test

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/PasswordImportExperimentMetricsTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/PasswordImportExperimentMetricsTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.importing
+
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.FakeMetricsPixelExtension
+import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
+import com.duckduckgo.feature.toggles.api.MetricType
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.FeatureName
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class PasswordImportExperimentMetricsTest {
+
+    private val fakeMetricsPixelExtension = FakeMetricsPixelExtension()
+    private val inventory: FeatureTogglesInventory = mock()
+    private val experimentToggle: Toggle = mock {
+        on { featureName() } doReturn FeatureName(parentName = "onboardingPasswordImport", name = "passwordImportExperimentAug25")
+    }
+    private lateinit var testee: PasswordImportExperimentMetrics
+
+    @Before
+    fun setup() {
+        fakeMetricsPixelExtension.register()
+        testee = PasswordImportExperimentMetricsImpl(inventory = inventory)
+    }
+
+    @Test
+    fun whenImportStartedThenSendsStartedMetricForExperimentToggle() = runTest {
+        givenExperimentEnrolled()
+
+        testee.fireImportStartedMetric()
+
+        assertSentMetric("password_import_started")
+    }
+
+    @Test
+    fun whenImportSuccessThenSendsSuccessMetricForExperimentToggle() = runTest {
+        givenExperimentEnrolled()
+
+        testee.fireImportSuccessMetric()
+
+        assertSentMetric("password_import_success")
+    }
+
+    @Test
+    fun whenImportFailedThenSendsFailedMetricForExperimentToggle() = runTest {
+        givenExperimentEnrolled()
+
+        testee.fireImportFailedMetric()
+
+        assertSentMetric("password_import_failed")
+    }
+
+    @Test
+    fun whenImportCancelledThenSendsCancelledMetricForExperimentToggle() = runTest {
+        givenExperimentEnrolled()
+
+        testee.fireImportCancelledMetric()
+
+        assertSentMetric("password_import_cancelled")
+    }
+
+    @Test
+    fun whenExperimentToggleNotInInventoryThenNoMetricSent() = runTest {
+        whenever(inventory.getAllTogglesForParent("onboardingPasswordImport")).thenReturn(emptyList())
+
+        testee.fireImportStartedMetric()
+        testee.fireImportSuccessMetric()
+        testee.fireImportFailedMetric()
+        testee.fireImportCancelledMetric()
+
+        assertTrue(fakeMetricsPixelExtension.sentMetrics.isEmpty())
+    }
+
+    private suspend fun givenExperimentEnrolled() {
+        whenever(inventory.getAllTogglesForParent("onboardingPasswordImport")).thenReturn(listOf(experimentToggle))
+    }
+
+    private fun assertSentMetric(metric: String) {
+        val sent = fakeMetricsPixelExtension.sentMetrics.single()
+        assertEquals(metric, sent.metric)
+        assertEquals("1", sent.value)
+        assertEquals(MetricType.NORMAL, sent.type)
+        assertEquals(
+            listOf(
+                ConversionWindow(lowerWindow = 0, upperWindow = 0),
+                ConversionWindow(lowerWindow = 0, upperWindow = 14),
+            ),
+            sent.conversionWindow,
+        )
+        assertEquals(experimentToggle, sent.toggle)
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowViewModelTest.kt
@@ -3,6 +3,7 @@ package com.duckduckgo.autofill.impl.importing.gpm.webflow
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.autofill.api.AutofillFeature
+import com.duckduckgo.autofill.api.AutofillImportLaunchSource.Onboarding
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.domain.app.LoginTriggerType.AUTOPROMPT
 import com.duckduckgo.autofill.api.domain.app.LoginTriggerType.USER_INITIATED
@@ -15,6 +16,7 @@ import com.duckduckgo.autofill.impl.importing.gpm.feature.AutofillImportPassword
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.Command.InjectCredentialsFromReauth
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.Command.NoCredentialsAvailable
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.Command.PromptUserToSelectFromStoredCredentials
+import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.UserCannotImportReason.ErrorParsingCsv
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.UserCannotImportReason.WebViewCrash
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.ViewState.LoadStartPage
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.ViewState.NavigatingBack
@@ -23,6 +25,7 @@ import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsW
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.ViewState.UserFinishedImportFlow
 import com.duckduckgo.autofill.impl.store.ReAuthenticationDetails
 import com.duckduckgo.autofill.impl.store.ReauthenticationHandler
+import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.ImportPasswordsPixelSender
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.runTest
@@ -49,8 +52,10 @@ class ImportGooglePasswordsWebFlowViewModelTest {
     private val urlToStageMapper: ImportGooglePasswordUrlToStageMapper = mock()
     private val reauthenticationHandler: ReauthenticationHandler = mock()
     private val autofillFeature: AutofillFeature = mock()
+    private val importPasswordsPixelSender: ImportPasswordsPixelSender = mock()
 
     private val testee = ImportGooglePasswordsWebFlowViewModel(
+        launchSource = Onboarding,
         dispatchers = coroutineTestRule.testDispatcherProvider,
         credentialImporter = credentialImporter,
         csvCredentialConverter = csvCredentialConverter,
@@ -58,6 +63,7 @@ class ImportGooglePasswordsWebFlowViewModelTest {
         urlToStageMapper = urlToStageMapper,
         reauthenticationHandler = reauthenticationHandler,
         autofillFeature = autofillFeature,
+        importPasswordsPixelSender = importPasswordsPixelSender,
     )
 
     @Test
@@ -327,6 +333,54 @@ class ImportGooglePasswordsWebFlowViewModelTest {
             val viewState = awaitItem() as UserFinishedCannotImport
             assertEquals(WebViewCrash, viewState.reason)
         }
+    }
+
+    @Test
+    fun whenCloseButtonPressedThenUserCancelledPixelSentWithStageAndLaunchSource() = runTest {
+        val expectedStage = "stage"
+        whenever(urlToStageMapper.getStage(any())).thenReturn(expectedStage)
+        testee.onCloseButtonPressed("https://example.com")
+
+        verify(importPasswordsPixelSender).onUserCancelledImportWebFlow(expectedStage, Onboarding)
+    }
+
+    @Test
+    fun whenBackButtonPressedAndCannotGoBackThenUserCancelledPixelSent() = runTest {
+        val expectedStage = "stage"
+        whenever(urlToStageMapper.getStage(any())).thenReturn(expectedStage)
+        testee.onBackButtonPressed(url = "https://example.com", canGoBack = false)
+
+        verify(importPasswordsPixelSender).onUserCancelledImportWebFlow(expectedStage, Onboarding)
+    }
+
+    @Test
+    fun whenBackButtonPressedAndCanGoBackThenNoUserCancelledPixelSent() = runTest {
+        testee.onBackButtonPressed(url = "https://example.com", canGoBack = true)
+
+        verify(importPasswordsPixelSender, never()).onUserCancelledImportWebFlow(any(), any())
+    }
+
+    @Test
+    fun whenCsvParseErrorThenImportFailedPixelSent() = runTest {
+        configureCsvParseError()
+
+        verify(importPasswordsPixelSender).onImportFailed(ErrorParsingCsv, Onboarding)
+    }
+
+    @Test
+    fun whenWebViewCrashesThenImportFailedPixelSent() = runTest {
+        testee.onWebViewCrash()
+
+        verify(importPasswordsPixelSender).onImportFailed(WebViewCrash, Onboarding)
+    }
+
+    @Test
+    fun whenCsvParsedThenImportStartedWithLaunchSource() = runTest {
+        val credentials = listOf(creds())
+
+        configureCsvSuccess(loginCredentialsToImport = credentials)
+
+        verify(credentialImporter).import(credentials, credentials.size, Onboarding)
     }
 
     private fun configureReAuthenticationFeatureFlagEnabled() {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowViewModelTest.kt
@@ -11,6 +11,7 @@ import com.duckduckgo.autofill.impl.importing.CredentialImporter
 import com.duckduckgo.autofill.impl.importing.CsvCredentialConverter
 import com.duckduckgo.autofill.impl.importing.CsvCredentialConverter.CsvCredentialImportResult.Error
 import com.duckduckgo.autofill.impl.importing.CsvCredentialConverter.CsvCredentialImportResult.Success
+import com.duckduckgo.autofill.impl.importing.PasswordImportExperimentMetrics
 import com.duckduckgo.autofill.impl.importing.gpm.feature.AutofillImportPasswordConfigStore
 import com.duckduckgo.autofill.impl.importing.gpm.feature.AutofillImportPasswordSettings
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.Command.InjectCredentialsFromReauth
@@ -53,6 +54,7 @@ class ImportGooglePasswordsWebFlowViewModelTest {
     private val reauthenticationHandler: ReauthenticationHandler = mock()
     private val autofillFeature: AutofillFeature = mock()
     private val importPasswordsPixelSender: ImportPasswordsPixelSender = mock()
+    private val passwordImportExperimentMetrics: PasswordImportExperimentMetrics = mock()
 
     private val testee = ImportGooglePasswordsWebFlowViewModel(
         launchSource = Onboarding,
@@ -64,6 +66,7 @@ class ImportGooglePasswordsWebFlowViewModelTest {
         reauthenticationHandler = reauthenticationHandler,
         autofillFeature = autofillFeature,
         importPasswordsPixelSender = importPasswordsPixelSender,
+        passwordImportExperimentMetrics = passwordImportExperimentMetrics,
     )
 
     @Test
@@ -381,6 +384,45 @@ class ImportGooglePasswordsWebFlowViewModelTest {
         configureCsvSuccess(loginCredentialsToImport = credentials)
 
         verify(credentialImporter).import(credentials, credentials.size, Onboarding)
+    }
+
+    @Test
+    fun whenOnViewCreatedThenImportStartedMetricFired() = runTest {
+        configureFeature()
+        testee.onViewCreated()
+        verify(passwordImportExperimentMetrics).fireImportStartedMetric()
+    }
+
+    @Test
+    fun whenCsvParseErrorThenImportFailedMetricFired() = runTest {
+        configureCsvParseError()
+        verify(passwordImportExperimentMetrics).fireImportFailedMetric()
+    }
+
+    @Test
+    fun whenWebViewCrashesThenImportFailedMetricFired() = runTest {
+        testee.onWebViewCrash()
+        verify(passwordImportExperimentMetrics).fireImportFailedMetric()
+    }
+
+    @Test
+    fun whenCloseButtonPressedThenImportCancelledMetricFired() = runTest {
+        whenever(urlToStageMapper.getStage(any())).thenReturn("stage")
+        testee.onCloseButtonPressed("https://example.com")
+        verify(passwordImportExperimentMetrics).fireImportCancelledMetric()
+    }
+
+    @Test
+    fun whenBackButtonPressedAndCannotGoBackThenImportCancelledMetricFired() = runTest {
+        whenever(urlToStageMapper.getStage(any())).thenReturn("stage")
+        testee.onBackButtonPressed(url = "https://example.com", canGoBack = false)
+        verify(passwordImportExperimentMetrics).fireImportCancelledMetric()
+    }
+
+    @Test
+    fun whenBackButtonPressedAndCanGoBackThenImportCancelledMetricNotFired() = runTest {
+        testee.onBackButtonPressed(url = "https://example.com", canGoBack = true)
+        verify(passwordImportExperimentMetrics, never()).fireImportCancelledMetric()
     }
 
     private fun configureReAuthenticationFeatureFlagEnabled() {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/google/ImportFromGooglePasswordsDialogViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/google/ImportFromGooglePasswordsDialogViewModelTest.kt
@@ -7,7 +7,6 @@ import com.duckduckgo.autofill.api.AutofillImportLaunchSource.InBrowserPromo
 import com.duckduckgo.autofill.impl.importing.CredentialImporter
 import com.duckduckgo.autofill.impl.importing.CredentialImporter.ImportResult.Finished
 import com.duckduckgo.autofill.impl.importing.CredentialImporter.ImportResult.InProgress
-import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.UserCannotImportReason.ErrorParsingCsv
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.ImportPasswordsPixelSender
 import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.google.ImportFromGooglePasswordsDialogViewModel.ViewMode
@@ -55,7 +54,7 @@ class ImportFromGooglePasswordsDialogViewModelTest {
 
     @Test
     fun whenParsingErrorOnImportThenViewModeUpdatedToError() = runTest {
-        testee.onImportFlowFinishedWithError(reason = ErrorParsingCsv, importSource = TEST_SOURCE)
+        testee.onImportFlowFinishedWithError()
         testee.viewState.test {
             assertTrue(awaitItem().viewMode is ViewMode.ImportError)
         }
@@ -65,7 +64,7 @@ class ImportFromGooglePasswordsDialogViewModelTest {
     fun whenSuccessfulImportThenViewModeUpdatedToInProgress() = runTest {
         configureImportInProgress()
         testee.shouldShowInitialInstructionalPrompt(importSource = TEST_SOURCE)
-        testee.onImportFlowFinishedSuccessfully(importSource = TEST_SOURCE)
+        testee.onImportFlowFinishedSuccessfully()
         testee.viewState.test {
             awaitImportInProgress()
         }
@@ -75,7 +74,7 @@ class ImportFromGooglePasswordsDialogViewModelTest {
     fun whenSuccessfulImportFlowThenImportFinishesNothingImportedThenViewModeUpdatedToResults() = runTest {
         configureImportFinished(savedCredentials = 0, numberSkipped = 0)
         testee.shouldShowInitialInstructionalPrompt(importSource = TEST_SOURCE)
-        testee.onImportFlowFinishedSuccessfully(importSource = TEST_SOURCE)
+        testee.onImportFlowFinishedSuccessfully()
         testee.viewState.test {
             awaitImportSuccess()
         }
@@ -85,7 +84,7 @@ class ImportFromGooglePasswordsDialogViewModelTest {
     fun whenSuccessfulImportFlowThenImportFinishesCredentialsImportedNoDuplicatesThenViewModeUpdatedToResults() = runTest {
         configureImportFinished(savedCredentials = 10, numberSkipped = 0)
         testee.shouldShowInitialInstructionalPrompt(importSource = TEST_SOURCE)
-        testee.onImportFlowFinishedSuccessfully(importSource = TEST_SOURCE)
+        testee.onImportFlowFinishedSuccessfully()
         testee.viewState.test {
             val result = awaitImportSuccess()
             assertEquals(10, result.importResult.savedCredentials)
@@ -97,7 +96,7 @@ class ImportFromGooglePasswordsDialogViewModelTest {
     fun whenSuccessfulImportFlowThenImportFinishesOnlyDuplicatesThenViewModeUpdatedToResults() = runTest {
         configureImportFinished(savedCredentials = 0, numberSkipped = 2)
         testee.shouldShowInitialInstructionalPrompt(importSource = TEST_SOURCE)
-        testee.onImportFlowFinishedSuccessfully(importSource = TEST_SOURCE)
+        testee.onImportFlowFinishedSuccessfully()
         testee.viewState.test {
             val result = awaitImportSuccess()
             assertEquals(0, result.importResult.savedCredentials)
@@ -108,7 +107,7 @@ class ImportFromGooglePasswordsDialogViewModelTest {
     @Test
     fun whenSuccessfulImportNoUpdatesThenThenViewModeFirstInitialisedToPreImport() = runTest {
         testee.shouldShowInitialInstructionalPrompt(importSource = TEST_SOURCE)
-        testee.onImportFlowFinishedSuccessfully(importSource = TEST_SOURCE)
+        testee.onImportFlowFinishedSuccessfully()
         testee.viewState.test {
             awaitItem().assertIsPreImport()
         }
@@ -154,7 +153,7 @@ class ImportFromGooglePasswordsDialogViewModelTest {
         whenever(credentialImporter.getImportStatus()).thenReturn(
             listOf(
                 InProgress,
-                Finished(savedCredentials = savedCredentials, numberSkipped = numberSkipped),
+                Finished(savedCredentials = savedCredentials, numberSkipped = numberSkipped, source = TEST_SOURCE),
             ).asFlow(),
         )
     }

--- a/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
+++ b/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
@@ -168,6 +168,7 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
                                 credentialImporter.import(
                                     parseResult.loginCredentialsToImport,
                                     parseResult.numberCredentialsInSource,
+                                    Unknown,
                                 )
                                 observePasswordInputUpdates()
                             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217594019546143?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

Adds the experiment metrics for onboarding passwords import experiment.
| Metric | Conversion windows |
| --- | --- |
| `onboarding_completed` | d0, d0-14 |
| `password_import_started` | d0, d0-14 |
| `password_import_success` | d0, d0-14 |
| `password_import_failed` | d0, d0-14 |
| `password_import_cancelled` | d0, d0-14 |

### Steps to test this PR

The wire pixels are `experiment_enroll_passwordImportExperimentAug25_<cohort>` and `experiment_metrics_passwordImportExperimentAug25_<cohort>`, the latter carrying the metric in a `metric=` param.


_logs_
- [x] Filter logcat by `message~:"passwordImportExperimentAug25"`.

_setup_
- [x] Apply the below diff, so the experiment is in the bundled config.
```diff
diff --git a/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json b/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
--- a/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
+++ b/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
@@ -973,6 +973,24 @@
                     ]
                 }
             }
+        },
+        "onboardingPasswordImport": {
+            "state": "enabled",
+            "features": {
+                "passwordImportExperimentAug25": {
+                    "state": "enabled",
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 1
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 0
+                        }
+                    ]
+                }
+            }
         }
     },
     "unprotectedTemporary": []
```

_no experiment_
- [x] Revert the two changes above (or set both sub-feature states to `disabled`).
- [x] Delete the `DuckDuckGo` folder from the device's **Downloads** 
- [x] Clean install.
- [x] Verify onboarding launches with **no** password import step.
- [x] Verify **no** `passwordImportExperimentAug25` pixels fire at all — no enrollment and no metrics.
- [x] Import passwords from Settings → Passwords → Import from Google, and verify still **no** metric pixels fire.

_control_
- [x] Restore the setup above, with `control` weight `1` and `treatment` weight `0` in **both** files.
- [x] Delete the `DuckDuckGo` folder from the device's Downloads.
- [x] Clean install.
- [x] Verify `experiment_enroll_passwordImportExperimentAug25_control` fires.
- [x] Verify onboarding runs **without** a password import step.
- [x] Walk the onboarding to the end and verify `metric=onboarding_completed`.
- [x] Go to Settings → Passwords → Import from Google and start the flow. Verify `metric=password_import_started`.
- [ ] Complete the import and verify `metric=password_import_success`.
- [x] Clear app data, repeat up to the import screen, then close it with the X or the back button. Verify `metric=password_import_cancelled`.

_treatment_
- [x] Set `control` weight to `0` and `treatment` weight to `1` in **both** `privacy_config.json` then rebuild.
- [x] Delete the `DuckDuckGo` folder from the device's Downloads.
- [x] Clean install.
- [x] Verify `experiment_enroll_passwordImportExperimentAug25_treatment` fires.
- [x] Verify the password import step **does** appear in onboarding.
- [x] Tap Import and verify `metric=password_import_started`.
- [ ] Complete the import and verify `metric=password_import_success`, and that the outcome card shows the imported/skipped counts.
- [x] Walk the onboarding to the end and verify `metric=onboarding_completed`.
- [ ] Clear app data and repeat, this time closing the Google import screen with the X. Verify `metric=password_import_cancelled` and that you land back on the import card.
- [x] Clear app data and repeat, this time tapping Skip on the import card. Verify the flow advances past the import steps and **no** `password_import_started` fires.

_reinstaller_
- [x] Keep the config from the treatment run, and **do not** delete the `DuckDuckGo` folder from Downloads.
- [x] Clean install.
- [x] Verify onboarding launches with **no** password import step (reinstallers are excluded from enrollment).
- [x] Verify **no** `passwordImportExperimentAug25` enrollment or metric pixels fire.

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes|No UI changes|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes gated on the experiment toggle; no user-facing behavior or credential handling logic is modified.
> 
> **Overview**
> Adds **native experiment instrumentation** for `passwordImportExperimentAug25`, registering five metrics (`onboarding_completed`, `password_import_started`, `password_import_success`, `password_import_failed`, `password_import_cancelled`) in pixel definitions with d0 and d0–14 conversion windows.
> 
> When onboarding reaches **ESTABLISHED**, the app now also sends `onboarding_completed` for this experiment (alongside existing onboarding experiment metrics). The Google password import web flow fires **started** on view create, **failed** on CSV parse errors or WebView crash, and **cancelled** when the user exits without navigating back; **success** is emitted when `CredentialImporter` reports a finished import (any entry point). Autofill resolves the experiment toggle by name via `FeatureTogglesInventory` so it does not depend on the onboarding module.
> 
> Unit tests cover metric payloads, observer wiring, and ViewModel/result-observer behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e21feda300430714ed4e605ecb3594cc12ff272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->