### PR TITLE
Bring the app rating prompt into the modal coordinator

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/rating/di/RatingModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/di/RatingModule.kt
@@ -49,8 +49,15 @@ class RatingModule {
         promptTypeDecider: PromptTypeDecider,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         preventDialogQueuingFeature: PreventFeedbackDialogQueuingFeature,
+        appRatingPromptModalFeature: AppRatingPromptModalFeature,
     ): MainProcessLifecycleObserver {
-        return AppEnjoymentAppCreationObserver(appEnjoymentPromptEmitter, promptTypeDecider, appCoroutineScope, preventDialogQueuingFeature)
+        return AppEnjoymentAppCreationObserver(
+            appEnjoymentPromptEmitter,
+            promptTypeDecider,
+            appCoroutineScope,
+            preventDialogQueuingFeature,
+            appRatingPromptModalFeature,
+        )
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/global/rating/AppEnjoymentAppCreationObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/rating/AppEnjoymentAppCreationObserver.kt
@@ -35,12 +35,24 @@ class AppEnjoymentAppCreationObserver(
     private val promptTypeDecider: PromptTypeDecider,
     private val appCoroutineScope: CoroutineScope,
     private val preventDialogQueuingFeature: PreventFeedbackDialogQueuingFeature,
+    private val appRatingPromptModalFeature: AppRatingPromptModalFeature,
     private val dispatchers: DispatcherProvider = DefaultDispatcherProvider(),
 ) : MainProcessLifecycleObserver {
 
     @UiThread
     override fun onStart(owner: LifecycleOwner) {
         appCoroutineScope.launch(dispatchers.main()) {
+            val coordinatedByModalEvaluator = withContext(dispatchers.io()) {
+                appRatingPromptModalFeature.self().isEnabled()
+            }
+
+            if (coordinatedByModalEvaluator) {
+                // AppRatingPromptEvaluator owns the prompt now; deciding it here as well would emit
+                // it outside the coordinator and bypass modal arbitration.
+                logcat { "app enjoyment prompt is coordinated by the modal evaluator, nothing to do on app start" }
+                return@launch
+            }
+
             val shouldPreventQueueing = withContext(dispatchers.io()) {
                 preventDialogQueuingFeature.self().isEnabled()
             }

--- a/app/src/main/java/com/duckduckgo/app/global/rating/AppRatingPromptEvaluator.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/rating/AppRatingPromptEvaluator.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.rating
+
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.promptscoordinator.api.ModalEvaluator
+import com.duckduckgo.promptscoordinator.api.ModalTrigger
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * Brings the app enjoyment / rating prompt under the prompts coordinator so it stops competing with
+ * the other modals. Gated by [AppRatingPromptModalFeature]: while that flag is off this evaluator
+ * always skips and [AppEnjoymentAppCreationObserver] retains the old app-start behaviour.
+ *
+ * Uses [ModalTrigger.NTP_RENDER] so the prompt is only offered while the browser is on a clean New
+ * Tab Page. The dialog is hosted by BrowserActivity, and an [ModalTrigger.APP_RESUME] pass can land
+ * on another screen, where the dialog is silently dropped after the coordinator has already recorded
+ * the modal as shown.
+ */
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = ModalEvaluator::class,
+)
+@SingleInstanceIn(scope = AppScope::class)
+class AppRatingPromptEvaluator @Inject constructor(
+    private val promptTypeDecider: PromptTypeDecider,
+    private val appEnjoymentPromptEmitter: AppEnjoymentPromptEmitter,
+    private val appRatingPromptModalFeature: AppRatingPromptModalFeature,
+    private val dispatchers: DispatcherProvider,
+) : ModalEvaluator {
+
+    override val priority: Int = PRIORITY
+    override val evaluatorId: String = "app_rating_prompt"
+    override val trigger: ModalTrigger = ModalTrigger.NTP_RENDER
+
+    override suspend fun evaluate(): ModalEvaluator.EvaluationResult = withContext(dispatchers.io()) {
+        if (!appRatingPromptModalFeature.self().isEnabled()) {
+            logcat { "AppRatingPromptEvaluator: skipped, feature disabled so the app-start observer owns the prompt" }
+            return@withContext ModalEvaluator.EvaluationResult.Skipped
+        }
+
+        val promptType = promptTypeDecider.determineInitialPromptType()
+        if (promptType == AppEnjoymentPromptOptions.ShowNothing) {
+            logcat { "AppRatingPromptEvaluator: skipped, decider selected no prompt" }
+            return@withContext ModalEvaluator.EvaluationResult.Skipped
+        }
+
+        delay(MODAL_DISPLAY_DELAY)
+        withContext(dispatchers.main()) {
+            appEnjoymentPromptEmitter.promptType.value = promptType
+        }
+        logcat { "AppRatingPromptEvaluator: emitted $promptType" }
+        ModalEvaluator.EvaluationResult.ModalShown
+    }
+
+    companion object {
+        private const val PRIORITY = 6
+        private const val MODAL_DISPLAY_DELAY = 250L
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/global/rating/AppRatingPromptModalFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/rating/AppRatingPromptModalFeature.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.rating
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+/**
+ * Routes the app enjoyment / rating prompt through the prompts coordinator instead of firing it
+ * directly on app start.
+ *
+ * When enabled (the default), [AppRatingPromptEvaluator] owns the decision and the prompt competes
+ * with the other modals at priority 6. Disabling it reverts to [AppEnjoymentAppCreationObserver]
+ * deciding the prompt type on every app start, unarbitrated.
+ *
+ * Exactly one of the two paths runs, so the prompt can never be evaluated twice in a single start.
+ */
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "appRatingPromptModal",
+)
+interface AppRatingPromptModalFeature {
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun self(): Toggle
+}

--- a/app/src/test/java/com/duckduckgo/app/global/rating/AppEnjoymentAppCreationObserverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/rating/AppEnjoymentAppCreationObserverTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -43,6 +44,7 @@ class AppEnjoymentAppCreationObserverTest {
     val instantTaskExecutorRule = InstantTaskExecutorRule()
 
     private val feature = FakeFeatureToggleFactory.create(PreventFeedbackDialogQueuingFeature::class.java)
+    private val appRatingPromptModalFeature = FakeFeatureToggleFactory.create(AppRatingPromptModalFeature::class.java)
 
     private lateinit var testee: AppEnjoymentAppCreationObserver
     private val mockAppEnjoymentPromptEmitter: AppEnjoymentPromptEmitter = mock()
@@ -61,8 +63,11 @@ class AppEnjoymentAppCreationObserverTest {
             promptTypeDecider = mockPromptTypeDecider,
             appCoroutineScope = testScope,
             preventDialogQueuingFeature = feature,
+            appRatingPromptModalFeature = appRatingPromptModalFeature,
             dispatchers = coroutineTestRule.testDispatcherProvider,
         )
+
+        appRatingPromptModalFeature.self().setRawStoredState(Toggle.State(enable = false))
     }
 
     @Test
@@ -174,5 +179,37 @@ class AppEnjoymentAppCreationObserverTest {
         testee.onStart(mock())
 
         verify(mockPromptTypeDecider, times(2)).determineInitialPromptType()
+    }
+
+    @Test
+    fun whenAppRatingPromptModalFeatureEnabledThenShouldNotDetermineInitialPromptType() = runTest {
+        appRatingPromptModalFeature.self().setRawStoredState(Toggle.State(enable = true))
+        feature.self().setRawStoredState(Toggle.State(enable = false))
+        promptTypeLiveData.value = null
+
+        testee.onStart(mock())
+
+        verify(mockPromptTypeDecider, never()).determineInitialPromptType()
+    }
+
+    @Test
+    fun whenAppRatingPromptModalFeatureEnabledThenShouldNotEmitPromptType() = runTest {
+        appRatingPromptModalFeature.self().setRawStoredState(Toggle.State(enable = true))
+        promptTypeLiveData.value = null
+
+        testee.onStart(mock())
+
+        assertNull(promptTypeLiveData.value)
+    }
+
+    @Test
+    fun whenAppRatingPromptModalFeatureDisabledThenShouldDetermineInitialPromptType() = runTest {
+        appRatingPromptModalFeature.self().setRawStoredState(Toggle.State(enable = false))
+        feature.self().setRawStoredState(Toggle.State(enable = true))
+        promptTypeLiveData.value = null
+
+        testee.onStart(mock())
+
+        verify(mockPromptTypeDecider).determineInitialPromptType()
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/global/rating/AppRatingPromptEvaluatorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/rating/AppRatingPromptEvaluatorTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.rating
+
+import android.annotation.SuppressLint
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.promptscoordinator.api.ModalEvaluator
+import com.duckduckgo.promptscoordinator.api.ModalTrigger
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@SuppressLint("DenyListedApi")
+class AppRatingPromptEvaluatorTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val promptTypeDecider: PromptTypeDecider = mock()
+    private val appEnjoymentPromptEmitter: AppEnjoymentPromptEmitter = mock()
+    private val appRatingPromptModalFeature = FakeFeatureToggleFactory.create(AppRatingPromptModalFeature::class.java)
+
+    private val promptTypeLiveData = MutableLiveData<AppEnjoymentPromptOptions>()
+
+    private lateinit var testee: AppRatingPromptEvaluator
+
+    @Before
+    fun before() {
+        whenever(appEnjoymentPromptEmitter.promptType).thenReturn(promptTypeLiveData)
+
+        testee = AppRatingPromptEvaluator(
+            promptTypeDecider = promptTypeDecider,
+            appEnjoymentPromptEmitter = appEnjoymentPromptEmitter,
+            appRatingPromptModalFeature = appRatingPromptModalFeature,
+            dispatchers = coroutineRule.testDispatcherProvider,
+        )
+
+        appRatingPromptModalFeature.self().setRawStoredState(Toggle.State(enable = true))
+    }
+
+    @Test
+    fun triggerIsNtpRender() {
+        assertEquals(ModalTrigger.NTP_RENDER, testee.trigger)
+    }
+
+    @Test
+    fun priorityIsSix() {
+        assertEquals(6, testee.priority)
+    }
+
+    @Test
+    fun evaluatorIdIsAppRatingPrompt() {
+        assertEquals("app_rating_prompt", testee.evaluatorId)
+    }
+
+    @Test
+    fun featureDefaultsToEnabled() {
+        val unsetFeature = FakeFeatureToggleFactory.create(AppRatingPromptModalFeature::class.java)
+
+        assertTrue(unsetFeature.self().isEnabled())
+    }
+
+    @Test
+    fun whenFeatureDisabledThenSkippedWithoutDeciding() = runTest {
+        appRatingPromptModalFeature.self().setRawStoredState(Toggle.State(enable = false))
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+        verify(promptTypeDecider, never()).determineInitialPromptType()
+        assertNull(promptTypeLiveData.value)
+    }
+
+    @Test
+    fun whenDeciderSelectsShowNothingThenSkippedAndNothingEmitted() = runTest {
+        whenever(promptTypeDecider.determineInitialPromptType()).thenReturn(AppEnjoymentPromptOptions.ShowNothing)
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+        assertNull(promptTypeLiveData.value)
+    }
+
+    @Test
+    fun whenDeciderSelectsEnjoymentPromptThenModalShownAndPromptEmitted() = runTest {
+        val expected = AppEnjoymentPromptOptions.ShowEnjoymentPrompt(PromptCount.first())
+        whenever(promptTypeDecider.determineInitialPromptType()).thenReturn(expected)
+
+        assertEquals(ModalEvaluator.EvaluationResult.ModalShown, testee.evaluate())
+        assertEquals(expected, promptTypeLiveData.value)
+    }
+
+    @Test
+    fun whenDeciderSelectsRatingPromptThenModalShownAndPromptEmitted() = runTest {
+        val expected = AppEnjoymentPromptOptions.ShowRatingPrompt(PromptCount.second())
+        whenever(promptTypeDecider.determineInitialPromptType()).thenReturn(expected)
+
+        assertEquals(ModalEvaluator.EvaluationResult.ModalShown, testee.evaluate())
+        assertEquals(expected, promptTypeLiveData.value)
+    }
+}

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInEvaluator.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/prompt/CookiePopupOptInEvaluator.kt
@@ -56,7 +56,7 @@ class CookiePopupOptInEvaluator @Inject constructor(
     private val appInstallTimeProvider: AppInstallTimeProvider,
 ) : ModalEvaluator {
 
-    override val priority: Int = 6
+    override val priority: Int = 7
 
     override val evaluatorId: String = "cookie_popup_opt_in"
 


### PR DESCRIPTION
Task/Issue URL:   https://app.asana.com/1/137249556945/project/72649045549333/task/1218278045050709?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Integrate the rate-our-app prompt into the prompt coordinator, use a feature flag default ON to switch back to old behaviour.
### Steps to test this PR

The following command will modify the code so that only one DDG search is needed to meet the thresholds.
```
sed -i '' 's/^const val MINIMUM_SEARCHES_THRESHOLD = 5$/const val MINIMUM_SEARCHES_THRESHOLD = 1/; s/^const val MINIMUM_DAYS_USAGE_BEFORE_FIRST_PROMPT = 3$/const val MINIMUM_DAYS_USAGE_BEFORE_FIRST_PROMPT = 0/' app/src/main/java/com/duckduckgo/app/global/rating/AppEnjoymentPromptCriteria.kt
```

Then build, and install. 

Perform one search and observe the dialog showing. 

Reset app add data, change flag value to False, then repeat.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how the rating prompt appears (NTP vs app start) and modal arbitration order; mitigated by a default-on remote flag that restores legacy behavior when disabled.
> 
> **Overview**
> Routes the **app enjoyment / rating prompt** through the **prompts coordinator** instead of firing unarbitrated on every app start.
> 
> When remote flag `appRatingPromptModal` is **on** (default), new `AppRatingPromptEvaluator` decides whether to show the prompt on **`NTP_RENDER`** at coordinator priority **6**, with a short delay before emitting via the existing `AppEnjoymentPromptEmitter`. `AppEnjoymentAppCreationObserver` **no-ops** on start so the prompt is not evaluated twice or outside arbitration.
> 
> When the flag is **off**, behavior reverts to the observer’s app-start path. **`CookiePopupOptInEvaluator`** priority moves **6 → 7** so the rating prompt can win ordering against the cookie opt-in modal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ced1846c6c726e81e773982760f2651d6fe6a5ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->