### PR TITLE
Add updatedPickers feature flag

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -297,4 +297,13 @@ interface DuckChatFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun sendDuckAiSessionWideEvent(): Toggle
+
+    /**
+     * @return `true` when the updated Duck.ai model and reasoning pickers are enabled: models grouped
+     * by availability, backend-driven ordering and sublines, and a gated section header that follows the
+     * user's tier.
+     * If the remote feature is not present defaults to `false`.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun updatedPickers(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218299205152314
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

Adds the `updatedPickers` toggle to `DuckChatFeature`. It gates the upcoming model and
reasoning picker changes, which move to availability-based grouping, backend-driven ordering
and tier-dependent headers together, so one flag covers both. Nothing reads the toggle yet.
It defaults to false rather than internal, so it stays opt-in from the internal feature flag
menu until the pickers are ready for wider testing.

### Steps to test this PR

_Feature 1_
- [ ] Install an internal build and open the debug menu, then the feature flags list
- [ ] Confirm `updatedPickers` appears under the aiChat feature and is off
- [ ] Toggle it on and off, then confirm Duck.ai behaves exactly as it does on develop (no
      visible change either way, since no code reads the flag yet)

### UI changes
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an unused feature toggle with a false default; no runtime behavior changes until consumers land.
> 
> **Overview**
> Adds a new **`updatedPickers`** remote feature toggle on **`DuckChatFeature`** (under the `aiChat` feature). When enabled, it will gate the upcoming Duck.ai **model and reasoning picker** work: availability-based grouping, backend-driven ordering/sublines, and tier-aware section headers—**one flag for both pickers**.
> 
> The toggle defaults to **`false`** (opt-in via internal debug flags), unlike many sibling flags that default to `internal`. **No call sites use it yet**, so behavior is unchanged until follow-up PRs wire it up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cd84aa276d50c591279a680a8fb5fb98052b905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->