### PR TITLE
Extract a shared picker row for both Duck.ai pickers

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PickerMenuRow.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PickerMenuRow.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import androidx.annotation.DrawableRes
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.view.isVisible
+import com.duckduckgo.common.ui.view.text.DaxTextView
+import com.duckduckgo.duckchat.impl.R
+
+/** Appended to rows that open a follow-up step, the platform convention for "this isn't a pick". */
+private const val FOLLOW_UP_SUFFIX = "…"
+
+/**
+ * A row shared by the Duck.ai model and reasoning pickers: leading icon, title with an optional
+ * subline, and a trailing tick for the current selection. The ADS [PopupMenuItemView] carries no
+ * secondary text, which is why these pickers own their row.
+ *
+ * Set [opensFollowUp] for a row that leads somewhere else, such as a gated model that opens an
+ * upsell, rather than selecting outright.
+ */
+internal fun pickerMenuItem(
+    parent: ViewGroup,
+    title: String,
+    @DrawableRes leadingIconRes: Int,
+    subtitle: String? = null,
+    selected: Boolean = false,
+    opensFollowUp: Boolean = false,
+    onClick: () -> Unit,
+): View {
+    val item = LayoutInflater.from(parent.context).inflate(R.layout.view_picker_menu_item, parent, false)
+
+    item.findViewById<ImageView>(R.id.pickerMenuItemLeadingIcon)
+        .setImageDrawable(AppCompatResources.getDrawable(parent.context, leadingIconRes))
+
+    item.findViewById<DaxTextView>(R.id.pickerMenuItemTitle).text =
+        if (opensFollowUp) "$title$FOLLOW_UP_SUFFIX" else title
+
+    item.findViewById<DaxTextView>(R.id.pickerMenuItemSubtitle).apply {
+        text = subtitle
+        isVisible = !subtitle.isNullOrEmpty()
+    }
+
+    item.findViewById<ImageView>(R.id.pickerMenuItemTrailingIcon).apply {
+        setImageResource(com.duckduckgo.mobile.android.R.drawable.ic_check_24)
+        // Invisible rather than gone so titles stay aligned across selected and unselected rows.
+        visibility = if (selected) View.VISIBLE else View.INVISIBLE
+    }
+
+    item.setOnClickListener { onClick() }
+    return item
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
@@ -19,21 +19,18 @@ package com.duckduckgo.duckchat.impl.ui.nativeinput.views
 import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
-import android.view.LayoutInflater
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.PopupWindow
 import android.widget.ScrollView
-import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
-import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
@@ -190,16 +187,13 @@ class ReasoningModePickerView @JvmOverloads constructor(
 
     private fun populate(container: LinearLayout, popup: PopupWindow, state: ReasoningModePickerState) {
         state.rows.forEach { row ->
-            val item = LayoutInflater.from(context)
-                .inflate(R.layout.view_reasoning_mode_picker_item, container, false)
-            item.findViewById<ImageView>(R.id.reasoningModeItemLeadingIcon)
-                .setImageDrawable(AppCompatResources.getDrawable(context, row.iconRes))
-            item.findViewById<DaxTextView>(R.id.reasoningModeItemTitle).setText(row.titleRes)
-            item.findViewById<DaxTextView>(R.id.reasoningModeItemSubtitle).setText(row.subtitleRes)
-            val trailingIcon = item.findViewById<ImageView>(R.id.reasoningModeItemTrailingIcon)
-            trailingIcon.setImageResource(com.duckduckgo.mobile.android.R.drawable.ic_check_24)
-            trailingIcon.visibility = if (row.selected) VISIBLE else INVISIBLE
-            item.setOnClickListener {
+            val item = pickerMenuItem(
+                parent = container,
+                title = context.getString(row.titleRes),
+                leadingIconRes = row.iconRes,
+                subtitle = context.getString(row.subtitleRes),
+                selected = row.selected,
+            ) {
                 viewModel.onModeTapped(row.mode, currentSurface())
                 popup.dismiss()
             }

--- a/duckchat/duckchat-impl/src/main/res/layout/view_picker_menu_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_picker_menu_item.xml
@@ -28,7 +28,7 @@
     android:paddingBottom="@dimen/keyline_2">
 
     <ImageView
-        android:id="@+id/reasoningModeItemLeadingIcon"
+        android:id="@+id/pickerMenuItemLeadingIcon"
         android:layout_width="@dimen/keyline_5"
         android:layout_height="@dimen/keyline_5"
         android:importantForAccessibility="no"
@@ -43,7 +43,7 @@
         android:orientation="vertical">
 
         <com.duckduckgo.common.ui.view.text.DaxTextView
-            android:id="@+id/reasoningModeItemTitle"
+            android:id="@+id/pickerMenuItemTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:lineSpacingExtra="0sp"
@@ -52,7 +52,7 @@
             tools:text="Fast" />
 
         <com.duckduckgo.common.ui.view.text.DaxTextView
-            android:id="@+id/reasoningModeItemSubtitle"
+            android:id="@+id/pickerMenuItemSubtitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:lineSpacingExtra="0sp"
@@ -63,7 +63,7 @@
     </LinearLayout>
 
     <ImageView
-        android:id="@+id/reasoningModeItemTrailingIcon"
+        android:id="@+id/pickerMenuItemTrailingIcon"
         android:layout_width="@dimen/keyline_5"
         android:layout_height="@dimen/keyline_5"
         android:layout_marginStart="@dimen/keyline_2"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218299205532625
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

Pure refactor ahead of the picker UI work. The reasoning picker's row layout already had
everything the model picker needs for sublines (leading icon, title, secondary text, trailing
tick), so this generalises it into `view_picker_menu_item` plus a single `pickerMenuItem`
builder. Both pickers can now share a row instead of the model picker using the ADS
`PopupMenuItemView`, which exposes no secondary text.

The builder takes an `opensFollowUp` flag that appends the platform's ellipsis convention to the
title, for gated rows that open an upsell rather than selecting outright. Nothing passes it yet,
the picker UI tasks do. The reasoning picker renders exactly as before, so there is nothing
visible in this PR.

Stacked on #9772.

### Steps to test this PR

_Feature 1_
- [x] Open Duck.ai, tap the reasoning picker and confirm the rows look identical to develop:
      icon, title, subline, and a tick on the selected mode only
- [x] Confirm the unselected rows still align with the selected one, the tick is invisible
      rather than removed
- [x] Pick a different reasoning mode and confirm the selection and dismissal still work

### UI changes
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactor with no intended visible change; reasoning picker should render and behave as before.
> 
> **Overview**
> Introduces a shared **`pickerMenuItem`** builder and **`view_picker_menu_item`** layout so Duck.ai model and reasoning pickers can use the same row (icon, title, optional subtitle, selection tick) instead of ADS `PopupMenuItemView`, which has no secondary line.
> 
> **Reasoning mode picker** now builds popup rows through that helper instead of inflating and wiring `view_reasoning_mode_picker_item` inline; layout view IDs are renamed to generic `pickerMenuItem*` names. Behavior is unchanged: invisible tick on unselected rows for alignment, same click/dismiss flow.
> 
> The builder adds an **`opensFollowUp`** flag that appends `…` to the title for rows that navigate (e.g. upsell) rather than selecting; nothing uses it in this PR—reserved for upcoming picker UI work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd3f4846a9f304e2333be9af4bdf34d87f0d25db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->