### PR TITLE
PIR: Handle freemium web handshake

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandler.kt
@@ -24,6 +24,10 @@ import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.js.messaging.api.JsMessage
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.pir.impl.PirRemoteFeatures
+import com.duckduckgo.pir.impl.checker.PirEligibility
+import com.duckduckgo.pir.impl.checker.PirRunMode
+import com.duckduckgo.pir.impl.checker.PirWorkHandler
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse
 import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
@@ -32,9 +36,11 @@ import com.duckduckgo.pir.impl.scan.PirForegroundScanService
 import com.duckduckgo.pir.impl.scan.PirScanScheduler
 import com.duckduckgo.pir.impl.scheduling.JobRecordUpdater
 import com.duckduckgo.pir.impl.scheduling.PirExecutionType
+import com.duckduckgo.pir.impl.store.PirFreemiumDataStore
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import logcat.logcat
 import javax.inject.Inject
@@ -55,6 +61,9 @@ class PirWebSaveProfileMessageHandler @Inject constructor(
     private val currentTimeProvider: CurrentTimeProvider,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val jobRecordUpdater: JobRecordUpdater,
+    private val pirWorkHandler: PirWorkHandler,
+    private val pirRemoteFeatures: PirRemoteFeatures,
+    private val pirFreemiumDataStore: PirFreemiumDataStore,
 ) : PirWebJsMessageHandler() {
 
     override val message = PirDashboardWebMessages.SAVE_PROFILE
@@ -101,6 +110,10 @@ class PirWebSaveProfileMessageHandler @Inject constructor(
             } else {
                 PirExecutionType.MANUAL_INITIAL
             }
+
+            // must be stored before the scan starts, as the scan service resolves eligibility again
+            // and a free user is only allowed to scan once activated
+            storeFreemiumActivation()
 
             // start the initial scan at this point as startScanAndOptOut message is not reliable
             startAndScheduleInitialScan(executionType)
@@ -177,6 +190,20 @@ class PirWebSaveProfileMessageHandler @Inject constructor(
             if (profileQueriesToUpdate.isNotEmpty()) {
                 jobRecordUpdater.removeScanJobRecordsWithNoMatchesForProfiles(profileQueriesToUpdate.map { it.id })
             }
+        }
+    }
+
+    /**
+     * A user who saves a profile while unable to run opt-outs is activating freemium PIR, which is
+     * what later grants them scan-only runs.
+     */
+    private suspend fun storeFreemiumActivation() {
+        val eligibility = pirWorkHandler.canRunPir().firstOrNull()
+        val canAlreadyRunOptOuts = (eligibility as? PirEligibility.Enabled)?.runMode == PirRunMode.SCAN_AND_OPT_OUT
+
+        if (!canAlreadyRunOptOuts && pirRemoteFeatures.freemium().isEnabled()) {
+            logcat { "PIR-WEB: PirWebSaveProfileMessageHandler: activating freemium" }
+            pirFreemiumDataStore.didActivate = true
         }
     }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/model/PirWebMessageResponse.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/model/PirWebMessageResponse.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.pir.impl.dashboard.messaging.model
 
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebConstants
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse.GetDataBrokersResponse.DataBroker
+import com.squareup.moshi.Json
 
 /**
  * Represents the response body sent by the client back to the JS layer in Pir Web UI.
@@ -36,7 +37,7 @@ sealed interface PirWebMessageResponse {
 
     data class HandshakeResponse(
         val success: Boolean,
-        val userData: UserData,
+        @Json(name = "userdata") val userData: UserData,
         val version: Int = PirDashboardWebConstants.SCRIPT_API_VERSION,
     ) : PirWebMessageResponse {
 

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebHandshakeMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebHandshakeMessageHandlerTest.kt
@@ -147,8 +147,8 @@ class PirWebHandshakeMessageHandlerTest {
         assertTrue(callbackData.params.has("success"))
         assertEquals(true, callbackData.params.getBoolean("success"))
 
-        assertTrue(callbackData.params.has("userData"))
-        val userData = callbackData.params.getJSONObject("userData")
+        assertTrue(callbackData.params.has("userdata"))
+        val userData = callbackData.params.getJSONObject("userdata")
 
         assertTrue(userData.has("isAuthenticatedUser"))
         assertEquals(isAuthenticated, userData.getBoolean("isAuthenticatedUser"))

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandlerTest.kt
@@ -21,8 +21,14 @@ import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.pir.impl.PirRemoteFeatures
+import com.duckduckgo.pir.impl.checker.DisabledReason
+import com.duckduckgo.pir.impl.checker.PirEligibility
+import com.duckduckgo.pir.impl.checker.PirRunMode
+import com.duckduckgo.pir.impl.checker.PirWorkHandler
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages.SAVE_PROFILE
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.createJsMessage
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.verifyResponse
@@ -34,7 +40,9 @@ import com.duckduckgo.pir.impl.scan.PirForegroundScanService
 import com.duckduckgo.pir.impl.scan.PirScanScheduler
 import com.duckduckgo.pir.impl.scheduling.JobRecordUpdater
 import com.duckduckgo.pir.impl.scheduling.PirExecutionType
+import com.duckduckgo.pir.impl.store.PirFreemiumDataStore
 import com.duckduckgo.pir.impl.store.PirRepository
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -44,6 +52,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -66,11 +75,19 @@ class PirWebSaveProfileMessageHandlerTest {
     private val mockJsMessaging: JsMessaging = mock()
     private val mockJsMessageCallback: JsMessageCallback = mock()
     private val mockJobRecordUpdater: JobRecordUpdater = mock()
+    private val mockPirWorkHandler: PirWorkHandler = mock()
+    private val mockPirRemoteFeatures: PirRemoteFeatures = mock()
+    private val mockFreemiumToggle: Toggle = mock()
+    private val mockPirFreemiumDataStore: PirFreemiumDataStore = mock()
     private val testScope = TestScope()
 
     @Before
     fun setUp() = runTest {
         whenever(mockRepository.getAllUserProfileQueries()).thenReturn(emptyList())
+        whenever(mockPirRemoteFeatures.freemium()).thenReturn(mockFreemiumToggle)
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(
+            flowOf(PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)),
+        )
 
         testee = PirWebSaveProfileMessageHandler(
             pirWebProfileStateHolder = mockPirWebProfileStateHolder,
@@ -81,6 +98,9 @@ class PirWebSaveProfileMessageHandlerTest {
             currentTimeProvider = mockCurrentTimeProvider,
             appCoroutineScope = testScope,
             jobRecordUpdater = mockJobRecordUpdater,
+            pirWorkHandler = mockPirWorkHandler,
+            pirRemoteFeatures = mockPirRemoteFeatures,
+            pirFreemiumDataStore = mockPirFreemiumDataStore,
         )
     }
 
@@ -627,6 +647,89 @@ class PirWebSaveProfileMessageHandlerTest {
             age = 35,
             deprecated = false,
         )
+    }
+
+    @Test
+    fun whenSaveSucceedsAndUserCannotRunOptOutsAndFreemiumEnabledThenStoresActivationBeforeStartingScan() = runTest {
+        // Given
+        val jsMessage = createJsMessage("""""", SAVE_PROFILE)
+        givenSuccessfulProfileSave()
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(
+            flowOf(PirEligibility.Disabled(DisabledReason.SUBSCRIPTION_EXPIRED)),
+        )
+        whenever(mockFreemiumToggle.isEnabled()).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then the scan service resolves eligibility again, so activation has to be stored first
+        inOrder(mockPirFreemiumDataStore, mockContext) {
+            verify(mockPirFreemiumDataStore).didActivate = true
+            verify(mockContext).startForegroundService(any())
+        }
+    }
+
+    @Test
+    fun whenSaveSucceedsAndUserCanAlreadyRunOptOutsThenDoesNotStoreActivation() = runTest {
+        // Given
+        val jsMessage = createJsMessage("""""", SAVE_PROFILE)
+        givenSuccessfulProfileSave()
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(
+            flowOf(PirEligibility.Enabled(PirRunMode.SCAN_AND_OPT_OUT)),
+        )
+        whenever(mockFreemiumToggle.isEnabled()).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirFreemiumDataStore, never()).didActivate = any()
+        verifyStartAndScheduleInitialScan(PirExecutionType.MANUAL_INITIAL)
+    }
+
+    @Test
+    fun whenSaveSucceedsAndUserCannotRunOptOutsButFreemiumDisabledThenDoesNotStoreActivation() = runTest {
+        // Given
+        val jsMessage = createJsMessage("""""", SAVE_PROFILE)
+        givenSuccessfulProfileSave()
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(
+            flowOf(PirEligibility.Disabled(DisabledReason.SUBSCRIPTION_EXPIRED)),
+        )
+        whenever(mockFreemiumToggle.isEnabled()).thenReturn(false)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirFreemiumDataStore, never()).didActivate = any()
+    }
+
+    @Test
+    fun whenSaveFailsThenDoesNotStoreActivation() = runTest {
+        // Given
+        val jsMessage = createJsMessage("""""", SAVE_PROFILE)
+        givenSuccessfulProfileSave()
+        whenever(mockRepository.updateProfileQueries(any(), any(), any())).thenReturn(false)
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(
+            flowOf(PirEligibility.Disabled(DisabledReason.SUBSCRIPTION_EXPIRED)),
+        )
+        whenever(mockFreemiumToggle.isEnabled()).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirFreemiumDataStore, never()).didActivate = any()
+    }
+
+    private suspend fun givenSuccessfulProfileSave() {
+        val currentYear = 2025
+        whenever(mockPirWebProfileStateHolder.isProfileComplete).thenReturn(true)
+        whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(LocalDateTime.of(currentYear, 6, 15, 10, 30))
+        whenever(mockPirWebProfileStateHolder.toProfileQueries(currentYear)).thenReturn(listOf(createProfileQuery()))
+        whenever(mockRepository.getValidUserProfileQueries()).thenReturn(emptyList())
+        whenever(mockRepository.getAllExtractedProfiles()).thenReturn(emptyList())
+        whenever(mockRepository.updateProfileQueries(any(), any(), any())).thenReturn(true)
     }
 
     private fun verifyStartAndScheduleInitialScan(expectedExecutionType: PirExecutionType) {

--- a/pir/pir-internal/build.gradle
+++ b/pir/pir-internal/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation project(':di')
     implementation project(':internal-features-api')
     implementation project(':navigation-api')
+    implementation project(':pir-api')
     implementation project(':pir-impl')
     implementation "com.squareup.logcat:logcat:_"
 

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevSettingsActivity.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevSettingsActivity.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
+import com.duckduckgo.pir.api.dashboard.PirDashboardWebViewScreen
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
 import com.duckduckgo.pir.impl.checker.isEnabled
 import com.duckduckgo.pir.impl.dashboard.PirDashboardUrlProvider
@@ -88,6 +89,12 @@ class PirDevSettingsActivity : DuckDuckGoActivity() {
     }
 
     private fun setupViews() {
+        // intentionally not gated on canRunPir(): this exists so a non-subscriber can reach the
+        // dashboard while the subscription-gated entry point is hidden for them
+        binding.pirOpenDashboard.setOnClickListener {
+            globalActivityStarter.start(this, PirDashboardWebViewScreen)
+        }
+
         binding.pirDebugScan.setOnClickListener {
             globalActivityStarter.start(this, PirDevScanScreenNoParams)
         }

--- a/pir/pir-internal/src/main/res/layout/activity_pir_internal_settings.xml
+++ b/pir/pir-internal/src/main/res/layout/activity_pir_internal_settings.xml
@@ -52,6 +52,12 @@
             android:paddingBottom="@dimen/keyline_4">
 
             <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/pirOpenDashboard"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/pirDevOpenDashboard" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
                 android:id="@+id/pirDebugScan"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/pir/pir-internal/src/main/res/values/donottranslate.xml
+++ b/pir/pir-internal/src/main/res/values/donottranslate.xml
@@ -17,6 +17,7 @@
 <resources>
     <string name="pirDevSettings">Pir Dev Settings</string>
     <string name="pirDevSettingsScan">PIR Scan</string>
+    <string name="pirDevOpenDashboard">Open PIR Dashboard</string>
     <string name="pirDevScanTitle">PIR Dev Scan</string>
     <string name="pirDevOptOutTitle">PIR Dev Opt-out</string>
     <string name="pirDevDebugOptOutTitle">PIR Dev Debug Opt-out</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1217677745393122?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1203581873609357/task/1213689395263676?focus=true
API Proposals URL(s) (if applicable): N/A

### Description
- Handles handshake between Web and Native to correctly display Freemium state
- Adds a button to PIR Dev Settings to launch PIR Dashboard without having a subscription entry point

### Steps to test this PR

_Verify Freemium screen is displayed at start of PIR onboarding when no subscription_
- [ ] Ensure no active subscription
- [ ] Open PIR Dev Settings
- [ ] Click Open PIR Dashboard
- [ ] Verify you see the Freemium screen and not typical first onboarding screen

_Verify subscription entry point is unchanged_
- [ ] Ensure you have an active subscription
- [ ] Open PIR dashboard from setting entry point
- [ ] Verify you see the typical first onboarding screen and not the freemium one

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PIR eligibility timing (freemium flag before scan) and the web handshake JSON contract; incorrect ordering or serialization could block scans or show wrong onboarding.
> 
> **Overview**
> Aligns native↔web PIR messaging for freemium onboarding and records when a non-subscriber activates freemium by saving a profile.
> 
> **Handshake JSON:** `HandshakeResponse` now serializes `userData` as **`userdata`** (Moshi `@Json(name = "userdata")`), matching what the web UI expects; handshake tests were updated accordingly.
> 
> **Freemium activation on save:** After a successful profile save, `PirWebSaveProfileMessageHandler` calls `storeFreemiumActivation()` **before** starting the foreground scan. If the user cannot run opt-outs, the freemium remote toggle is on, and they are not already in `SCAN_AND_OPT_OUT` mode, it sets `PirFreemiumDataStore.didActivate = true` so the scan service’s eligibility check allows scan-only freemium runs. New unit tests cover activation ordering, opt-out eligibility, toggle off, and failed saves.
> 
> **Dev tooling:** PIR internal dev settings add an **Open PIR Dashboard** entry (not gated on `canRunPir()`) so non-subscribers can reach the web dashboard when the production entry point is hidden; `pir-api` is added as a dependency for `PirDashboardWebViewScreen`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0af53a5dc35280bfee9a3e06043d9a39d8c1e9b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->