### PR TITLE
Update check your other device copy

### DIFF
--- a/sync/sync-impl/src/main/res/values/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values/strings-sync.xml
@@ -376,7 +376,7 @@
 
     <!-- Pairing screen -->
     <string name="sync_simplified_pairing_headline">Sync&#160;&amp;&#160;Backup is end-to-end encrypted on all your devices.</string>
-    <string name="sync_simplified_pairing_headline_check_other_device">Check your other device</string>
+    <string name="sync_simplified_pairing_headline_check_other_device">Check your other device.</string>
     <string name="sync_simplified_pairing_headline_recovery">Recovering data</string>
     <string name="sync_simplified_pairing_body">Connecting…</string>
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218362898011218?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description

Copy update.

### Steps to test this PR

QA optional.

### UI changes
N/A


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single English string punctuation change with no behavioral impact.
> 
> **Overview**
> Updates the **Simplified Sync** pairing screen headline copy for the “waiting on other device” state: `sync_simplified_pairing_headline_check_other_device` now ends with a period (**“Check your other device.”** instead of **“Check your other device”**).
> 
> No logic or layout changes—only the default `strings-sync.xml` English string used when pairing is waiting (e.g. in `ProcessSyncCodeActivity`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 619475a1f7006e393bb728eec7aeb0a380bac3d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->