### PR TITLE
check whether widget provide is registered before updating it

### DIFF
--- a/app/src/main/java/com/duckduckgo/widget/SearchWidgetProviderInfoUpdater.kt
+++ b/app/src/main/java/com/duckduckgo/widget/SearchWidgetProviderInfoUpdater.kt
@@ -55,10 +55,14 @@ class SearchWidgetProviderInfoUpdater internal constructor(
             LEGACY_PROVIDER_INFO_METADATA_KEY
         }
 
-        appWidgetManager.updateAppWidgetProviderInfo(ComponentName(context, SearchWidget::class.java), metadataKey)
-        appWidgetManager.updateAppWidgetProviderInfo(ComponentName(context, SearchWidgetLight::class.java), metadataKey)
-        appWidgetManager.updateAppWidgetProviderInfo(ComponentName(context, SearchOnlyWidget::class.java), metadataKey)
-        appWidgetManager.updateAppWidgetProviderInfo(ComponentName(context, SearchAndFavoritesWidget::class.java), metadataKey)
+        val registeredProviders = appWidgetManager
+            .getInstalledProvidersForPackage(context.packageName, null)
+            .map { it.provider }
+
+        SEARCH_WIDGET_PROVIDERS
+            .map { ComponentName(context, it) }
+            .filter { it in registeredProviders }
+            .forEach { appWidgetManager.updateAppWidgetProviderInfo(it, metadataKey) }
     }
 
     fun syncAndRequestPinAppWidget(
@@ -71,5 +75,12 @@ class SearchWidgetProviderInfoUpdater internal constructor(
 
     private companion object {
         const val LEGACY_PROVIDER_INFO_METADATA_KEY = "com.duckduckgo.widget.legacy_provider_info"
+
+        val SEARCH_WIDGET_PROVIDERS = listOf(
+            SearchWidget::class.java,
+            SearchWidgetLight::class.java,
+            SearchOnlyWidget::class.java,
+            SearchAndFavoritesWidget::class.java,
+        )
     }
 }

--- a/app/src/test/java/com/duckduckgo/widget/SearchWidgetProviderInfoUpdaterTest.kt
+++ b/app/src/test/java/com/duckduckgo/widget/SearchWidgetProviderInfoUpdaterTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.widget
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProviderInfo
 import android.content.ComponentName
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -26,10 +27,12 @@ import com.duckduckgo.feature.toggles.api.Toggle
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
@@ -50,7 +53,20 @@ class SearchWidgetProviderInfoUpdaterTest {
     fun setUp() {
         whenever(context.packageName).thenReturn(PACKAGE_NAME)
         whenever(toggles.addressBar()).thenReturn(addressBarToggle)
+        givenRegisteredProviders(
+            SearchWidget::class.java.name,
+            SearchWidgetLight::class.java.name,
+            SearchOnlyWidget::class.java.name,
+            SearchAndFavoritesWidget::class.java.name,
+        )
         testee = SearchWidgetProviderInfoUpdater(context, appWidgetManager, toggles)
+    }
+
+    private fun givenRegisteredProviders(vararg classNames: String) {
+        val providers = classNames.map { className ->
+            AppWidgetProviderInfo().apply { provider = ComponentName(PACKAGE_NAME, className) }
+        }
+        whenever(appWidgetManager.getInstalledProvidersForPackage(eq(PACKAGE_NAME), isNull())).thenReturn(providers)
     }
 
     @Test
@@ -127,6 +143,41 @@ class SearchWidgetProviderInfoUpdaterTest {
             )
             verify(appWidgetManager).requestPinAppWidget(provider, null, pendingIntent)
         }
+    }
+
+    @Test
+    fun whenProviderIsNotRegisteredThenItsProviderInfoIsNotUpdated() {
+        whenever(addressBarToggle.isEnabled()).thenReturn(false)
+        givenRegisteredProviders(SearchWidget::class.java.name)
+
+        testee.sync()
+
+        verify(appWidgetManager).updateAppWidgetProviderInfo(
+            eq(ComponentName(PACKAGE_NAME, SearchWidget::class.java.name)),
+            eq(LEGACY_PROVIDER_INFO_METADATA_KEY),
+        )
+        verify(appWidgetManager, never()).updateAppWidgetProviderInfo(
+            eq(ComponentName(PACKAGE_NAME, SearchWidgetLight::class.java.name)),
+            anyOrNull(),
+        )
+        verify(appWidgetManager, never()).updateAppWidgetProviderInfo(
+            eq(ComponentName(PACKAGE_NAME, SearchOnlyWidget::class.java.name)),
+            anyOrNull(),
+        )
+        verify(appWidgetManager, never()).updateAppWidgetProviderInfo(
+            eq(ComponentName(PACKAGE_NAME, SearchAndFavoritesWidget::class.java.name)),
+            anyOrNull(),
+        )
+    }
+
+    @Test
+    fun whenNoProvidersAreRegisteredThenNoProviderInfoIsUpdated() {
+        whenever(addressBarToggle.isEnabled()).thenReturn(false)
+        givenRegisteredProviders()
+
+        testee.sync()
+
+        verify(appWidgetManager, never()).updateAppWidgetProviderInfo(anyOrNull(), anyOrNull())
     }
 
     companion object {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1218354970503019?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

Fixes an issue where we were trying to update a widget provider that might've not existed, e.g. in cases where the app is installed into Private Spaces and doesn't support widget providers.

### Steps to test this PR

_widget presentation_
- [x] Clean install a `PlayRelease` build.
- [x] Add a widget (for example search-only) to the home screen.
- [x] Verify it is not pill shaped (note: Pixel launcher always reshapes the widget to be pill shaped, try on a different device like a Samsung). 
- [x] Open the app, verify the address bar is not pill shaped.
- [x] Apply below diff:
```diff
diff --git a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/store/AppBrandDesignUpdateToggles.kt b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/store/AppBrandDesignUpdateToggles.kt
index ab71a81031..58284a8483 100644
--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/store/AppBrandDesignUpdateToggles.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/store/AppBrandDesignUpdateToggles.kt
@@ -53,3 +53,3 @@ interface AppBrandDesignUpdateToggles {
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun addressBar(): Toggle

```
- [x] Update the app (reinstall, do note remove or clear caches).
- [x] Verify the widget updates to a pill shape.
- [x] Open the app, verify the address bar is pill shaped.
- [x] Uninstall the app to clean up.

_Private Space compatibility_
- [x] `git checkout 5.295.0`
- [x] `./gradlew app:installPlayRelease`
- [x] Set up Private Space (Settings → Security & privacy → Private Space → Set up).
- [x] Open the app list, scroll to the bottom, unlock the private space.
- [x] Call `adb shell pm list users`.
- [x] Find something like `UserInfo{10:Private space:1010}` running , take the id (`10`).
- [x] Call `adb shell pm install-existing --user 10 com.duckduckgo.mobile.android`.
- [x] Try opening the app from the Private Space, verify it crashes (confirmed crashing on Pixel devices, can't repro on Samsungs).
- [x] `git checkout fix/lpaczos/updating-widgets-in-private-spaces`
- [x] `./gradlew app:installPlayRelease`
- [x] Try opening the app from the Private Space, verify it does not crash.
- [x] Verify the corners of the address bar inside the app are pill shaped.
- [x] Revert the earlier feature flag change (disable `addressBar`).
- [x] `./gradlew app:installPlayRelease`
- [x] Verify the corners of the address bar inside the app are not pill shaped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive change to widget sync with added unit coverage; behavior unchanged when all providers are registered.
> 
> **Overview**
> **`SearchWidgetProviderInfoUpdater.sync()`** no longer calls `updateAppWidgetProviderInfo` for every search widget class unconditionally. It first loads providers registered for the app via `getInstalledProvidersForPackage`, intersects that set with a shared **`SEARCH_WIDGET_PROVIDERS`** list, and updates provider info only for components that are actually installed—avoiding failures when widgets are unavailable (e.g. Private Space installs).
> 
> Tests mock registered providers in setup and add cases for partial registration and zero registered providers, asserting `updateAppWidgetProviderInfo` is skipped when appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6aa95e6914563b8026e537695f059d8e4edb34b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->