### PR TITLE
Parse model label and sort labelled models first

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
@@ -36,6 +36,7 @@ data class RemoteAIChatModel(
     @field:Json(name = "supportedReasoningEffort") val supportedReasoningEffort: List<String>? = null,
     @field:Json(name = "reasoningEffortAccess") val reasoningEffortAccess: List<RemoteReasoningEffortAccess>? = null,
     @field:Json(name = "supportedTools") val supportedTools: List<String>? = null,
+    @field:Json(name = "label") val label: String? = null,
 )
 
 data class RemoteTierAttachmentLimits(
@@ -112,6 +113,7 @@ data class AIChatModel(
     val supportedReasoningEfforts: List<ReasoningEffort> = emptyList(),
     val reasoningEffortAccess: List<ReasoningEffortAccess> = emptyList(),
     val supportedTools: List<Tool> = emptyList(),
+    val label: ModelLabel? = null,
 ) {
     val supportsFileUpload: Boolean
         get() = supportedFileTypes.isNotEmpty()
@@ -123,6 +125,26 @@ data class AIChatModel(
 
     companion object {
         val NATIVE_SUPPORTED_IMAGE_FORMATS = listOf("png", "jpeg", "webp")
+    }
+}
+
+/**
+ * Editorial descriptor the backend attaches to a model, shown as a subline in the picker. The raw
+ * values are stable ids, never display text, so each client maps them to its own strings.
+ */
+enum class ModelLabel(val rawValue: String) {
+    EVERYDAY_USE("EVERYDAY_USE"),
+    USES_LIMITS_FASTER("USES_LIMITS_FASTER"),
+
+    /** A label added after this version shipped. Still treated as recommended, but renders no subline. */
+    UNKNOWN(""),
+    ;
+
+    companion object {
+        fun from(raw: String?): ModelLabel? = when {
+            raw.isNullOrBlank() -> null
+            else -> entries.firstOrNull { it.rawValue == raw } ?: UNKNOWN
+        }
     }
 }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
@@ -185,7 +185,10 @@ class RealDuckAiModelManager @Inject constructor(
                     }
                 val attachmentLimits = resolveAttachmentLimits(response.attachmentLimits, userTier)
                 stateMutex.withLock {
+                    // Selection is resolved before sorting so the derived default keeps following
+                    // endpoint order, and only the picker's display order changes.
                     val selectedModelId = resolveSelection(models)
+                    val displayModels = models.sortLabelledFirst()
                     val selectedModel = models.find { it.id == selectedModelId }
                     val available = ReasoningResolver.availableModes(
                         supported = selectedModel?.supportedReasoningEfforts.orEmpty(),
@@ -195,7 +198,7 @@ class RealDuckAiModelManager @Inject constructor(
                     val nextReasoningMode = validateAndPersistReasoningMode(_modelState.value.selectedReasoningMode, available)
 
                     _modelState.value = _modelState.value.copy(
-                        models = models,
+                        models = displayModels,
                         selectedModelId = selectedModelId,
                         selectedModelShortName = selectedModel?.shortName,
                         userTier = userTier,
@@ -204,7 +207,7 @@ class RealDuckAiModelManager @Inject constructor(
                         selectedReasoningMode = nextReasoningMode,
                         availableReasoningModes = available,
                     )
-                    logcat { "Duck.ai Model Manager: fetched ${models.size} models, tier=$userTier, selected=$selectedModelId" }
+                    logcat { "Duck.ai Model Manager: fetched ${displayModels.size} models, tier=$userTier, selected=$selectedModelId" }
                 }
             } catch (e: Exception) {
                 logcat { "Duck.ai Model Manager: failed to fetch models: ${e.message}" }
@@ -384,6 +387,12 @@ class RealDuckAiModelManager @Inject constructor(
         )
     }
 
+    /** Labelled models lead the list, as the backend marks them as the ones to recommend. */
+    private suspend fun List<AIChatModel>.sortLabelledFirst(): List<AIChatModel> {
+        if (!duckChatFeature.get().updatedPickers().isEnabled()) return this
+        return sortedBy { if (it.label != null) 0 else 1 }
+    }
+
     private fun resolveModel(
         remote: RemoteAIChatModel,
         userTier: UserTier,
@@ -413,6 +422,7 @@ class RealDuckAiModelManager @Inject constructor(
                 ReasoningEffortAccess(effort = effort, accessTier = tiers, isAccessible = accessible)
             },
             supportedTools = remote.supportedTools.orEmpty().mapNotNull(Tool::from),
+            label = ModelLabel.from(remote.label),
         )
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/AIChatModelDecodingTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/AIChatModelDecodingTest.kt
@@ -29,6 +29,20 @@ class AIChatModelDecodingTest {
     private val adapter: JsonAdapter<RemoteAIChatModel> = moshi.adapter(RemoteAIChatModel::class.java)
 
     @Test
+    fun whenLabelMissingThenFieldIsNull() {
+        val json = """{"id":"m","name":"n"}"""
+        val parsed = adapter.fromJson(json)!!
+        assertNull(parsed.label)
+    }
+
+    @Test
+    fun whenLabelPopulatedThenFieldDecoded() {
+        val json = """{"id":"m","name":"n","label":"EVERYDAY_USE"}"""
+        val parsed = adapter.fromJson(json)!!
+        assertEquals("EVERYDAY_USE", parsed.label)
+    }
+
+    @Test
     fun whenSupportedReasoningEffortMissingThenFieldIsNull() {
         val json = """{"id":"m","name":"n"}"""
         val parsed = adapter.fromJson(json)!!

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
@@ -774,6 +774,106 @@ class RealDuckAiModelManagerTest {
     }
 
     @Test
+    fun whenModelHasKnownLabelThenLabelParsed() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(modelsService.getModels(any(), anyOrNull())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel("everyday", label = "EVERYDAY_USE"),
+                    remoteModel("hungry", label = "USES_LIMITS_FASTER"),
+                    remoteModel("plain", label = null),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        val models = testee.modelState.value.models
+        assertEquals(ModelLabel.EVERYDAY_USE, models.first { it.id == "everyday" }.label)
+        assertEquals(ModelLabel.USES_LIMITS_FASTER, models.first { it.id == "hungry" }.label)
+        assertNull(models.first { it.id == "plain" }.label)
+    }
+
+    @Test
+    fun whenModelHasUnrecognisedLabelThenLabelIsUnknown() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(modelsService.getModels(any(), anyOrNull())).thenReturn(
+            AIChatModelsResponse(listOf(remoteModel("id", label = "BRAND_NEW_LABEL"))),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        assertEquals(ModelLabel.UNKNOWN, testee.modelState.value.models[0].label)
+    }
+
+    @Test
+    fun whenUpdatedPickersEnabledThenLabelledModelsSortFirstKeepingEndpointOrder() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        duckChatFeature.updatedPickers().setRawStoredState(Toggle.State(enable = true))
+        whenever(modelsService.getModels(any(), anyOrNull())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel("plain1"),
+                    remoteModel("labelled1", label = "EVERYDAY_USE"),
+                    remoteModel("plain2"),
+                    remoteModel("labelled2", label = "USES_LIMITS_FASTER"),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        assertEquals(
+            listOf("labelled1", "labelled2", "plain1", "plain2"),
+            testee.modelState.value.models.map { it.id },
+        )
+    }
+
+    @Test
+    fun whenUpdatedPickersDisabledThenEndpointOrderKept() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        duckChatFeature.updatedPickers().setRawStoredState(Toggle.State(enable = false))
+        whenever(modelsService.getModels(any(), anyOrNull())).thenReturn(
+            AIChatModelsResponse(
+                listOf(remoteModel("plain"), remoteModel("labelled", label = "EVERYDAY_USE")),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        assertEquals(listOf("plain", "labelled"), testee.modelState.value.models.map { it.id })
+    }
+
+    @Test
+    fun whenLabelledModelSortsFirstThenDerivedDefaultStillFollowsEndpointOrder() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        duckChatFeature.updatedPickers().setRawStoredState(Toggle.State(enable = true))
+        whenever(modelsService.getModels(any(), anyOrNull())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel("first-in-response"),
+                    remoteModel("labelled", label = "EVERYDAY_USE"),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        assertEquals("first-in-response", testee.modelState.value.selectedModelId)
+        assertEquals("labelled", testee.modelState.value.models[0].id)
+    }
+
+    @Test
     fun whenEntitlementsChangeThenModelsFetched() = runTest {
         whenever(dataStore.getSelectedModel()).thenReturn(null)
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
@@ -963,6 +1063,7 @@ class RealDuckAiModelManagerTest {
         supportedFileTypes: List<String>? = null,
         supportedReasoningEffort: List<String>? = null,
         reasoningEffortAccess: List<RemoteReasoningEffortAccess>? = null,
+        label: String? = null,
     ) = RemoteAIChatModel(
         id = id,
         name = id,
@@ -975,6 +1076,7 @@ class RealDuckAiModelManagerTest {
         supportedFileTypes = supportedFileTypes,
         supportedReasoningEffort = supportedReasoningEffort,
         reasoningEffortAccess = reasoningEffortAccess,
+        label = label,
     )
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218292003967948
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

Parses the `label` the models endpoint attaches to recommended models, `EVERYDAY_USE` or
`USES_LIMITS_FASTER`, which the updated picker will show as a subline. Unrecognised values map
to `ModelLabel.UNKNOWN`, so a label added after this version ships still sorts as recommended
but renders no subline.

The labelled-first sort applies to the display list only and sits behind `updatedPickers`. Note
that `resolveSelection` derives the default model for users who never picked one from the first
accessible model in the list, so the selection is resolved before sorting; otherwise labelling
a model would silently change the default for that whole group. There's a test covering it.

Stacked on #9764.

### Steps to test this PR

_Feature 1_
- [x] With `updatedPickers` off, open the model picker and confirm the order matches
      `/duckchat/v1/models` response order, unchanged from develop
- [x] Enable `updatedPickers`, force stop and relaunch, then sign in with a subscription so the
      response carries labels
- [ ] Open the model picker and confirm models with a label appear at the top, and that
      unlabelled models keep their relative response order below them
- [ ] Without having picked a model manually, confirm the selected model in the chip is still
      the first accessible model in response order, not the first labelled one

### UI changes
None yet, sublines and grouping land with the picker UI task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is gated behind `updatedPickers`; selection semantics are explicitly preserved with tests, and changes are limited to model parsing and list ordering.
> 
> **Overview**
> Adds support for the models API **`label`** field so recommended models can drive the upcoming picker sublines. **`ModelLabel`** maps stable ids (`EVERYDAY_USE`, `USES_LIMITS_FASTER`) from JSON into domain models; missing labels stay `null`, and unknown server values become **`UNKNOWN`** (still treated as labelled for sorting, with no subline until UI maps them).
> 
> When **`updatedPickers`** is on, **`DuckAiModelManager`** publishes a display list with labelled models first while preserving endpoint order within each group. **Default selection is resolved on the unsorted list** so users who never pick a model still get the first accessible model in API order, not the first labelled one. No picker UI in this PR—data layer and tests only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e021aee43657b65ff197c5d82a3c2e5f8f351c86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->