### PR TITLE
Update action-maestro-cloud to v3

### DIFF
--- a/.github/actions/maestro-cloud-asana-reporter/action.yml
+++ b/.github/actions/maestro-cloud-asana-reporter/action.yml
@@ -79,7 +79,7 @@ runs:
   steps:
     - name: Run Maestro Cloud
       id: maestro-run
-      uses: mobile-dev-inc/action-maestro-cloud@v1.9.8
+      uses: mobile-dev-inc/action-maestro-cloud@v3.0.1
       with:
         api-key: ${{ inputs.maestro_api_key }}
         project-id: ${{ inputs.maestro_project_id }}
@@ -87,7 +87,7 @@ runs:
         timeout: ${{ inputs.maestro_timeout }}
         app-file: ${{ inputs.maestro_app_binary_id == '' && inputs.maestro_app_file || '' }}
         app-binary-id: ${{ inputs.maestro_app_binary_id != '' && inputs.maestro_app_binary_id || '' }}
-        android-api-level: ${{ inputs.maestro_api_level }}
+        device-os: android-${{ inputs.maestro_api_level }}
         workspace: .maestro
         include-tags: ${{ inputs.maestro_include_tags }}
         env: ${{ inputs.maestro_env }}

--- a/.github/workflows/design-system-composable-pr-test.yml
+++ b/.github/workflows/design-system-composable-pr-test.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run Design System Maestro Tests
         id: maestro-run
-        uses: mobile-dev-inc/action-maestro-cloud@v1.9.8
+        uses: mobile-dev-inc/action-maestro-cloud@v3.0.1
         timeout-minutes: 30
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
@@ -71,7 +71,7 @@ jobs:
           name: design_system_pr_${{ github.event.pull_request.number }}_${{ github.sha }}
           timeout: 15
           app-file: apk/internal.apk
-          android-api-level: 30
+          device-os: android-30
           workspace: .maestro
           include-tags: androidDesignSystemTest
 

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -35,14 +35,14 @@ jobs:
 
       - name: Maestro tests flows
         id: release-tests
-        uses: mobile-dev-inc/action-maestro-cloud@v1.9.8
+        uses: mobile-dev-inc/action-maestro-cloud@v3.0.1
         timeout-minutes: 120
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: ${{ steps.assemble.outputs.play_apk_path }}
-          android-api-level: 30
+          device-os: android-30
           workspace: .maestro
           include-tags: releaseTest
 

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -1,7 +1,3 @@
-appStartup:
-  enabled: false
-appSize:
-  enabled: false
 disableRetries: false
 
 flows:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216661206348410?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable): None

### Description

This is @Fishbowler's work from #9229, re-created as an internal branch so all checks can run. Dan's from the Maestro team and noticed we were still on `action-maestro-cloud` v1.9.8 and passing a field they've since deprecated.

### Steps to test this PR

Nothing to check on device, it's all CI plumbing. I've run sanity checks already and they ran successfully 
- [binaryUpload](https://github.com/duckduckgo/Android/actions/runs/34587191612)
- [releaseTest](https://github.com/duckduckgo/Android/actions/runs/34594172938)
- [androidDesignSystemTest](https://github.com/duckduckgo/Android/actions/runs/34605215919)


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Maestro action and config updates; no app runtime or security-sensitive code paths.
> 
> **Overview**
> Upgrades **Maestro Cloud** GitHub integration from `action-maestro-cloud` **v1.9.8 → v3.0.1** in the composite Asana reporter action and in the design-system PR and ad-hoc release test workflows.
> 
> Replaces the deprecated **`android-api-level`** input with **`device-os`** (e.g. `android-30` or `android-${{ inputs.maestro_api_level }}` in the reporter). Drops **`appStartup`** and **`appSize`** disabled flags from `.maestro/config.yaml`, leaving retries and flow globs unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c52fd8effca0e00155df6346a10b133693af82d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->