### PR TITLE
Reuse translated New Chat string in Duck.ai menus

### DIFF
--- a/browser/browser-ui/src/main/res/values/donottranslate.xml
+++ b/browser/browser-ui/src/main/res/values/donottranslate.xml
@@ -24,7 +24,6 @@
     <string name="duck_ai_tab_icon_content_description">Duck.ai icon</string>
     <string name="browserMenuChats">Chats</string>
 
-    <string name="chatMenuPopupNewChat">New Chat</string>
     <string name="chatMenuPopupNewVoiceChat">New Voice Chat</string>
     <string name="chatMenuPopupNewTab">New Tab</string>
     <string name="chatMenuPopupNewFireTab">New Fire Tab</string>

--- a/duckchat/duckchat-impl/src/main/res/layout/popup_chat_menu.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/popup_chat_menu.xml
@@ -26,7 +26,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:leadingIcon="@drawable/ic_compose_24"
-        app:primaryText="@string/chatMenuPopupNewChat" />
+        app:primaryText="@string/browserMenuNewChat" />
 
     <com.duckduckgo.common.ui.view.PopupMenuItemView
         android:id="@+id/chatMenuPopupNewVoiceChat"

--- a/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chat_menu.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chat_menu.xml
@@ -30,7 +30,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:leadingIcon="@drawable/ic_compose_24"
-        app:primaryText="@string/chatMenuPopupNewChat" />
+        app:primaryText="@string/browserMenuNewChat" />
 
     <com.duckduckgo.common.ui.view.PopupMenuItemView
         android:id="@+id/contextualChatMenuAskAboutPage"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1218276494773132
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

"New Chat" in both Duck.ai popup menus came from `chatMenuPopupNewChat`, which lives in `browser-ui`'s `donottranslate.xml`, so it rendered in English on translated devices while the items beside it were localised. `browserMenuNewChat` in the same module carries identical copy and is already translated in all 24 locales, so both layouts now point at it and the untranslated key is deleted. The three remaining strings in the "+" menu (New Voice Chat, New Tab, New Fire Tab) have the same defect and are tracked in the Asana task; they are deliberately not in this PR. The view id `@+id/chatMenuPopupNewChat` keeps its name, it is a separate namespace from the string key.

### Steps to test this PR

_Contextual address bar menu_
- [ ] Set the device language to Español (España) under Settings > System > Languages and move it to the top
- [ ] Install the internal build and load any web page
- [ ] Tap the Duck.ai icon in the address bar to open its menu
- [ ] Confirm the first item reads "Nuevo chat", above "Preguntar sobre la página"

_Duck.ai "+" menu_
- [ ] Still in Spanish, open a Duck.ai chat
- [ ] Tap the + button in the omnibar
- [ ] Confirm the first item reads "Nuevo chat"; the other three items are expected to still be in English

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String resource reference swap only; no logic or behavior changes beyond correct localization for one menu label.
> 
> **Overview**
> **Duck.ai “New Chat”** in the contextual address-bar menu and the **+** popup menu was wired to `chatMenuPopupNewChat` in `donottranslate.xml`, so it stayed English on localized devices while neighboring items were translated.
> 
> Both layouts now use **`browserMenuNewChat`**, which already has the same copy and is localized across locales. The redundant **`chatMenuPopupNewChat`** entry is removed from `donottranslate.xml`. View ids (e.g. `chatMenuPopupNewChat`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 300e6f80746f726d765dd024f2569bda2331ab0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->