### PR TITLE
Update content scope scripts to version 17.5.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -8324,6 +8324,39 @@
     return { result };
   }
 
+  // src/features/broker-protection/actions/execute-script.js
+  init_define_import_meta_trackerLookup();
+  async function executeScript(action, userProfile, root) {
+    if (typeof action.script !== "string" || !action.script.trim()) {
+      return new ErrorResponse({
+        actionID: action.id,
+        message: "executeScript failed: Error: No script provided to executeScript action"
+      });
+    }
+    try {
+      const fn = new Function("userProfile", "root", action.script);
+      await fn(userProfile, root);
+      return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: null });
+    } catch (e) {
+      return new ErrorResponse({ actionID: action.id, message: formatScriptError(e) });
+    }
+  }
+  function formatScriptError(error) {
+    let name = "Error";
+    let message = "Unknown error";
+    try {
+      if (error !== null && typeof error === "object" && "message" in error) {
+        const errorName = "name" in error ? error.name : void 0;
+        if (typeof errorName === "string" && errorName) name = errorName;
+        message = String(error.message);
+      } else {
+        message = String(error);
+      }
+    } catch {
+    }
+    return `executeScript failed: ${name}: ${message}`.replace(/[\u0000-\u001f\u007f-\u009f\u2028\u2029]/g, "").slice(0, 500);
+  }
+
   // src/features/broker-protection/actions/expectation.js
   init_define_import_meta_trackerLookup();
 
@@ -9361,6 +9394,8 @@
           return condition(action, root);
         case "scroll":
           return scroll(action, root);
+        case "executeScript":
+          return await executeScript(action, data(action, inputData, "userProfile"), root);
         default: {
           return new ErrorResponse({
             actionID: action.id,

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -8293,6 +8293,39 @@
     return { result };
   }
 
+  // src/features/broker-protection/actions/execute-script.js
+  init_define_import_meta_trackerLookup();
+  async function executeScript(action, userProfile, root) {
+    if (typeof action.script !== "string" || !action.script.trim()) {
+      return new ErrorResponse({
+        actionID: action.id,
+        message: "executeScript failed: Error: No script provided to executeScript action"
+      });
+    }
+    try {
+      const fn = new Function("userProfile", "root", action.script);
+      await fn(userProfile, root);
+      return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: null });
+    } catch (e) {
+      return new ErrorResponse({ actionID: action.id, message: formatScriptError(e) });
+    }
+  }
+  function formatScriptError(error) {
+    let name = "Error";
+    let message = "Unknown error";
+    try {
+      if (error !== null && typeof error === "object" && "message" in error) {
+        const errorName = "name" in error ? error.name : void 0;
+        if (typeof errorName === "string" && errorName) name = errorName;
+        message = String(error.message);
+      } else {
+        message = String(error);
+      }
+    } catch {
+    }
+    return `executeScript failed: ${name}: ${message}`.replace(/[\u0000-\u001f\u007f-\u009f\u2028\u2029]/g, "").slice(0, 500);
+  }
+
   // src/features/broker-protection/actions/expectation.js
   init_define_import_meta_trackerLookup();
 
@@ -9330,6 +9363,8 @@
           return condition(action, root);
         case "scroll":
           return scroll(action, root);
+        case "executeScript":
+          return await executeScript(action, data(action, inputData, "userProfile"), root);
         default: {
           return new ErrorResponse({
             actionID: action.id,
@@ -9457,6 +9492,7 @@
      * @returns
      */
     retryConfigFor(action) {
+      if (action.actionType === "executeScript") return void 0;
       const retryConfig = action.retry?.environment === "web" ? action.retry : void 0;
       if (!retryConfig && action.actionType === "extract") {
         return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^16.34.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#17.2.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#17.5.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "16.38.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.38.0.tgz",
-      "integrity": "sha512-DNMsSOX9P5btSXc1Y8aWmdm0/P1eHWtKomaa97rL/XrCdq+LXPa8/38TOcLYsU5mdprHzYnqPwxWJm6V/xVS/w==",
+      "version": "16.39.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.39.0.tgz",
+      "integrity": "sha512-9aLAjWEL787jHR/SKkzZ3nRDZvWxY+Gxi8SzNG5DRLF745MCsqCau/kIbjZaipZvKXg7EUiXo0M1+ttYMbhdNQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "tldts-experimental": "^7.4.3"
@@ -61,7 +61,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9287f33ab29e2a00e71a9741bce5107ef7604d00",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#907ad0fa4a3c40dd915b956010d869e2253b9b87",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -196,13 +196,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
-      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
+      "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~8.9.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -594,24 +594,24 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.11",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
-      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.12.tgz",
+      "integrity": "sha512-nYNzS2WRf4QJmjzFFgAxLOBjyBxAGRbCy9PVBPaglcYyYajh40VBn+v5Ngr96ZMc7oM0+aCJdtQnNejvdBnXMQ==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.4.11",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.11.tgz",
-      "integrity": "sha512-xbNzxktqwNYSryb4FclztEZ+G5waTnMCVBnwoWD1Fq0gjOykgr0rQWe4/2TdIJYHbyjIol5pdNh7OmCRWxIltw==",
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.12.tgz",
+      "integrity": "sha512-9ekSzO1PiwKHPS+WfA4EIXj49c8hFLi5TeEnW1xAlc6EufOX4Owp1rSC6HoSWq34z3cFLa7Ov2wUQm4fy+31xA==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.11"
+        "tldts-core": "^7.4.12"
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^16.34.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#17.2.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#17.5.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1218314640411491

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces dynamic script execution in broker-protection flows; behavior depends on remote workflow definitions and runs in the page injection context.
> 
> **Overview**
> Bumps **`@duckduckgo/content-scope-scripts`** from **17.2.0** to **17.5.0** in `package.json` / `package-lock.json` and refreshes the vendored Android broker-protection bundles (`autofillImport.js`, `brokerProtection.js`).
> 
> The notable upstream change is a new broker-protection action type **`executeScript`**: workflow steps can run a script string against **`userProfile`** and **`root`** via dynamic evaluation, with validation when no script is provided and sanitized error messages on failure. The action dispatcher now handles **`executeScript`**; in **`brokerProtection.js`**, **`executeScript`** is explicitly excluded from default retry behavior.
> 
> The lockfile also picks up minor transitive bumps (e.g. **`@duckduckgo/autoconsent`**, **`tldts`**, **`@types/node`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd8a44c97b8e3592b8898701394422acaf3e636f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->