### PR TITLE
Add origin when launching paywall

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.subscriptions.api.Product.DuckAiPlus
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.subscriptions.api.model.Entitlement
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ORIGIN_QUERY_PARAM_KEY
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.PRIVACY_SUBSCRIPTIONS_PATH
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.SUBSCRIPTIONS_ETLD
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.SUBSCRIPTIONS_PATH
@@ -124,7 +125,7 @@ class RealSubscriptions @Inject constructor(
     }
 
     override fun launchSubscription(context: Context, uri: Uri?) {
-        val origin = uri?.getQueryParameter("origin")
+        val origin = uri?.getQueryParameter(ORIGIN_QUERY_PARAM_KEY)
         // Launch the subscription web view on top of the caller's task, with no Settings screen
         // pre-stacked beneath it. The user returns to wherever they came from on a plain back; the
         // subscription screen navigates to Settings itself only on completion (see

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionUrlExtensions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionUrlExtensions.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl
+
+import androidx.core.net.toUri
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.FUNNEL_ORIGIN_ALLOWLIST
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ORIGIN_QUERY_PARAM_KEY
+
+internal fun String.appendFunnelOriginParam(origin: String?): String {
+    val allowedOrigin = origin?.takeIf { it in FUNNEL_ORIGIN_ALLOWLIST } ?: return this
+    return runCatching {
+        val uri = toUri()
+        if (!uri.isHierarchical || uri.getQueryParameter(ORIGIN_QUERY_PARAM_KEY) != null) {
+            this
+        } else {
+            uri.buildUpon().appendQueryParameter(ORIGIN_QUERY_PARAM_KEY, allowedOrigin).build().toString()
+        }
+    }.getOrDefault(this)
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
@@ -92,6 +92,7 @@ object SubscriptionsConstants {
     const val PARTNER_BENEFITS_URL = "https://duckduckgo.com/partner-benefits"
     const val SUBSCRIPTIONS_ETLD = "duckduckgo.com"
     const val FEATURE_PAGE_QUERY_PARAM_KEY = "featurePage"
+    const val ORIGIN_QUERY_PARAM_KEY = "origin"
     const val SUBSCRIPTIONS_PATH = "pro"
     const val PRIVACY_SUBSCRIPTIONS_PATH = "subscriptions"
 
@@ -99,8 +100,9 @@ object SubscriptionsConstants {
     // launch the buy webview (ProSettingView) and on the app-settings click pixel (SubscriptionPixelSender).
     const val ORIGIN_APP_SETTINGS = "funnel_appsettings_android"
 
-    // Allowlist of funnel entry-point origins permitted on subscription telemetry. The offer/subscribe
-    // origin can arrive from a web-supplied `?origin=` URL param, so it is bounded to this set.
+    // Allowlist of funnel entry-point origins permitted on subscription telemetry and on the `?origin=`
+    // param of the URL loaded in the subscriptions webview. The origin can arrive from a web-supplied
+    // URL param or JS message, so it is bounded to this set.
     // TODO: Consider moving this list to the remove privacy configuration if it will change regularly.
     val FUNNEL_ORIGIN_ALLOWLIST = setOf(
         "funnel_addressbar_android__aitoggle",

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.common.utils.extensions.toSanitizedLanguageTag
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.FUNNEL_ORIGIN_ALLOWLIST
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ORIGIN_APP_SETTINGS
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ORIGIN_QUERY_PARAM_KEY
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.ACTIVATE_SUBSCRIPTION_ENTER_EMAIL_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.ACTIVATE_SUBSCRIPTION_RESTORE_PURCHASE_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_GET_SUBSCRIPTION_CLICK
@@ -183,7 +184,7 @@ class SubscriptionPixelSenderImpl @Inject constructor(
     // value so a web page cannot inject a unique per-user identifier that would follow the user downstream.
     private fun funnelOriginParams(origin: String?): Map<String, String> =
         origin?.takeIf { it in FUNNEL_ORIGIN_ALLOWLIST }
-            ?.let { mapOf("origin" to it) } ?: emptyMap()
+            ?.let { mapOf(ORIGIN_QUERY_PARAM_KEY to it) } ?: emptyMap()
 
     override fun reportPurchaseFailureOther(
         errorType: String,
@@ -221,7 +222,7 @@ class SubscriptionPixelSenderImpl @Inject constructor(
             SubscriptionPixelParameter.FREE_TRIAL to isFreeTrial.toString(),
         )
         origin?.let {
-            map.put("origin", origin)
+            map.put(ORIGIN_QUERY_PARAM_KEY, origin)
         }
         fire(PURCHASE_SUCCESS_ORIGIN, map)
     }
@@ -281,7 +282,7 @@ class SubscriptionPixelSenderImpl @Inject constructor(
         fire(APP_SETTINGS_IDTR_CLICK)
 
     override fun reportAppSettingsGetSubscriptionClick() =
-        fire(APP_SETTINGS_GET_SUBSCRIPTION_CLICK, mapOf("origin" to ORIGIN_APP_SETTINGS))
+        fire(APP_SETTINGS_GET_SUBSCRIPTION_CLICK, mapOf(ORIGIN_QUERY_PARAM_KEY to ORIGIN_APP_SETTINGS))
 
     override fun reportAppSettingsRestorePurchaseClick() =
         fire(APP_SETTINGS_RESTORE_PURCHASE_CLICK)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -90,6 +90,7 @@ import com.duckduckgo.subscriptions.impl.R.string
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.FEATURE_PAGE_QUERY_PARAM_KEY
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ITR_URL
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
+import com.duckduckgo.subscriptions.impl.appendFunnelOriginParam
 import com.duckduckgo.subscriptions.impl.databinding.ActivitySubscriptionsWebviewBinding
 import com.duckduckgo.subscriptions.impl.internal.SubscriptionsUrlProvider
 import com.duckduckgo.subscriptions.impl.pir.PirActivity.Companion.PirScreenWithEmptyParams
@@ -398,19 +399,24 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
                 } else {
                     webViewActivityWithParams
                 }
-            }
+            }.appendFunnelOriginToUrl()
         }
 
         intent.getActivityParams(SubscriptionUpgrade::class.java)?.let { params ->
             return SubscriptionsWebViewActivityWithParams(
                 url = subscriptionsUrlProvider.upgradeToProUrl,
                 origin = params.origin,
-            )
+            ).appendFunnelOriginToUrl()
         }
 
-        return intent.getActivityParams(SubscriptionsWebViewActivityWithParams::class.java)
-            ?: SubscriptionsWebViewActivityWithParams(subscriptionsUrlProvider.buyUrl)
+        return (
+            intent.getActivityParams(SubscriptionsWebViewActivityWithParams::class.java)
+                ?: SubscriptionsWebViewActivityWithParams(subscriptionsUrlProvider.buyUrl)
+            ).appendFunnelOriginToUrl()
     }
+
+    private fun SubscriptionsWebViewActivityWithParams.appendFunnelOriginToUrl(): SubscriptionsWebViewActivityWithParams =
+        copy(url = url.appendFunnelOriginParam(origin))
 
     private fun launchDownloadMessagesJob() {
         downloadMessagesJob += lifecycleScope.launch {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/SubscriptionUrlExtensionsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/SubscriptionUrlExtensionsTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl
+
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ORIGIN_APP_SETTINGS
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SubscriptionUrlExtensionsTest {
+
+    @Test
+    fun whenOriginIsAllowlistedThenItIsAppended() {
+        assertEquals(
+            "$BUY_URL?origin=$ORIGIN_APP_SETTINGS",
+            BUY_URL.appendFunnelOriginParam(ORIGIN_APP_SETTINGS),
+        )
+    }
+
+    @Test
+    fun whenOriginIsNotAllowlistedThenUrlIsUnchanged() {
+        assertEquals(BUY_URL, BUY_URL.appendFunnelOriginParam("funnel_unique_user_identifier"))
+    }
+
+    @Test
+    fun whenOriginIsNullThenUrlIsUnchanged() {
+        assertEquals(BUY_URL, BUY_URL.appendFunnelOriginParam(null))
+    }
+
+    @Test
+    fun whenOriginIsBlankThenUrlIsUnchanged() {
+        assertEquals(BUY_URL, BUY_URL.appendFunnelOriginParam(" "))
+    }
+
+    @Test
+    fun whenUrlAlreadyHasOriginThenItIsNotAppendedAgain() {
+        val url = "$BUY_URL?origin=funnel_onboarding_android"
+
+        assertEquals(url, url.appendFunnelOriginParam(ORIGIN_APP_SETTINGS))
+    }
+
+    @Test
+    fun whenUrlAlreadyHasOtherQueryParamsThenOriginIsAddedAlongsideThem() {
+        val result = "$BUY_URL/plans?tier=pro".appendFunnelOriginParam(ORIGIN_APP_SETTINGS).toUri()
+
+        assertEquals("pro", result.getQueryParameter("tier"))
+        assertEquals(ORIGIN_APP_SETTINGS, result.getQueryParameter("origin"))
+    }
+
+    @Test
+    fun whenUrlHasFeaturePageThenBothParamsArePresent() {
+        val result = "$BUY_URL?featurePage=duckai".appendFunnelOriginParam("funnel_duckai_android__modelpicker").toUri()
+
+        assertEquals("duckai", result.getQueryParameter("featurePage"))
+        assertEquals("funnel_duckai_android__modelpicker", result.getQueryParameter("origin"))
+    }
+
+    @Test
+    fun whenUrlIsNotHierarchicalThenUrlIsUnchanged() {
+        val url = "mailto:someone@example.com"
+
+        assertEquals(url, url.appendFunnelOriginParam(ORIGIN_APP_SETTINGS))
+    }
+
+    companion object {
+        private const val BUY_URL = "https://duckduckgo.com/pro"
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207260194172075/task/1218019265846236?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Attach origin to the URL when SubscriptionsWebViewActivity is launched with an origin param but the URL itself doesn't already contain it

### Steps to test this PR

_Pre steps_
- [x] Apply patch on https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true

_App Settings_
- [x] Install from branch
- [x] Go to Settings
- [x] Tap on Subscribe to DuckDuckGo
- [x] Check in logcat that the paywall is launched with `origin=funnel_appmenu_android` appended to the URL

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to subscription WebView URL construction and pixel param key naming; origin values remain allowlist-gated with no change to purchase or auth flows.
> 
> **Overview**
> Ensures the subscription paywall WebView loads with a funnel **`origin`** query param when launch params carry an allowlisted origin but the target URL does not already include it—so the web offer page can attribute the entry point consistently with native telemetry.
> 
> Adds **`String.appendFunnelOriginParam`**, which only appends `origin` for values in **`FUNNEL_ORIGIN_ALLOWLIST`**, skips non-hierarchical URLs and URLs that already have `origin`, and is applied on every **`SubscriptionsWebViewActivity`** param resolution path (purchase, upgrade, and default). Introduces **`ORIGIN_QUERY_PARAM_KEY`** and replaces hardcoded `"origin"` strings in **`RealSubscriptions`** and **`SubscriptionPixelSender`**; unit tests cover the URL helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91b14ce95fc72aa3c4d721e778e7892d335f2de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->