### PR TITLE
Recognize the performance-optimized paywall paths as subscription URLs

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.toTldPlusOne
+import com.duckduckgo.common.utils.replaceQueryParameters
 import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
@@ -183,10 +184,17 @@ class RealSubscriptions @Inject constructor(
         val buyUri = buyUrl.toUri()
         val builder = buyUri.buildUpon()
 
-        val query = mergeQueries(buyUri.encodedQuery, uri.encodedQuery)
+        val featurePage = featurePageFromPath(uri)
+
+        val incomingQuery = if (featurePage != null) {
+            uri.withoutParam(FEATURE_PAGE_QUERY_PARAM_KEY)
+        } else {
+            uri.encodedQuery
+        }
+
+        val query = mergeQueries(buyUri.encodedQuery, incomingQuery)
         if (!query.isNullOrBlank()) builder.encodedQuery(query)
 
-        val featurePage = featurePageFromPath(uri)
         if (featurePage != null) builder.appendQueryParameter(FEATURE_PAGE_QUERY_PARAM_KEY, featurePage)
 
         return builder.build().toString()
@@ -202,9 +210,14 @@ class RealSubscriptions @Inject constructor(
     }
 
     private fun featurePageFromPath(uri: Uri): String? {
-        val explicitPage = uri.getQueryParameter(FEATURE_PAGE_QUERY_PARAM_KEY)
-        if (!explicitPage.isNullOrBlank()) return null
+        val explicitPage = uri.getQueryParameters(FEATURE_PAGE_QUERY_PARAM_KEY).firstOrNull { it.isNotBlank() }
+        if (explicitPage != null) return null
         return optimizedPaywallFeaturePage(uri)
+    }
+
+    private fun Uri.withoutParam(key: String): String? {
+        val keysToKeep = queryParameterNames.filterNot { it == key }
+        return replaceQueryParameters(keysToKeep).encodedQuery
     }
 }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -37,10 +37,12 @@ import com.duckduckgo.subscriptions.api.Product.DuckAiPlus
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.subscriptions.api.model.Entitlement
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.FEATURE_PAGE_QUERY_PARAM_KEY
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ORIGIN_QUERY_PARAM_KEY
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.PRIVACY_SUBSCRIPTIONS_PATH
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.SUBSCRIPTIONS_ETLD
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.SUBSCRIPTIONS_PATH
+import com.duckduckgo.subscriptions.impl.internal.PaywallPathProvider
 import com.duckduckgo.subscriptions.impl.internal.SubscriptionsUrlProvider
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.repository.isActiveOrWaiting
@@ -67,6 +69,7 @@ class RealSubscriptions @Inject constructor(
     private val subscriptionsFeature: Lazy<SubscriptionsFeature>,
     private val dispatcherProvider: DispatcherProvider,
     private val subscriptionsUrlProvider: SubscriptionsUrlProvider,
+    private val paywallPathProvider: Lazy<PaywallPathProvider>,
 ) : Subscriptions {
     override suspend fun isSignedIn(): Boolean =
         subscriptionsManager.isSignedIn()
@@ -153,9 +156,16 @@ class RealSubscriptions @Inject constructor(
 
     override fun isSubscriptionUrl(uri: Uri): Boolean {
         val eTld = uri.host?.toTldPlusOne() ?: return false
-        val size = uri.pathSegments.size
+        if (eTld != SUBSCRIPTIONS_ETLD) return false
         val path = uri.pathSegments.firstOrNull()
-        return eTld == SUBSCRIPTIONS_ETLD && size == 1 && (path == SUBSCRIPTIONS_PATH || path == PRIVACY_SUBSCRIPTIONS_PATH)
+        if (uri.pathSegments.size == 1 && (path == SUBSCRIPTIONS_PATH || path == PRIVACY_SUBSCRIPTIONS_PATH)) return true
+        return optimizedPaywallFeaturePage(uri) != null
+    }
+
+    private fun optimizedPaywallFeaturePage(uri: Uri): String? {
+        if (!subscriptionsFeature.get().performanceOptimizedPaywalls().isEnabled()) return null
+        val path = uri.path ?: return null
+        return paywallPathProvider.get().getFeaturePage(path)
     }
 
     override suspend fun isFreeTrialEligible(): Boolean {
@@ -167,12 +177,34 @@ class RealSubscriptions @Inject constructor(
     }
 
     private fun buildSubscriptionUrl(uri: Uri?): String {
-        val queryParams = uri?.query
-        return if (!queryParams.isNullOrBlank()) {
-            "${subscriptionsUrlProvider.buyUrl}?$queryParams"
-        } else {
-            subscriptionsUrlProvider.buyUrl
-        }
+        val buyUrl = subscriptionsUrlProvider.buyUrl
+        if (uri == null) return buyUrl
+
+        val buyUri = buyUrl.toUri()
+        val builder = buyUri.buildUpon()
+
+        val query = mergeQueries(buyUri.encodedQuery, uri.encodedQuery)
+        if (!query.isNullOrBlank()) builder.encodedQuery(query)
+
+        val featurePage = featurePageFromPath(uri)
+        if (featurePage != null) builder.appendQueryParameter(FEATURE_PAGE_QUERY_PARAM_KEY, featurePage)
+
+        return builder.build().toString()
+    }
+
+    private fun mergeQueries(
+        buyUrlQuery: String?,
+        incomingQuery: String?,
+    ): String? = when {
+        buyUrlQuery.isNullOrBlank() -> incomingQuery
+        incomingQuery.isNullOrBlank() -> buyUrlQuery
+        else -> "$buyUrlQuery&$incomingQuery"
+    }
+
+    private fun featurePageFromPath(uri: Uri): String? {
+        val explicitPage = uri.getQueryParameter(FEATURE_PAGE_QUERY_PARAM_KEY)
+        if (!explicitPage.isNullOrBlank()) return null
+        return optimizedPaywallFeaturePage(uri)
     }
 }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PaywallPathProvider.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/PaywallPathProvider.kt
@@ -22,12 +22,16 @@ import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dagger.SingleInstanceIn
 import javax.inject.Inject
 
 interface PaywallPathProvider {
     fun getPath(featurePage: String): String?
+
+    fun getFeaturePage(path: String): String?
 }
 
+@SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealPaywallPathProvider @Inject constructor(
     private val subscriptionsFeature: SubscriptionsFeature,
@@ -38,16 +42,49 @@ class RealPaywallPathProvider @Inject constructor(
         moshi.newBuilder().add(KotlinJsonAdapterFactory()).build().adapter(PaywallsSettings::class.java)
     }
 
-    override fun getPath(featurePage: String): String? {
-        val entryPoints = parseSettings()?.entryPoints ?: return null
-        val path = entryPoints[featurePage]?.path ?: return null
-        return path.takeIf { it.isNotBlank() }
+    @Volatile
+    private var cache: CachedPaths? = null
+
+    override fun getPath(featurePage: String): String? = entryPoints()?.pathByFeaturePage?.get(featurePage)
+
+    override fun getFeaturePage(path: String): String? = entryPoints()?.featurePageByPath?.get(path.trimEnd('/'))
+
+    private fun entryPoints(): CachedPaths? {
+        val settings = subscriptionsFeature.performanceOptimizedPaywalls().getSettings() ?: return null
+
+        val cached = cache
+        if (cached != null && cached.settings == settings) return cached
+
+        val parsed = parse(settings)
+        cache = parsed
+        return parsed
     }
 
-    private fun parseSettings(): PaywallsSettings? =
-        subscriptionsFeature.performanceOptimizedPaywalls().getSettings()?.let {
-            runCatching { jsonAdapter.fromJson(it) }.getOrNull()
+    private fun parse(settings: String): CachedPaths {
+        val entryPoints = runCatching { jsonAdapter.fromJson(settings) }.getOrNull()?.entryPoints
+        val pathByFeaturePage = pathsByFeaturePage(entryPoints)
+        val featurePageByPath = pathByFeaturePage.entries.associate { (featurePage, path) -> path to featurePage }
+        return CachedPaths(
+            settings = settings,
+            pathByFeaturePage = pathByFeaturePage,
+            featurePageByPath = featurePageByPath,
+        )
+    }
+
+    private fun pathsByFeaturePage(entryPoints: Map<String, EntryPoint>?): Map<String, String> = buildMap {
+        entryPoints?.forEach { (featurePage, entryPoint) ->
+            val path = entryPoint.path?.trimEnd('/')
+            if (!path.isNullOrBlank()) {
+                put(featurePage, path)
+            }
         }
+    }
+
+    private class CachedPaths(
+        val settings: String,
+        val pathByFeaturePage: Map<String, String>,
+        val featurePageByPath: Map<String, String>,
+    )
 
     private class PaywallsSettings(
         val entryPoints: Map<String, EntryPoint>?,

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
@@ -35,9 +35,12 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.WAITING
 import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.duckduckgo.subscriptions.impl.internal.DefaultSubscriptionsBaseUrl
+import com.duckduckgo.subscriptions.impl.internal.RealPaywallPathProvider
 import com.duckduckgo.subscriptions.impl.internal.RealSubscriptionsUrlProvider
+import com.duckduckgo.subscriptions.impl.internal.SubscriptionsUrlProvider
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionsWebViewActivityWithParams
+import com.squareup.moshi.Moshi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -69,6 +72,14 @@ class RealSubscriptionsTest {
     private val globalActivityStarter: GlobalActivityStarter = mock()
     private val pixel: SubscriptionPixelSender = mock()
     private val subscriptionsUrlProvider = RealSubscriptionsUrlProvider(DefaultSubscriptionsBaseUrl())
+    private val stagingUrlProvider = object : SubscriptionsUrlProvider {
+        override val buyUrl = "https://duckduckgo.com/subscriptions?environment=staging"
+        override val welcomeUrl = ""
+        override val activateUrl = ""
+        override val manageUrl = ""
+        override val plansUrl = ""
+        override val upgradeToProUrl = ""
+    }
     private lateinit var subscriptions: RealSubscriptions
     private val subscriptionFeature: SubscriptionsFeature = FakeFeatureToggleFactory.create(SubscriptionsFeature::class.java)
 
@@ -87,12 +98,18 @@ class RealSubscriptionsTest {
         whenever(mockSubscriptionsManager.canSupportEncryption()).thenReturn(true)
         whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(emptyList())
         subscriptions = RealSubscriptions(
-            mockSubscriptionsManager,
-            globalActivityStarter,
-            pixel,
-            { subscriptionFeature },
-            coroutineRule.testDispatcherProvider,
-            subscriptionsUrlProvider,
+            subscriptionsManager = mockSubscriptionsManager,
+            globalActivityStarter = globalActivityStarter,
+            pixel = pixel,
+            subscriptionsFeature = { subscriptionFeature },
+            dispatcherProvider = coroutineRule.testDispatcherProvider,
+            subscriptionsUrlProvider = subscriptionsUrlProvider,
+            paywallPathProvider = {
+                RealPaywallPathProvider(
+                    subscriptionsFeature = subscriptionFeature,
+                    moshi = Moshi.Builder().build(),
+                )
+            },
         )
     }
 
@@ -363,6 +380,195 @@ class RealSubscriptionsTest {
         assertNull((captor.lastValue as SubscriptionsWebViewActivityWithParams).origin)
     }
 
+    @Test
+    fun whenPerformanceOptimizedPaywallsOnThenConfiguredPathIsASubscriptionUrl() = runTest {
+        givenPerformanceOptimizedPaywalls(enabled = true)
+
+        assertTrue(subscriptions.isSubscriptionUrl("https://duckduckgo.com/subscriptions/new/mobile/vpn".toUri()))
+        assertTrue(subscriptions.isSubscriptionUrl("https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true".toUri()))
+    }
+
+    @Test
+    fun whenPerformanceOptimizedPaywallsOffThenConfiguredPathIsNotASubscriptionUrl() = runTest {
+        givenPerformanceOptimizedPaywalls(enabled = false)
+
+        assertFalse(subscriptions.isSubscriptionUrl("https://duckduckgo.com/subscriptions/new/mobile/vpn".toUri()))
+    }
+
+    @Test
+    fun whenPathIsNotConfiguredThenItIsNotASubscriptionUrl() = runTest {
+        givenPerformanceOptimizedPaywalls(enabled = true)
+
+        assertFalse(subscriptions.isSubscriptionUrl("https://duckduckgo.com/subscriptions/new/mobile/itr".toUri()))
+        assertFalse(subscriptions.isSubscriptionUrl("https://duckduckgo.com/subscriptions/welcome".toUri()))
+    }
+
+    @Test
+    fun whenConfiguredPathIsOnAnotherDomainThenItIsNotASubscriptionUrl() = runTest {
+        givenPerformanceOptimizedPaywalls(enabled = true)
+
+        assertFalse(subscriptions.isSubscriptionUrl("https://example.com/subscriptions/new/mobile/vpn".toUri()))
+    }
+
+    @Test
+    fun whenLaunchingFromAConfiguredPathThenItsFeaturePageIsCarriedToActivity() = runTest {
+        givenPerformanceOptimizedPaywalls(enabled = true)
+        whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
+
+        val captor = argumentCaptor<ActivityParams>()
+        subscriptions.launchSubscription(context, "https://duckduckgo.com/subscriptions/new/mobile/duckai".toUri())
+
+        verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
+        assertEquals(
+            subscriptionsUrlProvider.buyUrl.appendQueryParams("featurePage=duckai"),
+            (captor.lastValue as SubscriptionsWebViewActivityWithParams).url,
+        )
+    }
+
+    @Test
+    fun whenLaunchingFromAConfiguredPathThenOtherParamsAreKept() = runTest {
+        givenPerformanceOptimizedPaywalls(enabled = true)
+        whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
+
+        val captor = argumentCaptor<ActivityParams>()
+        subscriptions.launchSubscription(context, "https://duckduckgo.com/subscriptions/new/mobile/duckai?origin=test".toUri())
+
+        verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
+        val params = captor.lastValue as SubscriptionsWebViewActivityWithParams
+        assertEquals(subscriptionsUrlProvider.buyUrl.appendQueryParams("origin=test&featurePage=duckai"), params.url)
+        assertEquals("test", params.origin)
+    }
+
+    @Test
+    fun whenLaunchingFromAConfiguredPathThatAlreadyStatesFeaturePageThenItIsNotDuplicated() = runTest {
+        givenPerformanceOptimizedPaywalls(enabled = true)
+        whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
+
+        val captor = argumentCaptor<ActivityParams>()
+        subscriptions.launchSubscription(context, "https://duckduckgo.com/subscriptions/new/mobile/duckai?featurePage=duckai".toUri())
+
+        verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
+        assertEquals(
+            subscriptionsUrlProvider.buyUrl.appendQueryParams("featurePage=duckai"),
+            (captor.lastValue as SubscriptionsWebViewActivityWithParams).url,
+        )
+    }
+
+    @Test
+    fun whenLaunchingFromAConfiguredPathThenEncodedParamValuesSurviveIntact() = runTest {
+        givenPerformanceOptimizedPaywalls(enabled = true)
+        whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
+
+        val captor = argumentCaptor<ActivityParams>()
+        subscriptions.launchSubscription(context, "https://duckduckgo.com/subscriptions/new/mobile/duckai?origin=a%26b".toUri())
+
+        verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
+        assertEquals(
+            subscriptionsUrlProvider.buyUrl.appendQueryParams("origin=a%26b&featurePage=duckai"),
+            (captor.lastValue as SubscriptionsWebViewActivityWithParams).url,
+        )
+    }
+
+    @Test
+    fun whenPerformanceOptimizedPaywallsOnThenConfiguredPathLaunchesTheSubscriptionFlow() = runTest {
+        givenPerformanceOptimizedPaywalls(enabled = true)
+        subscriptionFeature.allowPurchase().setRawStoredState(State(true))
+        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
+        whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(UNKNOWN)
+
+        assertTrue(subscriptions.shouldLaunchSubscriptionForUrl("https://duckduckgo.com/subscriptions/new/mobile/vpn"))
+        assertTrue(subscriptions.shouldLaunchSubscriptionForUrl("https://duckduckgo.com/subscriptions/new/mobile/duckai?origin=test"))
+        assertFalse(subscriptions.shouldLaunchSubscriptionForUrl("https://duckduckgo.com/subscriptions/new/mobile/itr"))
+    }
+
+    @Test
+    fun whenPerformanceOptimizedPaywallsOffThenConfiguredPathDoesNotLaunchTheSubscriptionFlow() = runTest {
+        givenPerformanceOptimizedPaywalls(enabled = false)
+        subscriptionFeature.allowPurchase().setRawStoredState(State(true))
+        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
+        whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(UNKNOWN)
+
+        assertFalse(subscriptions.shouldLaunchSubscriptionForUrl("https://duckduckgo.com/subscriptions/new/mobile/vpn"))
+    }
+
+    @Test
+    fun whenLaunchSubscriptionWithNoUriThenBuyUrlIsUsed() = runTest {
+        whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
+
+        val captor = argumentCaptor<ActivityParams>()
+        subscriptions.launchSubscription(context, null)
+
+        verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
+        val params = captor.lastValue as SubscriptionsWebViewActivityWithParams
+        assertEquals(subscriptionsUrlProvider.buyUrl, params.url)
+        assertNull(params.origin)
+    }
+
+    @Test
+    fun whenPerformanceOptimizedPaywallsOffThenNoFeaturePageIsAddedForAConfiguredPath() = runTest {
+        givenPerformanceOptimizedPaywalls(enabled = false)
+        whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
+
+        val captor = argumentCaptor<ActivityParams>()
+        subscriptions.launchSubscription(context, "https://duckduckgo.com/subscriptions/new/mobile/duckai?origin=test".toUri())
+
+        verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
+        assertEquals(
+            subscriptionsUrlProvider.buyUrl.appendQueryParams("origin=test"),
+            (captor.lastValue as SubscriptionsWebViewActivityWithParams).url,
+        )
+    }
+
+    @Test
+    fun whenFeaturePageInQueryIsBlankThenItIsTakenFromThePath() = runTest {
+        givenPerformanceOptimizedPaywalls(enabled = true)
+        whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
+
+        val captor = argumentCaptor<ActivityParams>()
+        subscriptions.launchSubscription(context, "https://duckduckgo.com/subscriptions/new/mobile/duckai?featurePage=".toUri())
+
+        verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
+        assertEquals(
+            subscriptionsUrlProvider.buyUrl.appendQueryParams("featurePage=&featurePage=duckai"),
+            (captor.lastValue as SubscriptionsWebViewActivityWithParams).url,
+        )
+    }
+
+    @Test
+    fun whenBuyUrlAlreadyHasQueryParamsThenTheyAreKept() = runTest {
+        givenPerformanceOptimizedPaywalls(enabled = true)
+        whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
+        val subscriptionsOnStaging = RealSubscriptions(
+            subscriptionsManager = mockSubscriptionsManager,
+            globalActivityStarter = globalActivityStarter,
+            pixel = pixel,
+            subscriptionsFeature = { subscriptionFeature },
+            dispatcherProvider = coroutineRule.testDispatcherProvider,
+            subscriptionsUrlProvider = stagingUrlProvider,
+            paywallPathProvider = {
+                RealPaywallPathProvider(
+                    subscriptionsFeature = subscriptionFeature,
+                    moshi = Moshi.Builder().build(),
+                )
+            },
+        )
+
+        val captor = argumentCaptor<ActivityParams>()
+        subscriptionsOnStaging.launchSubscription(context, "https://duckduckgo.com/subscriptions/new/mobile/duckai?origin=test".toUri())
+
+        verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
+        assertEquals(
+            "https://duckduckgo.com/subscriptions?environment=staging&origin=test&featurePage=duckai",
+            (captor.lastValue as SubscriptionsWebViewActivityWithParams).url,
+        )
+    }
+
+    private fun givenPerformanceOptimizedPaywalls(enabled: Boolean) {
+        subscriptionFeature.performanceOptimizedPaywalls().setRawStoredState(
+            State(remoteEnableState = enabled, settings = ENTRY_POINTS_SETTINGS),
+        )
+    }
+
     private fun fakeIntent(): Intent {
         return Intent().also { it.addFlags(FLAG_ACTIVITY_NEW_TASK) }
     }
@@ -370,5 +576,16 @@ class RealSubscriptionsTest {
     private fun String.appendQueryParams(queryParams: String): String {
         val separator = if (this.contains("?")) "&" else "?"
         return this + separator + queryParams
+    }
+
+    private companion object {
+        val ENTRY_POINTS_SETTINGS = """
+            {
+                "entryPoints": {
+                    "vpn": { "path": "/subscriptions/new/mobile/vpn" },
+                    "duckai": { "path": "/subscriptions/new/mobile/duckai" }
+                }
+            }
+        """.trimIndent()
     }
 }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
@@ -529,7 +529,22 @@ class RealSubscriptionsTest {
 
         verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
         assertEquals(
-            subscriptionsUrlProvider.buyUrl.appendQueryParams("featurePage=&featurePage=duckai"),
+            subscriptionsUrlProvider.buyUrl.appendQueryParams("featurePage=duckai"),
+            (captor.lastValue as SubscriptionsWebViewActivityWithParams).url,
+        )
+    }
+
+    @Test
+    fun whenFeaturePageInQueryIsBlankThenOtherParamsAreKept() = runTest {
+        givenPerformanceOptimizedPaywalls(enabled = true)
+        whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
+
+        val captor = argumentCaptor<ActivityParams>()
+        subscriptions.launchSubscription(context, "https://duckduckgo.com/subscriptions/new/mobile/duckai?featurePage=&origin=test".toUri())
+
+        verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
+        assertEquals(
+            subscriptionsUrlProvider.buyUrl.appendQueryParams("origin=test&featurePage=duckai"),
             (captor.lastValue as SubscriptionsWebViewActivityWithParams).url,
         )
     }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/internal/RealPaywallPathProviderTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/internal/RealPaywallPathProviderTest.kt
@@ -98,6 +98,93 @@ class RealPaywallPathProviderTest {
         assertNull(testee.getPath("vpn"))
     }
 
+    @Test
+    fun whenPathIsConfiguredThenFeaturePageIsReturned() {
+        givenSettings(ENTRY_POINTS_SETTINGS)
+
+        assertEquals("vpn", testee.getFeaturePage("/subscriptions/new/mobile/vpn"))
+        assertEquals("duckai", testee.getFeaturePage("/subscriptions/new/mobile/duckai"))
+        assertEquals("pir", testee.getFeaturePage("/subscriptions/new/mobile/pir"))
+    }
+
+    @Test
+    fun whenPathHasTrailingSlashThenFeaturePageIsReturned() {
+        givenSettings(ENTRY_POINTS_SETTINGS)
+
+        assertEquals("vpn", testee.getFeaturePage("/subscriptions/new/mobile/vpn/"))
+    }
+
+    @Test
+    fun whenConfiguredPathHasTrailingSlashThenItIsNormalized() {
+        givenSettings("""{"entryPoints":{"vpn":{"path":"/subscriptions/new/mobile/vpn/"}}}""")
+
+        assertEquals("/subscriptions/new/mobile/vpn", testee.getPath("vpn"))
+        assertEquals("vpn", testee.getFeaturePage("/subscriptions/new/mobile/vpn"))
+        assertEquals("vpn", testee.getFeaturePage("/subscriptions/new/mobile/vpn/"))
+    }
+
+    @Test
+    fun whenConfiguredPathIsOnlyASlashThenItIsIgnored() {
+        givenSettings("""{"entryPoints":{"vpn":{"path":"/"}}}""")
+
+        assertNull(testee.getPath("vpn"))
+        assertNull(testee.getFeaturePage("/"))
+        assertNull(testee.getFeaturePage(""))
+    }
+
+    @Test
+    fun whenPathIsNotConfiguredThenNoFeaturePage() {
+        givenSettings(ENTRY_POINTS_SETTINGS)
+
+        assertNull(testee.getFeaturePage("/subscriptions/new/mobile/itr"))
+        assertNull(testee.getFeaturePage("/subscriptions"))
+        assertNull(testee.getFeaturePage(""))
+    }
+
+    @Test
+    fun whenFeatureDisabledThenFeaturePageIsStillReturned() {
+        subscriptionsFeature.performanceOptimizedPaywalls().setRawStoredState(
+            State(remoteEnableState = false, settings = ENTRY_POINTS_SETTINGS),
+        )
+
+        assertEquals("vpn", testee.getFeaturePage("/subscriptions/new/mobile/vpn"))
+    }
+
+    @Test
+    fun whenNoSettingsThenNoFeaturePage() {
+        subscriptionsFeature.performanceOptimizedPaywalls().setRawStoredState(State(remoteEnableState = true))
+
+        assertNull(testee.getFeaturePage("/subscriptions/new/mobile/vpn"))
+    }
+
+    @Test
+    fun whenSettingsMalformedThenNoFeaturePage() {
+        givenSettings("not json")
+
+        assertNull(testee.getFeaturePage("/subscriptions/new/mobile/vpn"))
+    }
+
+    @Test
+    fun whenPathBlankThenNoFeaturePage() {
+        givenSettings("""{"entryPoints":{"vpn":{"path":"  "}}}""")
+
+        assertNull(testee.getFeaturePage("  "))
+    }
+
+    @Test
+    fun whenSettingsChangeThenTheNewEntryPointsAreUsed() {
+        givenSettings(ENTRY_POINTS_SETTINGS)
+        assertEquals("/subscriptions/new/mobile/vpn", testee.getPath("vpn"))
+        assertEquals("vpn", testee.getFeaturePage("/subscriptions/new/mobile/vpn"))
+
+        givenSettings("""{"entryPoints":{"vpn":{"path":"/subscriptions/new/mobile/vpn-v2"}}}""")
+
+        assertEquals("/subscriptions/new/mobile/vpn-v2", testee.getPath("vpn"))
+        assertEquals("vpn", testee.getFeaturePage("/subscriptions/new/mobile/vpn-v2"))
+        assertNull(testee.getFeaturePage("/subscriptions/new/mobile/vpn"))
+        assertNull(testee.getPath("duckai"))
+    }
+
     private fun givenSettings(settings: String) {
         subscriptionsFeature.performanceOptimizedPaywalls().setRawStoredState(
             State(remoteEnableState = true, settings = settings),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218361229739464
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description
Makes the app recognize the performance-optimized paywall paths as subscription URLs, so a link straight to one of them opens the purchase screen instead of a plain tab the user cannot buy from.

- The matcher accepted `/pro` and `/subscriptions` with nothing after them, so the new paths fell through. It now also accepts the paths from the flag settings, which keeps them remote-configurable https://github.com/duckduckgo/privacy-configuration/pull/5809
- Params the app does not own, such as `origin`, and any query the buy URL itself carries are both preserved.
- With the flag off, nothing is matched and behavior is unchanged.

### Steps to test this PR
- [x] Apply the pinned staging patch from https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true and install the internal debug build on a device with Google Play. Without offers from Play the paywall URL is never rewritten, so every check below would fail.
- [x] Settings > Internal Features > Feature Flag Inventory, search `performanceOptimizedPaywalls`, turn it on.
- [x] Filter logcat on `SubscriptionsWebViewActivity`. It logs the URL every time the paywall opens, and every check below just reads that line.
- [x] Optional, to see the page render: take the current front end tunnel URL from https://app.asana.com/1/137249556945/task/1216295712277568, put it in Settings > Internal Features > Subscriptions Dev Settings > "Enter the base URL for subscriptions", and Save. The tunnel is temporary.

_A link to a new path opens the purchase screen_
- [x] Open `https://duckduckgo.com/subscriptions/new/mobile/duckai` from the address bar. The purchase screen opens, not a web page in the tab, and the URL is `/subscriptions/new/mobile/duckai` with `trial` and `pir`.
- [x] Repeat with `/subscriptions/new/mobile/vpn`. URL should be `/subscriptions/new/mobile/vpn`.

_Only configured paths_
- [x] Open `https://duckduckgo.com/subscriptions/new/mobile/itr`, which is not in the config. It stays a web page in the tab.

_Params_
- [x] Open `https://duckduckgo.com/subscriptions/new/mobile/duckai?origin=test`. `origin=test` survives onto the loaded URL alongside `trial` and `pir`.

_Old entry points_
- [x] Open `https://duckduckgo.com/pro`. Purchase screen opens, and with no `featurePage` the URL defaults to `/subscriptions/new/mobile/vpn`.
- [x] Open the paywall from Settings > Privacy Pro. Unchanged from #9757.

_Flag off_
- [x] Turn `performanceOptimizedPaywalls` off, open `/subscriptions/new/mobile/duckai` again. It stays a web page in the tab, which is the behaviour on `develop`.
- [x] Open `https://duckduckgo.com/pro`. Purchase screen opens on `/subscriptions`, with no `trial` or `pir`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subscription deep-link routing and paywall URL rewriting behind a feature flag; incorrect matching or query merging could send users to the wrong paywall or break attribution params.
> 
> **Overview**
> When **`performanceOptimizedPaywalls`** is on, deep links to remotely configured paywall paths (e.g. `/subscriptions/new/mobile/vpn`) are treated like `/pro` and `/subscriptions`, so they open the native purchase WebView instead of a normal tab.
> 
> **`isSubscriptionUrl`** and **`shouldLaunchSubscriptionForUrl`** use **`PaywallPathProvider.getFeaturePage`** for those paths; with the flag off, matching stays limited to the legacy single-segment URLs.
> 
> **`buildSubscriptionUrl`** now merges the buy URL’s existing query with the incoming link, maps a configured path to a **`featurePage`** query param (without duplicating an explicit non-blank **`featurePage`**), and preserves params like **`origin`**. **`PaywallPathProvider`** adds reverse path lookup, trailing-slash normalization, and in-memory caching of parsed flag settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e7ddc033425801f36f58b774588522ada7cb8ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->