### PR TITLE
Add pixel for max tab reuse distance

### DIFF
--- a/PixelDefinitions/pixels/definitions/tab_manager.json5
+++ b/PixelDefinitions/pixels/definitions/tab_manager.json5
@@ -2,7 +2,7 @@
 // Fired by the browser tab pager, covering how tabs are retained and revisited.
 {
     "tab_max_reuse_distance": {
-        "description": "Fires when the browser is paused, reporting the furthest a user went back in the tab activation order during the session. Distance is the number of distinct other tabs activated since the revisited tab was last active, bucketed. Fires again in the same session only when a further distance is reached. Sizes the user impact of lowering the number of retained tab fragments.",
+        "description": "Fires when the browser is paused, reporting the furthest a user went back in the tab activation order since this pixel was last sent. Distance is the number of distinct other tabs activated since the revisited tab was last active, bucketed. Anything that pauses the browser closes the reporting window and resets the running maximum, including opening another screen of the app such as settings or the tab switcher, so a stretch of browsing broken up by those screens reports several smaller maxima instead of one larger one and the reported distance is a lower bound on the furthest reuse within a longer user session. The activation order itself is not reset, so a distance measured after resuming can span tabs activated before the pause. Sizes the user impact of lowering the number of retained tab fragments.",
         "owners": ["catalinradoiu"],
         "triggers": ["other"],
         "parameters": [

--- a/PixelDefinitions/pixels/definitions/tab_manager.json5
+++ b/PixelDefinitions/pixels/definitions/tab_manager.json5
@@ -1,0 +1,25 @@
+// Tab manager pixels
+// Fired by the browser tab pager, covering how tabs are retained and revisited.
+{
+    "tab_max_reuse_distance": {
+        "description": "Fires when the browser is paused, reporting the furthest a user went back in the tab activation order during the session. Distance is the number of distinct other tabs activated since the revisited tab was last active, bucketed. Fires again in the same session only when a further distance is reached. Sizes the user impact of lowering the number of retained tab fragments.",
+        "owners": ["catalinradoiu"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "distance_bucket",
+                "type": "string",
+                "description": "How far back in the tab activation order the revisited tab was, as a range of distinct other tabs activated since",
+                "enum": ["1_3", "4_6", "7_9", "10_12", "13_15", "16_plus"]
+            },
+            {
+                "key": "tab_count_bucket",
+                "type": "string",
+                "description": "How many tabs were open when the distance was reported, as a range",
+                "enum": ["1_3", "4_6", "7_9", "10_12", "13_15", "16_25", "26_50", "51_plus"]
+            }
+        ],
+        "expires": "2027-03-31"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -73,6 +73,7 @@ import com.duckduckgo.app.browser.shortcut.ShortcutBuilder
 import com.duckduckgo.app.browser.state.ModeSwitchRecreateSignal
 import com.duckduckgo.app.browser.tabs.TabManager
 import com.duckduckgo.app.browser.tabs.TabManager.TabModel
+import com.duckduckgo.app.browser.tabs.TabReuseDistanceReporter
 import com.duckduckgo.app.browser.tabs.adapter.TabPagerAdapter
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.fire.AppShortcutDataClearer
@@ -216,6 +217,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
     lateinit var tabManager: TabManager
 
     @Inject
+    lateinit var tabReuseDistanceReporter: TabReuseDistanceReporter
+
+    @Inject
     lateinit var duckChat: DuckChat
 
     @Inject
@@ -300,7 +304,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
     }
 
     private val tabPagerAdapter by lazy {
-        TabPagerAdapter(this)
+        TabPagerAdapter(this, tabReuseDistanceReporter)
     }
 
     private lateinit var omnibarToolbarMockupBinding: IncludeOmnibarToolbarMockupBinding
@@ -612,6 +616,12 @@ open class BrowserActivity : DuckDuckGoActivity() {
         super.onResume()
         appReturnPixelSender.fireIfNeeded(pendingLaunchSource ?: LaunchSourceValues.STANDARD)
         pendingLaunchSource = null
+    }
+
+    override fun onPause() {
+        tabReuseDistanceReporter.onBrowserPaused()
+
+        super.onPause()
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/TabReuseDistanceReporter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/TabReuseDistanceReporter.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.tabs
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.tabs.TabManagerFeatureFlags
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ActivityScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * Reports the furthest back in the activation order a tab was when the user returned to it.
+ *
+ * The distance is expressed in the same unit the retention limit uses: the number of *distinct other
+ * tabs* activated since this tab was last activated.
+ */
+interface TabReuseDistanceReporter {
+
+    fun onTabActivated(tabId: String)
+
+    fun onTabsRemoved(tabIds: Collection<String>)
+
+    fun onTabCountChanged(tabCount: Int)
+
+    fun onBrowserPaused()
+}
+
+@SingleInstanceIn(ActivityScope::class)
+@ContributesBinding(ActivityScope::class)
+class RealTabReuseDistanceReporter @Inject constructor(
+    private val pixel: Pixel,
+    private val tabManagerFeatureFlags: TabManagerFeatureFlags,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+) : TabReuseDistanceReporter {
+
+    private val activationOrder = mutableListOf<String>()
+
+    private var maxDistance = 0
+    private var tabCount = 0
+
+    private var pixelEnabled: Boolean? = null
+
+    @Synchronized
+    override fun onTabActivated(tabId: String) {
+        val index = activationOrder.indexOf(tabId)
+        if (index >= 0 && index == activationOrder.lastIndex) {
+            return
+        }
+
+        if (index >= 0) {
+            val distance = activationOrder.lastIndex - index
+            maxDistance = maxOf(maxDistance, distance)
+            activationOrder.removeAt(index)
+        }
+
+        activationOrder.add(tabId)
+    }
+
+    @Synchronized
+    override fun onTabsRemoved(tabIds: Collection<String>) {
+        activationOrder.removeAll(tabIds.toSet())
+    }
+
+    @Synchronized
+    override fun onTabCountChanged(tabCount: Int) {
+        this.tabCount = tabCount
+    }
+
+    @Synchronized
+    override fun onBrowserPaused() {
+        if (maxDistance == 0) {
+            return
+        }
+
+        val parameters = mapOf(
+            PARAM_DISTANCE_BUCKET to distanceBucketFor(maxDistance),
+            PARAM_TAB_COUNT_BUCKET to tabCountBucketFor(tabCount),
+        )
+        maxDistance = 0
+
+        appCoroutineScope.launch(dispatchers.io()) {
+            if (isPixelEnabled()) {
+                logcat(tag = TAG) { "firing ${AppPixelName.TAB_MAX_REUSE_DISTANCE.pixelName} with $parameters" }
+                pixel.fire(AppPixelName.TAB_MAX_REUSE_DISTANCE, parameters)
+            }
+        }
+    }
+
+    private fun isPixelEnabled(): Boolean =
+        pixelEnabled ?: (
+            tabManagerFeatureFlags.self().isEnabled() && tabManagerFeatureFlags.tabMaxReuseDistancePixel().isEnabled()
+            ).also { pixelEnabled = it }
+
+    private fun distanceBucketFor(distance: Int): String = when {
+        distance <= 3 -> "1_3"
+        distance <= 6 -> "4_6"
+        distance <= 9 -> "7_9"
+        distance <= 12 -> "10_12"
+        distance <= 15 -> "13_15"
+        else -> "16_plus"
+    }
+
+    private fun tabCountBucketFor(tabCount: Int): String = when {
+        tabCount <= 3 -> "1_3"
+        tabCount <= 6 -> "4_6"
+        tabCount <= 9 -> "7_9"
+        tabCount <= 12 -> "10_12"
+        tabCount <= 15 -> "13_15"
+        tabCount <= 25 -> "16_25"
+        tabCount <= 50 -> "26_50"
+        else -> "51_plus"
+    }
+
+    companion object {
+        private const val TAG = "TabReuseDistanceReporter"
+
+        private const val PARAM_DISTANCE_BUCKET = "distance_bucket"
+        private const val PARAM_TAB_COUNT_BUCKET = "tab_count_bucket"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
@@ -88,6 +88,7 @@ import logcat.LogcatKt;
  *     hidden until a limit is reached (<code>TabManager.MAX_ACTIVE_TABS</code>). When the limit is
  *     reached, the oldest fragment is removed
  * <li>The list of fragments to remove is managed by a FIFO queue (<code>itemIdQueue</code>)
+ * <li>Subclasses can observe that queue's activation order through {@link #onItemPlaced(long)}
  * </ul>
  */
 public abstract class FragmentStateAdapter extends RecyclerView.Adapter<FragmentViewHolder>
@@ -180,6 +181,13 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
     public abstract @NonNull Fragment createFragment(int position);
 
     public abstract @NonNull Boolean shouldPlaceFragmentInViewHolder(int position);
+
+    /**
+     * Called whenever an item is placed in a view holder, immediately after it has been promoted to
+     * the most recent entry of {@link #itemIdQueue}. Subclasses can use this to observe the
+     * activation order that drives eviction.
+     */
+    protected void onItemPlaced(long itemId) {}
 
     @NonNull
     @Override
@@ -314,6 +322,7 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
         long itemId = holder.getItemId();
         itemIdQueue.remove(itemId);
         itemIdQueue.add(itemId);
+        onItemPlaced(itemId);
 
         Fragment fragment = mFragments.get(itemId);
         if (fragment == null) {

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
@@ -25,12 +25,14 @@ import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.BrowserTabFragment
 import com.duckduckgo.app.browser.tabs.TabManager.TabModel
+import com.duckduckgo.app.browser.tabs.TabReuseDistanceReporter
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class TabPagerAdapter(
     private val activity: BrowserActivity,
+    private val tabReuseDistanceReporter: TabReuseDistanceReporter,
 ) : FragmentStateAdapter(activity) {
     private val tabs = mutableListOf<TabModel>()
 
@@ -86,6 +88,11 @@ class TabPagerAdapter(
         return currentTabIndex != -1 || position != 0
     }
 
+    override fun onItemPlaced(itemId: Long) {
+        val tab = tabs.firstOrNull { it.tabId.hashCode().toLong() == itemId } ?: return
+        tabReuseDistanceReporter.onTabActivated(tab.tabId)
+    }
+
     fun restore(state: Bundle) {
         // state is only useful when there are fragments to restore (also avoids a crash)
         if (activity.supportFragmentManager.fragments.isNotEmpty()) {
@@ -112,14 +119,16 @@ class TabPagerAdapter(
 
     @SuppressLint("NotifyDataSetChanged")
     fun onTabsUpdated(newTabs: List<TabModel>) {
+        tabReuseDistanceReporter.onTabCountChanged(newTabs.size)
         if (tabs.map { it.tabId } != newTabs.map { it.tabId }) {
             val newIds = newTabs.map { it.tabId }.toSet()
-            val hadRemovals = tabs.any { it.tabId !in newIds }
+            val removedIds = tabs.map { it.tabId }.filter { it !in newIds }
             tabs.clear()
             tabs.addAll(newTabs)
             notifyDataSetChanged()
-            if (hadRemovals) {
+            if (removedIds.isNotEmpty()) {
                 cleanupRemovedItems()
+                tabReuseDistanceReporter.onTabsRemoved(removedIds)
             }
         } else {
             // the state of tabs is managed separately, so we don't need to notify the adapter, but we need URL and skipHome to create new fragments

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -457,6 +457,8 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     SWIPE_TABS_USED("m_swipe_tabs_used"),
     SWIPE_TABS_USED_DAILY("m_swipe_tabs_used_daily"),
 
+    TAB_MAX_REUSE_DISTANCE("tab_max_reuse_distance"),
+
     DUCK_PLAYER_SETTING_ALWAYS_OVERLAY_YOUTUBE("duckplayer_setting_always_overlay_youtube"),
     DUCK_PLAYER_SETTING_ALWAYS_SERP("duckplayer_setting_always_overlay_serp"),
     DUCK_PLAYER_SETTING_NEVER_SERP("duckplayer_setting_never_overlay_serp"),

--- a/app/src/main/java/com/duckduckgo/app/tabs/TabFeatureFlags.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/TabFeatureFlags.kt
@@ -32,4 +32,12 @@ interface TabManagerFeatureFlags {
 
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun tabInsertionFixes(): Toggle
+
+    /**
+     * Reports the furthest a user went back in the tab activation order, so that the effect of
+     * lowering the retained fragment limit can be sized before it is changed.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.InternalAlwaysEnabled
+    fun tabMaxReuseDistancePixel(): Toggle
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/tabs/RealTabReuseDistanceReporterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/tabs/RealTabReuseDistanceReporterTest.kt
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.tabs
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.tabs.TabManagerFeatureFlags
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+
+@RunWith(AndroidJUnit4::class)
+class RealTabReuseDistanceReporterTest {
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    private val pixel: Pixel = mock()
+    private val tabManagerFeatureFlags = FakeFeatureToggleFactory.create(TabManagerFeatureFlags::class.java)
+
+    private val testee = RealTabReuseDistanceReporter(
+        pixel = pixel,
+        tabManagerFeatureFlags = tabManagerFeatureFlags,
+        appCoroutineScope = coroutineTestRule.testScope,
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+    )
+
+    @Before
+    fun setup() {
+        setToggles(parent = true, maxDistancePixel = true)
+        testee.onTabCountChanged(3)
+    }
+
+    @Test
+    fun whenNoTabWasReturnedToThenNoPixelIsFired() {
+        activate("tab1", "tab2", "tab3")
+        testee.onBrowserPaused()
+
+        verifyNoInteractions(pixel)
+    }
+
+    @Test
+    fun whenAlreadyActiveTabIsPlacedAgainThenNoPixelIsFired() {
+        activate("tab1", "tab1", "tab1")
+        testee.onBrowserPaused()
+
+        verifyNoInteractions(pixel)
+    }
+
+    @Test
+    fun whenReturnHappensThenPixelIsFiredOnlyOnPause() {
+        activate("tab1", "tab2", "tab1")
+
+        verifyNoInteractions(pixel)
+
+        testee.onBrowserPaused()
+
+        verifyBucketFired("1_3")
+    }
+
+    @Test
+    fun whenThreeOtherTabsActivatedInBetweenThenBucketIsOneToThree() {
+        returnToTargetAfter(otherTabs = 3)
+
+        verifyBucketFired("1_3")
+    }
+
+    @Test
+    fun whenFourOtherTabsActivatedInBetweenThenBucketIsFourToSix() {
+        returnToTargetAfter(otherTabs = 4)
+
+        verifyBucketFired("4_6")
+    }
+
+    @Test
+    fun whenNineOtherTabsActivatedInBetweenThenBucketIsSevenToNine() {
+        returnToTargetAfter(otherTabs = 9)
+
+        verifyBucketFired("7_9")
+    }
+
+    @Test
+    fun whenTenOtherTabsActivatedInBetweenThenBucketIsTenToTwelve() {
+        returnToTargetAfter(otherTabs = 10)
+
+        verifyBucketFired("10_12")
+    }
+
+    @Test
+    fun whenTwelveOtherTabsActivatedInBetweenThenBucketIsTenToTwelve() {
+        returnToTargetAfter(otherTabs = 12)
+
+        verifyBucketFired("10_12")
+    }
+
+    @Test
+    fun whenFifteenOtherTabsActivatedInBetweenThenBucketIsThirteenToFifteen() {
+        returnToTargetAfter(otherTabs = 15)
+
+        verifyBucketFired("13_15")
+    }
+
+    @Test
+    fun whenSixteenOtherTabsActivatedInBetweenThenBucketIsSixteenPlus() {
+        returnToTargetAfter(otherTabs = 16)
+
+        verifyBucketFired("16_plus")
+    }
+
+    @Test
+    fun whenSeveralReturnsHappenThenOnlyTheFurthestIsReported() {
+        activate("near1", "near2", "near1")
+        activate("target")
+        activate(*otherTabs(10))
+        testee.onTabActivated("target")
+        activate("near3", "near4", "near3")
+        testee.onBrowserPaused()
+
+        verifyBucketFired("10_12")
+        verifyNoMoreInteractions(pixel)
+    }
+
+    @Test
+    fun whenOtherTabIsRepeatedlyPlacedInBetweenThenOnlyDistinctTabsCount() {
+        activate("target")
+        repeat(20) { testee.onTabActivated("other") }
+        testee.onTabActivated("target")
+        testee.onBrowserPaused()
+
+        verifyBucketFired("1_3")
+    }
+
+    @Test
+    fun whenTabsRemovedThenTheyNoLongerContributeToDistance() {
+        activate("target")
+        activate(*otherTabs(10))
+        testee.onTabsRemoved(listOf("other0", "other1", "other2"))
+        testee.onTabActivated("target")
+        testee.onBrowserPaused()
+
+        verifyBucketFired("7_9")
+    }
+
+    @Test
+    fun whenReturningFromVeryFarBackThenBucketIsSixteenPlus() {
+        returnToTargetAfter(otherTabs = 100)
+
+        verifyBucketFired("16_plus")
+    }
+
+    @Test
+    fun whenANewSessionHasNoReturnThenNoPixelIsFired() {
+        returnToTargetAfter(otherTabs = 10)
+        verifyBucketFired("10_12")
+
+        testee.onBrowserPaused()
+        testee.onBrowserPaused()
+
+        verifyNoMoreInteractions(pixel)
+    }
+
+    @Test
+    fun whenANewSessionHasANearerReturnThenItsOwnMaxIsReported() {
+        returnToTargetAfter(otherTabs = 10)
+        verifyBucketFired("10_12")
+
+        activate("near1", "near2", "near1")
+        testee.onBrowserPaused()
+
+        verifyBucketFired("1_3")
+    }
+
+    @Test
+    fun whenANewSessionHasAFurtherReturnThenItsOwnMaxIsReported() {
+        returnToTargetAfter(otherTabs = 10)
+        verifyBucketFired("10_12")
+
+        activate(*otherTabs(16))
+        testee.onTabActivated("target")
+        testee.onBrowserPaused()
+
+        verifyBucketFired("16_plus")
+    }
+
+    @Test
+    fun whenTabCountIsReportedThenItIsBucketed() {
+        testee.onTabCountChanged(20)
+
+        returnToTargetAfter(otherTabs = 4)
+
+        verifyBucketFired(bucket = "4_6", tabCountBucket = "16_25")
+    }
+
+    @Test
+    fun whenTabCountIsAboveEveryBucketThenBucketIsFiftyOnePlus() {
+        testee.onTabCountChanged(120)
+
+        returnToTargetAfter(otherTabs = 4)
+
+        verifyBucketFired(bucket = "4_6", tabCountBucket = "51_plus")
+    }
+
+    @Test
+    fun whenTabCountChangesBeforePauseThenTheLatestCountIsReported() {
+        testee.onTabCountChanged(40)
+        activate("target")
+        activate(*otherTabs(4))
+        testee.onTabActivated("target")
+        testee.onTabCountChanged(8)
+        testee.onBrowserPaused()
+
+        verifyBucketFired(bucket = "4_6", tabCountBucket = "7_9")
+    }
+
+    @Test
+    fun whenParentToggleDisabledThenNoPixelIsFired() {
+        setToggles(parent = false, maxDistancePixel = true)
+
+        returnToTargetAfter(otherTabs = 10)
+
+        verifyNoInteractions(pixel)
+    }
+
+    @Test
+    fun whenPixelToggleDisabledThenNoPixelIsFired() {
+        setToggles(parent = true, maxDistancePixel = false)
+
+        returnToTargetAfter(otherTabs = 10)
+
+        verifyNoInteractions(pixel)
+    }
+
+    @Test
+    fun whenPixelToggleDisabledThenActivationOrderIsStillRecorded() {
+        setToggles(parent = true, maxDistancePixel = false)
+        activate("target")
+        activate(*otherTabs(10))
+        verifyNoInteractions(pixel)
+
+        setToggles(parent = true, maxDistancePixel = true)
+        testee.onTabActivated("target")
+        testee.onBrowserPaused()
+
+        verifyBucketFired("10_12")
+    }
+
+    private fun setToggles(
+        parent: Boolean,
+        maxDistancePixel: Boolean,
+    ) {
+        tabManagerFeatureFlags.self().setRawStoredState(State(enable = parent))
+        tabManagerFeatureFlags.tabMaxReuseDistancePixel().setRawStoredState(State(enable = maxDistancePixel))
+    }
+
+    private fun returnToTargetAfter(otherTabs: Int) {
+        activate("target")
+        activate(*otherTabs(otherTabs))
+        testee.onTabActivated("target")
+        testee.onBrowserPaused()
+    }
+
+    private fun verifyBucketFired(
+        bucket: String,
+        tabCountBucket: String = "1_3",
+    ) {
+        verify(pixel).fire(
+            pixel = AppPixelName.TAB_MAX_REUSE_DISTANCE,
+            parameters = mapOf("distance_bucket" to bucket, "tab_count_bucket" to tabCountBucket),
+            encodedParameters = emptyMap(),
+            type = Count,
+        )
+    }
+
+    private fun activate(vararg tabIds: String) {
+        tabIds.forEach { testee.onTabActivated(it) }
+    }
+
+    private fun otherTabs(count: Int): Array<String> = Array(count) { "other$it" }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1214069186174646
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

### Description

Adds a pixel that reports, once per foreground session, the furthest a user went back in the tab activation order (the tab reuse distance), bucketed, alongside a bucketed count of currently open tabs. This distance is the condition that decides whether a given tab would still be retained if the fragment retention limit (`MAX_ACTIVE_TABS`) were lowered, so the pixel sizes the UX cost of doing that before the limit is actually changed.

The pixel is gated behind the `tabManager.tabMaxReuseDistancePixel` sub-feature, off by default, with the parent `tabManager` toggle checked explicitly at the call site.

### Steps to test this PR

_Feature 1: Tab reuse distance pixel fires once per foreground session_
- [x] Enable the `tabManager.tabMaxReuseDistancePixel` sub-feature (and ensure the parent `tabManager` feature is enabled)
- [x] Open several tabs and switch between them so some tabs are reused further back in the activation order
- [x] Background and foreground the app
- [x] Confirm the pixel fires with bucketed reuse-distance and open-tab-count values, and only once per foreground session

_Feature 2: Pixel stays off when the sub-feature is disabled_
- [x] Leave `tabManager.tabMaxReuseDistancePixel` disabled (default)
- [x] Repeat the tab-switching steps above
- [x] Confirm no pixel fires

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes|No UI changes|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only path behind feature flags; tab pager wiring adds hooks on activation/pause with no user-facing behavior changes.
> 
> **Overview**
> Adds **`tab_max_reuse_distance`** telemetry to measure how far users jump back in tab activation order before revisiting a tab—aligned with the same “distinct other tabs since last active” notion used for fragment retention under **`MAX_ACTIVE_TABS`**.
> 
> A new activity-scoped **`TabReuseDistanceReporter`** tracks activations (via **`onItemPlaced`** on the tab pager adapter), tab closes, and open-tab count; on **`BrowserActivity.onPause`** it fires one bucketed pixel per foreground stretch (`distance_bucket`, `tab_count_bucket`) when the user actually returned to an earlier tab. Reporting is gated by **`tabManager`** and the new **`tabMaxReuseDistancePixel`** sub-toggle (default off). Pixel schema, **`AppPixelName`**, and unit tests cover bucketing, session reset on pause, removals, and toggle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6763e103ca3c2440d48c682ba84918e20149cc44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->