### PR TITLE
PIR: Add freemium eligibility and feature flag

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirRemoteFeatures.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirRemoteFeatures.kt
@@ -68,6 +68,13 @@ interface PirRemoteFeatures {
      */
     @DefaultValue(DefaultFeatureValue.TRUE)
     fun workQueueScheduling(): Toggle
+
+    /**
+     * Enables Freemium PIR: an activated, unauthenticated user may run scans, but never
+     * opt-outs or maintenance scans.
+     */
+    @DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun freemium(): Toggle
 }
 
 @SingleInstanceIn(AppScope::class)

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/checker/PirEligibility.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/checker/PirEligibility.kt
@@ -17,8 +17,18 @@
 package com.duckduckgo.pir.impl.checker
 
 sealed interface PirEligibility {
-    data object Enabled : PirEligibility
+    data class Enabled(val runMode: PirRunMode) : PirEligibility
     data class Disabled(val reason: DisabledReason) : PirEligibility
+}
+
+/**
+ * What work an eligible user is allowed to run.
+ */
+enum class PirRunMode {
+    SCAN_AND_OPT_OUT,
+
+    /** A freemium user: scans only, never opt-outs and never repeat maintenance scans. */
+    SCAN_ONLY,
 }
 
 enum class DisabledReason {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/checker/PirWorkHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/checker/PirWorkHandler.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.pir.impl.notifications.PirNotificationManager
 import com.duckduckgo.pir.impl.optout.PirForegroundOptOutService
 import com.duckduckgo.pir.impl.scan.PirForegroundScanService
 import com.duckduckgo.pir.impl.scan.PirScanScheduler
+import com.duckduckgo.pir.impl.store.PirFreemiumDataStore
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
@@ -46,11 +47,12 @@ import javax.inject.Inject
  */
 interface PirWorkHandler {
     /**
-     * Checks if PIR can run based on remote features, subscription status, entitlement and
-     * repository availability.
+     * Checks if PIR can run based on remote features, subscription status, entitlement, freemium
+     * activation and repository availability.
      *
-     * @return Flow that emits [PirEligibility.Enabled] when PIR can run, or
-     * [PirEligibility.Disabled] (carrying the failing [DisabledReason]) otherwise.
+     * @return Flow that emits [PirEligibility.Enabled] (carrying the [PirRunMode] the user is
+     * allowed to run) when PIR can run, or [PirEligibility.Disabled] (carrying the failing
+     * [DisabledReason]) otherwise.
      */
     suspend fun canRunPir(): Flow<PirEligibility>
 
@@ -77,6 +79,7 @@ class RealPirWorkHandler @Inject constructor(
     private val pirRepository: PirRepository,
     private val pirNotificationManager: PirNotificationManager,
     private val pirScanWideEvent: PirScanWideEvent,
+    private val pirFreemiumDataStore: PirFreemiumDataStore,
 ) : PirWorkHandler {
 
     override suspend fun canRunPir(): Flow<PirEligibility> {
@@ -129,11 +132,26 @@ class RealPirWorkHandler @Inject constructor(
             -> true
         }
 
-        return when {
-            !subscriptionActive -> PirEligibility.Disabled(DisabledReason.SUBSCRIPTION_EXPIRED)
-            !hasValidEntitlement -> PirEligibility.Disabled(DisabledReason.ENTITLEMENT_LOST)
-            !pirRepository.isRepositoryAvailable() -> PirEligibility.Disabled(DisabledReason.REPOSITORY_UNAVAILABLE)
-            else -> PirEligibility.Enabled
+        // The paid path resolves first so a subscriber is never routed onto the scan-only path.
+        val runMode = when {
+            subscriptionActive && hasValidEntitlement -> PirRunMode.SCAN_AND_OPT_OUT
+            canRunFreemiumScans() -> PirRunMode.SCAN_ONLY
+            else -> null
         }
+
+        return when {
+            runMode == null -> if (subscriptionActive) {
+                PirEligibility.Disabled(DisabledReason.ENTITLEMENT_LOST)
+            } else {
+                PirEligibility.Disabled(DisabledReason.SUBSCRIPTION_EXPIRED)
+            }
+
+            !pirRepository.isRepositoryAvailable() -> PirEligibility.Disabled(DisabledReason.REPOSITORY_UNAVAILABLE)
+            else -> PirEligibility.Enabled(runMode)
+        }
+    }
+
+    private suspend fun canRunFreemiumScans(): Boolean = withContext(dispatcherProvider.io()) {
+        pirRemoteFeatures.freemium().isEnabled() && pirFreemiumDataStore.didActivate
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/di/PirModule.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/di/PirModule.kt
@@ -51,8 +51,10 @@ import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.NavigateRespons
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.SolveCaptchaResponse
 import com.duckduckgo.pir.impl.service.DbpService
 import com.duckduckgo.pir.impl.store.PirDataStore
+import com.duckduckgo.pir.impl.store.PirFreemiumDataStore
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.store.RealPirDataStore
+import com.duckduckgo.pir.impl.store.RealPirFreemiumDataStore
 import com.duckduckgo.pir.impl.store.RealPirRepository
 import com.duckduckgo.pir.impl.store.secure.PirSecureStorageDatabaseFactory
 import com.squareup.anvil.annotations.ContributesTo
@@ -74,6 +76,12 @@ class PirModule {
     fun providePirDataStore(
         sharedPreferencesProvider: SharedPreferencesProvider,
     ): PirDataStore = RealPirDataStore(sharedPreferencesProvider)
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    fun providePirFreemiumDataStore(
+        sharedPreferencesProvider: SharedPreferencesProvider,
+    ): PirFreemiumDataStore = RealPirFreemiumDataStore(sharedPreferencesProvider)
 
     @Provides
     @SingleInstanceIn(AppScope::class)

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirFreemiumDataStore.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirFreemiumDataStore.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.store
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
+
+interface PirFreemiumDataStore {
+    /**
+     * Whether the user has activated freemium PIR by saving a profile through the dashboard.
+     */
+    var didActivate: Boolean
+}
+
+internal class RealPirFreemiumDataStore(
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
+) : PirFreemiumDataStore {
+    private val preferences: SharedPreferences by lazy {
+        sharedPreferencesProvider.getSharedPreferences(
+            FILENAME,
+            multiprocess = true,
+            migrate = false,
+        )
+    }
+
+    override var didActivate: Boolean
+        get() = preferences.getBoolean(KEY_DID_ACTIVATE, false)
+        set(value) {
+            // committed synchronously as both dashboard (:main) and scan (:pir) read it one after another
+            preferences.edit(commit = true) {
+                putBoolean(KEY_DID_ACTIVATE, value)
+            }
+        }
+
+    companion object {
+        private const val FILENAME = "com.duckduckgo.pir.freemium.v1"
+        private const val KEY_DID_ACTIVATE = "KEY_DID_ACTIVATE"
+    }
+}

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserverTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserverTest.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.pir.impl.PirFeatureDataCleaner
 import com.duckduckgo.pir.impl.checker.DisabledReason
 import com.duckduckgo.pir.impl.checker.PirEligibility
+import com.duckduckgo.pir.impl.checker.PirRunMode
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
 import com.duckduckgo.pir.impl.pixels.PirPixelSender
 import com.duckduckgo.pir.impl.scan.PirScanScheduler
@@ -95,7 +96,7 @@ class PirDataUpdateObserverTest {
         // First call (enabled): 0L so featureReceivedMs gets set; second call (disabled): non-zero to trigger cleanup
         whenever(pirRepository.getFeatureReceivedMs()).thenReturn(0L, 1000L)
 
-        canRunPirFlow.value = PirEligibility.Enabled
+        canRunPirFlow.value = PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)
         pirDataUpdateObserver.onCreate(lifecycleOwner)
         verify(brokerJsonUpdater).update()
 
@@ -116,21 +117,21 @@ class PirDataUpdateObserverTest {
         verify(pirFeatureDataCleaner, never()).removeAllData()
 
         // Then enable PIR
-        canRunPirFlow.value = PirEligibility.Enabled
+        canRunPirFlow.value = PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)
         verify(brokerJsonUpdater).update()
     }
 
     @Test
     fun whenOnCreateCalledMultipleTimesAndPIREnabledThenUpdatesBrokerOnce() = runTest {
         whenever(brokerJsonUpdater.update()).thenReturn(true)
-        canRunPirFlow.value = PirEligibility.Enabled
+        canRunPirFlow.value = PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)
 
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
         // MutableStateFlow deduplicates same values, so no additional emissions
-        canRunPirFlow.value = PirEligibility.Enabled
-        canRunPirFlow.value = PirEligibility.Enabled
-        canRunPirFlow.value = PirEligibility.Enabled
+        canRunPirFlow.value = PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)
+        canRunPirFlow.value = PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)
+        canRunPirFlow.value = PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)
 
         verify(brokerJsonUpdater, times(1)).update()
         verifyNoInteractions(pirFeatureDataCleaner)
@@ -148,7 +149,7 @@ class PirDataUpdateObserverTest {
     @Test
     fun whenOnCreateWithPIREnabledThenUpdatesBrokers() = runTest {
         whenever(brokerJsonUpdater.update()).thenReturn(true)
-        canRunPirFlow.value = PirEligibility.Enabled
+        canRunPirFlow.value = PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)
 
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
@@ -161,7 +162,7 @@ class PirDataUpdateObserverTest {
     fun whenPirEnabledAndValidProfileExistsThenReschedulesScans() = runTest {
         whenever(brokerJsonUpdater.update()).thenReturn(true)
         whenever(pirRepository.getValidUserProfileQueries()).thenReturn(listOf(mock()))
-        canRunPirFlow.value = PirEligibility.Enabled
+        canRunPirFlow.value = PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)
 
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
@@ -172,7 +173,7 @@ class PirDataUpdateObserverTest {
     fun whenPirEnabledButNoValidProfileThenDoesNotRescheduleScans() = runTest {
         whenever(brokerJsonUpdater.update()).thenReturn(true)
         whenever(pirRepository.getValidUserProfileQueries()).thenReturn(emptyList())
-        canRunPirFlow.value = PirEligibility.Enabled
+        canRunPirFlow.value = PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)
 
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
@@ -195,7 +196,7 @@ class PirDataUpdateObserverTest {
         whenever(pirRepository.getFeatureReceivedMs()).thenReturn(0L)
         whenever(currentTimeProvider.currentTimeMillis()).thenReturn(12345L)
 
-        canRunPirFlow.value = PirEligibility.Enabled
+        canRunPirFlow.value = PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
         verify(pirRepository).setFeatureReceivedMs(12345L)
@@ -207,7 +208,7 @@ class PirDataUpdateObserverTest {
         // featureReceivedMs already set from a previous session
         whenever(pirRepository.getFeatureReceivedMs()).thenReturn(5000L)
 
-        canRunPirFlow.value = PirEligibility.Enabled
+        canRunPirFlow.value = PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
         verify(pirRepository, never()).setFeatureReceivedMs(any())

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/checker/RealPirWorkHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/checker/RealPirWorkHandlerTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.pir.impl.PirRemoteFeatures
 import com.duckduckgo.pir.impl.notifications.PirNotificationManager
 import com.duckduckgo.pir.impl.scan.PirScanScheduler
+import com.duckduckgo.pir.impl.store.PirFreemiumDataStore
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
@@ -56,12 +57,15 @@ class RealPirWorkHandlerTest {
     private val pirRepository: PirRepository = mock()
     private val pirNotificationManager: PirNotificationManager = mock()
     private val pirScanWideEvent: PirScanWideEvent = mock()
+    private val freemiumToggle: Toggle = mock()
+    private val pirFreemiumDataStore: PirFreemiumDataStore = mock()
 
     private lateinit var pirWorkHandler: RealPirWorkHandler
 
     @Before
     fun setUp() = runTest {
         whenever(pirRemoteFeatures.pirBeta()).thenReturn(pirBetaToggle)
+        whenever(pirRemoteFeatures.freemium()).thenReturn(freemiumToggle)
         whenever(pirRepository.isRepositoryAvailable()).thenReturn(true)
 
         pirWorkHandler = RealPirWorkHandler(
@@ -73,6 +77,7 @@ class RealPirWorkHandlerTest {
             pirRepository = pirRepository,
             pirNotificationManager = pirNotificationManager,
             pirScanWideEvent = pirScanWideEvent,
+            pirFreemiumDataStore = pirFreemiumDataStore,
         )
     }
 
@@ -106,7 +111,7 @@ class RealPirWorkHandlerTest {
             whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
 
             pirWorkHandler.canRunPir().test {
-                assertEquals(PirEligibility.Enabled, awaitItem())
+                assertEquals(PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT), awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -119,7 +124,7 @@ class RealPirWorkHandlerTest {
             whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.NOT_AUTO_RENEWABLE))
 
             pirWorkHandler.canRunPir().test {
-                assertEquals(PirEligibility.Enabled, awaitItem())
+                assertEquals(PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT), awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -132,7 +137,7 @@ class RealPirWorkHandlerTest {
             whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.GRACE_PERIOD))
 
             pirWorkHandler.canRunPir().test {
-                assertEquals(PirEligibility.Enabled, awaitItem())
+                assertEquals(PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT), awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -226,7 +231,7 @@ class RealPirWorkHandlerTest {
 
             pirWorkHandler.canRunPir().test {
                 // Initially enabled
-                assertEquals(PirEligibility.Enabled, awaitItem())
+                assertEquals(PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT), awaitItem())
 
                 // Remove PIR entitlement
                 entitlementFlow.value = emptyList()
@@ -234,7 +239,7 @@ class RealPirWorkHandlerTest {
 
                 // Add PIR entitlement back
                 entitlementFlow.value = listOf(Product.PIR)
-                assertEquals(PirEligibility.Enabled, awaitItem())
+                assertEquals(PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT), awaitItem())
 
                 cancelAndIgnoreRemainingEvents()
             }
@@ -250,7 +255,7 @@ class RealPirWorkHandlerTest {
 
         pirWorkHandler.canRunPir().test {
             // Initially enabled
-            assertEquals(PirEligibility.Enabled, awaitItem())
+            assertEquals(PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT), awaitItem())
 
             // Emit same value multiple times - should only get one emission due to distinctUntilChanged
             entitlementFlow.value = listOf(Product.PIR)
@@ -274,6 +279,103 @@ class RealPirWorkHandlerTest {
         pirWorkHandler.canRunPir().test {
             assertEquals(PirEligibility.Disabled(DisabledReason.REPOSITORY_UNAVAILABLE), awaitItem())
             cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenFreemiumEnabledAndActivatedAndNoSubscriptionThenCanRunPirEnabledWithScanOnly() = runTest {
+        whenever(pirBetaToggle.isEnabled()).thenReturn(true)
+        whenever(freemiumToggle.isEnabled()).thenReturn(true)
+        whenever(pirFreemiumDataStore.didActivate).thenReturn(true)
+        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
+        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.INACTIVE))
+
+        pirWorkHandler.canRunPir().test {
+            assertEquals(PirEligibility.Enabled(PirRunMode.SCAN_ONLY), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenFreemiumEnabledAndActivatedButAlsoPirEntitledThenCanRunPirEnabledWithScanAndOptOut() = runTest {
+        whenever(pirBetaToggle.isEnabled()).thenReturn(true)
+        whenever(freemiumToggle.isEnabled()).thenReturn(true)
+        whenever(pirFreemiumDataStore.didActivate).thenReturn(true)
+        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
+        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
+
+        pirWorkHandler.canRunPir().test {
+            assertEquals(PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenFreemiumEnabledAndActivatedAndSubscribedButNotPirEntitledThenCanRunPirEnabledWithScanOnly() = runTest {
+        whenever(pirBetaToggle.isEnabled()).thenReturn(true)
+        whenever(freemiumToggle.isEnabled()).thenReturn(true)
+        whenever(pirFreemiumDataStore.didActivate).thenReturn(true)
+        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.NetP)))
+        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
+
+        pirWorkHandler.canRunPir().test {
+            assertEquals(PirEligibility.Enabled(PirRunMode.SCAN_ONLY), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenFreemiumDisabledButActivatedAndNoSubscriptionThenCanRunPirDisabledWithSubscriptionExpired() = runTest {
+        whenever(pirBetaToggle.isEnabled()).thenReturn(true)
+        whenever(freemiumToggle.isEnabled()).thenReturn(false)
+        whenever(pirFreemiumDataStore.didActivate).thenReturn(true)
+        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
+        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.INACTIVE))
+
+        pirWorkHandler.canRunPir().test {
+            assertEquals(PirEligibility.Disabled(DisabledReason.SUBSCRIPTION_EXPIRED), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenFreemiumEnabledButNotActivatedAndNoSubscriptionThenCanRunPirDisabledWithSubscriptionExpired() = runTest {
+        whenever(pirBetaToggle.isEnabled()).thenReturn(true)
+        whenever(freemiumToggle.isEnabled()).thenReturn(true)
+        whenever(pirFreemiumDataStore.didActivate).thenReturn(false)
+        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
+        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.INACTIVE))
+
+        pirWorkHandler.canRunPir().test {
+            assertEquals(PirEligibility.Disabled(DisabledReason.SUBSCRIPTION_EXPIRED), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenFreemiumEnabledAndActivatedButRepositoryNotAvailableThenCanRunPirDisabledWithRepositoryUnavailable() = runTest {
+        whenever(pirBetaToggle.isEnabled()).thenReturn(true)
+        whenever(freemiumToggle.isEnabled()).thenReturn(true)
+        whenever(pirFreemiumDataStore.didActivate).thenReturn(true)
+        whenever(pirRepository.isRepositoryAvailable()).thenReturn(false)
+        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
+        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.INACTIVE))
+
+        pirWorkHandler.canRunPir().test {
+            assertEquals(PirEligibility.Disabled(DisabledReason.REPOSITORY_UNAVAILABLE), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenPirBetaDisabledAndFreemiumActivatedThenCanRunPirDisabledWithFeatureDisabled() = runTest {
+        whenever(pirBetaToggle.isEnabled()).thenReturn(false)
+        whenever(freemiumToggle.isEnabled()).thenReturn(true)
+        whenever(pirFreemiumDataStore.didActivate).thenReturn(true)
+
+        pirWorkHandler.canRunPir().test {
+            assertEquals(PirEligibility.Disabled(DisabledReason.FEATURE_DISABLED), awaitItem())
+            awaitComplete()
         }
     }
 

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/RealPirUserUtilsTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/RealPirUserUtilsTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.pir.impl
 
 import com.duckduckgo.pir.impl.checker.DisabledReason
 import com.duckduckgo.pir.impl.checker.PirEligibility
+import com.duckduckgo.pir.impl.checker.PirRunMode
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
 import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.store.PirRepository
@@ -61,7 +62,7 @@ class RealPirUserUtilsTest {
 
     @Test
     fun whenCanRunPirAndHasProfileQueriesThenIsActiveUserReturnsTrue() = runTest {
-        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Enabled))
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)))
         whenever(mockPirRepository.getValidUserProfileQueries()).thenReturn(listOf(testProfileQuery))
 
         val result = testee.isActiveUser()
@@ -81,7 +82,7 @@ class RealPirUserUtilsTest {
 
     @Test
     fun whenCanRunPirButNoProfileQueriesThenIsActiveUserReturnsFalse() = runTest {
-        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Enabled))
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)))
         whenever(mockPirRepository.getValidUserProfileQueries()).thenReturn(emptyList())
 
         val result = testee.isActiveUser()
@@ -123,7 +124,7 @@ class RealPirUserUtilsTest {
             age = 38,
             deprecated = false,
         )
-        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Enabled))
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)))
         whenever(mockPirRepository.getValidUserProfileQueries()).thenReturn(listOf(testProfileQuery, profileQuery2))
 
         val result = testee.isActiveUser()

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scan/PirScheduledScanRemoteWorkerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scan/PirScheduledScanRemoteWorkerTest.kt
@@ -22,6 +22,7 @@ import androidx.work.testing.TestListenableWorkerBuilder
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.pir.impl.PirFeatureDataCleaner
 import com.duckduckgo.pir.impl.checker.PirEligibility
+import com.duckduckgo.pir.impl.checker.PirRunMode
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
 import com.duckduckgo.pir.impl.scheduling.PirJobsRunner
 import kotlinx.coroutines.flow.flowOf
@@ -64,7 +65,7 @@ class PirScheduledScanRemoteWorkerTest {
 
     @Test
     fun whenForegroundScanServiceRunningThenSkipsRunWithSuccessWithoutRunningJobs() = runTest {
-        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Enabled))
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)))
         whenever(mockMonitor.isRunning()).thenReturn(true)
 
         val result = buildWorker().doRemoteWork()
@@ -75,7 +76,7 @@ class PirScheduledScanRemoteWorkerTest {
 
     @Test
     fun whenForegroundScanServiceNotRunningThenRunsEligibleJobs() = runTest {
-        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Enabled))
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)))
         whenever(mockMonitor.isRunning()).thenReturn(false)
         whenever(mockPirJobsRunner.runEligibleJobs(any(), any())).thenReturn(kotlin.Result.success(Unit))
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1213684502971022?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1203581873609357/task/1213689395263676?focus=true
API Proposals URL(s) (if applicable): N/A

### Description
- Adds a new feature flag for PIR Freemium that's enabled by default for internal builds. 
- Adds storing of PIR Freemium activated state
- Updates PIR eligibility checks to account for the feature flag and stored activated state

Out of scope:
- Writing the activated flag will be done later

### Steps to test this PR

_Verify PIR entry point behaves correctly_
- [ ] Remove existing subscription
- [ ] Install this build
- [ ] Verify you don't see PIR entry point
- [ ] Add subscription
- [ ] Verify you still see the PIR entry point and it opens the PIR Web dashboard

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subscription gating and eligibility semantics for PIR; incorrect precedence could let freemium users run paid work or block subscribers until follow-up run-mode enforcement lands.
> 
> **Overview**
> Introduces **freemium PIR** behind a new internal-default `freemium()` remote toggle and a `PirFreemiumDataStore` that persists whether the user activated freemium (read path only in this PR; setting `didActivate` is deferred).
> 
> `canRunPir()` no longer returns a bare enabled/disabled: **`PirEligibility.Enabled` now carries `PirRunMode`** (`SCAN_AND_OPT_OUT` for active PIR subscribers, `SCAN_ONLY` when the freemium flag is on and the user has activated). Paid entitlement is resolved **before** freemium so subscribers are never downgraded to scan-only. Users without subscription or PIR entitlement can still become eligible via freemium instead of always getting `SUBSCRIPTION_EXPIRED` / `ENTITLEMENT_LOST`.
> 
> Tests are updated for the new `Enabled(runMode)` shape and add coverage for freemium vs subscription precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3866103d9ee8bebb1dc717cc1df08274307075d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->