### PR TITLE
Add Recent Chats to the Duck.ai address bar menu

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -278,6 +278,12 @@ interface DuckChatInternal : DuckChat {
     fun isContextualSheetRedesignEnabled(): Boolean
 
     /**
+     * Returns whether the All Chats entry is shown in the Duck.ai address bar menu. Only
+     * meaningful when the redesigned contextual entry is also enabled.
+     */
+    fun isContextualMenuAllChatsEnabled(): Boolean
+
+    /**
      * Returns the side the Search/Duck.ai toggle is defaulted to.
      */
     fun resolvedTogglePosition(): NativeInputState.ToggleSelection
@@ -520,6 +526,7 @@ class RealDuckChat @Inject constructor(
     private var clearChatHistory: Boolean = true
     private var isContextualModeEnabled: Boolean = false
     private var contextualSheetRedesignEnabled: Boolean = false
+    private var contextualMenuAllChatsEnabled: Boolean = false
     private var isAutomaticContextAttachmentEnabled: Boolean = false
     private var duckAiNativeStorage: Boolean = false
     private var areMultipleContentAttachmentsEnabled: Boolean = false
@@ -600,6 +607,8 @@ class RealDuckChat @Inject constructor(
     override fun isDuckChatContextualModeEnabled(): Boolean = isContextualModeEnabled
 
     override fun isContextualSheetRedesignEnabled(): Boolean = contextualSheetRedesignEnabled
+
+    override fun isContextualMenuAllChatsEnabled(): Boolean = contextualMenuAllChatsEnabled
 
     override fun isAutomaticContextAttachmentEnabled(): Boolean = isAutomaticContextAttachmentEnabled
     override fun isNativeStorageEnabled(): Boolean = duckAiNativeStorage
@@ -1104,6 +1113,8 @@ class RealDuckChat @Inject constructor(
             _showContextualMode.emit(isContextualModeEnabled)
 
             contextualSheetRedesignEnabled = isContextualModeEnabled && duckChatFeature.contextualSheetRedesign().isEnabled()
+
+            contextualMenuAllChatsEnabled = contextualSheetRedesignEnabled && duckChatFeature.contextualMenuAllChats().isEnabled()
 
             isAutomaticContextAttachmentEnabled = isContextualModeEnabled &&
                 duckChatFeature.automaticContextAttachment()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
@@ -27,13 +27,16 @@ import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.ui.view.PopupMenuItemView
+import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckChatContextual
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
+import com.duckduckgo.duckchat.api.DuckChatHistoryNoParams
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
+import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
@@ -47,6 +50,7 @@ class RealDuckChatContextual @Inject constructor(
     private val duckChatPixels: DuckChatPixels,
     private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector,
     private val contextualEntryPromptStore: ContextualEntryPromptStore,
+    private val globalActivityStarter: GlobalActivityStarter,
 ) : DuckChatContextual {
 
     override suspend fun launch(
@@ -124,6 +128,14 @@ class RealDuckChatContextual @Inject constructor(
                 duckChatPixels.reportContextualAddressBarMenuAskAboutPageSelected()
                 showEntryDialog(anchor, sourceTabId, onAskAboutPage)
             }
+        }
+        if (duckChatInternal.isContextualMenuAllChatsEnabled()) {
+            popup.onMenuItemClicked(content.findViewById(R.id.contextualChatMenuAllChats)) {
+                globalActivityStarter.start(activity, DuckChatHistoryNoParams)
+            }
+        } else {
+            content.findViewById<View>(R.id.contextualChatMenuAllChats).gone()
+            content.findViewById<View>(R.id.contextualChatMenuAllChatsDivider).gone()
         }
         popup.showAnchoredView(activity, anchor.rootView, anchor)
         duckChatPixels.reportContextualAddressBarMenuShown()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -285,6 +285,13 @@ interface DuckChatFeature {
     fun contextualSheetRedesign(): Toggle
 
     /**
+     * @return `true` when the All Chats entry (and its divider) is shown in the Duck.ai address bar menu.
+     * If the remote feature is not present defaults to `INTERNAL`.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun contextualMenuAllChats(): Toggle
+
+    /**
      * @return `true` when the Duck.ai session wide event should be sent
      * If the remote feature is not present defaults to `internal`
      */

--- a/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chat_menu.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chat_menu.xml
@@ -39,4 +39,17 @@
         app:leadingIcon="@drawable/ic_chevron_circle_down_24"
         app:primaryText="@string/duckChatContextualAskAboutPage" />
 
+    <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+        android:id="@+id/contextualChatMenuAllChatsDivider"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:defaultPadding="false" />
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/contextualChatMenuAllChats"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_chats_24"
+        app:primaryText="@string/duckChatContextualAllChats" />
+
 </LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -39,4 +39,7 @@
     <!-- Duck.ai on/off, shown in the onboarding Duck.ai state choice -->
     <string name="duckChatOnboardingDuckAiStateOn">Turn Duck.ai On</string>
     <string name="duckChatOnboardingDuckAiStateOff">Keep Duck.ai Off</string>
+
+    <!-- Duck.ai address bar menu -->
+    <string name="duckChatContextualAllChats">All Chats</string>
 </resources>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -1604,6 +1604,36 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun `when all chats menu item enabled and sheet redesign enabled, isContextualMenuAllChatsEnabled returns true`() = runTest {
+        duckChatFeature.contextualMode().setRawStoredState(State(enable = true))
+        duckChatFeature.contextualSheetRedesign().setRawStoredState(State(enable = true))
+        duckChatFeature.contextualMenuAllChats().setRawStoredState(State(enable = true))
+        testee.onPrivacyConfigDownloaded()
+
+        assertTrue(testee.isContextualMenuAllChatsEnabled())
+    }
+
+    @Test
+    fun `when all chats menu item disabled, isContextualMenuAllChatsEnabled returns false`() = runTest {
+        duckChatFeature.contextualMode().setRawStoredState(State(enable = true))
+        duckChatFeature.contextualSheetRedesign().setRawStoredState(State(enable = true))
+        duckChatFeature.contextualMenuAllChats().setRawStoredState(State(enable = false))
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.isContextualMenuAllChatsEnabled())
+    }
+
+    @Test
+    fun `when all chats menu item enabled and sheet redesign disabled, isContextualMenuAllChatsEnabled returns false`() = runTest {
+        duckChatFeature.contextualMode().setRawStoredState(State(enable = true))
+        duckChatFeature.contextualSheetRedesign().setRawStoredState(State(enable = false))
+        duckChatFeature.contextualMenuAllChats().setRawStoredState(State(enable = true))
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.isContextualMenuAllChatsEnabled())
+    }
+
+    @Test
     fun `when duckAiNativeStorage enabled, isNativeStorageEnabled returns true`() = runTest {
         duckChatFeature.duckAiNativeStorage().setRawStoredState(State(enable = true))
         testee.onPrivacyConfigDownloaded()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextualTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextualTest.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
+import com.duckduckgo.navigation.api.GlobalActivityStarter
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -39,6 +40,7 @@ class RealDuckChatContextualTest {
     private val duckChatPixels: DuckChatPixels = mock()
     private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector = mock()
     private val contextualEntryPromptStore = RealContextualEntryPromptStore()
+    private val globalActivityStarter: GlobalActivityStarter = mock()
     private val anchor: View = mock()
 
     private val testee = RealDuckChatContextual(
@@ -50,6 +52,7 @@ class RealDuckChatContextualTest {
         duckChatPixels,
         duckDuckGoUrlDetector,
         contextualEntryPromptStore,
+        globalActivityStarter,
     )
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -203,6 +203,8 @@ class FakeDuckChatInternal(
 
     override fun isContextualSheetRedesignEnabled(): Boolean = false
 
+    override fun isContextualMenuAllChatsEnabled(): Boolean = false
+
     override fun resolvedTogglePosition(): NativeInputState.ToggleSelection = NativeInputState.ToggleSelection.SEARCH
 
     override fun isDuckChatFeatureEnabled(): Boolean = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211654189969294/task/1218198744135582
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

### Description

The Duck.ai address bar menu, shown when a tab has no active chat, offered only New Chat and Ask About Page, so there was no route to chat history from it. This adds Recent Chats as a third entry below a divider, opening the existing Chats screen. The entry and its divider are both behind a new `contextualMenuRecentChats` flag defaulting to INTERNAL, which nests under `contextualSheetRedesign`, so the menu keeps its two items until the flag is turned on remotely.

### Steps to test this PR

_Recent Chats entry_
- [x] Install an internal build, then browse to any web page on a tab with no Duck.ai chat open
- [x] Tap the Duck.ai button in the address bar; the menu shows New Chat, Ask About Page, a divider, then Recent Chats
- [x] Tap Recent Chats; the Chats screen opens, showing "No chats yet" on a fresh install
- [x] Open Feature Flag Inventory, search `contextualMenuRecentChats`, turn it off, force stop and relaunch the app
- [x] Reopen the menu; only New Chat and Ask About Page remain, with no divider left behind

### UI changes
| Before  | After |
| ------ | ----- |
!<img width="1344" height="2992" alt="image-1788880134108" src="https://github.com/user-attachments/assets/2ccc08e0-9bbd-4a9c-aa40-19d3d504e5f9" />|<img width="1344" height="2992" alt="image-1788880129911" src="https://github.com/user-attachments/assets/94a14871-6702-473f-98c3-4b1d3ff4c5e4" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and menu UI behind a nested remote feature flag; reuses the existing chat history activity with no auth or data-model changes.
> 
> **Overview**
> Adds an optional **All Chats** row (with divider) to the redesigned Duck.ai **address bar anchored menu** when a tab has no active contextual chat, so users can open chat history without leaving the browser tab flow.
> 
> Visibility is gated by a new remote toggle **`contextualMenuAllChats`** (default **INTERNAL**), which only applies when **`contextualSheetRedesign`** is already on. **`RealDuckChat`** exposes **`isContextualMenuAllChatsEnabled()`** and computes it during privacy-config refresh. **`RealDuckChatContextual`** wires the menu item to launch the existing chats screen via **`GlobalActivityStarter`** and **`DuckChatHistoryNoParams`**, or hides the row and divider when the flag is off.
> 
> Unit tests cover the flag dependency chain; test fakes were updated for the new API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d92500ad173f0090d9c3fc9bef94ff55da8efd25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->