### PR TITLE
Rename the Duck.ai menu's Chats entry and menu to NTP

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3108,7 +3108,13 @@ class BrowserTabFragment :
                 val anchor = duckChatButtonAnchor
                 duckChatButtonAnchor = null
                 viewLifecycleOwner.lifecycleScope.launch(dispatchers.main()) {
-                    duckChatContextual.launch(tabId, sourceUrl, anchor) { showDuckChatContextualSheet(tabId) }
+                    duckChatContextual.launch(tabId, sourceUrl, anchor) {
+                        if (sourceUrl == null) {
+                            viewModel.openDuckChatFromOmnibar(query = null, hasFocus = false, isNtp = true)
+                        } else {
+                            showDuckChatContextualSheet(tabId)
+                        }
+                    }
                 }
             }
             is Command.StartAddressBarTrackersAnimation -> {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -391,6 +391,7 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.contextual.PageContextJSHelper
 import com.duckduckgo.duckchat.impl.contextual.RealPageContextJSHelper.Companion.PAGE_CONTEXT_FEATURE_NAME
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
@@ -552,6 +553,7 @@ class BrowserTabViewModel @Inject constructor(
     private val httpErrorPixels: Lazy<HttpErrorPixels>,
     private val duckPlayer: DuckPlayer,
     private val duckChat: DuckChat,
+    private val duckChatInternal: DuckChatInternal,
     private val duckAiHostProvider: DuckAiHostProvider,
     private val duckAiFeatureState: DuckAiFeatureState,
     private val duckChatInputModeState: DuckChatInputModeState,
@@ -5897,10 +5899,16 @@ class BrowserTabViewModel @Inject constructor(
         }
 
         when {
-            // Contextual chat is about the page you're viewing, so it's only offered from the
-            // unfocused omnibar. Once the omnibar is focused (composing), fall through to full-screen
-            // Duck.ai.
-            duckAiFeatureState.showContextualMode.value && !isNtp && !hasFocus -> {
+            // Contextual chat is about the page you're viewing, so on a page it's only offered from
+            // the unfocused omnibar: once focused (composing), fall through to full-screen Duck.ai.
+            // The NTP omnibar is focused from the start, so there the menu hangs off an empty query
+            // instead, and only when it carries the Chats entry alongside New Chat.
+            duckAiFeatureState.showContextualMode.value &&
+                if (isNtp) {
+                    duckChatInternal.isContextualMenuAllChatsEnabled() && query.isNullOrBlank()
+                } else {
+                    !hasFocus
+                } -> {
                 command.value = Command.ShowDuckAIContextualMode(tabId, url)
             }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -391,7 +391,6 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
-import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.contextual.PageContextJSHelper
 import com.duckduckgo.duckchat.impl.contextual.RealPageContextJSHelper.Companion.PAGE_CONTEXT_FEATURE_NAME
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
@@ -553,7 +552,6 @@ class BrowserTabViewModel @Inject constructor(
     private val httpErrorPixels: Lazy<HttpErrorPixels>,
     private val duckPlayer: DuckPlayer,
     private val duckChat: DuckChat,
-    private val duckChatInternal: DuckChatInternal,
     private val duckAiHostProvider: DuckAiHostProvider,
     private val duckAiFeatureState: DuckAiFeatureState,
     private val duckChatInputModeState: DuckChatInputModeState,
@@ -5904,38 +5902,44 @@ class BrowserTabViewModel @Inject constructor(
             // The NTP omnibar is focused from the start, so there the menu hangs off an empty query
             // instead, and only when it carries the Chats entry alongside New Chat.
             duckAiFeatureState.showContextualMode.value &&
-                if (isNtp) {
-                    duckChatInternal.isContextualMenuAllChatsEnabled() && query.isNullOrBlank()
-                } else {
-                    !hasFocus
-                } -> {
+                if (isNtp) query.isNullOrBlank() else !hasFocus -> {
                 command.value = Command.ShowDuckAIContextualMode(tabId, url)
             }
 
-            else -> {
-                val (url, submittedAiPrompt) = when {
-                    hasFocus && isNtp && query.isNullOrBlank() -> duckChat.getDuckChatUrl(query ?: "", false) to false
-                    hasFocus && queryUrlPredictor.isUrl(query ?: "") -> (query ?: "") to false
-                    hasFocus -> duckChat.getDuckChatUrl(query ?: "", true) to !query.isNullOrBlank()
-                    else -> duckChat.getDuckChatUrl(query ?: "", false) to false
-                }
-                if (duckChat.isDuckChatUrl(url.toUri())) {
-                    if (submittedAiPrompt) {
-                        browserInteractionsPlugins.getPlugins().forEach {
-                            it.onAiPromptSubmitted(source = DuckChatEntryPoint.ADDRESS_BAR_ICON.name.lowercase())
-                        }
-                    }
-                    duckChat.reportDuckChatEntry(
-                        DuckChatEntryPoint.ADDRESS_BAR_ICON,
-                        opensNewTab = false,
-                        hasPrompt = submittedAiPrompt,
-                    )
-                    submitQuery(url, QueryOrigin.FromUser, QuerySubmissionSource.INTERNAL_NAVIGATION)
-                } else {
-                    // The typed-URL branch above: genuinely a URL submission, not a Duck.ai one.
-                    onUserSubmittedQuery(url)
+            else -> openDuckChatFromOmnibar(query, hasFocus, isNtp)
+        }
+    }
+
+    /**
+     * Opens Duck.ai straight from the address bar icon. Also the fallback when the NTP menu declines
+     * to show, so that path keeps behaving exactly as it did before the menu existed.
+     */
+    fun openDuckChatFromOmnibar(
+        query: String?,
+        hasFocus: Boolean,
+        isNtp: Boolean,
+    ) {
+        val (url, submittedAiPrompt) = when {
+            hasFocus && isNtp && query.isNullOrBlank() -> duckChat.getDuckChatUrl(query ?: "", false) to false
+            hasFocus && queryUrlPredictor.isUrl(query ?: "") -> (query ?: "") to false
+            hasFocus -> duckChat.getDuckChatUrl(query ?: "", true) to !query.isNullOrBlank()
+            else -> duckChat.getDuckChatUrl(query ?: "", false) to false
+        }
+        if (duckChat.isDuckChatUrl(url.toUri())) {
+            if (submittedAiPrompt) {
+                browserInteractionsPlugins.getPlugins().forEach {
+                    it.onAiPromptSubmitted(source = DuckChatEntryPoint.ADDRESS_BAR_ICON.name.lowercase())
                 }
             }
+            duckChat.reportDuckChatEntry(
+                DuckChatEntryPoint.ADDRESS_BAR_ICON,
+                opensNewTab = false,
+                hasPrompt = submittedAiPrompt,
+            )
+            submitQuery(url, QueryOrigin.FromUser, QuerySubmissionSource.INTERNAL_NAVIGATION)
+        } else {
+            // The typed-URL branch above: genuinely a URL submission, not a Duck.ai one.
+            onUserSubmittedQuery(url)
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -320,10 +320,10 @@ import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.duckchat.api.DuckAiSessionCallback
 import com.duckduckgo.duckchat.api.DuckAiSessionExitTrigger
 import com.duckduckgo.duckchat.api.DuckChat
-import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.contextual.PageContextJSHelper
 import com.duckduckgo.duckchat.impl.contextual.RealPageContextJSHelper.Companion.PAGE_CONTEXT_FEATURE_NAME
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -323,7 +323,6 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
-import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.contextual.PageContextJSHelper
 import com.duckduckgo.duckchat.impl.contextual.RealPageContextJSHelper.Companion.PAGE_CONTEXT_FEATURE_NAME
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
@@ -690,7 +689,6 @@ class BrowserTabViewModelTest {
     private val mockDuckChat: DuckChat = mock {
         on { observeTriggerVoiceChatSessionEnd() } doReturn voiceSessionEndTriggerFlow
     }
-    private val mockDuckChatInternal: DuckChatInternal = mock()
     private val mockDuckAiHostProvider: DuckAiHostProvider = mock()
     private val mockSyncStatusChangedObserver: SyncStatusChangedObserver = mock()
     private val syncStatusChangedEventsFlow = MutableSharedFlow<JSONObject>()
@@ -1037,7 +1035,6 @@ class BrowserTabViewModelTest {
                 httpErrorPixels = { mockHttpErrorPixels },
                 duckPlayer = mockDuckPlayer,
                 duckChat = mockDuckChat,
-                duckChatInternal = mockDuckChatInternal,
                 duckAiHostProvider = mockDuckAiHostProvider,
                 duckAiFeatureState = mockDuckAiFeatureState,
                 duckChatInputModeState = mockDuckChatInputModeState,
@@ -10146,9 +10143,8 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenOnDuckChatOmnibarButtonClickedOnNtpWithBlankQueryAndAllChatsMenuEnabledThenShowsContextualMenu() {
+    fun whenOnDuckChatOmnibarButtonClickedOnNtpWithBlankQueryThenShowsContextualMenu() {
         mockDuckAiContextualModeFlow.value = true
-        whenever(mockDuckChatInternal.isContextualMenuAllChatsEnabled()).thenReturn(true)
 
         testee.onDuckChatOmnibarButtonClicked(query = null, hasFocus = true, isNtp = true)
 
@@ -10157,22 +10153,8 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenOnDuckChatOmnibarButtonClickedOnNtpWithAllChatsMenuDisabledThenOpensDuckChat() {
-        mockDuckAiContextualModeFlow.value = true
-        whenever(mockDuckChatInternal.isContextualMenuAllChatsEnabled()).thenReturn(false)
-        whenever(mockOmnibarConverter.convertQueryToUrl(duckChatURL, null)).thenReturn(duckChatURL)
-
-        testee.onDuckChatOmnibarButtonClicked(query = null, hasFocus = false, isNtp = true)
-
-        verify(mockDuckChat).getDuckChatUrl(eq(""), eq(false), any())
-        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
-        assertFalse(commandCaptor.allValues.any { it is Command.ShowDuckAIContextualMode })
-    }
-
-    @Test
     fun whenOnDuckChatOmnibarButtonClickedOnNtpWithTypedQueryThenOpensDuckChatNotMenu() {
         mockDuckAiContextualModeFlow.value = true
-        whenever(mockDuckChatInternal.isContextualMenuAllChatsEnabled()).thenReturn(true)
         whenever(mockOmnibarConverter.convertQueryToUrl(duckChatURL, null)).thenReturn(duckChatURL)
 
         testee.onDuckChatOmnibarButtonClicked(query = "example", hasFocus = true, isNtp = true)
@@ -10180,6 +10162,15 @@ class BrowserTabViewModelTest {
         verify(mockDuckChat).getDuckChatUrl(eq("example"), eq(true), any())
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         assertFalse(commandCaptor.allValues.any { it is Command.ShowDuckAIContextualMode })
+    }
+
+    @Test
+    fun whenOpenDuckChatFromOmnibarOnNtpThenOpensDuckChatWithoutPrompt() {
+        whenever(mockOmnibarConverter.convertQueryToUrl(duckChatURL, null)).thenReturn(duckChatURL)
+
+        testee.openDuckChatFromOmnibar(query = null, hasFocus = false, isNtp = true)
+
+        verify(mockDuckChat).getDuckChatUrl(eq(""), eq(false), any())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -320,6 +320,7 @@ import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.duckchat.api.DuckAiSessionCallback
 import com.duckduckgo.duckchat.api.DuckAiSessionExitTrigger
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.api.DuckChatEntryPoint
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
@@ -689,6 +690,7 @@ class BrowserTabViewModelTest {
     private val mockDuckChat: DuckChat = mock {
         on { observeTriggerVoiceChatSessionEnd() } doReturn voiceSessionEndTriggerFlow
     }
+    private val mockDuckChatInternal: DuckChatInternal = mock()
     private val mockDuckAiHostProvider: DuckAiHostProvider = mock()
     private val mockSyncStatusChangedObserver: SyncStatusChangedObserver = mock()
     private val syncStatusChangedEventsFlow = MutableSharedFlow<JSONObject>()
@@ -1035,6 +1037,7 @@ class BrowserTabViewModelTest {
                 httpErrorPixels = { mockHttpErrorPixels },
                 duckPlayer = mockDuckPlayer,
                 duckChat = mockDuckChat,
+                duckChatInternal = mockDuckChatInternal,
                 duckAiHostProvider = mockDuckAiHostProvider,
                 duckAiFeatureState = mockDuckAiFeatureState,
                 duckChatInputModeState = mockDuckChatInputModeState,
@@ -10140,6 +10143,43 @@ class BrowserTabViewModelTest {
 
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         assertTrue(commandCaptor.allValues.any { it is Command.ShowDuckAIContextualMode })
+    }
+
+    @Test
+    fun whenOnDuckChatOmnibarButtonClickedOnNtpWithBlankQueryAndAllChatsMenuEnabledThenShowsContextualMenu() {
+        mockDuckAiContextualModeFlow.value = true
+        whenever(mockDuckChatInternal.isContextualMenuAllChatsEnabled()).thenReturn(true)
+
+        testee.onDuckChatOmnibarButtonClicked(query = null, hasFocus = true, isNtp = true)
+
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        assertTrue(commandCaptor.allValues.any { it is Command.ShowDuckAIContextualMode })
+    }
+
+    @Test
+    fun whenOnDuckChatOmnibarButtonClickedOnNtpWithAllChatsMenuDisabledThenOpensDuckChat() {
+        mockDuckAiContextualModeFlow.value = true
+        whenever(mockDuckChatInternal.isContextualMenuAllChatsEnabled()).thenReturn(false)
+        whenever(mockOmnibarConverter.convertQueryToUrl(duckChatURL, null)).thenReturn(duckChatURL)
+
+        testee.onDuckChatOmnibarButtonClicked(query = null, hasFocus = false, isNtp = true)
+
+        verify(mockDuckChat).getDuckChatUrl(eq(""), eq(false), any())
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        assertFalse(commandCaptor.allValues.any { it is Command.ShowDuckAIContextualMode })
+    }
+
+    @Test
+    fun whenOnDuckChatOmnibarButtonClickedOnNtpWithTypedQueryThenOpensDuckChatNotMenu() {
+        mockDuckAiContextualModeFlow.value = true
+        whenever(mockDuckChatInternal.isContextualMenuAllChatsEnabled()).thenReturn(true)
+        whenever(mockOmnibarConverter.convertQueryToUrl(duckChatURL, null)).thenReturn(duckChatURL)
+
+        testee.onDuckChatOmnibarButtonClicked(query = "example", hasFocus = true, isNtp = true)
+
+        verify(mockDuckChat).getDuckChatUrl(eq("example"), eq(true), any())
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        assertFalse(commandCaptor.allValues.any { it is Command.ShowDuckAIContextualMode })
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
@@ -71,7 +71,7 @@ class RealDuckChatContextual @Inject constructor(
                 ?.takeIf { duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(it) }
                 ?.let { duckDuckGoUrlDetector.extractQuery(it) }
                 ?.takeIf { it.isNotBlank() }
-            showMenu(sourceTabId, anchor, serpQuery, showChatSurface)
+            showMenu(sourceTabId, anchor, sourceUrl, serpQuery, showChatSurface)
         }
     }
 
@@ -106,6 +106,7 @@ class RealDuckChatContextual @Inject constructor(
     private fun showMenu(
         sourceTabId: String,
         anchor: View,
+        sourceUrl: String?,
         serpQuery: String?,
         onAskAboutPage: () -> Unit,
     ) {
@@ -117,7 +118,10 @@ class RealDuckChatContextual @Inject constructor(
             openNewChatTab(activity, sourceTabId)
         }
         val askItem = content.findViewById<PopupMenuItemView>(R.id.contextualChatMenuAskAboutPage)
-        if (serpQuery != null) {
+        if (sourceUrl == null) {
+            // No page open (NTP or a blank tab), so there is nothing to ask about.
+            askItem.gone()
+        } else if (serpQuery != null) {
             askItem.setPrimaryText(activity.getString(R.string.duckChatContextualAskAboutSearch))
             popup.onMenuItemClicked(askItem) {
                 duckChatPixels.reportContextualAddressBarMenuAskAboutSearchSelected()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextual.kt
@@ -63,6 +63,12 @@ class RealDuckChatContextual @Inject constructor(
             showChatSurface()
             return
         }
+        if (sourceUrl == null && !duckChatInternal.isContextualMenuAllChatsEnabled()) {
+            // Nothing to ask about and no Chats entry, so a one-item menu would be worse than the
+            // caller's own fallback (opening Duck.ai).
+            showChatSurface()
+            return
+        }
         if (hasChatInProgress(sourceTabId)) {
             // The sheet would reopen the existing chat for this tab, so skip the entry menu and open it directly.
             showChatSurface()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -31,6 +31,12 @@ interface NativeInputHost {
     /** Submit the current input as a chat message; opens a new chat session if the input is empty. */
     fun submit()
 
+    /** `true` when the input carries nothing submittable, i.e. [submit] would start an empty chat. */
+    fun isInputEmpty(): Boolean
+
+    /** The tab the widget is currently configured for, or null before it has been configured. */
+    fun tabId(): String?
+
     /** Stop the active chat stream. Delegates to the host's [NativeInputWidget.onStopTapped] callback. */
     fun stop()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
@@ -37,6 +37,6 @@ class StartChatNativeInputPlugin @Inject constructor() : NativeInputPlugin {
     override val containerId: Int = R.id.startChatContainer
 
     override fun createView(context: Context, host: NativeInputHost): View = StartChatView(context).apply {
-        onIconClicked = { host.submit() }
+        this.host = host
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -2072,6 +2072,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
     }
 
+    override fun isInputEmpty(): Boolean = inputField.text.getTextToSubmit() == null
+
+    override fun tabId(): String? = activeTabId
+
     override fun stop() {
         // Single chokepoint for every stop affordance (the streaming-plugin button routes here via
         // host.stop(), and the input-screen stop button calls stop() too), so the pixel fires once.

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatView.kt
@@ -29,11 +29,14 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.DuckChatContextual
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @InjectWith(ViewScope::class)
@@ -45,6 +48,8 @@ class StartChatView @JvmOverloads constructor(
 
     @Inject lateinit var viewModelFactory: ViewViewModelFactory
 
+    @Inject lateinit var duckChatContextual: DuckChatContextual
+
     private val viewModel by lazy {
         ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[StartChatViewModel::class.java]
     }
@@ -52,7 +57,7 @@ class StartChatView @JvmOverloads constructor(
     private val icon: ImageView by lazy { findViewById(R.id.aiChatIconMenu) }
     private var visibilityJob: Job? = null
 
-    var onIconClicked: (() -> Unit)? = null
+    var host: NativeInputHost? = null
 
     init {
         inflate(context, R.layout.view_start_chat, this)
@@ -61,7 +66,7 @@ class StartChatView @JvmOverloads constructor(
     override fun onAttachedToWindow() {
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
-        icon.setOnClickListener { onIconClicked?.invoke() }
+        icon.setOnClickListener { onIconTapped() }
         observeVisibility()
     }
 
@@ -69,6 +74,20 @@ class StartChatView @JvmOverloads constructor(
         super.onDetachedFromWindow()
         visibilityJob?.cancel()
         visibilityJob = null
+    }
+
+    private fun onIconTapped() {
+        val host = host ?: return
+        val tabId = host.tabId()
+        val scope = findViewTreeLifecycleOwner()?.lifecycleScope
+        val showMenu = viewModel.onIconClicked(inputEmpty = host.isInputEmpty()) == StartChatViewModel.IconAction.SHOW_MENU
+        if (!showMenu || tabId == null || scope == null) {
+            host.submit()
+            return
+        }
+        // No page behind the new tab page, so the menu drops Ask About Page and offers New Chat and
+        // Chats. Submitting stays the fallback for when the menu itself declines to show.
+        scope.launch { duckChatContextual.launch(tabId, sourceUrl = null, anchor = icon) { host.submit() } }
     }
 
     private fun observeVisibility() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
@@ -31,9 +31,18 @@ import javax.inject.Inject
 @ContributesViewModel(ViewScope::class)
 class StartChatViewModel @Inject constructor(
     duckAiFeatureState: DuckAiFeatureState,
-    duckChatInternal: DuckChatInternal,
+    private val duckChatInternal: DuckChatInternal,
     nativeInputStateProvider: NativeInputStateProvider,
 ) : ViewModel() {
+
+    enum class IconAction { SUBMIT, SHOW_MENU }
+
+    /**
+     * An empty input has nothing to send, so it offers the Duck.ai menu instead of starting a chat.
+     * Anything typed always goes straight to Duck.ai.
+     */
+    fun onIconClicked(inputEmpty: Boolean): IconAction =
+        if (inputEmpty && duckChatInternal.isContextualMenuAllChatsEnabled()) IconAction.SHOW_MENU else IconAction.SUBMIT
 
     /**
      * Show the start-chat icon only when Duck.ai is available (feature enabled +

--- a/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chat_menu.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chat_menu.xml
@@ -50,6 +50,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:leadingIcon="@drawable/ic_chats_24"
-        app:primaryText="@string/duckChatContextualAllChats" />
+        app:primaryText="@string/duck_ai_chat_history_title" />
 
 </LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -39,7 +39,4 @@
     <!-- Duck.ai on/off, shown in the onboarding Duck.ai state choice -->
     <string name="duckChatOnboardingDuckAiStateOn">Turn Duck.ai On</string>
     <string name="duckChatOnboardingDuckAiStateOff">Keep Duck.ai Off</string>
-
-    <!-- Duck.ai address bar menu -->
-    <string name="duckChatContextualAllChats">All Chats</string>
 </resources>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextualTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealDuckChatContextualTest.kt
@@ -78,6 +78,18 @@ class RealDuckChatContextualTest {
     }
 
     @Test
+    fun whenNoPageAndChatsEntryDisabledThenChatSurfaceShownInsteadOfMenu() = runTest {
+        whenever(duckChatInternal.isContextualSheetRedesignEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isContextualMenuAllChatsEnabled()).thenReturn(false)
+        var askAboutPageCount = 0
+
+        testee.launch("tabId", sourceUrl = null, anchor = anchor) { askAboutPageCount++ }
+
+        // A menu of just New Chat is worse than the caller's own fallback.
+        assertEquals(1, askAboutPageCount)
+    }
+
+    @Test
     fun whenChatInProgressThenAskAboutPageInvokedWithoutShowingMenu() = runTest {
         whenever(duckChatInternal.isContextualSheetRedesignEnabled()).thenReturn(true)
         whenever(contextualDataStore.getTabChatUrl("tabId")).thenReturn("https://duckduckgo.com/?chatId=123")
@@ -92,6 +104,7 @@ class RealDuckChatContextualTest {
     @Test
     fun whenStoredChatSessionExpiredThenTreatedAsNoChatInProgress() = runTest {
         whenever(duckChatInternal.isContextualSheetRedesignEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isContextualMenuAllChatsEnabled()).thenReturn(true)
         whenever(contextualDataStore.getTabChatUrl("tabId")).thenReturn("https://duckduckgo.com/?chatId=123")
         whenever(contextualDataStore.getTabClosedTimestamp("tabId")).thenReturn(0L)
         whenever(sessionTimeoutProvider.sessionTimeoutMillis()).thenReturn(1L)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModelTest.kt
@@ -25,10 +25,12 @@ import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputMode
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.StartChatViewModel.IconAction
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -59,6 +61,27 @@ class StartChatViewModelTest {
     }
 
     private val testee = StartChatViewModel(duckAiFeatureState, duckChatInternal, nativeInputStateProvider)
+
+    @Test
+    fun whenIconClickedWithEmptyInputAndMenuEnabledThenShowMenu() {
+        whenever(duckChatInternal.isContextualMenuAllChatsEnabled()).thenReturn(true)
+
+        assertEquals(IconAction.SHOW_MENU, testee.onIconClicked(inputEmpty = true))
+    }
+
+    @Test
+    fun whenIconClickedWithEmptyInputAndMenuDisabledThenSubmit() {
+        whenever(duckChatInternal.isContextualMenuAllChatsEnabled()).thenReturn(false)
+
+        assertEquals(IconAction.SUBMIT, testee.onIconClicked(inputEmpty = true))
+    }
+
+    @Test
+    fun whenIconClickedWithTypedInputThenSubmitEvenWithMenuEnabled() {
+        whenever(duckChatInternal.isContextualMenuAllChatsEnabled()).thenReturn(true)
+
+        assertEquals(IconAction.SUBMIT, testee.onIconClicked(inputEmpty = false))
+    }
 
     @Test
     fun whenSearchOnlyModeAndSearchToggleAndDuckAiEnabledThenVisible() = runTest {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1218339917320990
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable): None

### Description

Brings the Duck.ai menu to the new tab page and relabels its third entry from All Chats to Chats. The NTP has two different Duck.ai affordances depending on the address bar setting, the omnibar icon and the native input's start-chat icon, so both now open the menu when the input is empty and `contextualMenuAllChats` is on; typed input still goes straight to Duck.ai, as does an empty input with the flag off. The rename reuses `duck_ai_chat_history_title`, already translated in all 24 locales, so no new string is introduced. Pixels are unchanged.

### Steps to test this PR

_NTP, address bar set to "Toggle between Search and Duck.ai"_
- [x] Settings, AI Features, Duck.ai section: choose "Toggle between Search and Duck.ai"
- [x] On a new tab, tap the Duck.ai icon in the address bar
- [x] Confirm a menu with New Chat and Chats, and no Ask About Page
- [x] Tap Chats and confirm the Chats screen opens

_NTP, address bar set to "Search Only"_
- [x] Switch the same setting to "Search Only"
- [x] On a new tab, tap the Duck.ai icon with the field empty; the same two-item menu appears
- [x] Type any text, tap the icon again, and confirm Duck.ai opens directly with no menu

_Page menu unchanged_
- [x] Load any web page and tap the Duck.ai icon
- [x] Confirm New Chat, Ask About Page, divider, Chats

_Flag off_
- [x] Turn `contextualMenuAllChats` off in Feature Flag Inventory, force stop and relaunch
- [x] On the NTP the icon opens Duck.ai directly; on a page the menu shows two items with no dangling divider

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches omnibar and NTP entry paths for Duck.ai with feature-flag gating; behavior is covered by new tests but affects high-traffic navigation UX.
> 
> **Overview**
> Extends the Duck.ai **contextual address-bar menu** to the **new tab page (NTP)** and relabels the history entry to **Chats** via the existing `duck_ai_chat_history_title` string.
> 
> On NTP, tapping Duck.ai with an **empty** omnibar (focused) or the native **start-chat** icon now opens a **two-item menu** (New Chat + Chats, no Ask About Page) when `contextualMenuAllChats` is on; **typed text** still opens Duck.ai directly. `BrowserTabViewModel` widens contextual-mode routing for NTP + blank query and extracts **`openDuckChatFromOmnibar`** as the shared fallback when the menu is skipped. `RealDuckChatContextual` hides Ask About Page when there is no `sourceUrl`, skips a useless one-item menu when Chats is disabled, and **`BrowserTabFragment`** routes null-URL menu dismissal back to opening Duck.ai. **`NativeInputHost`** gains `isInputEmpty()` / `tabId()` so **`StartChatView`** can mirror the omnibar behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dfa1451a9b7faeda3eec89e33290578037711bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218294323286428