### PR TITLE
Do not show Got It dialog when syncing on v2.1+

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -308,10 +308,18 @@ class RealSyncCodeDispatcher @Inject constructor(
         peerKind: PeerKind?,
     ): DispatchOutcome? = when (transition.to) {
         ExchangeV2State.Joiner.Confirming ->
-            DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+            DispatchOutcome.JoinerConfirmationRequested(
+                peerName = runner.peerName,
+                protocolVersion = runner.protocolVersion,
+                peerKind = peerKind,
+            )
 
         ExchangeV2State.Host.Confirming ->
-            DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+            DispatchOutcome.HostConfirmationRequested(
+                peerName = runner.peerName,
+                protocolVersion = runner.protocolVersion,
+                peerKind = peerKind,
+            )
 
         ExchangeV2State.Host.Done -> hostDoneToOutcome(transition.trigger, peerKind)
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.sync.impl
 
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
@@ -118,14 +119,26 @@ sealed interface DispatchOutcome {
     /**
      * SM reached Joiner.Confirming. Caller must prompt the user ("Sync your data with [peerName]?")
      * then call [SyncCodeDispatcher.confirmJoiner] or [SyncCodeDispatcher.denyJoiner] to resume.
+     * [protocolVersion] is the session's negotiated exchange version, letting the caller pick the
+     * post-confirmation UX (v2.1+ skips the acknowledgment dialog).
      */
-    data class JoinerConfirmationRequested(val peerName: String?, val peerKind: PeerKind? = null) : DispatchOutcome
+    data class JoinerConfirmationRequested(
+        val peerName: String?,
+        val protocolVersion: ExchangeProtocolVersion.V2,
+        val peerKind: PeerKind? = null,
+    ) : DispatchOutcome
 
     /**
      * SM reached Host.Confirming. Caller must prompt the user ("Allow [peerName] to join your
      * sync & backup?") then call [SyncCodeDispatcher.confirmHost] or [SyncCodeDispatcher.denyHost].
+     * [protocolVersion] is the session's negotiated exchange version, letting the caller pick the
+     * post-confirmation UX (v2.1+ skips the acknowledgment dialog).
      */
-    data class HostConfirmationRequested(val peerName: String?, val peerKind: PeerKind? = null) : DispatchOutcome
+    data class HostConfirmationRequested(
+        val peerName: String?,
+        val protocolVersion: ExchangeProtocolVersion.V2,
+        val peerKind: PeerKind? = null,
+    ) : DispatchOutcome
 
     /**
      * Emitted once per [SyncCodeDispatcher.presentV2] session, before any confirmation or

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -111,6 +111,12 @@ interface ExchangeV2Runner {
     val peerKind: String?
 
     /**
+     * Protocol version negotiated with the peer: the lower of the two sides' versions. Baseline
+     * v2.0 until the peer's version is learned (from the scanned linking code or the hello message).
+     */
+    val protocolVersion: ExchangeProtocolVersion.V2
+
+    /**
      * Join the session behind a linking code this device scanned or pasted. Returns immediately;
      * the session is only usable once [ExchangeV2Event.SessionStarted] has been emitted, and a code
      * that doesn't parse surfaces as a [ExchangeV2Event.SessionError] rather than a thrown exception.
@@ -207,6 +213,7 @@ class RealExchangeV2Runner @Inject constructor(
     override val canStartAsPresenter: Boolean get() = true
     override val peerName: String? get() = peerData?.name
     override val peerKind: String? get() = peerData?.kind
+    override val protocolVersion: ExchangeProtocolVersion.V2 get() = negotiatedVersion
 
     // -----------------------------------------------------------------------
     // Entry points

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/pairing/process/ProcessSyncCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/pairing/process/ProcessSyncCodeViewModel.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.sync.impl.SyncAuthCode.Unknown
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters
@@ -128,15 +129,11 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
     }
 
     fun onAcknowledgmentConfirmed() {
-        _viewState.update { it.copy(dialog = null) }
-        if (viewState.value.isWaitingForOtherDevice) return
-        viewModelScope.launch {
-            _commands.send(Command.RunAcknowledgmentAnimation)
-        }
+        dismissDialogAndRunAnimation()
     }
 
     fun onHostConfirmed() {
-        _viewState.update { it.copy(dialog = DialogType.PairingAcknowledgment) }
+        handleRoleConfirmation()
         codeDispatcher.confirmHost()
     }
 
@@ -146,7 +143,7 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
     }
 
     fun onJoinerConfirmed() {
-        _viewState.update { it.copy(dialog = DialogType.PairingAcknowledgment) }
+        handleRoleConfirmation()
         codeDispatcher.confirmJoiner()
     }
 
@@ -273,19 +270,31 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
             is DispatchOutcome.LinkingCodeReady -> Unit
 
             is DispatchOutcome.HostConfirmationRequested -> {
-                _viewState.update { it.copy(dialog = DialogType.HostConfirmation(outcome.peerName, outcome.peerKind)) }
+                _viewState.update {
+                    it.copy(
+                        protocolVersion = outcome.protocolVersion,
+                        dialog = DialogType.HostConfirmation(outcome.peerName, outcome.peerKind),
+                    )
+                }
             }
 
             is DispatchOutcome.JoinerConfirmationRequested -> {
-                _viewState.update { it.copy(dialog = DialogType.JoinerConfirmation(outcome.peerName, outcome.peerKind)) }
+                _viewState.update {
+                    it.copy(
+                        protocolVersion = outcome.protocolVersion,
+                        dialog = DialogType.JoinerConfirmation(outcome.peerName, outcome.peerKind),
+                    )
+                }
             }
 
             is DispatchOutcome.LoggedIn -> {
                 val stateBeforeLogin = viewState.value
                 _viewState.update { it.copy(isLoggedIn = true, isWaitingForOtherDevice = false, dialog = null) }
-                // The animation normally starts when the user confirms the acknowledgment dialog; if the
-                // login lands while that dialog is still open, it has to be started here or the wait for
-                // the animation below would never finish.
+                // The animation normally starts on role confirmation (v2.1+) or on confirming the
+                // acknowledgment dialog (v2.0); if the login lands while that dialog is still open, or
+                // while we were waiting for the other device (where confirming skips the animation), it
+                // has to be started here or the wait below would never finish. A duplicate command is
+                // harmless: the Activity plays the animation at most once.
                 val startAnimation = outcome.path == SetupPath.RECOVERY ||
                     stateBeforeLogin.isWaitingForOtherDevice ||
                     stateBeforeLogin.dialog == DialogType.PairingAcknowledgment
@@ -340,6 +349,23 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
         fireLoginSuccessPixels(path, myRole, peerKind)
         _commands.send(Command.SetPairingResult(pairingResult()))
         _commands.send(Command.Close)
+    }
+
+    private fun handleRoleConfirmation() {
+        val protocol = _viewState.value.protocolVersion
+        if (protocol == null || protocol < ExchangeProtocolVersion.V2_1) {
+            _viewState.update { it.copy(dialog = DialogType.PairingAcknowledgment) }
+        } else {
+            dismissDialogAndRunAnimation()
+        }
+    }
+
+    private fun dismissDialogAndRunAnimation() {
+        _viewState.update { it.copy(dialog = null) }
+        if (viewState.value.isWaitingForOtherDevice) return
+        viewModelScope.launch {
+            _commands.send(Command.RunAcknowledgmentAnimation)
+        }
     }
 
     private fun fireCodeParsedPixel(decision: RouteDecision) {
@@ -411,6 +437,7 @@ class ProcessSyncCodeViewModel @AssistedInject constructor(
     internal data class ViewState(
         val isLoggedIn: Boolean = false,
         val isWaitingForOtherDevice: Boolean = false,
+        val protocolVersion: ExchangeProtocolVersion.V2? = null,
         val dialog: DialogType? = null,
     )
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -86,6 +86,7 @@ class RealSyncCodeDispatcherTest {
             runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
         }
         whenever(it.localTrigger(any())).thenAnswer { Job().apply { complete() } }
+        whenever(it.protocolVersion).thenReturn(ExchangeProtocolVersion.V2_0)
     }
 
     private val dispatcher = RealSyncCodeDispatcher(
@@ -643,7 +644,10 @@ class RealSyncCodeDispatcherTest {
         whenever(runner.peerName).thenReturn("Peer Phone")
         dispatcher.presentV2().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
-            assertEquals(DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone"), awaitItem())
+            assertEquals(
+                DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone", protocolVersion = ExchangeProtocolVersion.V2_0),
+                awaitItem(),
+            )
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -654,7 +658,11 @@ class RealSyncCodeDispatcherTest {
         dispatcher.presentV2().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
             assertEquals(
-                DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.THIRD_PARTY),
+                DispatchOutcome.HostConfirmationRequested(
+                    peerName = "Peer Phone",
+                    protocolVersion = ExchangeProtocolVersion.V2_0,
+                    peerKind = PeerKind.THIRD_PARTY,
+                ),
                 awaitItem(),
             )
             cancelAndIgnoreRemainingEvents()
@@ -667,7 +675,37 @@ class RealSyncCodeDispatcherTest {
         dispatcher.presentV2().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Joiner.Confirming))
             assertEquals(
-                DispatchOutcome.JoinerConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.DDG),
+                DispatchOutcome.JoinerConfirmationRequested(
+                    peerName = "Peer Phone",
+                    protocolVersion = ExchangeProtocolVersion.V2_0,
+                    peerKind = PeerKind.DDG,
+                ),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `Presenter carries the negotiated protocol version on HostConfirmationRequested`() = runTest {
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.protocolVersion).thenReturn(ExchangeProtocolVersion.V2_1)
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
+            assertEquals(
+                DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone", protocolVersion = ExchangeProtocolVersion.V2_1),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `Presenter carries the negotiated protocol version on JoinerConfirmationRequested`() = runTest {
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.protocolVersion).thenReturn(ExchangeProtocolVersion.V2_1)
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Joiner.Confirming))
+            assertEquals(
+                DispatchOutcome.JoinerConfirmationRequested(peerName = "Peer Phone", protocolVersion = ExchangeProtocolVersion.V2_1),
                 awaitItem(),
             )
             cancelAndIgnoreRemainingEvents()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -350,6 +350,7 @@ class RealExchangeV2RunnerTest {
 
         val negotiation = runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().single()
         assertEquals(negotiated.toProtocolVersion(), negotiation.negotiatedVersion)
+        assertEquals(negotiated.toProtocolVersion(), runner.protocolVersion)
     }
 
     @Test
@@ -376,6 +377,7 @@ class RealExchangeV2RunnerTest {
 
         val negotiation = runner.events.replayCache.filterIsInstance<ExchangeV2Event.VersionNegotiated>().single()
         assertEquals(negotiated.toProtocolVersion(), negotiation.negotiatedVersion)
+        assertEquals(negotiated.toProtocolVersion(), runner.protocolVersion)
     }
 
     @Test fun `Scanner reports the scanned code as the source of the peer version`() = runTest {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/pairing/process/ProcessSyncCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/pairing/process/ProcessSyncCodeViewModelTest.kt
@@ -40,6 +40,7 @@ import com.duckduckgo.sync.impl.SyncCodeType
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.autorestore.RestorePayload
 import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
@@ -437,7 +438,7 @@ class ProcessSyncCodeViewModelTest {
 
     @Test
     fun `when the host confirmation is requested then the host confirmation dialog is shown`() = runTest {
-        givenV2Outcomes(DispatchOutcome.HostConfirmationRequested(peerName = "Other Device"))
+        givenV2Outcomes(DispatchOutcome.HostConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0))
 
         val testee = createTestee()
         advanceUntilIdle()
@@ -447,7 +448,7 @@ class ProcessSyncCodeViewModelTest {
 
     @Test
     fun `when the joiner confirmation is requested then the joiner confirmation dialog is shown`() = runTest {
-        givenV2Outcomes(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device"))
+        givenV2Outcomes(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0))
 
         val testee = createTestee()
         advanceUntilIdle()
@@ -612,13 +613,31 @@ class ProcessSyncCodeViewModelTest {
     }
 
     @Test
-    fun `when the host is confirmed then the dispatcher is notified and the acknowledgment dialog is shown`() = runTest {
-        givenV2Outcomes()
+    fun `when the host is confirmed on a v2_0 session then the dispatcher is notified and the acknowledgment dialog is shown`() = runTest {
+        givenV2Outcomes(DispatchOutcome.HostConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0))
 
         val testee = createTestee()
+        advanceUntilIdle()
         testee.onHostConfirmed()
 
         assertEquals(DialogType.PairingAcknowledgment, testee.viewState.value.dialog)
+        verify(codeDispatcher).confirmHost()
+    }
+
+    @Test
+    fun `when the host is confirmed on a v2_1 session then the animation runs instead of the acknowledgment dialog`() = runTest {
+        givenV2Outcomes(DispatchOutcome.HostConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_1))
+
+        val testee = createTestee()
+        advanceUntilIdle()
+
+        testee.commands.test {
+            testee.onHostConfirmed()
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+
+            cancel()
+        }
+        assertEquals(null, testee.viewState.value.dialog)
         verify(codeDispatcher).confirmHost()
     }
 
@@ -634,13 +653,31 @@ class ProcessSyncCodeViewModelTest {
     }
 
     @Test
-    fun `when the joiner is confirmed then the dispatcher is notified and the acknowledgment dialog is shown`() = runTest {
-        givenV2Outcomes()
+    fun `when the joiner is confirmed on a v2_0 session then the dispatcher is notified and the acknowledgment dialog is shown`() = runTest {
+        givenV2Outcomes(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0))
 
         val testee = createTestee()
+        advanceUntilIdle()
         testee.onJoinerConfirmed()
 
         assertEquals(DialogType.PairingAcknowledgment, testee.viewState.value.dialog)
+        verify(codeDispatcher).confirmJoiner()
+    }
+
+    @Test
+    fun `when the joiner is confirmed on a v2_1 session then the animation runs instead of the acknowledgment dialog`() = runTest {
+        givenV2Outcomes(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_1))
+
+        val testee = createTestee()
+        advanceUntilIdle()
+
+        testee.commands.test {
+            testee.onJoinerConfirmed()
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+
+            cancel()
+        }
+        assertEquals(null, testee.viewState.value.dialog)
         verify(codeDispatcher).confirmJoiner()
     }
 
@@ -680,7 +717,7 @@ class ProcessSyncCodeViewModelTest {
         val testee = createTestee()
         advanceUntilIdle()
 
-        outcomes.emit(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device"))
+        outcomes.emit(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0))
         advanceUntilIdle()
         testee.onJoinerConfirmed()
         outcomes.emit(DispatchOutcome.LoggedIn(path = SetupPath.PAIRING))
@@ -698,6 +735,32 @@ class ProcessSyncCodeViewModelTest {
     }
 
     @Test
+    fun `when the login completes after a v2_1 confirmation then the success result is set after the animation completes`() = runTest {
+        val outcomes = MutableSharedFlow<DispatchOutcome>(extraBufferCapacity = 8)
+        whenever(codeDispatcher.route(any())).thenReturn(RouteDecision.V2InProgress(SyncCodeType.LINKING, outcomes))
+        givenThisConnectedDevice()
+
+        val testee = createTestee()
+        advanceUntilIdle()
+
+        outcomes.emit(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_1))
+        advanceUntilIdle()
+
+        testee.commands.test {
+            testee.onJoinerConfirmed()
+            assertIs<RunAcknowledgmentAnimation>(awaitItem())
+            assertEquals(null, testee.viewState.value.dialog)
+
+            outcomes.emit(DispatchOutcome.LoggedIn(path = SetupPath.PAIRING))
+            testee.onAnimationComplete()
+            assertIs<SetPairingResult>(awaitItem())
+            assertIs<Close>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
     fun `when the join outcome is unknown then the waiting screen replaces the acknowledgment dialog`() = runTest {
         val outcomes = MutableSharedFlow<DispatchOutcome>(extraBufferCapacity = 8)
         whenever(codeDispatcher.route(any())).thenReturn(RouteDecision.V2InProgress(SyncCodeType.LINKING, outcomes))
@@ -705,7 +768,7 @@ class ProcessSyncCodeViewModelTest {
         val testee = createTestee()
         advanceUntilIdle()
 
-        outcomes.emit(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device"))
+        outcomes.emit(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0))
         advanceUntilIdle()
         testee.onJoinerConfirmed()
         outcomes.emit(DispatchOutcome.JoinOutcomeUnknown())

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/pairing/show/DisplayQrCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/pairing/show/DisplayQrCodeViewModelTest.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAccountRepository.AuthCode
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.ExchangeProtocolVersion
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
@@ -358,7 +359,9 @@ class DisplayQrCodeViewModelTest {
     @Test
     fun `when the host confirmation is requested then the host confirmation dialog is shown`() = runTest {
         givenV2Enabled()
-        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.HostConfirmationRequested(peerName = "Other Device")))
+        whenever(codeDispatcher.presentV2()).thenReturn(
+            flowOf(DispatchOutcome.HostConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0)),
+        )
 
         val testee = createTestee()
 
@@ -372,7 +375,9 @@ class DisplayQrCodeViewModelTest {
     @Test
     fun `when the joiner confirmation is requested then the joiner confirmation dialog is shown`() = runTest {
         givenV2Enabled()
-        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device")))
+        whenever(codeDispatcher.presentV2()).thenReturn(
+            flowOf(DispatchOutcome.JoinerConfirmationRequested(peerName = "Other Device", protocolVersion = ExchangeProtocolVersion.V2_0)),
+        )
 
         val testee = createTestee()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218258811849715?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Skips the Got It acknowledgment dialog during Sync Exchange pairing when both devices have negotiated protocol v2.1 or higher.

- The negotiated protocol version is now carried on `HostConfirmationRequested` and `JoinerConfirmationRequested`, so `ProcessSyncCodeViewModel` knows which version is in use when the user confirms their role.
- On a v2.0 session, confirming the host or joiner role still shows the acknowledgment dialog as before.
- On a v2.1+ session, confirming the host or joiner role dismisses any dialog and starts the pairing animation directly, skipping the acknowledgment dialog.
- If login completes while still waiting for the other device on a v2.1+ session, the success result is set once the animation finishes, same as the existing v2.0 behavior.

### Steps to test this PR

_Pairing on v2.0_
- [ ] On one of the devices disable the `canUseExchangeV2Point1` feature flag.
- [ ] Sync two devices.
- [ ] Confirm syncing on the Scanner device.
- [ ] Verify the "Confirm on your other device…" dialog with the "Got It" button is shown.
- [ ] Finish syncing.

_Pairing on v2.1+_
- [ ] On both devices enable the `canUseExchangeV2Point1` feature flag.
- [ ] Sync two devices.
- [ ] Confirm syncing on the Scanner device.
- [ ] Verify the "Confirm on your other device…" dialog with the "Got It" button is not shown.
- [ ] Finish syncing.

---

Recreated after #9742 was auto-closed by GitHub: its stacked base branch was squash-merged into `develop` while this PR sat in the merge queue, GitHub retargeted the base and then closed the PR instead of leaving it open. Rebased onto current `develop`; only the "Do not show Got It dialog" commit remains, no stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pairing UX branching on negotiated protocol version only; exchange and login paths are unchanged aside from an extra field on confirmation outcomes.
> 
> **Overview**
> **Skips the post-confirmation "Got It" pairing acknowledgment when Sync Exchange v2.1+ is negotiated**, while keeping the extra step for v2.0 sessions.
> 
> `HostConfirmationRequested` and `JoinerConfirmationRequested` now include **`protocolVersion`** from `ExchangeV2Runner` (negotiated min of local and peer versions). `RealSyncCodeDispatcher` passes `runner.protocolVersion` into those outcomes.
> 
> On the code-processing screen (`ProcessSyncCodeViewModel`), the negotiated version is stored in view state. After the user confirms host or joiner, **v2.0** still opens `PairingAcknowledgment`; **v2.1+** dismisses the dialog and runs the acknowledgment animation immediately. Login-completion logic was adjusted so animation still starts when login lands during the old acknowledgment dialog or while waiting on the peer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d6a1f9192a80dc75d82c0b41a8ac59d900bd104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->