### PR TITLE
Add the missing ddg wrap when adopting a 3party-minted account_info key, and repair already-broken devices on unified device-list read.

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoDdgWrapRepairer.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoDdgWrapRepairer.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.annotation.WorkerThread
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel
+import com.duckduckgo.sync.impl.pixels.toAccountInfoKeyWrapFailureReason
+import com.duckduckgo.sync.store.SyncStore
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import logcat.LogPriority.ERROR
+import logcat.logcat
+import javax.inject.Inject
+
+@WorkerThread
+interface AccountInfoDdgWrapRepairer {
+    /**
+     * Adds a `ddg` wrap for the existing `account_info` key identified by [kid].
+     *
+     * [entries] avoids another fetch when the caller already has the server's protected keys.
+     */
+    fun repair(
+        kid: String,
+        entries: List<ProtectedKeyEntry>? = null,
+    ): Result<Unit>
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealAccountInfoDdgWrapRepairer @Inject constructor(
+    private val syncStore: SyncStore,
+    private val syncApi: SyncApi,
+    private val protectedKeyUnwrapper: ProtectedKeyUnwrapper,
+    private val nativeLib: SyncLib,
+    private val syncPixels: SyncPixels,
+) : AccountInfoDdgWrapRepairer {
+
+    override fun repair(kid: String, entries: List<ProtectedKeyEntry>?): Result<Unit> {
+        if (syncStore.scopedPassword?.raw.isNullOrEmpty()) {
+            logcat { "Sync-UnifiedDevices: cannot repair ddg account_info wrap without a scoped password" }
+            return Error(reason = "RepairAccountInfoDdgWrap: no scoped password")
+        }
+        val token = syncStore.token.takeUnless { it.isNullOrEmpty() }
+            ?: return Error(reason = "RepairAccountInfoDdgWrap: no token")
+        val accountSecretKey = syncStore.secretKey?.takeUnless { it.isEmpty() }
+            ?: return Error(reason = "RepairAccountInfoDdgWrap: no account secret key")
+
+        val protectedKeys = entries ?: when (val result = syncApi.getProtectedKeys(token)) {
+            is Success -> result.data
+            is Error -> return failRequest(result)
+        }
+        val accountInfoKeys = protectedKeys.filter { it.purpose == SYNC_PURPOSE_ACCOUNT_INFO && it.kid == kid }
+        if (accountInfoKeys.any { it.encryptedWith == CREDENTIAL_ID_DDG }) {
+            logcat { "Sync-UnifiedDevices: account_info already has a ddg wrap (kid=$kid)" }
+            return Success(Unit)
+        }
+        val thirdPartyEntry = accountInfoKeys.firstOrNull { it.encryptedWith == CREDENTIAL_ID_3PARTY }
+            ?: return Error(reason = "RepairAccountInfoDdgWrap: no 3party wrap for kid=$kid")
+
+        logcat { "Sync-UnifiedDevices: adding missing ddg wrap for account_info (kid=$kid)" }
+        val ddgEntry = when (val result = buildDdgWrap(thirdPartyEntry, accountSecretKey)) {
+            is Success -> result.data
+            is Error -> {
+                logcat(ERROR) { "Sync-UnifiedDevices: failed to build ddg wrap for account_info: ${result.reason}" }
+                syncPixels.fireUnifiedDeviceListPixel(
+                    UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(
+                        UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.UNWRAP_FAILED,
+                    ),
+                )
+                return result
+            }
+        }
+
+        return when (val result = syncApi.setKeysIfAbsent(token, SYNC_PURPOSE_ACCOUNT_INFO, listOf(ddgEntry))) {
+            is Error -> failRequest(result)
+            is Success -> when (val outcome = result.data) {
+                SetKeysIfAbsentResult.Created -> {
+                    logcat { "Sync-UnifiedDevices: added ddg wrap for account_info (kid=$kid)" }
+                    syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyWrapSuccess)
+                    Success(Unit)
+                }
+                is SetKeysIfAbsentResult.Existing -> {
+                    if (outcome.kid != kid) {
+                        return failRequest(Error(reason = "RepairAccountInfoDdgWrap: server returned different kid"))
+                    }
+                    confirmDdgWrap(token, kid)
+                }
+                SetKeysIfAbsentResult.ExistsFetchRequired -> confirmDdgWrap(token, kid)
+            }
+        }
+    }
+
+    private fun confirmDdgWrap(token: String, kid: String): Result<Unit> {
+        return when (val result = syncApi.getProtectedKeys(token)) {
+            is Error -> failRequest(result)
+            is Success -> {
+                val ddgWrapExists = result.data.any {
+                    it.purpose == SYNC_PURPOSE_ACCOUNT_INFO && it.kid == kid && it.encryptedWith == CREDENTIAL_ID_DDG
+                }
+                if (ddgWrapExists) {
+                    logcat { "Sync-UnifiedDevices: confirmed ddg account_info wrap (kid=$kid)" }
+                    Success(Unit)
+                } else {
+                    failRequest(Error(reason = "RepairAccountInfoDdgWrap: ddg wrap was not stored"))
+                }
+            }
+        }
+    }
+
+    private fun buildDdgWrap(source: ProtectedKeyEntry, accountSecretKey: String): Result<ProtectedKeyEntry> {
+        val rawPrivateKeyBytes = when (val result = protectedKeyUnwrapper.unwrap(source)) {
+            is Success -> result.data
+            is Error -> return result
+        }
+        val encryptedPrivateKey = when (
+            val result = ddgWrapPrivateKey(rawPrivateKeyBytes, accountSecretKey, nativeLib, "RepairAccountInfoDdgWrap")
+        ) {
+            is Success -> result.data
+            is Error -> return result
+        }
+        return Success(
+            source.copy(
+                encryptedWith = CREDENTIAL_ID_DDG,
+                encryptedPrivateKey = encryptedPrivateKey,
+            ),
+        )
+    }
+
+    private fun failRequest(error: Error): Error {
+        logcat(ERROR) { "Sync-UnifiedDevices: failed to add ddg account_info wrap: ${error.reason}" }
+        syncPixels.fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(error.toAccountInfoKeyWrapFailureReason()),
+        )
+        return error
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoKeyManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoKeyManager.kt
@@ -80,6 +80,7 @@ class RealAccountInfoKeyManager @Inject constructor(
     private val thirdPartyCredentialManager: ThirdPartyCredentialManager,
     private val dispatchers: DispatcherProvider,
     private val syncPixels: SyncPixels,
+    private val accountInfoDdgWrapRepairer: AccountInfoDdgWrapRepairer,
 ) : AccountInfoKeyManager {
 
     override suspend fun ensureKeyRegistered(): Result<AccountInfoKeyResult> = withContext(dispatchers.io()) {
@@ -183,30 +184,35 @@ class RealAccountInfoKeyManager @Inject constructor(
                 )
             }
             is SetKeysIfAbsentResult.Existing -> {
+                val publicKeyToAdopt = outcome.publicKey
+                    ?: return adoptExistingFromServer(token, wrapsSent, outcome.kid)
                 logcat { "Sync-UnifiedDevices: another device's key won (kid=${outcome.kid}); adopting from response" }
-                syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyAdoptSuccess)
-                Success(
-                    AccountInfoKeyResult(kid = outcome.kid, publicKey = outcome.publicKey, created = false, wrapsSent = wrapsSent),
-                )
+                finishAdopt(kid = outcome.kid, publicKey = publicKeyToAdopt, wrapsSent = wrapsSent)
             }
             SetKeysIfAbsentResult.ExistsFetchRequired -> adoptExistingFromServer(token, wrapsSent)
         }
     }
 
     /** The server has a key for this purpose but didn't return it (409, or a 200 shim); fetch and adopt it. */
-    private fun adoptExistingFromServer(token: String, wrapsSent: Int): Result<AccountInfoKeyResult> {
+    private fun adoptExistingFromServer(
+        token: String,
+        wrapsSent: Int,
+        expectedKid: String? = null,
+    ): Result<AccountInfoKeyResult> {
         logcat { "Sync-UnifiedDevices: key already exists on server; fetching to adopt" }
         return when (val result = syncApi.getProtectedKeys(token)) {
             is Success -> {
-                val existing = result.data.firstOrNull { it.purpose == SYNC_PURPOSE_ACCOUNT_INFO }
+                val keyToAdopt = result.data.firstOrNull { entry ->
+                    entry.purpose == SYNC_PURPOSE_ACCOUNT_INFO &&
+                        entry.publicKey != null &&
+                        (expectedKid == null || entry.kid == expectedKid)
+                }
+                val publicKeyToAdopt = keyToAdopt?.publicKey
                     ?: return Error(reason = "CreateAccountInfoKey: server reported an existing key but none was found on fetch").also {
                         fireAdoptFailed(it)
                     }
-                logcat { "Sync-UnifiedDevices: adopted existing key (kid=${existing.kid})" }
-                syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyAdoptSuccess)
-                Success(
-                    AccountInfoKeyResult(kid = existing.kid, publicKey = existing.publicKey, created = false, wrapsSent = wrapsSent),
-                )
+                logcat { "Sync-UnifiedDevices: adopted existing key (kid=${keyToAdopt.kid})" }
+                finishAdopt(kid = keyToAdopt.kid, publicKey = publicKeyToAdopt, wrapsSent = wrapsSent, entries = result.data)
             }
             is Error -> {
                 logcat(ERROR) { "Sync-UnifiedDevices: failed to fetch keys to adopt existing: ${result.reason}" }
@@ -214,6 +220,20 @@ class RealAccountInfoKeyManager @Inject constructor(
                 result
             }
         }
+    }
+
+    /** Wrap repair is best-effort: a missing ddg wrap must not fail public-key adoption. */
+    private fun finishAdopt(
+        kid: String,
+        publicKey: RsaJwk,
+        wrapsSent: Int,
+        entries: List<ProtectedKeyEntry>? = null,
+    ): Result<AccountInfoKeyResult> {
+        accountInfoDdgWrapRepairer.repair(kid, entries)
+        syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyAdoptSuccess)
+        return Success(
+            AccountInfoKeyResult(kid = kid, publicKey = publicKey, created = false, wrapsSent = wrapsSent),
+        )
     }
 
     private fun fireAdoptFailed(error: Error) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/LoginDeviceInfoWriter.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/LoginDeviceInfoWriter.kt
@@ -18,16 +18,9 @@ package com.duckduckgo.sync.impl
 
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.sync.crypto.SyncLib
-import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
-import com.duckduckgo.sync.impl.pixels.SyncPixels
-import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel
-import com.duckduckgo.sync.impl.pixels.toAccountInfoKeyWrapFailureReason
-import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.withContext
-import logcat.LogPriority.ERROR
 import logcat.logcat
 import javax.inject.Inject
 
@@ -45,122 +38,20 @@ interface LoginDeviceInfoWriter {
 
 @ContributesBinding(AppScope::class)
 class RealLoginDeviceInfoWriter @Inject constructor(
-    private val syncStore: SyncStore,
-    private val syncApi: SyncApi,
     private val syncFeature: SyncFeature,
-    private val protectedKeyUnwrapper: ProtectedKeyUnwrapper,
-    private val nativeLib: SyncLib,
+    private val accountInfoDdgWrapRepairer: AccountInfoDdgWrapRepairer,
     private val deviceInfoMigrator: DeviceInfoMigrator,
     private val dispatchers: DispatcherProvider,
-    private val syncPixels: SyncPixels,
 ) : LoginDeviceInfoWriter {
 
-    /**
-     *  If the account_info key exists wrapped only for 3party, it first adds the missing ddg wrap so this device can read the list
-     *  It then runs the shared [DeviceInfoMigrator.ensureMigrated] to ensure the key exists and PATCH this device's device_info.
-     *
-     *  No-op when the write feature flag is off.
-     */
     override suspend fun onLogin(loginResponseKeys: List<ProtectedKeyEntry>?): Result<Unit> = withContext(dispatchers.io()) {
         if (!syncFeature.canWriteDeviceInfo()) return@withContext Success(Unit)
-        addDdgWrapIfThirdPartyOnly(loginResponseKeys)
-        deviceInfoMigrator.ensureMigrated()
-    }
-
-    /** Silent no-op unless the account_info key is present, 3party-only, and we hold the scoped password to unwrap it. */
-    private fun addDdgWrapIfThirdPartyOnly(loginResponseKeys: List<ProtectedKeyEntry>?) {
         val accountInfoKeys = loginResponseKeys.orEmpty().filter { it.purpose == SYNC_PURPOSE_ACCOUNT_INFO }
         if (accountInfoKeys.isEmpty()) {
             logcat { "Sync-UnifiedDevices: no account_info key in login response; migration will create it" }
-            return
+        } else {
+            accountInfoDdgWrapRepairer.repair(accountInfoKeys.first().kid, accountInfoKeys)
         }
-
-        // if encrypted with DDG, nothing to do as already ddg-readable
-        if (accountInfoKeys.any { it.encryptedWith == CREDENTIAL_ID_DDG }) {
-            logcat { "Sync-UnifiedDevices: account_info already has a ddg wrap; no re-wrap needed" }
-            return
-        }
-
-        val threeParty = accountInfoKeys.firstOrNull { it.encryptedWith == CREDENTIAL_ID_3PARTY }
-        if (threeParty == null) {
-            logcat { "Sync-UnifiedDevices: account_info has no ddg or 3party wrap; nothing to re-wrap" }
-            return
-        }
-        if (syncStore.scopedPassword?.raw.isNullOrEmpty()) {
-            logcat { "Sync-UnifiedDevices: account_info is 3party-only but no scoped password held; skipping ddg re-wrap" }
-            return
-        }
-        val token = syncStore.token.takeUnless { it.isNullOrEmpty() } ?: run {
-            logcat { "Sync-UnifiedDevices: account_info is 3party-only but no token; skipping ddg re-wrap" }
-            return
-        }
-        val accountSecretKey = syncStore.secretKey?.takeUnless { it.isEmpty() } ?: run {
-            logcat { "Sync-UnifiedDevices: account_info is 3party-only but no account secret key; skipping ddg re-wrap" }
-            return
-        }
-
-        logcat { "Sync-UnifiedDevices: account_info is 3party-only; re-wrapping for ddg (kid=${threeParty.kid})" }
-        val ddgEntry = when (val result = buildDdgWrap(threeParty, accountSecretKey)) {
-            is Success -> result.data
-            is Error -> {
-                logcat(ERROR) { "Sync-UnifiedDevices: failed to build ddg wrap for account_info: ${result.reason}" }
-                syncPixels.fireUnifiedDeviceListPixel(
-                    UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(
-                        UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.UNWRAP_FAILED,
-                    ),
-                )
-                return
-            }
-        }
-
-        // Add the missing ddg wrap via set-if-absent, reusing the existing key's kid.
-        // Best-effort; any failure just leaves this device's reads degraded until the key converges; it never blocks the device_info write below.
-        when (val result = syncApi.setKeysIfAbsent(token, SYNC_PURPOSE_ACCOUNT_INFO, listOf(ddgEntry))) {
-            is Success -> when (result.data) {
-                SetKeysIfAbsentResult.Created -> {
-                    logcat { "Sync-UnifiedDevices: added ddg wrap for account_info (kid=${threeParty.kid})" }
-                    syncPixels.fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyWrapSuccess)
-                }
-                // 200: this encrypted_with was already stored; this device did not add a wrap
-                is SetKeysIfAbsentResult.Existing -> {
-                    logcat { "Sync-UnifiedDevices: ddg account_info wrap already present (kid=${threeParty.kid})" }
-                }
-                SetKeysIfAbsentResult.ExistsFetchRequired -> {
-                    logcat(ERROR) { "Sync-UnifiedDevices: server rejected the ddg account_info wrap" }
-                    syncPixels.fireUnifiedDeviceListPixel(
-                        UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(
-                            UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.REQUEST_FAILED,
-                        ),
-                    )
-                }
-            }
-            is Error -> {
-                logcat(ERROR) { "Sync-UnifiedDevices: set-if-absent of ddg account_info wrap failed: ${result.reason}" }
-                syncPixels.fireUnifiedDeviceListPixel(
-                    UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(result.toAccountInfoKeyWrapFailureReason()),
-                )
-            }
-        }
-    }
-
-    /** Unwrap [source] with the scoped password and re-wrap the raw private key for `ddg`, preserving its kid and public key. */
-    private fun buildDdgWrap(source: ProtectedKeyEntry, accountSecretKey: String): Result<ProtectedKeyEntry> {
-        val rawPrivateKeyBytes = when (val result = protectedKeyUnwrapper.unwrap(source)) {
-            is Success -> result.data
-            is Error -> return result
-        }
-        val wireEncryptedPrivateKey = when (val result = ddgWrapPrivateKey(rawPrivateKeyBytes, accountSecretKey, nativeLib, "LoginReWrap")) {
-            is Success -> result.data
-            is Error -> return result
-        }
-        return Success(
-            ProtectedKeyEntry(
-                kid = source.kid,
-                purpose = SYNC_PURPOSE_ACCOUNT_INFO,
-                encryptedWith = CREDENTIAL_ID_DDG,
-                encryptedPrivateKey = wireEncryptedPrivateKey,
-                publicKey = source.publicKey,
-            ),
-        )
+        deviceInfoMigrator.ensureMigrated()
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -180,6 +180,7 @@ class AppSyncAccountRepository @Inject constructor(
     private val signupAccountInfoBuilder: SignupAccountInfoBuilder,
     private val deviceInfoUpdater: DeviceInfoUpdater,
     private val deviceInfoPublishWatcher: DeviceInfoPublishWatcher,
+    private val accountInfoDdgWrapRepairer: AccountInfoDdgWrapRepairer,
 ) : SyncAccountRepository {
 
     // Bounded backoff for the 3party→ddg upgrade network calls.
@@ -187,6 +188,9 @@ class AppSyncAccountRepository @Inject constructor(
 
     // The user id we've already re-published device_info for. Stops us repairing again every time the device list is shown.
     private val republishedDeviceInfoForUserId = AtomicReference<String?>(null)
+
+    // Same latch shape for a missing ddg account_info wrap. Released on failure so the next list load can retry.
+    private val repairedAccountInfoDdgWrapForUserId = AtomicReference<String?>(null)
 
     /**
      * If there is a key-exchange flow in progress, we need to keep a reference to them
@@ -995,6 +999,9 @@ class AppSyncAccountRepository @Inject constructor(
                     val decryptResult = thirdPartyDeviceListDecryptor.decryptAll(entriesV2, syncStore.deviceId, publishSnapshot)
                     logoutFailedV2Devices(decryptResult.undecryptable)
                     fireUnifiedDeviceListReadPixels(decryptResult)
+                    if (decryptResult.keyUnavailableReason == AccountInfoKeyUnavailableReason.NO_WRAP_FOR_OUR_CREDENTIAL) {
+                        repairAccountInfoDdgWrap()
+                    }
                     if (decryptResult.thisDeviceInfoNeedsRepair) republishThisDeviceInfo()
                     decryptResult.decrypted.map { it.toConnectedDevice() }
                 } else {
@@ -1067,6 +1074,29 @@ class AppSyncAccountRepository @Inject constructor(
                     logcat(WARN) { "Sync-UnifiedDevices: device_info re-publish failed: ${result.reason}" }
                     // release the slot so the next device list load can try again, without clobbering a claim another account has since made
                     republishedDeviceInfoForUserId.compareAndSet(userId, null)
+                }
+            }
+        }
+    }
+
+    /**
+     * Best-effort add of a missing ddg wrap after a list read that could not unwrap account_info for this credential.
+     * Native (ddg) devices only: a 3party device already holds the wrap it needs. Failure never changes the list
+     * being built; the per-account latch is released so the next load can retry without clobbering another account.
+     */
+    private fun repairAccountInfoDdgWrap() {
+        if ((syncStore.credentialId ?: CREDENTIAL_ID_DDG) != CREDENTIAL_ID_DDG) return
+        val userId = syncStore.userId ?: return
+        val kid = syncStore.accountInfoPublicKey?.keyId ?: return
+        if (repairedAccountInfoDdgWrapForUserId.getAndSet(userId) == userId) return
+
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            logcat { "Sync-UnifiedDevices: ddg account_info wrap unavailable on read; repairing it" }
+            when (val result = accountInfoDdgWrapRepairer.repair(kid)) {
+                is Success -> logcat { "Sync-UnifiedDevices: ddg account_info wrap repaired" }
+                is Error -> {
+                    logcat(WARN) { "Sync-UnifiedDevices: ddg account_info wrap repair failed: ${result.reason}" }
+                    repairedAccountInfoDdgWrapForUserId.compareAndSet(userId, null)
                 }
             }
         }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoDdgWrapRepairerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoDdgWrapRepairerTest.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.sync.TestSyncFixtures.secretKey
+import com.duckduckgo.sync.TestSyncFixtures.token
+import com.duckduckgo.sync.crypto.EncryptBytesResult
+import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel
+import com.duckduckgo.sync.store.ScopedPassword
+import com.duckduckgo.sync.store.SyncStore
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class AccountInfoDdgWrapRepairerTest {
+
+    private val syncStore: SyncStore = mock()
+    private val syncApi: SyncApi = mock()
+    private val protectedKeyUnwrapper: ProtectedKeyUnwrapper = mock()
+    private val nativeLib: SyncLib = mock()
+    private val syncPixels: SyncPixels = mock()
+
+    private lateinit var repairer: AccountInfoDdgWrapRepairer
+
+    @Before
+    fun before() {
+        repairer = RealAccountInfoDdgWrapRepairer(
+            syncStore = syncStore,
+            syncApi = syncApi,
+            protectedKeyUnwrapper = protectedKeyUnwrapper,
+            nativeLib = nativeLib,
+            syncPixels = syncPixels,
+        )
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.secretKey).thenReturn(secretKey)
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword("scoped-password"))
+    }
+
+    @Test
+    fun whenWinningKeyIsThirdPartyOnlyThenAddsDdgWrapForThatKid() {
+        val thirdPartyEntry = givenRewrappableThirdPartyEntry()
+        givenSetKeysIfAbsent(Result.Success(SetKeysIfAbsentResult.Created))
+
+        val result = repairer.repair("winning-kid", listOf(thirdPartyEntry))
+
+        assertTrue(result is Result.Success<*>)
+        verify(syncApi).setKeysIfAbsent(
+            eq(token),
+            eq(SYNC_PURPOSE_ACCOUNT_INFO),
+            check { entries ->
+                assertTrue(entries.size == 1)
+                assertTrue(entries.single().kid == "winning-kid")
+                assertTrue(entries.single().encryptedWith == CREDENTIAL_ID_DDG)
+            },
+        )
+        verify(syncPixels).fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyWrapSuccess)
+    }
+
+    @Test
+    fun whenWinningKeyAlreadyHasDdgWrapThenDoesNothing() {
+        val entries = listOf(
+            accountInfoEntry(kid = "winning-kid", encryptedWith = CREDENTIAL_ID_DDG),
+            accountInfoEntry(kid = "winning-kid", encryptedWith = CREDENTIAL_ID_3PARTY),
+        )
+
+        val result = repairer.repair("winning-kid", entries)
+
+        assertTrue(result is Result.Success<*>)
+        verifyNoInteractions(protectedKeyUnwrapper, nativeLib, syncPixels)
+        verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
+    }
+
+    @Test
+    fun whenThirdPartyWrapBelongsToDifferentKidThenDoesNotAddDdgWrap() {
+        val thirdPartyEntry = accountInfoEntry(kid = "losing-kid", encryptedWith = CREDENTIAL_ID_3PARTY)
+
+        val result = repairer.repair("winning-kid", listOf(thirdPartyEntry))
+
+        assertTrue(result is Result.Error)
+        verifyNoInteractions(protectedKeyUnwrapper, nativeLib, syncPixels)
+        verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
+    }
+
+    @Test
+    fun whenEntriesAreNotProvidedThenFetchesBeforeRepairing() {
+        val thirdPartyEntry = givenRewrappableThirdPartyEntry()
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Result.Success(listOf(thirdPartyEntry)))
+        givenSetKeysIfAbsent(Result.Success(SetKeysIfAbsentResult.Created))
+
+        val result = repairer.repair("winning-kid")
+
+        assertTrue(result is Result.Success<*>)
+        verify(syncApi).getProtectedKeys(token)
+        verify(syncApi).setKeysIfAbsent(eq(token), eq(SYNC_PURPOSE_ACCOUNT_INFO), any())
+    }
+
+    @Test
+    fun whenAddingDdgWrapFailsThenReturnsError() {
+        val thirdPartyEntry = givenRewrappableThirdPartyEntry()
+        givenSetKeysIfAbsent(Result.Error(reason = "server error"))
+
+        val result = repairer.repair("winning-kid", listOf(thirdPartyEntry))
+
+        assertTrue(result is Result.Error)
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.REQUEST_FAILED),
+        )
+    }
+
+    @Test
+    fun whenServerReturnsDifferentExistingKidThenReturnsError() {
+        val thirdPartyEntry = givenRewrappableThirdPartyEntry()
+        givenSetKeysIfAbsent(Result.Success(SetKeysIfAbsentResult.Existing("different-kid", RsaJwk(n = "other", e = "AQAB"))))
+
+        val result = repairer.repair("winning-kid", listOf(thirdPartyEntry))
+
+        assertTrue(result is Result.Error)
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.REQUEST_FAILED),
+        )
+    }
+
+    @Test
+    fun whenServerReturnsSameExistingKidWithoutDdgWrapThenReturnsError() {
+        val thirdPartyEntry = givenRewrappableThirdPartyEntry()
+        givenSetKeysIfAbsent(Result.Success(SetKeysIfAbsentResult.Existing("winning-kid", RsaJwk(n = "n", e = "AQAB"))))
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Result.Success(listOf(thirdPartyEntry)))
+
+        val result = repairer.repair("winning-kid", listOf(thirdPartyEntry))
+
+        assertTrue(result is Result.Error)
+        verify(syncPixels).fireUnifiedDeviceListPixel(
+            UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.REQUEST_FAILED),
+        )
+    }
+
+    @Test
+    fun whenServerReturnsSameExistingKidWithDdgWrapThenReturnsSuccess() {
+        val thirdPartyEntry = givenRewrappableThirdPartyEntry()
+        val ddgEntry = accountInfoEntry(kid = "winning-kid", encryptedWith = CREDENTIAL_ID_DDG)
+        givenSetKeysIfAbsent(Result.Success(SetKeysIfAbsentResult.Existing("winning-kid", RsaJwk(n = "n", e = "AQAB"))))
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Result.Success(listOf(thirdPartyEntry, ddgEntry)))
+
+        val result = repairer.repair("winning-kid", listOf(thirdPartyEntry))
+
+        assertTrue(result is Result.Success<*>)
+    }
+
+    @Test
+    fun whenScopedPasswordIsMissingThenReturnsErrorWithoutFetchingKeys() {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+
+        val result = repairer.repair("winning-kid")
+
+        assertTrue(result is Result.Error)
+        verify(syncApi, never()).getProtectedKeys(any())
+        verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
+    }
+
+    private fun givenRewrappableThirdPartyEntry(
+        kid: String = "winning-kid",
+    ): ProtectedKeyEntry {
+        val entry = accountInfoEntry(kid = kid, encryptedWith = CREDENTIAL_ID_3PARTY)
+        whenever(protectedKeyUnwrapper.unwrap(entry)).thenReturn(Result.Success("raw-key".toByteArray()))
+        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey)))
+            .thenReturn(EncryptBytesResult(0, "ddg-wrapped".toByteArray()))
+        return entry
+    }
+
+    private fun givenSetKeysIfAbsent(result: Result<SetKeysIfAbsentResult>) {
+        whenever(syncApi.setKeysIfAbsent(eq(token), eq(SYNC_PURPOSE_ACCOUNT_INFO), any())).thenReturn(result)
+    }
+
+    private fun accountInfoEntry(kid: String, encryptedWith: String) = ProtectedKeyEntry(
+        kid = kid,
+        purpose = SYNC_PURPOSE_ACCOUNT_INFO,
+        encryptedWith = encryptedWith,
+        encryptedPrivateKey = "wrapped-private-key",
+        publicKey = RsaJwk(n = "n", e = "AQAB"),
+    )
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoKeyManagerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoKeyManagerTest.kt
@@ -58,6 +58,7 @@ class AccountInfoKeyManagerTest {
     private val nativeLib: SyncLib = mock()
     private val thirdPartyCredentialManager: ThirdPartyCredentialManager = mock()
     private val syncPixels: SyncPixels = mock()
+    private val accountInfoDdgWrapRepairer: AccountInfoDdgWrapRepairer = mock()
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
@@ -75,8 +76,10 @@ class AccountInfoKeyManagerTest {
             thirdPartyCredentialManager = thirdPartyCredentialManager,
             dispatchers = coroutineTestRule.testDispatcherProvider,
             syncPixels = syncPixels,
+            accountInfoDdgWrapRepairer = accountInfoDdgWrapRepairer,
         )
         configureForSuccessfulKeypairMint()
+        whenever(accountInfoDdgWrapRepairer.repair(any(), anyOrNull())).thenReturn(Success(Unit))
     }
 
     private fun configureForSuccessfulKeypairMint() {
@@ -240,25 +243,15 @@ class AccountInfoKeyManagerTest {
         assertTrue(!result.data.created)
         verify(syncPixels).fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyAdoptSuccess)
         verify(syncStore).accountInfoPublicKey = AccountInfoPublicKey(keyId = "other-kid", modulus = "other-mod", exponent = "AQAB")
+        verify(accountInfoDdgWrapRepairer).repair("other-kid")
     }
 
     @Test
     fun whenSetIfAbsentRequiresFetchThenFetchesKeysAndAdopts() = runTest {
+        val serverEntry = accountInfoEntry(kid = "server-kid", encryptedWith = "ddg", modulus = "server-mod")
         whenever(syncStore.scopedPassword).thenReturn(null)
         whenever(syncApi.setKeysIfAbsent(eq(token), eq("account_info"), any())).thenReturn(Success(SetKeysIfAbsentResult.ExistsFetchRequired))
-        whenever(syncApi.getProtectedKeys(token)).thenReturn(
-            Success(
-                listOf(
-                    ProtectedKeyEntry(
-                        kid = "server-kid",
-                        purpose = "account_info",
-                        encryptedWith = "ddg",
-                        encryptedPrivateKey = "AAAA",
-                        publicKey = RsaJwk(n = "server-mod", e = "AQAB"),
-                    ),
-                ),
-            ),
-        )
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(listOf(serverEntry)))
 
         val result = manager.ensureKeyRegistered() as Success
 
@@ -267,6 +260,34 @@ class AccountInfoKeyManagerTest {
         assertTrue(!result.data.created)
         verify(syncPixels).fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyAdoptSuccess)
         verify(syncStore).accountInfoPublicKey = AccountInfoPublicKey(keyId = "server-kid", modulus = "server-mod", exponent = "AQAB")
+        verify(accountInfoDdgWrapRepairer).repair("server-kid", listOf(serverEntry))
+    }
+
+    @Test
+    fun whenRepairingAdoptedKeyFailsThenStillAdoptsAndCachesPublicKey() = runTest {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncApi.setKeysIfAbsent(eq(token), eq("account_info"), any()))
+            .thenReturn(Success(SetKeysIfAbsentResult.Existing(kid = "other-kid", publicKey = RsaJwk(n = "other-mod", e = "AQAB"))))
+        whenever(accountInfoDdgWrapRepairer.repair("other-kid")).thenReturn(Error(reason = "repair failed"))
+
+        val result = manager.ensureKeyRegistered()
+
+        assertTrue(result is Success)
+        verify(syncStore).accountInfoPublicKey = AccountInfoPublicKey(keyId = "other-kid", modulus = "other-mod", exponent = "AQAB")
+    }
+
+    @Test
+    fun whenExistingResponseHasNoPublicKeyThenFetchesAndAdoptsFullKey() = runTest {
+        val serverEntry = accountInfoEntry(kid = "server-kid", encryptedWith = "3party", modulus = "server-mod")
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncApi.setKeysIfAbsent(eq(token), eq("account_info"), any()))
+            .thenReturn(Success(SetKeysIfAbsentResult.Existing(kid = "server-kid", publicKey = null)))
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(listOf(serverEntry)))
+
+        val result = manager.ensureKeyRegistered() as Success
+
+        assertEquals(RsaJwk(n = "server-mod", e = "AQAB"), result.data.publicKey)
+        verify(accountInfoDdgWrapRepairer).repair("server-kid", listOf(serverEntry))
     }
 
     @Test
@@ -321,4 +342,16 @@ class AccountInfoKeyManagerTest {
 
         assertEquals(1, result.data.wrapsSent)
     }
+
+    private fun accountInfoEntry(
+        kid: String,
+        encryptedWith: String,
+        modulus: String,
+    ) = ProtectedKeyEntry(
+        kid = kid,
+        purpose = "account_info",
+        encryptedWith = encryptedWith,
+        encryptedPrivateKey = "AAAA",
+        publicKey = RsaJwk(n = modulus, e = "AQAB"),
+    )
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -139,6 +139,7 @@ class AppSyncAccountRepositoryTest {
     private val signupAccountInfoBuilder: SignupAccountInfoBuilder = mock()
     private val deviceInfoUpdater: DeviceInfoUpdater = mock()
     private val publishTracker = DeviceInfoPublishWatcher()
+    private val accountInfoDdgWrapRepairer: AccountInfoDdgWrapRepairer = mock()
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
@@ -166,11 +167,13 @@ class AppSyncAccountRepositoryTest {
             signupAccountInfoBuilder = signupAccountInfoBuilder,
             deviceInfoUpdater = deviceInfoUpdater,
             deviceInfoPublishWatcher = publishTracker,
+            accountInfoDdgWrapRepairer = accountInfoDdgWrapRepairer,
         )
         (syncRepo as AppSyncAccountRepository).upgradeRetryDelayMillis = 0L // keep retry-path tests instant
 
         // passthrough by default (no modifications)
         whenever(syncCodeUrlWrapper.wrapCodeInUrl(any())).thenAnswer { it.arguments[0] as String }
+        whenever(accountInfoDdgWrapRepairer.repair(any(), anyOrNull())).thenReturn(Success(Unit))
     }
 
     @Test
@@ -806,6 +809,37 @@ class AppSyncAccountRepositoryTest {
         verify(syncPixels).fireUnifiedDeviceListPixel(
             UnifiedDeviceListPixel.AccountInfoKeyUnavailable(AccountInfoKeyUnavailableReason.RATE_LIMITED),
         )
+        verifyNoInteractions(accountInfoDdgWrapRepairer)
+    }
+
+    @Test
+    fun whenDdgWrapIsUnavailableThenRepairsCachedAccountInfoKey() = runTest {
+        givenAccountInfoDdgWrapUnavailable()
+
+        syncRepo.getConnectedDevices()
+
+        verify(accountInfoDdgWrapRepairer).repair("account-info-kid")
+    }
+
+    @Test
+    fun whenDdgWrapRepairSucceedsThenDoesNotRepairAgainForSameAccount() = runTest {
+        givenAccountInfoDdgWrapUnavailable()
+
+        syncRepo.getConnectedDevices()
+        syncRepo.getConnectedDevices()
+
+        verify(accountInfoDdgWrapRepairer, times(1)).repair("account-info-kid")
+    }
+
+    @Test
+    fun whenDdgWrapRepairFailsThenRetriesOnNextDeviceListRead() = runTest {
+        givenAccountInfoDdgWrapUnavailable()
+        whenever(accountInfoDdgWrapRepairer.repair("account-info-kid")).thenReturn(Error(reason = "repair failed"))
+
+        syncRepo.getConnectedDevices()
+        syncRepo.getConnectedDevices()
+
+        verify(accountInfoDdgWrapRepairer, times(2)).repair("account-info-kid")
     }
 
     @Test
@@ -1018,6 +1052,27 @@ class AppSyncAccountRepositoryTest {
                 decrypted = listOf(DecryptedDevice(deviceId = deviceId, name = deviceName, type = "phone")),
                 undecryptable = emptyList(),
                 thisDeviceInfoNeedsRepair = unresolved,
+            ),
+        )
+    }
+
+    private fun givenAccountInfoDdgWrapUnavailable() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canReadUnifiedDeviceList().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.deviceId).thenReturn(deviceId)
+        whenever(syncStore.userId).thenReturn(userId)
+        whenever(syncStore.accountInfoPublicKey).thenReturn(
+            AccountInfoPublicKey(keyId = "account-info-kid", modulus = "modulus", exponent = "AQAB"),
+        )
+        val own = DeviceV2(deviceId = deviceId, credentialId = CREDENTIAL_ID_DDG)
+        whenever(syncApi.getDevices(token)).thenReturn(Success(DeviceEntries(emptyList(), listOf(own))))
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(own), deviceId, 0)).thenReturn(
+            DecryptAllResult(
+                decrypted = listOf(DecryptedDevice(deviceId, deviceName, "phone")),
+                undecryptable = emptyList(),
+                keyUnavailableReason = AccountInfoKeyUnavailableReason.NO_WRAP_FOR_OUR_CREDENTIAL,
             ),
         )
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/LoginDeviceInfoWriterTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/LoginDeviceInfoWriterTest.kt
@@ -20,14 +20,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
-import com.duckduckgo.sync.TestSyncFixtures.token
-import com.duckduckgo.sync.TestSyncFixtures.userId
-import com.duckduckgo.sync.crypto.EncryptBytesResult
-import com.duckduckgo.sync.crypto.SyncLib
-import com.duckduckgo.sync.impl.pixels.SyncPixels
-import com.duckduckgo.sync.impl.pixels.UnifiedDeviceListPixel
-import com.duckduckgo.sync.store.ScopedPassword
-import com.duckduckgo.sync.store.SyncStore
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue
@@ -36,8 +28,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
-import org.mockito.kotlin.check
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -47,39 +37,26 @@ import org.mockito.kotlin.whenever
 @RunWith(AndroidJUnit4::class)
 class LoginDeviceInfoWriterTest {
 
-    private val syncStore: SyncStore = mock()
-    private val syncApi: SyncApi = mock()
-    private val protectedKeyUnwrapper: ProtectedKeyUnwrapper = mock()
-    private val nativeLib: SyncLib = mock()
+    private val accountInfoDdgWrapRepairer: AccountInfoDdgWrapRepairer = mock()
     private val deviceInfoMigrator: DeviceInfoMigrator = mock()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
-    private val syncPixels: SyncPixels = mock()
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
 
     private lateinit var writer: RealLoginDeviceInfoWriter
 
-    private val secretKey = "accountSecretKey"
-
     @Before
     fun before() {
         writer = RealLoginDeviceInfoWriter(
-            syncStore = syncStore,
-            syncApi = syncApi,
             syncFeature = syncFeature,
-            protectedKeyUnwrapper = protectedKeyUnwrapper,
-            nativeLib = nativeLib,
+            accountInfoDdgWrapRepairer = accountInfoDdgWrapRepairer,
             deviceInfoMigrator = deviceInfoMigrator,
             dispatchers = coroutineTestRule.testDispatcherProvider,
-            syncPixels = syncPixels,
         )
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(enable = true))
         syncFeature.canWriteUnifiedDeviceList().setRawStoredState(State(enable = true))
-        whenever(syncStore.token).thenReturn(token)
-        whenever(syncStore.secretKey).thenReturn(secretKey)
-        whenever(syncStore.userId).thenReturn(userId)
-        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword("c2NvcGVk"))
+        whenever(accountInfoDdgWrapRepairer.repair(any(), any())).thenReturn(Result.Success(Unit))
         runBlocking { whenever(deviceInfoMigrator.ensureMigrated()).thenReturn(Result.Success(Unit)) }
     }
 
@@ -88,111 +65,29 @@ class LoginDeviceInfoWriterTest {
         val result = writer.onLogin(loginResponseKeys = emptyList())
 
         assertTrue(result is Result.Success)
-        verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
+        verifyNoInteractions(accountInfoDdgWrapRepairer)
         verify(deviceInfoMigrator).ensureMigrated()
     }
 
     @Test
-    fun whenAccountInfoKeyAlreadyDdgWrappedThenNoReWrap() = runTest {
-        writer.onLogin(loginResponseKeys = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_DDG)))
+    fun whenAccountInfoKeyExistsThenRepairsItsDdgWrapBeforeMigrating() = runTest {
+        val entries = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY))
 
-        verify(protectedKeyUnwrapper, never()).unwrap(any())
-        verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
-        verify(deviceInfoMigrator).ensureMigrated()
-    }
-
-    @Test
-    fun whenAccountInfo3partyOnlyAndScopedPasswordHeldThenReWrapsForDdgThenMigrates() = runTest {
-        whenever(protectedKeyUnwrapper.unwrap(any())).thenReturn(Result.Success("rawKey".toByteArray()))
-        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey)))
-            .thenReturn(EncryptBytesResult(0, "ddgWrapped".toByteArray()))
-        whenever(syncApi.setKeysIfAbsent(eq(token), eq(SYNC_PURPOSE_ACCOUNT_INFO), any()))
-            .thenReturn(Result.Success(SetKeysIfAbsentResult.Created))
-
-        writer.onLogin(loginResponseKeys = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
-
-        verify(syncApi).setKeysIfAbsent(
-            eq(token),
-            eq(SYNC_PURPOSE_ACCOUNT_INFO),
-            check { keys ->
-                assertTrue(keys.size == 1)
-                assertTrue(keys.first().encryptedWith == CREDENTIAL_ID_DDG)
-                assertTrue(keys.first().kid == "kid-1")
-            },
-        )
-        verify(deviceInfoMigrator).ensureMigrated()
-        verify(syncPixels).fireUnifiedDeviceListPixel(UnifiedDeviceListPixel.AccountInfoKeyWrapSuccess)
-    }
-
-    @Test
-    fun whenAccountInfo3partyOnlyButNoScopedPasswordThenSkipsReWrapButStillMigrates() = runTest {
-        whenever(syncStore.scopedPassword).thenReturn(null)
-
-        writer.onLogin(loginResponseKeys = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
-
-        verify(protectedKeyUnwrapper, never()).unwrap(any())
-        verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
-        verify(deviceInfoMigrator).ensureMigrated()
-    }
-
-    @Test
-    fun whenUnwrapFailsThenSkipsReWrapButStillMigrates() = runTest {
-        whenever(protectedKeyUnwrapper.unwrap(any())).thenReturn(Result.Error(reason = "cannot unwrap"))
-
-        writer.onLogin(loginResponseKeys = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
-
-        verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
-        verify(deviceInfoMigrator).ensureMigrated()
-        verify(syncPixels).fireUnifiedDeviceListPixel(
-            UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.UNWRAP_FAILED),
-        )
-    }
-
-    @Test
-    fun whenSetKeysIfAbsentFailsThenStillMigrates() = runTest {
-        whenever(protectedKeyUnwrapper.unwrap(any())).thenReturn(Result.Success("rawKey".toByteArray()))
-        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey)))
-            .thenReturn(EncryptBytesResult(0, "ddgWrapped".toByteArray()))
-        whenever(syncApi.setKeysIfAbsent(any(), any(), any())).thenReturn(Result.Error(reason = "server error"))
-
-        val result = writer.onLogin(loginResponseKeys = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
+        val result = writer.onLogin(loginResponseKeys = entries)
 
         assertTrue(result is Result.Success)
-        verify(deviceInfoMigrator).ensureMigrated()
-        verify(syncPixels).fireUnifiedDeviceListPixel(
-            UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.REQUEST_FAILED),
-        )
-    }
-
-    @Test
-    fun whenSetKeysIfAbsentReportsExistingThenNoWrapPixelFires() = runTest {
-        whenever(protectedKeyUnwrapper.unwrap(any())).thenReturn(Result.Success("rawKey".toByteArray()))
-        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey)))
-            .thenReturn(EncryptBytesResult(0, "ddgWrapped".toByteArray()))
-        whenever(syncApi.setKeysIfAbsent(any(), any(), any())).thenReturn(
-            Result.Success(SetKeysIfAbsentResult.Existing("kid-1", RsaJwk(n = "n", e = "AQAB"))),
-        )
-
-        writer.onLogin(loginResponseKeys = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
-
-        verifyNoInteractions(syncPixels)
+        verify(accountInfoDdgWrapRepairer).repair("kid-1", entries)
         verify(deviceInfoMigrator).ensureMigrated()
     }
 
     @Test
-    fun whenSetKeysIfAbsentReportsConflictThenWrapFailedPixelFires() = runTest {
-        whenever(protectedKeyUnwrapper.unwrap(any())).thenReturn(Result.Success("rawKey".toByteArray()))
-        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey)))
-            .thenReturn(EncryptBytesResult(0, "ddgWrapped".toByteArray()))
-        whenever(syncApi.setKeysIfAbsent(any(), any(), any())).thenReturn(
-            Result.Success(SetKeysIfAbsentResult.ExistsFetchRequired),
-        )
+    fun whenDdgWrapRepairFailsThenStillMigrates() = runTest {
+        val entries = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY))
+        whenever(accountInfoDdgWrapRepairer.repair("kid-1", entries)).thenReturn(Result.Error(reason = "repair failed"))
 
-        writer.onLogin(loginResponseKeys = listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
+        val result = writer.onLogin(loginResponseKeys = entries)
 
-        verify(syncPixels).fireUnifiedDeviceListPixel(
-            UnifiedDeviceListPixel.AccountInfoKeyWrapFailed(UnifiedDeviceListPixel.AccountInfoKeyWrapFailureReason.REQUEST_FAILED),
-        )
+        assertTrue(result is Result.Success)
         verify(deviceInfoMigrator).ensureMigrated()
     }
 
@@ -203,7 +98,7 @@ class LoginDeviceInfoWriterTest {
         val result = writer.onLogin(listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
 
         assertTrue(result is Result.Success)
-        verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
+        verifyNoInteractions(accountInfoDdgWrapRepairer)
         verify(deviceInfoMigrator, never()).ensureMigrated()
     }
 
@@ -213,9 +108,8 @@ class LoginDeviceInfoWriterTest {
 
         writer.onLogin(listOf(accountInfoEntry(encryptedWith = CREDENTIAL_ID_3PARTY)))
 
-        verify(syncApi, never()).setKeysIfAbsent(any(), any(), any())
+        verifyNoInteractions(accountInfoDdgWrapRepairer)
         verify(deviceInfoMigrator, never()).ensureMigrated()
-        verifyNoInteractions(syncPixels)
     }
 
     private fun accountInfoEntry(encryptedWith: String) = ProtectedKeyEntry(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218328293620602?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

The unified device list is encrypted with one shared `account_info` key that lives on the server. That key gets stored once per browser "kind" that needs it — one copy locked for us (`ddg`), one copy locked for third-party browsers like Chrome (`3party`). You can only read the list if there's a copy locked for you.

If Chrome creates the key before we do — which happens whenever a device signs up while `canWriteUnifiedDeviceList` is off, and it also happens on Chrome-first pairings — the server ends up with a `3party` copy only. We then adopt Chrome's key, happily encrypt our own device with it, but we never made ourselves a copy we can open. So writes look fine and reads silently fall back to the old device names, logging `no_wrap_for_our_credential`.

We already had code that fixes this, but it only ran at login, so it never fired on the adopt path.

**The fix:** make our own copy of the key whenever we adopt someone else's, and for devices already stuck like this, make it the first time a device-list read complains it can't open the key.


### Steps to test this PR

_Clean install — the bug_
- [ ] Open 3rd party browser (e.g., Chrome) and visit duck ai test site (see asana task)
- [ ] Fresh install `internalDebug`. 
- In Sync Internal Settings set 
  - [ ] `canUseV2ConnectFlow` **on**, 
  - [ ] `canWriteUnifiedDeviceList` **off**
  - [ ] `canReadUnifiedDeviceList` **off**
- [ ] On Android, choose to `Sync with another device` and share the text pairing code and paste it into duck ai test site sync setup (`Settings & More` -> `Settings` -> `Sync & Backup / Turn on` -> `Sync with another device`). And tap done when finished pairing to return to device list.
- [ ] In Andriod, confirm no `signup wrote device_info + account_info key` and the list logs `0 via device_info`
- [ ] On Android, in internal sync dev screen, tap **Fetch Keys** and verify it shows `account_info` with `encrypted_with=3party` only
- [ ] Turn both unified flags **on**, then **Run migration now**
- [ ] Expect `adopted existing key` → `adding missing ddg wrap` → `added ddg wrap`, list becomes `2 via device_info`, and **Fetch Keys** shows both `ddg` and `3party` under the same kid


Logcat filter: `adb logcat -v time | grep -E "Sync-UnifiedDevices|account_info_key"`

### UI changes
No UI changes

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes protected-key wrapping and server key uploads for sync account_info; failures are best-effort but incorrect repair could leave native devices unable to read the unified device list until a retry succeeds.
> 
> **Overview**
> Introduces **`AccountInfoDdgWrapRepairer`** to add a missing native (`ddg`) wrap on the shared `account_info` key when the server only has a `3party` wrap—unwrap via scoped password, re-encrypt for `ddg`, and upload with `setKeysIfAbsent`, including confirm-after-conflict paths and wrap pixels.
> 
> **Adoption and login:** `AccountInfoKeyManager` runs repair best-effort in `finishAdopt` (including when `Existing` has no public key and keys must be fetched). `LoginDeviceInfoWriter` drops its duplicated re-wrap block and delegates to the repairer.
> 
> **Already-broken clients:** On unified device-list read, when decryption reports `NO_WRAP_FOR_OUR_CREDENTIAL`, `SyncAccountRepository` triggers the same repair once per account (retries after failure). Tests cover the repairer, adoption, login, and list-read latch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17d699c21e1b0424afa05746c902126a205d1e6c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

