### PR TITLE
Disable WebView zoom on Duck.ai pages

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2425,6 +2425,11 @@ class BrowserTabFragment :
         }
     }
 
+    // Pinch and double-tap zoom distort the Duck.ai chat layout, so zoom is only supported off Duck.ai.
+    private fun setWebViewZoomSupported(supported: Boolean) {
+        webView?.settings?.setSupportZoom(supported)
+    }
+
     private fun showDuckAI(browserViewState: BrowserViewState) {
         renderBrowserMenu(viewState = browserViewState, omnibarViewMode = ViewMode.DuckAI)
         omnibar.setViewMode(ViewMode.DuckAI)
@@ -3093,8 +3098,13 @@ class BrowserTabFragment :
 
             is Command.EnqueueCookiesAnimation -> enqueueCookiesAnimation(it.isCosmetic)
             is Command.PageStarted -> onPageStarted()
-            is Command.EnableDuckAIFullScreen -> showDuckAI(it.browserViewState)
+            is Command.EnableDuckAIFullScreen -> {
+                setWebViewZoomSupported(false)
+                showDuckAI(it.browserViewState)
+            }
+
             is Command.DuckAIFullScreenDisabled -> {
+                setWebViewZoomSupported(true)
                 if (omnibar.viewMode == DuckAI) {
                     nativeInputManager.hideNativeInput()
                 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -393,12 +393,11 @@ class DuckChatContextualFragment :
                 domStorageEnabled = true
                 loadWithOverviewMode = true
                 useWideViewPort = true
-                builtInZoomControls = true
-                displayZoomControls = false
                 mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
                 setSupportMultipleWindows(true)
                 databaseEnabled = false
-                setSupportZoom(true)
+                // Pinch and double-tap zoom distort the chat layout, so zoom stays off in the contextual sheet.
+                setSupportZoom(false)
             }
 
             it.setDownloadListener { url, _, contentDisposition, mimeType, _ ->

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualWebViewFragment.kt
@@ -344,12 +344,11 @@ class DuckChatContextualWebViewFragment :
                 domStorageEnabled = true
                 loadWithOverviewMode = true
                 useWideViewPort = true
-                builtInZoomControls = true
-                displayZoomControls = false
                 mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
                 setSupportMultipleWindows(true)
                 databaseEnabled = false
-                setSupportZoom(true)
+                // Pinch and double-tap zoom distort the chat layout, so zoom stays off in the contextual sheet.
+                setSupportZoom(false)
             }
 
             it.setDownloadListener { url, _, contentDisposition, mimeType, _ ->


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1218241023018339
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

Pinch and double-tap zoom distort the Duck.ai chat layout, so zoom is now disabled while Duck.ai is showing. In a browser tab this rides the existing `EnableDuckAIFullScreen` / `DuckAIFullScreenDisabled` commands, so zoom comes back as soon as the tab navigates to any other site. The contextual sheet WebViews only ever host Duck.ai and disable zoom at creation. Search result pages are out of scope here and still zoom.

### Steps to test this PR

_Duck.ai in a browser tab_
- [ ] Open a Duck.ai chat in a tab, try to pinch-zoom and double-tap-zoom, neither should do anything
- [ ] From that tab navigate to any other website, pinch-zoom should work again
- [ ] Go back to Duck.ai, zoom should be blocked again

_Duck.ai contextual sheet_
- [ ] Open the contextual Duck.ai sheet from a page, try to pinch-zoom and double-tap-zoom, neither should do anything

_Search unaffected_
- [ ] Run a search, pinch-zoom on the results page should still work

### UI changes
No UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized WebView settings toggles around Duck.ai entry/exit with no auth or data-path changes; main regression risk is zoom staying off after leaving Duck.ai in a tab.
> 
> **Overview**
> **Disables pinch and double-tap zoom on Duck.ai** because zoom breaks the chat layout. Regular browsing and SERP zoom behavior are unchanged.
> 
> In **browser tabs**, a new `setWebViewZoomSupported` helper turns zoom off when `EnableDuckAIFullScreen` runs and turns it back on when `DuckAIFullScreenDisabled` fires (leaving Duck.ai for another URL).
> 
> In the **contextual Duck.ai sheet**, both contextual WebView fragments no longer enable built-in zoom controls and call `setSupportZoom(false)` at setup, since those WebViews only load Duck.ai.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2492939bd5572b1e76cc3921539d245cc21fe841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->