### PR TITLE
Onboarding: Disable Fire Button highlight if Trackers Blocked dialog is showing

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -753,16 +753,32 @@ class BrowserTabViewModel @Inject constructor(
 
     private val fireproofWebsiteState: LiveData<List<FireproofWebsiteEntity>> = fireproofWebsiteRepository.getFireproofWebsites()
 
+    private enum class PulseCtaEffect { FORCES, SUPPRESSES, NEUTRAL }
+
     @ExperimentalCoroutinesApi
     @FlowPreview
     private val showPulseAnimation: LiveData<Boolean> =
         combine(
-            ctaViewState.asFlow().map {
-                it.cta is OnboardingDaxDialogCta.DaxDuckAiFireButtonCta || it.cta is DaxDuckAiFireButtonBrandDesignUpdateContextualCta
+            ctaViewState.asFlow().map { state ->
+                when {
+                    // The trackers dialog points at the privacy shield; a fire pulse would compete.
+                    state.cta is OnboardingDaxDialogCta.DaxTrackersBlockedCta ||
+                        state.cta is DaxTrackersBlockedBrandDesignUpdateContextualCta -> PulseCtaEffect.SUPPRESSES
+
+                    state.cta is OnboardingDaxDialogCta.DaxDuckAiFireButtonCta ||
+                        state.cta is DaxDuckAiFireButtonBrandDesignUpdateContextualCta -> PulseCtaEffect.FORCES
+
+                    else -> PulseCtaEffect.NEUTRAL
+                }
             }.distinctUntilChanged(),
             ctaViewModel.showFireButtonPulseAnimation,
-        ) { isShowingDuckAiFireButtonCta, showPulseAnimation -> isShowingDuckAiFireButtonCta || showPulseAnimation }
-            .asLiveData(context = viewModelScope.coroutineContext)
+        ) { ctaEffect, showPulseAnimation ->
+            when (ctaEffect) {
+                PulseCtaEffect.SUPPRESSES -> false
+                PulseCtaEffect.FORCES -> true
+                PulseCtaEffect.NEUTRAL -> showPulseAnimation
+            }
+        }.asLiveData(context = viewModelScope.coroutineContext)
 
     private var autoCompleteJob = ConflatedJob()
     private var serpLogoJob = ConflatedJob()

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -74,7 +74,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
@@ -767,7 +767,7 @@ class CtaViewModel @Inject constructor(
         }
 
     private suspend fun tooManyTabsOpenForFireEducation(): Boolean =
-        aggregateTabProvider.observe().first().size >= MAX_TABS_OPEN_FIRE_EDUCATION
+        (aggregateTabProvider.observe().firstOrNull()?.size ?: 0) >= MAX_TABS_OPEN_FIRE_EDUCATION
 
     @ExperimentalCoroutinesApi
     private fun getShowFireButtonPulseAnimationFlow(): Flow<Boolean> = dismissedCtaDao.dismissedCtas()

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -74,6 +74,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
@@ -359,7 +360,8 @@ class CtaViewModel @Inject constructor(
 
     suspend fun getFireDialogCta(): OnboardingDaxDialogCta? {
         return withContext(dispatchers.io()) {
-            if (!daxOnboardingActive() || daxDialogFireEducationShown()) return@withContext null
+            if (!daxOnboardingActive() || daxDialogFireEducationShown() || hideTips()) return@withContext null
+            if (tooManyTabsOpenForFireEducation()) return@withContext null
             if (isBrandDesignUpdateEnabled()) {
                 return@withContext DaxFireButtonBrandDesignUpdateContextualCta(
                     onboardingStore = onboardingStore,
@@ -763,6 +765,9 @@ class CtaViewModel @Inject constructor(
             if (tabs.size >= MAX_TABS_OPEN_FIRE_EDUCATION) return@map true
             return@map false
         }
+
+    private suspend fun tooManyTabsOpenForFireEducation(): Boolean =
+        aggregateTabProvider.observe().first().size >= MAX_TABS_OPEN_FIRE_EDUCATION
 
     @ExperimentalCoroutinesApi
     private fun getShowFireButtonPulseAnimationFlow(): Flow<Boolean> = dismissedCtaDao.dismissedCtas()

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -11413,9 +11413,9 @@ class BrowserTabViewModelTest {
         fakeCustomHeadersPlugin.headers = mapOf(X_DUCKDUCKGO_ANDROID_HEADER to "TEST_VALUE")
     }
 
-    private suspend fun givenFireButtonPulsing() {
+    private suspend fun givenFireButtonPulsing(dismissedCta: CtaId = DAX_DIALOG_TRACKERS_FOUND) {
         whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
-        dismissedCtaDaoChannel.send(listOf(DismissedCta(DAX_DIALOG_TRACKERS_FOUND)))
+        dismissedCtaDaoChannel.send(listOf(DismissedCta(dismissedCta)))
     }
 
     private inline fun <reified T : Command> assertCommandIssued(instanceAssertions: T.() -> Unit = {}) {
@@ -11616,6 +11616,22 @@ class BrowserTabViewModelTest {
     private fun brandDesignDuckAiFireButtonCta() = DaxDuckAiFireButtonBrandDesignUpdateContextualCta(
         onboardingStore = mockOnboardingStore,
         appInstallStore = mockAppInstallStore,
+        isLightTheme = true,
+        deviceInfo = mockDeviceInfo,
+    )
+
+    private fun trackersBlockedCta() = DaxTrackersBlockedCta(
+        onboardingStore = mockOnboardingStore,
+        appInstallStore = mockAppInstallStore,
+        trackers = emptyList(),
+        settingsDataStore = mockSettingsDataStore,
+    )
+
+    private fun brandDesignTrackersBlockedCta() = DaxTrackersBlockedBrandDesignUpdateContextualCta(
+        onboardingStore = mockOnboardingStore,
+        appInstallStore = mockAppInstallStore,
+        trackers = emptyList(),
+        settingsDataStore = mockSettingsDataStore,
         isLightTheme = true,
         deviceInfo = mockDeviceInfo,
     )
@@ -13376,6 +13392,46 @@ class BrowserTabViewModelTest {
         advanceUntilIdle()
 
         assertFalse((browserViewState().fireButton as HighlightableButton.Visible).highlighted)
+    }
+
+    @Test
+    fun whenTrackersBlockedCtaShownAndPulseActiveThenFireButtonNotHighlighted() = runTest {
+        val observer = ValueCaptorObserver<BrowserViewState>(false)
+        testee.browserViewState.observeForever(observer)
+        givenFireButtonPulsing(DAX_DIALOG_NETWORK)
+
+        testee.ctaViewState.value = ctaViewState().copy(cta = trackersBlockedCta())
+        advanceUntilIdle()
+
+        assertFalse((browserViewState().fireButton as HighlightableButton.Visible).highlighted)
+    }
+
+    @Test
+    fun whenBrandDesignTrackersBlockedCtaShownAndPulseActiveThenFireButtonNotHighlighted() = runTest {
+        val observer = ValueCaptorObserver<BrowserViewState>(false)
+        testee.browserViewState.observeForever(observer)
+        givenFireButtonPulsing(DAX_DIALOG_NETWORK)
+
+        testee.ctaViewState.value = ctaViewState().copy(cta = brandDesignTrackersBlockedCta())
+        advanceUntilIdle()
+
+        assertFalse((browserViewState().fireButton as HighlightableButton.Visible).highlighted)
+    }
+
+    @Test
+    fun whenTrackersBlockedCtaDismissedAndPulseActiveThenFireButtonHighlightRestored() = runTest {
+        val observer = ValueCaptorObserver<BrowserViewState>(false)
+        testee.browserViewState.observeForever(observer)
+        givenFireButtonPulsing(DAX_DIALOG_NETWORK)
+
+        testee.ctaViewState.value = ctaViewState().copy(cta = trackersBlockedCta())
+        advanceUntilIdle()
+        assertFalse((browserViewState().fireButton as HighlightableButton.Visible).highlighted)
+
+        testee.ctaViewState.value = ctaViewState().copy(cta = null)
+        advanceUntilIdle()
+
+        assertTrue((browserViewState().fireButton as HighlightableButton.Visible).highlighted)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -899,6 +899,38 @@ class CtaViewModelTest {
     }
 
     @Test
+    fun whenEnoughTabsOpenToStopFirePulseThenFireDialogCtaIsNull() = runTest {
+        givenDaxOnboardingActive()
+        db.tabsDao().insertTab(TabEntity(tabId = "0", position = 0))
+        db.tabsDao().insertTab(TabEntity(tabId = "1", position = 1))
+
+        val fireDialogCta = testee.getFireDialogCta()
+
+        assertNull(fireDialogCta)
+    }
+
+    @Test
+    fun whenOnlyOneTabOpenThenFireDialogCtaShown() = runTest {
+        givenDaxOnboardingActive()
+        db.tabsDao().insertTab(TabEntity(tabId = "0", position = 0))
+
+        val fireDialogCta = testee.getFireDialogCta()
+
+        assertNotNull(fireDialogCta)
+    }
+
+    @Test
+    fun whenHideTipsEnabledThenFireDialogCtaIsNull() = runTest {
+        givenDaxOnboardingActive()
+        db.tabsDao().insertTab(TabEntity(tabId = "0", position = 0))
+        whenever(mockSettingsDataStore.hideTips).thenReturn(true)
+
+        val fireDialogCta = testee.getFireDialogCta()
+
+        assertNull(fireDialogCta)
+    }
+
+    @Test
     fun whenRefreshCtaOnHomeTabAndIntroCtaWasNotPreviouslyShownThenSearchSuggestionsCtaShown() = runTest {
         givenDaxOnboardingActive()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(false)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCtaTest.kt
@@ -54,6 +54,7 @@ import com.duckduckgo.subscriptions.api.SubscriptionPromoCtaShownPlugin
 import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -122,6 +123,7 @@ class DaxFireButtonBrandDesignUpdateContextualCtaTest {
     @Before
     fun before() = runTest {
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(disabledToggle)
+        whenever(mockAggregateTabProvider.observe()).thenReturn(flowOf(emptyList()))
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
         whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(DISABLED)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1176956903599313/task/1217885575503833?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Disable the Fire Button highlight if it’s already showing at the time the Trackers Blocked highlight is triggered

### Steps to test this PR

_Feature 1_
- [x] Go through linear onboarding and get to the in-browser stage.
- [x] Perform a search.
- [x] You will be prompted to "visit a site".
- [x] Pick a site that doesn't immediately get trackers blocked, like the suggested ebay.com.
- [x] A "Go ahead - keep browsing" CTA is shown.
- [x] Do not click "Got it" but rather continue browsing as the CTA suggests.
- [x] Go directly to a website that has trackers blocked, for example yahoo.com.
- [x] A "trackers blocked" CTA is shown 
- [ ] Verify fire button highlight animation is **not** playing
- [ ] Verify privacy shield button highlight animation is playing
- [ ] Tap on 'Got it!'
- [ ] Verify fire button highlight animation is playing
- [ ] Verify privacy shield button highlight animation is **not** playing

### UI changes
| Before  | After |
| ------ | ----- |
<img width="600" alt="Screenshot_20260818_103152_DuckDuckGo" src="https://github.com/user-attachments/assets/11870cca-840f-4e33-9409-78ea8a2f4b9c" />|<img width="600" alt="Screenshot 2026-09-11 at 14 47 22" src="https://github.com/user-attachments/assets/432f6256-bf95-404a-909d-9255d22f5047" />|
