### PR TITLE
Align input text with bottom row icons

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1240,8 +1240,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun removeMargins() {
+        // Keeps the text aligned with the bottom row icon glyphs
         inputField.updateLayoutParams<MarginLayoutParams> {
-            marginStart = 0
+            marginStart = resources.getDimensionPixelSize(R.dimen.nativeInputFieldStartMargin)
         }
         inputScreenButtonsContainer.updateLayoutParams<MarginLayoutParams> {
             marginEnd = 0

--- a/duckchat/duckchat-impl/src/main/res/values/dimens.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/dimens.xml
@@ -30,6 +30,9 @@
     <dimen name="nativeInputMenuWidth">260dp</dimen>
     <dimen name="nativeInputButtonSize">36dp</dimen>
 
+    <!-- Added to keyline_0 so the input text aligns with the bottom row icon glyphs -->
+    <dimen name="nativeInputFieldStartMargin">6dp</dimen>
+
     <!-- Width of the contextual sheet "recent chats" popup menu. Wider than the default popupMenuWidth (200dp) to fit chat titles. -->
     <dimen name="contextualChatsPopupMenuWidth">280dp</dimen>
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1157893581871903/task/1217495363527447
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

The input screen zeroed the input field's start margin, so the hint and typed text sat 6dp left of the attach and options icons in the row below, which are 20dp glyphs centred in a 36dp touch target. This restores a 6dp start margin on top of the row's 2dp padding, putting the text on the same vertical line as the icon artwork as it is on iOS. The margin is applied in `removeMargins()`, which runs from `onAttachedToWindow`, so the contextual sheet and edit prompt widgets pick up the same alignment.

### Steps to test this PR

_Input screen alignment_
- [ ] Tap the omnibar and switch to the Duck.ai tab
- [ ] Confirm the "Ask anything privately…" text starts on the same vertical line as the paperclip icon below it
- [ ] Repeat with the address bar in bottom position
- [ ] Open the Duck.ai contextual sheet from a web page and confirm the text lines up there too

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="1080" height="2400" alt="image 16" src="https://github.com/user-attachments/assets/3ef74d52-5620-47c4-8aab-1b10380e5aef" />|<img width="1080" height="2424" alt="pr_input_alignment" src="https://github.com/user-attachments/assets/db9aa278-0598-4784-8e00-8d56a08026c2" />|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only margin change on the native input widget with no logic, API, or data-handling impact.
> 
> **Overview**
> Restores **6dp start margin** on the Duck.ai native input field so hint and typed text line up vertically with the bottom-row icon glyphs (attach, options, etc.), matching iOS.
> 
> Previously `removeMargins()` set `marginStart` to **0**, which left text ~6dp left of the icons in their 36dp touch targets. The margin now comes from a new `nativeInputFieldStartMargin` dimen and is still applied in `removeMargins()` during attach, so the main input screen, contextual sheet, and edit-prompt surfaces share the same alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 569f62f54b9fd37e98097f873cba10cdcabc0250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->