### PR TITLE
Open the performance-optimized paywall URLs when the flag is on

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
@@ -96,6 +96,12 @@ object SubscriptionsConstants {
     const val SUBSCRIPTIONS_PATH = "pro"
     const val PRIVACY_SUBSCRIPTIONS_PATH = "subscriptions"
 
+    const val DUCK_AI_FEATURE_PAGE = "duckai"
+    const val VPN_FEATURE_PAGE = "vpn"
+
+    const val TRIAL_QUERY_PARAM_KEY = "trial"
+    const val PIR_QUERY_PARAM_KEY = "pir"
+
     // Subscription-funnel origin for the app-settings "Get Subscription" entry point. Used both to
     // launch the buy webview (ProSettingView) and on the app-settings click pixel (SubscriptionPixelSender).
     const val ORIGIN_APP_SETTINGS = "funnel_appsettings_android"

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PaywallUrlResolver.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PaywallUrlResolver.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.internal
+
+import android.net.Uri
+import androidx.core.net.toUri
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.api.Product
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.FEATURE_PAGE_QUERY_PARAM_KEY
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.PIR_QUERY_PARAM_KEY
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.TRIAL_QUERY_PARAM_KEY
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.VPN_FEATURE_PAGE
+import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
+import com.duckduckgo.subscriptions.impl.SubscriptionsManager
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+interface PaywallUrlResolver {
+    suspend fun resolve(url: String): String
+}
+
+@ContributesBinding(AppScope::class)
+class RealPaywallUrlResolver @Inject constructor(
+    private val subscriptionsUrlProvider: SubscriptionsUrlProvider,
+    private val subscriptionsManager: SubscriptionsManager,
+    private val subscriptionsFeature: SubscriptionsFeature,
+    private val paywallPathProvider: PaywallPathProvider,
+    private val dispatcherProvider: DispatcherProvider,
+) : PaywallUrlResolver {
+
+    override suspend fun resolve(url: String): String = withContext(dispatcherProvider.io()) {
+        runCatching {
+            optimizedUrl(url)
+        }.getOrNull() ?: url
+    }
+
+    private suspend fun optimizedUrl(url: String): String? {
+        if (!subscriptionsFeature.performanceOptimizedPaywalls().isEnabled()) return null
+        val uri = url.toUri()
+        if (!isPaywallUrl(uri)) return null
+        return rewrite(uri)
+    }
+
+    private fun isPaywallUrl(uri: Uri): Boolean {
+        val buyUri = subscriptionsUrlProvider.buyUrl.toUri()
+        return uri.host == buyUri.host && uri.path == buyUri.path
+    }
+
+    private suspend fun rewrite(uri: Uri): String? {
+        val featurePage = uri.getQueryParameter(FEATURE_PAGE_QUERY_PARAM_KEY)?.takeIf { it.isNotBlank() } ?: VPN_FEATURE_PAGE
+        val path = paywallPathProvider.getPath(featurePage) ?: return null
+
+        val offers = subscriptionsManager.getSubscriptionOffer()
+        if (offers.isEmpty()) return null
+
+        return buildUrl(
+            uri = uri,
+            path = path,
+            isFreeTrialEligible = subscriptionsManager.isFreeTrialEligible(),
+            isPirOnOffer = offers.any { Product.PIR.value in it.features },
+        )
+    }
+
+    private fun buildUrl(
+        uri: Uri,
+        path: String,
+        isFreeTrialEligible: Boolean,
+        isPirOnOffer: Boolean,
+    ): String {
+        val builder = uri.buildUpon().encodedPath(path).clearQuery()
+
+        uri.queryParameterNames
+            .filterNot { it in REWRITTEN_QUERY_PARAM_KEYS }
+            .forEach { name ->
+                uri.getQueryParameters(name).forEach { value -> builder.appendQueryParameter(name, value) }
+            }
+
+        builder.appendQueryParameter(TRIAL_QUERY_PARAM_KEY, isFreeTrialEligible.toString())
+        if (!isPirOnOffer) {
+            builder.appendQueryParameter(PIR_QUERY_PARAM_KEY, "false")
+        }
+        return builder.build().toString()
+    }
+
+    private companion object {
+        val REWRITTEN_QUERY_PARAM_KEYS = setOf(FEATURE_PAGE_QUERY_PARAM_KEY, TRIAL_QUERY_PARAM_KEY, PIR_QUERY_PARAM_KEY)
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PaywallUrlResolver.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PaywallUrlResolver.kt
@@ -51,9 +51,9 @@ class RealPaywallUrlResolver @Inject constructor(
     }
 
     private suspend fun optimizedUrl(url: String): String? {
-        if (!subscriptionsFeature.performanceOptimizedPaywalls().isEnabled()) return null
         val uri = url.toUri()
         if (!isPaywallUrl(uri)) return null
+        if (!subscriptionsFeature.performanceOptimizedPaywalls().isEnabled()) return null
         return rewrite(uri)
     }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsJSHelper.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsJSHelper.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionUpgrade
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionsSettingsScreenWithEmptyParams
 import com.duckduckgo.subscriptions.api.SubscriptionsJSHelper
 import com.duckduckgo.subscriptions.impl.AccessTokenResult
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.DUCK_AI_FEATURE_PAGE
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
 import com.squareup.anvil.annotations.ContributesBinding
@@ -228,7 +229,6 @@ class RealSubscriptionsJSHelper @Inject constructor(
         private const val METHOD_OPEN_SUBSCRIPTION_PURCHASE = "openSubscriptionPurchase"
         private const val METHOD_OPEN_SUBSCRIPTION_UPGRADE = "openSubscriptionUpgrade"
         private const val MESSAGE_PARAM_ORIGIN_KEY = "origin"
-        private const val DUCK_AI_FEATURE_PAGE = "duckai"
         private const val USE_PRO_TIER = "useProTier"
         private const val OPEN_SUBSCRIPTION_UPGRADE = "openSubscriptionUpgrade"
     }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -120,6 +120,9 @@ class SubscriptionWebViewViewModel @Inject constructor(
     private val _currentPurchaseViewState = MutableStateFlow(CurrentPurchaseViewState())
     val currentPurchaseViewState = _currentPurchaseViewState.asStateFlow()
 
+    private val _initialUrl = MutableStateFlow<String?>(null)
+    val initialUrl = _initialUrl.asStateFlow()
+
     private lateinit var subscriptionStatus: SubscriptionStatus
 
     private var pendingScheduleNotificationDaysBeforeCancel: Int? = null
@@ -174,9 +177,10 @@ class SubscriptionWebViewViewModel @Inject constructor(
             .launchIn(viewModelScope)
     }
 
-    fun loadInitialUrl(url: String) {
+    fun resolveInitialUrl(url: String) {
+        if (_initialUrl.value != null) return
         viewModelScope.launch {
-            command.send(LoadUrl(paywallUrlResolver.resolve(url)))
+            _initialUrl.value = paywallUrlResolver.resolve(url)
         }
     }
 
@@ -807,7 +811,6 @@ class SubscriptionWebViewViewModel @Inject constructor(
     }
 
     sealed class Command {
-        data class LoadUrl(val url: String) : Command()
         data object BackToSettings : Command()
         data object BackToSettingsActivateSuccess : Command()
         data class SendJsEvent(val event: SubscriptionEventData) : Command()

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -66,6 +66,7 @@ import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PRO_PLAN_
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
 import com.duckduckgo.subscriptions.impl.billing.SubscriptionReplacementMode
+import com.duckduckgo.subscriptions.impl.internal.PaywallUrlResolver
 import com.duckduckgo.subscriptions.impl.notification.SubscriptionExpirationReminderScheduler
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionFailureErrorType
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
@@ -104,6 +105,7 @@ class SubscriptionWebViewViewModel @Inject constructor(
     private val subscriptionsFeature: SubscriptionsFeature,
     private val pirFeature: PirFeature,
     private val subscriptionExpirationReminderScheduler: SubscriptionExpirationReminderScheduler,
+    private val paywallUrlResolver: PaywallUrlResolver,
 ) : ViewModel() {
 
     private val moshi = Moshi.Builder().add(JSONObjectAdapter()).build()
@@ -170,6 +172,12 @@ class SubscriptionWebViewViewModel @Inject constructor(
         subscriptionsManager.subscriptionStatus
             .onEach { subscriptionStatus = it }
             .launchIn(viewModelScope)
+    }
+
+    fun loadInitialUrl(url: String) {
+        viewModelScope.launch {
+            command.send(LoadUrl(paywallUrlResolver.resolve(url)))
+        }
     }
 
     fun processJsCallbackMessage(featureName: String, method: String, id: String?, data: JSONObject?) {
@@ -799,6 +807,7 @@ class SubscriptionWebViewViewModel @Inject constructor(
     }
 
     sealed class Command {
+        data class LoadUrl(val url: String) : Command()
         data object BackToSettings : Command()
         data object BackToSettingsActivateSuccess : Command()
         data class SendJsEvent(val event: SubscriptionEventData) : Command()

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -104,6 +104,7 @@ import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.GoToNetP
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.GoToPIR
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.GoToPIRDashboard
+import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.LoadUrl
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.Reload
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.RequestNotificationsPermission
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.RestoreSubscription
@@ -324,17 +325,14 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
             }
         }
 
-        logcat {
-            "SubscriptionsWebViewActivity: Loading subscriptions webview with URL: ${params.url}"
-        }
-        binding.webview.loadUrl(params.url)
-
         viewModel.start()
 
         viewModel.commands()
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { processCommand(it) }
             .launchIn(lifecycleScope)
+
+        viewModel.loadInitialUrl(params.url)
 
         viewModel.currentPurchaseViewState.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).distinctUntilChanged().onEach {
             renderPurchaseState(it.purchaseState)
@@ -570,6 +568,7 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
 
     private fun processCommand(command: Command) {
         when (command) {
+            is LoadUrl -> loadUrl(command.url)
             is BackToSettings, BackToSettingsActivateSuccess -> finishToSettings()
             is SendJsEvent -> sendJsEvent(command.event)
             is SendResponseToJs -> sendResponseToJs(command.data)
@@ -585,6 +584,13 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
             is RequestNotificationsPermission -> launchNotificationsPermission(command.id)
             Reload -> binding.webview.reload()
         }
+    }
+
+    private fun loadUrl(url: String) {
+        logcat {
+            "SubscriptionsWebViewActivity: Loading subscriptions webview with URL: $url"
+        }
+        binding.webview.loadUrl(url)
     }
 
     private fun goToPIRDashboard() {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -104,7 +104,6 @@ import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.GoToNetP
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.GoToPIR
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.GoToPIRDashboard
-import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.LoadUrl
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.Reload
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.RequestNotificationsPermission
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.RestoreSubscription
@@ -121,8 +120,10 @@ import com.duckduckgo.user.agent.api.UserAgentProvider
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import logcat.logcat
 import org.json.JSONObject
@@ -332,7 +333,14 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
             .onEach { processCommand(it) }
             .launchIn(lifecycleScope)
 
-        viewModel.loadInitialUrl(params.url)
+        viewModel.initialUrl
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .filterNotNull()
+            .take(1)
+            .onEach { loadUrl(it) }
+            .launchIn(lifecycleScope)
+
+        viewModel.resolveInitialUrl(params.url)
 
         viewModel.currentPurchaseViewState.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).distinctUntilChanged().onEach {
             renderPurchaseState(it.purchaseState)
@@ -568,7 +576,6 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
 
     private fun processCommand(command: Command) {
         when (command) {
-            is LoadUrl -> loadUrl(command.url)
             is BackToSettings, BackToSettingsActivateSuccess -> finishToSettings()
             is SendJsEvent -> sendJsEvent(command.event)
             is SendResponseToJs -> sendResponseToJs(command.data)

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/internal/RealPaywallUrlResolverTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/internal/RealPaywallUrlResolverTest.kt
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.internal
+
+import android.annotation.SuppressLint
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.subscriptions.api.Product
+import com.duckduckgo.subscriptions.api.model.Entitlement
+import com.duckduckgo.subscriptions.impl.SubscriptionOffer
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.DUCK_AI_FEATURE_PAGE
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.VPN_FEATURE_PAGE
+import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
+import com.duckduckgo.subscriptions.impl.SubscriptionsManager
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+@SuppressLint("DenyListedApi")
+class RealPaywallUrlResolverTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val subscriptionsManager: SubscriptionsManager = mock()
+    private val subscriptionsFeature: SubscriptionsFeature = FakeFeatureToggleFactory.create(SubscriptionsFeature::class.java)
+    private val subscriptionsUrlProvider = RealSubscriptionsUrlProvider(DefaultSubscriptionsBaseUrl())
+    private val paywallPathProvider: PaywallPathProvider = mock()
+
+    private val testee = RealPaywallUrlResolver(
+        subscriptionsUrlProvider = subscriptionsUrlProvider,
+        subscriptionsManager = subscriptionsManager,
+        subscriptionsFeature = subscriptionsFeature,
+        paywallPathProvider = paywallPathProvider,
+        dispatcherProvider = coroutineRule.testDispatcherProvider,
+    )
+
+    @Before
+    fun before() = runTest {
+        subscriptionsFeature.performanceOptimizedPaywalls().setRawStoredState(State(remoteEnableState = true))
+        givenEntryPointPath(featurePage = VPN_FEATURE_PAGE, path = "/subscriptions/new/mobile/vpn")
+        givenEntryPointPath(featurePage = DUCK_AI_FEATURE_PAGE, path = "/subscriptions/new/mobile/duckai")
+        givenOfferedProducts(Product.NetP.value)
+        givenFreeTrialEligible(false)
+    }
+
+    @Test
+    fun whenFeatureDisabledThenUrlIsUnchanged() = runTest {
+        subscriptionsFeature.performanceOptimizedPaywalls().setRawStoredState(State(remoteEnableState = false))
+
+        assertEquals(BUY_URL, testee.resolve(BUY_URL))
+        assertEquals("$BUY_URL?featurePage=duckai", testee.resolve("$BUY_URL?featurePage=duckai"))
+    }
+
+    @Test
+    fun whenVpnPaywallThenServerRenderedVpnUrl() = runTest {
+        assertEquals("$BUY_URL/new/mobile/vpn?trial=false&pir=false", testee.resolve(BUY_URL))
+    }
+
+    @Test
+    fun whenDuckAiPaywallThenServerRenderedDuckAiUrl() = runTest {
+        assertEquals("$BUY_URL/new/mobile/duckai?trial=false&pir=false", testee.resolve("$BUY_URL?featurePage=duckai"))
+    }
+
+    @Test
+    fun whenFreeTrialEligibleThenTrialIsTrue() = runTest {
+        givenFreeTrialEligible(true)
+
+        assertEquals("$BUY_URL/new/mobile/vpn?trial=true&pir=false", testee.resolve(BUY_URL))
+    }
+
+    @Test
+    fun whenPirIsOnOfferThenPirParamIsOmitted() = runTest {
+        givenOfferedProducts(Product.NetP.value, Product.PIR.value)
+
+        assertEquals("$BUY_URL/new/mobile/vpn?trial=false", testee.resolve(BUY_URL))
+        assertEquals("$BUY_URL/new/mobile/duckai?trial=false", testee.resolve("$BUY_URL?featurePage=duckai"))
+    }
+
+    @Test
+    fun whenVpnNamedExplicitlyAsFeaturePageThenServerRenderedVpnUrl() = runTest {
+        assertEquals("$BUY_URL/new/mobile/vpn?trial=false&pir=false", testee.resolve("$BUY_URL?featurePage=vpn"))
+    }
+
+    @Test
+    fun whenUnknownFeaturePageThenUrlIsUnchanged() = runTest {
+        val url = "$BUY_URL?featurePage=itr"
+
+        assertEquals(url, testee.resolve(url))
+    }
+
+    @Test
+    fun whenUrlCarriesOtherParamsThenTheyAreCarriedOntoTheNewPath() = runTest {
+        assertEquals(
+            "$BUY_URL/new/mobile/vpn?origin=funnel_appsettings_android&trial=false&pir=false",
+            testee.resolve("$BUY_URL?origin=funnel_appsettings_android"),
+        )
+        assertEquals(
+            "$BUY_URL/new/mobile/duckai?origin=funnel_appsettings_android&trial=false&pir=false",
+            testee.resolve("$BUY_URL?featurePage=duckai&origin=funnel_appsettings_android"),
+        )
+    }
+
+    @Test
+    fun whenFeaturePageIsBlankThenServerRenderedVpnUrl() = runTest {
+        assertEquals("$BUY_URL/new/mobile/vpn?trial=false&pir=false", testee.resolve("$BUY_URL?featurePage="))
+    }
+
+    @Test
+    fun whenAParamRepeatsThenEveryValueIsCarriedOntoTheNewPath() = runTest {
+        assertEquals(
+            "$BUY_URL/new/mobile/vpn?origin=first&origin=second&trial=false&pir=false",
+            testee.resolve("$BUY_URL?origin=first&origin=second"),
+        )
+    }
+
+    @Test
+    fun whenAParamIsEncodedThenItStaysEncodedOnTheNewPath() = runTest {
+        assertEquals(
+            "$BUY_URL/new/mobile/vpn?origin=funnel%20appsettings%26x%3D1&trial=false&pir=false",
+            testee.resolve("$BUY_URL?origin=funnel%20appsettings%26x%3D1"),
+        )
+    }
+
+    @Test
+    fun whenUrlAlreadyStatesTrialOrPirThenOurAnswerReplacesIt() = runTest {
+        assertEquals(
+            "$BUY_URL/new/mobile/vpn?trial=false&pir=false",
+            testee.resolve("$BUY_URL?trial=true&pir=true"),
+        )
+    }
+
+    @Test
+    fun whenNotAPaywallUrlThenUrlIsUnchanged() = runTest {
+        assertEquals(subscriptionsUrlProvider.welcomeUrl, testee.resolve(subscriptionsUrlProvider.welcomeUrl))
+        assertEquals(subscriptionsUrlProvider.activateUrl, testee.resolve(subscriptionsUrlProvider.activateUrl))
+        assertEquals(subscriptionsUrlProvider.manageUrl, testee.resolve(subscriptionsUrlProvider.manageUrl))
+        assertEquals(subscriptionsUrlProvider.plansUrl, testee.resolve(subscriptionsUrlProvider.plansUrl))
+        assertEquals(subscriptionsUrlProvider.upgradeToProUrl, testee.resolve(subscriptionsUrlProvider.upgradeToProUrl))
+    }
+
+    @Test
+    fun whenNoOffersAreAvailableThenUrlIsUnchanged() = runTest {
+        whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(emptyList())
+
+        assertEquals(BUY_URL, testee.resolve(BUY_URL))
+        assertEquals("$BUY_URL?featurePage=duckai", testee.resolve("$BUY_URL?featurePage=duckai"))
+    }
+
+    @Test
+    fun whenResolvingFailsThenUrlIsUnchanged() = runTest {
+        whenever(subscriptionsManager.getSubscriptionOffer()).thenThrow(RuntimeException())
+
+        assertEquals(BUY_URL, testee.resolve(BUY_URL))
+    }
+
+    @Test
+    fun whenBaseUrlIsOverriddenThenServerRenderedUrlIsBuiltOnIt() = runTest {
+        val overriddenBaseUrl = "https://example.devtunnels.ms/subscriptions"
+        val testeeWithOverriddenBaseUrl = RealPaywallUrlResolver(
+            subscriptionsUrlProvider = RealSubscriptionsUrlProvider(
+                object : SubscriptionsBaseUrl {
+                    override val subscriptionsBaseUrl = overriddenBaseUrl
+                },
+            ),
+            subscriptionsManager = subscriptionsManager,
+            subscriptionsFeature = subscriptionsFeature,
+            paywallPathProvider = paywallPathProvider,
+            dispatcherProvider = coroutineRule.testDispatcherProvider,
+        )
+
+        assertEquals(
+            "$overriddenBaseUrl/new/mobile/duckai?trial=false&pir=false",
+            testeeWithOverriddenBaseUrl.resolve("$overriddenBaseUrl?featurePage=duckai"),
+        )
+    }
+
+    @Test
+    fun whenUrlIsNotASubscriptionsUrlThenUrlIsUnchanged() = runTest {
+        val url = "https://example.com/subscriptions"
+
+        assertEquals(url, testee.resolve(url))
+    }
+
+    @Test
+    fun whenNoEntryPointForTheFeaturePageThenOnlyThatPageIsUnchanged() = runTest {
+        givenEntryPointPath(featurePage = DUCK_AI_FEATURE_PAGE, path = null)
+
+        assertEquals("$BUY_URL/new/mobile/vpn?trial=false&pir=false", testee.resolve(BUY_URL))
+        assertEquals("$BUY_URL?featurePage=duckai", testee.resolve("$BUY_URL?featurePage=duckai"))
+    }
+
+    @Test
+    fun whenEntryPointPathChangesThenServerRenderedUrlFollowsIt() = runTest {
+        givenEntryPointPath(featurePage = VPN_FEATURE_PAGE, path = "/subscriptions/faster/vpn")
+
+        assertEquals("$BUY_URL/faster/vpn?trial=false&pir=false", testee.resolve(BUY_URL))
+    }
+
+    private fun givenEntryPointPath(featurePage: String, path: String?) {
+        whenever(paywallPathProvider.getPath(featurePage)).thenReturn(path)
+    }
+
+    private suspend fun givenFreeTrialEligible(eligible: Boolean) {
+        whenever(subscriptionsManager.isFreeTrialEligible()).thenReturn(eligible)
+    }
+
+    private suspend fun givenOfferedProducts(vararg products: String) {
+        whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(
+            listOf(
+                SubscriptionOffer(
+                    planId = "test",
+                    offerId = null,
+                    tier = "plus",
+                    pricingPhases = emptyList(),
+                    entitlements = products.map { Entitlement(name = "plus", product = it) }.toSet(),
+                ),
+            ),
+        )
+    }
+
+    private companion object {
+        const val BUY_URL = "https://duckduckgo.com/subscriptions"
+    }
+}

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PRO_PLAN_
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PRO_PLAN_US
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
+import com.duckduckgo.subscriptions.impl.internal.PaywallUrlResolver
 import com.duckduckgo.subscriptions.impl.notification.SubscriptionExpirationReminderScheduler
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.repository.Subscription
@@ -85,6 +86,7 @@ class SubscriptionWebViewViewModelTest {
     private val subscriptionsFeature = FakeFeatureToggleFactory.create(SubscriptionsFeature::class.java, FakeToggleStore())
     private val pirFeature: PirFeature = mock()
     private val subscriptionExpirationReminderScheduler: SubscriptionExpirationReminderScheduler = mock()
+    private val paywallUrlResolver: PaywallUrlResolver = mock()
 
     private lateinit var viewModel: SubscriptionWebViewViewModel
 
@@ -93,16 +95,33 @@ class SubscriptionWebViewViewModelTest {
         whenever(networkProtectionAccessState.getScreenForCurrentState()).thenReturn(NetworkProtectionManagementScreenNoParams)
         whenever(pirFeature.getPirFeatureState()).thenReturn(PirFeatureState.DISABLED)
         viewModel = SubscriptionWebViewViewModel(
-            coroutineTestRule.testDispatcherProvider,
-            subscriptionsManager,
-            subscriptionsChecker,
-            networkProtectionAccessState,
-            pixelSender,
-            subscriptionsFeature,
-            pirFeature,
-            subscriptionExpirationReminderScheduler,
+            dispatcherProvider = coroutineTestRule.testDispatcherProvider,
+            subscriptionsManager = subscriptionsManager,
+            subscriptionsChecker = subscriptionsChecker,
+            networkProtectionAccessState = networkProtectionAccessState,
+            pixelSender = pixelSender,
+            subscriptionsFeature = subscriptionsFeature,
+            pirFeature = pirFeature,
+            subscriptionExpirationReminderScheduler = subscriptionExpirationReminderScheduler,
+            paywallUrlResolver = paywallUrlResolver,
         )
         givenSubscriptionStatus(UNKNOWN)
+    }
+
+    @Test
+    fun whenLoadInitialUrlThenLoadsResolvedUrl() = runTest {
+        val buyUrl = "https://duckduckgo.com/subscriptions"
+        val resolvedUrl = "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false"
+        whenever(paywallUrlResolver.resolve(buyUrl)).thenReturn(resolvedUrl)
+
+        viewModel.commands().test {
+            viewModel.loadInitialUrl(buyUrl)
+
+            val result = awaitItem()
+            assertTrue(result is Command.LoadUrl)
+            assertEquals(resolvedUrl, (result as Command.LoadUrl).url)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
@@ -64,6 +64,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -109,17 +110,37 @@ class SubscriptionWebViewViewModelTest {
     }
 
     @Test
-    fun whenLoadInitialUrlThenLoadsResolvedUrl() = runTest {
+    fun whenResolveInitialUrlThenInitialUrlHoldsResolvedUrl() = runTest {
         val buyUrl = "https://duckduckgo.com/subscriptions"
         val resolvedUrl = "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false"
         whenever(paywallUrlResolver.resolve(buyUrl)).thenReturn(resolvedUrl)
 
-        viewModel.commands().test {
-            viewModel.loadInitialUrl(buyUrl)
+        viewModel.resolveInitialUrl(buyUrl)
 
-            val result = awaitItem()
-            assertTrue(result is Command.LoadUrl)
-            assertEquals(resolvedUrl, (result as Command.LoadUrl).url)
+        assertEquals(resolvedUrl, viewModel.initialUrl.value)
+    }
+
+    @Test
+    fun whenResolveInitialUrlCalledAgainThenUrlIsResolvedOnlyOnce() = runTest {
+        val buyUrl = "https://duckduckgo.com/subscriptions"
+        val resolvedUrl = "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false"
+        whenever(paywallUrlResolver.resolve(buyUrl)).thenReturn(resolvedUrl)
+
+        viewModel.resolveInitialUrl(buyUrl)
+        viewModel.resolveInitialUrl(buyUrl)
+
+        verify(paywallUrlResolver, times(1)).resolve(buyUrl)
+    }
+
+    @Test
+    fun whenCollectedAfterResolvingThenResolvedUrlIsStillReplayed() = runTest {
+        val buyUrl = "https://duckduckgo.com/subscriptions"
+        val resolvedUrl = "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false"
+        whenever(paywallUrlResolver.resolve(buyUrl)).thenReturn(resolvedUrl)
+        viewModel.resolveInitialUrl(buyUrl)
+
+        viewModel.initialUrl.test {
+            assertEquals(resolvedUrl, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1217319487385906/task/1217750626830941?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description
Opens the performance-optimized paywall page when the `performanceOptimizedPaywalls` flag is on, so the front end can test the **faster** entry points on Android.

- The paths come from the flag settings, so they can change in remote config without an app release https://github.com/duckduckgo/privacy-configuration/pull/5809
- The URL carries `trial=true` or `trial=false` from free trial eligibility, and `pir=false` when PIR is not part of the offer, so the page renders without asking the app what the user is being offered.
- Params the app already sets, such as `origin`, are carried onto the new path unchanged.
- With the flag off, the old URL is loaded and nothing changes.

### Steps to test this PR
- [x] Apply the pinned staging patch from https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true and install the internal debug build on a device with Google Play.
- [x] Launch the app once with network and confirm the remote config has landed: Settings > Internal Features > Privacy Config Internal Settings, check "Latest Loaded Date" is today. The paths come from the config, not from the app, and they ship in https://github.com/duckduckgo/privacy-configuration/pull/5809.
- [ ] Settings > Internal Features > Feature Flag Inventory, search `performanceOptimizedPaywalls`, turn it on.
- [ ] Filter logcat on `SubscriptionsWebViewActivity`. It logs the URL every time the paywall opens. Every check below just reads that line.
- [ ] Optional, to see the page render: take the current front end tunnel URL from https://app.asana.com/1/137249556945/task/1216295712277568, put it in Settings > Internal Features > Subscriptions Dev Settings > "Enter the base URL for subscriptions", and Save. The tunnel is temporary.

_VPN paywall_
- [ ] Open from Settings > Privacy Pro. URL should be `/subscriptions/new/mobile/vpn`.

_Duck.ai paywall_
- [ ] Open from a Duck.ai entry point. URL should be `/subscriptions/new/mobile/duckai`, with no `featurePage` in the query.

_Query params_
- [ ] Trial eligible account: `trial=true`. Account that already used a trial: `trial=false`.
- [ ] Region without PIR: `pir=false` present. Region with PIR: no `pir` param.
- [ ] Open from app settings: `origin=funnel_appsettings_android` and `environment=staging` both survive onto the new path.

_Flag off_
- [ ] Turn `performanceOptimizedPaywalls` off, open the paywall. URL should be `/subscriptions` with no `trial` or `pir`, and the old page loads.

_Fallback_
- [ ] Force stop the app, reopen, go to the paywall before Google Play has loaded products. Old URL loads, no error page, no crash.

### UX changes
| Before  | After |
| ------ | ----- |
https://github.com/user-attachments/assets/5f6a6240-da74-4a85-9e98-c0974be6841e|https://github.com/user-attachments/assets/43d3462f-8e03-4f73-9c88-84e3a6998baf|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which URL loads at paywall open and depends on Play offer/trial state; fallbacks keep the legacy URL, but wrong rewrite could affect purchase funnel and analytics origins.
> 
> **Overview**
> When **`performanceOptimizedPaywalls`** is enabled, the subscriptions webview no longer loads the generic buy URL directly. A new **`PaywallUrlResolver`** rewrites matching paywall URLs to remote-config entry paths (VPN vs Duck.ai from `featurePage`), injects **`trial`** from free-trial eligibility and **`pir=false`** when PIR isn’t on the offer, and preserves other query params like **`origin`**. If the flag is off, offers aren’t ready, or rewrite fails, the original URL is used unchanged.
> 
> **`SubscriptionWebViewViewModel`** resolves that URL once and exposes it via **`initialUrl`**; **`SubscriptionsWebViewActivity`** waits for the first resolved URL before **`loadUrl`**. Shared constants for feature pages and query keys replace a local Duck.ai string in JS messaging. Unit tests cover resolver behavior and view-model URL resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6efc658430a974ff401c09ebaea98a776dfb07ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->